### PR TITLE
Use position independent code flag for compilation of gribapi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - ./.travis_no_output wget https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.9.16.tar.gz --no-check-certificate
   - ./.travis_no_output tar -xvf grib_api-1.9.16.tar.gz
   - cd grib_api-1.9.16/
-  - ../.travis_no_output ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
+  - ../.travis_no_output CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
   - ../.travis_no_output make
   - ../.travis_no_output sudo make install
   - cd python


### PR DESCRIPTION
Force use of '-fPIC' when building the grib api on travis-ci.
