### PR TITLE
Attempt to fix pep8 issues in cube.py

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1689,9 +1689,11 @@ class Cube(CFVariableMixin):
         Args:
 
         * points
-            **Either** Array of dicts with identical keys, for example:
-            ``[{'latitude': 0, 'longitude': 0},
-               {'latitude': 1, 'longitude': 1}]``
+            **Either** Array of dicts with identical keys, for example::
+
+                [{'latitude': 0, 'longitude': 0},
+                 {'latitude': 1, 'longitude': 1}]
+
             **Or** a :class:`iris.analysis.trajectory.Trajectory` instance.
 
         The coordinates specified by the points will be boiled down into a


### PR DESCRIPTION
Long lines in code example docstrings remain. The diff is too big for github. A sure sign that I should have broken this up into smaller bite sized chunks.
