### PR TITLE
Fixed cube.summary() to handle unicode cube attributes.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1320,13 +1320,13 @@ class Cube(CFVariableMixin):
             if self.attributes:
                 attribute_summary = []
                 for name, value in sorted(self.attributes.iteritems()):
+                    value = unicode(value)
                     if name == 'history':
-                        value = re.sub("[\d\/]{8} [\d\:]{8} Iris\: ", '', str(value))
-                    else:
-                        value = str(value)
-                    attribute_summary.append('%*s%s: %s' % (indent, ' ', name, iris.util.clip_string(value)))
+                        value = re.sub("[\d\/]{8} [\d\:]{8} Iris\: ", '', value)
+                    value = iris.util.clip_string(value)
+                    attribute_summary.append('%*s%s: %s' % (indent, ' ', name, value))
                 summary += '\n     Attributes:\n' + '\n'.join(attribute_summary)
-        
+
             #
             # Generate summary of cube cell methods
             #
@@ -1349,7 +1349,7 @@ class Cube(CFVariableMixin):
         warnings.warn('Cube.assert_valid() has been deprecated.')
 
     def __str__(self):
-        return self.summary()
+        return self.summary().encode('utf-8')
 
     def __repr__(self):
         return "<iris 'Cube' of %s>" % self.summary(shorten=True, name_padding=1)

--- a/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__str__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          source: ꀀabcd޴

--- a/lib/iris/tests/results/cdm/str_repr/unicode_history.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_history.__str__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          history: ꀀwxyz޴

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -319,6 +319,20 @@ class TestCubeStringRepresentations(IrisDotTest):
         cube.add_aux_coord(aux, 0)
         self.assertString(str(cube), ('cdm', 'str_repr', 'simple.__str__.txt'))
 
+    def test_unicode_attribute(self):
+        unicode_str = unichr(40960) + u'abcd' + unichr(1972)
+        cube = iris.tests.stock.simple_1d()
+        cube.attributes['source'] = unicode_str
+        self.assertString(str(cube), ('cdm', 'str_repr',
+                                      'unicode_attribute.__str__.txt'))
+
+    def test_unicode_history(self):
+        unicode_str = unichr(40960) + u'wxyz' + unichr(1972)
+        cube = iris.tests.stock.simple_1d()
+        cube.add_history(unicode_str)
+        self.assertString(str(cube), ('cdm', 'str_repr',
+                                      'unicode_history.__str__.txt'))
+
 
 @iris.tests.skip_data
 class TestValidity(tests.IrisTest):


### PR DESCRIPTION
I have come across cf-netcdf files which when loaded into Iris give me a cube with attributes that are unicode (this is allowed under CF). These files load and save ok, but if I `print cube` I get a UnicodeEncodeError. For example:

``` python
import iris.tests.stock
unicode_str = unichr(40960) + u'wxyz' + unichr(1972)
cube = iris.tests.stock.simple_1d()
cube.attributes['source'] = unicode_str
print cube
```

gives:
`UnicodeEncodeError: 'ascii' codec can't encode character u'\ua000' in position 0: ordinal not in range(128)`

This PR modifies `cube.summary()` so that it handles unicode attributes.
