### PR TITLE
externalise tests -5

### DIFF
--- a/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
@@ -3,7 +3,9 @@
   <cube long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
+      <attribute name="NCO" value="4.1.0"/>
       <attribute name="experiment" value="ER3"/>
+      <attribute name="history" value="Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc"/>
       <attribute name="institution" value="DMI"/>
       <attribute name="source" value="HIRHAM"/>
     </attributes>
@@ -52,11 +54,7 @@
         <dimCoord bounds="[[2922.5, 2923.5],
 		[2923.5, 2924.5],
 		[2924.5, 2925.5],
-		..., 
-		[4015.5, 4016.5],
-		[4016.5, 4017.5],
-		[4017.5, 4018.5]]" id="4d427378" long_name="Julian Day" points="[2922.5, 2923.5, 2924.5, ..., 4015.5, 4016.5,
-		4017.5]" shape="(1096,)" standard_name="time" units="Unit('days since 1950-01-01 00:00:00.0', calendar='gregorian')" value_type="float32"/>
+		[2925.5, 2926.5]]" id="4d427378" long_name="Julian Day" points="[2922.5, 2923.5, 2924.5, 2925.5]" shape="(4,)" standard_name="time" units="Unit('days since 1950-01-01 00:00:00.0', calendar='gregorian')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>
@@ -64,6 +62,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x79bb3556" dtype="float32" shape="(1096, 190, 174)"/>
+    <data checksum="-0x501a2fe4" dtype="float32" shape="(4, 190, 174)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
@@ -3,7 +3,9 @@
   <cube long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="NCO" value="4.1.0"/>
       <attribute name="experiment" value="ER3"/>
+      <attribute name="history" value="Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc"/>
       <attribute name="institution" value="DMI"/>
       <attribute name="source" value="HIRHAM"/>
     </attributes>
@@ -52,11 +54,7 @@
         <dimCoord bounds="[[2922.5, 2923.5],
 		[2923.5, 2924.5],
 		[2924.5, 2925.5],
-		..., 
-		[4015.5, 4016.5],
-		[4016.5, 4017.5],
-		[4017.5, 4018.5]]" id="b8bd03ce" long_name="Julian Day" points="[2922.5, 2923.5, 2924.5, ..., 4015.5, 4016.5,
-		4017.5]" shape="(1096,)" standard_name="time" units="Unit('days since 1950-01-01 00:00:00.0', calendar='gregorian')" value_type="float32"/>
+		[2925.5, 2926.5]]" id="b8bd03ce" long_name="Julian Day" points="[2922.5, 2923.5, 2924.5, 2925.5]" shape="(4,)" standard_name="time" units="Unit('days since 1950-01-01 00:00:00.0', calendar='gregorian')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>
@@ -64,6 +62,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x79bb3556" dtype="float32" shape="(1096, 190, 174)"/>
+    <data checksum="-0x501a2fe4" dtype="float32" shape="(4, 190, 174)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
@@ -1,5 +1,5 @@
 dimensions:
-	time = UNLIMITED ; // (1096 currently)
+	time = UNLIMITED ; // (4 currently)
 	grid_latitude = 190 ;
 	grid_longitude = 174 ;
 	bnds = 2 ;
@@ -8,7 +8,9 @@ variables:
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:long_name = "Precipitation" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
+		precipitation_flux:NCO = "4.1.0" ;
 		precipitation_flux:experiment = "ER3" ;
+		precipitation_flux:history = "Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc" ;
 		precipitation_flux:institution = "DMI" ;
 		precipitation_flux:source = "HIRHAM" ;
 		precipitation_flux:cell_methods = "time: mean" ;

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -63,38 +63,47 @@ class TestCaching(unittest.TestCase):
 @iris.tests.skip_data
 class TestCFReader(tests.IrisTest):
     def setUp(self):
-        self.filename = tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc'))
-        self.cfr = cf.CFReader(self.filename)
+        filename = tests.get_data_path(
+            ('NetCDF', 'rotated', 'xyt', 'small_rotPole_precipitation.nc'))
+        self.cfr = cf.CFReader(filename)
 
     def test_ancillary_variables_pass_0(self):
         self.assertEqual(self.cfr.cf_group.ancillary_variables, {})
 
     def test_auxiliary_coordinates_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group.auxiliary_coordinates.keys()), ['lat', 'lon'])
+        self.assertEqual(sorted(self.cfr.cf_group.auxiliary_coordinates.keys()),
+                         ['lat', 'lon'])
 
         lat = self.cfr.cf_group['lat']
         self.assertEqual(lat.shape, (190, 174))
         self.assertEqual(lat.dimensions, ('rlat', 'rlon'))
         self.assertEqual(lat.ndim, 2)
