### PR TITLE
small data

### DIFF
--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -180,7 +180,7 @@ def _load_4d_testcube():
 @cache
 def _load_wind_no_bounds():
     # Load the COLPEX data => TZYX
-    path = tests.get_data_path(('PP', 'COLPEX', 'uwind_and_orog.pp'))
+    path = tests.get_data_path(('PP', 'COLPEX', 'small_eastward_wind.pp'))
     wind = iris.load_cube(path, 'eastward_wind')
 
     # Remove bounds from all coords that have them.


### PR DESCRIPTION
Doesn't require the 280MB test file, which is not in the [reduced data set](https://github.com/bblay/iris_test_data).
