### PR TITLE
Changes for rc1.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,15 +15,26 @@ Features added
   :meth:`iris.cube.Cube.coord()`, :meth:`iris.cube.Cube.coords()` and
   :meth:`iris.cube.Cube.aux_factory()` methods.
 * :meth:`iris.coords.Coord.is_compatible()` has been added. This method is
-  used to determine whether two coordinates are are sufficiently alike to
+  used to determine whether two coordinates are sufficiently alike to
   allow operations such as :meth:`iris.coords.Coord.intersect()` and
   :func:`iris.analysis.interpolate.regrid()` to take place. A corresponding
   method for cubes, :meth:`iris.cube.Cube.is_compatible()`, has also been
   added.
+* Printing a :class:`~iris.cube.Cube` is now more user friendly with regards 
+  to dates and time. All *time* and *forecast_reference_time* scalar coordinates
+  now display human readable date/time information.
+* The units of a :class:`~iris.cube.Cube` are now shown when it is printed.
+* The area weights calculated by :func:`iris.analysis.cartography.area_weights`
+  may now be normalised relative to the total grid area.
+* Weights may now be passed to :meth:`iris.cube.Cube.rolling_window` aggregations,
+  thus allowing arbitrary digital filters to be applied to a :class:`~iris.cube.Cube`.
 
 Bugs fixed
 ----------
-* N/A
+* The GRIB hindcast interpretation of negative forecast times can be enabled
+  via the :data:`iris.fileformats.grib.hindcast_workaround` flag.
+* The NIMROD file loader has been extended to cope with orography vertical
+  coordinates.
 
 Incompatible changes
 --------------------
@@ -40,6 +51,8 @@ Deprecations
   AuxCoord have changed. This should have no impact if you are providing
   parameters as keyword arguments, but it may cause issues if you are relying
   on the position/order of the arguments.
+* Iteration over a :class:`~iris.cube.Cube` has been deprecated. Instead,
+  users should use :meth:`iris.cube.Cube.slices`.
 
 
 ----------------------------

--- a/docs/iris/src/whatsnew/1.2.rst
+++ b/docs/iris/src/whatsnew/1.2.rst
@@ -25,15 +25,26 @@ A summary of the main features added with version 1.2:
   :meth:`iris.cube.Cube.coord()`, :meth:`iris.cube.Cube.coords()` and
   :meth:`iris.cube.Cube.aux_factory()` methods.
 * :meth:`iris.coords.Coord.is_compatible()` has been added. This method is
-  used to determine whether two coordinates are are sufficiently alike to
+  used to determine whether two coordinates are sufficiently alike to
   allow operations such as :meth:`iris.coords.Coord.intersect()` and
   :func:`iris.analysis.interpolate.regrid()` to take place. A corresponding
   method for cubes, :meth:`iris.cube.Cube.is_compatible()`, has also been
   added.
+* Printing a :class:`~iris.cube.Cube` is now more user friendly with regards 
+  to dates and time. All *time* and *forecast_reference_time* scalar coordinates
+  now display human readable date/time information.
+* The units of a :class:`~iris.cube.Cube` are now shown when it is printed.
+* The area weights calculated by :func:`iris.analysis.cartography.area_weights`
+  may now be normalised relative to the total grid area.
+* Weights may now be passed to :meth:`iris.cube.Cube.rolling_window` aggregations,
+  thus allowing arbitrary digital filters to be applied to a :class:`~iris.cube.Cube`.
 
 Bugs fixed
 ----------
-* N/A
+* The GRIB hindcast interpretation of negative forecast times can be enabled
+  via the :data:`iris.fileformats.grib.hindcast_workaround` flag.
+* The NIMROD file loader has been extended to cope with orography vertical
+  coordinates.
 
 Incompatible changes
 --------------------
@@ -50,6 +61,8 @@ Deprecations
   AuxCoord have changed. This should have no impact if you are providing
   parameters as keyword arguments, but it may cause issues if you are relying
   on the position/order of the arguments.
+* Iteration over a :class:`~iris.cube.Cube` has been deprecated. Instead,
+  users should use :meth:`iris.cube.Cube.slices`.
 
 
 

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -109,7 +109,7 @@ import iris.io
 
 
 # Iris revision.
-__version__ = '1.2.0-dev'
+__version__ = '1.2.0-rc1'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw', 'load_strict', 'save',

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1355,6 +1355,11 @@ class Cube(CFVariableMixin):
         return "<iris 'Cube' of %s>" % self.summary(shorten=True, name_padding=1)
 
     def __iter__(self):
+        """
+        .. deprecated:: 1.2
+            Use :class:`iris.cube.Cube.slices() instead`.
+
+        """
         # Emit a warning about iterating over the cube.
         # __getitem__ makes this possible, but now deprecated as confusing.
         warnings.warn('Cube iteration has been deprecated: '

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,7 @@ class BuildPyWithExtras(build_py.build_py):
 
 setup(
     name='Iris',
-    version='1.2.0-dev',
+    version='1.2.0-rc1',
     url='http://scitools.github.com/iris',
     author='UK Met Office',
 


### PR DESCRIPTION
Release changes for Iris 1.2-rc1 on upstream/v1.2.x branch.

Excludes any Cartopy SHA update in `.travis.yml`.
