### PR TITLE
Convert source from coord to attribute. Fixes #10

### DIFF
--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -46,9 +46,9 @@ data representing their difference:
          Scalar coordinates:
               forecast_reference_time: -953274.0 hours since 1970-01-01 00:00:00
               height: 1.5 m
-              source: Data from Met Office Unified Model 6.05
          Attributes:
               history: air_temperature - air_temperature (ignoring forecast_period, time)
+
 
 .. note::
     Notice that the coordinates "time" and "forecast_period" have been removed from the resultant cube; this 

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -38,12 +38,9 @@ Instead of downsampling the data, a similar goal can be achieved using statistic
               surface_altitude               -                      -                 x                    x
          Derived coordinates:
               altitude                       -                      x                 x                    x
-         Scalar coordinates:
-              source: Data from Met Office Unified Model 7.03
          Attributes:
               STASH: m01s00i004
-
-
+              source: Data from Met Office Unified Model 7.03
 
 
 In this case we have a 4 dimensional cube; to mean the vertical (z) dimension down to a single valued extent we can pass the coordinate
@@ -66,10 +63,10 @@ name and the aggregation definition to the :meth:`Cube.collapsed() <iris.cube.Cu
               level_height: Cell(point=696.66663, bound=(0.0, 1393.3333)) m
               model_level_number: Cell(point=10, bound=(1, 19))
               sigma: Cell(point=0.92292976, bound=(0.84585959, 1.0))
-              source: Data from Met Office Unified Model 7.03
          Attributes:
               STASH: m01s00i004
               history: Mean of air_potential_temperature over model_level_number
+              source: Data from Met Office Unified Model 7.03
          Cell methods:
               mean: model_level_number
 
@@ -111,15 +108,13 @@ These areas can now be passed to the ``collapsed`` method as weights:
          Scalar coordinates:
               grid_latitude: Cell(point=1.5145501, bound=(0.14430022, 2.8848)) degrees
               grid_longitude: Cell(point=358.74948, bound=(357.49399, 360.00497)) degrees
-              source: Data from Met Office Unified Model 7.03
               surface_altitude: Cell(point=399.625, bound=(-14.0, 813.25)) m
          Attributes:
               STASH: m01s00i004
               history: Mean of air_potential_temperature over grid_longitude, grid_latitude
+              source: Data from Met Office Unified Model 7.03
          Cell methods:
               mean: grid_longitude, grid_latitude
-
-
 
 
 

--- a/docs/iris/src/userguide/iris_cubes.rst
+++ b/docs/iris/src/userguide/iris_cubes.rst
@@ -168,10 +168,9 @@ output as this is the quickest way of inspecting the contents of a cube. Here is
               surface_altitude               -                      -                 x                    x
          Derived coordinates:
               altitude                       -                      x                 x                    x
-         Scalar coordinates:
-              source: Data from Met Office Unified Model 7.03
          Attributes:
               STASH: m01s00i004
+              source: Data from Met Office Unified Model 7.03
 
 
 Using this output we can deduce that:
@@ -185,7 +184,6 @@ Using this output we can deduce that:
  * There are 7 distinct values in the "model_level_number" coordinate. Similar inferences can
    be made for the other dimension coordinates.
  * There are 7, not necessarily distinct, values in the ``level_height`` coordinate.
- * There is 1 coordinate (``source``) which represents a scalar value over all of the data dimensions.
  * The cube has one further attribute relating to the  phenomenon. 
    In this case the originating file format, PP, encodes information in a STASH code which in some cases can
    be useful for identifying advanced experiment information relating to the phenomenon.

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -81,10 +81,9 @@ example, list indexing *could* be used:
               surface_altitude               -                      -                 x                    x
          Derived coordinates:
               altitude                       -                      x                 x                    x
-         Scalar coordinates:
-              source: Data from Met Office Unified Model 7.03
          Attributes:
               STASH: m01s00i004
+              source: Data from Met Office Unified Model 7.03
 
 
 Notice that the result of printing a **cube** is a little more verbose than it was when printing a 

--- a/docs/iris/src/userguide/navigating_a_cube.rst
+++ b/docs/iris/src/userguide/navigating_a_cube.rst
@@ -30,11 +30,11 @@ We have already seen a basic string representation of a cube when printing:
               grid_longitude                          -                   x
          Scalar coordinates:
               forecast_period: 0.0 hours
-              source: Data from Met Office Unified Model 6.01
               time: 319536.0 hours since 1970-01-01 00:00:00
          Attributes:
-              STASH: m01s16i222
               Conventions: CF-1.5
+              STASH: m01s16i222
+              source: Data from Met Office Unified Model 6.01
 
 
 This representation is equivalent to passing the cube to the :func:`str` function.  This function can be used on 
@@ -113,7 +113,7 @@ Alternatively, we can use *list comprehension* to store the names in a list::
 The result is a basic Python list which could be sorted alphabetically and joined together:
 
      >>> print ', '.join(sorted(coord_names))
-     forecast_period, grid_latitude, grid_longitude, source, time
+     forecast_period, grid_latitude, grid_longitude, time
 
 To get an individual coordinate given its name, the :meth:`Cube.coord <iris.cube.Cube.coord>` method can be used::
 
@@ -152,11 +152,11 @@ We can add and remove coordinates via :func:`Cube.add_dim_coord<iris.cube.Cube.a
          Scalar coordinates:
               forecast_period: 0.0 hours
               my_custom_coordinate: 1
-              source: Data from Met Office Unified Model 6.01
               time: 319536.0 hours since 1970-01-01 00:00:00
          Attributes:
-              STASH: m01s16i222
               Conventions: CF-1.5
+              STASH: m01s16i222
+              source: Data from Met Office Unified Model 6.01
 
 
 The coordinate ``my_custom_coordinate`` now exists on the cube and is listed under the non-dimensioned single valued scalar coordinates.

--- a/etc/iris_tests_results/COLPEX/uwind_and_orog.cml
+++ b/etc/iris_tests_results/COLPEX/uwind_and_orog.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -482,9 +483,6 @@
 		0.0407843, 0.0206052, 0.00587961, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
       </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[110.742, 136.728, 174.916, ..., 51.326, 52.346,
  		50.7854],
