### PR TITLE
New load/merge API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,8 @@ Features added
 * Automatic and manual use of Cynthia Brewer colour palettes.
 * Readability improvements to Cube summary.
 * Ensures netCDF files are properly closed.
-* The ability to bypass merging when loading data.
+* A more explicit set of load functions, which also allow the automatic
+  cube merging to be bypassed as a last resort.
 * Save netCDF files with an unlimited dimension.
 
 Incompatible changes
@@ -30,8 +31,8 @@ Incompatible changes
 Deprecations
 ------------
 * The methods `Coord.cos()` and `Coord.sin()` have been deprecated.
-* The function `load_strict()` function has been deprecated. Code should
-  now use `iris.load_cube()` and `iris.load_cubes()` instead.
+* The function `load_strict()` has been deprecated. Code should now use
+  `iris.load_cube()` and `iris.load_cubes()` instead.
 
 
 ----------------------------

--- a/docs/iris/example_code/graphics/COP_1d_plot.py
+++ b/docs/iris/example_code/graphics/COP_1d_plot.py
@@ -33,9 +33,9 @@ import matplotlib.dates as mdates
 
 def main():
     # Load data into three Cubes, one for each set of PP files
-    e1 = iris.load_strict(iris.sample_data_path('E1_north_america.nc'))
+    e1 = iris.load_cube(iris.sample_data_path('E1_north_america.nc'))
     
-    a1b = iris.load_strict(iris.sample_data_path('A1B_north_america.nc'))
+    a1b = iris.load_cube(iris.sample_data_path('A1B_north_america.nc'))
     
     # load in the global pre-industrial mean temperature, and limit the domain to
     # the same North American region that e1 and a1b are at.
@@ -43,9 +43,8 @@ def main():
                                     longitude=lambda v: 225 <= v <= 315,
                                     latitude=lambda v: 15 <= v <= 60,
                                     )
-    pre_industrial = iris.load_strict(iris.sample_data_path('pre-industrial.pp'),
-                                  north_america
-                                  )
+    pre_industrial = iris.load_cube(iris.sample_data_path('pre-industrial.pp'),
+                                    north_america)
     
     pre_industrial_mean = pre_industrial.collapsed(['latitude', 'longitude'], iris.analysis.MEAN)
     e1_mean = e1.collapsed(['latitude', 'longitude'], iris.analysis.MEAN)

--- a/docs/iris/example_code/graphics/COP_maps.py
+++ b/docs/iris/example_code/graphics/COP_maps.py
@@ -44,13 +44,13 @@ def cop_metadata_callback(cube, field, filename):
 
 def main():
     # Load e1 and a1 using the callback to update the metadata
-    e1 = iris.load_strict(iris.sample_data_path('E1.2098.pp'),
-                           callback=cop_metadata_callback)
-    a1b = iris.load_strict(iris.sample_data_path('A1B.2098.pp'),
-                            callback=cop_metadata_callback)
+    e1 = iris.load_cube(iris.sample_data_path('E1.2098.pp'),
+                        callback=cop_metadata_callback)
+    a1b = iris.load_cube(iris.sample_data_path('A1B.2098.pp'),
+                         callback=cop_metadata_callback)
     
     # Load the global average data and add an 'Experiment' coord it
-    global_avg = iris.load_strict(iris.sample_data_path('pre-industrial.pp'))
+    global_avg = iris.load_cube(iris.sample_data_path('pre-industrial.pp'))
     
     # Define evenly spaced contour levels: -2.5, -1.5, ... 15.5, 16.5 with the specific colours
     levels = numpy.arange(20) - 2.5

--- a/docs/iris/example_code/graphics/TEC.py
+++ b/docs/iris/example_code/graphics/TEC.py
@@ -26,7 +26,7 @@ def total_electron_content_filter(cube, field, filename):
 def main():
     # Load the "total electron content" cube.
     filename = iris.sample_data_path('space_weather.nc')
-    cube = iris.load_strict(filename, 'total electron content')
+    cube = iris.load_cube(filename, 'total electron content')
 
     # Explicitly mask negative electron content.
     cube.data = np.ma.masked_less(cube.data, 0)

--- a/docs/iris/example_code/graphics/cross_section.py
+++ b/docs/iris/example_code/graphics/cross_section.py
@@ -15,7 +15,7 @@ import iris.quickplot as qplt
 
 def main():
     fname = iris.sample_data_path('hybrid_height.nc')
-    theta = iris.load_strict(fname)
+    theta = iris.load_cube(fname)
     
     # Extract a single height vs longitude cross-section. N.B. This could easily be changed to
     # extract a specific slice, or even to loop over *all* cross section slices.

--- a/docs/iris/example_code/graphics/custom_file_loading.py
+++ b/docs/iris/example_code/graphics/custom_file_loading.py
@@ -36,7 +36,7 @@ To create a format specification we need to define the following:
 In the following example, the function :func:`load_NAME_III` has been defined to handle the loading of the raw data from the custom file format.
 This function is called from :func:`NAME_to_cube` which uses this data to create and yield Iris cubes.
 
