### PR TITLE
Cube concatenate.

### DIFF
--- a/lib/iris/experimental/concatenate.py
+++ b/lib/iris/experimental/concatenate.py
@@ -1,0 +1,806 @@
+# (C) British Crown Copyright 2013 Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Automatic concatenation of multiple cubes over one or more existing dimensions.
+
+.. warning::
+
+    Currently, the :func:`concatenate` routine will load the data payload
+    of all cubes passed to it.
+
+    This restriction will be relaxed in a future release.
+
+"""
+
+from collections import defaultdict, namedtuple
+
+import numpy as np
+import numpy.ma as ma
+
+import iris.coords
+import iris.cube
+from iris.util import guess_coord_axis, array_equal
+
+
+#
+# TODO:
+#
+#   * Deal with scalar coordinate promotion to a new dimension
+#     e.g. promote scalar z coordinate in 2D cube (y:m, x:n) to
+#     give the similar 3D cube (z:1, y:m, x:n). These two types
+#     of cubes are one and the same, and as such should concatenate
+#     together.
+#
+#   * Cope with auxiliary coordinate factories.
+#
+#   * Don't load the cube data payload.
+#
+#   * Deal with anonymous dimensions.
+#
+#   * Allow concatentation over a user specified dimension.
+#
+
+
+# Restrict the names imported from this namespace.
+__all__ = ['concatenate']
+
+# Direction of dimension coordinate value order.
+_CONSTANT = 0
+_DECREASING = -1
+_INCREASING = 1
+
+
+class _CoordAndDims(namedtuple('CoordAndDims',
+                               ['coord', 'dims'])):
+    """
+    Container for a coordinate and the associated data dimension(s)
+    spanned over a :class:`iris.cube.Cube`.
+
+    Args:
+
+    * coord:
+        A :class:`iris.coords.DimCoord` or :class:`iris.coords.AuxCoord`
+        coordinate instance.
+
+    * dims:
+        A tuple of the data dimension(s) spanned by the coordinate.
+
+    """
+
+
+class _CoordMetaData(namedtuple('CoordMetaData',
+                                ['defn', 'dims', 'points_dtype',
+                                 'bounds_dtype', 'kwargs'])):
+    """
+    Container for the metadata that defines a dimension or auxiliary
+    coordinate.
+
+    Args:
+
+    * defn:
+        The :class:`iris.coords.CoordDefn` metadata that represents a
+        coordinate.
+
+    * dims:
+        The dimension(s) associated with the coordinate.
+
+    * points_dtype:
+        The points data :class:`np.dtype` of an associated coordinate.
+
+    * bounds_dtype:
+        The bounds data :class:`np.dtype` of an associated coordinate.
+
+    * kwargs:
+        A dictionary of key/value pairs required to define a coordinate.
+
+    """
+    def __new__(cls, coord, dims):
+        """
+        Create a new :class:`_CoordMetaData` instance.
+
+        Args:
+
+        * coord:
+            The :class:`iris.coord.DimCoord` or :class:`iris.coord.AuxCoord`.
+
+        * dims:
+            The dimension(s) associated with the coordinate.
+
+        Returns:
+            The new class instance.
+
+        """
+        defn = coord._as_defn()
+        points_dtype = coord.points.dtype
+        bounds_dtype = coord.bounds.dtype if coord.bounds is not None \
+            else None
+        kwargs = {}
+        # Add circular flag metadata for dimensional coordinates.
+        if hasattr(coord, 'circular'):
+            kwargs['circular'] = coord.circular
+        if isinstance(coord, iris.coords.DimCoord):
+            # Mix the monotonic ordering into the metadata.
+            if coord.points[0] == coord.points[-1]:
+                order = _CONSTANT
+            elif coord.points[-1] > coord.points[0]:
+                order = _INCREASING
+            else:
+                order = _DECREASING
+            kwargs['order'] = order
+        metadata = super(_CoordMetaData, cls).__new__(cls, defn, dims,
+                                                      points_dtype,
+                                                      bounds_dtype,
+                                                      kwargs)
+        return metadata
+
+
+class _SkeletonCube(namedtuple('SkeletonCube',
+                               ['signature', 'data'])):
+    """
+    Basis of a source-cube, containing the associated coordinate metadata,
+    coordinates and cube data payload.
+
+    Args:
+
+    * signature:
+        The :class:`CoordSignature` of an associated source-cube.
+
+    * data:
+        The data payload of an associated :class:`iris.cube.Cube` source-cube.
+
+    """
+
+
+class _Extent(namedtuple('Extent',
+                         ['min', 'max'])):
+    """
+    Container representing the limits of a one-dimensional extent/range.
+
+    Args:
+
+    * min:
+        The minimum value of the extent.
+
+    * max:
+        The maximum value of the extent.
+
+    """
+
+
+class _CoordExtent(namedtuple('CoordExtent',
+                              ['points', 'bounds'])):
+    """
+    Container representing the points and bounds extent of a one dimensional
+    coordinate.
+
+    Args:
+
+    * points:
+        The :class:`_Extent` of the coordinate point values.
+
+    * bounds:
+        A list containing the :class:`_Extent` of the coordinate lower
+        bound and the upper bound. Defaults to None if no associated
+        bounds exist for the coordinate.
+
+    """
+
+
+def concatenate(cubes):
+    """
+    Concatenate the provided cubes over common existing dimensions.
+
+    Args:
+
+    * cubes:
+        An iterable containing one or more :class:`iris.cube.Cube` instances
+        to be concatenated together.
+
+    Returns:
+        A :class:`iris.cube.CubeList` of concatenated :class:`iris.cube.Cube`
+        instances.
+
+    .. warning::
+
+        This routine will load your data payload!
+
+    """
+    proto_cubes_by_name = defaultdict(list)
+    # Initialise the nominated axis (dimension) of concatenation
+    # which requires to be negotiated.
+    axis = None
+
+    # Register each cube with its appropriate proto-cube.
+    for cube in cubes:
+        # TODO: Remove this when new deferred data mechanism is available.
+        # Avoid deferred data/data manager issues, and load the cube data!
+        cube.data
+
+        name = cube.standard_name or cube.long_name
+        proto_cubes = proto_cubes_by_name[name]
+        registered = False
+
+        # Register cube with an existing proto-cube.
+        for proto_cube in proto_cubes:
+            registered = proto_cube.register(cube, axis)
+            if registered:
+                axis = proto_cube.axis
+                break
+
+        # Create a new proto-cube for an unregistered cube.
+        if not registered:
+            proto_cubes.append(ProtoCube(cube))
+
+    # Construct a concatenated cube from each of the proto-cubes.
+    concatenated_cubes = iris.cube.CubeList()
+
+    for name in sorted(proto_cubes_by_name):
+        for proto_cube in proto_cubes_by_name[name]:
+            # Construct the concatenated cube.
+            concatenated_cubes.append(proto_cube.concatenate())
+
+    # Perform concatenation until we've reached an equilibrium.
+    count = len(concatenated_cubes)
+    if count != 1 and count != len(cubes):
+        concatenated_cubes = concatenate(concatenated_cubes)
+
+    return concatenated_cubes
+
+
+class CubeSignature(object):
+    """
+    Template for identifying a specific type of :class:`iris.cube.Cube` based
+    on its metadata and coordinates.
+
+    """
+    def __init__(self, cube):
+        """
+        Represents the cube metadata and associated coordinate metadata that
+        allows suitable cubes for concatenation to be identified.
+
+        Args:
+
+        * cube:
+            The :class:`iris.cube.Cube` source-cube.
+
+        """
+        self.aux_coords_and_dims = []
+        self.aux_metadata = []
+        self.dim_coords = cube.dim_coords
+        self.dim_metadata = []
+        self.mdi = None
+        self.ndim = cube.ndim
+        self.scalar_coords = []
+
+        # Determine whether there are any anonymous cube dimensions.
+        covered = set(cube.coord_dims(coord)[0] for coord in self.dim_coords)
+        self.anonymous = covered != set(range(self.ndim))
+
+        self.defn = cube.metadata
+        self.data_type = cube.data.dtype
+
+        if ma.isMaskedArray(cube.data):
+            # Only set when we're dealing with a masked payload.
+            self.mdi = cube.data.fill_value
+
+        #
+        # Collate the dimension coordinate metadata.
+        #
+        for coord in self.dim_coords:
+            metadata = _CoordMetaData(coord, cube.coord_dims(coord))
+            self.dim_metadata.append(metadata)
+
+        #
+        # Collate the auxiliary coordinate metadata and scalar coordinates.
+        #
+        axes = dict(T=0, Z=1, Y=2, X=3)
+        # Coordinate sort function - by guessed coordinate axis, then
+        # by coordinate definition, then by dimensions, in ascending order.
+        key_func = lambda coord: (axes.get(guess_coord_axis(coord),
+                                           len(axes) + 1),
+                                  coord._as_defn(),
+                                  cube.coord_dims(coord))
+
+        for coord in sorted(cube.aux_coords, key=key_func):
+            dims = cube.coord_dims(coord)
+            if dims:
+                metadata = _CoordMetaData(coord, dims)
+                self.aux_metadata.append(metadata)
+                coord_and_dims = _CoordAndDims(coord, tuple(dims))
+                self.aux_coords_and_dims.append(coord_and_dims)
+            else:
+                self.scalar_coords.append(coord)
+
+    def __eq__(self, other):
+        result = NotImplemented
+
+        if isinstance(other, CubeSignature):
+            # Only concatenate with fully described cubes.
+            if self.anonymous or other.anonymous:
+                result = False
+            else:
+                result = self.aux_metadata == other.aux_metadata and \
+                    self.data_type == other.data_type and \
+                    self.defn == other.defn and \
+                    self.dim_metadata == other.dim_metadata and \
+                    self.mdi == other.mdi and \
+                    self.ndim == other.ndim and \
+                    self.scalar_coords == other.scalar_coords
+
+        return result
+
+    def __ne__(self, other):
+        return not self == other
+
+
+class CoordSignature(object):
+    """
+    Template for identifying a specific type of :class:`iris.cube.Cube` based
+    on its coordinates.
+
+    """
+    def __init__(self, cube_signature):
+        """
+        Represents the coordinate metadata required to identify suitable
+        non-overlapping :class:`iris.cube.Cube` source-cubes for
+        concatenation over a common single dimension.
+
+        Args:
+
+        * cube_signature:
+            The :class:`CubeSignature` that defines the source-cube.
+
+        """
+        self.aux_coords_and_dims = cube_signature.aux_coords_and_dims
+        self.dim_coords = cube_signature.dim_coords
+        self.dim_extents = []
+        self.dim_order = [metadata.kwargs['order']
+                          for metadata in cube_signature.dim_metadata]
+
+        # Calculate the extents for each dimensional coordinate.
+        self._calculate_extents()
+
+    @staticmethod
+    def _cmp(coord, other):
+        """
+        Compare the coordinates for concatenation compatibility.
+
+        Returns:
+            A boolean tuple pair of whether the coordinates are compatible,
+            and whether they represent a candidate axis of concatenation.
+
+        """
+        # A candidate axis must have non-identical coordinate points.
+        candidate_axis = not array_equal(coord.points, other.points)
+
+        if candidate_axis:
+            # Ensure both have equal availability of bounds.
+            result = (coord.bounds is None) == (other.bounds is None)
+        else:
+            if coord.bounds is not None and other.bounds is not None:
+                # Ensure equality of bounds.
+                result = array_equal(coord.bounds, other.bounds)
+            else:
+                # Ensure both have equal availability of bounds.
+                result = coord.bounds is None and other.bounds is None
+
+        return result, candidate_axis
+
+    def candidate_axis(self, other):
+        """
+        Determine the candidate axis of concatenation with the
+        given coordinate signature.
+
+        If a candidate axis is found, then the coordinate
+        signatures are compatible.
+
+        Args:
+
+        * other:
+            The :class:`CoordSignature`
+
+        Returns:
+            None if no single candidate axis exists, otherwise
+            the candidate axis of concatenation.
+
+        """
+        result = False
+        candidate_axes = []
+
+        # Compare dimension coordinates.
+        for dim, coord in enumerate(self.dim_coords):
+            result, candidate_axis = self._cmp(coord,
+                                               other.dim_coords[dim])
+            if not result:
+                break
+            if candidate_axis:
+                candidate_axes.append(dim)
+
+        # Only permit one degree of dimensional freedom when
+        # determining the candidate axis of concatenation.
+        if result and len(candidate_axes) == 1:
+            result = candidate_axes[0]
+        else:
+            result = None
+
+        return result
+
+    def _calculate_extents(self):
+        """
+        Calculate the extent over each dimension coordinates points and bounds.
+
+        """
+        self.dim_extents = []
+        for coord, order in zip(self.dim_coords, self.dim_order):
+            if order == _CONSTANT or order == _INCREASING:
+                points = _Extent(coord.points[0], coord.points[-1])
+                if coord.bounds is not None:
+                    bounds = (_Extent(coord.bounds[0, 0], coord.bounds[-1, 0]),
+                              _Extent(coord.bounds[0, 1], coord.bounds[-1, 1]))
+                else:
+                    bounds = None
+            else:
+                # The order must be decreasing ...
+                points = _Extent(coord.points[-1], coord.points[0])
+                if coord.bounds is not None:
+                    bounds = (_Extent(coord.bounds[-1, 0], coord.bounds[0, 0]),
+                              _Extent(coord.bounds[-1, 1], coord.bounds[0, 1]))
+                else:
+                    bounds = None
+
+            self.dim_extents.append(_CoordExtent(points, bounds))
+
+
+class ProtoCube(object):
+    """
+    Framework for concatenating multiple source-cubes over one
+    common dimension.
+
+    """
+    def __init__(self, cube):
+        """
+        Create a new ProtoCube from the given cube and record the cube
+        as a source-cube.
+
+        Args:
+
+        * cube:
+            Source :class:`iris.cube.Cube` of the :class:`ProtoCube`.
+
+        """
+        # Cache the source-cube of this proto-cube.
+        self._cube = cube
+
+        # The cube signature is a combination of cube and coordinate
+        # metadata that defines this proto-cube.
+        self._cube_signature = CubeSignature(cube)
+
+        # The coordinate signature allows suitable non-overlapping
+        # source-cubes to be identified.
+        self._coord_signature = CoordSignature(self._cube_signature)
+
+        # The list of source-cubes relevant to this proto-cube.
+        self._skeletons = []
+        self._add_skeleton(self._coord_signature, cube.data)
+
+        # The nominated axis of concatenation.
+        self._axis = None
+
+    @property
+    def axis(self):
+        """Return the nominated dimension of concatenation."""
+
+        return self._axis
+
+    def concatenate(self):
+        """
+        Concatenates all the source-cubes registered with the
+        :class:`ProtoCube` over the nominated common dimension.
+
+        Returns:
+            The concatenated :class:`iris.cube.Cube`.
+
+        """
+        if len(self._skeletons) > 1:
+            skeletons = self._skeletons
+            order = self._coord_signature.dim_order[self.axis]
+            cube_signature = self._cube_signature
+
+            # Sequence the skeleton segments into the correct order
+            # pending concatenation.
+            key_func = lambda skeleton: skeleton.signature.dim_extents
+            skeletons.sort(key=key_func,
+                           reverse=(order == _DECREASING))
+
+            # Concatenate the new dimension coordinate.
+            dim_coords_and_dims = self._build_dim_coordinates()
+
+            # Concatenate the new auxiliary coordinates.
+            aux_coords_and_dims = self._build_aux_coordinates()
+
+            # Concatenate the new data payload.
+            data = self._build_data()
+
+            # Build the new cube.
+            kwargs = cube_signature.defn._asdict()
+            cube = iris.cube.Cube(data,
+                                  dim_coords_and_dims=dim_coords_and_dims,
+                                  aux_coords_and_dims=aux_coords_and_dims,
+                                  **kwargs)
+        else:
+            # There are no other source-cubes to concatenate
+            # with this proto-cube.
+            cube = self._cube
+
+        return cube
+
+    def register(self, cube, axis=None):
+        """
+        Determine whether the given source-cube is suitable for concatenation
+        with this :class:`ProtoCube`.
+
+        Args:
+
+        * cube:
+            The :class:`iris.cube.Cube` source-cube candidate for
+            concatenation.
+
+        Kwargs:
+
+        * axis:
+            Seed the dimension of concatenation for the :class:`ProtoCube`
+            rather than rely on negotiation with source-cubes.
+
+        Returns:
+            Boolean.
+
+        """
+        # Verify and assert the nominated axis.
+        if axis is not None and self.axis is not None and self.axis != axis:
+            msg = 'Nominated axis [{}] is not equal ' \
+                'to negotiated axis [{}]'.format(axis, self.axis)
+            raise ValueError(msg)
+
+        # Check for compatible cube signatures.
+        cube_signature = CubeSignature(cube)
+        match = self._cube_signature == cube_signature
+
+        # Check for compatible coordinate signatures.
+        if match:
+            coord_signature = CoordSignature(cube_signature)
+            candidate_axis = self._coord_signature.candidate_axis(
+                coord_signature)
+            match = candidate_axis is not None and \
+                (candidate_axis == axis or axis is None)
+
+        # Check for compatible coordinate extents.
+        if match:
+            match = self._sequence(coord_signature.dim_extents[candidate_axis],
+                                   candidate_axis)
+
+        if match:
+            # Register the cube as a source-cube for this proto-cube.
+            self._add_skeleton(coord_signature, cube.data)
+            # Declare the nominated axis of concatenation.
+            self._axis = candidate_axis
+
+        return match
+
+    def _add_skeleton(self, coord_signature, data):
+        """
+        Create and add the source-cube skeleton to the
+        :class:`ProtoCube`.
+
+        Args:
+
+        * coord_signature:
+            The :class:`CoordSignature` of the associated
+            given source-cube.
+
+        * data:
+            The data payload of an associated :class:`iris.cube.Cube`
+            source-cube.
+
+        """
+        skeleton = _SkeletonCube(coord_signature, data)
+        self._skeletons.append(skeleton)
+
+    def _build_aux_coordinates(self):
+        """
+        Generate the auxiliary coordinates with associated dimension(s)
+        mapping for the new concatenated cube.
+
+        Returns:
+            A list of auxiliary coordinates and dimension(s) tuple pairs.
+
+        """
+        # Setup convenience hooks.
+        skeletons = self._skeletons
+        cube_signature = self._cube_signature
+
+        aux_coords_and_dims = []
+
+        # Generate all the auxiliary coordinates for the new concatenated cube.
+        for i, (coord, dims) in enumerate(cube_signature.aux_coords_and_dims):
+            # Check whether the coordinate spans the nominated
+            # dimension of concatenation.
+            if self.axis in dims:
+                # Concatenate the points together.
+                dim = dims.index(self.axis)
+                points = [skton.signature.aux_coords_and_dims[i].coord.points
+                          for skton in skeletons]
+                points = np.concatenate(tuple(points), axis=dim)
+
+                # Concatenate the bounds together.
+                bnds = None
+                if coord.has_bounds():
+                    bnds = [skton.signature.aux_coords_and_dims[i].coord.bounds
+                            for skton in skeletons]
+                    bnds = np.concatenate(tuple(bnds), axis=dim)
+
+                # Generate the associated coordinate metadata.
+                kwargs = cube_signature.aux_metadata[i].defn._asdict()
+
+                # Build the concatenated coordinate.
+                if isinstance(coord, iris.coords.AuxCoord):
+                    coord = iris.coords.AuxCoord(points, bounds=bnds, **kwargs)
+                else:
+                    # Attempt to create a DimCoord, otherwise default to
+                    # an AuxCoord on failure.
+                    try:
+                        coord = iris.coords.DimCoord(points, bounds=bnds,
+                                                     **kwargs)
+                    except ValueError:
+                        coord = iris.coords.AuxCoord(points, bounds=bnds,
+                                                     **kwargs)
+
+            aux_coords_and_dims.append((coord.copy(), dims))
+
+        # Generate all the scalar coordinates for the new concatenated cube.
+        for coord in cube_signature.scalar_coords:
+            aux_coords_and_dims.append((coord.copy(), ()))
+
+        return aux_coords_and_dims
+
+    def _build_data(self):
+        """
+        Generate the data payload for the new concatenated cube.
+
+        Returns:
+            The concatenated :class:`iris.cube.Cube` data payload.
+
+        """
+        skeletons = self._skeletons
+        data = [skeleton.data for skeleton in skeletons]
+
+        if self._cube_signature.mdi is not None:
+            # Preserve masked entries.
+            data = ma.concatenate(tuple(data), axis=self.axis)
+        else:
+            data = np.concatenate(tuple(data), axis=self.axis)
+
+        return data
+
+    def _build_dim_coordinates(self):
+        """
+        Generate the dimension coordinates with associated dimension
+        mapping for the new concatenated cube.
+
+        Return:
+            A list of dimension coordinate and dimension tuple pairs.
+
+        """
+        # Setup convenience hooks.
+        skeletons = self._skeletons
+        axis = self.axis
+        defn = self._cube_signature.dim_metadata[axis].defn
+        circular = self._cube_signature.dim_metadata[axis].kwargs['circular']
+
+        # Concatenate the points together for the nominated dimension.
+        points = [skeleton.signature.dim_coords[axis].points
+                  for skeleton in skeletons]
+        points = np.concatenate(tuple(points))
+
+        # Concatenate the bounds together for the nominated dimension.
+        bounds = None
+        if self._cube_signature.dim_coords[axis].has_bounds():
+            bounds = [skeleton.signature.dim_coords[axis].bounds
+                      for skeleton in skeletons]
+            bounds = np.concatenate(tuple(bounds))
+
+        # Populate the new dimension coordinate with the concatenated
+        # points, bounds and associated metadata.
+        kwargs = defn._asdict()
+        kwargs['circular'] = circular
+        dim_coord = iris.coords.DimCoord(points, bounds=bounds, **kwargs)
+
+        # Generate all the dimension coordinates for the new concatenated cube.
+        dim_coords_and_dims = []
+        for dim, coord in enumerate(self._cube_signature.dim_coords):
+            if dim == axis:
+                dim_coords_and_dims.append((dim_coord, dim))
+            else:
+                dim_coords_and_dims.append((coord.copy(), dim))
+
+        return dim_coords_and_dims
+
+    def _sequence(self, extent, axis):
+        """
+        Determine whether the given extent can be sequenced along with
+        all the extents of the source-cubes already registered with
+        this :class:`ProtoCube` into non-overlapping segments for the
+        given axis.
+
+        Args:
+
+        * extent:
+            The :class:`_CoordExtent` of the candidate source-cube.
+
+        * axis:
+            The candidate axis of concatenation.
+
+        Returns:
+            Boolean.
+
+        """
+        result = True
+
+        # Add the new extent to the current extents collection.
+        dim_extents = [skeleton.signature.dim_extents[axis]
+                       for skeleton in self._skeletons]
+        dim_extents.append(extent)
+
+        # Sort into the appropriate dimension order.
+        order = self._coord_signature.dim_order[axis]
+        dim_extents.sort(reverse=(order == _DECREASING))
+
+        # Ensure that the extents don't overlap.
+        if len(dim_extents) > 1:
+            for i, extent in enumerate(dim_extents[1:]):
+                # Check the points - must be strictly monotonic.
+                if order == _DECREASING:
+                    left = dim_extents[i].points.min
+                    right = extent.points.max
+                else:
+                    left = dim_extents[i].points.max
+                    right = extent.points.min
+
+                if left >= right:
+                    result = False
+                    break
+
+                # Check the bounds - must be strictly monotonic.
+                if extent.bounds is not None:
+                    if order == _DECREASING:
+                        left_0 = dim_extents[i].bounds[0].min
+                        left_1 = dim_extents[1].bounds[1].min
+                        right_0 = extent.bounds[0].max
+                        right_1 = extent.bounds[1].max
+                    else:
+                        left_0 = dim_extents[i].bounds[0].max
+                        left_1 = dim_extents[i].bounds[1].max
+                        right_0 = extent.bounds[0].min
+                        right_1 = extent.bounds[1].min
+
+                    lower_bound_fail = left_0 >= right_0
+                    upper_bound_fail = left_1 >= right_1
+
+                    if lower_bound_fail or upper_bound_fail:
+                        result = False
+                        break
+
+        return result

--- a/lib/iris/tests/experimental/test_concatenate.py
+++ b/lib/iris/tests/experimental/test_concatenate.py
@@ -1,0 +1,874 @@
+# (C) British Crown Copyright 2013 Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test the cube concatenate mechanism.
+
+"""
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import numpy as np
+import numpy.ma as ma
+
+import iris.cube
+from iris.coords import DimCoord, AuxCoord
+import iris.tests.stock as stock
+from iris.experimental.concatenate import concatenate as cube_concatenate
+
+
+def _make_cube(x, y, data, aux=None, offset=0, scalar=None):
+    """
+    A convenience test function that creates a custom 2D cube.
+
+    Args:
+
+    * x:
+        A (start, stop, step) tuple for specifying the
+        x-axis dimensional coordinate points. Bounds are
+        automatically guessed.
+
+    * y:
+        A (start, stop, step) tuple for specifying the
+        y-axis dimensional coordinate points. Bounds are
+        automatically guessed.
+
+    * data:
+        The data payload for the cube.
+
+    Kwargs:
+
+    * aux:
+        A CSV string specifying which points only auxiliary
+        coordinates to create. Accepts either of 'x', 'y', 'xy'.
+
+    * offset:
+        Offset value to be added to the 'xy' auxiliary coordinate
+        points.
+
+    * scalar:
+        Create a 'height' scalar coordinate with the given value.
+
+    Returns:
+        The newly created 2D :class:`iris.cube.Cube`.
+
+    """
+    x_range = np.arange(*x, dtype=np.float32)
+    y_range = np.arange(*y, dtype=np.float32)
+    x_size = len(x_range)
+    y_size = len(y_range)
+
+    cube_data = np.empty((y_size, x_size), dtype=np.float32)
+    cube_data[:] = data
+    cube = iris.cube.Cube(cube_data)
+    coord = DimCoord(y_range, long_name='y')
+    coord.guess_bounds()
+    cube.add_dim_coord(coord, 0)
+    coord = DimCoord(x_range, long_name='x')
+    coord.guess_bounds()
+    cube.add_dim_coord(coord, 1)
+
+    if aux is not None:
+        aux = aux.split(',')
+        if 'y' in aux:
+            coord = AuxCoord(y_range * 10, long_name='y-aux')
+            cube.add_aux_coord(coord, (0,))
+        if 'x' in aux:
+            coord = AuxCoord(x_range * 10, long_name='x-aux')
+            cube.add_aux_coord(coord, (1,))
+        if 'xy' in aux:
+            payload = np.arange(y_size * x_size,
+                                dtype=np.float32).reshape(y_size, x_size)
+            coord = AuxCoord(payload * 100 + offset, long_name='xy-aux')
+            cube.add_aux_coord(coord, (0, 1))
+
+    if scalar is not None:
+        data = np.array([scalar], dtype=np.float32)
+        coord = AuxCoord(data, long_name='height', units='m')
+        cube.add_aux_coord(coord, ())
+
+    return cube
+
+
+def _make_cube_3d(x, y, z, data, aux=None, offset=0):
+    """
+    A convenience test function that creates a custom 3D cube.
+
+    Args:
+
+    * x:
+        A (start, stop, step) tuple for specifying the
+        x-axis dimensional coordinate points. Bounds are
+        automatically guessed.
+
+    * y:
+        A (start, stop, step) tuple for specifying the
+        y-axis dimensional coordinate points. Bounds are
+        automatically guessed.
+
+    * z:
+        A (start, stop, step) tuple for specifying the
+        z-axis dimensional coordinate points. Bounds are
+        automatically guessed.
+
+    * data:
+        The data payload for the cube.
+
+    Kwargs:
+
+    * aux:
+        A CSV string specifying which points only auxiliary
+        coordinates to create. Accepts either of 'x', 'y', 'z',
+        'xy', 'xz', 'yz', 'xyz'.
+
+    * offset:
+        Offset value to be added to non-1D auxiliary coordinate
+        points.
+
+    Returns:
+        The newly created 3D :class:`iris.cube.Cube`.
+
+    """
+    x_range = np.arange(*x, dtype=np.float32)
+    y_range = np.arange(*y, dtype=np.float32)
+    z_range = np.arange(*z, dtype=np.float32)
+    x_size, y_size, z_size = len(x_range), len(y_range), len(z_range)
+
+    cube_data = np.empty((x_size, y_size, z_size), dtype=np.float32)
+    cube_data[:] = data
+    cube = iris.cube.Cube(cube_data)
+    coord = DimCoord(z_range, long_name='z')
+    coord.guess_bounds()
+    cube.add_dim_coord(coord, 0)
+    coord = DimCoord(y_range, long_name='y')
+    coord.guess_bounds()
+    cube.add_dim_coord(coord, 1)
+    coord = DimCoord(x_range, long_name='x')
+    coord.guess_bounds()
+    cube.add_dim_coord(coord, 2)
+
+    if aux is not None:
+        aux = aux.split(',')
+        if 'z' in aux:
+            coord = AuxCoord(z_range * 10, long_name='z-aux')
+            cube.add_aux_coord(coord, (0,))
+        if 'y' in aux:
+            coord = AuxCoord(y_range * 10, long_name='y-aux')
+            cube.add_aux_coord(coord, (1,))
+        if 'x' in aux:
+            coord = AuxCoord(x_range * 10, long_name='x-aux')
+            cube.add_aux_coord(coord, (2,))
+        if 'xy' in aux:
+            payload = np.arange(x_size * y_size,
+                                dtype=np.float32).reshape(y_size, x_size)
+            coord = AuxCoord(payload + offset, long_name='xy-aux')
+            cube.add_aux_coord(coord, (1, 2))
+        if 'xz' in aux:
+            payload = np.arange(x_size * z_size,
+                                dtype=np.float32).reshape(z_size, x_size)
+            coord = AuxCoord(payload * 10 + offset, long_name='xz-aux')
+            cube.add_aux_coord(coord, (0, 2))
+        if 'yz' in aux:
+            payload = np.arange(y_size * z_size,
+                                dtype=np.float32).reshape(z_size, y_size)
+            coord = AuxCoord(payload * 100 + offset, long_name='yz-aux')
+            cube.add_aux_coord(coord, (0, 1))
+        if 'xyz' in aux:
+            payload = np.arange(x_size * y_size * z_size,
+                                dtype=np.float32).reshape(z_size,
+                                                          y_size,
+                                                          x_size)
+            coord = AuxCoord(payload * 1000 + offset, long_name='xyz-aux')
+            cube.add_aux_coord(coord, (0, 1, 2))
+
+    return cube
+
+
+def concatenate(cubes, order=None):
+    """
+    Explicitly force the contiguous major order of cube data
+    alignment to ensure consistent CML crc32 checksums.
+
+    Defaults to contiguous 'C' row-major order.
+
+    """
+    if order is None:
+        order = 'C'
+
+    result = cube_concatenate(cubes)
+
+    for cube in result:
+        if ma.isMaskedArray(cube.data):
+#            cube.data = ma.copy(cube.data, order=order)
+            data = np.array(cube.data.data, copy=True, order=order)
+            mask = np.array(cube.data.mask, copy=True, order=order)
+            fill_value = cube.data.fill_value
+            cube.data = ma.array(data, mask=mask, fill_value=fill_value)
+        else:
+#            cube.data = np.copy(cube.data, order=order)
+            cube.data = np.array(cube.data, copy=True, order=order)
+
+    return result
+
+
+class TestSimple(tests.IrisTest):
+    def test_empty(self):
+        cubes = iris.cube.CubeList()
+        self.assertEqual(concatenate(cubes), iris.cube.CubeList())
+        cubes = []
+        self.assertEqual(concatenate(cubes), iris.cube.CubeList())
+        cubes = ()
+        self.assertEqual(concatenate(cubes), iris.cube.CubeList())
+
+    def test_single(self):
+        cubes = [stock.simple_2d()]
+        self.assertEqual(concatenate(cubes), cubes)
+
+    def test_multi_equal(self):
+        cubes = [stock.simple_2d()] * 2
+        self.assertEqual(concatenate(cubes), cubes)
+
+
+class TestNoConcat(tests.IrisTest):
+    def test_anonymous(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1))
+        cubes.append(_make_cube((2, 4), y, 2))
+        cube = _make_cube((4, 6), y, 3)
+        cube.remove_coord('x')
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_anonymous.cml'))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, (2, 4))
+        self.assertEqual(result[1].shape, (2, 2))
+
+    def test_points_overlap_increasing(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1))
+        cubes.append(_make_cube((1, 3), y, 2))
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_points_overlap_decreasing(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (3, 0, -1), 1))
+        cubes.append(_make_cube(x, (1, -1, -1), 2))
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_bounds_overlap_increasing(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1))
+        cube = _make_cube((2, 4), y, 1)
+        cube.coord('x').bounds = np.array([[0.5, 2.5], [2.5, 3.5]])
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_bounds_overlap_decreasing(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((3, 1, -1), y, 1))
+        cube = _make_cube((1, -1, -1), y, 2)
+        cube.coord('x').bounds = np.array([[2.5, 0.5], [0.5, -0.5]])
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_scalar_difference(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1, scalar=10))
+        cubes.append(_make_cube((2, 4), y, 2, scalar=20))
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_uncommon(self):
+        cubes = []
+        cubes.append(_make_cube((0, 2), (0, 2), 1))
+        cubes.append(_make_cube((2, 4), (2, 4), 2))
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_order(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1))
+        cubes.append(_make_cube((6, 1, -1), y, 2))
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_masked_vs_unmasked(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1))
+        cube = _make_cube((2, 4), y, 2)
+        cube.data = ma.asarray(cube.data)
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+    def test_masked_fill_value(self):
+        cubes = []
+        y = (0, 2)
+        cube = _make_cube((0, 2), y, 1)
+        cube.data = ma.asarray(cube.data)
+        cube.data.fill_value = 10
+        cubes.append(cube)
+        cube = _make_cube((2, 4), y, 1)
+        cube.data = ma.asarray(cube.data)
+        cube.data.fill_value = 20
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 2)
+
+
+class Test2D(tests.IrisTest):
+    def test_concat_masked_2x2d(self):
+        cubes = []
+        y = (0, 2)
+        cube = _make_cube((0, 2), y, 1)
+        cube.data = ma.asarray(cube.data)
+        cube.data[(0, 1), (0, 1)] = ma.masked
+        cubes.append(cube)
+        cube = _make_cube((2, 4), y, 2)
+        cube.data = ma.asarray(cube.data)
+        cube.data[(0, 1), (1, 0)] = ma.masked
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_masked_2x2d.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 4))
+        mask = np.array([[True, False, False, True],
+                         [False, True, True, False]], dtype=np.bool)
+        self.assertArrayEqual(result[0].data.mask, mask)
+
+    def test_concat_masked_2y2d(self):
+        cubes = []
+        x = (0, 2)
+        cube = _make_cube(x, (0, 2), 1)
+        cube.data = np.ma.asarray(cube.data)
+        cube.data[(0, 1), (0, 1)] = ma.masked
+        cubes.append(cube)
+        cube = _make_cube(x, (2, 4), 2)
+        cube.data = ma.asarray(cube.data)
+        cube.data[(0, 1), (1, 0)] = ma.masked
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_masked_2y2d.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (4, 2))
+        mask = np.array([[True, False],
+                         [False, True],
+                         [False, True],
+                         [True, False]], dtype=np.bool)
+        self.assertArrayEqual(result[0].data.mask, mask)
+
+    def test_concat_2x2d(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1))
+        cubes.append(_make_cube((4, 6), y, 2))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1))
+        cubes.append(_make_cube(x, (4, 6), 2))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_x(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='x'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='x'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_x.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_x(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='x'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='x'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_x.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_y(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='y'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='y'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_y.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_y(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='y'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='y'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_y.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_x_y(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='x,y'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='x,y'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_x_y.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_x_y(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='x,y'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='x,y'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_x_y.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='xy'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='xy'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_x_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='x,xy'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='x,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_x_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_x_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='x,xy'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='x,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_x_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_y_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='y,xy'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='y,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_y_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_y_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='y,xy'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='y,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_y_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_x_y_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 4), y, 1, aux='x,y,xy'))
+        cubes.append(_make_cube((4, 6), y, 2, aux='x,y,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2x2d_aux_x_y_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2y2d_aux_x_y_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 4), 1, aux='x,y,xy'))
+        cubes.append(_make_cube(x, (4, 6), 2, aux='x,y,xy'))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_2y2d_aux_x_y_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 2))
+
+    def test_concat_2x2d_aux_x_bounds(self):
+        cubes = []
+        y = (0, 2)
+        cube = _make_cube((0, 4), y, 1, aux='x')
+        cube.coord('x-aux').guess_bounds()
+        cubes.append(cube)
+        cube = _make_cube((4, 6), y, 2, aux='x')
+        cube.coord('x-aux').guess_bounds()
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate',
+                                'concat_2x2d_aux_x_bounds.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 6))
+
+    def test_concat_2x2d_aux_xy_bounds(self):
+        cubes = []
+        y = (0, 2)
+        cube = _make_cube((0, 2), y, 1, aux='xy', offset=1)
+        coord = cube.coord('xy-aux')
+        coord.bounds = np.array([1, 2, 3, 4,
+                                 101, 102, 103, 104,
+                                 201, 202, 203, 204,
+                                 301, 302, 303, 304]).reshape(2, 2, 4)
+        cubes.append(cube)
+        cube = _make_cube((2, 4), y, 2, aux='xy', offset=2)
+        coord = cube.coord('xy-aux')
+        coord.bounds = np.array([2, 3, 4, 5,
+                                 102, 103, 104, 105,
+                                 202, 203, 204, 205,
+                                 302, 303, 304, 305]).reshape(2, 2, 4)
+        cubes.append(cube)
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate',
+                                'concat_2x2d_aux_xy_bounds.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 4))
+
+
+class TestMulti2D(tests.IrisTest):
+    def test_concat_4x2d_aux_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1, aux='xy', offset=1))
+        cubes.append(_make_cube((2, 4), y, 2, aux='xy', offset=2))
+        y = (2, 4)
+        cubes.append(_make_cube((0, 2), y, 3, aux='xy', offset=3))
+        cubes.append(_make_cube((2, 4), y, 4, aux='xy', offset=4))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_4x2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (4, 4))
+
+    def test_concat_4y2d_aux_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 2), 1, aux='xy', offset=1))
+        cubes.append(_make_cube(x, (2, 4), 2, aux='xy', offset=2))
+        x = (2, 4)
+        cubes.append(_make_cube(x, (0, 2), 3, aux='xy', offset=3))
+        cubes.append(_make_cube(x, (2, 4), 4, aux='xy', offset=4))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_4y2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (4, 4))
+
+    def test_concat_4mix2d_aux_xy(self):
+        cubes = []
+        cubes.append(_make_cube((0, 2), (0, 2), 1, aux='xy', offset=1))
+        cubes.append(_make_cube((2, 4), (2, 4), 2, aux='xy', offset=2))
+        cubes.append(_make_cube((2, 4), (0, 2), 3, aux='xy', offset=3))
+        cubes.append(_make_cube((0, 2), (2, 4), 4, aux='xy', offset=4))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_4mix2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (4, 4))
+
+    def test_concat_9x2d_aux_xy(self):
+        cubes = []
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1, aux='xy', offset=1))
+        cubes.append(_make_cube((2, 4), y, 2, aux='xy', offset=2))
+        cubes.append(_make_cube((4, 6), y, 3, aux='xy', offset=3))
+        y = (2, 4)
+        cubes.append(_make_cube((0, 2), y, 4, aux='xy', offset=4))
+        cubes.append(_make_cube((2, 4), y, 5, aux='xy', offset=5))
+        cubes.append(_make_cube((4, 6), y, 6, aux='xy', offset=6))
+        y = (4, 6)
+        cubes.append(_make_cube((0, 2), y, 7, aux='xy', offset=7))
+        cubes.append(_make_cube((2, 4), y, 8, aux='xy', offset=8))
+        cubes.append(_make_cube((4, 6), y, 9, aux='xy', offset=9))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_9x2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 6))
+
+    def test_concat_9y2d_aux_xy(self):
+        cubes = []
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 2), 1, aux='xy', offset=1))
+        cubes.append(_make_cube(x, (2, 4), 2, aux='xy', offset=2))
+        cubes.append(_make_cube(x, (4, 6), 3, aux='xy', offset=3))
+        x = (2, 4)
+        cubes.append(_make_cube(x, (0, 2), 4, aux='xy', offset=4))
+        cubes.append(_make_cube(x, (2, 4), 5, aux='xy', offset=5))
+        cubes.append(_make_cube(x, (4, 6), 6, aux='xy', offset=6))
+        x = (4, 6)
+        cubes.append(_make_cube(x, (0, 2), 7, aux='xy', offset=7))
+        cubes.append(_make_cube(x, (2, 4), 8, aux='xy', offset=8))
+        cubes.append(_make_cube(x, (4, 6), 9, aux='xy', offset=9))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_9y2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 6))
+
+    def test_concat_9mix2d_aux_xy(self):
+        cubes = []
+        cubes.append(_make_cube((0, 2), (0, 2), 1, aux='xy', offset=1))
+        cubes.append(_make_cube((2, 4), (2, 4), 2, aux='xy', offset=2))
+        cubes.append(_make_cube((4, 6), (4, 6), 3, aux='xy', offset=3))
+        cubes.append(_make_cube((4, 6), (0, 2), 4, aux='xy', offset=4))
+        cubes.append(_make_cube((0, 2), (4, 6), 5, aux='xy', offset=5))
+        cubes.append(_make_cube((0, 2), (2, 4), 6, aux='xy', offset=6))
+        cubes.append(_make_cube((2, 4), (0, 2), 7, aux='xy', offset=7))
+        cubes.append(_make_cube((4, 6), (2, 4), 8, aux='xy', offset=8))
+        cubes.append(_make_cube((2, 4), (4, 6), 9, aux='xy', offset=9))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_9mix2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (6, 6))
+
+
+class TestMulti2DScalar(tests.IrisTest):
+    def test_concat_scalar_4x2d_aux_xy(self):
+        cubes = iris.cube.CubeList()
+        # Level 1.
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 1, aux='xy', offset=1, scalar=10))
+        cubes.append(_make_cube((2, 4), y, 2, aux='xy', offset=2, scalar=10))
+        y = (2, 4)
+        cubes.append(_make_cube((0, 2), y, 3, aux='xy', offset=3, scalar=10))
+        cubes.append(_make_cube((2, 4), y, 4, aux='xy', offset=4, scalar=10))
+        # Level 2.
+        y = (0, 2)
+        cubes.append(_make_cube((0, 2), y, 5, aux='xy', offset=1, scalar=20))
+        cubes.append(_make_cube((2, 4), y, 6, aux='xy', offset=2, scalar=20))
+        y = (2, 4)
+        cubes.append(_make_cube((0, 2), y, 7, aux='xy', offset=3, scalar=20))
+        cubes.append(_make_cube((2, 4), y, 8, aux='xy', offset=4, scalar=20))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate',
+                                'concat_scalar_4x2d_aux_xy.cml'))
+        self.assertEqual(len(result), 2)
+        for cube in result:
+            self.assertEqual(cube.shape, (4, 4))
+
+        merged = result.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_merged_scalar_4x2d_aux_xy.cml'))
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].shape, (2, 4, 4))
+
+        # Test concatenate and merge are commutative operations.
+        merged = cubes.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_pre_merged_scalar_4x2_aux_xy.cml'))
+        self.assertEqual(len(merged), 4)
+
+        result = concatenate(merged)
+        self.assertCML(result, ('concatenate',
+                                'concat_merged_scalar_4x2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 4, 4))
+
+    def test_concat_scalar_4y2d_aux_xy(self):
+        cubes = iris.cube.CubeList()
+        # Level 1.
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 2), 1, aux='xy', offset=1, scalar=10))
+        cubes.append(_make_cube(x, (2, 4), 2, aux='xy', offset=2, scalar=10))
+        x = (2, 4)
+        cubes.append(_make_cube(x, (0, 2), 3, aux='xy', offset=3, scalar=10))
+        cubes.append(_make_cube(x, (2, 4), 4, aux='xy', offset=4, scalar=10))
+        # Level 2.
+        x = (0, 2)
+        cubes.append(_make_cube(x, (0, 2), 5, aux='xy', offset=1, scalar=20))
+        cubes.append(_make_cube(x, (2, 4), 6, aux='xy', offset=2, scalar=20))
+        x = (2, 4)
+        cubes.append(_make_cube(x, (0, 2), 7, aux='xy', offset=3, scalar=20))
+        cubes.append(_make_cube(x, (2, 4), 8, aux='xy', offset=4, scalar=20))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate',
+                                'concat_scalar_4y2d_aux_xy.cml'))
+        self.assertEqual(len(result), 2)
+        for cube in result:
+            self.assertEqual(cube.shape, (4, 4))
+
+        merged = result.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_merged_scalar_4y2d_aux_xy.cml'))
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].shape, (2, 4, 4))
+
+        # Test concatenate and merge are commutative operations.
+        merged = cubes.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_pre_merged_scalar_4y2d_aux_xy.cml'))
+        self.assertEqual(len(merged), 4)
+
+        result = concatenate(merged)
+        self.assertEqual(len(result), 1)
+        self.assertCML(result, ('concatenate',
+                                'concat_merged_scalar_4y2d_aux_xy.cml'))
+        self.assertEqual(result[0].shape, (2, 4, 4))
+
+    def test_concat_scalar_4mix2d_aux_xy(self):
+        cubes = iris.cube.CubeList()
+        cubes.append(_make_cube((0, 2), (0, 2), 1, aux='xy',
+                                offset=1, scalar=10))
+        cubes.append(_make_cube((2, 4), (2, 4), 8, aux='xy',
+                                offset=4, scalar=20))
+        cubes.append(_make_cube((0, 2), (0, 2), 5, aux='xy',
+                                offset=1, scalar=20))
+        cubes.append(_make_cube((2, 4), (0, 2), 2, aux='xy',
+                                offset=2, scalar=10))
+        cubes.append(_make_cube((0, 2), (2, 4), 7, aux='xy',
+                                offset=3, scalar=20))
+        cubes.append(_make_cube((0, 2), (2, 4), 3, aux='xy',
+                                offset=3, scalar=10))
+        cubes.append(_make_cube((2, 4), (2, 4), 4, aux='xy',
+                                offset=4, scalar=10))
+        cubes.append(_make_cube((2, 4), (0, 2), 6, aux='xy',
+                                offset=2, scalar=20))
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate',
+                                'concat_scalar_4mix2d_aux_xy.cml'))
+        self.assertEqual(len(result), 2)
+        for cube in result:
+            self.assertEqual(cube.shape, (4, 4))
+
+        merged = result.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_merged_scalar_4mix2d_aux_xy.cml'))
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].shape, (2, 4, 4))
+
+        # Test concatenate and merge are commutative operations.
+        merged = cubes.merge()
+        self.assertCML(merged, ('concatenate',
+                                'concat_pre_merged_scalar_4mix2d_aux_xy.cml'))
+        self.assertEqual(len(merged), 4)
+
+        result = concatenate(merged)
+        self.assertCML(result, ('concatenate',
+                                'concat_merged_scalar_4mix2d_aux_xy.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (2, 4, 4))
+
+
+class Test3D(tests.IrisTest):
+    def _make_group(self, xoff=0, yoff=0, zoff=0, doff=0):
+        xoff *= 4
+        yoff *= 4
+        zoff *= 4
+        doff *= 8
+        cubes = []
+        cubes.append(_make_cube_3d((0 + xoff, 2 + xoff),
+                                   (0 + yoff, 2 + yoff),
+                                   (0 + zoff, 2 + zoff),
+                                   1 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((2 + xoff, 4 + xoff),
+                                   (0 + yoff, 2 + yoff),
+                                   (0 + zoff, 2 + zoff),
+                                   2 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((0 + xoff, 2 + xoff),
+                                   (2 + yoff, 4 + yoff),
+                                   (0 + zoff, 2 + zoff),
+                                   3 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((2 + xoff, 4 + xoff),
+                                   (2 + yoff, 4 + yoff),
+                                   (0 + zoff, 2 + zoff),
+                                   4 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+
+        cubes.append(_make_cube_3d((0 + xoff, 2 + xoff),
+                                   (0 + yoff, 2 + yoff),
+                                   (2 + zoff, 4 + zoff),
+                                   5 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((2 + xoff, 4 + xoff),
+                                   (0 + yoff, 2 + yoff),
+                                   (2 + zoff, 4 + zoff),
+                                   6 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((0 + xoff, 2 + xoff),
+                                   (2 + yoff, 4 + yoff),
+                                   (2 + zoff, 4 + zoff),
+                                   7 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+        cubes.append(_make_cube_3d((2 + xoff, 4 + xoff),
+                                   (2 + yoff, 4 + yoff),
+                                   (2 + zoff, 4 + zoff),
+                                   8 + doff, aux='x,y,z,xy,xz,yz,xyz'))
+
+        return cubes
+
+    def test_concat_3d_simple(self):
+        cubes = self._make_group()
+        result = concatenate(cubes)
+        self.assertCML(result, ('concatenate', 'concat_3d_simple.cml'))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (4, 4, 4))
+
+    def test_concat_3d_mega(self):
+        cubes = []
+        cubes.extend(self._make_group(xoff=0, doff=0))
+        cubes.extend(self._make_group(xoff=1, doff=1))
+        cubes.extend(self._make_group(yoff=1, doff=2))
+        cubes.extend(self._make_group(xoff=1, yoff=1, doff=3))
+
+        cubes.extend(self._make_group(xoff=0, zoff=1, doff=4))
+        cubes.extend(self._make_group(xoff=1, zoff=1, doff=5))
+        cubes.extend(self._make_group(yoff=1, zoff=1, doff=6))
+        cubes.extend(self._make_group(xoff=1, yoff=1, zoff=1, doff=7))
+        result = concatenate(cubes)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (8, 8, 8))
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/results/concatenate/concat_2x2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x.cml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_bounds.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_bounds.cml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord bounds="[[-5.0, 5.0],
+		[5.0, 15.0],
+		[15.0, 25.0],
+		[25.0, 35.0],
+		[35.0, 45.0],
+		[45.0, 55.0]]" id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_xy.cml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0, 200.0, 300.0, 0.0, 100.0],
+		[400.0, 500.0, 600.0, 700.0, 200.0, 300.0]]" shape="(2, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y.cml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y_xy.cml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0, 200.0, 300.0, 0.0, 100.0],
+		[400.0, 500.0, 600.0, 700.0, 200.0, 300.0]]" shape="(2, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy.cml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0, 200.0, 300.0, 0.0, 100.0],
+		[400.0, 500.0, 600.0, 700.0, 200.0, 300.0]]" shape="(2, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy_bounds.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy_bounds.cml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord bounds="[[[1, 2, 3, 4],
+ 		[101, 102, 103, 104],
+ 		[2, 3, 4, 5],
+ 		[102, 103, 104, 105]],
+
+		[[201, 202, 203, 204],
+ 		[301, 302, 303, 304],
+ 		[202, 203, 204, 205],
+ 		[302, 303, 304, 305]]]" id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0]]" shape="(2, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4fc3cae2" dtype="float32" shape="(2, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_y.cml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_y_xy.cml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0, 200.0, 300.0, 0.0, 100.0],
+		[400.0, 500.0, 600.0, 700.0, 200.0, 300.0]]" shape="(2, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1693595c" dtype="float32" shape="(2, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x.cml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_xy.cml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0],
+		[200.0, 300.0],
+		[400.0, 500.0],
+		[600.0, 700.0],
+		[0.0, 100.0],
+		[200.0, 300.0]]" shape="(6, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y.cml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y_xy.cml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0],
+		[200.0, 300.0],
+		[400.0, 500.0],
+		[600.0, 700.0],
+		[0.0, 100.0],
+		[200.0, 300.0]]" shape="(6, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_xy.cml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0],
+		[200.0, 300.0],
+		[400.0, 500.0],
+		[600.0, 700.0],
+		[0.0, 100.0],
+		[200.0, 300.0]]" shape="(6, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_y.cml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_y_xy.cml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 100.0],
+		[200.0, 300.0],
+		[400.0, 500.0],
+		[600.0, 700.0],
+		[0.0, 100.0],
+		[200.0, 300.0]]" shape="(6, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6951c04d" dtype="float32" shape="(6, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_3d_simple.cml
+++ b/lib/iris/tests/results/concatenate/concat_3d_simple.cml
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <auxCoord id="f49a8b85" long_name="x-aux" points="[0.0, 10.0, 20.0, 30.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[0.0, 1.0, 0.0, 1.0],
+		[2.0, 3.0, 2.0, 3.0],
+		[0.0, 1.0, 0.0, 1.0],
+		[2.0, 3.0, 2.0, 3.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1, 2]">
+        <auxCoord id="cd7d6c9f" long_name="xyz-aux" points="[[[0.0, 1000.0, 0.0, 1000.0],
+ 		[2000.0, 3000.0, 2000.0, 3000.0],
+ 		[0.0, 1000.0, 0.0, 1000.0],
+ 		[2000.0, 3000.0, 2000.0, 3000.0]],
+
+		[[4000.0, 5000.0, 4000.0, 5000.0],
+ 		[6000.0, 7000.0, 6000.0, 7000.0],
+ 		[4000.0, 5000.0, 4000.0, 5000.0],
+ 		[6000.0, 7000.0, 6000.0, 7000.0]],
+
+		[[0.0, 1000.0, 0.0, 1000.0],
+ 		[2000.0, 3000.0, 2000.0, 3000.0],
+ 		[0.0, 1000.0, 0.0, 1000.0],
+ 		[2000.0, 3000.0, 2000.0, 3000.0]],
+
+		[[4000.0, 5000.0, 4000.0, 5000.0],
+ 		[6000.0, 7000.0, 6000.0, 7000.0],
+ 		[4000.0, 5000.0, 4000.0, 5000.0],
+ 		[6000.0, 7000.0, 6000.0, 7000.0]]]" shape="(4, 4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 2]">
+        <auxCoord id="336c5f3a" long_name="xz-aux" points="[[0.0, 10.0, 0.0, 10.0],
+		[20.0, 30.0, 20.0, 30.0],
+		[0.0, 10.0, 0.0, 10.0],
+		[20.0, 30.0, 20.0, 30.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f52f7698" long_name="y-aux" points="[0.0, 10.0, 20.0, 30.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="506b861e" long_name="yz-aux" points="[[0.0, 100.0, 0.0, 100.0],
+		[200.0, 300.0, 200.0, 300.0],
+		[0.0, 100.0, 0.0, 100.0],
+		[200.0, 300.0, 200.0, 300.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="69ffe425" long_name="z" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f7f171bf" long_name="z-aux" points="[0.0, 10.0, 20.0, 30.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x46ae21bf" dtype="float32" shape="(4, 4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4mix2d_aux_xy.cml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 3.0, 103.0],
+		[201.0, 301.0, 203.0, 303.0],
+		[4.0, 104.0, 2.0, 102.0],
+		[204.0, 304.0, 202.0, 302.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6b809bc6" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4x2d_aux_xy.cml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x56451659" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4y2d_aux_xy.cml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 3.0, 103.0],
+		[201.0, 301.0, 203.0, 303.0],
+		[2.0, 102.0, 4.0, 104.0],
+		[202.0, 302.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x56fa8d93" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_9mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9mix2d_aux_xy.cml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 7.0, 107.0, 4.0, 104.0],
+		[201.0, 301.0, 207.0, 307.0, 204.0, 304.0],
+		[6.0, 106.0, 2.0, 102.0, 8.0, 108.0],
+		[206.0, 306.0, 202.0, 302.0, 208.0, 308.0],
+		[5.0, 105.0, 9.0, 109.0, 3.0, 103.0],
+		[205.0, 305.0, 209.0, 309.0, 203.0, 303.0]]" shape="(6, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4af87466" dtype="float32" shape="(6, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_9x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9x2d_aux_xy.cml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0, 3.0, 103.0],
+		[201.0, 301.0, 202.0, 302.0, 203.0, 303.0],
+		[4.0, 104.0, 5.0, 105.0, 6.0, 106.0],
+		[204.0, 304.0, 205.0, 305.0, 206.0, 306.0],
+		[7.0, 107.0, 8.0, 108.0, 9.0, 109.0],
+		[207.0, 307.0, 208.0, 308.0, 209.0, 309.0]]" shape="(6, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x6b673084" dtype="float32" shape="(6, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_9y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9y2d_aux_xy.cml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 4.0, 104.0, 7.0, 107.0],
+		[201.0, 301.0, 204.0, 304.0, 207.0, 307.0],
+		[2.0, 102.0, 5.0, 105.0, 8.0, 108.0],
+		[202.0, 302.0, 205.0, 305.0, 208.0, 308.0],
+		[3.0, 103.0, 6.0, 106.0, 9.0, 109.0],
+		[203.0, 303.0, 206.0, 306.0, 209.0, 309.0]]" shape="(6, 6)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5],
+		[4.5, 5.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]" shape="(6,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x1517e094" dtype="float32" shape="(6, 6)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_anonymous.cml
+++ b/lib/iris/tests/results/concatenate/concat_anonymous.cml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4fc3cae2" dtype="float32" shape="(2, 4)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x7e568ae8" dtype="float32" shape="(2, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4fc3cae2" dtype="float32" mask_checksum="-0x73ce52cf" shape="(2, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x40bcd949" dtype="float32" mask_checksum="-0x73ce52cf" shape="(4, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4mix2d_aux_xy.cml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x115b7d73" dtype="float32" shape="(2, 4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4x2d_aux_xy.cml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x115b7d73" dtype="float32" shape="(2, 4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4y2d_aux_xy.cml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 3.0, 103.0],
+		[201.0, 301.0, 203.0, 303.0],
+		[2.0, 102.0, 4.0, 104.0],
+		[202.0, 302.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x44b61215" dtype="float32" shape="(2, 4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4mix2d_aux_xy.cml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0],
+		[201.0, 301.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x10e8e9a5" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[4.0, 104.0],
+		[204.0, 304.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x324b04c8" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[2.0, 102.0],
+		[202.0, 302.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[3.0, 103.0],
+		[203.0, 303.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x1350eb16" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4x2_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4x2_aux_xy.cml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0],
+		[201.0, 301.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x10e8e9a5" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[2.0, 102.0],
+		[202.0, 302.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[3.0, 103.0],
+		[203.0, 303.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x1350eb16" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[4.0, 104.0],
+		[204.0, 304.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x324b04c8" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4y2d_aux_xy.cml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0],
+		[201.0, 301.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x10e8e9a5" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[2.0, 102.0],
+		[202.0, 302.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[3.0, 103.0],
+		[203.0, 303.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x1350eb16" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="c7be93c8" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[4.0, 104.0],
+		[204.0, 304.0]]" shape="(2, 2)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[2.0, 3.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x324b04c8" dtype="float32" shape="(2, 2, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4mix2d_aux_xy.cml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x56451659" dtype="float32" shape="(4, 4)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x320887ba" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4x2d_aux_xy.cml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x56451659" dtype="float32" shape="(4, 4)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 2.0, 102.0],
+		[201.0, 301.0, 202.0, 302.0],
+		[3.0, 103.0, 4.0, 104.0],
+		[203.0, 303.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x320887ba" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4y2d_aux_xy.cml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 3.0, 103.0],
+		[201.0, 301.0, 203.0, 303.0],
+		[2.0, 102.0, 4.0, 104.0],
+		[202.0, 302.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x56fa8d93" dtype="float32" shape="(4, 4)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord>
+        <auxCoord id="c7be93c8" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="b0c4282a" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="31b2581d" long_name="xy-aux" points="[[1.0, 101.0, 3.0, 103.0],
+		[201.0, 301.0, 203.0, 303.0],
+		[2.0, 102.0, 4.0, 104.0],
+		[202.0, 302.0, 204.0, 304.0]]" shape="(4, 4)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5]]" id="31e14d0d" long_name="y" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4da8b5a0" dtype="float32" shape="(4, 4)"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
This PR introduces experimental functionality to support the concatenation of two or more cubes over a **common** and already **existing** dimension. This is opposed to cube merge (aka cube _stack_ as it's currently being rebranded as) which creates **new** cube dimensions based on mutually common scalar coordinates.

As mentioned previously, the cube concatenation functionality is experimental, hence the `iris.x_concatenate` namespace. This will change once cube concatenation is eventually adopted into the Iris core functionality.

**Health warning ...**
Due to limitations with the current Iris deferred loading mechanism, `iris.x_concatenate.concatenate()` will **load** the data payload of **all** your cubes. Heed this warning! This restriction will be relaxed in future revisions when the appropriate infrastructure is in place.

**In a nutshell ...**
The `iris.x_concatenate.concatenate()` function takes a list of cubes and returns the least number of largest possible cubes concatenated as many times necessary over common existing single dimensions ... yeah, like that helped clarify the matter! I think some examples might help here ...

E.g. The time-series cubes `A(t:2, y:m, x:n)`, `B(t:4, y:m, x:n)`, and `C(t:6, y:m, x:n)` are all geo-located but differ by non-overlapping time points over the first dimention. Thus `concatenate([A, B, C])` will return the following concatenated cube `(t:12, y:m, x:n)` within an `iris.cube.CubeList`.

E.g. Building on the previous example, let its result be the cube named `X`. In addition to this we have  the following sequence of time-series cubes `D(t:2, y:m, x:p)`, `E(t:4, y:m, x:p)`, `F(t:6, y:m, x:p)`, which are co-located in latitude with cube `X` but not in longitude. Also,
- `A` and `D` share the same time points,
- `B` and `E` share the same time points, and
- `C` and `F` share the same time points.

Then `concatenate([X, D, E, F])` will return the single concatenated cube `(t:12, y:m, x:n+p)`. Indeed, `concatenate([A, B, C, D, E, F])` will return exactly the same result. Naturally, if `D`, `E` and `F` are _west_ of `X`, then we would get `(t:12, y:m, x:p+n)`, if you know what I mean. Note that, the order of cubes in the list presented to `concatenate()` does not matter. So `concatenate([F, E, D, C, B, A])` and `concatenate([B, A, D, F, E, C])` or whatever, will all result in the same answer.

Cubes that have one or more _anonymous_ dimension are ambiguous, and as such are considered incompatible with all other cubes. Therefore no cube can be concatenated with another cube that has at least one _anonymous_ dimension.

As with cube merge (aka stack) `concatenate()` is strict and unforgiving. Cube metadata, dimensionality and coordinate metadata must match for two cubes to be considered compatible for concatenation. Beware lowly `history` entries in the `attributes` dictionary of a cube!

The important point is that `concatenate()` will _discover_ the _one_ common dimension and concatenate all compatible cubes into one cube. Only one degree of common dimensional freedom is permitted per concatenation, yet this can be any one single dimension, and `concatenate()` will exhaustively concatenate until there is no such commonality.

**Note ...**
- All code is PEP8 compliant, so I'll have no "Oh! that's a long line" comments thanks @rhattersley! :smiling_imp: 
- There's still a `TODO` list. See the `iris.x_concatenate.py` preamble.
