### PR TITLE
Added tolerances to Coord.is_contiguous()

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -664,15 +664,26 @@ class Coord(CFVariableMixin):
                 ' are only defined for coordinates with 2 bounds.'.format(
                     self.name(), self.nbounds))
 
-    def is_contiguous(self):
+    def is_contiguous(self, rtol=1e-05, atol=1e-08):
         """
         Return True if, and only if, this Coord is bounded with contiguous
-        bounds.
+        bounds to within the specified relative and absolute tolerances.
+
+        Args:
+
+        * rtol:
+            The relative tolerance parameter (default is 1e-05).
+        * atol:
+            The absolute tolerance parameter (default is 1e-08).
+
+        Returns:
+            Boolean.
 
         """
         if self.bounds is not None:
             self._sanity_check_contiguous()
-            return np.all(self.bounds[1:, 0] == self.bounds[:-1, 1])
+            return np.allclose(self.bounds[1:, 0], self.bounds[:-1, 1],
+                               rtol=rtol, atol=atol)
         else:
             return False
 


### PR DESCRIPTION
The `iris.coords.Coord.is_contiguous()` method tests for equality between adjacent upper and lower bounds to determine whether bounds are contiguous. This runs into issues with floating point numbers. For example:

``` python
import numpy as np
import iris

delta = np.float64(0.00001)
lower = -1.0 + delta
upper = 3.0 - delta
points, step = np.linspace(lower, upper, 2,
                           endpoint=False, retstep=True)
points += step * 0.5 
coord = iris.coords.DimCoord(points)
coord.guess_bounds()
coord.is_contiguous()
```

returns False.

This PR modifies `is_contiguous()` to use `np.allclose()` adding the tolerance keyword args to `is_contiguous()`.
