### PR TITLE
PP save with no time forecast.

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -130,6 +130,18 @@ THEN
 ### time - lbtim, t1, t2 and lbft (but not lbproc) ###
 ######################################################
 
+#no forecast
+IF
+    scalar_coord(cm, 'time') is not None
+    scalar_coord(cm, 'forecast_period') is None
+    scalar_coord(cm, 'forecast_reference_time') is None
+THEN
+    pp.lbtim.ia = 0
+    pp.lbtim.ib = 0
+    pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').points[0])
+    pp.t2 = netcdftime.datetime(0, 0, 0)
+
+
 #forecast
 IF
     scalar_coord(cm, 'time') is not None

--- a/lib/iris/tests/results/cube_to_pp/no_forecast_time.cml
+++ b/lib/iris/tests/results/cube_to_pp/no_forecast_time.cml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord id="a42bcac2" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="63128986" points="[-1, 0, 1, 2]" shape="(4,)" standard_name="longitude" units="Unit('degrees')" value_type="int32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[24]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x49adf4af" dtype="int32" order="C" shape="(3, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/cube_to_pp/no_forecast_time.txt
+++ b/lib/iris/tests/results/cube_to_pp/no_forecast_time.txt
@@ -1,0 +1,57 @@
+[PP Field
+   lbyr: 1970
+   lbmon: 1
+   lbdat: 2
+   lbhr: 0
+   lbmin: 0
+   lbsec: 0
+   lbyrd: 0
+   lbmond: 0
+   lbdatd: 0
+   lbhrd: 0
+   lbmind: 0
+   lbsecd: 0
+   lbtim: 1
+   lbft: 0
+   lblrec: 12
+   lbcode: 1
+   lbhem: 3
+   lbrow: 3
+   lbnpt: 4
+   lbext: 0
+   lbpack: 0
+   lbrel: 3
+   lbfc: 0
+   lbcfc: 0
+   lbproc: 0
+   lbvc: 0
+   lbrvc: 0
+   lbexp: 0
+   lbegin: 0
+   lbnrec: 0
+   lbproj: 0
+   lbtyp: 0
+   lblev: 0
+   lbrsvd: (0, 0, 0, 0)
+   lbsrce: 0
+   lbuser: (2, 0, 0, 0, 0, 0, 0)
+   brsvd: (0.0, 0.0, 0.0, 0.0)
+   bdatum: 0.0
+   bacc: 0.0
+   blev: 0.0
+   brlev: 0.0
+   bhlev: 0.0
+   bhrlev: 0.0
+   bplat: 90.0
+   bplon: 0.0
+   bgor: 0.0
+   bzy: -2.0
+   bdy: 1.0
+   bzx: -2.0
+   bdx: 1.0
+   bmdi: -1e+30
+   bmks: 1.0
+   data: [[ 0  1  2  3]
+ [ 4  5  6  7]
+ [ 8  9 10 11]]
+]

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -34,13 +34,22 @@ from iris.coord_systems import GeogCS, RotatedGeogCS
 
 def lat_lon_cube():
     """
-    Returns a cube with a latitude and longitude suitable for testing saving to PP/NetCDF etc.
+    Returns a cube with a latitude and longitude suitable for testing
+    saving to PP/NetCDF etc.
     
     """
     cube = Cube(np.arange(12, dtype=np.int32).reshape((3, 4)))
     cs = GeogCS(6371229)
-    cube.add_dim_coord(iris.coords.DimCoord(points=np.array([-1, 0, 1], dtype=np.int32), standard_name='latitude', units='degrees', coord_system=cs), 0)
-    cube.add_dim_coord(iris.coords.DimCoord(points=np.array([-1, 0, 1, 2], dtype=np.int32), standard_name='longitude', units='degrees', coord_system=cs), 1)
+    coord = iris.coords.DimCoord(points=np.array([-1, 0, 1], dtype=np.int32),
+                                 standard_name='latitude',
+                                 units='degrees',
+                                 coord_system=cs)
+    cube.add_dim_coord(coord, 0)
+    coord = iris.coords.DimCoord(points=np.array([-1, 0, 1, 2], dtype=np.int32),
+                                 standard_name='longitude',
+                                 units='degrees',
+                                 coord_system=cs)
+    cube.add_dim_coord(coord, 1)
     return cube
 
 

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -42,6 +42,18 @@ def itab_callback(cube, field, filename):
 
 @iris.tests.skip_data
 class TestPPSave(tests.IrisTest, pp.PPTest):
+    def test_no_forecast_time(self):
+        cube = stock.lat_lon_cube()
+        coord = iris.coords.DimCoord(24,
+                                     standard_name='time',
+                                     units='hours since epoch')
+        cube.add_aux_coord(coord)
+        self.assertCML(cube, ['cube_to_pp', 'no_forecast_time.cml'])
+
+        reference_txt_path = tests.get_result_path(('cube_to_pp', 'no_forecast_time.txt'))
+        with self.cube_save_test(reference_txt_path, reference_cubes=cube) as temp_pp_path:
+            iris.save(cube, temp_pp_path)
+
     def test_pp_save_rules(self):
         # Test pp save rules without user rules.
 


### PR DESCRIPTION
With respect to time, this PR allows cubes that only contain a `time` coordinate with no `forecast_period` coordinate or `forecast_reference_time` coordinate to be saved to PP.