-In the ``main()`` function the filenames are loaded via the ``iris.load_strict`` function which automatically
+In the ``main()`` function the filenames are loaded via the ``iris.load_cube`` function which automatically
 invokes the ``FormatSpecification`` we defined. The cube returned from the load function is then used to produce a plot.
 
 """
@@ -213,7 +213,7 @@ def main():
     boundary_volc_ash_constraint = iris.Constraint('VOLCANIC_ASH_AIR_CONCENTRATION', flight_level='From FL000 - FL200')
 
     # Callback shown as None to illustrate where a cube-level callback function would be used if required
-    cube = iris.load_strict(fname, boundary_volc_ash_constraint, callback=None)
+    cube = iris.load_cube(fname, boundary_volc_ash_constraint, callback=None)
 
     iplt.map_setup(xlim=(-70, 20), ylim=(20, 75))
     plt.gca().coastlines()

--- a/docs/iris/example_code/graphics/deriving_phenomena.py
+++ b/docs/iris/example_code/graphics/deriving_phenomena.py
@@ -34,7 +34,8 @@ def main():
     # define the constraint on standard name and model level
     constraints = [iris.Constraint(phenom, model_level_number=1) for phenom in phenomena]
     
-    air_potential_temperature, air_pressure = iris.load_strict(fname, constraints) 
+    air_potential_temperature, air_pressure = iris.load_cubes(fname,
+                                                              constraints) 
     
     # define a coordinate which represents 1000 hPa 
     p0 = coords.AuxCoord(100000, long_name='P0', units='Pa')

--- a/docs/iris/example_code/graphics/global_map.py
+++ b/docs/iris/example_code/graphics/global_map.py
@@ -15,7 +15,7 @@ import iris.quickplot as qplt
 
 def main():
     fname = iris.sample_data_path('air_temp.pp')
-    temperature = iris.load_strict(fname)
+    temperature = iris.load_cube(fname)
     
     qplt.contourf(temperature, 15)
     plt.gca().coastlines()

--- a/docs/iris/example_code/graphics/hovmoller.py
+++ b/docs/iris/example_code/graphics/hovmoller.py
@@ -19,7 +19,7 @@ def main():
     fname = iris.sample_data_path('ostia_monthly.nc')
     
     # load a single cube of surface temperature between +/- 5 latitude
-    cube = iris.load_strict(fname, iris.Constraint('surface_temperature', latitude=lambda v: -5 < v < 5))
+    cube = iris.load_cube(fname, iris.Constraint('surface_temperature', latitude=lambda v: -5 < v < 5))
     
     # Take the mean over latitude
     cube = cube.collapsed('latitude', iris.analysis.MEAN)

--- a/docs/iris/example_code/graphics/lagged_ensemble.py
+++ b/docs/iris/example_code/graphics/lagged_ensemble.py
@@ -39,7 +39,7 @@ def realization_metadata(cube, field, fname):
 
 def main():
     # extract surface temperature cubes which have an ensemble member coordinate, adding appropriate lagged ensemble metadata
-    surface_temp = iris.load_strict(iris.sample_data_path('GloSea4', 'ensemble_???.pp'),
+    surface_temp = iris.load_cube(iris.sample_data_path('GloSea4', 'ensemble_???.pp'),
                   iris.Constraint('surface_temperature', realization=lambda value: True),
                   callback=realization_metadata,
                   )

--- a/docs/iris/example_code/graphics/lineplot_with_legend.py
+++ b/docs/iris/example_code/graphics/lineplot_with_legend.py
@@ -12,7 +12,7 @@ def main():
     fname = iris.sample_data_path('air_temp.pp')
     
     # Load exactly one cube from the given file
-    temperature = iris.load_strict(fname)
+    temperature = iris.load_cube(fname)
     
     # We only want a small number of latitudes, so filter some out using "extract".
     temperature = temperature.extract(iris.Constraint(latitude=lambda cell: 68 <= cell < 78))

--- a/docs/iris/example_code/graphics/rotated_pole_mapping.py
+++ b/docs/iris/example_code/graphics/rotated_pole_mapping.py
@@ -21,7 +21,7 @@ import iris.analysis.cartography
 
 def main():
     fname = iris.sample_data_path('rotated_pole.nc')
-    temperature = iris.load_strict(fname)
+    temperature = iris.load_cube(fname)
     
     # Plot #1: Point plot showing data values & a colorbar
     plt.figure()

--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -21,7 +21,7 @@ Calculating the difference between two cubes
 Let's load some air temperature which runs from 1860 to 2100::
 
     filename = iris.sample_data_path('E1_north_america.nc')
-    air_temp = iris.load_strict(filename, 'air_temperature')
+    air_temp = iris.load_cube(filename, 'air_temperature')
 
 We could now get the first and last time slices using indexing (see :doc:`reducing_a_cube` for a reminder)::
 
@@ -31,7 +31,7 @@ We could now get the first and last time slices using indexing (see :doc:`reduci
 .. testsetup::
 
     filename = iris.sample_data_path('E1_north_america.nc')
-    cube = iris.load_strict(filename, 'air_temperature')
+    cube = iris.load_cube(filename, 'air_temperature')
     t_first = cube[0, :, :]
     t_last = cube[-1, :, :]
 
@@ -72,7 +72,7 @@ First, let's load pressure and potential temperature cubes::
 
     filename = iris.sample_data_path('colpex.pp')
     phenomenon_names = ['air_potential_temperature', 'air_pressure']
-    pot_temperature, pressure = iris.load_strict(filename, phenomenon_names)
+    pot_temperature, pressure = iris.load_cubes(filename, phenomenon_names)
 
 In order to calculate :math:`\frac{p}{p_0}` we can define a coordinate which represents the standard reference pressure of 1000 hPa::
 

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -10,7 +10,7 @@ Collapsing entire data dimensions
 
     import iris
     filename = iris.sample_data_path('uk_hires.pp')
-    cube = iris.load_strict(filename, 'air_potential_temperature')
+    cube = iris.load_cube(filename, 'air_potential_temperature')
 
     import iris.analysis.cartography
     cube.coord('grid_latitude').guess_bounds()
@@ -23,7 +23,7 @@ Instead of downsampling the data, a similar goal can be achieved using statistic
 
     >>> import iris
     >>> filename = iris.sample_data_path('uk_hires.pp')
-    >>> cube = iris.load_strict(filename, 'air_potential_temperature')
+    >>> cube = iris.load_cube(filename, 'air_potential_temperature')
     >>> print cube
     air_potential_temperature           (time: 3; model_level_number: 7; grid_latitude: 204; grid_longitude: 187)
          Dimension coordinates:
@@ -137,7 +137,7 @@ First, let's create two coordinates on a cube which represent the climatological
     import iris.coord_categorisation
 
     filename = iris.sample_data_path('ostia_monthly.nc')
-    cube = iris.load_strict(filename, 'surface_temperature')
+    cube = iris.load_cube(filename, 'surface_temperature')
 
     iris.coord_categorisation.add_season(cube, 'time', name='clim_season')
     iris.coord_categorisation.add_season_year(cube, 'time', name='season_year')
@@ -148,7 +148,7 @@ First, let's create two coordinates on a cube which represent the climatological
     import iris
 
     filename = iris.sample_data_path('ostia_monthly.nc')
-    cube = iris.load_strict(filename, 'surface_temperature')
+    cube = iris.load_cube(filename, 'surface_temperature')
 
     import iris.coord_categorisation
     iris.coord_categorisation.add_season(cube, 'time', name='clim_season')

--- a/docs/iris/src/userguide/iris_cubes.rst
+++ b/docs/iris/src/userguide/iris_cubes.rst
@@ -151,7 +151,7 @@ output as this is the quickest way of inspecting the contents of a cube. Here is
      import iris
      filename = iris.sample_data_path('uk_hires.pp')
      # NOTE: Every time the output of this cube changes, the full list of deductions below should be re-assessed. 
-     print iris.load_strict(filename, 'air_potential_temperature')
+     print iris.load_cube(filename, 'air_potential_temperature')
      
 .. testoutput::
 

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -190,26 +190,32 @@ when loading ``PP`` files, then specific STASH codes can be filtered::
 Strict loading
 --------------
 
-The :py:func:`iris.load_strict` function is similar to :py:func:`iris.load` except that it can only return *one cube per constraint*.
-Providing no constraints to :func:`iris.load_strict` is equivalent to requesting exactly one cube of any type. 
+The :py:func:`iris.load_cube` and :py:func:`iris.load_cubes` functions are
+similar to :py:func:`iris.load` except they can only return *one cube per constraint*.
+The :func:`iris.load_cube` function accepts a single constraint and
+returns a single cube. The :func:`iris.load_cubes` function accepts any
+number of constraints and returns a list of cubes (as an `iris.cube.CubeList`).
+Providing no constraints to :func:`iris.load_cube` or :func:`iris.load_cubes`
+is equivalent to requesting exactly one cube of any type. 
 
 A single cube is loaded in the following example::
 
     filename = iris.sample_data_path('air_temp.pp')
-    cube = iris.load_strict(filename)
+    cube = iris.load_cube(filename)
     print cube
 
 However, when attempting to load data which would result in anything other than one cube, an exception is raised::
 
     filename = iris.sample_data_path('uk_hires.pp')
-    cube = iris.load_strict(filename)
+    cube = iris.load_cube(filename)
 
 .. note::
  
-    :func:`iris.load_strict` and :py:func:`iris.load` share many of the same features, hence multiple
+    All the load functions share many of the same features, hence multiple
     files could be loaded with wildcard filenames or by providing a list of filenames.
 
-The strict nature of :py:func:`iris.load_strict` means that, when combined with constrained loading, it is 
+The strict nature of :func:`iris.load_cube` and :func:`iris.load_cubes`
+means that, when combined with constrained loading, it is 
 possible to ensure that precisely what was asked for on load is given - otherwise an exception is raised. 
 This fact can be utilised to make code only run successfully if the data provided has the expected criteria.
 
@@ -217,18 +223,18 @@ For example, suppose that code needed ``air_potential_temperature`` in order to 
 
     import iris
     filename = iris.sample_data_path('uk_hires.pp')
-    air_pot_temp = iris.load_strict(filename, 'air_potential_temperature')
+    air_pot_temp = iris.load_cube(filename, 'air_potential_temperature')
     print air_pot_temp
 
-Should the file not contain exactly one cube with a standard name of air potential temperature, an exception will be raised.
+Should the file not produce exactly one cube with a standard name of air potential temperature, an exception will be raised.
 
 Similarly, supposing a routine needed both 'surface_altitude' and 'air_potential_temperature' to be able to run::
 
     import iris
     filename = iris.sample_data_path('uk_hires.pp')
-    altitude_cube, pot_temp_cube = iris.load_strict(filename, ['surface_altitude', 'air_potential_temperature'])
+    altitude_cube, pot_temp_cube = iris.load_cubes(filename, ['surface_altitude', 'air_potential_temperature'])
 
-The result of :func:`iris.load_strict` in this case will be a list of 2 cubes ordered by the constraints provided. 
+The result of :func:`iris.load_cubes` in this case will be a list of 2 cubes ordered by the constraints provided. 
 Multiple assignment has been used to put these two cubes into separate variables.
 
 .. note::

--- a/docs/iris/src/userguide/navigating_a_cube.rst
+++ b/docs/iris/src/userguide/navigating_a_cube.rst
@@ -6,8 +6,8 @@ Navigating a cube
 
         import iris
         filename = iris.sample_data_path('rotated_pole.nc')
-        # pot_temp = iris.load_strict(filename, 'air_potential_temperature')
-        cube = iris.load_strict(filename)
+        # pot_temp = iris.load_cube(filename, 'air_potential_temperature')
+        cube = iris.load_cube(filename)
         coord_names = [coord.name() for coord in cube.coords()]
         coord = cube.coord('grid_latitude')
 
@@ -22,7 +22,7 @@ We have already seen a basic string representation of a cube when printing:
 
     >>> import iris
     >>> filename = iris.sample_data_path('rotated_pole.nc')
-    >>> cube = iris.load_strict(filename)
+    >>> cube = iris.load_cube(filename)
     >>> print cube
     air_pressure_at_sea_level           (grid_latitude: 22; grid_longitude: 36)
          Dimension coordinates:
@@ -173,7 +173,7 @@ This is often caused by one of the following:
  * There is not enough metadata loaded from the original file as Iris has not handled the format fully. *(in which case, 
    please let us know about it)*
 
-To solve this, both :func:`iris.load` and :func:`iris.load_strict` support a callback keyword. 
+To solve this, all of :func:`iris.load`, :func:`iris.load_cube`, and :func:`iris.load_cubes` support a callback keyword. 
 
 The callback is a user defined function which must have the calling sequence ``function(cube, field, filename)`` 
 which can make any modifications to the cube in-place.

--- a/docs/iris/src/userguide/plotting_examples/1d_quickplot_simple.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_quickplot_simple.py
@@ -4,7 +4,7 @@ import iris
 import iris.quickplot as qplt
 
 fname = iris.sample_data_path('air_temp.pp')
-temperature = iris.load_strict(fname)
+temperature = iris.load_cube(fname)
 
 # Take a 1d slice using array style indexing.
 temperature_1d = temperature[5, :]

--- a/docs/iris/src/userguide/plotting_examples/1d_simple.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_simple.py
@@ -4,7 +4,7 @@ import iris
 import iris.plot as iplt
 
 fname = iris.sample_data_path('air_temp.pp')
-temperature = iris.load_strict(fname)
+temperature = iris.load_cube(fname)
 
 # Take a 1d slice using array style indexing.
 temperature_1d = temperature[5, :]

--- a/docs/iris/src/userguide/plotting_examples/1d_with_legend.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_with_legend.py
@@ -7,7 +7,7 @@ import iris.quickplot as qplt
 fname = iris.sample_data_path('air_temp.pp')
 
 # Load exactly one cube from the given file
-temperature = iris.load_strict(fname)
+temperature = iris.load_cube(fname)
 
 # We are only interested in a small number of longitudes (the 4 after and including the 5th element), so index them out
 temperature = temperature[5:9, :]

--- a/docs/iris/src/userguide/plotting_examples/cube_blockplot.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_blockplot.py
@@ -5,7 +5,7 @@ import iris.quickplot as qplt
 import iris.plot as iplt
 
 fname = iris.sample_data_path('air_temp.pp')
-temperature_cube = iris.load_strict(fname)
+temperature_cube = iris.load_cube(fname)
 
 # put bounds on the latitude and longitude coordinates
 temperature_cube.coord('latitude').guess_bounds()

--- a/docs/iris/src/userguide/plotting_examples/cube_contour.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_contour.py
@@ -6,7 +6,7 @@ import iris.quickplot as qplt
 
 fname = iris.sample_data_path('air_temp.pp')
 
-temperature_cube = iris.load_strict(fname)
+temperature_cube = iris.load_cube(fname)
 
 # Add a contour, and put the result in a variable called contour.
 contour = qplt.contour(temperature_cube)

--- a/docs/iris/src/userguide/plotting_examples/cube_contourf.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_contourf.py
@@ -5,7 +5,7 @@ import iris.quickplot as qplt
 import iris.plot as iplt
 
 fname = iris.sample_data_path('air_temp.pp')
-temperature_cube = iris.load_strict(fname)
+temperature_cube = iris.load_cube(fname)
 
 # Draw the contour with 25 levels
 qplt.contourf(temperature_cube, 25)

--- a/docs/iris/src/userguide/reducing_a_cube.rst
+++ b/docs/iris/src/userguide/reducing_a_cube.rst
@@ -16,7 +16,7 @@ Cube extraction
 A subset of a cube can be "extracted" from a multi-dimensional cube in order to reduce its dimensionality::
 
     filename = iris.sample_data_path('hybrid_height.pp')
-    cube = iris.load_strict(filename)
+    cube = iris.load_cube(filename)
     print cube
     equator_slice = cube.extract(iris.Constraint(grid_latitude=0))
     print equator_slice
@@ -52,7 +52,7 @@ For example to get a ``model_level_number`` of 10 at the equator the following l
 The two steps required to get ``model_level_number`` of 10 at the equator can be simplified into a single constraint::
 
 	filename = iris.sample_data_path('PP', 'globClim1', 'theta.pp')
-	cube = iris.load_strict(filename)
+	cube = iris.load_cube(filename)
 	equator_model_level_10_slice = cube.extract(iris.Constraint(grid_latitude=0, model_level_number=10))
 	print equator_model_level_10_slice
 
@@ -75,7 +75,7 @@ which make up the full 3d cube.::
 
 	import iris
 	filename = iris.sample_data_path('hybrid_height.nc')
-	cube = iris.load_strict(filename)
+	cube = iris.load_cube(filename)
 	print cube
 	for yx_slice in cube.slices(['grid_latitude', 'grid_longitude']):
 	   print repr(yx_slice)
@@ -94,7 +94,7 @@ This method can handle n-dimensional slices by providing more or fewer coordinat
 
 	import iris
 	filename = iris.sample_data_path('hybrid_height.nc')
-	cube = iris.load_strict(filename)
+	cube = iris.load_cube(filename)
 	print cube
 	for i, x_slice in enumerate(cube.slices(['grid_longitude'])):
 	   print i, repr(x_slice)
@@ -153,7 +153,7 @@ Similarly, Iris cubes have indexing capability::
 
 	import iris
         filename = iris.sample_data_path('hybrid_height.nc')
-	cube = iris.load_strict(filename)
+	cube = iris.load_cube(filename)
 
 	print cube
 

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -51,18 +51,18 @@ class Constraint(object):
             The name of the argument gives the name of a coordinate, and the value
             of the argument is the condition to meet on that coordinate::
             
-                Constraint(model_level=10)
+                Constraint(model_level_number=10)
                 
             Coordinate level constraints can be of several types:
             
-            * **string, int or float** - the value of the coordinate to match. e.g. ``model_level=10``
+            * **string, int or float** - the value of the coordinate to match. e.g. ``model_level_number=10``
             
             * **list of values** - the possible values that the coordinate may have to match. 
-              e.g. ``model_level=[10, 12]``
+              e.g. ``model_level_number=[10, 12]``
             
             * **callable** - a function which accepts a :class:`iris.coords.Cell` instance as its first 
               and only argument returning True or False if the value of the Cell is desired.
-              e.g. ``model_level=lambda cell: 5 < cell < 10``
+              e.g. ``model_level_number=lambda cell: 5 < cell < 10``
         
         
         The :ref:`user guide <loading_iris_cubes>` covers cube much of constraining in detail, however an example which
@@ -71,7 +71,7 @@ class Constraint(object):
             Constraint(name='air_potential_temperature', 
                        cube_func=lambda cube: cube.units == 'kelvin',
                        coord_values={'latitude':lambda cell: 0 < cell < 90}, 
-                       model_level=[10, 12]) & Constraint(ensemble_member=2)
+                       model_level_number=[10, 12]) & Constraint(ensemble_member=2)
         
         Constraint filtering is performed at the cell level. For further details on how cell comparisons are performed 
         see :class:`iris.coords.Cell`.

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -22,7 +22,6 @@ Various utilities and numeric transformations relevant to cartography.
 import math
 import warnings
 
-import pyproj
 import numpy
 import cartopy.crs
 
@@ -54,6 +53,7 @@ def _proj4(pole_lon, pole_lat):
     proj4_params = {'proj': 'ob_tran', 'o_proj': 'latlon', 'o_lon_p': 0,
         'o_lat_p': pole_lat, 'lon_0': 180 + pole_lon,
         'to_meter': math.degrees(1)}
+    from mpl_toolkits.basemap import pyproj
     proj = pyproj.Proj(proj4_params)
     return proj
 

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -93,7 +93,7 @@ def nearest_neighbour_indices(cube, sample_points):
     dimensions. Any dimensions unspecified will default to a full slice.
 
     For example:
-        >>> cube = iris.load_strict(iris.sample_data_path('ostia_monthly.nc'))
+        >>> cube = iris.load_cube(iris.sample_data_path('ostia_monthly.nc'))
         >>> iris.analysis.interpolate.nearest_neighbour_indices(cube, [('latitude', 0), ('longitude', 10)])
         (slice(None, None, None), 9, 12)
         >>> iris.analysis.interpolate.nearest_neighbour_indices(cube, [('latitude', 0)])
@@ -295,7 +295,7 @@ def extract_nearest_neighbour(cube, sample_points):
     dimensions. Any dimensions unspecified will default to a full slice.
 
     For example:
-        >>> cube = iris.load_strict(iris.sample_data_path('ostia_monthly.nc'))
+        >>> cube = iris.load_cube(iris.sample_data_path('ostia_monthly.nc'))
         >>> iris.analysis.interpolate.extract_nearest_neighbour(cube, [('latitude', 0), ('longitude', 10)])
         <iris 'Cube' of surface_temperature (time: 54)>
         >>> iris.analysis.interpolate.extract_nearest_neighbour(cube, [('latitude', 0)])
@@ -323,7 +323,7 @@ def nearest_neighbour_data_value(cube, sample_points):
     dimensions.
 
     For example:
-        >>> cube = iris.load_strict(iris.sample_data_path('air_temp.pp'))
+        >>> cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
         >>> iris.analysis.interpolate.nearest_neighbour_data_value(cube, [('latitude', 0), ('longitude', 10)])
         299.21564
         >>> iris.analysis.interpolate.nearest_neighbour_data_value(cube, [('latitude', 0)])

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -51,7 +51,7 @@ def izip(*cubes, **kwargs):
         A tuple of iterators for the resulting slices.
     
     For example:
-        >>> e_content, e_density = iris.load_strict(iris.sample_data_path('space_weather.nc'),
+        >>> e_content, e_density = iris.load_cubes(iris.sample_data_path('space_weather.nc'),
         ...    ['total electron content', 'electron density'])
         >>> for tslice, hslice in iris.iterate.izip(e_content, e_density, coords=['grid_latitude','grid_longitude']):
         ...    pass

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -56,13 +56,13 @@ def global_pp():
         cube.standard_name = 'air_temperature'
         cube.units = 'K'
     path = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
-    cube = iris.load_strict(path, callback=callback_global_pp)
+    cube = iris.load_cube(path, callback=callback_global_pp)
     return cube
 
 
 def simple_pp():
     filename = tests.get_data_path(['PP', 'simple_pp', 'global.pp'])   # Differs from global_pp()
-    cube = iris.load_strict(filename)
+    cube = iris.load_cube(filename)
     return cube
 
 
@@ -296,7 +296,7 @@ def realistic_4d():
     """
     # the stock arrays were created in Iris 0.8 with:
 #    >>> fname = iris.sample_data_path('PP', 'COLPEX', 'theta_and_orog_subset.pp')