-        self.assertEqual(lat.cf_attrs(), (('long_name', 'latitude'), ('standard_name', 'latitude'), ('units', 'degrees_north')))
+        self.assertEqual(lat.cf_attrs(), 
+                         (('long_name', 'latitude'), 
+                          ('standard_name', 'latitude'), 
+                          ('units', 'degrees_north')))
 
         lon = self.cfr.cf_group['lon']
         self.assertEqual(lon.shape, (190, 174))
         self.assertEqual(lon.dimensions, ('rlat', 'rlon'))
         self.assertEqual(lon.ndim, 2)
-        self.assertEqual(lon.cf_attrs(), (('long_name', 'longitude'), ('standard_name', 'longitude'), ('units', 'degrees_east')))
+        self.assertEqual(lon.cf_attrs(), 
+                         (('long_name', 'longitude'), 
+                          ('standard_name', 'longitude'), 
+                          ('units', 'degrees_east')))
 
     def test_bounds_pass_0(self):
         self.assertEqual(sorted(self.cfr.cf_group.bounds.keys()), ['time_bnds'])
 
         time_bnds = self.cfr.cf_group['time_bnds']
-        self.assertEqual(time_bnds.shape, (1096, 2))
+        self.assertEqual(time_bnds.shape, (4, 2))
         self.assertEqual(time_bnds.dimensions, ('time', 'time_bnds'))
         self.assertEqual(time_bnds.ndim, 2)
         self.assertEqual(time_bnds.cf_attrs(), ())
 
     def test_coordinates_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group.coordinates.keys()), ['rlat', 'rlon', 'time'])
+        self.assertEqual(sorted(self.cfr.cf_group.coordinates.keys()), 
+                         ['rlat', 'rlon', 'time'])
 
         rlat = self.cfr.cf_group['rlat']
         self.assertEqual(rlat.shape, (190,))
@@ -119,7 +128,7 @@ class TestCFReader(tests.IrisTest):
         self.assertEqual(rlon.cf_attrs(), tuple(attr))
 
         time = self.cfr.cf_group['time']
-        self.assertEqual(time.shape, (1096,))
+        self.assertEqual(time.shape, (4,))
         self.assertEqual(time.dimensions, ('time',))
         self.assertEqual(time.ndim, 1)
         attr = []
@@ -131,10 +140,11 @@ class TestCFReader(tests.IrisTest):
         self.assertEqual(time.cf_attrs(), tuple(attr))
 
     def test_data_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group.data_variables.keys()), ['pr'])
+        self.assertEqual(sorted(self.cfr.cf_group.data_variables.keys()), 
+                         ['pr'])
 
         data = self.cfr.cf_group['pr']
-        self.assertEqual(data.shape, (1096, 190, 174))
+        self.assertEqual(data.shape, (4, 190, 174))
         self.assertEqual(data.dimensions, ('time', 'rlat', 'rlon'))
         self.assertEqual(data.ndim, 3)
         attr = []
@@ -157,7 +167,8 @@ class TestCFReader(tests.IrisTest):
         self.assertEqual(self.cfr.cf_group.formula_terms, {})
 
     def test_grid_mapping_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group.grid_mappings.keys()), ['rotated_pole'])
+        self.assertEqual(sorted(self.cfr.cf_group.grid_mappings.keys()), 
+                         ['rotated_pole'])
 
         rotated_pole = self.cfr.cf_group['rotated_pole']
         self.assertEqual(rotated_pole.shape, ())
@@ -173,34 +184,56 @@ class TestCFReader(tests.IrisTest):
         self.assertEqual(self.cfr.cf_group.cell_measures, {})
 
     def test_global_attributes_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group.global_attributes.keys()), ['Conventions', 'experiment', 'institution', 'source',])
+        self.assertEqual(
+            sorted(self.cfr.cf_group.global_attributes.keys()),
+            ['Conventions', 'NCO', 'experiment', 
+                'history', 'institution', 'source',]
+        )
 
-        self.assertEqual(self.cfr.cf_group.global_attributes['Conventions'], 'CF-1.0')
-        self.assertEqual(self.cfr.cf_group.global_attributes['experiment'], 'ER3')
-        self.assertEqual(self.cfr.cf_group.global_attributes['institution'], 'DMI')
-        self.assertEqual(self.cfr.cf_group.global_attributes['source'], 'HIRHAM')
+        self.assertEqual(self.cfr.cf_group.global_attributes['Conventions'], 
+                         'CF-1.0')
+        self.assertEqual(self.cfr.cf_group.global_attributes['experiment'], 
+                         'ER3')
+        self.assertEqual(self.cfr.cf_group.global_attributes['institution'], 
+                         'DMI')
+        self.assertEqual(self.cfr.cf_group.global_attributes['source'], 
+                         'HIRHAM')
 
     def test_variable_cf_group_pass_0(self):
