### PR TITLE
Removed data_repository from site.cfg.template

### DIFF
--- a/lib/iris/etc/site.cfg.template
+++ b/lib/iris/etc/site.cfg.template
@@ -3,7 +3,6 @@ udunits2_path = /path/to/libudunits2.so
 dot_path = /path/to/dot # see iris.fileformats.dot
 
 [Resources]
-data_repository = /path/to/iris/resources
 sample_data_dir = /path/to/iris/resources/sample_data
 test_data_dir = /path/to/iris/resources/test_data
 


### PR DESCRIPTION
This PR removes the redundant `data_repository` config option in the Resources section of `site.cfg.template`. This should have been done as part of PR #406.
