### PR TITLE
Added verbose functionality to is_compatible

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -536,6 +536,10 @@ class Cube(CFVariableMixin):
         Returns:
            Boolean.
 
+        .. seealso::
+        
+            :meth:`iris.util.describe_diff()`
+        
         """
         compatible = (self.name() == other.name() and
                       self.units == other.units and

--- a/lib/iris/tests/results/compatible_cubes.str.txt
+++ b/lib/iris/tests/results/compatible_cubes.str.txt
@@ -1,0 +1,1 @@
+Cubes are compatible

--- a/lib/iris/tests/results/incompatible_attr.str.txt
+++ b/lib/iris/tests/results/incompatible_attr.str.txt
@@ -1,0 +1,1 @@
+"Conventions" cube_a attribute value "CF-1.5" is not compatible with cube_b attribute value "CF-1.6"

--- a/lib/iris/tests/results/incompatible_cubes.str.txt
+++ b/lib/iris/tests/results/incompatible_cubes.str.txt
@@ -1,0 +1,8 @@
+"Conventions" cube_a attribute value "CF-1.5" is not compatible with cube_b attribute value "CF-1.6"
+cube_a name "relative_humidity" is not compatible with cube_b name "air_potential_temperature"
+cube_a units "m" are not compatible with cube_b units "K"
+Cell methods
+()
+and
+(CellMethod(method='mean', coord_names=('model_level_number',), intervals=(), comments=()),)
+are not compatible

--- a/lib/iris/tests/results/incompatible_meth.str.txt
+++ b/lib/iris/tests/results/incompatible_meth.str.txt
@@ -1,0 +1,5 @@
+Cell methods
+()
+and
+(CellMethod(method='mean', coord_names=('model_level_number',), intervals=(), comments=()),)
+are not compatible

--- a/lib/iris/tests/results/incompatible_name.str.txt
+++ b/lib/iris/tests/results/incompatible_name.str.txt
@@ -1,0 +1,1 @@
+cube_a name "relative_humidity" is not compatible with cube_b name "air_potential_temperature"

--- a/lib/iris/tests/results/incompatible_unit.str.txt
+++ b/lib/iris/tests/results/incompatible_unit.str.txt
@@ -1,0 +1,1 @@
+cube_a units "m" are not compatible with cube_b units "K"

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -23,6 +23,7 @@ import abc
 import collections
 import inspect
 import os
+import sys
 import tempfile
 import time
 
@@ -124,6 +125,63 @@ def delta(ndarray, dimension, circular=False):
         _delta = np.diff(ndarray, axis=dimension)
     
     return _delta
+
+
+def describe_diff(cube_a, cube_b, output_file=None):
+    """
+    Prints the differences that prevent compatibility between two cubes, as
+    defined by :meth:`iris.cube.Cube.is_compatible()`.
+
+    Args:
+
+    * cube_a:
+        An instance of :class:`iris.cube.Cube` or
+        :class:`iris.cube.CubeMetadata`.
+
+    * cube_b:
+        An instance of :class:`iris.cube.Cube` or
+        :class:`iris.cube.CubeMetadata`.
+
+    * output_file:
+        A :class:`file` or file-like object to receive output. Defaults to
+        sys.stdout.
+
+    .. seealso::
+        
+        :meth:`iris.cube.Cube.is_compatible()`
+
+    """
+
+    if output_file is None:
+        output_file = sys.stdout
+
+    if cube_a.is_compatible(cube_b):
+        output_file.write('Cubes are compatible\n')
+    else:
+        common_keys = set(cube_a.attributes).intersection(cube_b.attributes)
+        for key in common_keys:
+            if cube_a.attributes[key] != cube_b.attributes[key]:
+                output_file.write('"%s" cube_a attribute value "%s" is not '
+                                  'compatible with cube_b '
+                                  'attribute value "%s"\n'
+                                  % (key,
+                                     cube_a.attributes[key],
+                                     cube_b.attributes[key]))
+
+        if cube_a.name() != cube_b.name():
+            output_file.write('cube_a name "%s" is not compatible '
+                              'with cube_b name "%s"\n'
+                              % (cube_a.name(), cube_b.name()))
+
+        if cube_a.units != cube_b.units:
+            output_file.write('cube_a units "%s" are not compatible with cube_b '
+                              'units "%s"\n'
+                              % (cube_a.units,
+                                 cube_b.units))
+
+        if cube_a.cell_methods != cube_b.cell_methods:
+            output_file.write('Cell methods\n%s\nand\n%s\nare not compatible\n'
+                              % (cube_a.cell_methods, cube_b.cell_methods))
 
 
 def guess_coord_axis(coord):

--- a/temp_test_output.txt
+++ b/temp_test_output.txt
@@ -1,0 +1,8 @@
+"Conventions" cube_a attribute value "CF-1.5" is not compatible with cube_b attribute value "CF-1.6"
+cube_a name "relative_humidity" is not compatible with cube_b name "air_potential_temperature"
+cube_a units "m" are not compatible with cube_b units "K"
+Cell methods
+()
+and
+(CellMethod(method='mean', coord_names=('model_level_number',), intervals=(), comments=()),)
+are not compatible


### PR DESCRIPTION
I've added some optional functionality to let the user know why two cubes have failed the is_compatible test. I'm not convince that the logic is the most graceful way to do it. I was trying to keep the verbose options out of the way so that it didn't compromise the efficiency of the unverbose functionality - but maybe that isn't an issue. I also wasn't sure weather to raise the differences as an error (in which case the code stops before checking other metadata, or just printing. In the end I went for a warning.
