### PR TITLE
Propogate all coord names in construct midpoint

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -111,9 +111,6 @@ def _construct_midpoint_coord(coord, circular=None):
         mid_point_coord = coord.from_coord(coord).copy(mid_point_points, mid_point_bounds)
     except ValueError:
         mid_point_coord = iris.coords.AuxCoord.from_coord(coord).copy(mid_point_points, mid_point_bounds)
-    
-    # Set the coord name to the original name (as coord_delta will have modified it to change_in_*)
-    mid_point_coord.rename(coord.name())
 
     return mid_point_coord
 

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_simple_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_simple_wrt_x.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lat.cml
@@ -19,7 +19,7 @@
         <dimCoord id="9eb36add" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="e7b4cad3" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9f0697c0" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lon.cml
@@ -16,7 +16,7 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <auxCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_x.cml
@@ -16,7 +16,7 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <auxCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_y.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_y.cml
@@ -19,7 +19,7 @@
         <dimCoord id="9eb36add" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="e7b4cad3" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9f0697c0" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
@@ -19,7 +19,7 @@
         <dimCoord id="9eb36add" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="e7b4cad3" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9f0697c0" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
@@ -16,7 +16,7 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <auxCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
@@ -16,7 +16,7 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="e60137ce" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <auxCoord id="9eb36add" long_name="x" points="[0.5, 1.5, 2.5, 1.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="9f0697c0" long_name="y" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
@@ -19,7 +19,7 @@
         <dimCoord id="9eb36add" long_name="x" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="e7b4cad3" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
+        <dimCoord id="9f0697c0" long_name="y" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple1_midpoint.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple1_midpoint.cml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<dimCoord id="c775b471" long_name="foo" points="[-135.0, -45.0, 45.0, 135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>
+<dimCoord id="6990c4d7" long_name="foo" points="[-135.0, -45.0, 45.0, 135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple2_midpoint.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple2_midpoint.cml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<dimCoord id="c775b471" long_name="foo" points="[135.0, 45.0, -45.0, -135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>
+<dimCoord id="6990c4d7" long_name="foo" points="[135.0, 45.0, -45.0, -135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple3_midpoint.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple3_midpoint.cml
@@ -2,4 +2,4 @@
 <dimCoord bounds="[[-180.0, -90.0],
 		[-90.0, 0.0],
 		[0.0, 90.0],
-		[90.0, 180.0]]" id="c775b471" long_name="foo" points="[-135.0, -45.0, 45.0, 135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>
+		[90.0, 180.0]]" id="6990c4d7" long_name="foo" points="[-135.0, -45.0, 45.0, 135.0]" shape="(4,)" units="Unit('degrees')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple4_midpoint.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple4_midpoint.cml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <auxCoord bounds="[[-180.0, -90.0],
 		[-90.0, 0.0],
-		[0.0, 90.0]]" id="c775b471" long_name="foo" points="[-135.0, -45.0, 45.0]" shape="(3,)" units="Unit('degrees')" value_type="float32"/>
+		[0.0, 90.0]]" id="6990c4d7" long_name="foo" points="[-135.0, -45.0, 45.0]" shape="(3,)" units="Unit('degrees')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple5_midpoint.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple5_midpoint.cml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<auxCoord id="ba72c5b1" long_name="foo" points="[-135.0, -45.0, 45.0, -45.0]" shape="(4,)" units="Unit('meter')" value_type="float32"/>
+<auxCoord id="ce47d1d8" long_name="foo" points="[-135.0, -45.0, 45.0, -45.0]" shape="(4,)" units="Unit('meter')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/delta_and_midpoint/simple6.cml
+++ b/lib/iris/tests/results/analysis/delta_and_midpoint/simple6.cml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<auxCoord id="192d74b8" long_name="foo" points="[0.5, 1.5, 2.5, 3.5, 2.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>
+<auxCoord id="6d1860d1" long_name="foo" points="[0.5, 1.5, 2.5, 3.5, 2.0]" shape="(5,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -43,6 +43,22 @@ class TestCubeDelta(tests.IrisTest):
         with self.assertRaises(ValueError):
             t = iris.analysis.calculus.cube_delta(cube, 'forecast_period')
 
+    def test_delta_coord_lookup(self):
+        cube = iris.cube.Cube(np.arange(10), standard_name='air_temperature')
+        # Add a coordinate with a lot of metadata.
+        coord = iris.coords.DimCoord(np.arange(10),
+                                     long_name='projection_x_coordinate',
+                                     var_name='foo',
+                                     attributes={'source': 'testing'},
+                                     units='m',
+                                     coord_system=iris.coord_systems.OSGB())
+        cube.add_dim_coord(coord, 0)
+        delta = iris.analysis.calculus.cube_delta(cube,
+                                                  'projection_x_coordinate')
+        delta_coord = delta.coord('projection_x_coordinate')
+        self.assertEqual(delta_coord, delta.coord(coord=coord))
+        self.assertEqual(coord, cube.coord(coord=delta_coord))
+
 
 class TestDeltaAndMidpoint(tests.IrisTest):
     def _simple_filename(self, suffix):


### PR DESCRIPTION
This is a squashed version of #497. @cpelley and I worked on this last week, but he's not around to squash.

> This fixes an issue with not finding a coordinate as the coordinate rename overrides the >var_name
> 
> This was necessary for getting curl operation to work
