### PR TITLE
Update to iris-test-data commit in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
 
   - export CARTOPY_REF=v0.7.0
 
-  - export IRIS_TEST_DATA_REF=v1.0
-  - export IRIS_TEST_DATA_ZIP_DIR_SUFFIX=1.0
+  - export IRIS_TEST_DATA_REF=v1.1
+  - export IRIS_TEST_DATA_ZIP_DIR_SUFFIX=1.1
 
   - export IRIS_SAMPLE_DATA_REF=v1.0
   - export IRIS_SAMPLE_DATA_ZIP_DIR_SUFFIX=1.0
@@ -87,7 +87,7 @@ install:
   - ./.travis_no_output /usr/bin/python setup.py std_names
   - echo "[Resources]" > lib/iris/etc/site.cfg
   - echo "sample_data_dir = $(pwd)/iris-sample-data-${IRIS_SAMPLE_DATA_ZIP_DIR_SUFFIX}/sample_data" >> lib/iris/etc/site.cfg
-  - echo "test_data_dir = $(pwd)/iris-test-data-${IRIS_TEST_DATA_ZIP_DIR_SUFFIX}/tests" >> lib/iris/etc/site.cfg
+  - echo "test_data_dir = $(pwd)/iris-test-data-${IRIS_TEST_DATA_ZIP_DIR_SUFFIX}/test_data" >> lib/iris/etc/site.cfg
   - ln -s $(pwd)/lib/iris /home/travis/.local/lib/python2.7/site-packages/iris
 
   


### PR DESCRIPTION
This PR updates the the commit for iris-test-data to v1.1.

This latest version of the test data has the files located in a subdirectory called `test_data` rather than `tests`. Consequently an update to the `site.cfg` is needed.
