### PR TITLE
Metaclass to disable cf profile for testing.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -29,6 +29,7 @@ import collections
 import contextlib
 import difflib
 import filecmp
+import functools
 import logging
 import os
 import os.path
@@ -122,15 +123,86 @@ def get_result_path(relative_path):
     return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
 
+def setUp_decorator(method):
+    """
+    Decorator for :class:`unittest.TestCase` test methods that disables
+    the CF profile.
+
+    """
+    # Check whether method has already been decorated.
+    if getattr(method, '_su_decorated', False):
+        return method
+
+    @functools.wraps(method)
+    def decorated_method(self, *args, **kwargs):
+        if 'cf_profile' in iris.site_configuration:
+            self._orig_cf_profile = iris.site_configuration['cf_profile']
+            iris.site_configuration['cf_profile'] = None
+        return method(self, *args, **kwargs)
+    # Add attribute to indicate decoration.
+    decorated_method._su_decorated = True
+    return decorated_method
+
+
+def tearDown_decorator(method):
+    """
+    Decorator for :class:`unittest.TestCase` test methods that restores
+    the CF profile.
+
+    """
+    # Check whether method has already been decorated.
+    if getattr(method, '_td_decorated', False):
+        return method
+
+    @functools.wraps(method)
+    def decorated_method(self, *args, **kwargs):
+        res = method(self, *args, **kwargs)
+        if 'cf_profile' in iris.site_configuration and \
+                hasattr(self, '_orig_cf_profile'):
+            iris.site_configuration['cf_profile'] = self._orig_cf_profile
+        return res
+    # Add attribute to indicate decoration.
+    decorated_method._td_decorated = True
+    return decorated_method
+
+
+class DisableCFProfileMetaclass(type):
+    """
+    Metaclass that decorates all :meth:`setUp` and :meth:`tearDown` methods
+    to disable the site CF profile during testing.
+
+    """
+    def __new__(cls, name, bases, local):
+        def decorate_method(method_name, decorator):
+            method = None
+            # Look in local, then bases for an attribute
+            # with the specified name.
+            if method_name in local:
+                method = local[method_name]
+            else:
+                for base in bases:
+                    if hasattr(base, method_name):
+                        method = getattr(base, method_name)
+                        break
+            # Decorate it if it's callable and put the decorated
+            # function in local.
+            if isinstance(method, collections.Callable):
+                local[method_name] = decorator(method)
+
+        decorate_method('setUp', setUp_decorator)
+        decorate_method('tearDown', tearDown_decorator)
+        return type.__new__(cls, name, bases, local)
+
+
 class IrisTest(unittest.TestCase):
-    """A subclass of unittest.TestCase which provides Iris specific testing functionality."""
+    """
+    A subclass of unittest.TestCase which provides Iris specific testing
+    functionality.
+
+    """
+    __metaclass__ = DisableCFProfileMetaclass
 
     _assertion_counts = collections.defaultdict(int)
-
-    @classmethod
-    def setUpClass(cls):
-        # Ensure that the CF profile if turned-off for testing.
-        iris.site_configuration['cf_profile'] = None
 
     def _assert_str_same(self, reference_str, test_str, reference_filename, type_comparison_name='Strings'):
         if reference_str != test_str:

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -354,6 +354,16 @@ class CheckForWarningsMetaclass(type):
         return type.__new__(cls, name, bases, local)
 
 
+class PlotTestingMetaclass(iris.tests.DisableCFProfileMetaclass,
+                           CheckForWarningsMetaclass):
+    """
+    Metaclass that provides warning checking functionality and disables the
+    CF profile.
+
+    """
+    pass
+
+
 @iris.tests.skip_data
 class TestPcolorNoBounds(tests.GraphicsTest, SliceMixin):
     """
@@ -361,7 +371,7 @@ class TestPcolorNoBounds(tests.GraphicsTest, SliceMixin):
     that have no bounds.
 
     """
-    __metaclass__ = CheckForWarningsMetaclass
+    __metaclass__ = PlotTestingMetaclass
 
     def setUp(self):
         self.wind = _load_wind_no_bounds()
@@ -375,7 +385,7 @@ class TestPcolormeshNoBounds(tests.GraphicsTest, SliceMixin):
     that have no bounds.
 
     """
-    __metaclass__ = CheckForWarningsMetaclass
+    __metaclass__ = PlotTestingMetaclass
 
     def setUp(self):
         self.wind = _load_wind_no_bounds()


### PR DESCRIPTION
Currently the site specific cf profile is disabled for testing using a `setUpClass` class method in `IrisTest`. The problem with this is if any test cases define their own `setUpClass` method and don't explicitly call the one in `IrisTest` the cf profile will not be disabled. Whilst not unreasonable, this requirement could easily be missed. Furthermore, the current approach does not restore the cf profile after testing. A `tearDownClass` method could be implemented to do this but this has issues with multiprocessing.

This PR disables and restores the cf profile using for all test methods of classes derived from IrisTests. It does this using a metaclass to decorate `setUp` and `tearDown`.
