### PR TITLE
fixed netcdf save cubelist bug

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -685,6 +685,8 @@ class Saver(object):
                     dimension_names.append(dim_name)
                     self._dim_coords.append(coord)
                 else:
+                    # Return the dim_name associated with the existing coordinate
+                    dim_name = self._name_coord_map.name(coord)
                     dimension_names.append(dim_name)
 
             else:

--- a/lib/iris/tests/results/netcdf/multi_dim_coord_slightly_different.cdl
+++ b/lib/iris/tests/results/netcdf/multi_dim_coord_slightly_different.cdl
@@ -1,0 +1,29 @@
+dimensions:
+	latitude_0 = UNLIMITED ; // (10 currently)
+	time = UNLIMITED ; // (2 currently)
+	latitude = 2 ;
+variables:
+	double temp(time, latitude) ;
+		temp:standard_name = "surface_temperature" ;
+		temp:units = "K" ;
+	int64 time(time) ;
+		time:units = "1" ;
+		time:standard_name = "time" ;
+	int64 latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "1" ;
+		latitude:standard_name = "latitude" ;
+	double temp3(latitude_0) ;
+		temp3:long_name = "air_temperature" ;
+		temp3:units = "K" ;
+	int64 latitude_0(latitude_0) ;
+		latitude_0:axis = "Y" ;
+		latitude_0:units = "1" ;
+		latitude_0:standard_name = "latitude" ;
+	double temp3_0(latitude_0) ;
+		temp3_0:long_name = "air_temperature" ;
+		temp3_0:units = "K" ;
+
+// global attributes:
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -348,7 +348,7 @@ class TestNetCDFSave(tests.IrisTest):
         self.assertCDL(file_out, ('netcdf', 'netcdf_save_samevar.cdl'))
         os.remove(file_out)
 
-    def test_netcdf_multi_wtih_coords(self):
+    def test_netcdf_multi_with_coords(self):
         # Testing the saving of a cublist with coordinates.
         lat = iris.coords.DimCoord(np.arange(2),
                                    long_name=None, var_name='lat',
@@ -391,6 +391,28 @@ class TestNetCDFSave(tests.IrisTest):
 
         # Check the netCDF file against CDL expected output.
         self.assertCDL(file_out, ('netcdf', 'netcdf_save_samedimcoord.cdl'))
+        os.remove(file_out)
+
+    def test_netcdf_multi_conflict_name_dup_coord(self):
+        # Duplicate coordinates with modified variable names lookup.
+        latitude1 = iris.coords.DimCoord(np.arange(10),
+                                         standard_name='latitude')
+        time2 = iris.coords.DimCoord(np.arange(2),
+                                     standard_name='time')
+        latitude2 = iris.coords.DimCoord(np.arange(2),
+                                         standard_name='latitude')
+
+        self.cube6.add_dim_coord(latitude1, 0)
+        self.cube.add_dim_coord(latitude2[:], 1)
+        self.cube.add_dim_coord(time2[:], 0)
+
+        cubes = iris.cube.CubeList([self.cube, self.cube6, self.cube6.copy()])
+        file_out = iris.util.create_temp_filename(suffix='.nc')
+        iris.save(cubes, file_out)
+
+        # Check the netCDF file against CDL expected output.
+        self.assertCDL(file_out, ('netcdf',
+                                  'multi_dim_coord_slightly_different.cdl'))
         os.remove(file_out)
 
     def test_netcdf_hybrid_height(self):


### PR DESCRIPTION
The problem resides in the case where the variable name is altered for an added coordinate but then this modified name not being looked up if used for adding future duplicate coordinates.
