### PR TITLE
Aggregate by on str dim err handling

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -917,7 +917,12 @@ class _Groupby(object):
                                           coord.points[stop]])
  
             # Now create the new bounded group shared coordinate.
-            new_points = np.array(new_bounds).mean(-1)
+            try:
+                new_points = np.array(new_bounds).mean(-1)
+            except TypeError as e:
+                raise ValueError('The {0!r} coordinate on the collapsing dimension'
+                                ' cannot be collapsed ({1}).'\
+                                .format(coord.name(), e.message))
 
             try:
                 self.coords.append(coord.copy(points=new_points,


### PR DESCRIPTION
Currently aggregation that involves aggregation of un-agregatible coordinates throws a rather uninformative error message. This is a common problem, for instance aggregating by season, when there is also a month coord classification on the same dimension. This update just gives the user a hint that they may need to remove an offending coordinate.
