### PR TITLE
Minor correction to what's new and CHANGES, plus apostrophe.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,7 +25,7 @@ Incompatible changes
   get_lat_lon_contiguous_grids(). They have been replaced with
   generalised versions: xy_range(), get_xy_grids(),
   and get_xy_contiguous_bounded_grids().
-* Cube.coord_dims() now returns a tuple instead of a list.
+* The method `Cube.coord_dims()` now returns a tuple instead of a list.
 
 Deprecations
 ------------

--- a/docs/iris/src/_templates/index.html
+++ b/docs/iris/src/_templates/index.html
@@ -76,7 +76,7 @@ With Iris you can:
 	</li>
 	<li>
 		<p class="biglink"><a class="biglink" href="whats_new.html">What's new in Iris 1.0?</a><br/>
-		<span class="linkdescr">recent changes in Iris' capabilities</span></p>
+		<span class="linkdescr">recent changes in Iris's capabilities</span></p>
 	</li>
 	</ul>
 </div>

--- a/docs/iris/src/whats_new.rst
+++ b/docs/iris/src/whats_new.rst
@@ -46,7 +46,7 @@ Incompatible changes
 --------------------
 * The "source" and "history" metadata are now represented as Cube
   attributes, where previously they used coordinates.
-* Cube.coord_dims() now returns a tuple instead of a list.
+* :meth:`iris.cube.Cube.coord_dims()` now returns a tuple instead of a list.
 
 Deprecations
 ------------


### PR DESCRIPTION
I'm fairly sure we want an apostrophe in possessive form of Iris. Happy to be proved wrong.
