### PR TITLE
Refactored is_x boolean methods in unit module.

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -441,7 +441,7 @@ class HybridHeightFactory(AuxCoordFactory):
             raise ValueError('Incompatible units: delta and orography must have'
                              ' the same units.')
         self.units = (delta and delta.units) or orography.units
-        if not self.units.convertible('m'):
+        if not self.units.is_convertible('m'):
             raise ValueError('Invalid units: delta and/or orography'
                              ' must be expressed in length units.')
         self.attributes = {'positive': 'up'}
@@ -600,7 +600,7 @@ class HybridPressureFactory(AuxCoordFactory):
             raise ValueError('Incompatible units: delta and surface_pressure'
                              ' must have the same units.')
         self.units = (delta and delta.units) or surface_pressure.units
-        if not self.units.convertible('Pa'):
+        if not self.units.is_convertible('Pa'):
             raise ValueError('Invalid units: delta and/or surface_pressure'
                              ' must be expressed in pressure units.')
         self.attributes = {}

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -442,7 +442,7 @@ class Coord(CFVariableMixin):
         return repr(self.units.num2date(dates_as_numbers))[6:-15]
 
     def __str__(self):
-        if self.units.time_reference:
+        if self.units.is_time_reference():
             fmt = '{cls}({points}{bounds}' \
                   ', standard_name={self.standard_name!r}' \
                   ', calendar={self.units.calendar!r}{other_metadata})'
@@ -598,7 +598,7 @@ class Coord(CFVariableMixin):
         """
         # If the coord has units convert the values in points (and bounds if
         # present).
-        if not self.units.unknown:
+        if not self.units.is_unknown():
             self.points = self.units.convert(self.points, unit)
             if self.bounds is not None:
                 self.bounds = self.units.convert(self.bounds, unit)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -530,7 +530,7 @@ class Cube(CFVariableMixin):
 
         """
         # If the cube has units convert the data.
-        if not self.units.unknown:
+        if not self.units.is_unknown():
             self.data = self.units.convert(self.data, unit)
         self.units = unit
 
@@ -1251,7 +1251,7 @@ class Cube(CFVariableMixin):
             if scalar_coords:
                 for coord in scalar_coords:
                     if (coord.units in ['1', 'no_unit', 'unknown'] or
-                        coord.units.time_reference):
+                        coord.units.is_time_reference()):
                         unit = ''
                     else:
                         unit = ' {!s}'.format(coord.units)
@@ -1269,7 +1269,7 @@ class Cube(CFVariableMixin):
                             coord_cell_split) + unit
                     else:
                         # Human readable times
-                        if coord.units.time_reference:
+                        if coord.units.is_time_reference():
                             coord_cell_cpoint = coord.units.num2date(
                                 coord_cell.point)
                             if coord_cell.bound is not None:

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -776,7 +776,7 @@ fc_extras
             attr_units = iris.unit._NO_UNIT_STRING
 
         # Get any assoicated calendar for a time reference coordinate.
-        if iris.unit.as_unit(attr_units).time_reference:
+        if iris.unit.as_unit(attr_units).is_time_reference():
             attr_calendar = getattr(cf_var, CF_ATTR_CALENDAR, None)
 
             if attr_calendar:
@@ -1074,7 +1074,7 @@ fc_extras
         attr_std_name = getattr(cf_var, CF_ATTR_STD_NAME, None)
         attr_axis = getattr(cf_var, CF_ATTR_AXIS, '')
         try:
-            is_time_reference = iris.unit.Unit(attr_units or 1).time_reference
+            is_time_reference = iris.unit.Unit(attr_units or 1).is_time_reference()
         except ValueError:
             is_time_reference = False
         

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -37,14 +37,14 @@ def _title(cube_or_coord, with_units):
     else:
         title = cube_or_coord.name().replace('_', ' ').capitalize()
         units = cube_or_coord.units
