### PR TITLE
Faster masked array creation in DataManager.

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1141,9 +1141,10 @@ class ProtoCube(object):
         aux_coords_and_dims = [(deepcopy(coord), dims) for coord, dims in self._aux_coords_and_dims]
         kwargs = dict(zip(iris.cube.CubeMetadata._fields, signature.defn))
 
-        # Create fully masked data i.e. all missing.
+        # Create fully masked data, i.e. all missing.
+        # (The CubeML checksum doesn't respect the mask, so we zero the
+        # underlying data to ensure repeatable checksums.)
         if signature.data_manager is None:
-            # Must zero the data in order to avoid random checksums.
             data = numpy.ma.MaskedArray(numpy.zeros(self._shape,
                                                     signature.data_type),
                                         mask=numpy.ones(self._shape, 'bool'),

--- a/lib/iris/fileformats/manager.py
+++ b/lib/iris/fileformats/manager.py
@@ -256,9 +256,9 @@ class DataManager(iris.util._OrderedHashable):
                                         fill_value=self.mdi)
         except ValueError:
             raise DataManager.ArrayTooBigForAddressSpace(
-                    'Cannot create an array of shape %r as it will not'
-                    ' fit in memory. Try reducing the shape of the'
-                    ' proxy array by using indexing.'.format(array_shape))
+                    'Cannot create an array of shape %r as it will not fit in'
+                    ' memory. Consider using indexing to select a subset of'
+                    ' the Cube.'.format(array_shape))
 
         for index, proxy in numpy.ndenumerate(proxy_array):
             if proxy not in [None, 0]:  # 0 can come from slicing masked proxy; numpy.array(masked_constant).


### PR DESCRIPTION
Doing `data.mask = True` is surprisingly slow ... so this PR avoids it. Happy days.

(The corresponding patch to NumPy is numpy/numpy#2760.)
