### PR TITLE
NF - add new weighting methods

### DIFF
--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -309,27 +309,86 @@ def area_weights(cube):
         ll_weights = ll_weights.transpose()
 
     # Now we create an array of weights for each cell.
+    broad_weights = iris.util.broadcast_weights(ll_weights,
+                                                cube.data,
+                                                (lat_dim, lon_dim))
 
-    # First, get the non latlon shape. Don't include scalar dimensions as they
-    # are not part of the cube's shape.
-    other_dims_shape = numpy.array(cube.shape)
-    if lat_dim is not None:
-        other_dims_shape[lat_dim] = 1
-    if lon_dim is not None:
-        other_dims_shape[lon_dim] = 1
-    other_dims_array = numpy.ones(other_dims_shape)
+    return broad_weights
 
-    # Set the shape of the weights array that matches the dimensionality
-    # of the cube. Again, we ignore scalar dimensions.
-    weights_shape = numpy.ones(cube.ndim)
-    if lat_dim is not None:
-        weights_shape[lat_dim] = cube.shape[lat_dim]
-    if lon_dim is not None:
-        weights_shape[lon_dim] = cube.shape[lon_dim]
 
-    # Create the broadcast object from the weights array and the 'other dims',
-    # to match the shape of the cube.
-    broad_weights = ll_weights.reshape(weights_shape) * other_dims_array
+def cosine_latitude_weights(cube):
+    """
+    Returns an array of latitude weights, with the same dimensions as
+    the cube. The weights are the cosine of latitude.
+
+    This is a 1D latitude weights array, repeated over the non-latitude
+    dimensions.
+
+    The cube must have a coordinate with 'latitude' in the name. Out of
+    range values (greater than 90 degrees or less than -90 degrees) will
+    be clipped to the valid range.
+
+    Weights are calculated for each latitude as:
+
+        .. math::
+
+           w_l = \cos \phi_l
+
+    Examples:
+
+    Compute weights suitable for averaging type operations:
+
+        from iris.analysis.cartography import cosine_latitude_weights
+        cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
+        weights = cosine_latitude_weights(cube)
+    
+    Compute weights suitable for EOF analysis (or other covariance type
+    analyses):
+
+        import numpy
+        from iris.analysis.cartography import cosine_latitude_weights
+        cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
+        weights = numpy.sqrt(cosine_latitude_weights(cube))
+
+    """
+    # Get the latitude coordinate.
+    lat_coords = filter(lambda coord: "latitude" in coord.name(),
+                        cube.coords())
+    if len(lat_coords) > 1:
+        raise ValueError("Multiple latitude coords are currently disallowed.")
+    try:
+        lat = lat_coords[0]
+    except IndexError:
+        raise ValueError('Cannot get latitude '
+                         'coordinate from cube {!r}.'.format(cube.name()))
+    if lat.ndim > 1:
+        raise iris.exceptions.CoordinateMultiDimError(lat)
+
+    # Get the position of the latitude coordinate.
+    lat_dim = cube.coord_dims(lat)
+    lat_dim = lat_dim[0] if lat_dim else None
+
+    # Convert to radians.
+    lat = lat.unit_converted('radians')
+
+    # Compute the weights as the cosine of latitude. In some cases,
+    # particularly when working in 32-bit precision, the latitude values can
+    # extend beyond the allowable range of [-pi/2, pi/2] due to numerical
+    # precision. We first check for genuinely out of range values, and issue a
+    # warning if these are found. Then the cosine is computed and clipped to
+    # the valid range [0, 1].
+    threshold = numpy.deg2rad(0.001)  # small value for grid resolution
+    if numpy.any(lat.points < -numpy.pi / 2. - threshold) or \
+            numpy.any(lat.points > numpy.pi / 2. + threshold):
+        warnings.warn('Out of range latitude values will be '
+                      'clipped to the valid range.',
+                      UserWarning)
+    l_weights = numpy.cos(lat.points).clip(0., 1.)
+
+    # Create weights for each grid point.
+    broad_weights = iris.util.broadcast_weights(l_weights,
+                                                cube.data,
+                                                (lat_dim,))
 
     return broad_weights
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -260,6 +260,9 @@ class IrisTest(unittest.TestCase):
     def assertArrayEqual(self, a, b):
         numpy.testing.assert_array_equal(a, b)
 