-        self.assertEqual(sorted(self.cfr.cf_group['time'].cf_group.keys()), ['time_bnds'])
-        self.assertEqual(sorted(self.cfr.cf_group['pr'].cf_group.keys()), ['lat', 'lon', 'rlat', 'rlon', 'rotated_pole', 'time'])
+        self.assertEqual(sorted(self.cfr.cf_group['time'].cf_group.keys()), 
+                         ['time_bnds'])
+        self.assertEqual(sorted(self.cfr.cf_group['pr'].cf_group.keys()), 
+                         ['lat', 'lon', 'rlat', 'rlon', 'rotated_pole', 'time'])
 
     def test_variable_attribute_touch_pass_0(self):
         lat = self.cfr.cf_group['lat']
         
-        self.assertEqual(lat.cf_attrs(), (('long_name', 'latitude'), ('standard_name', 'latitude'), ('units', 'degrees_north')))
+        self.assertEqual(lat.cf_attrs(), 
+                         (('long_name', 'latitude'), 
+                          ('standard_name', 'latitude'), 
+                          ('units', 'degrees_north')))
         self.assertEqual(lat.cf_attrs_used(), ())
-        self.assertEqual(lat.cf_attrs_unused(), (('long_name', 'latitude'), ('standard_name', 'latitude'), ('units', 'degrees_north')))
+        self.assertEqual(lat.cf_attrs_unused(), 
+                         (('long_name', 'latitude'), 
+                          ('standard_name', 'latitude'), 
+                          ('units', 'degrees_north')))
 
         # touch some variable attributes.
         lat.long_name
         lat.units
-        self.assertEqual(lat.cf_attrs_used(), (('long_name', 'latitude'), ('units', 'degrees_north')))
-        self.assertEqual(lat.cf_attrs_unused(), (('standard_name', 'latitude'),))
+        self.assertEqual(lat.cf_attrs_used(), 
+                         (('long_name', 'latitude'), 
+                          ('units', 'degrees_north')))
+        self.assertEqual(lat.cf_attrs_unused(), 
+                         (('standard_name', 'latitude'),))
 
         # clear the attribute touch history.
         lat.cf_attrs_reset()
         self.assertEqual(lat.cf_attrs_used(), ())
-        self.assertEqual(lat.cf_attrs_unused(), (('long_name', 'latitude'), ('standard_name', 'latitude'), ('units', 'degrees_north')))
+        self.assertEqual(lat.cf_attrs_unused(), 
+                         (('long_name', 'latitude'), 
+                          ('standard_name', 'latitude'), 
+                          ('units', 'degrees_north')))
 
 
 @iris.tests.skip_data
@@ -211,9 +244,16 @@ class TestLoad(tests.IrisTest):
         self.assertEquals(cube.coord('height').attributes, {})
         
     def test_attributes_populated(self):
-        filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'FC_167_mon_19601101.nc'))
+        filename = tests.get_data_path(
+            ('NetCDF', 'label_and_climate', 'small_FC_167_mon_19601101.nc'))
         cube = iris.load_cube(filename)
-        self.assertEquals(sorted(cube.coord('longitude').attributes.items()), [('data_type', 'float'), ('modulo', 360), ('topology', 'circular')])
+        self.assertEquals(
+            sorted(cube.coord('longitude').attributes.items()), 
+            [('data_type', 'float'), 
+             ('modulo', 360), 
+             ('topology', 'circular')
+            ]
+        )
 
     def test_cell_methods(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc'))
@@ -224,8 +264,9 @@ class TestLoad(tests.IrisTest):
 @iris.tests.skip_data
 class TestClimatology(tests.IrisTest):
     def setUp(self):
-        self.filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'A1B-99999a-river-sep-2070-2099.nc'))
-        self.cfr = cf.CFReader(self.filename)
+        filename = tests.get_data_path(('NetCDF', 'label_and_climate',
+                                        'A1B-99999a-river-sep-2070-2099.nc'))
+        self.cfr = cf.CFReader(filename)
 
     def test_bounds(self):
         time = self.cfr.cf_group['temp_dmax_tmean_abs'].cf_group.coordinates['time']
