### PR TITLE
Added missing blank lines after sphinx directives.

### DIFF
--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -16,6 +16,7 @@ intended. This example could be rectified by changing the units attribute::
    cube.units = 'celsius'
 
 .. note::
+
     :meth:`iris.cube.Cube.convert_units` can be used to automatically convert a
     cube's data and update its units attribute.
     So, the two steps above can be achieved by::
@@ -64,6 +65,7 @@ but with the data representing their difference:
 
 
 .. note::
+
     Notice that the coordinates "time" and "forecast_period" have been removed 
     from the resultant cube; 
     this is because these coordinates differed between the two input cubes. 
@@ -118,10 +120,12 @@ The result could now be plotted using the guidance provided in the
 :doc:`plotting_a_cube` section.
 
 .. htmlonly::
+
     A very similar example to this can be found in 
     :doc:`/examples/graphics/deriving_phenomena`.
 
 .. latexonly::
+
     A very similar example to this can be found in the examples section, 
     with the title "Deriving Exner Pressure and Air Temperature".
 

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -169,6 +169,7 @@ to represent the climatological seasons and the season year respectively::
 
 
 .. note::
+
     The 'season year' is not the same as year number, because (e.g.) the months 
     Dec11, Jan12 + Feb12 all belong to 'DJF-12'.  
     See :meth:`iris.coord_categorisation.add_season_year`.

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -48,12 +48,14 @@ The ``air_potential_temperature`` cubes were 4 dimensional with:
    * a ``model_level_number`` dimension of length 7
 
 .. note::
+
      The result of :func:`iris.load` is **always** a 
      :class:`list of cubes <iris.cube.CubeList>`. 
      Anything that can be done with a Python :class:`list` can be done 
      with the resultant list of cubes.
 
 .. hint::
+
     Throughout this user guide you will see the function 
     ``iris.sample_data_path`` being used to get the filename for the resources 
     used in the examples. The result of this function is just a string.
@@ -101,6 +103,7 @@ on the coordinates which constitute the cube in question.
 This was the output discussed at the end of the :doc:`iris_cubes` section.
 
 .. note::
+
      Dimensioned coordinates will have a dimension marker ``x`` in the 
      appropriate column for each cube data dimension that they describe. 
 
@@ -189,6 +192,7 @@ this can be achieved by passing the constraint a function::
     cubes = iris.load(filename, level_lt_16)
      
 .. note::
+
     As with many of the examples later in this documentation, the 
     simple function above can be conveniently written as a lambda function 
     on a single line::

--- a/docs/iris/src/userguide/navigating_a_cube.rst
+++ b/docs/iris/src/userguide/navigating_a_cube.rst
@@ -77,7 +77,8 @@ Each cube also has a :mod:`numpy` array which represents the phenomenon of the c
 
     print type(cube.data)
 
-.. note:: 
+.. note::
+
     When loading some file formats in Iris, the data itself is not loaded until the **first** time that the data is requested. 
     Hence you may have noticed that running the previous command for the first time takes a little longer than it does for 
     subsequent calls.

--- a/docs/iris/src/userguide/plotting_a_cube.rst
+++ b/docs/iris/src/userguide/plotting_a_cube.rst
@@ -55,7 +55,8 @@ The current rendering mode can be determined as follows::
 	import matplotlib.pyplot as plt
 	print plt.isinteractive()
 
-.. note:: 
+.. note::
+
 	For clarity, each example includes all of the imports required to run on its 
 	own; when combining examples such as the two above, it would not be necessary 
 	to repeat the import statement more than once::
@@ -137,6 +138,7 @@ except that ``quickplot`` will add a title, x and y labels and a colorbar
 where appropriate.
 
 .. note::
+
    In all subsequent examples the ``matplotlib.pyplot``, ``iris.plot`` and 
    ``iris.quickplot`` modules are imported as ``plt``, ``iplt`` and ``qplt`` 
    respectively in order to make the code more readable.
@@ -162,7 +164,8 @@ keyword arguments are equivalent:
 For more information on how this example reduced the 2D cube to 1 dimension see 
 the previous section entitled :doc:`reducing_a_cube`.
 
