### PR TITLE
removal of cf conventions, title and history global attr, closes #365

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -629,7 +629,12 @@ fc_extras
     CF_ATTR_LONG_NAME = 'long_name'
     CF_ATTR_UNITS = 'units'
     CF_ATTR_CELL_METHODS = 'cell_methods'
-    
+
+    #
+    # CF Ignore Global.
+    #
+    CF_ATTR_IGNORE = ['history', 'title', 'conventions']
+
     #
     # CF Attribute Value Constants.
     #
@@ -704,13 +709,14 @@ fc_extras
 
         # Set the cube global attributes. 
         for attr_name, attr_value in cf_var.cf_group.global_attributes.iteritems():
-            if isinstance(attr_value, unicode):
-                try:
-                    cube.attributes[str(attr_name)] = str(attr_value)
-                except UnicodeEncodeError:
+            if attr_name.lower() not in CF_ATTR_IGNORE:
+                if isinstance(attr_value, unicode):
+                    try:
+                        cube.attributes[str(attr_name)] = str(attr_value)
+                    except UnicodeEncodeError:
+                        cube.attributes[str(attr_name)] = attr_value
+                else:
                     cube.attributes[str(attr_name)] = attr_value
-            else:
-                cube.attributes[str(attr_name)] = attr_value
 
 
     ################################################################################

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -61,12 +61,12 @@ SPATIO_TEMPORAL_AXES = ['t', 'z', 'y', 'x']
 
 # Pass through CF attributes:
 #  - comment
-#  - Conventions
-#  - history
+#  - Conventions (pyke rules filter out global attr)
+#  - history (pyke rules filter out global attr)
 #  - institution
-#  - reference
+#  - references
 #  - source
-#  - title
+#  - title (pyke rules filter out global attr)
 #
 _CF_ATTRS = ['add_offset', 'ancillary_variables', 'axis', 'bounds', 'calendar',
             'cell_measures', 'cell_methods', 'climatology', 'compress',
@@ -80,7 +80,7 @@ _CF_CONVENTIONS_VERSION = 'CF-1.5'
 
 
 _FactoryDefn = collections.namedtuple('_FactoryDefn', ('primary', 'std_name',
-                                                     'formula_terms_format'))
+                                                       'formula_terms_format'))
 _FACTORY_DEFNS = {
     iris.aux_factory.HybridHeightFactory: _FactoryDefn(
         primary='delta',
@@ -237,10 +237,6 @@ def _load_cube(engine, cf, cf_var, filename):
 
     # Reset the pyke inference engine.
     engine.reset()
-
-    # Remove conventions attribute so that it does not enter cube.
-    if 'Conventions' in cf_var.cf_group.global_attributes:
-        del cf_var.cf_group.global_attributes['Conventions']
 
     # Initialise pyke engine rule processing hooks.
     engine.cf_var = cf_var


### PR DESCRIPTION
**Do not merge until google thread has concluded!**

This comes from the perspective of writing a cube to a netcdf file.
On loading this file, I expect the resulting cube to be the same as that I wrote (i.e. no conventions attribute on the cube) other than floating point precision differences.