@@ -511,6 +509,7 @@
   <cube standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -540,9 +539,6 @@
 		360.079]" shape="(412,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_0.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_0.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -26,9 +27,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[361980.0, 361983.0, 361986.0]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_1.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_1.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -29,9 +30,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[361980.0, 361983.0],

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_2.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_2.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -29,9 +30,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[361980.0, 361983.0],

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_3.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_3.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -477,9 +478,6 @@
 		0.000575306328556, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float64"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[2776.62, 2776.62, 2776.62, ..., 2776.62,

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_4.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_air_temperature_4.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -22,9 +23,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[850.0]" shape="(1,)" units="Unit('hPa')" value_type="float64"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[361980.0, 361983.0, 361986.0]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_0.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_0.cml
@@ -3,6 +3,7 @@
   <cube standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord>
@@ -19,9 +20,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[361980.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_1.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_1.cml
@@ -3,6 +3,7 @@
   <cube standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord>
@@ -19,9 +20,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[361980.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_2.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_2.cml
@@ -3,6 +3,7 @@
   <cube standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord>
@@ -19,9 +20,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[361980.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_3.cml
+++ b/etc/iris_tests_results/FF/qtgl.ssps_006_soil_temperature_3.cml
@@ -3,6 +3,7 @@
   <cube standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.07"/>
     </attributes>
     <coords>
       <coord>
@@ -19,9 +20,6 @@
 		359.648]" shape="(1024,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.07]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[361980.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/abs.cml
+++ b/etc/iris_tests_results/analysis/abs.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition.cml
+++ b/etc/iris_tests_results/analysis/addition.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_coord_x.cml
+++ b/etc/iris_tests_results/analysis/addition_coord_x.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_coord_y.cml
+++ b/etc/iris_tests_results/analysis/addition_coord_y.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_different_std_name.cml
+++ b/etc/iris_tests_results/analysis/addition_different_std_name.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_in_place.cml
+++ b/etc/iris_tests_results/analysis/addition_in_place.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_in_place_coord.cml
+++ b/etc/iris_tests_results/analysis/addition_in_place_coord.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/addition_scalar.cml
+++ b/etc/iris_tests_results/analysis/addition_scalar.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/areaweights_original.cml
+++ b/etc/iris_tests_results/analysis/areaweights_original.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/division.cml
+++ b/etc/iris_tests_results/analysis/division.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/division_by_array.cml
+++ b/etc/iris_tests_results/analysis/division_by_array.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/division_by_latitude.cml
+++ b/etc/iris_tests_results/analysis/division_by_latitude.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/division_by_longitude.cml
+++ b/etc/iris_tests_results/analysis/division_by_longitude.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/division_by_singular_coord.cml
+++ b/etc/iris_tests_results/analysis/division_by_singular_coord.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/division_scalar.cml
+++ b/etc/iris_tests_results/analysis/division_scalar.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/exponentiate.cml
+++ b/etc/iris_tests_results/analysis/exponentiate.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/gmean_latitude.cml
+++ b/etc/iris_tests_results/analysis/gmean_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Geometric mean of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/gmean_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/gmean_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Geometric mean of air_pressure_at_sea_level over grid_latitude
 Geometric mean of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Geometric mean of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/gmean_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/gmean_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Geometric mean of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/hmean_latitude.cml
+++ b/etc/iris_tests_results/analysis/hmean_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Harmonic mean of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/hmean_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/hmean_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Harmonic mean of air_pressure_at_sea_level over grid_latitude
 Harmonic mean of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Harmonic mean of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/hmean_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/hmean_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Harmonic mean of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/interpolation/linear/real_2dslice.cml
+++ b/etc/iris_tests_results/analysis/interpolation/linear/real_2dslice.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/linear/real_2slices.cml
+++ b/etc/iris_tests_results/analysis/interpolation/linear/real_2slices.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/etc/iris_tests_results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
+++ b/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -23,9 +24,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
+++ b/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -23,9 +24,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
+++ b/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -23,9 +24,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -23,9 +24,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/log.cml
+++ b/etc/iris_tests_results/analysis/log.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/log10.cml
+++ b/etc/iris_tests_results/analysis/log10.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/log2.cml
+++ b/etc/iris_tests_results/analysis/log2.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/maths_original.cml
+++ b/etc/iris_tests_results/analysis/maths_original.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -30,9 +31,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/analysis/max_latitude.cml
+++ b/etc/iris_tests_results/analysis/max_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Maximum of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/max_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/max_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Maximum of air_pressure_at_sea_level over grid_latitude
 Maximum of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Maximum of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/max_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/max_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Maximum of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/mean_latitude.cml
+++ b/etc/iris_tests_results/analysis/mean_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Mean of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/mean_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/mean_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Mean of air_pressure_at_sea_level over grid_latitude
 Mean of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Mean of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/mean_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/mean_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Mean of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/median_latitude.cml
+++ b/etc/iris_tests_results/analysis/median_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Median of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/median_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/median_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Median of air_pressure_at_sea_level over grid_latitude
 Median of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Median of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/median_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/median_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Median of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/min_latitude.cml
+++ b/etc/iris_tests_results/analysis/min_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Minimum of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/min_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/min_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Minimum of air_pressure_at_sea_level over grid_latitude
 Minimum of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Minimum of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/min_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/min_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Minimum of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/multiply.cml
+++ b/etc/iris_tests_results/analysis/multiply.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/multiply_different_std_name.cml
+++ b/etc/iris_tests_results/analysis/multiply_different_std_name.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/original.cml
+++ b/etc/iris_tests_results/analysis/original.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/original_common.cml
+++ b/etc/iris_tests_results/analysis/original_common.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/original_hmean.cml
+++ b/etc/iris_tests_results/analysis/original_hmean.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/sqrt.cml
+++ b/etc/iris_tests_results/analysis/sqrt.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/std_dev_latitude.cml
+++ b/etc/iris_tests_results/analysis/std_dev_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Standard deviation of air_pressure_at_sea_level over grid_latitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/std_dev_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/std_dev_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Standard deviation of air_pressure_at_sea_level over grid_latitude (delta degrees of freedom: 1)
 Standard deviation of air_pressure_at_sea_level over grid_longitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Standard deviation of air_pressure_at_sea_level over grid_longitude (delta degre
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/std_dev_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Standard deviation of air_pressure_at_sea_level over grid_latitude, grid_longitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/subtract.cml
+++ b/etc/iris_tests_results/analysis/subtract.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/subtract_array.cml
+++ b/etc/iris_tests_results/analysis/subtract_array.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/subtract_coord_x.cml
+++ b/etc/iris_tests_results/analysis/subtract_coord_x.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/subtract_coord_y.cml
+++ b/etc/iris_tests_results/analysis/subtract_coord_y.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/subtract_scalar.cml
+++ b/etc/iris_tests_results/analysis/subtract_scalar.cml
@@ -32,9 +32,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[215280.0, 249840.0]]" id="559b95abfcdf35de" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/analysis/sum_latitude.cml
+++ b/etc/iris_tests_results/analysis/sum_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Sum of air_pressure_at_sea_level over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/sum_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/sum_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Sum of air_pressure_at_sea_level over grid_latitude
 Sum of air_pressure_at_sea_level over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Sum of air_pressure_at_sea_level over grid_longitude"/>
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/sum_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/sum_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Sum of air_pressure_at_sea_level over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/variance_latitude.cml
+++ b/etc/iris_tests_results/analysis/variance_latitude.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Variance of air_pressure_at_sea_level over grid_latitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/variance_latitude_longitude.cml
+++ b/etc/iris_tests_results/analysis/variance_latitude_longitude.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Variance of air_pressure_at_sea_level over grid_latitude (delta degrees of freedom: 1)
 Variance of air_pressure_at_sea_level over grid_longitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -21,9 +22,6 @@ Variance of air_pressure_at_sea_level over grid_longitude (delta degrees of free
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/variance_latitude_longitude_1call.cml
+++ b/etc/iris_tests_results/analysis/variance_latitude_longitude_1call.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="history" value="Variance of air_pressure_at_sea_level over grid_latitude, grid_longitude (delta degrees of freedom: 1)"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -20,9 +21,6 @@
         <DimCoord bounds="[[313.02, 392.11]]" id="3bf28623a9db078e" points="[352.565]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[319536.0, 319537.0, 319538.0, 319539.0,

--- a/etc/iris_tests_results/analysis/weighted_mean_original.cml
+++ b/etc/iris_tests_results/analysis/weighted_mean_original.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cdm/extract/lat_eq_10.cml
+++ b/etc/iris_tests_results/cdm/extract/lat_eq_10.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cdm/extract/lat_gt_10.cml
+++ b/etc/iris_tests_results/cdm/extract/lat_gt_10.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -135,9 +136,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
+++ b/etc/iris_tests_results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -136,9 +137,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cdm/masked_cube.cml
+++ b/etc/iris_tests_results/cdm/masked_cube.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i???"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -25,9 +26,6 @@
       <coord datadims="[0]">
         <AuxCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0, 1000.0, 1000.0, 800.0, 800.0, 800.0,
 		900.0, 900.0]" shape="(8,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <AuxCoord id="559b95abfcdf35de" points="[999.999999996, 1003.0, 1006.0, 999.999999996,

--- a/etc/iris_tests_results/cdm/string_representations/0d_cube.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/0d_cube.__str__.txt
@@ -4,7 +4,7 @@ air_temperature                     (scalar cube)
           latitude: 90.0 degrees
           longitude: 0.0 degrees
           pressure: 1000.0 hPa
-          source: Data from Met Office Unified Model
           time: 253464.0 hours since 1970-01-01 00:00:00
      Attributes:
           STASH: m01s16i203
+          source: Data from Met Office Unified Model

--- a/etc/iris_tests_results/cdm/string_representations/5d_pp.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/5d_pp.__str__.txt
@@ -11,8 +11,7 @@ eastward_wind                       (time: 6; model_level_number: 70; grid_latit
           surface_altitude               -                      -                  x                    x
      Derived coordinates:
           altitude                       -                      x                  x                    x
-     Scalar coordinates:
-          source: Data from Met Office Unified Model 7.04
      Attributes:
-          my_attribute: foobar
           STASH: m01s00i002
+          my_attribute: foobar
+          source: Data from Met Office Unified Model 7.04

--- a/etc/iris_tests_results/cdm/string_representations/cell_methods.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/cell_methods.__str__.txt
@@ -5,10 +5,10 @@ air_temperature                     (latitude: 73; longitude: 96)
      Scalar coordinates:
           forecast_period: 6477.0 hours
           pressure: 1000.0 hPa
-          source: Data from Met Office Unified Model
           time: 253464.0 hours since 1970-01-01 00:00:00
      Attributes:
           STASH: m01s16i203
+          source: Data from Met Office Unified Model
      Cell methods:
           mean: longitude (6 minutes, This is a test comment), latitude (12 minutes)
           average: longitude (6 minutes, This is another test comment), latitude (15 minutes, This is another comment)

--- a/etc/iris_tests_results/cdm/string_representations/muliple_history.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/muliple_history.__str__.txt
@@ -5,7 +5,6 @@ unknown                             (latitude: 73; longitude: 96)
      Scalar coordinates:
           forecast_period: 6477.0 hours
           pressure: 1000.0 hPa
-          source: Data from Met Office Unified Model
           time: 253464.0 hours since 1970-01-01 00:00:00
      Attributes:
           history: unknown - unknown

--- a/etc/iris_tests_results/cdm/string_representations/realistic_0d.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/realistic_0d.__str__.txt
@@ -7,6 +7,7 @@ air_potential_temperature           (scalar cube)
           level_height: Cell(point=5.0, bound=(0.0, 13.333332)) m
           model_level_number: 1
           sigma: Cell(point=0.9994238, bound=(1.0, 0.99846387))
-          source: Iris test case
           surface_altitude: 413.937 m
           time: 347921.166667 hours since 1970-01-01 00:00:00
+     Attributes:
+          source: Iris test case

--- a/etc/iris_tests_results/cdm/string_representations/realistic_1d.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/realistic_1d.__str__.txt
@@ -11,5 +11,6 @@ air_potential_temperature           (grid_longitude: 100)
           level_height: Cell(point=5.0, bound=(0.0, 13.333332)) m
           model_level_number: 1
           sigma: Cell(point=0.9994238, bound=(1.0, 0.99846387))
-          source: Iris test case
           time: 347921.166667 hours since 1970-01-01 00:00:00
+     Attributes:
+          source: Iris test case

--- a/etc/iris_tests_results/cdm/string_representations/realistic_2d.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/realistic_2d.__str__.txt
@@ -11,5 +11,6 @@ air_potential_temperature           (grid_latitude: 100; grid_longitude: 100)
           level_height: Cell(point=5.0, bound=(0.0, 13.333332)) m
           model_level_number: 1
           sigma: Cell(point=0.9994238, bound=(1.0, 0.99846387))
-          source: Iris test case
           time: 347921.166667 hours since 1970-01-01 00:00:00
+     Attributes:
+          source: Iris test case

--- a/etc/iris_tests_results/cdm/string_representations/realistic_3d.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/realistic_3d.__str__.txt
@@ -11,5 +11,6 @@ air_potential_temperature           (model_level_number: 70; grid_latitude: 100;
           altitude                                     x                  x                    x
      Scalar coordinates:
           forecast_period: 0.0 hours
-          source: Iris test case
           time: 347921.166667 hours since 1970-01-01 00:00:00
+     Attributes:
+          source: Iris test case

--- a/etc/iris_tests_results/cdm/string_representations/realistic_4d.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/realistic_4d.__str__.txt
@@ -12,4 +12,5 @@ air_potential_temperature           (time: 6; model_level_number: 70; grid_latit
           altitude                       -                      x                  x                    x
      Scalar coordinates:
           forecast_period: 0.0 hours
+     Attributes:
           source: Iris test case

--- a/etc/iris_tests_results/cdm/string_representations/similar.__str__.txt
+++ b/etc/iris_tests_results/cdm/string_representations/similar.__str__.txt
@@ -11,9 +11,7 @@ air_temperature                     (latitude: 73; longitude: 96)
      Scalar coordinates:
           forecast_period: 6477.0 hours
           pressure: 1000.0 hPa
-          source: Data from Met Office Unified Model
-          source: Data from Met Office Unified Model
-             reliability='low'
           time: 253464.0 hours since 1970-01-01 00:00:00
      Attributes:
           STASH: m01s16i203
+          source: Data from Met Office Unified Model

--- a/etc/iris_tests_results/constrained_load/all_10_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/all_10_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -39,9 +40,6 @@
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -55,6 +53,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -92,9 +91,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -108,6 +104,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -145,9 +142,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -161,6 +155,7 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -195,9 +190,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/all_ml_10_22_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/all_ml_10_22_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -41,9 +42,6 @@
 		[0.222443, 0.177555]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571, 0.199878]" shape="(2,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -57,6 +55,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -96,9 +95,6 @@
 		[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914, 0.222443]" shape="(2,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -112,6 +108,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -151,9 +148,6 @@
 		[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914, 0.222443]" shape="(2,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -167,6 +161,7 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -203,9 +198,6 @@
       <coord datadims="[0]">
         <AuxCoord bounds="[[0.803914, 0.763465],
 		[0.222443, 0.177555]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571, 0.199878]" shape="(2,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/attribute_constraint.cml
+++ b/etc/iris_tests_results/constrained_load/attribute_constraint.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="my_attribute" value="foobar"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -127,9 +128,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -39,9 +40,6 @@
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -55,6 +53,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -112,9 +111,6 @@
 		[0.0, 0.0],
 		[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.997716, 0.990882, 0.979543, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0]" shape="(11,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -39,9 +40,6 @@
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -55,6 +53,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -112,9 +111,6 @@
 		[0.0, 0.0],
 		[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.997716, 0.990882, 0.979543, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0]" shape="(11,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_10_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_10_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -37,9 +38,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_10_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_10_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -37,9 +38,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_and_all_10_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_and_all_10_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -128,9 +129,6 @@
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -144,6 +142,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -180,9 +179,6 @@
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -196,6 +192,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -233,9 +230,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -249,6 +243,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -286,9 +281,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -302,6 +294,7 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -336,9 +329,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_and_theta_10_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_and_theta_10_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -128,9 +129,6 @@
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -144,6 +142,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -178,9 +177,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_and_theta_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_and_theta_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -144,6 +142,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -267,9 +266,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_and_theta_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_and_theta_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -144,6 +142,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -267,9 +266,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_gt_30_le_3_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_gt_30_le_3_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -60,9 +61,6 @@
 		[0.0, 0.0],
 		[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.997716, 0.990882, 0.979543, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0]" shape="(11,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_gt_30_le_3_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_gt_30_le_3_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -60,9 +61,6 @@
 		[0.0, 0.0],
 		[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.997716, 0.990882, 0.979543, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0]" shape="(11,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_lat_30_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_lat_30_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_lat_30_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_lat_30_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_lat_gt_30_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_lat_gt_30_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -131,9 +132,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_lat_gt_30_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_lat_gt_30_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -131,9 +132,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_load_match.cml
+++ b/etc/iris_tests_results/constrained_load/theta_load_match.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/constrained_load/theta_load_strict.cml
+++ b/etc/iris_tests_results/constrained_load/theta_load_strict.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/latitude_longitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_longitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude
 Mean of air_potential_temperature over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -81,9 +82,6 @@ Mean of air_potential_temperature over grid_longitude"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/latitude_longitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_longitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -80,9 +81,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/latitude_model_level_number_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_model_level_number_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude
 Mean of air_potential_temperature over model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -43,9 +44,6 @@ Mean of air_potential_temperature over model_level_number"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/latitude_model_level_number_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_model_level_number_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude, model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/latitude_time_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_time_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude
 Mean of air_potential_temperature over time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -88,9 +89,6 @@ Mean of air_potential_temperature over time"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/latitude_time_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/latitude_time_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude, time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -87,9 +88,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/longitude_latitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_latitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude
 Mean of air_potential_temperature over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -81,9 +82,6 @@ Mean of air_potential_temperature over grid_latitude"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/longitude_latitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_latitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude, grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -80,9 +81,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/longitude_model_level_number_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_model_level_number_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude
 Mean of air_potential_temperature over model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -43,9 +44,6 @@ Mean of air_potential_temperature over model_level_number"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/longitude_model_level_number_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_model_level_number_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude, model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/longitude_time_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_time_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude
 Mean of air_potential_temperature over time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -88,9 +89,6 @@ Mean of air_potential_temperature over time"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/longitude_time_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/longitude_time_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_longitude, time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -87,9 +88,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_latitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_latitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number
 Mean of air_potential_temperature over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -43,9 +44,6 @@ Mean of air_potential_temperature over grid_latitude"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_latitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_latitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number, grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_longitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_longitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number
 Mean of air_potential_temperature over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -43,9 +44,6 @@ Mean of air_potential_temperature over grid_longitude"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_longitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_longitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_time_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_time_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number
 Mean of air_potential_temperature over time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -50,9 +51,6 @@ Mean of air_potential_temperature over time"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/model_level_number_time_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/model_level_number_time_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number, time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -49,9 +50,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/original.cml
+++ b/etc/iris_tests_results/cube_collapsed/original.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -93,9 +94,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_collapsed/time_latitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_latitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time
 Mean of air_potential_temperature over grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -88,9 +89,6 @@ Mean of air_potential_temperature over grid_latitude"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/time_latitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_latitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time, grid_latitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -87,9 +88,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/time_longitude_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_longitude_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time
 Mean of air_potential_temperature over grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -88,9 +89,6 @@ Mean of air_potential_temperature over grid_longitude"/>
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/time_longitude_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_longitude_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -87,9 +88,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/time_model_level_number_dual_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_model_level_number_dual_stage.cml
@@ -5,6 +5,7 @@
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time
 Mean of air_potential_temperature over model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -50,9 +51,6 @@ Mean of air_potential_temperature over model_level_number"/>
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/time_model_level_number_single_stage.cml
+++ b/etc/iris_tests_results/cube_collapsed/time_model_level_number_single_stage.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over time, model_level_number"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -49,9 +50,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/triple_collapse_lat_ml_pt.cml
+++ b/etc/iris_tests_results/cube_collapsed/triple_collapse_lat_ml_pt.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over grid_latitude, model_level_number, time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_collapsed/triple_collapse_ml_pt_lon.cml
+++ b/etc/iris_tests_results/cube_collapsed/triple_collapse_ml_pt_lon.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="history" value="Mean of air_potential_temperature over model_level_number, time, grid_longitude"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -42,9 +43,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 1.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[347921.166667, 347922.0]]" id="559b95abfcdf35de" points="[347921.583333]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_io/pickling/cubelist.cml
+++ b/etc/iris_tests_results/cube_io/pickling/cubelist.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -482,9 +483,6 @@
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
       </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
  		324.58],
@@ -510,6 +508,7 @@
   <cube standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -538,9 +537,6 @@
 		359.669]" shape="(100,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/cube_io/pickling/single_cube.cml
+++ b/etc/iris_tests_results/cube_io/pickling/single_cube.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -481,9 +482,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,

--- a/etc/iris_tests_results/cube_io/pickling/theta.cml
+++ b/etc/iris_tests_results/cube_io/pickling/theta.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_io/pp/load/global.cml
+++ b/etc/iris_tests_results/cube_io/pp/load/global.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_io/pp/no_std_name.cml
+++ b/etc/iris_tests_results/cube_io/pp/no_std_name.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s??i999"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing1.cml
+++ b/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing1.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -17,9 +18,6 @@
         <DimCoord id="3bf28623a9db078e" points="[313.02]" shape="(1,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <AuxCoord id="559b95abfcdf35de" points="[319536.0, 319540.0, 319541.0, 319538.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing2.cml
+++ b/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing2.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord>
@@ -17,9 +18,6 @@
         <AuxCoord id="3bf28623a9db078e" points="[313.35, 313.57, 313.57]" shape="(3,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </AuxCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[319536.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing3.cml
+++ b/etc/iris_tests_results/cube_slice/real_data_dual_tuple_indexing3.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -17,9 +18,6 @@
         <AuxCoord id="3bf28623a9db078e" points="[313.35, 313.57, 313.57]" shape="(3,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </AuxCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <AuxCoord id="559b95abfcdf35de" points="[319536.0, 319540.0, 319541.0, 319538.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/cube_slice/real_empty_data_indexing.cml
+++ b/etc/iris_tests_results/cube_slice/real_empty_data_indexing.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord>
@@ -18,9 +19,6 @@
 		392.11]" shape="(720,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=37.5, longitude=177.5)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[319539.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/derived/column.cml
+++ b/etc/iris_tests_results/derived/column.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(1,)">
         <AuxCoord bounds="[[413.937, 426.634],
@@ -102,9 +105,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <AuxCoord id="cf20c06c74c057c" points="[413.937]" shape="(1,)" standard_name="surface_altitude" units="Unit('m')" value_type="float32"/>

--- a/etc/iris_tests_results/derived/no_orog.__str__.txt
+++ b/etc/iris_tests_results/derived/no_orog.__str__.txt
@@ -12,4 +12,5 @@ air_potential_temperature           (time: 6; model_level_number: 70; grid_latit
           altitude                       -                      x                  -                    -
      Scalar coordinates:
           forecast_period: 0.0 hours
+     Attributes:
           source: Iris test case

--- a/etc/iris_tests_results/derived/no_orog.cml
+++ b/etc/iris_tests_results/derived/no_orog.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(1,)">
         <AuxCoord bounds="[[0.0, 13.3333],
@@ -116,9 +119,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,

--- a/etc/iris_tests_results/derived/removed_orog.__str__.txt
+++ b/etc/iris_tests_results/derived/removed_orog.__str__.txt
@@ -11,4 +11,5 @@ air_potential_temperature           (time: 6; model_level_number: 70; grid_latit
           altitude                       -                      x                  -                    -
      Scalar coordinates:
           forecast_period: 0.0 hours
+     Attributes:
           source: Iris test case

--- a/etc/iris_tests_results/derived/removed_orog.cml
+++ b/etc/iris_tests_results/derived/removed_orog.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(1,)">
         <AuxCoord bounds="[[0.0, 13.3333],
@@ -116,9 +119,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/derived/removed_sigma.__str__.txt
+++ b/etc/iris_tests_results/derived/removed_sigma.__str__.txt
@@ -11,4 +11,5 @@ air_potential_temperature           (time: 6; model_level_number: 70; grid_latit
           altitude                       -                      x                  x                    x
      Scalar coordinates:
           forecast_period: 0.0 hours
+     Attributes:
           source: Iris test case

--- a/etc/iris_tests_results/derived/removed_sigma.cml
+++ b/etc/iris_tests_results/derived/removed_sigma.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
         <AuxCoord bounds="[[[[0.0, 13.3333],
@@ -442,9 +445,6 @@
             <attribute name="positive" value="up"/>
           </attributes>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,

--- a/etc/iris_tests_results/derived/transposed.cml
+++ b/etc/iris_tests_results/derived/transposed.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(0, 1, 2)">
         <AuxCoord bounds="[[[[413.937, 426.634],
@@ -478,9 +481,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1, 0]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,

--- a/etc/iris_tests_results/file_load/5d_pp.dot
+++ b/etc/iris_tests_results/file_load/5d_pp.dot
@@ -13,7 +13,7 @@ digraph CubeGraph{
 
 #   Nodes
     ":Cube" [
-        label = "Cube|STASH: m01s00i002"
+        label = "Cube|STASH: m01s00i002\nsource: Data from Met Office Unified Model 7.04"
     ]
 
     
@@ -63,12 +63,9 @@ digraph CubeGraph{
             label = "AuxCoord|standard_name: None\nlong_name: sigma\nunits: 1"
         ]
         "Coord_7" [
-            label = "AuxCoord|standard_name: None\nlong_name: source\nunits: no_unit"
-        ]
-        "Coord_8" [
             label = "AuxCoord|standard_name: surface_altitude\nlong_name: None\nunits: m"
         ]
-        "Coord_9" [
+        "Coord_8" [
             label = "DimCoord|standard_name: time\nlong_name: None\nunits: hours since 1970-01-01 00:00:00\ncircular: False"
         ]
 
@@ -102,7 +99,6 @@ digraph CubeGraph{
     ":Cube" -> "Coord_6"
     ":Cube" -> "Coord_7"
     ":Cube" -> "Coord_8"
-    ":Cube" -> "Coord_9"
     edge [
         style="dashed"
         arrowhead = "onormal"
@@ -119,8 +115,8 @@ digraph CubeGraph{
     "Coord_4" -> "CubeDimension_1":w
     "Coord_5" -> "CubeDimension_1":w
     "Coord_6" -> "CubeDimension_1":w
-    "Coord_8" -> "CubeDimension_2":w
-    "Coord_8" -> "CubeDimension_3":w
-    "Coord_9" -> "CubeDimension_0":w
+    "Coord_7" -> "CubeDimension_2":w
+    "Coord_7" -> "CubeDimension_3":w
+    "Coord_8" -> "CubeDimension_0":w
 }
     

--- a/etc/iris_tests_results/file_load/coord_attributes.dot
+++ b/etc/iris_tests_results/file_load/coord_attributes.dot
@@ -13,7 +13,7 @@ digraph CubeGraph{
 
 #   Nodes
     ":Cube" [
-        label = "Cube|STASH: m01s16i203\nmy_attribute: foobar"
+        label = "Cube|STASH: m01s16i203\nmy_attribute: foobar\nsource: Data from Met Office Unified Model"
     ]
 
     
@@ -46,9 +46,6 @@ digraph CubeGraph{
             label = "DimCoord|standard_name: None\nlong_name: pressure\nunits: hPa\ncircular: False"
         ]
         "Coord_4" [
-            label = "AuxCoord|standard_name: None\nlong_name: source\nunits: no_unit"
-        ]
-        "Coord_5" [
             label = "DimCoord|standard_name: time\nlong_name: None\nunits: hours since 1970-01-01 00:00:00\ncircular: False\nbrain: hurts\nmonty: python"
         ]
 
@@ -78,7 +75,6 @@ digraph CubeGraph{
     ":Cube" -> "Coord_2"
     ":Cube" -> "Coord_3"
     ":Cube" -> "Coord_4"
-    ":Cube" -> "Coord_5"
     edge [
         style="dashed"
         arrowhead = "onormal"

--- a/etc/iris_tests_results/file_load/global_pp.dot
+++ b/etc/iris_tests_results/file_load/global_pp.dot
@@ -13,7 +13,7 @@ digraph CubeGraph{
 
 #   Nodes
     ":Cube" [
-        label = "Cube|STASH: m01s16i203\nmy_attribute: foobar"
+        label = "Cube|STASH: m01s16i203\nmy_attribute: foobar\nsource: Data from Met Office Unified Model"
     ]
 
     
@@ -46,9 +46,6 @@ digraph CubeGraph{
             label = "DimCoord|standard_name: None\nlong_name: pressure\nunits: hPa\ncircular: False"
         ]
         "Coord_4" [
-            label = "AuxCoord|standard_name: None\nlong_name: source\nunits: no_unit"
-        ]
-        "Coord_5" [
             label = "DimCoord|standard_name: time\nlong_name: None\nunits: hours since 1970-01-01 00:00:00\ncircular: False"
         ]
 
@@ -78,7 +75,6 @@ digraph CubeGraph{
     ":Cube" -> "Coord_2"
     ":Cube" -> "Coord_3"
     ":Cube" -> "Coord_4"
-    ":Cube" -> "Coord_5"
     edge [
         style="dashed"
         arrowhead = "onormal"

--- a/etc/iris_tests_results/file_load/theta_levels.cml
+++ b/etc/iris_tests_results/file_load/theta_levels.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -39,9 +40,6 @@
         <AuxCoord bounds="[[1.0, 0.994296]]" id="5634c91ba5717382" long_name="sigma" points="[0.997716]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -55,6 +53,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -91,9 +90,6 @@
         <AuxCoord bounds="[[0.994296, 0.985204]]" id="5634c91ba5717382" long_name="sigma" points="[0.990882]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -107,6 +103,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -143,9 +140,6 @@
         <AuxCoord bounds="[[0.985204, 0.971644]]" id="5634c91ba5717382" long_name="sigma" points="[0.979543]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -159,6 +153,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -195,9 +190,6 @@
         <AuxCoord bounds="[[0.971644, 0.95371]]" id="5634c91ba5717382" long_name="sigma" points="[0.963777]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -211,6 +203,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -247,9 +240,6 @@
         <AuxCoord bounds="[[0.95371, 0.931527]]" id="5634c91ba5717382" long_name="sigma" points="[0.943695]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -263,6 +253,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -299,9 +290,6 @@
         <AuxCoord bounds="[[0.931527, 0.905253]]" id="5634c91ba5717382" long_name="sigma" points="[0.919438]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -315,6 +303,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -351,9 +340,6 @@
         <AuxCoord bounds="[[0.905253, 0.875075]]" id="5634c91ba5717382" long_name="sigma" points="[0.891178]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -367,6 +353,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -403,9 +390,6 @@
         <AuxCoord bounds="[[0.875075, 0.841212]]" id="5634c91ba5717382" long_name="sigma" points="[0.859118]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -419,6 +403,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -455,9 +440,6 @@
         <AuxCoord bounds="[[0.841212, 0.803914]]" id="5634c91ba5717382" long_name="sigma" points="[0.823493]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -471,6 +453,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -507,9 +490,6 @@
         <AuxCoord bounds="[[0.803914, 0.763465]]" id="5634c91ba5717382" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -523,6 +503,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -559,9 +540,6 @@
         <AuxCoord bounds="[[0.763465, 0.720176]]" id="5634c91ba5717382" long_name="sigma" points="[0.742646]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -575,6 +553,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -611,9 +590,6 @@
         <AuxCoord bounds="[[0.720176, 0.674393]]" id="5634c91ba5717382" long_name="sigma" points="[0.69805]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -627,6 +603,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -663,9 +640,6 @@
         <AuxCoord bounds="[[0.674393, 0.626491]]" id="5634c91ba5717382" long_name="sigma" points="[0.651143]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -679,6 +653,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -715,9 +690,6 @@
         <AuxCoord bounds="[[0.626491, 0.576877]]" id="5634c91ba5717382" long_name="sigma" points="[0.602314]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -731,6 +703,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -767,9 +740,6 @@
         <AuxCoord bounds="[[0.576877, 0.525991]]" id="5634c91ba5717382" long_name="sigma" points="[0.551989]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -783,6 +753,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -819,9 +790,6 @@
         <AuxCoord bounds="[[0.525991, 0.474301]]" id="5634c91ba5717382" long_name="sigma" points="[0.50062]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -835,6 +803,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -871,9 +840,6 @@
         <AuxCoord bounds="[[0.474301, 0.42231]]" id="5634c91ba5717382" long_name="sigma" points="[0.448693]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -887,6 +853,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -923,9 +890,6 @@
         <AuxCoord bounds="[[0.42231, 0.370549]]" id="5634c91ba5717382" long_name="sigma" points="[0.396726]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -939,6 +903,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -975,9 +940,6 @@
         <AuxCoord bounds="[[0.370549, 0.319582]]" id="5634c91ba5717382" long_name="sigma" points="[0.345265]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -991,6 +953,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1027,9 +990,6 @@
         <AuxCoord bounds="[[0.319582, 0.270005]]" id="5634c91ba5717382" long_name="sigma" points="[0.294891]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1043,6 +1003,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1079,9 +1040,6 @@
         <AuxCoord bounds="[[0.270005, 0.222443]]" id="5634c91ba5717382" long_name="sigma" points="[0.246215]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1095,6 +1053,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1131,9 +1090,6 @@
         <AuxCoord bounds="[[0.222443, 0.177555]]" id="5634c91ba5717382" long_name="sigma" points="[0.199878]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1147,6 +1103,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1183,9 +1140,6 @@
         <AuxCoord bounds="[[0.177555, 0.13603]]" id="5634c91ba5717382" long_name="sigma" points="[0.156554]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1199,6 +1153,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1235,9 +1190,6 @@
         <AuxCoord bounds="[[0.13603, 0.0985881]]" id="5634c91ba5717382" long_name="sigma" points="[0.116948]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1251,6 +1203,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1287,9 +1240,6 @@
         <AuxCoord bounds="[[0.0985881, 0.0659808]]" id="5634c91ba5717382" long_name="sigma" points="[0.0817952]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1303,6 +1253,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1339,9 +1290,6 @@
         <AuxCoord bounds="[[0.0659808, 0.0389824]]" id="5634c91ba5717382" long_name="sigma" points="[0.0518637]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1355,6 +1303,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1391,9 +1340,6 @@
         <AuxCoord bounds="[[0.0389824, 0.0183147]]" id="5634c91ba5717382" long_name="sigma" points="[0.0279368]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1407,6 +1353,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1443,9 +1390,6 @@
         <AuxCoord bounds="[[0.0183147, 0.00487211]]" id="5634c91ba5717382" long_name="sigma" points="[0.0107165]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1459,6 +1403,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1495,9 +1440,6 @@
         <AuxCoord bounds="[[0.00487211, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.00130179]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1511,6 +1453,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1547,9 +1490,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1563,6 +1503,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1599,9 +1540,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1615,6 +1553,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1651,9 +1590,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1667,6 +1603,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1703,9 +1640,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1719,6 +1653,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1755,9 +1690,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1771,6 +1703,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1807,9 +1740,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1823,6 +1753,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1859,9 +1790,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1875,6 +1803,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1911,9 +1840,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1927,6 +1853,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1961,9 +1888,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/file_load/u_wind_levels.cml
+++ b/etc/iris_tests_results/file_load/u_wind_levels.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -40,9 +41,6 @@
         <AuxCoord bounds="[[1.0, 0.997716]]" id="5634c91ba5717382" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -56,6 +54,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -93,9 +92,6 @@
         <AuxCoord bounds="[[0.997716, 0.990882]]" id="5634c91ba5717382" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -109,6 +105,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -146,9 +143,6 @@
         <AuxCoord bounds="[[0.990882, 0.979543]]" id="5634c91ba5717382" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -162,6 +156,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -199,9 +194,6 @@
         <AuxCoord bounds="[[0.979543, 0.963777]]" id="5634c91ba5717382" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -215,6 +207,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -252,9 +245,6 @@
         <AuxCoord bounds="[[0.963777, 0.943695]]" id="5634c91ba5717382" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -268,6 +258,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -305,9 +296,6 @@
         <AuxCoord bounds="[[0.943695, 0.919438]]" id="5634c91ba5717382" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -321,6 +309,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -358,9 +347,6 @@
         <AuxCoord bounds="[[0.919438, 0.891178]]" id="5634c91ba5717382" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -374,6 +360,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -411,9 +398,6 @@
         <AuxCoord bounds="[[0.891178, 0.859118]]" id="5634c91ba5717382" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -427,6 +411,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -464,9 +449,6 @@
         <AuxCoord bounds="[[0.859118, 0.823493]]" id="5634c91ba5717382" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -480,6 +462,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -517,9 +500,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -533,6 +513,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -570,9 +551,6 @@
         <AuxCoord bounds="[[0.784571, 0.742646]]" id="5634c91ba5717382" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -586,6 +564,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -623,9 +602,6 @@
         <AuxCoord bounds="[[0.742646, 0.69805]]" id="5634c91ba5717382" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -639,6 +615,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -676,9 +653,6 @@
         <AuxCoord bounds="[[0.69805, 0.651143]]" id="5634c91ba5717382" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -692,6 +666,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -729,9 +704,6 @@
         <AuxCoord bounds="[[0.651143, 0.602314]]" id="5634c91ba5717382" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -745,6 +717,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -782,9 +755,6 @@
         <AuxCoord bounds="[[0.602314, 0.551989]]" id="5634c91ba5717382" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -798,6 +768,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -835,9 +806,6 @@
         <AuxCoord bounds="[[0.551989, 0.50062]]" id="5634c91ba5717382" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -851,6 +819,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -888,9 +857,6 @@
         <AuxCoord bounds="[[0.50062, 0.448693]]" id="5634c91ba5717382" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -904,6 +870,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -941,9 +908,6 @@
         <AuxCoord bounds="[[0.448693, 0.396726]]" id="5634c91ba5717382" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -957,6 +921,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -994,9 +959,6 @@
         <AuxCoord bounds="[[0.396726, 0.345265]]" id="5634c91ba5717382" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1010,6 +972,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1047,9 +1010,6 @@
         <AuxCoord bounds="[[0.345265, 0.294891]]" id="5634c91ba5717382" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1063,6 +1023,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1100,9 +1061,6 @@
         <AuxCoord bounds="[[0.294891, 0.246215]]" id="5634c91ba5717382" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1116,6 +1074,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1153,9 +1112,6 @@
         <AuxCoord bounds="[[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1169,6 +1125,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1206,9 +1163,6 @@
         <AuxCoord bounds="[[0.199878, 0.156554]]" id="5634c91ba5717382" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1222,6 +1176,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1259,9 +1214,6 @@
         <AuxCoord bounds="[[0.156554, 0.116948]]" id="5634c91ba5717382" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1275,6 +1227,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1312,9 +1265,6 @@
         <AuxCoord bounds="[[0.116948, 0.0817952]]" id="5634c91ba5717382" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1328,6 +1278,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1365,9 +1316,6 @@
         <AuxCoord bounds="[[0.0817952, 0.0518637]]" id="5634c91ba5717382" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1381,6 +1329,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1418,9 +1367,6 @@
         <AuxCoord bounds="[[0.0518637, 0.0279368]]" id="5634c91ba5717382" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1434,6 +1380,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1471,9 +1418,6 @@
         <AuxCoord bounds="[[0.0279368, 0.0107165]]" id="5634c91ba5717382" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1487,6 +1431,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1524,9 +1469,6 @@
         <AuxCoord bounds="[[0.0107165, 0.00130179]]" id="5634c91ba5717382" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1540,6 +1482,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1577,9 +1520,6 @@
         <AuxCoord bounds="[[0.00130179, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1593,6 +1533,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1630,9 +1571,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1646,6 +1584,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1683,9 +1622,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1699,6 +1635,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1736,9 +1673,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1752,6 +1686,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1789,9 +1724,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1805,6 +1737,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1842,9 +1775,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1858,6 +1788,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1895,9 +1826,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1911,6 +1839,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1948,9 +1877,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1964,6 +1890,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1999,9 +1926,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/file_load/v_wind_levels.cml
+++ b/etc/iris_tests_results/file_load/v_wind_levels.cml
@@ -3,6 +3,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -40,9 +41,6 @@
         <AuxCoord bounds="[[1.0, 0.997716]]" id="5634c91ba5717382" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -56,6 +54,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -93,9 +92,6 @@
         <AuxCoord bounds="[[0.997716, 0.990882]]" id="5634c91ba5717382" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -109,6 +105,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -146,9 +143,6 @@
         <AuxCoord bounds="[[0.990882, 0.979543]]" id="5634c91ba5717382" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -162,6 +156,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -199,9 +194,6 @@
         <AuxCoord bounds="[[0.979543, 0.963777]]" id="5634c91ba5717382" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -215,6 +207,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -252,9 +245,6 @@
         <AuxCoord bounds="[[0.963777, 0.943695]]" id="5634c91ba5717382" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -268,6 +258,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -305,9 +296,6 @@
         <AuxCoord bounds="[[0.943695, 0.919438]]" id="5634c91ba5717382" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -321,6 +309,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -358,9 +347,6 @@
         <AuxCoord bounds="[[0.919438, 0.891178]]" id="5634c91ba5717382" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -374,6 +360,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -411,9 +398,6 @@
         <AuxCoord bounds="[[0.891178, 0.859118]]" id="5634c91ba5717382" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -427,6 +411,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -464,9 +449,6 @@
         <AuxCoord bounds="[[0.859118, 0.823493]]" id="5634c91ba5717382" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -480,6 +462,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -517,9 +500,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -533,6 +513,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -570,9 +551,6 @@
         <AuxCoord bounds="[[0.784571, 0.742646]]" id="5634c91ba5717382" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -586,6 +564,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -623,9 +602,6 @@
         <AuxCoord bounds="[[0.742646, 0.69805]]" id="5634c91ba5717382" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -639,6 +615,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -676,9 +653,6 @@
         <AuxCoord bounds="[[0.69805, 0.651143]]" id="5634c91ba5717382" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -692,6 +666,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -729,9 +704,6 @@
         <AuxCoord bounds="[[0.651143, 0.602314]]" id="5634c91ba5717382" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -745,6 +717,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -782,9 +755,6 @@
         <AuxCoord bounds="[[0.602314, 0.551989]]" id="5634c91ba5717382" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -798,6 +768,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -835,9 +806,6 @@
         <AuxCoord bounds="[[0.551989, 0.50062]]" id="5634c91ba5717382" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -851,6 +819,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -888,9 +857,6 @@
         <AuxCoord bounds="[[0.50062, 0.448693]]" id="5634c91ba5717382" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -904,6 +870,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -941,9 +908,6 @@
         <AuxCoord bounds="[[0.448693, 0.396726]]" id="5634c91ba5717382" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -957,6 +921,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -994,9 +959,6 @@
         <AuxCoord bounds="[[0.396726, 0.345265]]" id="5634c91ba5717382" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1010,6 +972,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1047,9 +1010,6 @@
         <AuxCoord bounds="[[0.345265, 0.294891]]" id="5634c91ba5717382" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1063,6 +1023,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1100,9 +1061,6 @@
         <AuxCoord bounds="[[0.294891, 0.246215]]" id="5634c91ba5717382" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1116,6 +1074,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1153,9 +1112,6 @@
         <AuxCoord bounds="[[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1169,6 +1125,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1206,9 +1163,6 @@
         <AuxCoord bounds="[[0.199878, 0.156554]]" id="5634c91ba5717382" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1222,6 +1176,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1259,9 +1214,6 @@
         <AuxCoord bounds="[[0.156554, 0.116948]]" id="5634c91ba5717382" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1275,6 +1227,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1312,9 +1265,6 @@
         <AuxCoord bounds="[[0.116948, 0.0817952]]" id="5634c91ba5717382" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1328,6 +1278,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1365,9 +1316,6 @@
         <AuxCoord bounds="[[0.0817952, 0.0518637]]" id="5634c91ba5717382" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1381,6 +1329,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1418,9 +1367,6 @@
         <AuxCoord bounds="[[0.0518637, 0.0279368]]" id="5634c91ba5717382" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1434,6 +1380,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1471,9 +1418,6 @@
         <AuxCoord bounds="[[0.0279368, 0.0107165]]" id="5634c91ba5717382" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1487,6 +1431,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1524,9 +1469,6 @@
         <AuxCoord bounds="[[0.0107165, 0.00130179]]" id="5634c91ba5717382" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1540,6 +1482,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1577,9 +1520,6 @@
         <AuxCoord bounds="[[0.00130179, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1593,6 +1533,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1630,9 +1571,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1646,6 +1584,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1683,9 +1622,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1699,6 +1635,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1736,9 +1673,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1752,6 +1686,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1789,9 +1724,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1805,6 +1737,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1842,9 +1775,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1858,6 +1788,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1895,9 +1826,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1911,6 +1839,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1948,9 +1877,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1964,6 +1890,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1999,9 +1926,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/file_load/wind_levels.cml
+++ b/etc/iris_tests_results/file_load/wind_levels.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -38,9 +39,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[1.0, 0.997716]]" id="5634c91ba5717382" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -56,6 +54,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -93,9 +92,6 @@
         <AuxCoord bounds="[[0.997716, 0.990882]]" id="5634c91ba5717382" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -109,6 +105,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -146,9 +143,6 @@
         <AuxCoord bounds="[[0.990882, 0.979543]]" id="5634c91ba5717382" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -162,6 +156,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -199,9 +194,6 @@
         <AuxCoord bounds="[[0.979543, 0.963777]]" id="5634c91ba5717382" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -215,6 +207,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -252,9 +245,6 @@
         <AuxCoord bounds="[[0.963777, 0.943695]]" id="5634c91ba5717382" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -268,6 +258,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -305,9 +296,6 @@
         <AuxCoord bounds="[[0.943695, 0.919438]]" id="5634c91ba5717382" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -321,6 +309,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -358,9 +347,6 @@
         <AuxCoord bounds="[[0.919438, 0.891178]]" id="5634c91ba5717382" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -374,6 +360,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -411,9 +398,6 @@
         <AuxCoord bounds="[[0.891178, 0.859118]]" id="5634c91ba5717382" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -427,6 +411,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -464,9 +449,6 @@
         <AuxCoord bounds="[[0.859118, 0.823493]]" id="5634c91ba5717382" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -480,6 +462,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -517,9 +500,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -533,6 +513,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -570,9 +551,6 @@
         <AuxCoord bounds="[[0.784571, 0.742646]]" id="5634c91ba5717382" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -586,6 +564,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -623,9 +602,6 @@
         <AuxCoord bounds="[[0.742646, 0.69805]]" id="5634c91ba5717382" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -639,6 +615,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -676,9 +653,6 @@
         <AuxCoord bounds="[[0.69805, 0.651143]]" id="5634c91ba5717382" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -692,6 +666,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -729,9 +704,6 @@
         <AuxCoord bounds="[[0.651143, 0.602314]]" id="5634c91ba5717382" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -745,6 +717,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -782,9 +755,6 @@
         <AuxCoord bounds="[[0.602314, 0.551989]]" id="5634c91ba5717382" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -798,6 +768,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -835,9 +806,6 @@
         <AuxCoord bounds="[[0.551989, 0.50062]]" id="5634c91ba5717382" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -851,6 +819,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -888,9 +857,6 @@
         <AuxCoord bounds="[[0.50062, 0.448693]]" id="5634c91ba5717382" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -904,6 +870,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -941,9 +908,6 @@
         <AuxCoord bounds="[[0.448693, 0.396726]]" id="5634c91ba5717382" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -957,6 +921,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -994,9 +959,6 @@
         <AuxCoord bounds="[[0.396726, 0.345265]]" id="5634c91ba5717382" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1010,6 +972,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1047,9 +1010,6 @@
         <AuxCoord bounds="[[0.345265, 0.294891]]" id="5634c91ba5717382" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1063,6 +1023,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1100,9 +1061,6 @@
         <AuxCoord bounds="[[0.294891, 0.246215]]" id="5634c91ba5717382" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1116,6 +1074,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1153,9 +1112,6 @@
         <AuxCoord bounds="[[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1169,6 +1125,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1206,9 +1163,6 @@
         <AuxCoord bounds="[[0.199878, 0.156554]]" id="5634c91ba5717382" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1222,6 +1176,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1259,9 +1214,6 @@
         <AuxCoord bounds="[[0.156554, 0.116948]]" id="5634c91ba5717382" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1275,6 +1227,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1312,9 +1265,6 @@
         <AuxCoord bounds="[[0.116948, 0.0817952]]" id="5634c91ba5717382" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1328,6 +1278,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1365,9 +1316,6 @@
         <AuxCoord bounds="[[0.0817952, 0.0518637]]" id="5634c91ba5717382" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1381,6 +1329,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1418,9 +1367,6 @@
         <AuxCoord bounds="[[0.0518637, 0.0279368]]" id="5634c91ba5717382" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1434,6 +1380,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1471,9 +1418,6 @@
         <AuxCoord bounds="[[0.0279368, 0.0107165]]" id="5634c91ba5717382" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1487,6 +1431,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1524,9 +1469,6 @@
         <AuxCoord bounds="[[0.0107165, 0.00130179]]" id="5634c91ba5717382" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1540,6 +1482,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1577,9 +1520,6 @@
         <AuxCoord bounds="[[0.00130179, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1593,6 +1533,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1630,9 +1571,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1646,6 +1584,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1683,9 +1622,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1699,6 +1635,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1736,9 +1673,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1752,6 +1686,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1789,9 +1724,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1805,6 +1737,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1842,9 +1775,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1858,6 +1788,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1895,9 +1826,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1911,6 +1839,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -1948,9 +1877,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -1964,6 +1890,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2001,9 +1928,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2017,6 +1941,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2054,9 +1979,6 @@
         <AuxCoord bounds="[[1.0, 0.997716]]" id="5634c91ba5717382" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2070,6 +1992,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2107,9 +2030,6 @@
         <AuxCoord bounds="[[0.997716, 0.990882]]" id="5634c91ba5717382" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2123,6 +2043,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2160,9 +2081,6 @@
         <AuxCoord bounds="[[0.990882, 0.979543]]" id="5634c91ba5717382" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2176,6 +2094,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2213,9 +2132,6 @@
         <AuxCoord bounds="[[0.979543, 0.963777]]" id="5634c91ba5717382" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2229,6 +2145,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2266,9 +2183,6 @@
         <AuxCoord bounds="[[0.963777, 0.943695]]" id="5634c91ba5717382" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2282,6 +2196,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2319,9 +2234,6 @@
         <AuxCoord bounds="[[0.943695, 0.919438]]" id="5634c91ba5717382" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2335,6 +2247,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2372,9 +2285,6 @@
         <AuxCoord bounds="[[0.919438, 0.891178]]" id="5634c91ba5717382" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2388,6 +2298,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2425,9 +2336,6 @@
         <AuxCoord bounds="[[0.891178, 0.859118]]" id="5634c91ba5717382" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2441,6 +2349,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2478,9 +2387,6 @@
         <AuxCoord bounds="[[0.859118, 0.823493]]" id="5634c91ba5717382" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2494,6 +2400,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2531,9 +2438,6 @@
         <AuxCoord bounds="[[0.823493, 0.784571]]" id="5634c91ba5717382" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2547,6 +2451,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2584,9 +2489,6 @@
         <AuxCoord bounds="[[0.784571, 0.742646]]" id="5634c91ba5717382" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2600,6 +2502,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2637,9 +2540,6 @@
         <AuxCoord bounds="[[0.742646, 0.69805]]" id="5634c91ba5717382" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2653,6 +2553,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2690,9 +2591,6 @@
         <AuxCoord bounds="[[0.69805, 0.651143]]" id="5634c91ba5717382" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2706,6 +2604,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2743,9 +2642,6 @@
         <AuxCoord bounds="[[0.651143, 0.602314]]" id="5634c91ba5717382" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2759,6 +2655,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2796,9 +2693,6 @@
         <AuxCoord bounds="[[0.602314, 0.551989]]" id="5634c91ba5717382" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2812,6 +2706,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2849,9 +2744,6 @@
         <AuxCoord bounds="[[0.551989, 0.50062]]" id="5634c91ba5717382" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2865,6 +2757,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2902,9 +2795,6 @@
         <AuxCoord bounds="[[0.50062, 0.448693]]" id="5634c91ba5717382" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2918,6 +2808,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -2955,9 +2846,6 @@
         <AuxCoord bounds="[[0.448693, 0.396726]]" id="5634c91ba5717382" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -2971,6 +2859,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3008,9 +2897,6 @@
         <AuxCoord bounds="[[0.396726, 0.345265]]" id="5634c91ba5717382" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3024,6 +2910,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3061,9 +2948,6 @@
         <AuxCoord bounds="[[0.345265, 0.294891]]" id="5634c91ba5717382" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3077,6 +2961,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3114,9 +2999,6 @@
         <AuxCoord bounds="[[0.294891, 0.246215]]" id="5634c91ba5717382" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3130,6 +3012,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3167,9 +3050,6 @@
         <AuxCoord bounds="[[0.246215, 0.199878]]" id="5634c91ba5717382" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3183,6 +3063,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3220,9 +3101,6 @@
         <AuxCoord bounds="[[0.199878, 0.156554]]" id="5634c91ba5717382" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3236,6 +3114,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3273,9 +3152,6 @@
         <AuxCoord bounds="[[0.156554, 0.116948]]" id="5634c91ba5717382" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3289,6 +3165,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3326,9 +3203,6 @@
         <AuxCoord bounds="[[0.116948, 0.0817952]]" id="5634c91ba5717382" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3342,6 +3216,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3379,9 +3254,6 @@
         <AuxCoord bounds="[[0.0817952, 0.0518637]]" id="5634c91ba5717382" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3395,6 +3267,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3432,9 +3305,6 @@
         <AuxCoord bounds="[[0.0518637, 0.0279368]]" id="5634c91ba5717382" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3448,6 +3318,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3485,9 +3356,6 @@
         <AuxCoord bounds="[[0.0279368, 0.0107165]]" id="5634c91ba5717382" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3501,6 +3369,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3538,9 +3407,6 @@
         <AuxCoord bounds="[[0.0107165, 0.00130179]]" id="5634c91ba5717382" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3554,6 +3420,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3591,9 +3458,6 @@
         <AuxCoord bounds="[[0.00130179, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3607,6 +3471,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3644,9 +3509,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3660,6 +3522,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3697,9 +3560,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3713,6 +3573,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3750,9 +3611,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3766,6 +3624,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3803,9 +3662,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3819,6 +3675,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3856,9 +3713,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3872,6 +3726,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3909,9 +3764,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3925,6 +3777,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -3962,9 +3815,6 @@
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -3978,6 +3828,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -4013,9 +3864,6 @@
       </coord>
       <coord>
         <AuxCoord bounds="[[0.0, 0.0]]" id="5634c91ba5717382" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/merge/dec.cml
+++ b/etc/iris_tests_results/merge/dec.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -128,9 +129,6 @@
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -144,6 +142,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -270,9 +269,6 @@
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -286,6 +282,7 @@
   <cube standard_name="northward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -412,9 +409,6 @@
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -428,6 +422,7 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -551,9 +546,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/merge/theta.cml
+++ b/etc/iris_tests_results/merge/theta.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.06]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[332352.0, 333096.0]]" id="559b95abfcdf35de" points="[332724.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/merge/theta_two_forecast_periods.cml
+++ b/etc/iris_tests_results/merge/theta_two_forecast_periods.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -481,9 +482,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[99.1904, 122.346, 151.11, ..., 49.5337,

--- a/etc/iris_tests_results/netcdf/netcdf_global_xyt_hires.cml
+++ b/etc/iris_tests_results/netcdf/netcdf_global_xyt_hires.cml
@@ -14,6 +14,7 @@
       <attribute name="project_id" value="IPCC Fourth Assessment"/>
       <attribute name="realization" value="1"/>
       <attribute name="references" value="K-1 Coupled GCM Description (K-1 Technical Report No.1) in preparation"/>
+      <attribute name="source" value="MIROC3.2 (2004): atmosphere: AGCM (AGCM5.7b, T106 L56); ocean &amp; sea ice: COCO (COCO3.3, T106 4x6 tiling L48); land: MATSIRO (T106 2x2 tiling)"/>
       <attribute name="table_id" value="Table A2 (17 November 2004)"/>
       <attribute name="title" value="CCSR/NIES/FRCGC  model output prepared for IPCC Fourth Assessment 720 ppm stabilization experiment (SRES A1B)"/>
     </attributes>
@@ -43,9 +44,6 @@
 		[358.3125, 359.4375]]" id="3207b04384adbdec" long_name="longitude" points="[0.0, 1.125, 2.25, ..., 356.625, 357.75, 358.875]" shape="(320,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[	MIROC3.2 (2004): atmosphere: AGCM (AGCM5.7b, T106 L56); ocean &amp; sea ice: COCO (COCO3.3, T106 4x6 tiling L48); land: MATSIRO (T106 2x2 tiling)]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[71588.0, 71589.0],

--- a/etc/iris_tests_results/netcdf/netcdf_rotated_xy_land.cml
+++ b/etc/iris_tests_results/netcdf/netcdf_rotated_xy_land.cml
@@ -9,6 +9,7 @@
       <attribute name="institution" value="MPI-M"/>
       <attribute name="project_id" value="ENSEMBLES"/>
       <attribute name="realization" value="1"/>
+      <attribute name="source" value="REMO"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -63,9 +64,6 @@
  		56.4394, 57.3444],
 		[-33.3788, -32.6612, -31.9316, ..., 56.1045,
  		57.0309, 57.9421]]" shape="(95, 85)" standard_name="longitude" units="Unit('degrees')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[REMO]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/etc/iris_tests_results/netcdf/netcdf_rotated_xyt_precipitation.cml
+++ b/etc/iris_tests_results/netcdf/netcdf_rotated_xyt_precipitation.cml
@@ -5,6 +5,7 @@
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="experiment" value="ER3"/>
       <attribute name="institution" value="DMI"/>
+      <attribute name="source" value="HIRHAM"/>
     </attributes>
     <coords>
       <coord datadims="[1]">
@@ -46,9 +47,6 @@
  		58.4633, 58.907],
 		[-34.421, -34.0711, -33.7182, ..., 58.3201,
  		58.7689, 59.214]]" shape="(190, 174)" standard_name="longitude" units="Unit('degrees')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[HIRHAM]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[2922.5, 2923.5],

--- a/etc/iris_tests_results/netcdf/netcdf_save_hybrid_height.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_hybrid_height.cdl
@@ -9,6 +9,7 @@ variables:
 		air_potential_temperature:standard_name = "air_potential_temperature" ;
 		air_potential_temperature:units = "K" ;
 		air_potential_temperature:ukmo__um_stash_source = "m01s00i004" ;
+		air_potential_temperature:source = "Data from Met Office Unified Model 7.04" ;
 		air_potential_temperature:grid_mapping = "rotated_latitude_longitude" ;
 		air_potential_temperature:coordinates = "forecast_period level_height sigma surface_altitude" ;
 	int rotated_latitude_longitude ;
@@ -64,5 +65,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model 7.04" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_load_hybrid_height.cml
+++ b/etc/iris_tests_results/netcdf/netcdf_save_load_hybrid_height.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
@@ -475,9 +476,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[99.1904, 122.346, 151.11, ..., 49.5337,

--- a/etc/iris_tests_results/netcdf/netcdf_save_load_ndim_auxiliary.cml
+++ b/etc/iris_tests_results/netcdf/netcdf_save_load_ndim_auxiliary.cml
@@ -5,6 +5,7 @@
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="experiment" value="ER3"/>
       <attribute name="institution" value="DMI"/>
+      <attribute name="source" value="HIRHAM"/>
     </attributes>
     <coords>
       <coord datadims="[1]">
@@ -46,9 +47,6 @@
  		58.4633, 58.907],
 		[-34.421, -34.0711, -33.7182, ..., 58.3201,
  		58.7689, 59.214]]" shape="(190, 174)" standard_name="longitude" units="Unit('degrees')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[HIRHAM]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[2922.5, 2923.5],

--- a/etc/iris_tests_results/netcdf/netcdf_save_multi_0.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_multi_0.cdl
@@ -8,6 +8,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -45,5 +46,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_multi_1.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_multi_1.cdl
@@ -8,6 +8,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: minimum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -45,5 +46,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_multi_2.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_multi_2.cdl
@@ -8,6 +8,7 @@ variables:
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:ukmo__um_stash_source = "m01s05i216" ;
+		precipitation_flux:source = "Data from Met Office Unified Model" ;
 		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
 		precipitation_flux:grid_mapping = "latitude_longitude" ;
 		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
@@ -41,5 +42,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_ndim_auxiliary.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_ndim_auxiliary.cdl
@@ -10,6 +10,7 @@ variables:
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:experiment = "ER3" ;
 		precipitation_flux:institution = "DMI" ;
+		precipitation_flux:source = "HIRHAM" ;
 		precipitation_flux:cell_methods = "time: mean" ;
 		precipitation_flux:grid_mapping = "rotated_latitude_longitude" ;
 		precipitation_flux:coordinates = "latitude longitude" ;
@@ -50,5 +51,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "HIRHAM" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_realistic_4d.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_realistic_4d.cdl
@@ -8,6 +8,7 @@ variables:
 	float air_potential_temperature(time, model_level_number, grid_latitude, grid_longitude) ;
 		air_potential_temperature:standard_name = "air_potential_temperature" ;
 		air_potential_temperature:units = "K" ;
+		air_potential_temperature:source = "Iris test case" ;
 		air_potential_temperature:grid_mapping = "rotated_latitude_longitude" ;
 		air_potential_temperature:coordinates = "forecast_period level_height sigma surface_altitude" ;
 	int rotated_latitude_longitude ;
@@ -63,5 +64,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Iris test case" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_realistic_4d_no_hybrid.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_realistic_4d_no_hybrid.cdl
@@ -8,6 +8,7 @@ variables:
 	float air_potential_temperature(time, model_level_number, grid_latitude, grid_longitude) ;
 		air_potential_temperature:standard_name = "air_potential_temperature" ;
 		air_potential_temperature:units = "K" ;
+		air_potential_temperature:source = "Iris test case" ;
 		air_potential_temperature:grid_mapping = "rotated_latitude_longitude" ;
 		air_potential_temperature:coordinates = "forecast_period level_height sigma surface_altitude" ;
 	int rotated_latitude_longitude ;
@@ -60,5 +61,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Iris test case" ;
 }

--- a/etc/iris_tests_results/netcdf/netcdf_save_single.cdl
+++ b/etc/iris_tests_results/netcdf/netcdf_save_single.cdl
@@ -7,6 +7,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
@@ -43,5 +44,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/pp_rules/global.cml
+++ b/etc/iris_tests_results/pp_rules/global.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/pp_rules/lbproc_mean_max_min.cml
+++ b/etc/iris_tests_results/pp_rules/lbproc_mean_max_min.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
     </attributes>
     <coords>
       <coord>
@@ -26,9 +27,6 @@
         </DimCoord>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.08]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord id="559b95abfcdf35de" points="[336948.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -38,6 +36,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
     </attributes>
     <coords>
       <coord>
@@ -62,9 +61,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.08]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[336924.0, 336948.0]]" id="559b95abfcdf35de" points="[336936.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -80,6 +76,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
     </attributes>
     <coords>
       <coord>
@@ -104,9 +101,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.08]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[336924.0, 336948.0]]" id="559b95abfcdf35de" points="[336936.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -122,6 +116,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
     </attributes>
     <coords>
       <coord>
@@ -148,9 +143,6 @@
         </DimCoord>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.08]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[336924.0, 336948.0]]" id="559b95abfcdf35de" points="[336936.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
@@ -164,6 +156,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
     </attributes>
     <coords>
       <coord>
@@ -184,9 +177,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 925.0, 950.0, 1000.0]" shape="(28,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.08]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[336948.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/pp_rules/rotated_uk.cml
+++ b/etc/iris_tests_results/pp_rules/rotated_uk.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s03i463"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.04"/>
     </attributes>
     <coords>
       <coord>
@@ -21,9 +22,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[-1.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[333627.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/theta_on_uwind_0d.cml
+++ b/etc/iris_tests_results/regrid/theta_on_uwind_0d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -34,9 +35,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.998464]]" id="5634c91ba5717382" long_name="sigma" points="[0.999424]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/theta_on_uwind_1d.cml
+++ b/etc/iris_tests_results/regrid/theta_on_uwind_1d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -37,9 +38,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.998464]]" id="5634c91ba5717382" long_name="sigma" points="[0.999424]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/theta_on_uwind_2d.cml
+++ b/etc/iris_tests_results/regrid/theta_on_uwind_2d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -40,9 +41,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.998464]]" id="5634c91ba5717382" long_name="sigma" points="[0.999424]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/theta_on_uwind_3d.cml
+++ b/etc/iris_tests_results/regrid/theta_on_uwind_3d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -48,9 +49,6 @@
 		[0.996162, 0.993097],
 		[0.993097, 0.989272],
 		[0.989272, 0.984692]]" id="5634c91ba5717382" long_name="sigma" points="[0.999424, 0.997504, 0.99482, 0.991375, 0.987171]" shape="(5,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/uwind_on_theta_0d.cml
+++ b/etc/iris_tests_results/regrid/uwind_on_theta_0d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -34,9 +35,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.999424]]" id="5634c91ba5717382" long_name="sigma" points="[0.999712]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/uwind_on_theta_1d.cml
+++ b/etc/iris_tests_results/regrid/uwind_on_theta_1d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -36,9 +37,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.999424]]" id="5634c91ba5717382" long_name="sigma" points="[0.999712]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/uwind_on_theta_2d.cml
+++ b/etc/iris_tests_results/regrid/uwind_on_theta_2d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -37,9 +38,6 @@
       </coord>
       <coord>
         <DimCoord bounds="[[1.0, 0.999424]]" id="5634c91ba5717382" long_name="sigma" points="[0.999712]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/regrid/uwind_on_theta_3d.cml
+++ b/etc/iris_tests_results/regrid/uwind_on_theta_3d.cml
@@ -3,6 +3,7 @@
   <cube standard_name="eastward_wind" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -45,9 +46,6 @@
 		[0.997504, 0.99482],
 		[0.99482, 0.991375],
 		[0.991375, 0.987171]]" id="5634c91ba5717382" long_name="sigma" points="[0.999712, 0.998464, 0.996162, 0.993097, 0.989272]" shape="(5,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[347921.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/stock/realistic_4d.cml
+++ b/etc/iris_tests_results/stock/realistic_4d.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
     <coords>
       <coord datadims="(1, 2, 3)">
         <AuxCoord bounds="[[[[413.937, 426.634],
@@ -478,9 +481,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Iris test case]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[2, 3]">
         <AuxCoord id="cf20c06c74c057c" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,

--- a/etc/iris_tests_results/trajectory/big_cube.cml
+++ b/etc/iris_tests_results/trajectory/big_cube.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -81,9 +82,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/trajectory/constant_latitude.cml
+++ b/etc/iris_tests_results/trajectory/constant_latitude.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -81,9 +82,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/trajectory/single_point.cml
+++ b/etc/iris_tests_results/trajectory/single_point.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -79,9 +80,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/trajectory/zigzag.cml
+++ b/etc/iris_tests_results/trajectory/zigzag.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
     </attributes>
     <coords>
       <coord>
@@ -81,9 +82,6 @@
 		0.0767339, 0.0525319, 0.0305214, 0.0126308,
 		0.00167859, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.04]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[347921.166667, 347921.333333, 347921.5,

--- a/etc/iris_tests_results/trui/air_temp_T00.cml
+++ b/etc/iris_tests_results/trui/air_temp_T00.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -24,9 +25,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[341148.0, 341172.0, 341196.0, 341220.0,

--- a/etc/iris_tests_results/trui/air_temp_T24.cml
+++ b/etc/iris_tests_results/trui/air_temp_T24.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -24,9 +25,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[341172.0, 341196.0, 341220.0, 341244.0,

--- a/etc/iris_tests_results/trui/air_temp_T24_subset.cml
+++ b/etc/iris_tests_results/trui/air_temp_T24_subset.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -24,9 +25,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[341172.0, 341196.0, 341220.0, 341244.0,

--- a/etc/iris_tests_results/trui/air_temp_T24_subset_mean.cml
+++ b/etc/iris_tests_results/trui/air_temp_T24_subset_mean.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="history" value="Mean of air_temperature over time"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -25,9 +26,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[341172.0, 341340.0]]" id="559b95abfcdf35de" points="[341256.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/trui/air_temp_trial_diff_T00_to_T24.cml
+++ b/etc/iris_tests_results/trui/air_temp_trial_diff_T00_to_T24.cml
@@ -22,9 +22,6 @@
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
       <coord datadims="[0]">
         <DimCoord id="559b95abfcdf35de" points="[341172.0, 341196.0, 341220.0, 341244.0,
 		341268.0, 341292.0, 341316.0, 341340.0,

--- a/etc/iris_tests_results/trui/mean_air_temp_trial_diff_T00_to_T24.cml
+++ b/etc/iris_tests_results/trui/mean_air_temp_trial_diff_T00_to_T24.cml
@@ -24,9 +24,6 @@ Mean of unknown over time"/>
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
-      <coord>
         <DimCoord bounds="[[341172.0, 341388.0]]" id="559b95abfcdf35de" points="[341280.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>

--- a/etc/iris_tests_results/uri_callback/trui_init.cml
+++ b/etc/iris_tests_results/uri_callback/trui_init.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -27,9 +28,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[341148.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/uri_callback/trui_t24.cml
+++ b/etc/iris_tests_results/uri_callback/trui_t24.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model 7.05"/>
     </attributes>
     <coords>
       <coord>
@@ -27,9 +28,6 @@
 		7.0, 10.0, 20.0, 30.0, 50.0, 70.0, 100.0, 150.0,
 		200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0,
 		850.0, 900.0, 925.0, 950.0, 1000.0]" shape="(29,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 7.05]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[341172.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -33,9 +34,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -33,9 +34,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
       <attribute name="ukmo__process_flags" value="(u'Maximum value of field during time period', u'Time mean field')"/>
     </attributes>
     <coords>
@@ -34,9 +35,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -34,9 +35,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[200.0, 500.0, 700.0]" shape="(3,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-944640.0, -942480.0]]" id="559b95abfcdf35de" points="[-943560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
       <attribute name="ukmo__process_flags" value="(u'Mean over an ensemble of parallel runs', u'Time mean field')"/>
     </attributes>
     <coords>
@@ -32,9 +33,6 @@
 		77.5, 80.0, 82.5, 85.0, 87.5, 90.0]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-426240.0, -253440.0]]" id="559b95abfcdf35de" points="[-339840.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -11,9 +12,6 @@
 		138.9, 203.7, 300.999, 447.049, 666.299,
 		995.549, 1500.85, 2116.15, 2731.4, 3346.65,
 		3961.9, 4577.15, 5192.45]" shape="(20,)" standard_name="depth" units="Unit('m')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord id="4289202fb9980552" points="[681540.0, 683340.0, 685140.0, 686940.0,

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s12i187"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord>
@@ -119,9 +120,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[163440.0, 165600.0]]" id="559b95abfcdf35de" points="[164520.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -21,9 +22,6 @@
       </coord>
       <coord datadims="[1]">
         <DimCoord id="5634c91ba5717382" long_name="site_number" points="[1.0, 2.0, 3.0]" shape="(3,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="4289202fb9980552" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_level_lat_orig.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_level_lat_orig.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -30,9 +31,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1226160.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_press_orig.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_press_orig.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -35,9 +36,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1226160.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_several.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_several.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -35,9 +36,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1054080.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -25,9 +26,6 @@
 		30.0, 33.75]" shape="(10,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1055520.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
@@ -4,15 +4,13 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord id="4289202fb9980552" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -11,9 +12,6 @@
       </coord>
       <coord datadims="[1]">
         <DimCoord id="5634c91ba5717382" long_name="site_number" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="4289202fb9980552" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -34,9 +35,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_1.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_1.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -34,9 +35,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_2.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_2.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s05i216"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -31,9 +32,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abxpa_press_lat.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/abxpa_press_lat.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -30,9 +31,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[7861680.0, 7948080.0]]" id="559b95abfcdf35de" points="[7904880.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/integer.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/integer.b_0.cml
@@ -3,6 +3,7 @@
   <cube standard_name="land_binary_mask" units="1">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -30,9 +31,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-944640.0, 178560.0]]" id="559b95abfcdf35de" points="[-383040.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/model.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/model.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -38,9 +39,6 @@
       <coord datadims="[1]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[30.0, 50.0, 100.0, 150.0, 200.0, 300.0, 500.0,
 		700.0, 850.0]" shape="(9,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[40320.0, 48960.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -42,9 +43,6 @@
 		89.375]" shape="(144,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-951120.0, 1122480.0]]" id="559b95abfcdf35de" points="[85680.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -22,9 +23,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 1.25, 2.5, ..., 356.25, 357.5, 358.75]" shape="(288,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[2003760.0, 2090160.0]]" id="559b95abfcdf35de" points="[2046960.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[2]">
@@ -25,9 +26,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="5634c91ba5717382" long_name="pseudo_level" points="[4, 8, 12, 16]" shape="(4,)" units="Unit('1')" value_type="int32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord bounds="[[-951120.0, -778320.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
@@ -4,6 +4,7 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s30i211"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[1]">
@@ -24,9 +25,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="5634c91ba5717382" long_name="pseudo_level" points="[4, 8, 12, 16]" shape="(4,)" units="Unit('1')" value_type="int32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord bounds="[[-951120.0, -778320.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -36,9 +37,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -36,9 +37,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
       <attribute name="ukmo__process_flags" value="('Maximum value of field during time period', 'Time mean field')"/>
     </attributes>
     <coords>
@@ -37,9 +38,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[183336.0, 185496.0]]" id="559b95abfcdf35de" points="[184416.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -33,9 +34,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[200.0, 500.0, 700.0]" shape="(3,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-944640.0, -942480.0]]" id="559b95abfcdf35de" points="[-943560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
       <attribute name="ukmo__process_flags" value="('Mean over an ensemble of parallel runs', 'Time mean field')"/>
     </attributes>
     <coords>
@@ -35,9 +36,6 @@
 		77.5, 80.0, 82.5, 85.0, 87.5, 90.0]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-426240.0, -253440.0]]" id="559b95abfcdf35de" points="[-339840.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -14,9 +15,6 @@
             <attribute name="positive" value="down"/>
           </attributes>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord id="4289202fb9980552" points="[681540.0, 683340.0, 685140.0, 686940.0,

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="tendency_of_upward_air_velocity_due_to_advection" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s12i187"/>
+      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
     </attributes>
     <coords>
       <coord>
@@ -126,9 +127,6 @@
 		0.156554, 0.116948, 0.0817952, 0.0518637,
 		0.0279368, 0.0107165, 0.00130179, 0.0, 0.0, 0.0,
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0]" shape="(38,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model 6.01]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[163440.0, 165600.0]]" id="559b95abfcdf35de" points="[164520.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="Celsius">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -24,9 +25,6 @@
       </coord>
       <coord datadims="[1]">
         <DimCoord id="5634c91ba5717382" long_name="site_number" points="[1.0, 2.0, 3.0]" shape="(3,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="4289202fb9980552" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -29,9 +30,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1226160.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -34,9 +35,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1226160.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -38,9 +39,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1054080.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube units="unknown">
+    <attributes>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+    </attributes>
     <coords>
       <coord datadims="[0]">
         <DimCoord id="fc2e5e733b5cf4c" points="[868320, 876960, 885600, 894240]" shape="(4,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
@@ -22,9 +25,6 @@
 		30.0, 33.75]" shape="(10,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[1053360.0, 1055520.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
@@ -3,15 +3,13 @@
   <cube standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord id="4289202fb9980552" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -14,9 +15,6 @@
       </coord>
       <coord datadims="[1]">
         <DimCoord id="5634c91ba5717382" long_name="site_number" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord id="4289202fb9980552" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -37,9 +38,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],
@@ -62,6 +60,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -97,9 +96,6 @@
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
       </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
-      </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],
 		[154824.0, 154848.0],
@@ -121,6 +117,7 @@
   <cube standard_name="precipitation_flux" units="kg m-2 s-1">
     <attributes>
       <attribute name="STASH" value="m01s05i216"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -148,9 +145,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[154800.0, 154824.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -29,9 +30,6 @@
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[10.0, 30.0, 50.0, 100.0, 150.0, 200.0, 250.0,
 		300.0, 400.0, 500.0, 600.0, 700.0, 850.0, 950.0,
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[7861680.0, 7948080.0]]" id="559b95abfcdf35de" points="[7904880.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/integer.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/integer.b.cml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube standard_name="land_binary_mask" units="1">
+    <attributes>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+    </attributes>
     <coords>
       <coord>
         <DimCoord id="fc2e5e733b5cf4c" points="[43200]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
@@ -27,9 +30,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-944640.0, 178560.0]]" id="559b95abfcdf35de" points="[-383040.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -37,9 +38,6 @@
       <coord datadims="[1]">
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[30.0, 50.0, 100.0, 150.0, 200.0, 300.0, 500.0,
 		700.0, 850.0]" shape="(9,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
         <DimCoord bounds="[[40320.0, 48960.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[0]">
@@ -45,9 +46,6 @@
 		89.375]" shape="(144,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[-951120.0, 1122480.0]]" id="559b95abfcdf35de" points="[85680.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -21,9 +22,6 @@
         <DimCoord id="3207b04384adbdec" points="[0.0, 1.25, 2.5, ..., 356.25, 357.5, 358.75]" shape="(288,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <latLonCS cs_type="spherical" datum="SpheroidDatum(label='spherical', semi_major_axis=6371229.0, semi_minor_axis=6371229.0, flattening=0.0, unit=Unit('m'))" n_pole="GeoPosition(latitude=90.0, longitude=0.0)" prime_meridian="PrimeMeridian(label='Greenwich', value=0.0)" reference_longitude="0.0"/>
         </DimCoord>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord bounds="[[2003760.0, 2090160.0]]" id="559b95abfcdf35de" points="[2046960.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
@@ -3,6 +3,7 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[2]">
@@ -28,9 +29,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="5634c91ba5717382" long_name="pseudo_level" points="[4, 8, 12, 16]" shape="(4,)" units="Unit('1')" value_type="int32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord bounds="[[-951120.0, -778320.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
@@ -3,6 +3,7 @@
   <cube standard_name="northward_ocean_heat_transport" units="PW">
     <attributes>
       <attribute name="STASH" value="m02s30i211"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord datadims="[1]">
@@ -23,9 +24,6 @@
       </coord>
       <coord datadims="[0]">
         <DimCoord id="5634c91ba5717382" long_name="pseudo_level" points="[4, 8, 12, 16]" shape="(4,)" units="Unit('1')" value_type="int32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
         <DimCoord bounds="[[-951120.0, -778320.0],

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cdl
@@ -7,6 +7,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
@@ -43,5 +44,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cdl
@@ -7,6 +7,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
@@ -43,5 +44,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cdl
@@ -7,6 +7,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:ukmo__process_flags = "Maximum_value_of_field_during_time_period Time_mean_field" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
@@ -43,5 +44,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		geopotential_height:standard_name = "geopotential_height" ;
 		geopotential_height:units = "m" ;
 		geopotential_height:ukmo__um_stash_source = "m01s16i202" ;
+		geopotential_height:source = "Data from Met Office Unified Model" ;
 		geopotential_height:cell_methods = "time: mean (interval: 4 hour)" ;
 		geopotential_height:grid_mapping = "latitude_longitude" ;
 		geopotential_height:coordinates = "forecast_period forecast_reference_time time" ;
@@ -44,5 +45,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cdl
@@ -6,6 +6,7 @@ variables:
 	float unknown(depth, latitude) ;
 		unknown:_FillValue = -1.e+30f ;
 		unknown:ukmo__um_stash_source = "m??s44i101" ;
+		unknown:source = "Data from Met Office Unified Model" ;
 		unknown:ukmo__process_flags = "Mean_over_an_ensemble_of_parallel_runs Time_mean_field" ;
 		unknown:grid_mapping = "latitude_longitude" ;
 		unknown:coordinates = "forecast_period forecast_reference_time time" ;
@@ -39,5 +40,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cdl
@@ -4,6 +4,7 @@ dimensions:
 variables:
 	float unknown(depth, time) ;
 		unknown:ukmo__um_stash_source = "m??s44i101" ;
+		unknown:source = "Data from Met Office Unified Model" ;
 		unknown:cell_methods = "time: mean (interval: 24 hour)" ;
 	float depth(depth) ;
 		depth:axis = "Z" ;
@@ -18,5 +19,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		tendency_of_upward_air_velocity_due_to_advection:standard_name = "tendency_of_upward_air_velocity_due_to_advection" ;
 		tendency_of_upward_air_velocity_due_to_advection:units = "m s-1" ;
 		tendency_of_upward_air_velocity_due_to_advection:ukmo__um_stash_source = "m01s12i187" ;
+		tendency_of_upward_air_velocity_due_to_advection:source = "Data from Met Office Unified Model 6.01" ;
 		tendency_of_upward_air_velocity_due_to_advection:cell_methods = "time: mean (interval: 1 hour)" ;
 		tendency_of_upward_air_velocity_due_to_advection:grid_mapping = "latitude_longitude" ;
 		tendency_of_upward_air_velocity_due_to_advection:coordinates = "forecast_period forecast_reference_time level_height sigma time" ;
@@ -56,5 +57,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model 6.01" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
@@ -7,6 +7,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "Celsius" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "height latitude longitude" ;
@@ -39,5 +40,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_level_lat_orig.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_level_lat_orig.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		geopotential_height:standard_name = "geopotential_height" ;
 		geopotential_height:units = "m" ;
 		geopotential_height:ukmo__um_stash_source = "m01s16i202" ;
+		geopotential_height:source = "Data from Met Office Unified Model" ;
 		geopotential_height:cell_methods = "time: mean" ;
 		geopotential_height:grid_mapping = "latitude_longitude" ;
 		geopotential_height:coordinates = "forecast_period forecast_reference_time" ;
@@ -41,5 +42,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_press_orig.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_press_orig.b_0.cdl
@@ -9,6 +9,7 @@ variables:
 		geopotential_height:standard_name = "geopotential_height" ;
 		geopotential_height:units = "m" ;
 		geopotential_height:ukmo__um_stash_source = "m01s16i202" ;
+		geopotential_height:source = "Data from Met Office Unified Model" ;
 		geopotential_height:cell_methods = "time: mean" ;
 		geopotential_height:grid_mapping = "latitude_longitude" ;
 		geopotential_height:coordinates = "forecast_period forecast_reference_time" ;
@@ -46,5 +47,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_several.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_several.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -45,5 +46,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_n10r13xy.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_n10r13xy.b_0.cdl
@@ -5,6 +5,7 @@ dimensions:
 	bnds = 2 ;
 variables:
 	float unknown(time, latitude, longitude) ;
+		unknown:source = "Data from Met Office Unified Model" ;
 		unknown:cell_methods = "time: mean (interval: 1 hour)" ;
 		unknown:grid_mapping = "latitude_longitude" ;
 		unknown:coordinates = "forecast_period forecast_reference_time height" ;
@@ -41,5 +42,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_time_press.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_time_press.b_0.cdl
@@ -6,6 +6,7 @@ variables:
 		geopotential_height:standard_name = "geopotential_height" ;
 		geopotential_height:units = "m" ;
 		geopotential_height:ukmo__um_stash_source = "m01s16i202" ;
+		geopotential_height:source = "Data from Met Office Unified Model" ;
 		geopotential_height:cell_methods = "time: mean" ;
 	float pressure(pressure) ;
 		pressure:axis = "Z" ;
@@ -19,5 +20,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_tseries.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_tseries.b_0.cdl
@@ -6,6 +6,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean" ;
 		air_temperature:coordinates = "height" ;
 	float time(time) ;
@@ -23,5 +24,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -45,5 +46,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_1.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_1.cdl
@@ -8,6 +8,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s03i236" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: minimum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -45,5 +46,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_2.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_2.cdl
@@ -8,6 +8,7 @@ variables:
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:ukmo__um_stash_source = "m01s05i216" ;
+		precipitation_flux:source = "Data from Met Office Unified Model" ;
 		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
 		precipitation_flux:grid_mapping = "latitude_longitude" ;
 		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
@@ -41,5 +42,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abxpa_press_lat.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/abxpa_press_lat.b_0.cdl
@@ -7,6 +7,7 @@ variables:
 		geopotential_height:standard_name = "geopotential_height" ;
 		geopotential_height:units = "m" ;
 		geopotential_height:ukmo__um_stash_source = "m01s16i202" ;
+		geopotential_height:source = "Data from Met Office Unified Model" ;
 		geopotential_height:cell_methods = "time: mean (interval: 4 hour)" ;
 		geopotential_height:grid_mapping = "latitude_longitude" ;
 		geopotential_height:coordinates = "forecast_period forecast_reference_time time" ;
@@ -39,5 +40,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/integer.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/integer.b_0.cdl
@@ -6,6 +6,7 @@ variables:
 	int land_binary_mask(latitude, longitude) ;
 		land_binary_mask:standard_name = "land_binary_mask" ;
 		land_binary_mask:units = "1" ;
+		land_binary_mask:source = "Data from Met Office Unified Model" ;
 		land_binary_mask:cell_methods = "time: mean" ;
 		land_binary_mask:grid_mapping = "latitude_longitude" ;
 		land_binary_mask:coordinates = "forecast_period forecast_reference_time time" ;
@@ -38,5 +39,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/model.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/model.b_0.cdl
@@ -9,6 +9,7 @@ variables:
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:ukmo__um_stash_source = "m01s16i203" ;
+		air_temperature:source = "Data from Met Office Unified Model" ;
 		air_temperature:cell_methods = "time: mean (interval: 4 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time" ;
@@ -46,5 +47,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/ocean_xsect.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/ocean_xsect.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 		sea_water_potential_temperature:standard_name = "sea_water_potential_temperature" ;
 		sea_water_potential_temperature:units = "degC" ;
 		sea_water_potential_temperature:ukmo__um_stash_source = "m02s00i101" ;
+		sea_water_potential_temperature:source = "Data from Met Office Unified Model" ;
 		sea_water_potential_temperature:cell_methods = "time: mean" ;
 		sea_water_potential_temperature:grid_mapping = "latitude_longitude" ;
 		sea_water_potential_temperature:coordinates = "forecast_period forecast_reference_time time" ;
@@ -43,5 +44,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st0fc699.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st0fc699.b_0.cdl
@@ -6,6 +6,7 @@ variables:
 	float unknown(latitude, longitude) ;
 		unknown:_FillValue = -1.e+30f ;
 		unknown:ukmo__um_stash_source = "m02s00i???" ;
+		unknown:source = "Data from Met Office Unified Model" ;
 		unknown:cell_methods = "time: mean (interval: 2 hour)" ;
 		unknown:grid_mapping = "latitude_longitude" ;
 		unknown:coordinates = "forecast_period forecast_reference_time time" ;
@@ -38,5 +39,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st0fc942.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st0fc942.b_0.cdl
@@ -8,6 +8,7 @@ variables:
 	float unknown(pseudo_level, time, depth, grid_latitude) ;
 		unknown:_FillValue = -1.e+30f ;
 		unknown:ukmo__um_stash_source = "m02s00i???" ;
+		unknown:source = "Data from Met Office Unified Model" ;
 		unknown:cell_methods = "time: mean" ;
 		unknown:grid_mapping = "rotated_latitude_longitude" ;
 		unknown:coordinates = "forecast_period forecast_reference_time" ;
@@ -48,5 +49,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st30211.b_0.cdl
+++ b/etc/iris_tests_results/usecases/pp_to_cf_conversion/to_netcdf/st30211.b_0.cdl
@@ -10,6 +10,7 @@ variables:
 		northward_ocean_heat_transport:standard_name = "northward_ocean_heat_transport" ;
 		northward_ocean_heat_transport:units = "PW" ;
 		northward_ocean_heat_transport:ukmo__um_stash_source = "m02s30i211" ;
+		northward_ocean_heat_transport:source = "Data from Met Office Unified Model" ;
 		northward_ocean_heat_transport:cell_methods = "time: mean" ;
 		northward_ocean_heat_transport:grid_mapping = "latitude_longitude" ;
 		northward_ocean_heat_transport:coordinates = "forecast_period forecast_reference_time" ;
@@ -46,5 +47,4 @@ variables:
 
 // global attributes:
 		:Conventions = "CF-1.5" ;
-		:source = "Data from Met Office Unified Model" ;
 }

--- a/etc/iris_tests_results/xml/pp.cml
+++ b/etc/iris_tests_results/xml/pp.cml
@@ -3,6 +3,7 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>
     <coords>
       <coord>
@@ -31,9 +32,6 @@
       </coord>
       <coord>
         <DimCoord id="411a2ed4ea259990" long_name="pressure" points="[1000.0]" shape="(1,)" units="Unit('hPa')" value_type="float32"/>
-      </coord>
-      <coord>
-        <AuxCoord id="2ba66fb2f0fc5dbd" long_name="source" points="[Data from Met Office Unified Model]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
         <DimCoord id="559b95abfcdf35de" points="[253464.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -229,10 +229,10 @@ class Cube(CFVariableMixin):
              Scalar coordinates:
                   forecast_period: 6477 hours
                   pressure: 1000.0 hPa
-                  source: Data from Met Office Unified Model
                   time: Cell(point=232560.0, bound=(215280.0, 249840.0)) hours since 1970-01-01 00:00:00
              Attributes:
                   STASH: m01s16i203
+                  source: Data from Met Office Unified Model
              Cell methods:
                   mean: time
 
@@ -1091,7 +1091,7 @@ class Cube(CFVariableMixin):
             #
             if self.attributes:
                 attribute_summary = []
-                for name, value in self.attributes.iteritems():
+                for name, value in sorted(self.attributes.iteritems()):
                     if name == 'history':
                         value = re.sub("[\d\/]{8} [\d\:]{8} Iris\: ", '', str(value))
                     else:
@@ -1898,11 +1898,12 @@ class Cube(CFVariableMixin):
                  Scalar coordinates:
                       forecast_reference_time: 364272.0 hours since 1970-01-01 00:00:00
                       realization: 10
-                      source: Data from Met Office Unified Model 7.06
                  Attributes:
                       STASH: m01s00i024
+                      source: Data from Met Office Unified Model 7.06
                  Cell methods:
                       mean: time (1 hour)
+
 
             >>> print air_press.rolling_window('time', iris.analysis.MEAN, 3)
             surface_temperature                 (time: 4; latitude: 145; longitude: 192)
@@ -1915,13 +1916,14 @@ class Cube(CFVariableMixin):
                  Scalar coordinates:
                       forecast_reference_time: 364272.0 hours since 1970-01-01 00:00:00
                       realization: 10
-                      source: Data from Met Office Unified Model 7.06
                  Attributes:
                       STASH: m01s00i024
                       history: Mean of surface_temperature with a rolling window of length 3 over tim...
+                      source: Data from Met Office Unified Model 7.06
                  Cell methods:
                       mean: time (1 hour)
                       mean: time
+
 
             Notice that the forecast_period dimension now represents the 4 possible windows of size 3 from the original cube. 
 

--- a/lib/iris/etc/pp_rules.txt
+++ b/lib/iris/etc/pp_rules.txt
@@ -374,15 +374,13 @@ IF
 (f.lbsrce % 10000) == 1111
 (f.lbsrce / 10000) / 100.0 > 0
 THEN
-#CMCustomAttribute('source', 'Data from Met Office Unified Model %4.2f' % ((f.lbsrce / 10000) / 100.0))
-CoordAndDims(AuxCoord('Data from Met Office Unified Model %4.2f' % ((f.lbsrce / 10000) / 100.0), long_name='source', units="no_unit"))
+CMCustomAttribute('source', 'Data from Met Office Unified Model %4.2f' % ((f.lbsrce / 10000) / 100.0))
 
 IF
 (f.lbsrce % 10000) == 1111
 (f.lbsrce / 10000) / 100.0 == 0
 THEN
-#CMCustomAttribute('source', 'Data from Met Office Unified Model')
-CoordAndDims(AuxCoord('Data from Met Office Unified Model', long_name='source', units="no_unit"))
+CMCustomAttribute('source', 'Data from Met Office Unified Model')
 
 IF
 f.lbuser[6] != 0 or (f.lbuser[3] / 1000) != 0 or (f.lbuser[3] % 1000) != 0

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -33,19 +33,19 @@ THEN
 
 #UM - no version number
 IF
-    scalar_coord(cm, 'source') is not None
-    len(scalar_coord(cm, 'source').points[0].rsplit("Data from Met Office Unified Model", 1)) > 1
-    len(scalar_coord(cm, 'source').points[0].rsplit("Data from Met Office Unified Model", 1)[1]) == 0
+    'source' in cm.attributes
+    len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)) > 1
+    len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) == 0
 THEN
     pp.lbsrce = 1111
 
 #UM - with version number
 IF
-    scalar_coord(cm, 'source') is not None
-    len(scalar_coord(cm, 'source').points[0].rsplit("Data from Met Office Unified Model", 1)) > 1
-    len(scalar_coord(cm, 'source').points[0].rsplit("Data from Met Office Unified Model", 1)[1]) > 0
+    'source' in cm.attributes
+    len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)) > 1
+    len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) > 0
 THEN
-    pp.lbsrce = int(float(scalar_coord(cm, 'source').points[0].rsplit("Data from Met Office Unified Model", 1)[1]) * 1000000) + 1111  # UM version
+    pp.lbsrce = int(float(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) * 1000000) + 1111  # UM version
 
 IF
     'STASH' in cm.attributes

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -259,11 +259,6 @@ def _load_cube(engine, cf, cf_var, filename):
     for attr_name, attr_value in itertools.ifilter(attribute_predicate, cf_var.cf_attrs_unused()):
         _set_attributes(cube.attributes, attr_name, attr_value)
 
-    # Deal with special case of "source" attribute.
-    # Convert the attribute to a coordinate (meta-data hook for PP save).
-    if 'source' in cube.attributes and not cube.coords('source'):
-        cube.add_aux_coord(iris.coords.AuxCoord(points=str(cube.attributes.pop('source')), long_name='source', units='no_unit'))
-
     # Show pyke session statistics.
     _pyke_stats(engine, cf_var.cf_name)
     
@@ -410,13 +405,6 @@ def _create_cf_variable(dataset, cube, dimension_names, coord, factory_defn):
         The string name of the associated CF-netCDF variable saved.
     
     """
-    # Deal with special case of "source" coordinate.
-    # This coordinate is never saved as a netCDF variable.
-    if coord.name() == 'source' and coord.points.ndim == 1: 
-        # Translate the coordinate into a netCDF global attribute.
-        dataset.source = coord.points[0]
-        return None
-   
     cf_name = coord.name()
 
     # Derive the data dimension names for the coordinate.

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -110,9 +110,7 @@ def guess_coord_axis(coord):
         axis = 'X'
     elif coord.standard_name in ('latitude', 'grid_latitude', 'projection_y_coordinate'):
         axis = 'Y'
-    elif 'height' in name or 'depth' in name or \
-            coord.units.convertible('hPa') or \
-            coord.attributes.get('positive') in ('up', 'down'):
+    elif coord.units.convertible('hPa') or coord.attributes.get('positive') in ('up', 'down'):
         axis = 'Z'
     elif coord.units.time_reference:    
         axis = 'T'

--- a/lib/iris_tests/stock.py
+++ b/lib/iris_tests/stock.py
@@ -342,7 +342,6 @@ def realistic_4d():
     sigma = icoords.AuxCoord(sigma_pts, long_name='sigma', units='1', bounds=sigma_bnds)
     orography = icoords.AuxCoord(orography, standard_name='surface_altitude', units='m')
     time = icoords.DimCoord(time_pts, standard_name='time', units='hours since 1970-01-01 00:00:00')
-    source = icoords.AuxCoord(['Iris test case'], long_name='source', units='no unit')
     forecast_period = icoords.DimCoord(forecast_period_pts, standard_name='forecast_period', units='hours')
     
     hybrid_height = iris.aux_factory.HybridHeightFactory(level_height, sigma, orography)
@@ -350,7 +349,8 @@ def realistic_4d():
     cube = iris.cube.Cube(data, standard_name='air_potential_temperature', units='K',
                           dim_coords_and_dims=[(time, 0), (model_level, 1), (lat, 2), (lon, 3)],
                           aux_coords_and_dims=[(orography, (2, 3)), (level_height, 1), (sigma, 1),
-                                               (source, None), (forecast_period, None)],
+                                               (forecast_period, None)],
+                          attributes={'source': 'Iris test case'},
                           aux_factories=[hybrid_height])
     return cube
 

--- a/lib/iris_tests/test_cdm.py
+++ b/lib/iris_tests/test_cdm.py
@@ -264,10 +264,6 @@ class TestCubeStringRepresentations(IrisDotTest):
         lat2.attributes['test'] = 'True'
         cube.add_aux_coord(lat2, [0])
 
-        src = cube.coord('source').copy()
-        src.attributes['reliability'] = 'low'
-        cube.add_aux_coord(src)
-
         self.assertString(str(cube), ('cdm', 'string_representations', 'similar.__str__.txt'))
 
     def test_cube_summary_cell_methods(self):

--- a/lib/iris_tests/test_interpolation.py
+++ b/lib/iris_tests/test_interpolation.py
@@ -282,7 +282,7 @@ class TestNearestNeighbour(tests.IrisTest):
         self.assertCML(b, ('analysis', 'interpolation', 'nearest_neighbour_extract_bounded_mid_point.cml'))
     
     def test_nearest_neighbour_locator_style_coord(self):
-        point_spec = [('latitude', 39), ('source', 38)]
+        point_spec = [('latitude', 39)]
         
         b = iris.analysis.interpolate.extract_nearest_neighbour(self.cube, point_spec) 
         self.assertCML(b, ('analysis', 'interpolation', 'nearest_neighbour_extract_latitude.cml'))

--- a/lib/iris_tests/test_netcdf.py
+++ b/lib/iris_tests/test_netcdf.py
@@ -230,13 +230,6 @@ class TestNetCDFSave(tests.IrisTest):
 
         # Read netCDF file.
         cube = iris.load_strict(file_out)
-        coord = cube.coord('time')
-        coord = cube.coord('forecast_period')
-        coord = cube.coord('source')
-        coord = cube.coord('sigma')
-        coord = cube.coord('atmosphere_hybrid_height_coordinate')
-        coord = cube.coord('model_level_number')
-        coord = cube.coord('surface_altitude')
 
         # Check the PP read, netCDF write, netCDF read mechanism.
         self.assertCML(cube, ('netcdf', 'netcdf_save_load_hybrid_height.cml'))


### PR DESCRIPTION
Convert <i>source</i> coordinate to cube attribute.

Note that, as the <i>source</i> is now an attribute, performing cube arithmetic e.g. `cube - cube` results in the cube attributes being cleared, and thus the <i>source</i> metadata is lost.

Cube <i>history</i> is maintained as a cube attribute as a result of the previous CF porting exercise.