-        if with_units and not (units.unknown or
-                               units.no_unit or
+        if with_units and not (units.is_unknown() or
+                               units.is_no_unit() or
                                units == iris.unit.Unit('1')):
 
             # For non-time units use the shortest unit representation e.g.
             # prefer 'K' over 'kelvin', but not '0.0174532925199433 rad'
             # over 'degrees'
-            if (not units.is_time() and not units.time_reference and
+            if (not units.is_time() and not units.is_time_reference() and
                 len(units.symbol) < len(str(units))):
                 units = units.symbol
             title += ' / {}'.format(units)
@@ -61,10 +61,10 @@ def _label(cube, mode, result=None, ndims=2, coords=None):
         draw_edges = mode == iris.coords.POINT_MODE
         bar = plt.colorbar(result, orientation='horizontal',
                            drawedges=draw_edges)
-        has_known_units = not (cube.units.unknown or cube.units.no_unit)
+        has_known_units = not (cube.units.is_unknown() or cube.units.is_no_unit())
         if has_known_units and cube.units != iris.unit.Unit('1'):
             # Use shortest unit representation for anything other than time
-            if (not cube.units.is_time() and not cube.units.time_reference and
+            if (not cube.units.is_time() and not cube.units.is_time_reference() and
                 len(cube.units.symbol) < len(str(cube.units))):
                 bar.set_label(cube.units.symbol)
             else:

--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -85,30 +85,30 @@ class TestConvertible(TestUnit):
     def test_convertible_fail_0(self):
         u = Unit("meter")
         v = Unit("newton")
-        self.assertFalse(u.convertible(v))
+        self.assertFalse(u.is_convertible(v))
 
     def test_convertible_pass_0(self):
         u = Unit("meter")
         v = Unit("mile")
-        self.assertTrue(u.convertible(v))
+        self.assertTrue(u.is_convertible(v))
         
     def test_convertible_fail_1(self):
         u = Unit('meter')
         v = Unit('unknown')
-        self.assertFalse(u.convertible(v))
-        self.assertFalse(v.convertible(u))
+        self.assertFalse(u.is_convertible(v))
+        self.assertFalse(v.is_convertible(u))
         
     def test_convertible_fail_2(self):
         u = Unit('meter')
         v = Unit('no unit')
-        self.assertFalse(u.convertible(v))
-        self.assertFalse(v.convertible(u))
+        self.assertFalse(u.is_convertible(v))
+        self.assertFalse(v.is_convertible(u))
         
     def test_convertible_fail_3(self):
         u = Unit('unknown')
         v = Unit('no unit')
-        self.assertFalse(u.convertible(v))
-        self.assertFalse(v.convertible(u))
+        self.assertFalse(u.is_convertible(v))
+        self.assertFalse(v.is_convertible(u))
 
 
 class TestDimensionless(TestUnit):
@@ -117,19 +117,19 @@ class TestDimensionless(TestUnit):
     #
     def test_dimensionless_fail_0(self):
         u = Unit("meter")
-        self.assertFalse(u.dimensionless)
+        self.assertFalse(u.is_dimensionless())
 
     def test_dimensionless_pass_0(self):
         u = Unit("1")
-        self.assertTrue(u.dimensionless)
+        self.assertTrue(u.is_dimensionless())
 
     def test_dimensionless_fail_1(self):
         u = Unit('unknown')
-        self.assertFalse(u.dimensionless)
+        self.assertFalse(u.is_dimensionless())
         
     def test_dimensionless_fail_2(self):
         u = Unit('no unit')
-        self.assertFalse(u.dimensionless)
+        self.assertFalse(u.is_dimensionless())
 
 
 class TestFormat(TestUnit):
@@ -343,8 +343,8 @@ class TestMultiply(TestUnit):
     def test_multiply_fail_1(self):
         u = Unit('unknown')
         v = Unit('meters')
-        self.assertTrue((u * v).unknown)
-        self.assertTrue((v * u).unknown)
+        self.assertTrue((u * v).is_unknown())
+        self.assertTrue((v * u).is_unknown())
         
     def test_multiply_fail_3(self):
         u = Unit('unknown')
@@ -384,8 +384,8 @@ class TestDivide(TestUnit):
     def test_divide_fail_1(self):
         u = Unit('unknown')
         v = Unit('meters')
-        self.assertTrue((u / v).unknown)
-        self.assertTrue((v / u).unknown)
+        self.assertTrue((u / v).is_unknown())
+        self.assertTrue((v / u).is_unknown())
         
     def test_divide_fail_3(self):
         u = Unit('unknown')
@@ -458,11 +458,11 @@ class TestCopy(TestUnit):
         
     def test_copy_pass_1(self):
         u = Unit('unknown')
-        self.assertTrue(copy.copy(u).unknown)
+        self.assertTrue(copy.copy(u).is_unknown())
         
     def test_copy_pass_2(self):
         u = Unit('no unit')
-        self.assertTrue(copy.copy(u).no_unit)
+        self.assertTrue(copy.copy(u).is_no_unit())
 
 
 class TestStringify(TestUnit):
@@ -675,23 +675,23 @@ class TestUnknown(TestUnit):
     #
     def test_unknown_unit_pass_0(self):
         u = Unit("?")
-        self.assertTrue(u.unknown)
+        self.assertTrue(u.is_unknown())
 
     def test_unknown_unit_pass_1(self):
         u = Unit("???")
-        self.assertTrue(u.unknown)
+        self.assertTrue(u.is_unknown())
 
     def test_unknown_unit_pass_2(self):
         u = Unit("unknown")
-        self.assertTrue(u.unknown)
+        self.assertTrue(u.is_unknown())
 
     def test_unknown_unit_fail_0(self):
         u = Unit('no unit')
-        self.assertFalse(u.unknown)
+        self.assertFalse(u.is_unknown())
         
     def test_unknown_unit_fail_2(self):
         u = Unit('meters')
-        self.assertFalse(u.unknown)
+        self.assertFalse(u.is_unknown())
 
 
 class TestNoUnit(TestUnit):
@@ -700,19 +700,19 @@ class TestNoUnit(TestUnit):
     #
     def test_no_unit_pass_0(self):
         u = Unit('no_unit')
-        self.assertTrue(u.no_unit)
+        self.assertTrue(u.is_no_unit())
         
     def test_no_unit_pass_1(self):
         u = Unit('no unit')
-        self.assertTrue(u.no_unit)
+        self.assertTrue(u.is_no_unit())
         
     def test_no_unit_pass_2(self):
         u = Unit('no-unit')
-        self.assertTrue(u.no_unit)
+        self.assertTrue(u.is_no_unit())
         
     def test_no_unit_pass_3(self):
         u = Unit('nounit')
-        self.assertTrue(u.no_unit)
+        self.assertTrue(u.is_no_unit())
 
 
 class TestTimeReference(TestUnit):
@@ -721,11 +721,11 @@ class TestTimeReference(TestUnit):
     #
     def test_time_reference_pass_0(self):
         u = Unit('hours since epoch')
-        self.assertTrue(u.time_reference)
+        self.assertTrue(u.is_time_reference())
         
     def test_time_reference_fail_0(self):
         u = Unit('hours')
-        self.assertFalse(u.time_reference)
+        self.assertFalse(u.is_time_reference())
 
 
 class TestTitle(TestUnit):

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -29,6 +29,7 @@ from __future__ import division
 import copy
 import ctypes
 import ctypes.util
+import warnings
 
 import netcdftime
 import numpy as np
@@ -899,7 +900,7 @@ class Unit(iris.util._OrderedHashable):
             False
 
         """
-        if self.unknown or self.no_unit:
+        if self.is_unknown() or self.is_no_unit():
             result = False
         else:
             result = _ut_are_convertible(self.ut_unit, _ut_get_unit_by_name(_ud_system, 'day')) != 0
@@ -923,7 +924,7 @@ class Unit(iris.util._OrderedHashable):
             True
 
         """
-        if self.unknown or self.no_unit:
+        if self.is_unknown() or self.is_no_unit():
             result = False
         else:
             result = _ut_are_convertible(self.ut_unit, _ut_get_unit_by_name(_ud_system, 'bar')) != 0 or \
@@ -934,10 +935,9 @@ class Unit(iris.util._OrderedHashable):
         """Return whether the unit is a vaild unit of UDUNITS."""
         return self.ut_unit is not None
 
-    @property
-    def time_reference(self):
+    def is_time_reference(self):
         """
-        *(read-only)* Return whether the unit is a time reference unit of the form
+        Return whether the unit is a time reference unit of the form
         '<time-unit> since <time-origin>' i.e. unit='days since 1970-01-01 00:00:00'
 
         Returns:
@@ -947,11 +947,22 @@ class Unit(iris.util._OrderedHashable):
 
             >>> import iris.unit as unit
             >>> u = unit.Unit('days since epoch')
-            >>> u.time_reference
+            >>> u.is_time_reference()
             True
 
         """
         return self.calendar is not None
+
+    @property
+    def time_reference(self):
+        """
+        .. deprecated:: 1.3
+            Please use the :meth:`~iris.unit.Unit.is_time_reference` method instead.
+        """
+        msg = "The 'time_reference' property is deprecated. "\
+              "Please use the 'is_time_reference' method instead."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return self.is_time_reference()
 
     def title(self, value):
         """
@@ -972,7 +983,7 @@ class Unit(iris.util._OrderedHashable):
             '1970-01-01 10:00:00'
 
         """
-        if self.time_reference:
+        if self.is_time_reference():
             dt = self.num2date(value)
             result = dt.strftime('%Y-%m-%d %H:%M:%S')
         else:
@@ -1009,7 +1020,7 @@ class Unit(iris.util._OrderedHashable):
             result = None
         return result
 
-    def convertible(self, other):
+    def is_convertible(self, other):
         """
         Return whether two units are convertible.
 
@@ -1025,21 +1036,31 @@ class Unit(iris.util._OrderedHashable):
             >>> import iris.unit as unit
             >>> u = unit.Unit('meters')
             >>> v = unit.Unit('kilometers')
-            >>> u.convertible(v)
+            >>> u.is_convertible(v)
             True
 
         """
         other = as_unit(other)
-        if self.unknown or self.no_unit or other.unknown or other.no_unit:
+        if self.is_unknown() or self.is_no_unit() or other.is_unknown() or \
+            other.is_no_unit():
             result = False
         else:
             result = self.calendar == other.calendar and _ut_are_convertible(self.ut_unit, other.ut_unit) != 0
         return result
 
-    @property
-    def dimensionless(self):
+    def convertible(self, other):
         """
-        *(read-only)* Return whether the unit is dimensionless.
+        .. deprecated:: 1.3
+            Please use the :meth:`~iris.unit.Unit.is_convertible` method instead.
+        """
+        msg = "The 'convertible' method is deprecated. "\
+              "Please use the 'is_convertible' method instead."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return self.is_convertible(other)
+
+    def is_dimensionless(self):
+        """
+        Return whether the unit is dimensionless.
 
         Returns:
             Boolean.
@@ -1048,19 +1069,29 @@ class Unit(iris.util._OrderedHashable):
 
             >>> import iris.unit as unit
             >>> u = unit.Unit('meters')
-            >>> u.dimensionless
+            >>> u.is_dimensionless()
             False
             >>> u = unit.Unit('1')
-            >>> u.dimensionless
+            >>> u.is_dimensionless()
             True
 
         """
         return self.category == _CATEGORY_UDUNIT and bool(_ut_is_dimensionless(self.ut_unit))
 
     @property
-    def unknown(self):
+    def dimensionless(self):
         """
-        *(read-only)* Return whether the unit is defined to be an *unknown* unit.
+        .. deprecated:: 1.3
+            Please use the :meth:`~iris.unit.Unit.is_dimensionless` method instead.
+        """
+        msg = "The 'dimensionless' property is deprecated. "\
+              "Please use the 'is_dimensionless' method instead."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return self.is_dimensionless()
+
+    def is_unknown(self):
+        """
+        Return whether the unit is defined to be an *unknown* unit.
 
         Returns:
             Boolean.
@@ -1069,19 +1100,29 @@ class Unit(iris.util._OrderedHashable):
 
             >>> import iris.unit as unit
             >>> u = unit.Unit('unknown')
-            >>> u.unknown
+            >>> u.is_unknown()
             True
             >>> u = unit.Unit('meters')
-            >>> u.unknown
+            >>> u.is_unknown()
             False
 
         """
         return self.category == _CATEGORY_UNKNOWN
 
     @property
-    def no_unit(self):
+    def unknown(self):
         """
-        *(read-only)* Return whether the unit is defined to be a *no_unit* unit.
+        .. deprecated:: 1.3
+            Please use the :meth:`~iris.unit.Unit.is_unknown` method instead.
+        """
+        msg = "The 'unknown' property is deprecated. "\
+              "Please use the 'is_unknown' method instead."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return self.is_unknown()
+
+    def is_no_unit(self):
+        """
+        Return whether the unit is defined to be a *no_unit* unit.
 
         Typically, a quantity such as a string, will have no associated unit to describe it. Such
         a class of quantity may be defined using the *no_unit* unit.
@@ -1093,14 +1134,25 @@ class Unit(iris.util._OrderedHashable):
 
             >>> import iris.unit as unit
             >>> u = unit.Unit('no unit')
-            >>> u.no_unit
+            >>> u.is_no_unit()
             True
             >>> u = unit.Unit('meters')
-            >>> u.no_unit
+            >>> u.is_no_unit()
             False
 
         """
         return self.category == _CATEGORY_NO_UNIT
+
+    @property
+    def no_unit(self):
+        """
+        .. deprecated:: 1.3
+            Please use the :meth:`~iris.unit.Unit.is_no_unit` method instead.
+        """
+        msg = "The 'no_unit' property is deprecated. "\
+              "Please use the 'is_no_unit' method instead."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return self.is_no_unit()
 
     def format(self, option=None):
         """
@@ -1136,9 +1188,9 @@ class Unit(iris.util._OrderedHashable):
             'm'
 
         """
-        if self.unknown:
+        if self.is_unknown():
             return _UNKNOWN_UNIT_STRING
-        elif self.no_unit:
+        elif self.is_no_unit():
             return _NO_UNIT_STRING
         else:
             bitmask = UT_ASCII
@@ -1192,9 +1244,9 @@ class Unit(iris.util._OrderedHashable):
             'W'
 
         """
-        if self.unknown:
+        if self.is_unknown():
             result = _UNKNOWN_UNIT_SYMBOL
-        elif self.no_unit:
+        elif self.is_no_unit():
             result = _NO_UNIT_SYMBOL
         else:
             result = self.format()
@@ -1219,9 +1271,9 @@ class Unit(iris.util._OrderedHashable):
             'm2.kg.s-3'
 
         """
-        if self.unknown:
+        if self.is_unknown():
             result = _UNKNOWN_UNIT_SYMBOL
-        elif self.no_unit:
+        elif self.is_no_unit():
             result = _NO_UNIT_SYMBOL
         else:
             result = self.format(UT_DEFINITION)
@@ -1270,9 +1322,9 @@ class Unit(iris.util._OrderedHashable):
             Unit('meter^-1')
 
         """
-        if self.unknown:
+        if self.is_unknown():
             result = self
-        elif self.no_unit:
+        elif self.is_no_unit():
             raise ValueError("Cannot invert a 'no-unit'.")
         else:
             ut_unit = _ut_invert(self.ut_unit)
@@ -1309,9 +1361,9 @@ class Unit(iris.util._OrderedHashable):
         except TypeError:
             raise TypeError('An int or long type for the root argument is required')
 
-        if self.unknown:
+        if self.is_unknown():
             result = self
-        elif self.no_unit:
+        elif self.is_no_unit():
             raise ValueError("Cannot take the logarithm of a 'no-unit'.")
         else:
             # only update the unit if it is not scalar
@@ -1349,9 +1401,9 @@ class Unit(iris.util._OrderedHashable):
         except TypeError:
             raise TypeError('A numeric type for the base argument is required')
 
-        if self.unknown:
+        if self.is_unknown():
             result = self
-        elif self.no_unit:
+        elif self.is_no_unit():
             raise ValueError("Cannot take the logarithm of a 'no-unit'.")
         else:
             ut_unit = _ut_log(base, self.ut_unit)
@@ -1406,9 +1458,9 @@ class Unit(iris.util._OrderedHashable):
         except TypeError:
             result = NotImplemented
         else:
-            if self.unknown:
+            if self.is_unknown():
                 result = self
-            elif self.no_unit:
+            elif self.is_no_unit():
                 raise ValueError("Cannot offset a 'no-unit'.")
             else:
                 ut_unit = _ut_offset(self.ut_unit, offset)
@@ -1438,10 +1490,10 @@ class Unit(iris.util._OrderedHashable):
 
         other = as_unit(other)
 
-        if self.no_unit or other.no_unit:
+        if self.is_no_unit() or other.is_no_unit():
             raise ValueError("Cannot %s a 'no-unit'." % op_label)
 
-        if self.unknown or other.unknown:
+        if self.is_unknown() or other.is_unknown():
             result = _Unit(_CATEGORY_UNKNOWN, None)
         else:
             ut_unit = op_func(self.ut_unit, other.ut_unit)
@@ -1559,9 +1611,9 @@ class Unit(iris.util._OrderedHashable):
         except ValueError:
             raise TypeError('A numeric value is required for the power argument.')
 
-        if self.unknown:
+        if self.is_unknown():
             result = self
-        elif self.no_unit:
+        elif self.is_no_unit():
             raise ValueError("Cannot raise the power of a 'no-unit'.")
         elif self == Unit('1'):
             # 1 ** N -> 1
@@ -1691,7 +1743,7 @@ class Unit(iris.util._OrderedHashable):
         if self == other:
             return value
 
-        if self.convertible(other):
+        if self.is_convertible(other):
             ut_converter = _ut_get_converter(self.ut_unit, other.ut_unit)
             if ut_converter:
                 if isinstance(value_copy, (int, float, long)):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -148,9 +148,9 @@ def guess_coord_axis(coord):
         axis = 'X'
     elif coord.standard_name in ('latitude', 'grid_latitude', 'projection_y_coordinate'):
         axis = 'Y'
-    elif coord.units.convertible('hPa') or coord.attributes.get('positive') in ('up', 'down'):
+    elif coord.units.is_convertible('hPa') or coord.attributes.get('positive') in ('up', 'down'):
         axis = 'Z'
-    elif coord.units.time_reference:    
+    elif coord.units.is_time_reference():    
         axis = 'T'
 
     return axis


### PR DESCRIPTION
This PR contains fairly minor code changes pertinent to this Iris [forum topic](https://groups.google.com/forum/#!topic/scitools-iris/LLSKr47kg2c).

To achieve consistency, all of the `is_x()` functions are now methods. Previously, some of the functions were implemented as properties using the `@property` decorator.

All of the unit tests and doctests passed with these code changes.

I couldn't find any references to the affected methods in the sphinx documentation (e.g. the user guide), so no doc changes have been made.

I have used the `deprecated:: 1.3` stanza in the relevant docstrings (of the old methods). However, it occurs to me that this PR may go into a 1.2.x release. In which case these stanzas will need to be fixed.

As this is my first time around the (devilishly complicated) Iris dev loop, it is almost certain that I have missed something :-)

Big thanks to bjlittle for assistance and patience.
