### PR TITLE
Added depth rules for bounds.

### DIFF
--- a/lib/iris/etc/pp_rules.txt
+++ b/lib/iris/etc/pp_rules.txt
@@ -333,7 +333,20 @@ len(f.lbcode) != 5
 f.lbvc == 2
 THEN
 CoordAndDims(DimCoord(f.lblev, standard_name='model_level_number', attributes={'positive': 'down'}))
+
+IF
+len(f.lbcode) != 5
+f.lbvc == 2
+f.brsvd[0] == f.brlev
+THEN
 CoordAndDims(DimCoord(f.blev, standard_name='depth', units='m', attributes={'positive': 'down'}))
+
+IF
+len(f.lbcode) != 5
+f.lbvc == 2
+f.brsvd[0] != f.brlev
+THEN
+CoordAndDims(DimCoord(f.blev, standard_name='depth', units='m', bounds=[f.brsvd[0], f.brlev], attributes={'positive': 'down'}))
 
 IF
 f.lbvc == 8

--- a/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
+++ b/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="degC">
+    <attributes>
+      <attribute name="STASH" value="m02s00i101"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[4.0, 6.0],
+		[14.0, 16.0],
+		[24.0, 26.0],
+		[34.0, 36.0],
+		[44.0, 46.0]]" id="5e355df2" points="[5.0, 15.0, 25.0, 35.0, 45.0]" shape="(5,)" standard_name="depth" units="Unit('m')" value_type="float64">
+          <attributes>
+            <attribute name="positive" value="down"/>
+          </attributes>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="73141289" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord>
+        <dimCoord id="88312288" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="a42bcac2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
+		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,
+		50.0, 47.5, 45.0, 42.5, 40.0, 37.5, 35.0, 32.5,
+		30.0, 27.5, 25.0, 22.5, 20.0, 17.5, 15.0, 12.5,
+		10.0, 7.50002, 5.00002, 2.50002, 1.52588e-05,
+		-2.49998, -4.99998, -7.49998, -9.99998, -12.5,
+		-15.0, -17.5, -20.0, -22.5, -25.0, -27.5, -30.0,
+		-32.5, -35.0, -37.5, -40.0, -42.5, -45.0, -47.5,
+		-50.0, -52.5, -55.0, -57.5, -60.0, -62.5, -65.0,
+		-67.5, -70.0, -72.5, -75.0, -77.5, -80.0, -82.5,
+		-85.0, -87.5, -90.0]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="63128986" points="[0.0, 3.75, 7.5, ..., 348.75, 352.5, 356.25]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="acd2e4a5" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int64">
+          <attributes>
+            <attribute name="positive" value="down"/>
+          </attributes>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord bounds="[[215280.0, 249840.0]]" id="4c12dc80" points="[232560.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="time"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" checksum="-0x3b22053b" dtype="float32" order="C" shape="(5, 73, 96)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_pp_to_cube.py
+++ b/lib/iris/tests/test_pp_to_cube.py
@@ -47,7 +47,7 @@ class TestPPLoadCustom(tests.IrisTest):
         cube = self.subcubes.merge()[0]
         self.assertCML(cube, ('pp_rules', 'lbtim_2.cml'))
 
-    def test_ocean_depth(self):
+    def _ocean_depth(self, bounded=False):
         lbuser = list(self.template.lbuser)
         lbuser[6] = 2
         lbuser[3] = 101
@@ -58,10 +58,23 @@ class TestPPLoadCustom(tests.IrisTest):
             field.lbvc = 2
             field.lbfc = 601
             field.lblev, field.blev = level_and_depth
+            if bounded:
+                brsvd = list(field.brsvd)
+                brsvd[0] = field.blev - 1
+                field.brsvd = tuple(brsvd)
+                field.brlev = field.blev + 1
             rules_result = self.load_rules.result(field)
             self.subcubes.append(rules_result.cube)
+
+    def test_ocean_depth(self):
+        self._ocean_depth()
         cube = self.subcubes.merge()[0]
         self.assertCML(cube, ('pp_rules', 'ocean_depth.cml'))
+
+    def test_ocean_depth_bounded(self):
+        self._ocean_depth(bounded=True)
+        cube = self.subcubes.merge()[0]
+        self.assertCML(cube, ('pp_rules', 'ocean_depth_bounded.cml'))
 
     def test_invalid_units(self):
         # UM to CF rules are mapped to the invalid unit "1e3 psu @0.035"


### PR DESCRIPTION
This PR adds bounds, if available, onto a `depth` coordinate for the PP loader.
