### PR TITLE
Modified cube.summary() to handle unicode cube attributes.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1121,9 +1121,9 @@ class Cube(CFVariableMixin):
 
     def summary(self, shorten=False, name_padding=35):
         """
-        String summary of the Cube with name, a list of dim coord names versus length 
-        and optionally relevant coordinate information.
-        
+        Unicode string summary of the Cube with name, a list of dim coord names
+        versus length and optionally relevant coordinate information.
+
         """
         # Create a set to contain the axis names for each data dimension.
         dim_names = [set() for dim in xrange(len(self.shape))]
@@ -1318,15 +1318,20 @@ class Cube(CFVariableMixin):
             # Generate summary of cube attributes.
             #
             if self.attributes:
-                attribute_summary = []
+                attribute_lines = []
                 for name, value in sorted(self.attributes.iteritems()):
+                    value = unicode(value)
                     if name == 'history':
-                        value = re.sub("[\d\/]{8} [\d\:]{8} Iris\: ", '', str(value))
-                    else:
-                        value = str(value)
-                    attribute_summary.append('%*s%s: %s' % (indent, ' ', name, iris.util.clip_string(value)))
-                summary += '\n     Attributes:\n' + '\n'.join(attribute_summary)
-        
+                        value = re.sub("[\d\/]{8} [\d\:]{8} Iris\: ", '',
+                                       value)
+                    value = iris.util.clip_string(value)
+                    line = u'{pad:{width}}{name}: {value}'.format(pad=' ',
+                                                                  width=indent,
+                                                                  name=name,
+                                                                  value=value)
+                    attribute_lines.append(line)
+                summary += '\n     Attributes:\n' + '\n'.join(attribute_lines)
+
             #
             # Generate summary of cube cell methods
             #
@@ -1349,6 +1354,9 @@ class Cube(CFVariableMixin):
         warnings.warn('Cube.assert_valid() has been deprecated.')
 
     def __str__(self):
+        return self.summary().encode(errors='replace')
+
+    def __unicode__(self):
         return self.summary()
 
     def __repr__(self):

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -235,7 +235,12 @@ class IrisTest(unittest.TestCase):
     
     def assertString(self, string, reference_filename):
         reference_path = get_result_path(reference_filename)
-        self._check_same(string, reference_path, reference_filename, type_comparison_name='Strings')
+        # If the test string is a unicode string, encode as
+        # utf-8 before comparison to the reference string.
+        if isinstance(string, unicode):
+            string = string.encode('utf-8')
+        self._check_same(string, reference_path, reference_filename,
+                         type_comparison_name='Strings')
     
     def assertRepr(self, obj, reference_filename):
         self.assertString(repr(obj), reference_filename)
@@ -247,7 +252,8 @@ class IrisTest(unittest.TestCase):
         else:
             self._ensure_folder(reference_path)
             logger.warning('Creating result file: %s', reference_path)
-            open(reference_path, 'w').writelines(item)
+            open(reference_path, 'w').writelines(line.encode('utf-8') for
+                                                 line in item)
 
     def assertXMLElement(self, obj, reference_filename):
         """

--- a/lib/iris/tests/results/cdm/str_repr/0d_cube.__unicode__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/0d_cube.__unicode__.txt
@@ -1,0 +1,11 @@
+air_temperature / K                 (scalar cube)
+     Scalar coordinates:
+          forecast_period: 6477.0 hours
+          forecast_reference_time: 1998-03-06 03:00:00
+          latitude: 90.0 degrees
+          longitude: 0.0 degrees
+          pressure: 1000.0 hPa
+          time: 1998-12-01 00:00:00
+     Attributes:
+          STASH: m01s16i203
+          source: Data from Met Office Unified Model

--- a/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__str__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          source: ?abcd?

--- a/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__unicode__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_attribute.__unicode__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          source: ꀀabcd޴

--- a/lib/iris/tests/results/cdm/str_repr/unicode_history.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_history.__str__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          history: ?wxyz?

--- a/lib/iris/tests/results/cdm/str_repr/unicode_history.__unicode__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/unicode_history.__unicode__.txt
@@ -1,0 +1,5 @@
+thingness / 1                       (foo: 11)
+     Dimension coordinates:
+          foo                           x
+     Attributes:
+          history: ꀀwxyz޴

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -270,8 +270,12 @@ class TestCubeStringRepresentations(IrisDotTest):
         self.assertString(repr(cube_list), ('cdm', 'str_repr', 'cubelist.__repr__.txt'))
 
     def test_basic_0d_cube(self):
-        self.assertString(repr(self.cube_2d[0, 0]), ('cdm', 'str_repr', '0d_cube.__repr__.txt'))
-        self.assertString(str(self.cube_2d[0, 0]), ('cdm', 'str_repr', '0d_cube.__str__.txt'))
+        self.assertString(repr(self.cube_2d[0, 0]),
+                          ('cdm', 'str_repr', '0d_cube.__repr__.txt'))
+        self.assertString(unicode(self.cube_2d[0, 0]),
+                          ('cdm', 'str_repr', '0d_cube.__unicode__.txt'))
+        self.assertString(str(self.cube_2d[0, 0]),
+                          ('cdm', 'str_repr', '0d_cube.__str__.txt'))
 
     def test_similar_coord(self):
         cube = self.cube_2d.copy()
@@ -318,6 +322,24 @@ class TestCubeStringRepresentations(IrisDotTest):
         aux = iris.coords.AuxCoord(range(11), long_name='This is a short long_name')
         cube.add_aux_coord(aux, 0)
         self.assertString(str(cube), ('cdm', 'str_repr', 'simple.__str__.txt'))
+
+    def test_unicode_attribute(self):
+        unicode_str = unichr(40960) + u'abcd' + unichr(1972)
+        cube = iris.tests.stock.simple_1d()
+        cube.attributes['source'] = unicode_str
+        self.assertString(str(cube), ('cdm', 'str_repr',
+                                      'unicode_attribute.__str__.txt'))
+        self.assertString(unicode(cube), ('cdm', 'str_repr',
+                                          'unicode_attribute.__unicode__.txt'))
+
+    def test_unicode_history(self):
+        unicode_str = unichr(40960) + u'wxyz' + unichr(1972)
+        cube = iris.tests.stock.simple_1d()
+        cube.add_history(unicode_str)
+        self.assertString(str(cube), ('cdm', 'str_repr',
+                                      'unicode_history.__str__.txt'))
+        self.assertString(unicode(cube), ('cdm', 'str_repr',
+                                          'unicode_history.__unicode__.txt'))
 
 
 @iris.tests.skip_data


### PR DESCRIPTION
Replaces PR #355

I have come across cf-netcdf files which when loaded into Iris give me a cube with attributes that are unicode (this is allowed under CF). These files load and save ok, but if I `print cube` I get a UnicodeEncodeError. For example:

``` python
import iris.tests.stock
unicode_str = unichr(40960) + u'wxyz' + unichr(1972)
cube = iris.tests.stock.simple_1d()
cube.attributes['source'] = unicode_str
print cube
```

gives:
`UnicodeEncodeError: 'ascii' codec can't encode character u'\ua000' in position 0: ordinal not in range(128)`

This PR modifies `cube.summary()` so that it handles unicode attributes.
