### PR TITLE
Make tests optional that depend on pydot and pandas (optional installs).

### DIFF
--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -29,6 +29,13 @@ import iris.util
 _GRAPH_INDENT = ' ' * 4
 _SUBGRAPH_INDENT = ' ' * 8
 
+_DOT_EXECUTABLE_PATH = iris.config.get_option('System', 'dot_path',
+                                              default='dot')
+if not os.path.exists(_DOT_EXECUTABLE_PATH):
+    _DOT_EXECUTABLE_PATH = None
+DOT_AVAILABLE = _DOT_EXECUTABLE_PATH is not None
+""" Whether the 'dot' program is present (required for "dotpng" output). """
+
 
 def save(cube, target):
     """Save a dot representation of the cube.
@@ -82,16 +89,20 @@ def save_png(source, target, launch=False):
         dot_file_path = source
     else:
         raise ValueError("Can only write dot png for a Cube or DOT file")
-        
+
     # Create png data
-    dot_exe = iris.config.get_option('System', 'dot_path', default='dot')
+    if not _DOT_EXECUTABLE_PATH:
+        raise ValueError('Executable "dot" not found: '
+                         'Review dot_path setting in site.cfg.')
     # To filename or open file handle?
     if isinstance(target, basestring):
-        subprocess.call([dot_exe, '-T', 'png', '-o', target, dot_file_path])
+        subprocess.call([_DOT_EXECUTABLE_PATH, '-T', 'png', '-o', target,
+                         dot_file_path])
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
             raise ValueError("Target not binary")
-        subprocess.call([dot_exe, '-T', 'png', dot_file_path], stdout=target)
+        subprocess.call([_DOT_EXECUTABLE_PATH, '-T', 'png', dot_file_path],
+                        stdout=target)
     else:
         raise ValueError("Can only write dot png for a filename or writable")
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -440,14 +440,21 @@ class GraphicsTest(IrisTest):
 
 def skip_data(fn):
     """
-    Decorator to decide if to run the test or not based on the
-    availability of external data.
+    Decorator to choose whether to run tests, based on the availability of
+    external data.
+
+    Example usage:
+        @skip_data
+        class MyDataTests(tests.IrisTest):
+            ...
 
     """
-    valid_data = (iris.config.TEST_DATA_DIR and
-                  os.path.isdir(iris.config.TEST_DATA_DIR))
-    if valid_data and not os.environ.get('IRIS_TEST_NO_DATA'):
-        return fn
-    else:
-        skip = unittest.skip("These/this test(s) requires external data.")
-        return skip(fn)
+    no_data = (not iris.config.TEST_DATA_DIR
+               or not os.path.isdir(iris.config.TEST_DATA_DIR)
+               or os.environ.get('IRIS_TEST_NO_DATA'))
+
+    skip = unittest.skipIf(
+        condition=no_data,
+        reason='Test(s) require external data.')
+
+    return skip(fn)

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ import iris.tests as tests
 
 import cStringIO
 import os
+import unittest
 
 import iris
 import iris.cube
@@ -31,7 +32,14 @@ import iris.util
 import iris.fileformats.pp as pp
 import iris.fileformats.dot as dot
 
+# Make a test skip decorator, for when DOT not available
+skip_dotpng = unittest.skipIf(
+    not dot.DOT_AVAILABLE,
+    'Test(s) require the "dot" executable, which was not found. '
+    'Check the dot_path setting in site.cfg.')
+
 CHKSUM_ERR = "Mismatch between checksum of iris.save and {}.save."
+
 
 def save_by_filename(filename1, filename2, cube, saver_fn, iosaver=None):
     """ Saves a cube to two different filenames using iris.save and the save method of the object representing the file type directly"""
@@ -129,6 +137,8 @@ class TestSaveDot(TestSaveMethods):
         # Compare files
         self.assertEquals(data, string_io.getvalue(), "Mismatch in data when comparing iris cstringio save and dot.save.")
 
+
+@skip_dotpng
 class TestSavePng(TestSaveMethods):
     """Test saving cubes to png"""
     ext = ".dotpng"
@@ -171,6 +181,7 @@ class TestSaver(TestSaveMethods):
         # Compare files
         self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
 
+    @skip_dotpng
     def test_png(self):
         # Make our own saver
         png_saver = iris.io.find_saver("DOTPNG")

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -21,17 +21,29 @@
 import iris.tests as tests
 
 import datetime
+import unittest
 
 import netcdftime
 import numpy as np
-import pandas
 
-from iris.coords import DimCoord
-from iris.cube import Cube
-import iris.pandas
-import iris.unit
+try:
+    import pandas
+except ImportError:
+    # Disable all these tests if pandas is not installed.
+    pandas = None
+
+skip_pandas = unittest.skipIf(pandas is None,
+                              'Test(s) require "pandas", '
+                              'which is not available.')
+
+if pandas is not None:
+    from iris.coords import DimCoord
+    from iris.cube import Cube
+    import iris.pandas
+    import iris.unit
 
 
+@skip_pandas
 class TestAsSeries(tests.IrisTest):
     """Test conversion of 1D cubes to Pandas using as_series()"""
 
@@ -128,6 +140,7 @@ class TestAsSeries(tests.IrisTest):
             series = iris.pandas.as_series(cube, copy=False)
 
 
+@skip_pandas
 class TestAsDataFrame(tests.IrisTest):
     """Test conversion of 2D cubes to Pandas using as_data_frame()"""
 
@@ -263,6 +276,7 @@ class TestAsDataFrame(tests.IrisTest):
             data_frame = iris.pandas.as_data_frame(cube, copy=False)
 
 
+@skip_pandas
 class TestSeriesAsCube(tests.IrisTest):
 
     def test_series_simple(self):
@@ -329,6 +343,7 @@ class TestSeriesAsCube(tests.IrisTest):
         self.assertEqual(series[5], 99)
 
 
+@skip_pandas
 class TestDataFrameAsCube(tests.IrisTest):
 
     def test_data_frame_simple(self):


### PR DESCRIPTION
Failed on these in my amazon instance VM.

We could probably do with an "official" list of what installs developers should use?
See also https://github.com/SciTools/iris/issues/478  -- but possibly this should have gone on discussion groups instead??
