### PR TITLE
Added lbtim.ib == 3 forecast_reference_time rule

### DIFF
--- a/lib/iris/etc/pp_rules.txt
+++ b/lib/iris/etc/pp_rules.txt
@@ -42,6 +42,7 @@ f.lbtim.ic in [1, 2]
 THEN
 CoordAndDims(DimCoord(f.lbft, standard_name='forecast_period', units='hours'))
 CoordAndDims(DimCoord((f.time_unit('hours').date2num(f.t1) + f.time_unit('hours').date2num(f.t2)) / 2.0, standard_name='time', units=f.time_unit('hours'), bounds=f.time_unit('hours').date2num([f.t1, f.t2])))
+CoordAndDims(DimCoord(f.time_unit('hours').date2num(f.t2) - f.lbft, standard_name='forecast_reference_time', units=f.time_unit('hours')))
 
 
 # add season information if lbtim.ib==3

--- a/lib/iris/tests/results/analysis/abs.cml
+++ b/lib/iris/tests/results/analysis/abs.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition.cml
+++ b/lib/iris/tests/results/analysis/addition.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_coord_x.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_x.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_coord_y.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_y.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/addition_different_std_name.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_in_place.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_in_place_coord.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place_coord.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/addition_scalar.cml
+++ b/lib/iris/tests/results/analysis/addition_scalar.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division.cml
+++ b/lib/iris/tests/results/analysis/division.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division_by_array.cml
+++ b/lib/iris/tests/results/analysis/division_by_array.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division_by_latitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_latitude.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division_by_longitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_longitude.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division_by_singular_coord.cml
+++ b/lib/iris/tests/results/analysis/division_by_singular_coord.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/division_scalar.cml
+++ b/lib/iris/tests/results/analysis/division_scalar.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
@@ -10,6 +10,9 @@
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+      <coord>
         <dimCoord id="9521240c" long_name="i" points="[21.0]" shape="(1,)" units="Unit('meters')" value_type="float32"/>
       </coord>
       <coord>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
@@ -10,6 +10,9 @@
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+      <coord>
         <dimCoord id="9521240c" long_name="i" points="[21.0]" shape="(1,)" units="Unit('meters')" value_type="float32"/>
       </coord>
       <coord>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
@@ -10,6 +10,9 @@
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+      <coord>
         <dimCoord id="9521240c" long_name="i" points="[20.0]" shape="(1,)" units="Unit('meters')" value_type="float32"/>
       </coord>
       <coord>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
@@ -10,6 +10,9 @@
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+      <coord>
         <dimCoord id="9521240c" long_name="i" points="[20.0]" shape="(1,)" units="Unit('meters')" value_type="float32"/>
       </coord>
       <coord>

--- a/lib/iris/tests/results/analysis/log.cml
+++ b/lib/iris/tests/results/analysis/log.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/log10.cml
+++ b/lib/iris/tests/results/analysis/log10.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/log2.cml
+++ b/lib/iris/tests/results/analysis/log2.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/maths_original.cml
+++ b/lib/iris/tests/results/analysis/maths_original.cml
@@ -9,6 +9,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/multiply.cml
+++ b/lib/iris/tests/results/analysis/multiply.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/multiply_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/multiply_different_std_name.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/project/default_source_cs.cml
+++ b/lib/iris/tests/results/analysis/project/default_source_cs.cml
@@ -10,6 +10,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0, 1]">
         <auxCoord id="76635505" points="[[-86.7919052194, -86.7919052194, -86.7919052194,
  		..., -86.7919052194, -86.7919052194,

--- a/lib/iris/tests/results/analysis/sqrt.cml
+++ b/lib/iris/tests/results/analysis/sqrt.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/subtract.cml
+++ b/lib/iris/tests/results/analysis/subtract.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/subtract_array.cml
+++ b/lib/iris/tests/results/analysis/subtract_array.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/subtract_coord_x.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_x.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/subtract_coord_y.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_y.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/analysis/subtract_scalar.cml
+++ b/lib/iris/tests/results/analysis/subtract_scalar.cml
@@ -8,6 +8,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,

--- a/lib/iris/tests/results/uri_callback/pp_global.cml
+++ b/lib/iris/tests/results/uri_callback/pp_global.cml
@@ -11,6 +11,9 @@
       <coord>
         <dimCoord id="e9a79206" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="1282a207" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
       <coord datadims="[0]">
         <dimCoord id="531655a2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
 		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,


### PR DESCRIPTION
All unit tests pass, with doctests also passing.
