### PR TITLE
g1_level1 handle surface level type

### DIFF
--- a/lib/iris/etc/grib_rules.txt
+++ b/lib/iris/etc/grib_rules.txt
@@ -553,10 +553,15 @@ CellMethod("_ratio", cm.coord("time"))
 
 IF
 grib.edition == 1
-grib.levelType == 'pl'
+grib.indicatorOfTypeOfLevel == 100
 THEN
 CoordAndDims(DimCoord(points=grib.level,  long_name="pressure", units="hPa"))
 
+IF
+grib.edition == 1
+grib.indicatorOfTypeOfLevel = 1
+THEN
+CoordAndDims(DimCoord(points=0,  long_name="height", units="m"))
 
 
 ###################


### PR DESCRIPTION
grib 1 file has low cloud cover grib message. 
indicatorOfParameter = 186;
 indicatorOfParameter = 186;
  # Surface  (of the Earth, which includes sea surface)  (grib1/3.table)  
  indicatorOfTypeOfLevel = 1;
  level = 0;

This pull request is to update the rules to handle this type of level.
