### PR TITLE
Changes to whats_new.rst, copied from PR.212

### DIFF
--- a/docs/iris/src/whats_new.rst
+++ b/docs/iris/src/whats_new.rst
@@ -309,6 +309,3 @@ Other changes
 =============
 * Cube summaries are now more readable when the scalar coordinates
   contain bounds.
-* Iris can now load NIMROD files.
-* The ability to bypass merging when loading data.
-* The methods `Coord.cos()` and `Coord.sin()` have been deprecated.


### PR DESCRIPTION
Replaces "part of" #212.
The last-but-one commit is the common ancestor with https://github.com/pp-mo/iris/tree/old_doc_changes
