### PR TITLE
BF - fix typo in udunits2 library locator

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -177,7 +177,7 @@ if _lib_c is None:
 #
 if _lib_ud is None:
     _lib_ud = iris.config.get_option('System', 'udunits2_path',
-                                     default=ctypes.util.find_library('libudunits2'))
+                                     default=ctypes.util.find_library('udunits2'))
     _lib_ud = ctypes.CDLL(_lib_ud, use_errno=True)
 
     #


### PR DESCRIPTION
A recent update to `unit.py` left me unable to build Iris. Looks like a typo in locating udunits2 (don't need the lib prefix). This fixes it for me.