-.. note:: 
+.. note::
+
     Axis labels and a plot title can be added using the
     :func:`plt.title() <matplotlib.pyplot.title>`,
     :func:`plt.xlabel() <matplotlib.pyplot.xlabel>` and
@@ -198,6 +201,7 @@ This example of consecutive ``qplt.plot`` calls coupled with the
 the temperature at some latitude cross-sections. 
 
 .. note::
+
     The previous example uses the ``if __name__ == "__main__"`` style to run 
     the desired code if and only if the script is run from the command line.
 
@@ -223,9 +227,10 @@ accessed with the :func:`matplotlib.pyplot.gca` function.
 Given the current map, you can draw gridlines and coastlines amongst other 
 things. 
 
-.. seealso:: 
-	:meth:`cartopy's gridlines() <cartopy.mpl.GeoAxes.gridlines>`, 
-	:meth:`cartopy's coastlines() <cartopy.mpl.GeoAxes.coastlines>`.
+.. seealso::
+
+    :meth:`cartopy's gridlines() <cartopy.mpl.GeoAxes.gridlines>`,
+    :meth:`cartopy's coastlines() <cartopy.mpl.GeoAxes.coastlines>`.
 
 
 Cube contour
@@ -257,6 +262,7 @@ Continuous block plots can be achieved with either :func:`iris.plot.pcolormesh`
 or :func:`iris.quickplot.pcolormesh`.
 
 .. note::
+
     If the cube's coordinates do not have bounds, :func:`iris.plot.pcolormesh`
     and :func:`iris.quickplot.pcolormesh` will attempt to guess suitable values
     based on their points (see also :func:`iris.coords.Coord.guess_bounds()`).
@@ -325,4 +331,3 @@ The recommended text for the Cynthia Brewer citation is provided by
 
 .. plot:: userguide/plotting_examples/cube_brewer_cite_contourf.py
    :include-source:
-

