### PR TITLE
Helper function for regridding that returns x and y coords.

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -24,6 +24,11 @@ def _get_xy_dim_coords(cube):
     """
     Return the x and y dimension coordinates from a cube.
 
+    This function raises a ValueError if the cube does not contain one and
+    only one set of x and y dimension coordinates. It also raises a ValueError
+    if the identified x and y coordinates do not have coordinate systems that
+    are equal.
+
     Args:
 
     * cube:

--- a/lib/iris/tests/experimental/regrid/test_get_xy_dim_coords.py
+++ b/lib/iris/tests/experimental/regrid/test_get_xy_dim_coords.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Test the regridding functions.
+Test the :func:`iris.experimental.regrid._get_xy_dim_coords` function.
 
 """
 # import iris tests first so that some things can be initialised


### PR DESCRIPTION
This PR add `iris.experimental.regrid._get_xy_dim_coords()`. This is a helper function for getting the x and y coords from a cube that form the horizontal grid.
