### PR TITLE
Refactor seasons categorisation functions.

### DIFF
--- a/lib/iris/tests/results/categorisation/customcheck.cml
+++ b/lib/iris/tests/results/categorisation/customcheck.cml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="test cube" units="metres">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="897c6e46" long_name="season_numbers" points="[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 0, 0, 0,
+		0, 1, 1, 1, 1, 1, 2]" shape="(23,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="f7f326a6" long_name="season_years" points="[1970, 1970, 1970, 1970, 1970, 1970, 1970, 1970,
+		1970, 1970, 1970, 1970, 1970, 1971, 1971, 1971,
+		1971, 1971, 1971, 1971, 1971, 1971, 1971]" shape="(23,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="e49804e7" long_name="seasons" points="[djfm, djfm, djfm, djfm, amjj, amjj, amjj, amjj,
+		ason, ason, ason, ason, ason, djfm, djfm, djfm,
+		djfm, amjj, amjj, amjj, amjj, amjj, ason]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="f7604e22" points="[0, 27, 54, 81, 108, 135, 162, 189, 216, 243,
+		270, 297, 324, 351, 378, 405, 432, 459, 486,
+		513, 540, 567, 594]" shape="(23,)" standard_name="time" units="Unit('days since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x2735ea03" dtype="int32" order="C" shape="(23,)"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
### Purpose:

To unify `add_season*` and `add_custom_season*`, reducing duplication of code and making the categorisation code easier to use and maintain.
### Action:

Following on from #480, this PR refactors the season categorisation code, deprecating the `add_custom_season*` functions in favour of adding their functionality to the existing season categorisation functions via a keyword argument `seasons`. The `add_custom_season_membership` function has no `add_season_membership` equivalent so is simply re-named.
