### PR TITLE
Unambiguous season year naming

### DIFF
--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -107,7 +107,7 @@ def add_year(cube, coord, name='year'):
         )
 
 
-def add_month_number(cube, coord, name='month'):
+def add_month_number(cube, coord, name='month_number'):
     """Add a categorical month coordinate, values 1..12."""
     add_categorised_coord(
         cube, name, coord,
@@ -124,7 +124,7 @@ def add_month_shortname(cube, coord, name='month'):
         )
 
 
-def add_month_fullname(cube, coord, name='month'):
+def add_month_fullname(cube, coord, name='month_full'):
     """Add a categorical month coordinate, values 'January'..'December'."""
     add_categorised_coord(
         cube, name, coord,
@@ -139,7 +139,7 @@ def add_month(cube, coord, name='month'):
     add_month_shortname(cube, coord, name)
 
 
-def add_day_of_month(cube, coord, name='day'):
+def add_day_of_month(cube, coord, name='day_of_month'):
     """Add a categorical day-of-month coordinate, values 1..31."""
     add_categorised_coord(
         cube, name, coord,
@@ -147,7 +147,7 @@ def add_day_of_month(cube, coord, name='day'):
         )
 
 
-def add_day_of_year(cube, coord, name='day'):
+def add_day_of_year(cube, coord, name='day_of_year'):
     """
     Add a categorical day-of-year coordinate, values 1..365
     (1..366 in leap years).
@@ -161,7 +161,7 @@ def add_day_of_year(cube, coord, name='day'):
 #--------------------------------------------
 # time categorisations : days of the week
  
-def add_weekday_number(cube, coord, name='weekday'):
+def add_weekday_number(cube, coord, name='weekday_number'):
     """Add a categorical weekday coordinate, values 0..6  [0=Monday]."""
     add_categorised_coord(
         cube, name, coord,
@@ -178,7 +178,7 @@ def add_weekday_shortname(cube, coord, name='weekday'):
         )
 
 
-def add_weekday_fullname(cube, coord, name='weekday'):
+def add_weekday_fullname(cube, coord, name='weekday_full'):
     """Add a categorical weekday coordinate, values 'Monday'..'Sunday'."""
     add_categorised_coord(
         cube, name, coord,
@@ -215,7 +215,7 @@ SEASON_MONTHS_INITIALS = ['djf', 'mam', 'jja', 'son']
 """Season month strings (3-character strings) for each season (0..3)."""
 
  
-def add_season_number(cube, coord, name='season'):
+def add_season_number(cube, coord, name='season_number'):
     """Add a categorical season-of-year coordinate, values 0..3  [0=djf, 1=mam, ...]."""
     add_categorised_coord(
         cube, name, coord,
@@ -445,7 +445,7 @@ def add_custom_season_year(cube, coord, seasons, name='season_year'):
     add_categorised_coord(cube, name, coord, _custom_season_year)
 
 
-def add_custom_season_membership(cube, coord, season, name='season'):
+def add_custom_season_membership(cube, coord, season, name='season_member'):
     """
     Add a categorical season membership coordinate for a user specified
     season.

--- a/lib/iris/tests/test_coord_categorisation.py
+++ b/lib/iris/tests/test_coord_categorisation.py
@@ -82,8 +82,7 @@ class TestCategorisations(tests.IrisTest):
                            'weekday_number',
                            'season_number',
                            'year_ofseason',
-                           'year',
-                           'day',
+                           'year',                           
                            'day_of_year']:
             cube.coord(coord_name).points = \
                 cube.coord(coord_name).points.astype(np.int64)


### PR DESCRIPTION
Currently, iris.coord_categorisation.add_season_year() adds a new coordinate called 'year' to the cube. I felt this was ambiguous so I made a very small change to call it 'season_year'. I haven't changed any of the other convenience functions (e.g. day_of_year and day_of_month both make coordinates called 'day') because they are less likely to be confused, but there is an argument that they should have their names changed as well.
