### PR TITLE
Experimental convenience hooks

### DIFF
--- a/lib/iris/experimental/__init__.py
+++ b/lib/iris/experimental/__init__.py
@@ -21,3 +21,54 @@ Changes to experimental code may be more extensive than in the rest of the
 codebase. The code is expected to graduate, eventually, to "full status".
 
 """
+
+from functools import wraps
+
+import concatenate
+
+
+__all__ = ['concatenate']
+
+
+def _experimental(func_call):
+    """
+    Decorator function that provides convenience to experimental
+    functionality.
+
+    Args:
+
+    * func_call:
+        The actual experimental function to be invoked.
+
+    Returns:
+        Closure wrapper function.
+
+    """
+    def _outer(func):
+        """
+        Closure that unwraps the dummy convenience function.
+
+        Args:
+
+        * func:
+            Top level dummy convenience function exposed at
+            the experimental module level.
+
+        Returns:
+            Closure wrapper function.
+
+        """
+        @wraps(func_call)
+        def _inner(*args, **kwargs):
+            """Performs the actual experimental function call"""
+
+            return func_call(*args, **kwargs)
+
+        return _inner
+
+    return _outer
+
+
+@_experimental(concatenate.concatenate)
+def concatenate(*args, **kwargs):
+    """Convenience wrapper function for concatenate"""


### PR DESCRIPTION
This PR provides a generic convenience mechanism to call top level experimental functionality.

It permits the following

```
import iris.experimental
result = iris.experimental.concatenate([cube1, cube2])
```

instead of 

```
import iris.experimental.concatenate
result = iris.experimental.concatenate.concatenate([cube1, cube2])
```
