### PR TITLE
Modified logic in Unit.convert to handle numpy scalars.

### DIFF
--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -590,7 +590,15 @@ class TestConvert(TestUnit):
         e = np.arange(2, dtype=np.float32) + 1
         self.assertEqual(res[0], e[0])
         self.assertEqual(res[1], e[1])
-        
+
+    def test_convert_np_float(self):
+        u = Unit("mile")
+        v = Unit("meter")
+        self.assertEqual(u.convert(np.float(1.0), v), 1609.344)
+        self.assertEqual(u.convert(np.float16(1.0), v), 1609.344)
+        self.assertEqual(u.convert(np.float32(1.0), v), 1609.344)
+        self.assertEqual(u.convert(np.float64(1.0), v), 1609.344)
+
     def test_convert_double_pass_0(self):
         u = Unit("meter")
         v = Unit("mile")
@@ -632,6 +640,15 @@ class TestConvert(TestUnit):
         e = (np.arange(2, dtype=np.float64) + 1) * 1609.344
         self.assertEqual(res.dtype, e.dtype)
         self.assertArrayAlmostEqual(res, e)
+
+    def test_convert_np_int(self):
+        u = Unit("mile")
+        v = Unit("meter")
+        self.assertEqual(u.convert(np.int(1), v), 1609.344)
+        self.assertEqual(u.convert(np.int8(1), v), 1609.344)
+        self.assertEqual(u.convert(np.int16(1), v), 1609.344)
+        self.assertEqual(u.convert(np.int32(1), v), 1609.344)
+        self.assertEqual(u.convert(np.int64(1), v), 1609.344)
 
     def test_convert_fail_0(self):
         u = Unit('unknown')

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1755,15 +1755,7 @@ class Unit(iris.util._OrderedHashable):
             else:
                 ut_converter = _ut_get_converter(self.ut_unit, other.ut_unit)
                 if ut_converter:
-                    if isinstance(value_copy, (int, float, long)):
-                        if ctype not in _cv_convert_scalar.keys():
-                            raise ValueError('Invalid target type. Can only '
-                                             'convert to float or double.')
-                        # Utilise global convenience dictionary
-                        # _cv_convert_scalar
-                        result = _cv_convert_scalar[ctype](ut_converter,
-                                                           ctype(value_copy))
-                    else:
+                    if isinstance(value_copy, np.ndarray):
                         # Can only handle array of np.float32 or np.float64 so
                         # cast array of ints to array of floats of requested
                         # precision.
@@ -1783,6 +1775,14 @@ class Unit(iris.util._OrderedHashable):
                         _cv_convert_array[ctype](ut_converter, pointer,
                                                  value_copy.size, pointer)
                         result = value_copy
+                    else:
+                        if ctype not in _cv_convert_scalar.keys():
+                            raise ValueError('Invalid target type. Can only '
+                                             'convert to float or double.')
+                        # Utilise global convenience dictionary
+                        # _cv_convert_scalar
+                        result = _cv_convert_scalar[ctype](ut_converter,
+                                                           ctype(value_copy))
                     _cv_free(ut_converter)
                 else:
                     self._raise_error('Failed to convert %r to %r' %


### PR DESCRIPTION
This PR modifies the logic in `iris.unit.Unit` convert method so it can handle numpy scalar types such as np.int32.

This fixes #470 and should resolve #431 avoiding the need for workaround #471.
