### PR TITLE
Installation of additional files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include CHANGES COPYING COPYING.LESSER
+# Additonal files from package_data not automatically added to source distributions
+include lib/iris/fileformats/_pyke_rules/*.k?b

--- a/setup.py
+++ b/setup.py
@@ -179,11 +179,10 @@ setup(
     packages=find_package_tree('lib/iris', 'iris'),
     package_dir={'': 'lib'},
     package_data={
-        'iris': ['resources/logos/*.png'] + \
-                list(file_walk_relative('lib/iris/etc', remove='lib/iris/')) + \
+        'iris': list(file_walk_relative('lib/iris/etc', remove='lib/iris/')) + \
+                list(file_walk_relative('lib/iris/tests/results', remove='lib/iris/')) + \
                 ['fileformats/_pyke_rules/*.k?b'] + \
-                list(file_walk_relative('lib/iris/tests/results', remove='lib/iris/'))
-              ,
+                ['tests/stock*.npz']
         },
     data_files=[('iris', ['CHANGES', 'COPYING', 'COPYING.LESSER'])],
     tests_require=['nose'],


### PR DESCRIPTION
Partially addresses issue #20. The requested files (CHANGES, COPYING and COPYING.LESSER) are copied on install, but not on build. I've also added a MANIFEST.in file so that the files are included when building a source distribution.
