### PR TITLE
Exposed merge keyword argument to public load api.

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -164,7 +164,7 @@ def load_strict(uris, constraints=None, callback=None):
     return cubes
 
 
-def load(uris, constraints=None, unique=False, callback=None):
+def load(uris, constraints=None, unique=False, callback=None, merge=True):
     """
     Loads cubes.
     
@@ -201,19 +201,22 @@ def load(uris, constraints=None, unique=False, callback=None):
     * constraints:
         An iterable of constraints.
     * unique:
-        If true, raise an error if duplicate cubes are detected.
+        If set to True, raise an error if duplicate cubes are detected (ignored if merge is False)
     * callback:
          A function to add metadata from the originating field and/or URI which obeys the following rules:
             1. Function signature must be: ``(cube, field, filename)``
             2. Must not return any value - any alterations to the cube must be made by reference
             3. If the cube is to be rejected the callback must raise an :class:`iris.exceptions.IgnoreCubeException`
+    * merge:
+        If set to False, make no attempt to merge the resulting cubes. Note that if True (default) and 
+        an iterable of constraints is provided, a separate merge is performed for each constraint.
 
     Returns:
         An :class:`iris.cube.CubeList`.
 
     """    
-    # Load zero or more merged Cubes from each constraint.
-    cubes = _load_common(uris, constraints, strict=False, unique=unique, callback=callback)
+    # Load zero or more Cubes from each constraint.
+    cubes = _load_common(uris, constraints, strict=False, unique=unique, callback=callback, merge=merge)
     return cubes
 
 

--- a/lib/iris/tests/test_file_load.py
+++ b/lib/iris/tests/test_file_load.py
@@ -25,26 +25,27 @@ import iris
 
 
 @iris.tests.skip_data
-class TestFileload_strict(tests.IrisTest):
+class TestFileload(tests.IrisTest):
     def _test_file(self, src_path, reference_filename):
         """
         Checks the result of loading the given file spec, or creates the
         reference file if it doesn't exist.
 
-        NB. The direct use of :func:`iris._load_common` bypasses the cube merge process.
-        
         """
-        cubes = iris._load_common(tests.get_data_path(src_path), constraints=None, strict=False, unique=True, merge=False)
+        cubes = iris.load(tests.get_data_path(src_path), merge=False)
         self.assertCML(cubes, ['file_load', reference_filename])
 
     def test_no_file(self):
-        # Test an IOError is recieved when a filename is given which doesnt match any files
+        # Test an IOError is received when a filename is given which doesn't match any files
         real_file = ['PP', 'globClim1', 'theta.pp']
         non_existant_file = ['PP', 'globClim1', 'no_such_file*']
 
-        self.assertRaises(IOError, iris.load, tests.get_data_path(non_existant_file))
-        self.assertRaises(IOError, iris.load, [tests.get_data_path(non_existant_file), tests.get_data_path(real_file)])
-        self.assertRaises(IOError, iris.load, [tests.get_data_path(real_file), tests.get_data_path(non_existant_file)])
+        with self.assertRaises(IOError):
+            iris.load(tests.get_data_path(non_existant_file))
+        with self.assertRaises(IOError):
+            iris.load([tests.get_data_path(non_existant_file), tests.get_data_path(real_file)])
+        with self.assertRaises(IOError):
+            iris.load([tests.get_data_path(real_file), tests.get_data_path(non_existant_file)])
 
     def test_single_file(self):
         src_path = ['PP', 'globClim1', 'theta.pp']


### PR DESCRIPTION
There are occasions (e.g. when using custom file loading) when the behaviour of merge is not desired. This pull request exposes the underlying `merge` keyword argument of `iris._load_common()` in the public API through `iris.load()` so users can disable merging.