@@ -241,28 +282,41 @@ class TestClimatology(tests.IrisTest):
 @iris.tests.skip_data
 class TestLabels(tests.IrisTest):
     def setUp(self):
-        filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'A1B-99999a-river-sep-2070-2099.nc'))
+        filename = tests.get_data_path(
+            ('NetCDF', 'label_and_climate', 
+             'A1B-99999a-river-sep-2070-2099.nc'))
         self.cfr_start = cf.CFReader(filename)
 
-        filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'FC_167_mon_19601101.nc'))
+        filename = tests.get_data_path(
+            ('NetCDF', 'label_and_climate', 
+             'small_FC_167_mon_19601101.nc'))
         self.cfr_end = cf.CFReader(filename)
 
     def test_label_dim_start(self):
         cf_data_var = self.cfr_start.cf_group['temp_dmax_tmean_abs']
 
-        self.assertEqual(sorted(self.cfr_start.cf_group.labels.keys()), [u'region_name'])
-        self.assertEqual(sorted(cf_data_var.cf_group.labels.keys()), [u'region_name'])
+        region_group = self.cfr_start.cf_group.labels['region_name']
+        self.assertEqual(sorted(self.cfr_start.cf_group.labels.keys()), 
+                         [u'region_name'])
+        self.assertEqual(sorted(cf_data_var.cf_group.labels.keys()), 
+                         [u'region_name'])
 
-        self.assertEqual(self.cfr_start.cf_group.labels['region_name'].cf_label_dimensions(cf_data_var), (u'georegion',))
-        self.assertEqual(self.cfr_start.cf_group.labels['region_name'].cf_label_data(cf_data_var)[0], 'Anglian')
+        self.assertEqual(region_group.cf_label_dimensions(cf_data_var), 
+                         (u'georegion',))
+        self.assertEqual(region_group.cf_label_data(cf_data_var)[0], 
+                         'Anglian')
 
         cf_data_var = self.cfr_start.cf_group['cdf_temp_dmax_tmean_abs']
 
-        self.assertEqual(sorted(self.cfr_start.cf_group.labels.keys()), [u'region_name'])
-        self.assertEqual(sorted(cf_data_var.cf_group.labels.keys()), [u'region_name'])
+        self.assertEqual(sorted(self.cfr_start.cf_group.labels.keys()), 
+                         [u'region_name'])
+        self.assertEqual(sorted(cf_data_var.cf_group.labels.keys()), 
+                         [u'region_name'])
 
-        self.assertEqual(self.cfr_start.cf_group.labels['region_name'].cf_label_dimensions(cf_data_var), (u'georegion',))
-        self.assertEqual(self.cfr_start.cf_group.labels['region_name'].cf_label_data(cf_data_var)[0], 'Anglian') 
+        self.assertEqual(region_group.cf_label_dimensions(cf_data_var), 
+                         (u'georegion',))
+        self.assertEqual(region_group.cf_label_data(cf_data_var)[0], 
+                         'Anglian') 
 
     def test_label_dim_end(self):
         cf_data_var = self.cfr_end.cf_group['tas']

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -71,7 +71,8 @@ class TestNetCDFLoad(tests.IrisTest):
 
     def test_load_rotated_xyt_precipitation(self):
         # Test loading single xyt rotated pole CF-netCDF file.
-        cube = iris.load_cube(tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc')))
+        cube = iris.load_cube(tests.get_data_path(
+            ('NetCDF', 'rotated', 'xyt', 'small_rotPole_precipitation.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xyt_precipitation.cml'))
 
     def test_cell_methods(self):
@@ -248,9 +249,10 @@ class TestNetCDFSave(tests.IrisTest):
         os.remove(file_out)
 
     def test_netcdf_save_ndim_auxiliary(self):
-        # Test saving a CF-netCDF file with multi-dimensional auxiliary coordinates.
+        # Test saving CF-netCDF with multi-dimensional auxiliary coordinates.
         # Read netCDF input file.
-        file_in = tests.get_data_path(('NetCDF', 'rotated', 'xyt', 'new_rotPole_precipitation.nc'))
+        file_in = tests.get_data_path(
+            ('NetCDF', 'rotated', 'xyt', 'small_rotPole_precipitation.nc'))
         cube = iris.load_cube(file_in)
         
         # Write Cube to nerCDF file.


### PR DESCRIPTION
fixed test_cf, test_netcdf for smaller resources
: 2 more files replaced - smaller versions extracted with NCO

Apologies for a blizzard  of 80-column-fixes, which rather obscure the significant functional changes.
Could do this differently in future?
