### PR TITLE
Renamed test data directory

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -110,7 +110,7 @@ def get_data_path(relative_path):
             relative_path = tuple(relative_path)
         _EXPORT_DATAPATHS_FILE.write(os.path.join(*relative_path) + '\n')
         
-    return iris.io.select_data_path('tests', relative_path)
+    return iris.io.select_data_path('test_data', relative_path)
 
 
 def get_result_path(relative_path):


### PR DESCRIPTION
This PR changes the name of the subdirectory containing test data from `tests` to `test_data`. This is to support https://github.com/SciTools/iris-test-data/pull/1

Note: This PR is against v1.3.x
