### PR TITLE
Make Cube.data deal in views.

### DIFF
--- a/lib/iris/tests/experimental/test_concatenate.py
+++ b/lib/iris/tests/experimental/test_concatenate.py
@@ -332,12 +332,14 @@ class TestNoConcat(tests.IrisTest):
         cubes = []
         y = (0, 2)
         cube = _make_cube((0, 2), y, 1)
-        cube.data = ma.asarray(cube.data)
-        cube.data.fill_value = 10
+        data = ma.asarray(cube.data)
+        data.fill_value = 10
+        cube.data = data
         cubes.append(cube)
         cube = _make_cube((2, 4), y, 1)
-        cube.data = ma.asarray(cube.data)
-        cube.data.fill_value = 20
+        data = ma.asarray(cube.data)
+        data.fill_value = 20
+        cube.data = data
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertEqual(len(result), 2)

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1106,7 +1106,9 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
 
         # extract the 2d field that has SOME missing values
         masked_slice = cube[0]
-        masked_slice.data.fill_value = 123456
+        data = masked_slice.data
+        data.fill_value = 123456
+        masked_slice.data = data
         
         # test saving masked data
         reference_txt_path = tests.get_result_path(('cdm', 'masked_save_pp.txt'))

--- a/lib/iris/tests/test_cube.py
+++ b/lib/iris/tests/test_cube.py
@@ -87,5 +87,38 @@ class Test_Cube_add_dim_coord(tests.IrisTest):
             self.cube.add_dim_coord(coord, 0)
 
 
+class Test_Cube_data(tests.IrisTest):
+    def test_reshape_after_creation(self):
+        # Make sure we can't invalidate the shape of a Cube after it's
+        # been created.
+        data = np.zeros((3, 4))
+        cube = iris.cube.Cube(data)
+        self.assertEqual(cube.shape, (3, 4))
+        data.shape = (2, 6)
+        self.assertEqual(cube.shape, (3, 4))
+
+    def test_reshape_after_read(self):
+        # Make sure we can't invalidate the shape of a Cube by reading
+        # the data and changing its shape.
+        data = np.zeros((3, 4))
+        cube = iris.cube.Cube(data)
+        self.assertEqual(cube.shape, (3, 4))
+        data = cube.data
+        data.shape = (2, 6)
+        self.assertEqual(cube.shape, (3, 4))
+
+    def test_reshape_after_update(self):
+        # Make sure we can't invalidate the shape of a Cube after we've
+        # updated the data.
+        data = np.zeros((3, 4))
+        cube = iris.cube.Cube(data)
+        self.assertEqual(cube.shape, (3, 4))
+        data = np.zeros((3, 4))
+        cube.data = data
+        self.assertEqual(cube.shape, (3, 4))
+        data.shape = (2, 6)
+        self.assertEqual(cube.shape, (3, 4))
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
This applies the same sort of shape protection to Cube.data as is currently enjoyed by Coord.points. 

Without this PR it is possible to change the shape of a Cube without the Cube realising:

```
>>> data = np.zeros((3, 4))
>>> cube = iris.cube.Cube(data)
>>> cube.shape
(3, 4)
>>> data.shape = (2, 6)
>>> cube.shape
(2, 6)
```
