### PR TITLE
Graceful netCDF units loading.

### DIFF
--- a/etc/iris_tests_results/netcdf/netcdf_units_0.nc
+++ b/etc/iris_tests_results/netcdf/netcdf_units_0.nc
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.1">
+  <cube standard_name="air_temperature" unit="kelvin">
+    <coords>
+      <coord>
+        <explicitCoord axis="height" definitive="true" name="height" points="[100]" unit="Unit('meters')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <regularCoord axis="time" count="5" name="time" start="0" step="1" unit="Unit('unknown')" value_type="int32">
+          <attributes invalid_units="wibble"/>
+        </regularCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0xb1c17f" dtype="int32" shape="(5,)"/>
+  </cube>
+</cubes>

--- a/etc/iris_tests_results/netcdf/netcdf_units_1.nc
+++ b/etc/iris_tests_results/netcdf/netcdf_units_1.nc
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.1">
+  <cube standard_name="air_temperature" unit="unknown">
+    <attributes>
+      <attribute name="invalid_units" value="kevin"/>
+    </attributes>
+    <coords>
+      <coord>
+        <explicitCoord axis="height" definitive="true" name="height" points="[100]" unit="Unit('meters')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <regularCoord axis="time" count="5" name="time" start="0" step="1" unit="Unit('unknown')" value_type="int32">
+          <attributes invalid_units="wibble"/>
+        </regularCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x240d403e" dtype="int32" shape="(5,)"/>
+  </cube>
+</cubes>

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -650,11 +650,7 @@ fc_extras
                     cube.long_name = standard_name
                 
         # Determine the cube units.
-        attr_units = getattr(cf_var, CF_ATTR_UNITS, iris.unit._UNKNOWN_UNIT_STRING)
-
-        if np.issubdtype(cf_var.dtype, np.str):
-            attr_units = iris.unit._NO_UNIT_STRING
-
+        attr_units = get_attr_units(cf_var, cube.attributes)
         cube.units = attr_units
 
         # Incorporate cell methods
@@ -663,7 +659,13 @@ fc_extras
 
         # Set the cube global attributes. 
         for attr_name, attr_value in cf_var.cf_group.global_attributes.iteritems():
-            cube.attributes[str(attr_name)] = str(attr_value) if isinstance(attr_value, basestring) else attr_value
+            if isinstance(attr_value, unicode):
+                try:
+                    cube.attributes[str(attr_name)] = str(attr_value)
+                except UnicodeEncodeError:
+                    cube.attributes[str(attr_name)] = attr_value
+            else:
+                cube.attributes[str(attr_name)] = attr_value
 
 
     ################################################################################
@@ -688,19 +690,27 @@ fc_extras
 
 
     ################################################################################
-    def get_attr_units(cf_coord_var):
-        attr_units = getattr(cf_coord_var, CF_ATTR_UNITS, iris.unit._UNKNOWN_UNIT_STRING)
+    def get_attr_units(cf_var, attributes):
+        attr_units = getattr(cf_var, CF_ATTR_UNITS, iris.unit._UNKNOWN_UNIT_STRING)
+
+        # Graceful loading of invalid units.
+        try:
+            iris.unit.as_unit(attr_units)
+        except ValueError:
+            warnings.warn('Ignoring netCDF variable %r invalid units %r' % (cf_var.cf_name, attr_units))
+            attributes['invalid_units'] = attr_units
+            attr_units = iris.unit._UNKNOWN_UNIT_STRING
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:
             attr_units = 'degrees'
 
-        if np.issubdtype(cf_coord_var.dtype, np.str):
+        if np.issubdtype(cf_var.dtype, np.str):
             attr_units = iris.unit._NO_UNIT_STRING
 
         # Get any assoicated calendar for a time reference coordinate.
         if iris.unit.as_unit(attr_units).time_reference:
-            attr_calendar = getattr(cf_coord_var, CF_ATTR_CALENDAR, None)
+            attr_calendar = getattr(cf_var, CF_ATTR_CALENDAR, None)
 
             if attr_calendar:
                 attr_units = iris.unit.Unit(attr_units, calendar=attr_calendar)
@@ -751,7 +761,7 @@ fc_extras
         cube = engine.cube
         attributes = {}
 
-        attr_units = get_attr_units(cf_coord_var)
+        attr_units = get_attr_units(cf_coord_var, attributes)
         points_data = cf_coord_var[:]
 
         # Get any coordinate bounds.
@@ -825,9 +835,9 @@ fc_extras
         cf_var = engine.cf_var
         cube = engine.cube
         attributes = {}
-        
+
         # Get units
-        attr_units = get_attr_units(cf_coord_var)
+        attr_units = get_attr_units(cf_coord_var, attributes)
 
         # Get any coordinate point data.
         if isinstance(cf_coord_var, cf.CFLabelVariable):
@@ -939,7 +949,10 @@ fc_extras
 
         attr_std_name = getattr(cf_var, CF_ATTR_STD_NAME, None)
         attr_axis = getattr(cf_var, CF_ATTR_AXIS, '')
-        is_time_reference = iris.unit.Unit(attr_units or 1).time_reference
+        try:
+            is_time_reference = iris.unit.Unit(attr_units or 1).time_reference
+        except ValueError:
+            is_time_reference = False
         
         return is_time_reference and (attr_std_name=='time' or attr_axis.lower()==CF_VALUE_AXIS_T)
 
