### PR TITLE
Deprecation of coord trig methods

### DIFF
--- a/etc/iris_tests_results/analysis/calculus/cos_simple.xml
+++ b/etc/iris_tests_results/analysis/calculus/cos_simple.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<AuxCoord id="5634c91ba5717382" long_name="cos(latitude)" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/etc/iris_tests_results/analysis/calculus/cos_simple_radians.xml
+++ b/etc/iris_tests_results/analysis/calculus/cos_simple_radians.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<AuxCoord id="5634c91ba5717382" long_name="cos(latitude)" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -25,10 +25,9 @@ import math
 import numpy
 
 import iris.analysis
-import iris.exceptions
 import iris.coords
 import iris.cube
-from iris.analysis import coord_comparison
+import iris.exceptions
 
 
 def abs(cube, update_history=True, in_place=False):
@@ -273,9 +272,9 @@ def _add_subtract_common(operation_function, operation_symbol, operation_noun, o
         # Deal with cube addition/subtraction by cube
         
         # get a coordinate comparison of this cube and the cube to do the operation with
-        coord_comparison = iris.analysis.coord_comparison(cube, other)
+        coord_comp = iris.analysis.coord_comparison(cube, other)
         
-        if coord_comparison['transposable']:
+        if coord_comp['transposable']:
             raise ValueError('Cubes cannot be %s, differing axes. '
                                  'cube.transpose() may be required to re-order the axes.' % operation_past_tense)
         
@@ -284,7 +283,7 @@ def _add_subtract_common(operation_function, operation_symbol, operation_noun, o
             warnings.warn('The "ignore" keyword has been deprecated in add/subtract. This functionality is now automatic. '
                           'The provided value to "ignore" has been ignored, and has been automatically calculated.')
 
-        bad_coord_grps = (coord_comparison['ungroupable_and_dimensioned'] + coord_comparison['resamplable'])
+        bad_coord_grps = (coord_comp['ungroupable_and_dimensioned'] + coord_comp['resamplable'])
         if bad_coord_grps:
             raise ValueError('This operation cannot be performed as there are differing coordinates (%s) remaining '
                              'which cannot be ignored.' % ', '.join({coord_grp.name() for coord_grp in bad_coord_grps}))
@@ -296,7 +295,7 @@ def _add_subtract_common(operation_function, operation_symbol, operation_noun, o
             new_cube = cube.copy(data=operation_function(cube.data, other.data))
 
         # If a coordinate is to be ignored - remove it
-        ignore = filter(None, [coord_grp[0] for coord_grp in coord_comparison['ignorable']])
+        ignore = filter(None, [coord_grp[0] for coord_grp in coord_comp['ignorable']])
         if not ignore:
             ignore_string = ''
         else:

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -30,6 +30,7 @@ import warnings
 
 import numpy
 
+import iris.analysis.calculus
 import iris.analysis.interpolate
 import iris.aux_factory
 import iris.exceptions
@@ -781,43 +782,23 @@ class Coord(CFVariableMixin):
         """
         Return a coordinate which represents sin(this coordinate).
 
-        .. note:: If coordinate is in degrees then it is converted into radians
-              before applying the sin() function.
+        .. deprecated::
+            This method has been deprecated.
 
         """
-        return self._trig_method(numpy.sin)
+        warnings.warn('Coord.sin() has been deprecated.') 
+        return iris.analysis.calculus._coord_sin(self)
 
     def cos(self):
         """
         Return a coordinate which represents cos(this coordinate).
 
-        .. note:: If coordinate is in degrees then it is converted into radians
-              before applying the cos() function.
+        .. deprecated::
+            This method has been deprecated.
 
         """
-        return self._trig_method(numpy.cos)
-
-    def _trig_method(self, trig_function):
-        """
-        Return a coordinate which represents trig_function(this coordinate).
-
-        trig_function - a reference to the appropriate function (e.g. numpy.sin)
-
-        """
-        # If we are in degrees convert our coordinate to radians.
-        if self.units == 'degrees':
-            coord = self.unit_converted('radians')
-        else:
-            coord = self
-        
-        points = trig_function(coord.points)
-        bounds = trig_function(coord.bounds) if coord.bounds is not None else None
-        
-        # TODO: Does this imply AuxCoord should be a superclass of DimCoord?
-        coord = iris.coords.AuxCoord.from_coord(coord).copy(points=points, bounds=bounds)
-        coord.units = '1'
-        coord.rename('%s(%s)' % (trig_function.__name__, coord.name())) 
-        return coord
+        warnings.warn('Coord.cos() has been deprecated.') 
+        return iris.analysis.calculus._coord_cos(self)
 
     def unit_converted(self, new_unit):
         """Return a coordinate converted to a given unit."""

--- a/lib/iris_tests/test_coord_api.py
+++ b/lib/iris_tests/test_coord_api.py
@@ -438,7 +438,10 @@ class TestCoordMaths(tests.IrisTest):
         self.count = 20
         self._build_coord()
         
-       
+
+# TODO - Remove this test class and results files when Coord.cos() and Coord.sin() are removed.
+# This class tests two deprecated Coord methods. These methods are now private functions in
+# analysis/calculus.py and corresponding tests are in test_analysis_calculus.py.
 class TestCoordTrig(TestCoordMaths):    
     def test_sin(self): 
         sin_of_coord = self.lon.sin()


### PR DESCRIPTION
Addresses issue #9. Deprecation of Coord.cos() and Coord.sin(). Equivalent private functions added to calculus.py where they are used. Relevant tests now in `test_analysis_calculus.py`, but original tests have been left in `test_coord_api.py` until the methods are removed entirely.
