### PR TITLE
Added cfchecker to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,16 @@ install:
   - ./.travis_no_output sudo apt-get install python-gdal
   - export LD_LIBRARY_PATH=/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH
 
+# cfchecker
+  - ./.travis_no_output sudo /usr/bin/pip install cdat-lite
+  - ./.travis_no_output sudo /usr/bin/pip install cfchecker
+  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml
+  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/area-type-table/current/area-type-table.xml
+  - echo '#!/usr/bin/env sh' > cfchecker
+  - echo "cfchecks -s `pwd`/cf-standard-name-table.xml -a `pwd`/area-type-table.xml -u /usr/share/xml/udunits/udunits2.xml \$1" >> cfchecker
+  - ./.travis_no_output sudo cp cfchecker /usr/local/bin/cfchecker
+  - ./.travis_no_output sudo chmod a+x /usr/local/bin/cfchecker
+
 # grib api
   - ./.travis_no_output sudo apt-get install libjasper-dev
   - ./.travis_no_output sudo apt-get build-dep libgrib-api-1.9.9 libgrib-api-dev libgrib-api-tools


### PR DESCRIPTION
This PR modifies `.travis.cml` so that cfchecker (and its dependency cdat-lite) get installed via pip. It wraps the resulting `cfchecks` commandline utility in a script called cfchecker (providing the required args to point to the cf standard name and area types xml files (downloaded) and the udunits xml file) so that the existing codebase can call it. 