@@ -952,7 +965,10 @@ fc_extras
         attr_units = getattr(cf_var, CF_ATTR_UNITS, None)
 
         if attr_units is not None:
-            is_valid = iris.unit.is_time(attr_units)
+            try:
+                is_valid = iris.unit.is_time(attr_units)
+            except ValueError:
+                is_valid = False
 
         return is_valid
 
@@ -1010,7 +1026,7 @@ fc_extras
             for m in CM_PARSE.finditer(nc_cell_methods):
                 d = m.groupdict()
                 if d[CM_METHOD].lower() not in CM_KNOWN_METHODS:
-                    warnings.warn('NCDF variable "%s" contains unknown cell method "%s"' % (cf_var_name, d[CM_METHOD]))
+                    warnings.warn('NetCDF variable "%s" contains unknown cell method "%s"' % (cf_var_name, d[CM_METHOD]))
                 name = d[CM_NAME]
                 name = name.replace(' ', '')
                 name = name.rstrip(':')

--- a/lib/iris/fileformats/grib_save_rules.py
+++ b/lib/iris/fileformats/grib_save_rules.py
@@ -413,7 +413,7 @@ def reference_time(cube, grib):
     pt = pt_coord.bounds[0,0] if pt_coord.has_bounds() else pt_coord.points[0]  # always in hours
     ft = cube.coord("forecast_period").points[0]   # always in hours
     rt = pt - ft
-    rt = iris.unit.num2date(rt, pt_coord.units.name, pt_coord.unit.calendar)
+    rt = iris.unit.num2date(rt, pt_coord.units.name, pt_coord.units.calendar)
     
     gribapi.grib_set_long(grib, "dataDate", "%04d%02d%02d" % (rt.year, rt.month, rt.day))
     gribapi.grib_set_long(grib, "dataTime", "%02d%02d" % (rt.hour, rt.minute))

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -204,6 +204,18 @@ def _pyke_stats(engine, cf_name):
                 print '\t%s%s' % (key, arg)
 
 
+def _set_attributes(attributes, key, value):
+    """Set the attributes dictionary, converting unicode strings appropriately."""
+
+    if isinstance(value, unicode):
+        try:
+            attributes[str(key)] = str(value)
+        except UnicodeEncodeError:
+            attributes[str(key)] = value
+    else:
+        attributes[str(key)] = value
+
+
 def _load_cube(engine, cf, cf_var, filename):
     """Create the cube associated with the CF-netCDF data variable."""
      
@@ -241,16 +253,11 @@ def _load_cube(engine, cf, cf_var, filename):
  
     for coord, cf_var_name in coordinates:
         for attr_name, attr_value in itertools.ifilter(attribute_predicate, cf.cf_group[cf_var_name].cf_attrs_unused()):
-            coord.attributes[str(attr_name)] = str(attr_value) if isinstance(attr_value, basestring) else attr_value
+            _set_attributes(coord.attributes, attr_name, attr_value)
                 
     # Attach untouched attributes of the associated CF-netCDF data variable to the cube.
     for attr_name, attr_value in itertools.ifilter(attribute_predicate, cf_var.cf_attrs_unused()):
-        cube.attributes[str(attr_name)] = str(attr_value) if isinstance(attr_value, basestring) else attr_value
-
-#    TODO - put this back in for new merge
-#    # Move any length 1 dimension coordinates to the aux_coords container, minimising the data dimensionality
-#    slices = [slice(None,None) if dim_len > 1 else 0 for dim_len in cube.shape]
-#    cube = cube[tuple(slices)]
+        _set_attributes(cube.attributes, attr_name, attr_value)
 
     # Deal with special case of "source" attribute.
     # Convert the attribute to a coordinate (meta-data hook for PP save).

--- a/lib/iris_tests/test_netcdf.py
+++ b/lib/iris_tests/test_netcdf.py
@@ -128,7 +128,7 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xyt_precipitation.cml'))
 
     def test_cell_methods(self):
-        # Test excercising CF-netCDF cell method parsing.
+        # Test exercising CF-netCDF cell method parsing.
         cubes = iris.load(tests.get_data_path(('NetCDF', 'testing', 'cell_methods.nc')))
 
         for cube in cubes:
@@ -168,6 +168,13 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertCML(cube[0:20:2][(9, 5, 8, 0), ][3], ('netcdf', 'netcdf_deferred_mix_0.cml'))
         self.assertCML(cube[(2, 7, 3, 4, 5, 0, 9, 10), ][2:6][3], ('netcdf', 'netcdf_deferred_mix_0.cml'))
         self.assertCML(cube[0][(0, 2), (1, 3)], ('netcdf', 'netcdf_deferred_mix_1.cml'))
+
+    def test_units(self):
+        # Test exercising graceful cube and coordinate units loading.
+        cube0, cube1 = iris.load(tests.get_data_path(('NetCDF', 'testing', 'units.nc')))
+
+        self.assertCML(cube0, ('netcdf', 'netcdf_units_0.nc'))
+        self.assertCML(cube1, ('netcdf', 'netcdf_units_1.nc'))
 
 
 class TestSave(tests.IrisTest):


### PR DESCRIPTION
Perform graceful netCDF units loading for both <i>cube</i> and <i>coordinate</i> units, on recommendation from the NERC evaluation.

If the units string is not a valid UDUNITS-2 unit, it is set to <i>unknown</i> and a <i>warning</i> is issued to the user. The invalid units string is cached in the <i>attributes</i> dictionary of the associated cube or coordinate, keyed under <i>invalid_units</i>.
