### PR TITLE
Unused "import unittest" removed from extests

### DIFF
--- a/docs/iris/example_tests/extest_util.py
+++ b/docs/iris/example_tests/extest_util.py
@@ -25,7 +25,6 @@ to run the example tests.
 import contextlib
 import os.path
 import sys
-import unittest
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/example_tests/test_COP_1d_plot.py
+++ b/docs/iris/example_tests/test_COP_1d_plot.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_COP_maps.py
+++ b/docs/iris/example_tests/test_COP_maps.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_SOI_filtering.py
+++ b/docs/iris/example_tests/test_SOI_filtering.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_TEC.py
+++ b/docs/iris/example_tests/test_TEC.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_cross_section.py
+++ b/docs/iris/example_tests/test_cross_section.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_custom_file_loading.py
+++ b/docs/iris/example_tests/test_custom_file_loading.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_deriving_phenomena.py
+++ b/docs/iris/example_tests/test_deriving_phenomena.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_global_map.py
+++ b/docs/iris/example_tests/test_global_map.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_hovmoller.py
+++ b/docs/iris/example_tests/test_hovmoller.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_lagged_ensemble.py
+++ b/docs/iris/example_tests/test_lagged_ensemble.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_lineplot_with_legend.py
+++ b/docs/iris/example_tests/test_lineplot_with_legend.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():

--- a/docs/iris/example_tests/test_rotated_pole_mapping.py
+++ b/docs/iris/example_tests/test_rotated_pole_mapping.py
@@ -19,8 +19,6 @@
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests
 
-import unittest
-
 import extest_util
 
 with extest_util.add_examples_to_path():


### PR DESCRIPTION
Fixes https://github.com/SciTools/iris/issues/324
