### PR TITLE
Used cartopy's new wrapping functionality when using pcolormesh.

### DIFF
--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -600,6 +600,10 @@ def outline(cube, coords=None):
     result = _draw_2d_from_bounds('pcolormesh', cube, facecolors='none', edgecolors='k', antialiased=True, coords=coords)
     # set the _is_stroked property to get a single color grid. See https://github.com/matplotlib/matplotlib/issues/1302
     result._is_stroked = False
+    # handle the posibility that cartopy has done some clever wrapping of the pcolormesh
+    secondary_collection = getattr(result, '_wrapped_collection_fix', None)
+    if secondary_collection is not None:
+        secondary_collection._is_stroked = False
     return result
 
 


### PR DESCRIPTION
Thanks to cartopy's pcolormesh handling improvements (proposed in https://github.com/SciTools/cartopy/pull/106) Iris can now do pcolormesh properly (before it wrapped badly, as seen on the iris plotting section in the userguide).

This should not be merged until it is clear where the cartopy fix is going to go (and therefore it is clear whether this can be merged into `v1.0.x` or `master`).
