### PR TITLE
Cube merge string coords.

### DIFF
--- a/lib/iris/etc/pp_rules.txt
+++ b/lib/iris/etc/pp_rules.txt
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -356,7 +356,7 @@ f.lbvc == 65
 THEN
 #need orography field to calculate 3D array height coord
 ###,  coord_system=HybridHeightCS(Reference('orography')))
-CoordAndDims(AuxCoord(f.lblev, standard_name='model_level_number', attributes={'positive': 'up'}))
+CoordAndDims(DimCoord(f.lblev, standard_name='model_level_number', attributes={'positive': 'up'}))
 CoordAndDims(DimCoord(f.blev, long_name='level_height', units='m', bounds=[f.brlev, f.brsvd[0]], attributes={'positive': 'up'}))
 CoordAndDims(AuxCoord(f.bhlev, long_name='sigma', bounds=[f.bhrlev, f.brsvd[1]]))
 Factory(HybridHeightFactory, [{'long_name': 'level_height'}, {'long_name': 'sigma'}, Reference('orography')])

--- a/lib/iris/tests/results/file_load/theta_levels.cml
+++ b/lib/iris/tests/results/file_load/theta_levels.cml
@@ -30,11 +30,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[1.0, 0.994296]]" id="5f88ebd6" long_name="sigma" points="[0.997716]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -80,11 +80,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.994296, 0.985204]]" id="5f88ebd6" long_name="sigma" points="[0.990882]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -130,11 +130,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.985204, 0.971644]]" id="5f88ebd6" long_name="sigma" points="[0.979543]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -180,11 +180,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.971644, 0.95371]]" id="5f88ebd6" long_name="sigma" points="[0.963777]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -230,11 +230,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.95371, 0.931527]]" id="5f88ebd6" long_name="sigma" points="[0.943695]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -280,11 +280,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.931527, 0.905253]]" id="5f88ebd6" long_name="sigma" points="[0.919438]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -330,11 +330,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.905253, 0.875075]]" id="5f88ebd6" long_name="sigma" points="[0.891178]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -380,11 +380,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.875075, 0.841212]]" id="5f88ebd6" long_name="sigma" points="[0.859118]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -430,11 +430,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.841212, 0.803914]]" id="5f88ebd6" long_name="sigma" points="[0.823493]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -480,11 +480,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.803914, 0.763465]]" id="5f88ebd6" long_name="sigma" points="[0.784571]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -530,11 +530,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.763465, 0.720176]]" id="5f88ebd6" long_name="sigma" points="[0.742646]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -580,11 +580,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.720176, 0.674393]]" id="5f88ebd6" long_name="sigma" points="[0.69805]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -630,11 +630,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.674393, 0.626491]]" id="5f88ebd6" long_name="sigma" points="[0.651143]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -680,11 +680,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.626491, 0.576877]]" id="5f88ebd6" long_name="sigma" points="[0.602314]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -730,11 +730,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.576877, 0.525991]]" id="5f88ebd6" long_name="sigma" points="[0.551989]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -780,11 +780,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.525991, 0.474301]]" id="5f88ebd6" long_name="sigma" points="[0.50062]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -830,11 +830,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.474301, 0.42231]]" id="5f88ebd6" long_name="sigma" points="[0.448693]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -880,11 +880,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.42231, 0.370549]]" id="5f88ebd6" long_name="sigma" points="[0.396726]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -930,11 +930,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.370549, 0.319582]]" id="5f88ebd6" long_name="sigma" points="[0.345265]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -980,11 +980,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.319582, 0.270005]]" id="5f88ebd6" long_name="sigma" points="[0.294891]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1030,11 +1030,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.270005, 0.222443]]" id="5f88ebd6" long_name="sigma" points="[0.246215]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1080,11 +1080,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.222443, 0.177555]]" id="5f88ebd6" long_name="sigma" points="[0.199878]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1130,11 +1130,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.177555, 0.13603]]" id="5f88ebd6" long_name="sigma" points="[0.156554]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1180,11 +1180,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.13603, 0.0985881]]" id="5f88ebd6" long_name="sigma" points="[0.116948]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1230,11 +1230,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0985881, 0.0659808]]" id="5f88ebd6" long_name="sigma" points="[0.0817952]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1280,11 +1280,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0659808, 0.0389824]]" id="5f88ebd6" long_name="sigma" points="[0.0518637]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1330,11 +1330,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0389824, 0.0183147]]" id="5f88ebd6" long_name="sigma" points="[0.0279368]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1380,11 +1380,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0183147, 0.00487211]]" id="5f88ebd6" long_name="sigma" points="[0.0107165]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1430,11 +1430,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.00487211, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.00130179]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1480,11 +1480,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1530,11 +1530,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1580,11 +1580,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1630,11 +1630,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1680,11 +1680,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1730,11 +1730,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1780,11 +1780,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1830,11 +1830,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1880,11 +1880,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/file_load/u_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/u_wind_levels.cml
@@ -31,11 +31,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[1.0, 0.997716]]" id="5f88ebd6" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -82,11 +82,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.997716, 0.990882]]" id="5f88ebd6" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -133,11 +133,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.990882, 0.979543]]" id="5f88ebd6" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -184,11 +184,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.979543, 0.963777]]" id="5f88ebd6" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -235,11 +235,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.963777, 0.943695]]" id="5f88ebd6" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -286,11 +286,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.943695, 0.919438]]" id="5f88ebd6" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -337,11 +337,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.919438, 0.891178]]" id="5f88ebd6" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -388,11 +388,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.891178, 0.859118]]" id="5f88ebd6" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -439,11 +439,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.859118, 0.823493]]" id="5f88ebd6" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -490,11 +490,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.823493, 0.784571]]" id="5f88ebd6" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -541,11 +541,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.784571, 0.742646]]" id="5f88ebd6" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -592,11 +592,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.742646, 0.69805]]" id="5f88ebd6" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -643,11 +643,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.69805, 0.651143]]" id="5f88ebd6" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -694,11 +694,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.651143, 0.602314]]" id="5f88ebd6" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -745,11 +745,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.602314, 0.551989]]" id="5f88ebd6" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -796,11 +796,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.551989, 0.50062]]" id="5f88ebd6" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -847,11 +847,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.50062, 0.448693]]" id="5f88ebd6" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -898,11 +898,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.448693, 0.396726]]" id="5f88ebd6" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -949,11 +949,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.396726, 0.345265]]" id="5f88ebd6" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1000,11 +1000,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.345265, 0.294891]]" id="5f88ebd6" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1051,11 +1051,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.294891, 0.246215]]" id="5f88ebd6" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1102,11 +1102,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.246215, 0.199878]]" id="5f88ebd6" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1153,11 +1153,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.199878, 0.156554]]" id="5f88ebd6" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1204,11 +1204,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.156554, 0.116948]]" id="5f88ebd6" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1255,11 +1255,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.116948, 0.0817952]]" id="5f88ebd6" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1306,11 +1306,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0817952, 0.0518637]]" id="5f88ebd6" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1357,11 +1357,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0518637, 0.0279368]]" id="5f88ebd6" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1408,11 +1408,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0279368, 0.0107165]]" id="5f88ebd6" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1459,11 +1459,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0107165, 0.00130179]]" id="5f88ebd6" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1510,11 +1510,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.00130179, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1561,11 +1561,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1612,11 +1612,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1663,11 +1663,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1714,11 +1714,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1765,11 +1765,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1816,11 +1816,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1867,11 +1867,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1918,11 +1918,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/file_load/v_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/v_wind_levels.cml
@@ -31,11 +31,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[1.0, 0.997716]]" id="5f88ebd6" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -82,11 +82,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.997716, 0.990882]]" id="5f88ebd6" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -133,11 +133,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.990882, 0.979543]]" id="5f88ebd6" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -184,11 +184,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.979543, 0.963777]]" id="5f88ebd6" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -235,11 +235,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.963777, 0.943695]]" id="5f88ebd6" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -286,11 +286,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.943695, 0.919438]]" id="5f88ebd6" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -337,11 +337,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.919438, 0.891178]]" id="5f88ebd6" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -388,11 +388,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.891178, 0.859118]]" id="5f88ebd6" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -439,11 +439,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.859118, 0.823493]]" id="5f88ebd6" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -490,11 +490,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.823493, 0.784571]]" id="5f88ebd6" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -541,11 +541,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.784571, 0.742646]]" id="5f88ebd6" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -592,11 +592,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.742646, 0.69805]]" id="5f88ebd6" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -643,11 +643,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.69805, 0.651143]]" id="5f88ebd6" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -694,11 +694,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.651143, 0.602314]]" id="5f88ebd6" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -745,11 +745,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.602314, 0.551989]]" id="5f88ebd6" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -796,11 +796,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.551989, 0.50062]]" id="5f88ebd6" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -847,11 +847,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.50062, 0.448693]]" id="5f88ebd6" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -898,11 +898,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.448693, 0.396726]]" id="5f88ebd6" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -949,11 +949,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.396726, 0.345265]]" id="5f88ebd6" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1000,11 +1000,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.345265, 0.294891]]" id="5f88ebd6" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1051,11 +1051,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.294891, 0.246215]]" id="5f88ebd6" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1102,11 +1102,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.246215, 0.199878]]" id="5f88ebd6" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1153,11 +1153,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.199878, 0.156554]]" id="5f88ebd6" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1204,11 +1204,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.156554, 0.116948]]" id="5f88ebd6" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1255,11 +1255,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.116948, 0.0817952]]" id="5f88ebd6" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1306,11 +1306,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0817952, 0.0518637]]" id="5f88ebd6" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1357,11 +1357,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0518637, 0.0279368]]" id="5f88ebd6" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1408,11 +1408,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0279368, 0.0107165]]" id="5f88ebd6" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1459,11 +1459,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0107165, 0.00130179]]" id="5f88ebd6" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1510,11 +1510,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.00130179, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1561,11 +1561,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1612,11 +1612,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1663,11 +1663,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1714,11 +1714,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1765,11 +1765,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1816,11 +1816,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1867,11 +1867,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1918,11 +1918,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/file_load/wind_levels.cml
+++ b/lib/iris/tests/results/file_load/wind_levels.cml
@@ -31,11 +31,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[1.0, 0.997716]]" id="5f88ebd6" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -82,11 +82,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.997716, 0.990882]]" id="5f88ebd6" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -133,11 +133,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.990882, 0.979543]]" id="5f88ebd6" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -184,11 +184,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.979543, 0.963777]]" id="5f88ebd6" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -235,11 +235,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.963777, 0.943695]]" id="5f88ebd6" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -286,11 +286,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.943695, 0.919438]]" id="5f88ebd6" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -337,11 +337,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.919438, 0.891178]]" id="5f88ebd6" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -388,11 +388,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.891178, 0.859118]]" id="5f88ebd6" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -439,11 +439,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.859118, 0.823493]]" id="5f88ebd6" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -490,11 +490,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.823493, 0.784571]]" id="5f88ebd6" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -541,11 +541,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.784571, 0.742646]]" id="5f88ebd6" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -592,11 +592,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.742646, 0.69805]]" id="5f88ebd6" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -643,11 +643,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.69805, 0.651143]]" id="5f88ebd6" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -694,11 +694,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.651143, 0.602314]]" id="5f88ebd6" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -745,11 +745,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.602314, 0.551989]]" id="5f88ebd6" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -796,11 +796,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.551989, 0.50062]]" id="5f88ebd6" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -847,11 +847,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.50062, 0.448693]]" id="5f88ebd6" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -898,11 +898,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.448693, 0.396726]]" id="5f88ebd6" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -949,11 +949,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.396726, 0.345265]]" id="5f88ebd6" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1000,11 +1000,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.345265, 0.294891]]" id="5f88ebd6" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1051,11 +1051,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.294891, 0.246215]]" id="5f88ebd6" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1102,11 +1102,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.246215, 0.199878]]" id="5f88ebd6" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1153,11 +1153,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.199878, 0.156554]]" id="5f88ebd6" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1204,11 +1204,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.156554, 0.116948]]" id="5f88ebd6" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1255,11 +1255,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.116948, 0.0817952]]" id="5f88ebd6" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1306,11 +1306,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0817952, 0.0518637]]" id="5f88ebd6" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1357,11 +1357,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0518637, 0.0279368]]" id="5f88ebd6" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1408,11 +1408,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0279368, 0.0107165]]" id="5f88ebd6" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1459,11 +1459,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0107165, 0.00130179]]" id="5f88ebd6" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1510,11 +1510,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.00130179, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1561,11 +1561,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1612,11 +1612,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1663,11 +1663,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1714,11 +1714,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1765,11 +1765,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1816,11 +1816,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1867,11 +1867,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1918,11 +1918,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -1969,11 +1969,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[1.0, 0.997716]]" id="5f88ebd6" long_name="sigma" points="[0.998858]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2020,11 +2020,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[2]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.997716, 0.990882]]" id="5f88ebd6" long_name="sigma" points="[0.994296]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2071,11 +2071,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[3]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.990882, 0.979543]]" id="5f88ebd6" long_name="sigma" points="[0.985204]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2122,11 +2122,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[4]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.979543, 0.963777]]" id="5f88ebd6" long_name="sigma" points="[0.971644]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2173,11 +2173,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[5]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.963777, 0.943695]]" id="5f88ebd6" long_name="sigma" points="[0.95371]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2224,11 +2224,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[6]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.943695, 0.919438]]" id="5f88ebd6" long_name="sigma" points="[0.931527]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2275,11 +2275,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[7]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.919438, 0.891178]]" id="5f88ebd6" long_name="sigma" points="[0.905253]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2326,11 +2326,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[8]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.891178, 0.859118]]" id="5f88ebd6" long_name="sigma" points="[0.875075]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2377,11 +2377,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[9]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.859118, 0.823493]]" id="5f88ebd6" long_name="sigma" points="[0.841212]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2428,11 +2428,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[10]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.823493, 0.784571]]" id="5f88ebd6" long_name="sigma" points="[0.803914]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2479,11 +2479,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[11]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.784571, 0.742646]]" id="5f88ebd6" long_name="sigma" points="[0.763465]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2530,11 +2530,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[12]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.742646, 0.69805]]" id="5f88ebd6" long_name="sigma" points="[0.720176]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2581,11 +2581,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[13]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.69805, 0.651143]]" id="5f88ebd6" long_name="sigma" points="[0.674393]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2632,11 +2632,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[14]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.651143, 0.602314]]" id="5f88ebd6" long_name="sigma" points="[0.626491]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2683,11 +2683,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[15]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.602314, 0.551989]]" id="5f88ebd6" long_name="sigma" points="[0.576877]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2734,11 +2734,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[16]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.551989, 0.50062]]" id="5f88ebd6" long_name="sigma" points="[0.525991]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2785,11 +2785,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[17]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.50062, 0.448693]]" id="5f88ebd6" long_name="sigma" points="[0.474301]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2836,11 +2836,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[18]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.448693, 0.396726]]" id="5f88ebd6" long_name="sigma" points="[0.42231]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2887,11 +2887,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[19]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.396726, 0.345265]]" id="5f88ebd6" long_name="sigma" points="[0.370549]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2938,11 +2938,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[20]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.345265, 0.294891]]" id="5f88ebd6" long_name="sigma" points="[0.319582]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -2989,11 +2989,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[21]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.294891, 0.246215]]" id="5f88ebd6" long_name="sigma" points="[0.270005]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3040,11 +3040,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[22]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.246215, 0.199878]]" id="5f88ebd6" long_name="sigma" points="[0.222443]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3091,11 +3091,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[23]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.199878, 0.156554]]" id="5f88ebd6" long_name="sigma" points="[0.177555]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3142,11 +3142,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[24]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.156554, 0.116948]]" id="5f88ebd6" long_name="sigma" points="[0.13603]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3193,11 +3193,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[25]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.116948, 0.0817952]]" id="5f88ebd6" long_name="sigma" points="[0.0985881]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3244,11 +3244,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[26]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0817952, 0.0518637]]" id="5f88ebd6" long_name="sigma" points="[0.0659808]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3295,11 +3295,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[27]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0518637, 0.0279368]]" id="5f88ebd6" long_name="sigma" points="[0.0389824]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3346,11 +3346,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[28]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0279368, 0.0107165]]" id="5f88ebd6" long_name="sigma" points="[0.0183147]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3397,11 +3397,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[29]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0107165, 0.00130179]]" id="5f88ebd6" long_name="sigma" points="[0.00487211]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3448,11 +3448,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[30]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.00130179, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3499,11 +3499,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[31]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3550,11 +3550,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[32]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3601,11 +3601,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[33]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3652,11 +3652,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[34]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3703,11 +3703,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3754,11 +3754,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[36]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3805,11 +3805,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[37]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
@@ -3856,11 +3856,11 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <dimCoord id="af0092b8" points="[38]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </auxCoord>
+        </dimCoord>
       </coord>
       <coord>
         <auxCoord bounds="[[0.0, 0.0]]" id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/a_aux_b_aux.cml