-#    >>> theta = iris.load_strict(fname, 'air_potential_temperature')
+#    >>> theta = iris.load_cube(fname, 'air_potential_temperature')
 #    >>> for coord in theta.coords():
 #    ...  print coord.name, coord.has_points(), coord.has_bounds(), coord.units
 #    ... 
@@ -397,5 +397,5 @@ def realistic_4d_w_missing_data():
 
 def global_grib2():
     path = tests.get_data_path(('GRIB', 'global_t', 'global.grib2'))
-    cube = iris.load_strict(path)
+    cube = iris.load_cube(path)
     return cube

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -65,7 +65,7 @@ class SystemInitialTest(tests.IrisTest):
             saved_tmpfile = iris.util.create_temp_filename(suffix=filetype)
             iris.save(cm, saved_tmpfile)
 
-            new_cube = iris.load_strict(saved_tmpfile)
+            new_cube = iris.load_cube(saved_tmpfile)
         
             self.assertCML(new_cube, ('system', 'supported_filetype_%s.cml' % filetype))
 

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -390,7 +390,7 @@ class TestRotatedPole(tests.IrisTest):
 
     def test_all(self):
         path = tests.get_data_path(('PP', 'ukVorog', 'ukv_orog_refonly.pp'))
-        master_cube = iris.load_strict(path)
+        master_cube = iris.load_cube(path)
 
         # Check overall behaviour
         cube = master_cube[::10, ::10]

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -232,7 +232,7 @@ class TestStockCubeStringRepresentations(tests.IrisTest):
 class TestCubeStringRepresentations(IrisDotTest):
     def setUp(self):
         path = tests.get_data_path(('PP', 'simple_pp', 'global.pp'))
