### PR TITLE
Travis-CI non git clone of Cartopy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ python:
 
 install:
 
-  - export CARTOPY_REF=v0.7.0
+  - export CARTOPY_REF="v0.7.0"
+  - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF=v1.1
-  - export IRIS_TEST_DATA_ZIP_DIR_SUFFIX=1.1
+  - export IRIS_TEST_DATA_REF="v1.1"
+  - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
-  - export IRIS_SAMPLE_DATA_REF=v1.0
-  - export IRIS_SAMPLE_DATA_ZIP_DIR_SUFFIX=1.0
-
+  - export IRIS_SAMPLE_DATA_REF="v1.0"
+  - export IRIS_SAMPLE_DATA_SUFFIX=$(echo "${IRIS_SAMPLE_DATA_REF}" | sed "s/^v//")
 
 # add repo
   - ./.travis_no_output sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192
@@ -60,9 +60,10 @@ install:
   - ./.travis_no_output sudo /usr/bin/python distribute_setup.py
 
 # cartopy
-  - ./.travis_no_output git clone git://github.com/SciTools/cartopy.git
+  - ./.travis_no_output wget -O cartopy.zip https://github.com/SciTools/cartopy/archive/${CARTOPY_REF}.zip
+  - ./.travis_no_output unzip -q cartopy.zip
+  - ln -s $(pwd)/cartopy-${CARTOPY_SUFFIX} cartopy
   - cd cartopy
-  - ../.travis_no_output git checkout ${CARTOPY_REF}
   - ../.travis_no_output /usr/bin/python setup.py install --user
   - cd ..
   
@@ -80,17 +81,19 @@ install:
 # iris test data
   - ./.travis_no_output wget -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip
   - ./.travis_no_output unzip -q iris-test-data.zip
+  - ln -s $(pwd)/iris-test-data-${IRIS_TEST_DATA_SUFFIX} iris-test-data
 
 # iris sample data
   - ./.travis_no_output wget -O iris-sample-data.zip https://github.com/SciTools/iris-sample-data/archive/${IRIS_SAMPLE_DATA_REF}.zip
   - ./.travis_no_output unzip -q iris-sample-data.zip
+  - ln -s $(pwd)/iris-sample-data-${IRIS_SAMPLE_DATA_SUFFIX} iris-sample-data
   
 # iris
   - ./.travis_no_output /usr/bin/python setup.py --with-unpack build_ext --inplace -I/usr/local/include -L/usr/local/lib -R/usr/local/lib
   - ./.travis_no_output /usr/bin/python setup.py std_names
   - echo "[Resources]" > lib/iris/etc/site.cfg
-  - echo "sample_data_dir = $(pwd)/iris-sample-data-${IRIS_SAMPLE_DATA_ZIP_DIR_SUFFIX}/sample_data" >> lib/iris/etc/site.cfg
-  - echo "test_data_dir = $(pwd)/iris-test-data-${IRIS_TEST_DATA_ZIP_DIR_SUFFIX}/test_data" >> lib/iris/etc/site.cfg
+  - echo "sample_data_dir = $(pwd)/iris-sample-data/sample_data" >> lib/iris/etc/site.cfg
+  - echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> lib/iris/etc/site.cfg
   - ln -s $(pwd)/lib/iris /home/travis/.local/lib/python2.7/site-packages/iris
 
   


### PR DESCRIPTION
This PR changes Travis-CI to use a zipped archive of a tagged Cartopy branch rather than perform a `git clone` and `git fetch` for speed-up.
