### PR TITLE
UDUNITS2 correct bad timestamp clock time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 # install deps
   - ./.travis_no_output sudo apt-get install python-scipy cython python-pip
   - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8 mock
-  - ./.travis_no_output sudo /usr/bin/pip install matplotlib
+  - ./.travis_no_output sudo /usr/bin/pip install matplotlib==1.2.0
   - ./.travis_no_output sudo apt-get install libgeos-dev libproj-dev
   - ./.travis_no_output sudo apt-get install libudunits2-dev libhdf5-serial-dev netcdf-bin libnetcdf-dev
   - ./.travis_no_output sudo apt-get install make unzip python-sphinx graphviz

--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -810,6 +810,10 @@ class TestBadClock(TestUnit):
             expected = 'hours {} 1970-01-01 01:00:00'.format(op)
             self.assertEqual(u.origin, expected)
 
+    def test_bad_clock_hour(self):
+        with self.assertRaises(ValueError):
+            Unit('hours since 1970-01-01 666')
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -68,7 +68,7 @@ _CATEGORY_UNKNOWN, _CATEGORY_NO_UNIT, _CATEGORY_UDUNIT = range(3)
 #
 _SHIFT_OP = '(@|after|from|since|ref)'
 _DATE = '[+-]?\d{1,4}-\d{1,2}(-\d{1,2})?'
-_BAD_CLOCK = '(?P<clock>[+-]?\d{1,2})'
+_BAD_CLOCK = '(?P<clock>[+-]?\d+)'
 _TIMESTAMP_PATTERN = '(?P<pre>^.*\s+{}\s+{}\s+){}\s*$'.format(_SHIFT_OP,
                                                               _DATE,
                                                               _BAD_CLOCK)


### PR DESCRIPTION
This PR performs a convenience correction of a units string containing an incomplete timestamp clock.

The UDUNITS2 grammar specifies that at a minimum the clock of a timestamp must include the hours **and** minutes i.e. `<hour> ":" <minute> (":" <second>)?` see http://www.unidata.ucar.edu/software/udunits/udunits-2/udunits2lib.html#Grammar.

Unfortunately, UDUNITS2 interprets the following incomplete timestamp `hours since 1970-01-01 9` as `hours since 1970-01-01 00:00:00` i.e. the incomplete clock time is silently ignored and the timestamp defaults to midnight.

This PR circumvents user confusion, thus `hours since 1970-01-01 9` is corrected to `hours since 1970-01-01 09:00:00`. 