-        self.cube_2d = iris.load_strict(path)
+        self.cube_2d = iris.load_cube(path)
 
     def test_dot_simple_pp(self):
         # Test dot output of a 2d cube loaded from pp.
@@ -321,7 +321,7 @@ class TestCubeStringRepresentations(IrisDotTest):
 @iris.tests.skip_data
 class TestValidity(tests.IrisTest):
     def setUp(self):
-        self.cube_2d = iris.load_strict(tests.get_data_path(('PP', 'simple_pp', 'global.pp')))
+        self.cube_2d = iris.load_cube(tests.get_data_path(('PP', 'simple_pp', 'global.pp')))
 
     def test_wrong_length_vector_coord(self):
         wobble = iris.coords.DimCoord(points=[1, 2], long_name='wobble', units='1')
@@ -561,7 +561,7 @@ class Test2dExtractionByCoord(TestCube2d):
 @iris.tests.skip_data
 class TestCubeExtract(tests.IrisTest):
     def setUp(self):
-        self.single_cube = iris.load_strict(tests.get_data_path(('PP', 'globClim1', 'theta.pp')), 'air_potential_temperature')
+        self.single_cube = iris.load_cube(tests.get_data_path(('PP', 'globClim1', 'theta.pp')), 'air_potential_temperature')
 
     def test_simple(self):
         constraint = iris.Constraint(latitude=10)
@@ -702,7 +702,7 @@ class TestCubeEquality(TestCube2d):
 @iris.tests.skip_data
 class TestDataManagerIndexing(TestCube2d):
     def setUp(self):
