### PR TITLE
Revert Iris version from 1.2.0-rc1 back to 1.2.0-dev.

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -109,7 +109,7 @@ import iris.io
 
 
 # Iris revision.
-__version__ = '1.2.0-rc1'
+__version__ = '1.2.0-dev'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw', 'load_strict', 'save',

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1357,7 +1357,7 @@ class Cube(CFVariableMixin):
     def __iter__(self):
         """
         .. deprecated:: 1.2
-            Use :class:`iris.cube.Cube.slices() instead`.
+            Use :meth:`iris.cube.Cube.slices` instead.
 
         """
         # Emit a warning about iterating over the cube.

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,7 @@ class BuildPyWithExtras(build_py.build_py):
 
 setup(
     name='Iris',
-    version='1.2.0-rc1',
+    version='1.2.0-dev',
     url='http://scitools.github.com/iris',
     author='UK Met Office',
 


### PR DESCRIPTION
Revert the Iris version string, and minor Sphinx doc-string tweak.

This PR is on `upstream/v1.2.x` branch.
