### PR TITLE
Externalise tests

### DIFF
--- a/lib/iris/tests/results/file_load/format_associations.txt
+++ b/lib/iris/tests/results/file_load/format_associations.txt
@@ -1,9 +1,0 @@
-NetCDF - NetCDF/global/xyt/SMALL_total_column_co2.nc
-NetCDF 64 bit offset format - NetCDF/global/xyt/SMALL_total_column_co2.nc.k2
-NetCDF_v4 - NetCDF/global/xyt/SMALL_total_column_co2.nc4.k3
-NetCDF_v4 - NetCDF/global/xyt/SMALL_total_column_co2.nc4.k4
-UM Fields file (FF) pre v3.1 - FF/n48_multi_field
-GRIB - GRIB/grib1_second_order_packing/GRIB_00008_FRANX01
-GRIB - GRIB/jpeg2000/file.grib2
-UM Post Processing file (PP) - PP/simple_pp/global.pp
-NIMROD - NIMROD/uk2km/WO0000000003452/201007020900_u1096_ng_ey00_visibility0180_screen_2km

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -24,7 +24,7 @@ import iris.tests as tests
 import os
 import unittest
 
-import iris.fileformats
+import iris.fileformats as iff
 import iris.io
 
 
@@ -51,39 +51,46 @@ class TestDecodeUri(unittest.TestCase):
 @iris.tests.skip_data
 class TestFileFormatPicker(tests.IrisTest):
     def test_known_formats(self):
-        a = str(iris.fileformats.FORMAT_AGENT)
+        a = str(iff.FORMAT_AGENT)
         self.assertString(a, tests.get_result_path(('file_load', 'known_loaders.txt')))
 
 
     def test_format_picker(self):
-        # make a list of testfile specs to test the picker on
-        fspecs = [
-                  ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc'], # NetCDF
-                  ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc.k2'], # NetCDF 64-bit offset
-                  ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k3'], # NetCDF - 4 
-                  ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k4'], # NetCDF - 4 "classic model"
-                  ['FF', 'n48_multi_field'], # UM FF
-                  ['GRIB', 'grib1_second_order_packing', 'GRIB_00008_FRANX01'], # GRIB1
-                  ['GRIB', 'jpeg2000', 'file.grib2'], # GRIB2
-                  ['PP', 'simple_pp', 'global.pp'], # PP
-#                  ['BUFR', 'mss', 'BUFR_Samples', 'JUPV78_EGRR_121200_00002501'], # BUFFR
-                  ['NIMROD', 'uk2km', 'WO0000000003452', '201007020900_u1096_ng_ey00_visibility0180_screen_2km'], # nimrod 
-#                  ['NAME', '20100509_18Z_variablesource_12Z_VAAC', 'Fields_grid1_201005110000.txt'], # NAME
-              ]
+        # ways to test the format picker = list of (format-name, file-spec)
+        test_specs = [
+            ('NetCDF',
+                ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc']),
+            ('NetCDF 64 bit offset format',
+                ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc.k2']),
+            ('NetCDF_v4',
+                ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k3']),
+            ('NetCDF_v4',
+                ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k4']),
+            ('UM Fields file (FF) pre v3.1',
+                ['FF', 'n48_multi_field']),
+            ('GRIB',
+                ['GRIB', 'grib1_second_order_packing', 'GRIB_00008_FRANX01']),
+            ('GRIB',
+                ['GRIB', 'jpeg2000', 'file.grib2']),
+            ('UM Post Processing file (PP)',
+                ['PP', 'simple_pp', 'global.pp']),
+#            ('BUFR',
+#                ['BUFR', 'mss', 'BUFR_Samples', 
+#                 'JUPV78_EGRR_121200_00002501']),
+            ('NIMROD',
+                ['NIMROD', 'uk2km', 'WO0000000003452',
+                 '201007020900_u1096_ng_ey00_visibility0180_screen_2km']),
+#            ('NAME',
+#                ['NAME', '20100509_18Z_variablesource_12Z_VAAC', 
+#                 'Fields_grid1_201005110000.txt']),
+        ]
         
-        # construct a dictionary of known filename:format associations from a results file
-        expected_results = {}
-        with open(tests.get_result_path(('file_load', 'format_associations.txt'))) as check_results_file:
-            for line_str in check_results_file.readlines():
-                format_name, file_name =  [str.strip() for str in line_str.split('-')] 
-                expected_results[file_name] = format_name
-
         # test that each filespec is identified as the expected format
-        for spec in fspecs:
-            relpath = os.path.join(*spec)
-            actpath = tests.get_data_path(spec)
-            a = iris.fileformats.FORMAT_AGENT.get_spec(actpath, open(actpath, 'r'))
-            self.assertEqual(a.name, expected_results[relpath])
+        for (expected_format_name, file_spec) in test_specs:
+            test_path = tests.get_data_path(file_spec)
+            with open(test_path, 'r') as test_file:
+                a = iff.FORMAT_AGENT.get_spec(test_path, test_file)
+                self.assertEqual(a.name, expected_format_name)
 
 
 @iris.tests.skip_data


### PR DESCRIPTION
First attempt to pare down the test data resources.  The 2 largest of all were **only** referred to in the io format picker test, so have now replaced these with equivalent little ones.
( Tested with fake local copy of standard testdata, to double-check we don't need these files for any other tests. )
