### PR TITLE
Remove redundant and erroneous standard_name to LBFC/STASH PP save rules.

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -100,6 +100,31 @@ IF
 THEN
     pp.lbfc = 608
 
+IF
+    cm.name() in ['wind_gust']
+THEN
+    pp.lbfc = 1694
+
+IF
+    cm.name() in ['wind_speed']
+THEN
+    pp.lbfc = 50
+
+IF
+    cm.name() in ['large_scale_rainfall_rate']
+THEN
+    pp.lbfc = 99
+
+IF
+    cm.name() in ['eastward_wind']
+THEN
+    pp.lbfc = 56
+
+IF
+    cm.name() in ['northward_wind']
+THEN
+    pp.lbfc = 57
+
 
 ######################################################
 ### time - lbtim, t1, t2 and lbft (but not lbproc) ###


### PR DESCRIPTION
Working with AQUM revealed that loading a Fieldsfile with a PP-field of `stash code 2` is translated to a cube with `standard_name` of `eastward_wind`, and that a PP-field of `stash code 3` is translated to a cube with `standard_name` of `northward_wind`.

On saving such cubes, the PP save rules set/clobber the `LBFC` and `LBUSER[3]` (stash section and item) based `only` on the `standard_name` of the cube:
- For `eastward_wind` it forces `56` and `15201`,
- For `northward_wind` it forces `57` and `15202`.

These PP save rules are clearly wrong. It is not safe to translate from `standard_name` to `stash code`.

These save rules have been removed, along with several other such similar rules. All test still pass after removal, so thankfully we don't have current tests that rely on this erroneous behaviour.
