### PR TITLE
Defer format-specific imports

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -104,7 +104,6 @@ import warnings
 import iris.config
 import iris.cube
 import iris._constraints
-import iris.fileformats
 import iris.io
 
 

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -21,20 +21,9 @@ A package for converting cubes to and from specific file formats.
 
 import iris.io.format_picker as fp
 from iris.io.format_picker import FormatSpecification as FormatSpec
-import ff
-import grib
-import netcdf
-import nimrod
-import pp
 
 
 __all__ = ['FORMAT_AGENT']
-
-
-def _pp_little_endian(filename, *args, **kwargs):
-    msg = 'PP file {!r} contains little-endian data, ' \
-          'please convert to big-endian with command line utility "bigend".'
-    raise ValueError(msg.format(filename))
 
 
 FORMAT_AGENT = fp.FormatAgent()
@@ -46,11 +35,22 @@ FORMAT_AGENT.__doc__ = "The FORMAT_AGENT is responsible for identifying the " \
 #
 # PP files.
 #
+def _pp(filenames, callback=None):
+    import iris.fileformats.pp
+    return iris.fileformats.pp.load_cubes(filenames, callback=callback)
+
+
 FORMAT_AGENT.add_spec(FormatSpec('UM Post Processing file (PP)',
                                  fp.MAGIC_NUMBER_32_BIT,
                                  0x00000100,
-                                 pp.load_cubes,
+                                 _pp,
                                  priority=5))
+
+
+def _pp_little_endian(filename, *args, **kwargs):
+    msg = 'PP file {!r} contains little-endian data, ' \
+          'please convert to big-endian with command line utility "bigend".'
+    raise ValueError(msg.format(filename))
 
 
 FORMAT_AGENT.add_spec(FormatSpec('UM Post Processing file (PP) little-endian',
@@ -63,27 +63,37 @@ FORMAT_AGENT.add_spec(FormatSpec('UM Post Processing file (PP) little-endian',
 #
 # GRIB files.
 #
+def _grib(filenames, callback=None):
+    import iris.fileformats.grib
+    return iris.fileformats.grib.load_cubes(filenames, callback=callback)
+
+
 FORMAT_AGENT.add_spec(FormatSpec('GRIB',
                                  fp.MAGIC_NUMBER_32_BIT,
                                  0x47524942,
-                                 grib.load_cubes,
+                                 _grib,
                                  priority=5))
 
 
 #
 # netCDF files.
 #
+def _netcdf(filenames, callback=None):
+    import iris.fileformats.netcdf
+    return iris.fileformats.netcdf.load_cubes(filenames, callback=callback)
+
+
 FORMAT_AGENT.add_spec(FormatSpec('NetCDF',
                                  fp.MAGIC_NUMBER_32_BIT,
                                  0x43444601,
-                                 netcdf.load_cubes,
+                                 _netcdf,
                                  priority=5))
 
 
 FORMAT_AGENT.add_spec(FormatSpec('NetCDF 64 bit offset format',
                                  fp.MAGIC_NUMBER_32_BIT,
                                  0x43444602,
-                                 netcdf.load_cubes,
+                                 _netcdf,
                                  priority=5))
     
 
@@ -91,38 +101,48 @@ FORMAT_AGENT.add_spec(FormatSpec('NetCDF 64 bit offset format',
 FORMAT_AGENT.add_spec(FormatSpec('NetCDF_v4',
                                  fp.MAGIC_NUMBER_64_BIT,
                                  0x894844460D0A1A0A,
-                                 netcdf.load_cubes,
+                                 _netcdf,
                                  priority=5))
 
 
 #
 # UM Fieldsfiles.
 #
+def _ff(filenames, callback=None):
+    import iris.fileformats.ff
+    return iris.fileformats.ff.load_cubes(filenames, callback=callback)
+
+
 FORMAT_AGENT.add_spec(FormatSpec('UM Fieldsfile (FF) pre v3.1',
                                  fp.MAGIC_NUMBER_64_BIT,
                                  0x000000000000000F,
-                                 ff.load_cubes,
+                                 _ff,
                                  priority=4))
 
 
 FORMAT_AGENT.add_spec(FormatSpec('UM Fieldsfile (FF) post v5.2',
                                  fp.MAGIC_NUMBER_64_BIT,
                                  0x0000000000000014,
-                                 ff.load_cubes,
+                                 _ff,
                                  priority=4))
 
 
 FORMAT_AGENT.add_spec(FormatSpec('UM Fieldsfile (FF) ancillary',
                                  fp.MAGIC_NUMBER_64_BIT,
                                  0xFFFFFFFFFFFF8000,
-                                 ff.load_cubes,
+                                 _ff,
                                  priority=4))
 
 #
 # NIMROD files.
 #
+def _nimrod(filenames, callback=None):
+    import iris.fileformats.nimrod
+    return iris.fileformats.nimrod.load_cubes(filenames, callback=callback)
+
+
 FORMAT_AGENT.add_spec(FormatSpec('NIMROD',
                                  fp.MAGIC_NUMBER_32_BIT,
                                  0x00000200,
-                                 nimrod.load_cubes,
+                                 _nimrod,
                                  priority=5))


### PR DESCRIPTION
Removes the need for the `iris.fileformats` module to import the various format modules on initialisation ... with the main benefit being that `import iris` no longer imports any of the format modules. This gives a small boost to the start-up speed: 0.83s -> 0.79s.
