### PR TITLE
Faster monotonic check

### DIFF
--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -324,7 +324,7 @@ def monotonic(array, strict=False, return_direction=False):
     
     d = delta(array, 0)
         
-    direction = numpy.sign(max(d, key=numpy.abs))
+    direction = numpy.sign(numpy.max(numpy.abs(d)))
     
     # ALL step of 0
     if direction == 0 and not strict:


### PR DESCRIPTION
For a simple `iris.load_raw()` which loads 840 fields at 411x412 resolution, the execution time drops from 8.5s to 3.4s. :balloon: 
