### PR TITLE
patch for IE9 support

### DIFF
--- a/docs/iris/src/_templates/layout.html
+++ b/docs/iris/src/_templates/layout.html
@@ -21,7 +21,7 @@
 <a href="{{ pathto('index') }}"><img src="{{pathto("_static/logo.png", 1) }}" style="float:right; clear:left; margin-right: 40px; " border="0" alt="Logo"/></a>
 -->
 
-<p style="margin-left: 15px; height:20px; font-weight:bolder; font-size:300%; letter-spacing:0.1ex;">
+<p style="margin-left: 15px; font-weight:bolder; font-size:300%; letter-spacing:0.1ex;">
 Iris {{version}}
 </p>
 


### PR DESCRIPTION
removed height:20px from instyle css properties so that the 'Iris version' title is rendered correctly in IE9.
Tests conducted under Windows 7 IE9, Linux RHEL6 FF 10.6 and IE 8