--- a/docs/iris/src/userguide/reducing_a_cube.rst
+++ b/docs/iris/src/userguide/reducing_a_cube.rst
@@ -25,7 +25,8 @@ In this example we start with a 3 dimensional cube, with dimensions of ``height`
 and extract every point where the latitude is 0, resulting in a 2d cube with axes of ``height`` and ``longitude``.
 
 
-.. warning:: 
+.. warning::
+
     Caution is required when using equality constraints with floating point coordinates such as ``latitude``. 
     Printing the points of a coordinate does not necessarily show the full precision of the underlying number and it 
     is very easy return no matches to a constraint when one was expected.
@@ -83,7 +84,8 @@ which make up the full 3d cube.::
 As the original cube had the shape (15, 100, 100) there were 15 latitude longitude slices and hence the
 line ``print repr(yx_slice)`` was run 15 times.
 
-.. note:: 
+.. note::
+
 	The order of latitude and longitude in the list is important; had they been swapped the resultant cube slices 
 	would have been transposed.
 

--- a/docs/iris/src/whatsnew/1.0.rst
+++ b/docs/iris/src/whatsnew/1.0.rst
@@ -131,7 +131,9 @@ interface:
             ax.coastlines()
             plt.show()
 
-.. note:: The ``iris.plot.gcm`` function to get the current map is now
+.. note::
+
+    The ``iris.plot.gcm`` function to get the current map is now
     redundant; instead the current map *is* the current matplotlib axes,
     and :func:`matplotlib.pyplot.gca` should be used instead.
 
@@ -235,7 +237,9 @@ Where previously it would have appeared as::
               source: Data from Met Office Unified Model
          ...
 
-.. note:: This change breaks backwards compatibility with Iris 0.9. But
+.. note::
+
+    This change breaks backwards compatibility with Iris 0.9. But
     if it is desirable to have the "source" metadata expressed as a
     coordinate then it can be done with the following pattern::
 

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -18,6 +18,7 @@
 A package for handling multi-dimensional data and associated metadata.
 
 .. note ::
+
     The Iris documentation has further usage information, including
     a :ref:`user guide <user_guide_index>` which should be the first port of
     call for new users.

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -599,8 +599,9 @@ For example, to compute the 90th percentile over time::
     result = cube.collapsed('time', iris.analysis.PERCENTILE, percent=90)
 
 .. note::
-    The default values of ``alphap`` and ``betap`` are both 1. For detailed meanings on
-    these values see :func:`scipy.stats.mstats.mquantiles`.
+
+    The default values of ``alphap`` and ``betap`` are both 1. For detailed
+    meanings on these values see :func:`scipy.stats.mstats.mquantiles`.
 
 """
 

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -133,7 +133,7 @@ def cube_delta(cube, coord, update_history=True):
     
         change_in_temperature_wrt_pressure = cube_delta(temperature_cube, 'pressure')
     
-    .. Note:: Missing data support not yet implemented.
+    .. note:: Missing data support not yet implemented.
     
     """
     # handle the case where a user passes a coordinate name

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -469,6 +469,7 @@ def project(cube, target_proj, nx=None, ny=None):
         extent of the projection.
 
     .. note::
+
         This function uses a nearest neighbour approach rather than any form
         of linear/non-linear interpolation to determine the data value of each
         cell in the resulting cube. Consequently it may have an adverse effect
@@ -476,6 +477,7 @@ def project(cube, target_proj, nx=None, ny=None):
         will not be preserved.
 
     .. note::
+
         This function assumes global data and will if necessary extrapolate
         beyond the geographical extent of the source cube using a nearest
         neighbour approach.

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -558,6 +558,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
     (bi-linear, tri-linear, etc.).
     
     .. note::
+
         By definition, linear interpolation requires all coordinates to
         be 1-dimensional.
     
@@ -582,6 +583,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
           attempted extrapolation.
     
     .. note::
+
         If the source cube's data, or any of its resampled coordinates,
         have an integer data type they will be promoted to a floating
         point data type in the result.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -94,9 +94,11 @@ class Cell(iris.util._OrderedHashable):
     relative comparisons (lt, le, ..) are defined to be consistent with
     this interpretation. So for a given value `n` and Cell `cell`, only
     one of the following can be true:
-        n < cell
-        n == cell
-        n > cell
+
+    |    n < cell
+    |    n == cell
+    |    n > cell
+
     Similarly, `n <= cell` implies either `n < cell` or `n == cell`.
     And `n >= cell` implies either `n > cell` or `n == cell`.
 
@@ -343,7 +345,8 @@ class Coord(CFVariableMixin):
         """
         Returns a new Coord whose values are obtained by conventional array indexing.
 
-        .. note:: 
+        .. note::
+
             Indexing of a circular coordinate results in a non-circular
             coordinate if the overall shape of the coordinate changes after
             indexing.
@@ -507,10 +510,15 @@ class Coord(CFVariableMixin):
 
         Mode constant is one of ADD, SUB, MUL, DIV, RDIV
 
-        .. note:: The unit is *not* changed when doing scalar operations on a coordinate. This means that
-                  a coordinate which represents "10 meters" when multiplied by a scalar i.e. "1000" would result
-                  in a coordinate of "10000 meters". An alternative approach could be taken to multiply the *unit*
-                  by 1000 and the resultant coordinate would represent "10 kilometers".
+        .. note::
+
+            The unit is *not* changed when doing scalar operations on a
+            coordinate. This means that a coordinate which represents
+            "10 meters" when multiplied by a scalar i.e. "1000" would result
+            in a coordinate of "10000 meters". An alternative approach could
+            be taken to multiply the *unit* by 1000 and the resultant
+            coordinate would represent "10 kilometers".
+
         """
         if isinstance(other, Coord):
             raise iris.exceptions.NotYetImplementedError('coord %s coord' % Coord._MODE_SYMBOL[mode_constant])
@@ -662,6 +670,7 @@ class Coord(CFVariableMixin):
         of length N.
 
         .. note::
+
             If the coordinate is does not have bounds, this method will
             return bounds positioned halfway between the coordinate's points.
 
@@ -852,6 +861,7 @@ class Coord(CFVariableMixin):
             A numpy array of shape (len(self.points), 2).
 
         .. note::
+
             This method only works for coordinates with ``coord.ndim == 1``.
         
         """
@@ -943,7 +953,7 @@ class Coord(CFVariableMixin):
 
         .. note:: If the coordinate contain bounds, these will be used to determine
             the nearest neighbour instead of the point values.
-            
+
         .. note:: Does not take into account the circular attribute of a coordinate.
 
         """
@@ -1259,7 +1269,7 @@ class AuxCoord(Coord):
         """
         Property containing the bound values, as a numpy array, 
         or None if no bound values are defined.
-        
+
         .. note:: The shape of the bound array should be: ``points.shape + (n_bounds, )``. 
 
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -911,11 +911,12 @@ class Cube(CFVariableMixin):
               coord_system=None, dim_coords=None):
         """
         Return a single coord given the same arguments as :meth:`Cube.coords`.
-        
+
         .. note::
+
             If the arguments given do not result in precisely 1 coordinate being matched,
             an :class:`iris.exceptions.CoordinateNotFoundError` is raised.
-            
+
         .. seealso:: :meth:`Cube.coords()<iris.cube.Cube.coords>` for full keyword documentation.
 
         """
@@ -999,6 +1000,7 @@ class Cube(CFVariableMixin):
         The :class:`numpy.ndarray` representing the multi-dimensional data of the cube.
         
         .. note::
+
             Cubes obtained from netCDF, PP, and FieldsFile files will only populate this attribute on
             its first use.
 
@@ -1190,11 +1192,13 @@ class Cube(CFVariableMixin):
             #
             def vector_summary(vector_coords, cube_header, max_line_offset):
                 """
-                Generates a list of suitably aligned strings containing coord names 
-                and dimensions indicated by one or more 'x' symbols.
+                Generates a list of suitably aligned strings containing coord
+                names and dimensions indicated by one or more 'x' symbols.
 
-                .. note:: 
-                    The function may need to update the cube header so this is returned with the list of strings. 
+                .. note::
+
+                    The function may need to update the cube header so this is
+                    returned with the list of strings.
                 
                 """
                 vector_summary = []
@@ -1929,6 +1933,7 @@ class Cube(CFVariableMixin):
 
 
         .. note::
+
             Some aggregations are not commutative and hence the order of processing is important i.e.::
             
                 cube.collapsed('realization', iris.analysis.VARIANCE).collapsed('height', iris.analysis.VARIANCE)

--- a/lib/iris/experimental/fileformats/abf.py
+++ b/lib/iris/experimental/fileformats/abf.py
@@ -183,6 +183,7 @@ def load_cubes(filespecs, callback=None):
     * callback - a function that can be passed to :func:`iris.io.run_callback`
 
     .. note::
+
         The resultant cubes may not be in the same order as in the file.
 
     """

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -342,7 +342,8 @@ def load_cubes(filenames, callback):
     
     * callback - a function which can be passed on to :func:`iris.io.run_callback`
     
-    .. note:: 
+    .. note::
+
         The resultant cubes may not be in the order that they are in the file (order 
         is not preserved when there is a field with orography references).
          

--- a/lib/iris/fileformats/manager.py
+++ b/lib/iris/fileformats/manager.py
@@ -94,10 +94,13 @@ class DataManager(iris.util._OrderedHashable):
     
     def pre_slice_array_shape(self, proxy_array):
         """
-        Given the associated proxy_array, calculate the shape of the resultant data without loading it.
+        Given the associated proxy_array, calculate the shape of the resultant
+        data without loading it.
         
         .. note::
-            This may differ from the result of :meth:`load` if there are pending post load slices in :attr:`deferred_slices`.
+
+            This may differ from the result of :meth:`load` if there are
+            pending post load slices in :attr:`deferred_slices`.
             
         """
         return proxy_array.shape + self._orig_data_shape

--- a/lib/iris/fileformats/nimrod.py
+++ b/lib/iris/fileformats/nimrod.py
@@ -216,6 +216,7 @@ def load_cubes(filenames, callback=None):
                  :func:`iris.io.run_callback`
 
     .. note::
+
         The resultant cubes may not be in the same order as in the files.
 
     """

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -500,6 +500,7 @@ class BitwiseInt(SplittableInt):
     A class to hold an integer, of fixed bit-length, which can easily get/set each bit individually.
     
     .. note::
+
         Uses a fixed number of bits.
         Will raise an Error when attempting to access an out-of-range flag.
     
@@ -953,8 +954,10 @@ class PPField(object):
         
         
         .. note::
-            The fields which are automatically calculated are: 'lbext', 'lblrec' and 'lbuser[0]'.
-            Some fields are not currently populated, these are: 'lbegin', 'lbnrec', 'lbuser[1]'.
+
+            The fields which are automatically calculated are: 'lbext',
+            'lblrec' and 'lbuser[0]'. Some fields are not currently
+            populated, these are: 'lbegin', 'lbnrec', 'lbuser[1]'.
             
         """
 
@@ -1502,7 +1505,8 @@ def load_cubes(filenames, callback=None):
     
     * callback - a function which can be passed on to :func:`iris.io.run_callback`
     
-    .. note:: 
+    .. note::
+
         The resultant cubes may not be in the order that they are in the file (order 
         is not preserved when there is a field with orography references)
          

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -117,9 +117,10 @@ def run_callback(callback, cube, field, filename):
             2. Must not return any value - any alterations to the cube must be made by reference
             3. If the cube is to be rejected the callback must raise an :class:`iris.exceptions.IgnoreCubeException`
    
-    .. note:: 
-        It is possible that this function returns None for certain callbacks, the caller of this 
-        function should handle this case.
+    .. note::
+
+        It is possible that this function returns None for certain callbacks,
+        the caller of this function should handle this case.
         
     """
     #call the custom uri cm func, if provided, for every loaded cube
@@ -196,10 +197,13 @@ def decode_uri(uri, default='file'):
 
 def load_files(filenames, callback):
     """
-    Takes a list of filenames which may also be globs, and optionally a callback function, and returns a generator of Cubes from the given files.
+    Takes a list of filenames which may also be globs, and optionally a
+    callback function, and returns a generator of Cubes from the given files.
     
-    .. note:: 
-        Typically, this function should not be called directly; instead, the intended interface for loading is :func:`iris.load`.
+    .. note::
+
+        Typically, this function should not be called directly; instead, the
+        intended interface for loading is :func:`iris.load`.
     
     """
     # Remove any hostname component - currently unused

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -674,6 +674,7 @@ def as_unit(unit):
     Returns a Unit corresponding to the given unit.
 
     .. note::
+
         If the given unit is already a Unit it will be returned unchanged.
 
     """
@@ -1301,6 +1302,7 @@ class Unit(iris.util._OrderedHashable):
             Unit('meter')
 
         .. note::
+
             Taking a fractional root of a unit is not supported.
 
         """
@@ -1679,8 +1681,9 @@ class Unit(iris.util._OrderedHashable):
                     46.40000153,  48.20000076], dtype=float32)
 
         .. note::
-            Conversion is done *in-place* for numpy arrays. Also note that, conversion between
-            unit calendars is not permitted.
+
+            Conversion is done *in-place* for numpy arrays. Also note that,
+            conversion between unit calendars is not permitted.
 
         """
         result = None

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -584,6 +584,7 @@ class _OrderedHashable(collections.Hashable):
         self._init(self, value1, value2, ..)
     
     .. note::
+
         It's the responsibility of the subclass to ensure that the values of
         its attributes are themselves hashable.
     


### PR DESCRIPTION
Sphinx reStructured text directives require a blank line between the directive and the content (a short form is also supported where the content is on the same line):

> The directive content follows after a blank line and is indented relative to the directive start.

(from http://sphinx-doc.org/rest.html)

I'm seeing a couple of errors on one of my linux boxes when building the docs and the corresponding note boxes are not rendered. This PR adds a bunch of blank lines. It also fixes a docstring in coords.py on [lines 99-100](https://github.com/esc24/iris/blob/f1dd5a69b70cbda6e52a4997cc4417f432037994/lib/iris/coords.py#L98-100) about cell comparison which is not rendering properly at the moment.
