### PR TITLE
Gracefully merge cubes with different history.

### DIFF
--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -210,7 +210,6 @@ Printing this cube now shows that two extra coordinates exist on the cube:
          Attributes:
               Conventions: CF-1.5
               STASH: m01s00i024
-              history: Mean of surface_temperature aggregated over month, year
          Cell methods:
               mean: month, year
 

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1252,7 +1252,9 @@ class ProtoCube(object):
     def _build_signature(self, cube):
         """Generate the signature that defines this cube."""
 
-        defn = cube.metadata
+        # Gracefully ignore any history attributes.
+        defn = deepcopy(cube.metadata)
+        defn.attributes.pop('history', None)
         data_shape = cube._data.shape
         data_manager = cube._data_manager
         mdi = None

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2196,8 +2196,7 @@ class Cube(CFVariableMixin):
                  Attributes:
                       Conventions: CF-1.5
                       STASH: m01s00i024
-                      history: Mean of surface_temperature aggregated over month, year
-            Mean of surface_temperature...
+                      history: Mean of surface_temperature over longitude
                  Cell methods:
                       mean: month, year
                       mean: longitude
@@ -2332,8 +2331,7 @@ class Cube(CFVariableMixin):
                  Attributes:
                       Conventions: CF-1.5
                       STASH: m01s00i024
-                      history: Mean of surface_temperature aggregated over month, year
-            Mean of surface_temperature...
+                      history: Mean of surface_temperature aggregated over year
                  Cell methods:
                       mean: month, year
                       mean: year

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
@@ -7,7 +7,6 @@
       <attribute name="comment" value="This run was initiated from the end of the corresponding 20C3M run of CCSR/NIES/FRCGC (the same resolution as this run, realization = 1). The conditions including GHGs concentration and various aerosols emissions were changed according to the IPCC SRES A1B scenario in the course of this run."/>
       <attribute name="contact" value="Seita Emori (emori@nies.go.jp)"/>
       <attribute name="experiment_id" value="720 ppm stabilization experiment (SRES A1B)"/>
-      <attribute name="history" value=" At   15:14:34 on 01/13/2005: CMOR altered the data in the following ways: converted from type &quot;double&quot; to type &quot;real&quot;; replaced missing value flag (-9.99000E+02) with standard missing value (1.00000E+20);  lat dimension direction was reversed;"/>
       <attribute name="institution" value="CCSR/NIES/FRCGC (Center for Climate System Research, Tokyo, Japan / National Institute for Environmental Studies, Ibaraki, Japan / Frontier Research Center for Global Change, Kanagawa, Japan)"/>
       <attribute name="original_name" value="10m zonal wind"/>
       <attribute name="original_units" value="m/s"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
@@ -3,8 +3,6 @@
   <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30
-2009-09-02 08:23:49 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[1]">

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -3,7 +3,6 @@
   <cube long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[2]">
@@ -29,7 +28,6 @@
   <cube long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[2]">

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -3,7 +3,6 @@
   <cube long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[2]">

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -3,7 +3,6 @@
   <cube long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
-      <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
     </attributes>
     <coords>
       <coord datadims="[2]">

--- a/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
@@ -5,7 +5,6 @@
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="NCO" value="4.1.0"/>
       <attribute name="experiment" value="ER3"/>
-      <attribute name="history" value="Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc"/>
       <attribute name="institution" value="DMI"/>
       <attribute name="source" value="HIRHAM"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
@@ -5,7 +5,6 @@
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="NCO" value="4.1.0"/>
       <attribute name="experiment" value="ER3"/>
-      <attribute name="history" value="Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc"/>
       <attribute name="institution" value="DMI"/>
       <attribute name="source" value="HIRHAM"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
@@ -10,7 +10,6 @@ variables:
 		pr:units = "kg m-2 s-1" ;
 		pr:NCO = "4.1.0" ;
 		pr:experiment = "ER3" ;
-		pr:history = "Thu Nov 29 10:45:50 2012: /project/ukmo/rhel6/nco/bin/ncks -d time,0,3 new_rotPole_precipitation.nc small_rotPole_precipitation.nc" ;
 		pr:institution = "DMI" ;
 		pr:source = "HIRHAM" ;
 		pr:cell_methods = "time: mean" ;

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -22,7 +22,6 @@
       <attribute name="NCO" value="4.0.8"/>
       <attribute name="TimeStamp" value="2008-SEP-09 11:18:37 GMT+0000"/>
       <attribute name="file_name" value="ORCA2_1d_00010101_00010101_grid_T_0000.nc"/>
-      <attribute name="history" value="Mon Apr  2 10:25:46 2012: /project/ukmo/rhel6/nco/bin/ncks -v votemper,deptht_bounds,nav_lat,nav_lon,areat,latt_bounds,lont_bounds ORCA2_1d_00010101_00010101_grid_T_0000.nc votemper.nc"/>
       <attribute name="interval_operation" value="5760.0"/>
       <attribute name="interval_write" value="86400.0"/>
       <attribute name="production" value="An IPSL model"/>

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -390,5 +390,21 @@ class TestCubeMergeTheoretical(tests.IrisTest):
         self.assertCML(r, ('cube_merge', 'test_simple_attributes3.cml'))
 
 
+class TestGracefulMerge(tests.IrisTest):
+    @iris.tests.skip_data
+    def test_attributes_history(self):
+        fname = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
+        seed = iris.load_cube(fname)
+        cubes = iris.cube.CubeList()
+        for value, (cube, history) in enumerate(zip([seed, seed.copy(), seed.copy()],
+                                                    [None, 'wibble', 'wobble'])):
+            cube.add_aux_coord(iris.coords.DimCoord(value, standard_name='height', units='m'))
+            if history is not None:
+                cube.attributes['history'] = history
+            cubes.append(cube)
+        merged = cubes.merge()
+        self.assertEqual(len(merged), 1)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
The `history` entry within a cubes' `attributes` dictionary is often the first point of failure for two or more cubes to merge, simply due to time-stamp differences.

The PR gracefully merges cubes by ignoring the `history` attributes entry.