-        self.cube = iris.load_strict(tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp')))
+        self.cube = iris.load_cube(tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp')))
         self.pa = self.cube._data
         self.dm = self.cube._data_manager
         self.data_array = self.dm.load(self.pa)
@@ -916,17 +916,17 @@ class TestTrimAttributes(tests.IrisTest):
 class TestMaskedData(tests.IrisTest, pp.PPTest):
     def _load_3d_cube(self):
         # This 3D data set has a missing a slice with SOME missing values (0)
-        return iris.load_strict(tests.get_data_path(["PP", "mdi_handmade_small", "*.pp"]))
+        return iris.load_cube(tests.get_data_path(["PP", "mdi_handmade_small", "*.pp"]))
     
     def test_complete_field(self):
         # This pp field has no missing data values
-        cube = iris.load_strict(tests.get_data_path(["PP", "mdi_handmade_small", "mdi_test_1000_3.pp"]))
+        cube = iris.load_cube(tests.get_data_path(["PP", "mdi_handmade_small", "mdi_test_1000_3.pp"]))
 
         self.assertTrue(isinstance(cube.data, numpy.ndarray), "Expected a numpy.ndarray")
 
     def test_masked_field(self):
         # This pp field has some missing data values
-        cube = iris.load_strict(tests.get_data_path(["PP", "mdi_handmade_small", "mdi_test_1000_0.pp"]))
+        cube = iris.load_cube(tests.get_data_path(["PP", "mdi_handmade_small", "mdi_test_1000_0.pp"]))
         self.assertTrue(isinstance(cube.data, numpy.ma.core.MaskedArray), "Expected a numpy.ma.core.MaskedArray")
 
     def test_missing_file(self):
@@ -965,7 +965,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
             iris.save(masked_slice, temp_pp_path)
         
             # test merge keeps the mdi we just saved
-            cube1 = iris.load_strict(temp_pp_path)
+            cube1 = iris.load_cube(temp_pp_path)
             cube2 = cube1.copy()
             # make cube1 and cube2 differ on a scalar coord, to make them mergeable into a 3d cube
             cube2.coord("pressure").points[0] = 1001.0

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -172,17 +172,17 @@ class TestCFReader(tests.IrisTest):
 class TestLoad(tests.IrisTest):
     def test_attributes_empty(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc'))
-        cube = iris.load_strict(filename)
+        cube = iris.load_cube(filename)
         self.assertEquals(cube.coord('height').attributes, {})
         
     def test_attributes_populated(self):
         filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'FC_167_mon_19601101.nc'))
-        cube = iris.load_strict(filename)
+        cube = iris.load_cube(filename)
         self.assertEquals(sorted(cube.coord('longitude').attributes.items()), [('data_type', 'float'), ('modulo', 360), ('topology', 'circular')])
 
     def test_cell_methods(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc'))
-        cube = iris.load_strict(filename)
+        cube = iris.load_cube(filename)
         self.assertEquals(cube.cell_methods, (iris.coords.CellMethod(method=u'mean', coords=(u'time',), intervals=(u'6 minutes',), comments=()),))
 
 

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -259,7 +259,7 @@ class TestCubeListStrictConstraint(StrictConstraintMixin, tests.IrisTest):
 class TestCubeExtract(TestMixin, tests.IrisTest):
     def setUp(self):
         TestMixin.setUp(self)
-        self.cube = iris.load_strict(self.theta_path)
+        self.cube = iris.load_cube(self.theta_path)
 
     def test_attribute_constraint(self):
         # there is no my_attribute attribute on the cube, so ensure it returns None
@@ -325,19 +325,19 @@ class TestConstraints(TestMixin, tests.IrisTest):
 
     def test_number_of_raw_cubes(self):
         # Test the constraints generate the correct number of raw cubes.    
-        raw_cubes = iris._load_common(self.theta_path, None, strict=False, unique=False, merge=False)
+        raw_cubes = iris.load_raw(self.theta_path)
         self.assertEqual(len(raw_cubes), 38)
 
-        raw_cubes = iris._load_common(self.theta_path, [self.level_10], strict=False, unique=False, merge=False)
+        raw_cubes = iris.load_raw(self.theta_path, [self.level_10])
         self.assertEqual(len(raw_cubes), 1)
 
-        raw_cubes = iris._load_common(self.theta_path, [self.theta], strict=False, unique=False, merge=False)
+        raw_cubes = iris.load_raw(self.theta_path, [self.theta])
         self.assertEqual(len(raw_cubes), 38)
 
-        raw_cubes = iris._load_common(self.dec_path, [self.level_30], strict=False, unique=False, merge=False)
+        raw_cubes = iris.load_raw(self.dec_path, [self.level_30])
         self.assertEqual(len(raw_cubes), 4)
 
-        raw_cubes = iris._load_common(self.dec_path, [self.theta], strict=False, unique=False, merge=False)
+        raw_cubes = iris.load_raw(self.dec_path, [self.theta])
         self.assertEqual(len(raw_cubes), 38)
        
 

--- a/lib/iris/tests/test_file_load.py
+++ b/lib/iris/tests/test_file_load.py
@@ -32,7 +32,7 @@ class TestFileload(tests.IrisTest):
         reference file if it doesn't exist.
 
         """
-        cubes = iris.load(tests.get_data_path(src_path), merge=False)
+        cubes = iris.load_raw(tests.get_data_path(src_path))
         self.assertCML(cubes, ['file_load', reference_filename])
 
     def test_no_file(self):

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -58,8 +58,8 @@ def save_by_filehandle(filehandle1, filehandle2, cube, fn_saver, binary_mode = T
 class TestSaveMethods(tests.IrisTest):
     """ Base class for file saving tests. Loads data and creates/deletes tempfiles"""
     def setUp(self):
-        self.cube1 = iris.load_strict(tests.get_data_path(('PP', 'aPPglob1', 'global.pp')))
-        self.cube2 = iris.load_strict(tests.get_data_path(('PP', 'aPPglob1', 'global_t_forecast.pp')))
+        self.cube1 = iris.load_cube(tests.get_data_path(('PP', 'aPPglob1', 'global.pp')))
+        self.cube2 = iris.load_cube(tests.get_data_path(('PP', 'aPPglob1', 'global_t_forecast.pp')))
         self.temp_filename1 = iris.util.create_temp_filename(self.ext)
         self.temp_filename2 = iris.util.create_temp_filename(self.ext)
 

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -134,7 +134,7 @@ class TestGribLoad(tests.GraphicsTest):
         # Test custom rule evaluation.
         # Default behaviour
 #        data_path = tests.get_data_path(('GRIB', 'global_t', 'global.grib2'))
-#        cube = iris.load_strict(data_path)
+#        cube = iris.load_cube(data_path)
         cube = tests.stock.global_grib2()
         self.assertEqual(cube.name(), 'air_temperature')
 
@@ -164,19 +164,19 @@ class TestGribLoad(tests.GraphicsTest):
     def test_fp_units(self):
 
         """Test different units for forecast period (just the ones we care about)."""
-        cube = iris.load_strict(tests.get_data_path(('GRIB', 'fp_units', 'minutes.grib2')))
+        cube = iris.load_cube(tests.get_data_path(('GRIB', 'fp_units', 'minutes.grib2')))
         self.assertEqual(cube.coord("forecast_period").units, "hours")
         self.assertEqual(cube.coord("forecast_period").points[0], 24)
 
-        cube = iris.load_strict(tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2')))
+        cube = iris.load_cube(tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2')))
         self.assertEqual(cube.coord("forecast_period").units, "hours")
         self.assertEqual(cube.coord("forecast_period").points[0], 24)
 
-        cube = iris.load_strict(tests.get_data_path(('GRIB', 'fp_units', 'days.grib2')))
+        cube = iris.load_cube(tests.get_data_path(('GRIB', 'fp_units', 'days.grib2')))
         self.assertEqual(cube.coord("forecast_period").units, "hours")
         self.assertEqual(cube.coord("forecast_period").points[0], 24)
         
-        cube = iris.load_strict(tests.get_data_path(('GRIB', 'fp_units', 'seconds.grib2')))
+        cube = iris.load_cube(tests.get_data_path(('GRIB', 'fp_units', 'seconds.grib2')))
         self.assertEqual(cube.coord("forecast_period").units, "hours")
         self.assertEqual(cube.coord("forecast_period").points[0], 24)
  

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -39,7 +39,7 @@ class TestHybridHeight(tests.IrisTest):
         # Load the COLPEX data => TZYX
         path = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog.pp'))
         
-        phenom = iris.load_strict(path, 'air_potential_temperature')
+        phenom = iris.load_cube(path, 'air_potential_temperature')
 
         # Select a ZX cross-section.
         cross_section = phenom[0, :, 0, :]

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -375,7 +375,7 @@ class TestLinear1dInterpolation(tests.IrisTest):
 class TestNearestLinearInterpolRealData(tests.IrisTest):
     def setUp(self):
         file = tests.get_data_path(('PP', 'globClim1', 'theta.pp'))
-        self.cube = iris.load_strict(file)
+        self.cube = iris.load_cube(file)
 
     def test_slice(self):
         r = iris.analysis.interpolate.linear(self.cube, [('latitude', 0)])

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -84,7 +84,7 @@ class TestFileFormatPicker(tests.IrisTest):
 class TestFileExceptions(tests.IrisTest):
     def test_pp_little_endian(self):
         filename = tests.get_data_path(('PP', 'aPPglob1', 'global_little_endian.pp'))
-        self.assertRaises(ValueError, iris.load_strict, filename)
+        self.assertRaises(ValueError, iris.load_cube, filename)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/test_load.py
+++ b/lib/iris/tests/test_load.py
@@ -1,0 +1,114 @@
+# (C) British Crown Copyright 2010 - 2012, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test the main loading API.
+
+"""
+# import iris tests first so that some things can be initialised before importing anything else
+import iris.tests as tests
+
+import iris
+import iris.tests.stock as stock
+
+
+class TestLoad(tests.IrisTest):
+    def test_normal(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        cubes = iris.load(paths)
+        self.assertEqual(len(cubes), 1)
+
+    def test_bogus(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        cubes = iris.load(paths, 'wibble')
+        self.assertEqual(len(cubes), 0)
+
+    def test_real_and_bogus(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        cubes = iris.load(paths, ('air_temperature', 'wibble'))
+        self.assertEqual(len(cubes), 1)
+
+    def test_duplicate(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+            tests.get_data_path(['PP', 'aPPglob1', 'gl?bal.pp'])
+        )
+        cubes = iris.load(paths)
+        self.assertEqual(len(cubes), 2)
+
+
+class TestLoadCube(tests.IrisTest):
+    def test_normal(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        cube = iris.load_cube(paths)
+
+    def test_not_enough(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        with self.assertRaises(iris.exceptions.ConstraintMismatchError):
+            iris.load_cube(paths, 'wibble')
+
+    def test_too_many(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+            tests.get_data_path(['PP', 'aPPglob1', 'gl?bal.pp'])
+        )
+        with self.assertRaises(iris.exceptions.ConstraintMismatchError):
+            iris.load_cube(paths)
+
+
+class TestLoadCubes(tests.IrisTest):
+    def test_normal(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        cubes = iris.load_cubes(paths)
+        self.assertEqual(len(cubes), 1)
+
+    def test_not_enough(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        with self.assertRaises(iris.exceptions.ConstraintMismatchError):
+            iris.load_cubes(paths, 'wibble')
+
+    def test_not_enough_multi(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+        )
+        with self.assertRaises(iris.exceptions.ConstraintMismatchError):
+            iris.load_cubes(paths, ('air_temperature', 'wibble'))
+
+    def test_too_many(self):
+        paths = (
+            tests.get_data_path(['PP', 'aPPglob1', 'global.pp']),
+            tests.get_data_path(['PP', 'aPPglob1', 'gl?bal.pp'])
+        )
+        with self.assertRaises(iris.exceptions.ConstraintMismatchError):
+            iris.load_cube(paths)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -92,7 +92,7 @@ def _pretend_unrotated(cube):
 class TestMappingSubRegion(tests.IrisTest):
     def setUp(self):
         cube_path = tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp'))
-        cube = iris.load_strict(cube_path)[0]
+        cube = iris.load_cube(cube_path)[0]
         # make the data slighly smaller to speed things up...
         self.cube = cube[::10, ::10]
 
@@ -181,7 +181,7 @@ class TestBoundedCube(tests.IrisTest):
 class TestLimitedAreaCube(tests.IrisTest):
     def setUp(self):
         cube_path = tests.get_data_path(('PP', 'aPProt1', 'rotated.pp'))
-        self.cube = iris.load_strict(cube_path)[::20, ::20]
+        self.cube = iris.load_cube(cube_path)[::20, ::20]
         self.cube.coord('grid_latitude').guess_bounds()
         self.cube.coord('grid_longitude').guess_bounds()
 

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -81,7 +81,7 @@ class TestMultiCube(tests.IrisTest, TestMixin):
             cube.coord('time').attributes['brain'] = 'hurts'
         
         # Load slices, decorating a coord with custom attributes
-        cubes = iris._load_cubes(self._data_path, callback=custom_coord_callback)
+        cubes = iris.load_raw(self._data_path, callback=custom_coord_callback)
         # Merge
         merged = iris.cube.CubeList._extract_and_merge(cubes, constraints=None, strict=False, merge_unique=False)
         # Check the custom attributes are in the merged cube
@@ -110,20 +110,20 @@ class TestDataMerge(tests.IrisTest):
         forecast_period_constraint1 = iris.Constraint(forecast_period=1.1666666753590107)
         forecast_period_constraint2 = iris.Constraint(forecast_period=1.3333333320915699)
         forecast_period_constraint1_and_2 = iris.Constraint(forecast_period=lambda c: c in [1.1666666753590107, 1.3333333320915699])
-        cube1 = iris.load_strict(data_path, phenom_constraint & forecast_period_constraint1)
-        cube2 = iris.load_strict(data_path, phenom_constraint & forecast_period_constraint2)
+        cube1 = iris.load_cube(data_path, phenom_constraint & forecast_period_constraint1)
+        cube2 = iris.load_cube(data_path, phenom_constraint & forecast_period_constraint2)
         
         # Merge the two halves
         cubes = iris.cube.CubeList([cube1, cube2]).merge(True)
         self.assertCML(cubes, ('merge', 'theta_two_forecast_periods.cml'))
 
         # Make sure we get the same result directly from load
-        cube = iris.load_strict(data_path, phenom_constraint & (forecast_period_constraint1_and_2))
+        cube = iris.load_cube(data_path, phenom_constraint & (forecast_period_constraint1_and_2))
         self.assertCML(cubes, ('merge', 'theta_two_forecast_periods.cml'))
 
     def test_real_data(self):
         data_path = tests.get_data_path(('PP', 'globClim1', 'theta.pp'))
-        cubes = iris._load_common(data_path, None, strict=False, unique=False, merge=False)
+        cubes = iris.load_raw(data_path)
         # Force the source 2-D cubes to load their data before the merge
         for cube in cubes:
             data = cube.data

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -37,12 +37,12 @@ import stock
 class TestNetCDFLoad(tests.IrisTest):
     def test_load_global_xyt_total(self):
         # Test loading single xyt CF-netCDF file.
-        cube = iris.load_strict(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')))
+        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_global_xyt_total.cml')) 
 
     def test_load_global_xyt_hires(self):
         # Test loading another single xyt CF-netCDF file.
-        cube = iris.load_strict(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc')))
+        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_global_xyt_hires.cml'))
 
     def test_load_global_xyzt_gems(self):
@@ -62,12 +62,12 @@ class TestNetCDFLoad(tests.IrisTest):
 
     def test_load_rotated_xy_land(self):
         # Test loading single xy rotated pole CF-netCDF file.
-        cube = iris.load_strict(tests.get_data_path(('NetCDF', 'rotated', 'xy', 'rotPole_landAreaFraction.nc')))
+        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'rotated', 'xy', 'rotPole_landAreaFraction.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xy_land.cml'))
 
     def test_load_rotated_xyt_precipitation(self):
         # Test loading single xyt rotated pole CF-netCDF file.
-        cube = iris.load_strict(tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc')))
+        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xyt_precipitation.cml'))
 
     def test_cell_methods(self):
@@ -82,7 +82,7 @@ class TestNetCDFLoad(tests.IrisTest):
     def test_deferred_loading(self):
         # Test exercising CF-netCDF deferred loading and deferred slicing.
         # shape (31, 161, 320)
-        cube = iris.load_strict(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')))
+        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')))
         
         # Consecutive index on same dimension.
         self.assertCML(cube[0], ('netcdf', 'netcdf_deferred_index_0.cml'))
@@ -153,7 +153,7 @@ class TestNetCDFSave(tests.IrisTest):
     def test_netcdf_save_format(self):
         # Read netCDF input file.
         file_in = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc'))
-        cube = iris.load_strict(file_in)
+        cube = iris.load_cube(file_in)
 
         file_out = iris.util.create_temp_filename(suffix='.nc')
 
@@ -191,7 +191,7 @@ class TestNetCDFSave(tests.IrisTest):
         # Test saving a single CF-netCDF file.
         # Read PP input file. 
         file_in = tests.get_data_path(('PP', 'cf_processing', '000003000000.03.236.000128.1990.12.01.00.00.b.pp'))
-        cube = iris.load_strict(file_in)
+        cube = iris.load_cube(file_in)
         
         # Write Cube to netCDF file.
         file_out = iris.util.create_temp_filename(suffix='.nc')
@@ -226,7 +226,7 @@ class TestNetCDFSave(tests.IrisTest):
         # Test saving a CF-netCDF file which contains an atmosphere hybrid height (dimensionless vertical) coordinate.
         # Read PP input file.
         file_in = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog.pp'))
-        cube = iris.load_strict(file_in, 'air_potential_temperature')
+        cube = iris.load_cube(file_in, 'air_potential_temperature')
 
         # Write Cube to netCDF file.
         file_out = iris.util.create_temp_filename(suffix='.nc')
@@ -236,7 +236,7 @@ class TestNetCDFSave(tests.IrisTest):
         self.assertCDL(file_out, ('netcdf', 'netcdf_save_hybrid_height.cdl'))
 
         # Read netCDF file.
-        cube = iris.load_strict(file_out)
+        cube = iris.load_cube(file_out)
 
         # Check the PP read, netCDF write, netCDF read mechanism.
         self.assertCML(cube, ('netcdf', 'netcdf_save_load_hybrid_height.cml'))
@@ -247,7 +247,7 @@ class TestNetCDFSave(tests.IrisTest):
         # Test saving a CF-netCDF file with multi-dimensional auxiliary coordinates.
         # Read netCDF input file.
         file_in = tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc'))
-        cube = iris.load_strict(file_in)
+        cube = iris.load_cube(file_in)
         
         # Write Cube to nerCDF file.
         file_out = iris.util.create_temp_filename(suffix='.nc')
@@ -257,7 +257,7 @@ class TestNetCDFSave(tests.IrisTest):
         self.assertCDL(file_out, ('netcdf', 'netcdf_save_ndim_auxiliary.cdl'))
 
         # Read the netCDF file.
-        cube = iris.load_strict(file_out)
+        cube = iris.load_cube(file_out)
 
         # Check the netCDF read, write, read mechanism.
         self.assertCML(cube, ('netcdf', 'netcdf_save_load_ndim_auxiliary.cml'))
@@ -292,7 +292,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
             iris.save(ll_cube, temp_filename)
 
             # Reload cube     
-            cube = iris.load_strict(temp_filename)
+            cube = iris.load_cube(temp_filename)
             
             
             # Check correct number and type of flags
@@ -318,7 +318,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
             iris.save(ll_cube, temp_filename)
             
             # Reload cube     
-            cube = iris.load_strict(temp_filename)
+            cube = iris.load_cube(temp_filename)
             
             # Check correct number and type of flags
             process_flags = cube.attributes["ukmo__process_flags"]

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -45,7 +45,7 @@ class TestPickle(tests.IrisTest):
     
     @iris.tests.skip_data
     def test_cube_pickle(self):
-        cube = iris.load_strict(tests.get_data_path(('PP', 'globClim1', 'theta.pp')))
+        cube = iris.load_cube(tests.get_data_path(('PP', 'globClim1', 'theta.pp')))
         self.assertCML(cube, ('cube_io', 'pickling', 'theta.cml'), checksum=False)
         
         for _, recon_cube in self.pickle_then_unpickle(cube):

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -138,7 +138,7 @@ def cache(fn, cache={}):
 def _load_wind():
     # Load the COLPEX data => TZYX
     path = tests.get_data_path(('PP', 'COLPEX', 'uwind_and_orog.pp'))
-    wind = iris.load_strict(path, 'eastward_wind')
+    wind = iris.load_cube(path, 'eastward_wind')
 
     # Until there is better mapping support for rotated-pole, pretend this isn't rotated.
     # ie. Move the pole from (37.5, 177.5) to (90, 0) and shift the coordinates.
@@ -289,18 +289,18 @@ class TestQuickplotPlot(tests.GraphicsTest, Slice1dMixin):
         self.draw_method = qplt.plot
 
 
-_load_strict_once_cache = {}
+_load_cube_once_cache = {}
 
 
-def load_strict_once(filename, constraint):
-    """Same syntax as load_strict, but will only load a file once, then cache the answer in a dictionary."""
-    global _load_strict_once_cache
+def load_cube_once(filename, constraint):
+    """Same syntax as load_cube, but will only load a file once, then cache the answer in a dictionary."""
+    global _load_cube_once_cache
     key = (filename, str(constraint))
-    cube = _load_strict_once_cache.get(key, None)
+    cube = _load_cube_once_cache.get(key, None)
     
     if cube is None:
-        cube = iris.load_strict(filename, constraint)
-        _load_strict_once_cache[key] = cube
+        cube = iris.load_cube(filename, constraint)
+        _load_cube_once_cache[key] = cube
         
     return cube
 
@@ -322,7 +322,7 @@ class LambdaStr(object):
 class TestPlotCoordinatesGiven(tests.GraphicsTest):
     def setUp(self):
         filename = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog_subset.pp'))
-        self.cube = load_strict_once(filename, 'air_potential_temperature')
+        self.cube = load_cube_once(filename, 'air_potential_temperature')
         
         self.draw_module = iris.plot
         self.contourf = LambdaStr('iris.plot.contourf', lambda cube, *args, **kwargs: iris.plot.contourf(cube, *args, **kwargs))

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -141,7 +141,7 @@ class TestAll(tests.IrisTest, pp.PPTest):
         # 3) Load the netCDF and check the Cube
         for index, nc_filename in enumerate(nc_filenames):
             # Read netCDF to Cube.
-            cube = iris.load_strict(nc_filename)
+            cube = iris.load_cube(nc_filename)
             self.assertCML(cube, self._ref_dir + ('from_netcdf', '%s_%d.cml' % (fname_name, index)))
             os.remove(nc_filename)
 

--- a/lib/iris/tests/test_pp_to_cube.py
+++ b/lib/iris/tests/test_pp_to_cube.py
@@ -97,7 +97,7 @@ class TestPPLoadRules(tests.IrisTest):
         # Test custom rule evaluation.
         # Default behaviour
         data_path = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
-        cube = iris.load_strict(data_path)
+        cube = iris.load_cube(data_path)
         self.assertEqual(cube.standard_name, 'air_temperature')
 
         # Custom behaviour
@@ -111,13 +111,13 @@ class TestPPLoadRules(tests.IrisTest):
             'CMAttribute("long_name", "customised")'))) 
         f.close()
         iris.fileformats.pp.add_load_rules(temp_path)
-        cube = iris.load_strict(data_path)
+        cube = iris.load_cube(data_path)
         self.assertEqual(cube.name(), 'customised')
         os.remove(temp_path)
         
         # Back to default
         iris.fileformats.pp.reset_load_rules()
-        cube = iris.load_strict(data_path)
+        cube = iris.load_cube(data_path)
         self.assertEqual(cube.standard_name, 'air_temperature')
 
     def test_cell_methods(self):
@@ -141,7 +141,7 @@ class TestPPLoadRules(tests.IrisTest):
             f.save(open(temp_filename, 'wb'))
         
             # Load pp file
-            cube = iris.load_strict(temp_filename)
+            cube = iris.load_cube(temp_filename)
         
             if value in cell_method_values:
                 # Check for cell method on cube
@@ -170,7 +170,7 @@ class TestPPLoadRules(tests.IrisTest):
             f.save(open(temp_filename, 'wb'))
         
             # Load pp file
-            cube = iris.load_strict(temp_filename)
+            cube = iris.load_cube(temp_filename)
 
             if value in omit_process_flags_values:
                 # Check ukmo__process_flags attribute not created
@@ -196,7 +196,7 @@ class TestPPLoadRules(tests.IrisTest):
             f.save(open(temp_filename, 'wb'))
         
             # Load pp file
-            cube = iris.load_strict(temp_filename)
+            cube = iris.load_cube(temp_filename)
 
             # Check the process flags created
             self.assertEquals(set(cube.attributes["ukmo__process_flags"]), set(multiple_map[sum(bit_values)]), "Mismatch between expected and actual process flags.")
@@ -208,7 +208,7 @@ class TestPPLoadRules(tests.IrisTest):
 class TestStdName(tests.IrisTest):
     def test_no_std_name(self):
         fname = tests.get_data_path(['PP', 'simple_pp', 'bad_global.pp'])
-        cube = iris.load_strict(fname)
+        cube = iris.load_cube(fname)
         self.assertCML([cube], ['cube_io', 'pp', 'no_std_name.cml'])
         
         

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -44,7 +44,7 @@ def cache(fn, cache={}):
 @cache
 def _load_theta():
     path = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog_subset.pp'))
-    theta = iris.load_strict(path, 'air_potential_temperature')
+    theta = iris.load_cube(path, 'air_potential_temperature')
     
     # Improve the unit
     theta.units = 'K'
@@ -60,7 +60,7 @@ def _load_theta():
 class TestQuickplotCoordinatesGiven(test_plot.TestPlotCoordinatesGiven):
     def setUp(self):
         filename = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog_subset.pp'))
-        self.cube = test_plot.load_strict_once(filename, 'air_potential_temperature')
+        self.cube = test_plot.load_cube_once(filename, 'air_potential_temperature')
         
         self.draw_module = iris.quickplot
         self.contourf = test_plot.LambdaStr('iris.quickplot.contourf', lambda cube, *args, **kwargs: 

--- a/lib/iris/tests/test_regrid.py
+++ b/lib/iris/tests/test_regrid.py
@@ -22,7 +22,7 @@ import iris.tests as tests
 import numpy
 
 import iris
-from iris import load_strict
+from iris import load_cube
 from iris.analysis.interpolate import regrid_to_max_resolution
 from iris.cube import Cube
 from iris.coords import DimCoord
@@ -55,8 +55,8 @@ class TestRegrid(tests.IrisTest):
         self.forecast_constraint = iris.Constraint(forecast_period=1.5)
 
     def test_regrid_low_dimensional(self):
-        theta = load_strict(self.theta_path, self.theta_constraint & self.level_constraint & self.forecast_constraint)
-        uwind = load_strict(self.uwind_path, self.uwind_constraint & self.level_constraint & self.forecast_constraint)
+        theta = load_cube(self.theta_path, self.theta_constraint & self.level_constraint & self.forecast_constraint)
+        uwind = load_cube(self.uwind_path, self.uwind_constraint & self.level_constraint & self.forecast_constraint)
         TestRegrid.patch_data(theta)
         TestRegrid.patch_data(uwind)
 
@@ -79,8 +79,8 @@ class TestRegrid(tests.IrisTest):
         self.assertCMLApproxData(uwind2.regridded(theta2, mode='nearest'), ('regrid', 'uwind_on_theta_2d.cml'))
 
     def test_regrid_3d(self):
-        theta = load_strict(self.theta_path, self.theta_constraint & self.multi_level_constraint & self.forecast_constraint)
-        uwind = load_strict(self.uwind_path, self.uwind_constraint & self.multi_level_constraint & self.forecast_constraint)
+        theta = load_cube(self.theta_path, self.theta_constraint & self.multi_level_constraint & self.forecast_constraint)
+        uwind = load_cube(self.uwind_path, self.uwind_constraint & self.multi_level_constraint & self.forecast_constraint)
         TestRegrid.patch_data(theta)
         TestRegrid.patch_data(uwind)
 

--- a/lib/iris/tests/test_trajectory.py
+++ b/lib/iris/tests/test_trajectory.py
@@ -56,7 +56,7 @@ class TestTrajectory(tests.IrisTest):
 
         # Load the COLPEX data => TZYX
         path = tests.get_data_path(['PP', 'COLPEX', 'theta_and_orog_subset.pp'])
-        cube = iris.load_strict(path, 'air_potential_temperature')
+        cube = iris.load_cube(path, 'air_potential_temperature')
         cube.coord('grid_latitude').bounds = None
         cube.coord('grid_longitude').bounds = None
         # TODO: Workaround until regrid can handle factories

--- a/lib/iris/tests/test_uri_callback.py
+++ b/lib/iris/tests/test_uri_callback.py
@@ -36,14 +36,14 @@ class TestCallbacks(tests.IrisTest):
             pass
         fname = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
         with self.assertRaises(TypeError):
-            iris.load_strict(fname, callback=invalid_callback)
+            iris.load_cube(fname, callback=invalid_callback)
 
     def test_invalid_return_type_callback(self):
         def invalid_callback(cube, field, filename):
             return 'Not valid to return a string'
         fname = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
         with self.assertRaises(TypeError):
-            iris.load_strict(fname, callback=invalid_callback)
+            iris.load_cube(fname, callback=invalid_callback)
 
     def test_non_returning_callback(self):
         def drop_all_callback(cube, field, filename):
@@ -89,7 +89,7 @@ class TestCallbacks(tests.IrisTest):
             cube.add_aux_coord(iris.coords.AuxCoord(field.extra_keys['_periodStartDateTime'], long_name='random element', units='no_unit'))
             
         fname = tests.get_data_path(('GRIB', 'global_t', 'global.grib2'))
-        cube = iris.load_strict(fname, callback=grib_thing_getter)
+        cube = iris.load_cube(fname, callback=grib_thing_getter)
         self.assertCML(cube, ['uri_callback', 'grib_global.cml'])
     
     def test_pp_callback(self):
@@ -97,7 +97,7 @@ class TestCallbacks(tests.IrisTest):
             cube.attributes['filename'] = os.path.basename(filename)
             cube.attributes['lbyr'] = field.lbyr
         fname = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
-        cube = iris.load_strict(fname, callback=pp_callback)
+        cube = iris.load_cube(fname, callback=pp_callback)
         self.assertCML(cube, ['uri_callback', 'pp_global.cml'])
 
 

--- a/lib/iris/tests/test_verbose_logging.py
+++ b/lib/iris/tests/test_verbose_logging.py
@@ -33,7 +33,7 @@ class TestVerboseLogging(tests.IrisTest):
         # check that verbose logging no longer breaks in pp.save()
         # load some data, enable logging, and save a cube to PP.
         data_path = tests.get_data_path(('PP', 'simple_pp', 'global.pp'))
-        cube = iris.load_strict(data_path)
+        cube = iris.load_cube(data_path)
         OLD_RULE_LOG_DIR = config.RULE_LOG_DIR
         config.RULE_LOG_DIR = '/var/tmp'
         old_log = rules.log


### PR DESCRIPTION
Deprecates `load_strict`, and replaces it with `load_cube` and `load_cubes`.
Removes the `merge=...` keyword from `load`, and adds `load_raw`. (NB. The `merge` keyword didn't exist in 0.9 so there's no need to deprecate it or mention it in the change log.)
