### PR TITLE
Safely build PyKE rule base.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ install:
   - echo "sample_data_dir = $(pwd)/iris-sample-data-${IRIS_SAMPLE_DATA_ZIP_DIR_SUFFIX}/sample_data" >> lib/iris/etc/site.cfg
   - echo "test_data_dir = $(pwd)/iris-test-data-${IRIS_TEST_DATA_ZIP_DIR_SUFFIX}/test_data" >> lib/iris/etc/site.cfg
   - ln -s $(pwd)/lib/iris /home/travis/.local/lib/python2.7/site-packages/iris
+  - ./.travis_no_output /usr/bin/python setup.py pyke_rules
 
   
 script:

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -184,14 +184,15 @@ def _pyke_kb_engine():
         tmpvar = [os.path.getmtime(os.path.join(compile_dir, fname)) for
                   fname in os.listdir(compile_dir) if not
                   fname.startswith('_')]
-        oldest_pyke_compile_file = min(tmpvar)
-        rule_age = os.path.getmtime(os.path.join(pyke_dir,
-                                                 _PYKE_RULE_BASE + '.krb'))
+        if tmpvar:
+            oldest_pyke_compile_file = min(tmpvar)
+            rule_age = os.path.getmtime(
+                os.path.join(pyke_dir, _PYKE_RULE_BASE + '.krb'))
 
-        if oldest_pyke_compile_file > rule_age:
-            # Initialise the pyke inference engine.
-            engine = knowledge_engine.engine(
-                (None, 'iris.fileformats._pyke_rules.compiled_krb'))
+            if oldest_pyke_compile_file > rule_age:
+                # Initialise the pyke inference engine.
+                engine = knowledge_engine.engine(
+                    (None, 'iris.fileformats._pyke_rules.compiled_krb'))
 
     if engine is None:
         engine = knowledge_engine.engine(iris.fileformats._pyke_rules)

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,32 @@ class MakeStdNames(Command):
         self.spawn(cmd)
 
 
+class MakePykeRules(Command):
+    """
+    Compile the PyKE CF-NetCDF loader rule base.
+
+    """
+    description = "compile CF-NetCDF loader rule base"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    @staticmethod
+    def _pyke_rule_compile():
+        """Compile the PyKE rule base."""
+        from pyke import knowledge_engine
+        import iris.fileformats._pyke_rules
+        knowledge_engine.engine(iris.fileformats._pyke_rules)
+
+    def run(self):
+        # Compile the PyKE rules.
+        MakePykeRules._pyke_rule_compile()
+
+
 class MissingHeaderError(Exception):
     """
     Raised when one or more files do not have the required copyright
@@ -205,7 +231,7 @@ class HeaderCheck(Command):
 class BuildPyWithExtras(build_py.build_py):
     """
     Adds the creation of the CF standard names module and compilation
-    of the pyke rules to the standard "build_py" command.
+    of the PyKE rules to the standard "build_py" command.
 
     """
     @contextlib.contextmanager
@@ -230,12 +256,9 @@ class BuildPyWithExtras(build_py.build_py):
         cmd = std_name_cmd(self.build_lib)
         self.spawn(cmd)
 
-        # Compile the pyke rules
+        # Compile the PyKE rules.
         with self.temporary_path():
-            # Compile the pyke rules
-            from pyke import knowledge_engine
-            import iris.fileformats._pyke_rules
-            e = knowledge_engine.engine(iris.fileformats._pyke_rules)
+            MakePykeRules._pyke_rule_compile()
 
 
 setup(
@@ -270,5 +293,6 @@ setup(
         )
     },
     cmdclass={'test': TestRunner, 'build_py': BuildPyWithExtras, 
-              'std_names': MakeStdNames, 'header_check': HeaderCheck},
+              'std_names': MakeStdNames, 'header_check': HeaderCheck,
+              'pyke_rules': MakePykeRules},
 )


### PR DESCRIPTION
Travis-CI testing has failed several times with the following error:

```
======================================================================
ERROR: system_test_supported_filetypes (iris.tests.system_test.SystemInitialTest)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/home/travis/build/SciTools/iris/lib/iris/tests/system_test.py", line 72, in system_test_supported_filetypes
new_cube = iris.load_cube(saved_tmpfile)
File "/home/travis/build/SciTools/iris/lib/iris/__init__.py", line 225, in load_cube
cubes = _load_collection(uris, constraints, callback).merged().cubes()
File "/home/travis/build/SciTools/iris/lib/iris/__init__.py", line 165, in _load_collection
result = iris.cube._CubeFilterCollection.from_cubes(cubes, constraints)
File "/home/travis/build/SciTools/iris/lib/iris/cube.py", line 135, in from_cubes
for cube in cubes:
File "/home/travis/build/SciTools/iris/lib/iris/__init__.py", line 156, in _generate_cubes
for cube in iris.io.load_files(part_names, callback):
File "/home/travis/build/SciTools/iris/lib/iris/io/__init__.py", line 177, in load_files
for cube in handling_format_spec.handler(fnames, callback):
File "/home/travis/build/SciTools/iris/lib/iris/fileformats/netcdf.py", line 419, in load_cubes
engine = _pyke_kb_engine()
File "/home/travis/build/SciTools/iris/lib/iris/fileformats/netcdf.py", line 187, in _pyke_kb_engine
oldest_pyke_compile_file = min(tmpvar)
ValueError: min() arg is an empty sequence
```

This PR attempts to resolve this issue.