+    def assertArrayAlmostEqual(self, a, b):
+        numpy.testing.assert_array_almost_equal(a, b)
+
     def assertAttributesEqual(self, attr1, attr2):
         """
         Asserts two mappings (dictionaries) are equal after

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -459,7 +459,7 @@ class TestAreaWeights(tests.IrisTest):
         self.assertAlmostEquals(area[2], [319251845980.7646484375])
 
 
-class TestWeightGeneration(tests.IrisTest):
+class TestAreaWeightGeneration(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()
 
@@ -499,6 +499,78 @@ class TestWeightGeneration(tests.IrisTest):
         cube = self.cube[:, :, 0, 0]
         weights = iris.analysis.cartography.area_weights(cube)
         self.assertEqual(weights.shape, cube.shape)
+
+
+class TestLatitudeWeightGeneration(tests.IrisTest):
+    def setUp(self):
+        # construct a 4d cube with global extent
+        ntime = 5
+        nlevs = 3
+        nlons = 144
+        nlats = 73
+        time_values = numpy.arange(ntime)
+        time_unit = 'days since 2001-01-01 00:00:0.0'
+        cal = 'Gregorian'
+        time_coord = iris.coords.DimCoord(time_values,
+                                          standard_name='time',
+                                          units=iris.unit.Unit(time_unit, cal))
+        lev_values = numpy.arange(1, nlevs + 1)
+        lev_coord = iris.coords.DimCoord(lev_values,
+                                         long_name='model_level_number',
+                                         units='1')
+        lat_values = numpy.linspace(-90, 90, nlats)
+        lat_coord = iris.coords.DimCoord(lat_values,
+                                         standard_name='latitude',
+                                         units=iris.unit.Unit('degrees_north'))
+        lon_values = numpy.arange(0., 360., 360./nlons)
+        lon_coord = iris.coords.DimCoord(lon_values,
+                                         standard_name='longitude',
+                                         units=iris.unit.Unit('degrees_east'))
+        data = numpy.ones([ntime, nlevs, nlats, nlons], dtype=numpy.float64)
+        self.cube = iris.cube.Cube(data, long_name='test_cube', units='1')
+        coords = (time_coord, lev_coord, lat_coord, lon_coord)
+        for icoord, coord in enumerate(coords):
+            self.cube.add_dim_coord(coord, icoord)
+        self.lat_coord = lat_coord.points
+
+    def test_sqrt_cosine_latitude_weights_range(self):
+        # range of weight values
+        weights = iris.analysis.cartography.cosine_latitude_weights(self.cube)
+        self.assertTrue(weights.max() <= 1)
+        self.assertTrue(weights.min() >= 0)
+
+    def test_cosine_latitude_weights_std(self):
+        # weights for 4d data
+        weights = iris.analysis.cartography.cosine_latitude_weights(self.cube)
+        self.assertEqual(weights.shape, self.cube.shape)
+        self.assertArrayAlmostEqual(weights[0, 0, :, 0],
+                                    numpy.cos(numpy.deg2rad(self.lat_coord)))
+
+    def test_cosine_latitude_weights_latitude_first(self):
+        # weights for data with latitude first in dimensions
+        order = [2, 0, 1, 3] # (lat, time, level, lon)
+        self.cube.transpose(order)
+        weights = iris.analysis.cartography.cosine_latitude_weights(self.cube)
+        self.assertEqual(weights.shape, self.cube.shape)
+        self.assertArrayAlmostEqual(weights[:, 0, 0, 0],
+                                    numpy.cos(numpy.deg2rad(self.lat_coord)))
+
+    def test_cosine_latitude_weights_latitude_last(self):
+        # weights for data with latitude last in dimensions
+        order = [0, 1, 3, 2] # (time, level, lon, lat)
+        self.cube.transpose(order)
+        weights = iris.analysis.cartography.cosine_latitude_weights(self.cube)
+        self.assertEqual(weights.shape, self.cube.shape)
+        self.assertArrayAlmostEqual(weights[0, 0, 0, :],
+                                    numpy.cos(numpy.deg2rad(self.lat_coord)))
+
+    def test_cosine_latitude_weights_scalar_latitude(self):
+        # weights for cube with a scalar latitude dimension
+        cube = self.cube[:, :, 0, :]
+        weights = iris.analysis.cartography.cosine_latitude_weights(cube)
+        self.assertEqual(weights.shape, cube.shape)
+        self.assertAlmostEqual(weights[0, 0, 0],
+                               numpy.cos(numpy.deg2rad(self.lat_coord[0])))
 
 
 class TestRollingWindow(tests.IrisTest):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -29,6 +29,44 @@ import time
 import numpy
 
 
+def broadcast_weights(weights, array, dims):
+    """
+    Broadcast a weights array to the shape of another array.
+
+    Each dimension of the weights array must correspond to a dimension
+    of the other array.
+
+    Args:
+
+    * weights (:class:`numpy.ndarray`-like):
+        An array of weights to broadcast.
+
+    * array (:class:`numpy.ndarray`-like):
+        An array whose shape is the target shape for *weights*.
+
+    * dims (:class:`list` :class:`tuple` etc.):
+        A sequence of dimension indices, specifying which dimensions of
+        *array* are represented in *weights*. The order the dimensions
+        are given in is not important, but the order of the dimensions
+        in *weights* should be the same as the relative ordering of the
+        corresponding dimensions in *array*. For example, if *array* is
+        4d with dimensions (ntime, nlev, nlat, nlon) and *weights*
+        provides latitude-longitude grid weightings then *dims* could be
+        set to [2, 3] or [3, 2] but *weights* must have shape
+        (nlat, nlon) since the latitude dimension comes before the
+        longitude dimension in *array*.
+
+    """
+    # Create a shape array, which *weights* can be re-shaped to, allowing
+    # them to be broadcast with *array*.
+    weights_shape = numpy.ones(array.ndim)
+    for dim in dims:
+        if dim is not None:
+            weights_shape[dim] = array.shape[dim]
+    # Broadcast the arrays together.
+    return numpy.broadcast_arrays(weights.reshape(weights_shape), array)[0]
+
+
 def delta(ndarray, dimension, circular=False):
     """
     Calculates the difference between values along a given dimension.


### PR DESCRIPTION
Add the ability to generate cosine of latitude and square-root of cosine of latitude weights.

Square-root of cosine of latitude weights are commonly used prior to EOF analysis or other covariance style analyses.

Cosine of latitude weights are sometimes used for averaging operations. They are included in this PR mainly because it is trivial to implement.