+++ b/lib/iris/tests/results/merge/a_aux_b_aux.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="9c870e8e" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[10.0, 11.0, 12.0, 13.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/a_aux_b_dim.cml
+++ b/lib/iris/tests/results/merge/a_aux_b_dim.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="9c870e8e" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[10.0, 11.0, 12.0, 13.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/a_dim_b_aux.cml
+++ b/lib/iris/tests/results/merge/a_dim_b_aux.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="9c870e8e" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[10.0, 11.0, 12.0, 13.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/a_dim_b_dim.cml
+++ b/lib/iris/tests/results/merge/a_dim_b_dim.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="9c870e8e" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[10.0, 11.0, 12.0, 13.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/separable_combination.cml
+++ b/lib/iris/tests/results/merge/separable_combination.cml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="9c870e8e" long_name="a" points="[2005, 2005, 2005, 2026, 2026, 2026, 2002, 2002,
+		2002, 2002, 2002, 2002, 2502, 2502, 2502, 2502,
+		2502, 2502, 2502, 2502, 2502]" shape="(21,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="c499a7a6" long_name="b" points="[ECMWF, ECMWF, ECMWF, UK Met Office,
+		UK Met Office, UK Met Office, CERFACS, CERFACS,
+		CERFACS, IFM-GEOMAR, IFM-GEOMAR, IFM-GEOMAR,
+		UK Met Office, UK Met Office, UK Met Office,
+		UK Met Office, UK Met Office, UK Met Office,
+		UK Met Office, UK Met Office, UK Met Office]" shape="(21,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="45bcc281" long_name="c" points="[HOPE-E, Sys 1, Met 1, ENSEMBLES,
+		HOPE-E, Sys 1, Met 1, ENSEMBLES,
+		HOPE-E, Sys 1, Met 1, ENSEMBLES,
+		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+		HadCM3, Sys 51, Met 10, ENSEMBLES,
+		HadCM3, Sys 51, Met 11, ENSEMBLES,
+		HadCM3, Sys 51, Met 12, ENSEMBLES,
+		HadCM3, Sys 51, Met 13, ENSEMBLES,
+		HadCM3, Sys 51, Met 14, ENSEMBLES,
+		HadCM3, Sys 51, Met 15, ENSEMBLES,
+		HadCM3, Sys 51, Met 16, ENSEMBLES,
+		HadCM3, Sys 51, Met 17, ENSEMBLES,
+		HadCM3, Sys 51, Met 18, ENSEMBLES]" shape="(21,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="74a4f5f6" long_name="d" points="[0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0,
+		0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0]" shape="(21,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(21, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/string_a_b.cml
+++ b/lib/iris/tests/results/merge/string_a_b.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="9c870e8e" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="c499a7a6" long_name="b" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/string_a_with_aux.cml
+++ b/lib/iris/tests/results/merge/string_a_with_aux.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="9c870e8e" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/string_a_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_a_with_dim.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="9c870e8e" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="c499a7a6" long_name="b" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/merge/string_b_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_b_with_dim.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="9c870e8e" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="c499a7a6" long_name="b" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="31e14d0d" long_name="y" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" dtype="float32" order="C" shape="(4, 4, 5)" state="loaded"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
Primarily, this PR extends the capability of cube merge to correctly deal with string coordinates.

Previously, cube merge did not take into account the `dtype` of a coordinate, and as a result it was possible for cube merge to consider/nominate a _string_ coordinate over other more appropriate _numeric_ coordinates to describe a dimension.

This PR allows cube merge to now favour _numeric_ over _string_ coordinates. It also takes the additional step to allow cube merge to favour `DimCoord` scalar coordinates over `AuxCoord` scalar coordinates. This provides a simple mechanism that allows a user to easily _hint_ to cube merge which scalar coordinate to consider when attempting to describe a dimension.

This PR also resolves the situation when a `NotYetImplementedError` exception was raised when the situation of `No functional relationship between separable and inseparable candidate dimensions` was determined. Instead, the candidate coordinates participating within this group are all enumerated along an anonymous dimension.
