### PR TITLE
Ocean sigma over z

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -42,7 +42,6 @@ class LazyArray(object):
     computed and cached for any subsequent access.
 
     """
-
     def __init__(self, shape, func):
         """
         Args:
@@ -367,6 +366,9 @@ class AuxCoordFactory(CFVariableMixin):
 
     def _shape(self, nd_values_by_key):
         nd_values = nd_values_by_key.values()
+        # Preference for starting with higher nd values (with shape)
+        # over any 0-d values (with no shape).
+        nd_values.sort(key=lambda nd_value: len(nd_value.shape))
         shape = list(nd_values.pop().shape)
         for array in nd_values:
             for i, size in enumerate(array.shape):
@@ -388,7 +390,6 @@ class HybridHeightFactory(AuxCoordFactory):
         z = a + b * orog
 
     """
-
     def __init__(self, delta=None, sigma=None, orography=None):
         """
         Creates a hybrid-height coordinate factory with the formula:
@@ -556,7 +557,6 @@ class HybridPressureFactory(AuxCoordFactory):
         p = ap + b * ps
 
     """
-
     def __init__(self, delta=None, sigma=None, surface_pressure=None):
         """
         Creates a hybrid-height coordinate factory with the formula:
@@ -714,3 +714,317 @@ class HybridPressureFactory(AuxCoordFactory):
                       'These will be disregarded.'.format(new_coord.name())
                 warnings.warn(msg, UserWarning, stacklevel=2)
             self.surface_pressure = new_coord
+
+
+class OceanSigmaZFactory(AuxCoordFactory):
+    """Defines an ocean sigma over z coordinate factory."""
+
+    def __init__(self, sigma=None, eta=None, depth=None,
+                 depth_c=None, nsigma=None, zlev=None):
+        """
+        Creates a ocean sigma over z coordinate factory with the formula:
+
+        if k < nsigma:
+            z(n, k, j, i) = eta(n, j, i) + sigma(k) *
+                             (min(depth_c, depth(j, i)) + eta(n, j, i))
+
+        if k >= nsigma:
+            z(n, k, j, i) = zlev(k)
+
+        The `zlev` coordinate and at least one of the `eta`, `depth` or
+        `depth_c` coordinates must be provided.
+
+        """
+        if zlev is None:
+            raise ValueError('Unable to determine units: no zlev coordinate '
+                             'available.')
+
+        super(OceanSigmaZFactory, self).__init__()
+
+        if sigma and sigma.nbounds not in (0, 2):
+            raise ValueError('Invalid sigma coordinate {!r}: must have either '
+                             '0 or 2 bounds.'.format(sigma.name()))
+        if zlev and zlev.nbounds not in (0, 2):
+            raise ValueError('Invalid zlev coordinate {!r}: must have either '
+                             '0 or 2 bounds.'.format(zlev.name()))
+        if sigma and sigma.nbounds != zlev.nbounds:
+            raise ValueError('The zlev coordiante {!r} and sigma '
+                             'coordinate {!r} must be equally '
+                             'bounded'.format(zlev.name(), sigma.name()))
+        if eta and eta.nbounds:
+            warnings.warn('Eta coordinate {!r} has bounds. '
+                          'These will be disregarded.'.format(eta.name()),
+                          UserWarning, stacklevel=2)
+        if depth and depth.nbounds:
+            warnings.warn('Depth coordinate {!r} has bounds. '
+                          'These will be disregarded.'.format(depth.name()),
+                          UserWarning, stacklevel=2)
+        if depth_c and depth_c.shape != (1,):
+            raise ValueError('Expected a scalar depth_c coordinate {!r}: '
+                             'got shape {!r}.'.format(depth_c.name(),
+                                                      depth_c.shape))
+        if nsigma and nsigma.shape != (1,):
+            raise ValueError('Expected a scalar nsigma coordinate {!r}: '
+                             'got shape {!r}.'.format(nsigma.name(),
+                                                      nsigma.shape))
+
+        self.sigma = sigma
+        self.eta = eta
+        self.depth = depth
+        self.depth_c = depth_c
+        self.nsigma = nsigma
+        self.zlev = zlev
+
+        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        if depth is None and depth_c is None and eta is None:
+            raise ValueError('Unable to determine units: no depth or depth_c '
+                             'or eta coordinate available.')
+        if depth and zlev.units and depth.units and zlev.units != depth.units:
+            raise ValueError('Incompatible units: zlev coordinate {!r} and '
+                             'depth coordinate {!r} must have the same '
+                             'units.'.format(zlev.name(), depth.name()))
+        if depth_c and zlev.units and depth_c.units and \
+                zlev.units != depth_c.units:
+            raise ValueError('Incompatible units: zlev coordinate {!r} and '
+                             'depth_c coordinate {!r} must have the same '
+                             'units.'.format(zlev.name(), depth_c.name()))
+        if eta and zlev.units and eta.units and zlev.units != eta.units:
+            raise ValueError('Incompatible units: zlev coordinate {!r} and '
+                             'eta coordinate {!r} must have the same '
+                             'units.'.format(zlev.name(), eta.name()))
+        self.units = zlev.units
+        if not self.units.is_convertible('m'):
+            raise ValueError('Invalid units: zlev coordinate {!r} must be '
+                             'expressed in length units: '
+                             'got {!r}.'.format(zlev.name(),
+                                                self.units))
+        self.attributes = {'positive': 'up'}
+
+    @property
+    def dependencies(self):
+        """
+        Returns a dictionary mapping from constructor argument names to
+        the corresponding coordinates.
+
+        """
+        return dict(sigma=self.sigma, eta=self.eta, depth=self.depth,
+                    depth_c=self.depth_c, nsigma=self.nsigma, zlev=self.zlev)
+
+    def _derive(self, sigma, eta, depth, depth_c, nsigma, zlev, shape,
+                nsigma_slice):
+        result = np.ones(shape, dtype=zlev.dtype) * zlev
+        if nsigma_slice is not None:
+            # Inefficient but simple.
+            # Note, performs a point-wise minimum.
+            temp = eta + sigma * (np.minimum(depth_c, depth) + eta)
+            try:
+                result[nsigma_slice] = temp[nsigma_slice]
+            except IndexError:
+                pass
+
+        return result
+
+    def _make_nsigma_slice(self, dependency_dims, derived_dims,
+                           nsigma, bounds=False):
+        """
+        Returns an nd-point compatible slice over the associated
+        vertical dimension.
+
+        """
+        nsigma_slice = None
+        if derived_dims:
+            nsigma_slice = [slice(None)] * len(derived_dims)
+            dim = dependency_dims['zlev']
+            if dim:
+                index = derived_dims.index(dim[0])
+                nsigma_slice[index] = slice(0, int(nsigma))
+            if bounds:
+                nsigma_slice += [slice(None)]
+        return nsigma_slice
+
+    def make_coord(self, coord_dims_func):
+        """
+        Returns a new :class:`iris.coords.AuxCoord` as defined by this factory.
+
+        Args:
+
+        * coord_dims_func:
+            A callable wich can return the list of dimesions relevant
+            to a given coordinate. See :meth:`iris.cube.Cube.coord_dims()`.
+
+        """
+        # Determine the relevant dimensions.
+        derived_dims = self.derived_dims(coord_dims_func)
+        dependency_dims = self._dependency_dims(coord_dims_func)
+
+        # Build a "lazy" points array.
+        nd_points_by_key = self._remap(dependency_dims, derived_dims)
+        points_shape = self._shape(nd_points_by_key)
+        nsigma_slice = self._make_nsigma_slice(dependency_dims, derived_dims,
+                                               nd_points_by_key['nsigma'])
+
+        # Define the function here to obtain a closure.
+        def calc_points():
+            return self._derive(nd_points_by_key['sigma'],
+                                nd_points_by_key['eta'],
+                                nd_points_by_key['depth'],
+                                nd_points_by_key['depth_c'],
+                                nd_points_by_key['nsigma'],
+                                nd_points_by_key['zlev'],
+                                points_shape,
+                                nsigma_slice)
+
+        points = LazyArray(points_shape, calc_points)
+
+        bounds = None
+        if (self.zlev and self.zlev.nbounds) or \
+                (self.sigma and self.sigma.nbounds):
+            # Build a "lazy" bounds array.
+            nd_values_by_key = self._remap_with_bounds(dependency_dims,
+                                                       derived_dims)
+            bounds_shape = self._shape(nd_values_by_key)
+            nsigma_slice_bounds = nsigma_slice + [slice(None)]
+
+            # Define the function here to obtain a closure.
+            def calc_bounds():
+                sigma = nd_values_by_key['sigma']
+                eta = nd_values_by_key['eta']
+                depth = nd_values_by_key['depth']
+                zlev = nd_values_by_key['zlev']
+                valid_shapes = [(), (1,), (2,)]
+                if sigma.shape[-1:] not in valid_shapes:
+                    raise ValueError('Invalid sigma coordinate {!r} '
+                                     'bounds.'.format(sigma.name()))
+                if zlev.shape[-1:] not in valid_shapes:
+                    raise ValueError('Invalid zlev coordinate {!r} '
+                                     'bounds.'.format(zlev.name()))
+                valid_shapes.pop()
+                if eta.shape[-1:] not in valid_shapes:
+                    warnings.warn('Eta coordinate {!r} has bounds. '
+                                  'These are being disregarded.',
+                                  UserWarning, stacklevel=2)
+                    # Swap bounds with points.
+                    shape = list(nd_points_by_key['eta'].shape)
+                    eta = nd_points_by_key['eta'].reshape(shape.append(1))
+                if depth.shape[-1:] not in valid_shapes:
+                    warnings.warn('Depth coordinate {!r} has bounds. '
+                                  'These are being disregarded.',
+                                  UserWarning, stacklevel=2)
+                    # Swap bounds with points.
+                    shape = list(nd_points_by_key['depth'].shape)
+                    depth = nd_points_by_key['depth'].reshape(shape.append(1))
+                return self._derive(sigma, eta, depth,
+                                    nd_values_by_key['depth_c'],
+                                    nd_values_by_key['nsigma'],
+                                    zlev, bounds_shape,
+                                    nsigma_slice_bounds)
+
+            bounds = LazyArray(bounds_shape, calc_bounds)
+
+        coord = iris.coords.AuxCoord(points,
+                                     standard_name=self.standard_name,
+                                     long_name=self.long_name,
+                                     var_name=self.var_name,
+                                     units=self.units,
+                                     bounds=bounds,
+                                     attributes=self.attributes,
+                                     coord_system=self.coord_system)
+        return coord
+
+    def update(self, old_coord, new_coord=None):
+        """
+        Notifies the factory of the removal/replacement of a coordinate
+        which might be a dependency.
+
+        Args:
+
+        * old_coord:
+            The coordinate to be removed/replaced.
+        * new_coord:
+            If None, any dependency using old_coord is removed, otherwise
+            any dependency using old_coord is updated to use new_coord.
+
+        """
+        if self.sigma is old_coord:
+            if new_coord:
+                if new_coord.nbounds not in (0, 2):
+                    raise ValueError('Invalid sigma coordinate {!r}: must '
+                                     'have either 0 or 2 '
+                                     'bounds.'.format(new_coord.name()))
+                if new_coord.nbounds != self.zlev.nbounds:
+                    raise ValueError('The zlev coordinate {!r} and sigma '
+                                     'coordinate {!r} must be equally '
+                                     'bounded'.format(self.zlev.name(),
+                                                      new_coord.name()))
+            self.sigma = new_coord
+        elif self.eta is old_coord:
+            if new_coord:
+                if new_coord.nbounds:
+                    warnings.warn('Eta coordinate {!r} has bounds. These '
+                                  'will be '
+                                  'disregarded.'.format(new_coord.name()),
+                                  UserWarning, stacklevel=2)
+                if new_coord.units and self.zlev.units and \
+                        self.zlev.units != new_coord.units:
+                    raise ValueError('Incompatible units: zlev coordinate '
+                                     '{!r} and eta coordinate {!r} must '
+                                     'have the same '
+                                     'units.'.format(self.zlev.name(),
+                                                     new_coord.name()))
+            self.eta = new_coord
+        elif self.depth is old_coord:
+            if new_coord:
+                if new_coord.nbounds:
+                    warnings.warn('Depth coordinate {!r} has bounds. These '
+                                  'will be '
+                                  'disregarded.'.format(new_coord.name()),
+                                  UserWarning, stacklevel=2)
+                if new_coord.units and self.zlev.units and \
+                        self.zlev.units != new_coord.units:
+                    raise ValueError('Incompatible units: zlev coordinate '
+                                     '{!r} and depth coordinate {!r} must '
+                                     'have the same '
+                                     'units.'.format(self.zlev.name(),
+                                                     new_coord.name()))
+            self.depth = new_coord
+        elif self.depth_c is old_coord:
+            if new_coord:
+                if new_coord.shape != (1,):
+                    raise ValueError('Expected a scalar depth_c coordinate '
+                                     '{!r}: got shape '
+                                     '{!r}.'.format(new_coord.name(),
+                                                    new_coord.shape))
+                if new_coord.units and self.zlev.units and \
+                        self.zlev.units != new_coord.units:
+                    raise ValueError('Incompatible units: zlev coordinate '
+                                     '{!r} and depth_c coordinate {!r} must '
+                                     'have the same '
+                                     'units.'.format(self.zlev.name(),
+                                                     new_coord.name()))
+            self.depth_c = new_coord
+        elif self.nsigma is old_coord:
+            if new_coord and new_coord.shape != (1,):
+                raise ValueError('Expected a scalar depth_c coordinate '
+                                 '{!r}: got shape '
+                                 '{!r}.'.format(new_coord.name(),
+                                                new_coord.shape))
+            self.nsigma = new_coord
+        elif self.zlev is old_coord:
+            if new_coord is None:
+                raise ValueError('Unable to determine units: no zlev '
+                                 'coordinate available.')
+            if new_coord.nbounds not in (0, 2):
+                raise ValueError('Invalid zlev coordinate {!r}: must have '
+                                 'either 0 or 2 '
+                                 'bounds.'.format(new_coord.name()))
+            self.units = new_coord.units
+            if not self.units.is_convertible('m'):
+                raise ValueError('Invalid units: zlev coordinate {!r} must '
+                                 'be expressed in length '
+                                 'units: got {!r}.'.format(new_coord.name(),
+                                                           self.units))
+            self.zlev = new_coord
+
+        if self.depth is None and self.depth_c is None and self.eta is None:
+            raise ValueError('Unable to determine units: no depth or depth_c '
+                             ' or eta coordinate available.')

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -608,8 +608,8 @@ fc_attribute_ukmo__process_flags
         python attr_value = engine.cf_var.ukmo__process_flags
         python engine.cube.attributes['ukmo__process_flags'] = tuple([x.replace("_", " ") for x in attr_value.split(" ")])
         python engine.rule_triggered.add(rule.name)
-        
-        
+
+ 
 #
 # Context:
 #   This rule will trigger iff a formula term that refers to a
@@ -625,6 +625,24 @@ fc_formula_type_atmosphere_hybrid_height_coordinate
     assert
         python engine.requires['formula_type'] = 'atmosphere_hybrid_height_coordinate'
         facts_cf.formula_type(atmosphere_hybrid_height_coordinate)
+        python engine.rule_triggered.add(rule.name)
+
+
+#
+# Context:
+#   This rule will trigger iff a formula term that refers to a
+#   dimensionless vertical coordinate of ocean sigma over z
+#
+# Purpose:
+#   Assert that the formula term refers to ocean sigma over z.
+#
+fc_formula_type_ocean_sigma_z_coordinate
+    foreach
+        facts_cf.formula_root($coordinate)
+        check getattr(engine.cf_var.cf_group[$coordinate], 'standard_name') == 'ocean_sigma_z_coordinate'
+    assert
+        python engine.requires['formula_type'] = 'ocean_sigma_z_coordinate'
+        facts_cf.formula_type(ocean_sigma_z_coordinate)
         python engine.rule_triggered.add(rule.name)
 
 

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_0d.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_0d.__str__.txt
@@ -1,0 +1,15 @@
+sea_water_potential_temperature / (K) (scalar cube)
+     Scalar coordinates:
+          depth: 100.0 m
+          depth_c: 50.0 m
+          eta: 1.0 m
+          latitude: 0.0 degrees
+          longitude: 0.0 degrees
+          model_level_number: 0
+          nsigma: 2
+          sea_surface_height_above_reference_ellipsoid: 0.0 m
+          sigma: -1.0
+          time: 1970-01-01 00:00:00
+          zlev: 0.0 m
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_0d.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_0d.cml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord>
+        <auxCoord id="75d4896e" points="[100.0]" shape="(1,)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord>
+        <auxCoord id="88f339a7" long_name="eta" points="[1.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord>
+        <dimCoord id="c7efdd09" points="[0.0]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="a523d045" points="[0.0]" shape="(1,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="f2bf14cc" points="[0]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord>
+        <auxCoord id="5e7bbdc1" points="[0.0]" shape="(1,)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord>
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0]" shape="(1,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[0.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord>
+        <auxCoord id="affea393" long_name="zlev" points="[0.0]" shape="(1,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="0x2144df1c" dtype="int32" order="C" shape="()"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_1d.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_1d.__str__.txt
@@ -1,0 +1,18 @@
+sea_water_potential_temperature                     (time: 2)
+     Dimension coordinates:
+          time                                             x
+     Auxiliary coordinates:
+          eta                                            x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x
+     Scalar coordinates:
+          depth: 100.0 m
+          depth_c: 50.0 m
+          latitude: 0.0 degrees
+          longitude: 0.0 degrees
+          model_level_number: 0
+          nsigma: 2
+          sigma: -1.0
+          zlev: 0.0 m
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_1d.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_1d.cml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord>
+        <auxCoord id="75d4896e" points="[100.0]" shape="(1,)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="88f339a7" long_name="eta" points="[1.0, 2.0]" shape="(2,)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord>
+        <dimCoord id="c7efdd09" points="[0.0]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="a523d045" points="[0.0]" shape="(1,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="f2bf14cc" points="[0]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="5e7bbdc1" points="[-50.0, -50.0]" shape="(2,)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord>
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0]" shape="(1,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord>
+        <auxCoord id="affea393" long_name="zlev" points="[0.0]" shape="(1,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x2a1b003b" dtype="int32" order="C" shape="(2,)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_2d.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_2d.__str__.txt
@@ -1,0 +1,18 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5)
+     Dimension coordinates:
+          time                                             x                      -
+          model_level_number                               -                      x
+     Auxiliary coordinates:
+          eta                                            x                      -
+          sigma                                          -                      x
+          zlev                                           -                      x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x
+     Scalar coordinates:
+          depth: 100.0 m
+          depth_c: 50.0 m
+          latitude: 0.0 degrees
+          longitude: 0.0 degrees
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_2d.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_2d.cml
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord>
+        <auxCoord id="75d4896e" points="[100.0]" shape="(1,)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="88f339a7" long_name="eta" points="[1.0, 2.0]" shape="(2,)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord>
+        <dimCoord id="c7efdd09" points="[0.0]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="a523d045" points="[0.0]" shape="(1,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="5e7bbdc1" points="[[-50.0, -101.0, 2.0, 3.0, 4.0],
+		[-50.0, -102.0, 2.0, 3.0, 4.0]]" shape="(2, 5)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x60a46385" dtype="int32" order="C" shape="(2, 5)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_3d.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_3d.__str__.txt
@@ -1,0 +1,18 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2)
+     Dimension coordinates:
+          time                                             x                      -            -
+          model_level_number                               -                      x            -
+          latitude                                         -                      -            x
+     Auxiliary coordinates:
+          eta                                            x                      -            x
+          sigma                                          -                      x            -
+          zlev                                           -                      x            -
+          depth                                          -                      -            x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x            x
+     Scalar coordinates:
+          depth_c: 50.0 m
+          longitude: 0.0 degrees
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_3d.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_3d.cml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2]">
+        <auxCoord id="75d4896e" points="[100.0, 103.0]" shape="(2,)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[1.0, 1.0],
+		[2.0, 2.0]]" shape="(2, 2)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord>
+        <dimCoord id="a523d045" points="[0.0]" shape="(1,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2]">
+        <auxCoord id="5e7bbdc1" points="[[[-50.0, -50.0],
+ 		[-101.0, -101.0],
+ 		[2.0, 2.0],
+ 		[3.0, 3.0],
+ 		[4.0, 4.0]],
+
+		[[-50.0, -50.0],
+ 		[-102.0, -102.0],
+ 		[2.0, 2.0],
+ 		[3.0, 3.0],
+ 		[4.0, 4.0]]]" shape="(2, 5, 2)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="0x28106f1d" dtype="int32" order="C" shape="(2, 5, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_bounds.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_bounds.cml
@@ -1,0 +1,183 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord bounds="[[[[[-24.5, -75.5],
+   		[-24.5, -75.5],
+   		[-24.5, -75.5]],
+
+  		[[-24.5, -75.5],
+   		[-24.5, -75.5],
+   		[-24.5, -75.5]]],
+
+
+ 		[[[-75.5, -126.5],
+   		[-75.5, -126.5],
+   		[-75.5, -126.5]],
+
+  		[[-75.5, -126.5],
+   		[-75.5, -126.5],
+   		[-75.5, -126.5]]],
+
+
+ 		[[[1.5, 2.5],
+   		[1.5, 2.5],
+   		[1.5, 2.5]],
+
+  		[[1.5, 2.5],
+   		[1.5, 2.5],
+   		[1.5, 2.5]]],
+
+
+ 		[[[2.5, 3.5],
+   		[2.5, 3.5],
+   		[2.5, 3.5]],
+
+  		[[2.5, 3.5],
+   		[2.5, 3.5],
+   		[2.5, 3.5]]],
+
+
+ 		[[[3.5, 4.5],
+   		[3.5, 4.5],
+   		[3.5, 4.5]],
+
+  		[[3.5, 4.5],
+   		[3.5, 4.5],
+   		[3.5, 4.5]]]],
+
+
+
+		[[[[-24.0, -76.0],
+   		[-24.0, -76.0],
+   		[-24.0, -76.0]],
+
+  		[[-24.0, -76.0],
+   		[-24.0, -76.0],
+   		[-24.0, -76.0]]],
+
+
+ 		[[[-76.0, -128.0],
+   		[-76.0, -128.0],
+   		[-76.0, -128.0]],
+
+  		[[-76.0, -128.0],
+   		[-76.0, -128.0],
+   		[-76.0, -128.0]]],
+
+
+ 		[[[1.5, 2.5],
+   		[1.5, 2.5],
+   		[1.5, 2.5]],
+
+  		[[1.5, 2.5],
+   		[1.5, 2.5],
+   		[1.5, 2.5]]],
+
+
+ 		[[[2.5, 3.5],
+   		[2.5, 3.5],
+   		[2.5, 3.5]],
+
+  		[[2.5, 3.5],
+   		[2.5, 3.5],
+   		[2.5, 3.5]]],
+
+
+ 		[[[3.5, 4.5],
+   		[3.5, 4.5],
+   		[3.5, 4.5]],
+
+  		[[3.5, 4.5],
+   		[3.5, 4.5],
+   		[3.5, 4.5]]]]]" id="5e7bbdc1" points="[[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-101.0, -101.0, -101.0],
+  		[-101.0, -101.0, -101.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-102.0, -102.0, -102.0],
+  		[-102.0, -102.0, -102.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord bounds="[[-0.5, -1.5],
+		[-1.5, -2.5],
+		[-2.5, -3.5],
+		[-3.5, -4.5],
+		[-4.5, -5.5]]" id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord bounds="[[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5],
+		[2.5, 3.5],
+		[3.5, 4.5]]" id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth.__str__.txt
@@ -1,0 +1,17 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2; longitude: 3)
+     Dimension coordinates:
+          time                                             x                      -            -             -
+          model_level_number                               -                      x            -             -
+          latitude                                         -                      -            x             -
+          longitude                                        -                      -            -             x
+     Auxiliary coordinates:
+          eta                                            x                      -            x             x
+          sigma                                          -                      x            -             -
+          zlev                                           -                      x            -             -
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x            x             x
+     Scalar coordinates:
+          depth_c: 50.0 m
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth.cml
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[-1.0, -1.0, -1.0],
+  		[-1.0, -1.0, -1.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[-2.0, -2.0, -2.0],
+  		[-2.0, -2.0, -2.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth_c.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth_c.__str__.txt
@@ -1,0 +1,17 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2; longitude: 3)
+     Dimension coordinates:
+          time                                             x                      -            -             -
+          model_level_number                               -                      x            -             -
+          latitude                                         -                      -            x             -
+          longitude                                        -                      -            -             x
+     Auxiliary coordinates:
+          eta                                            x                      -            x             x
+          sigma                                          -                      x            -             -
+          zlev                                           -                      x            -             -
+          depth                                          -                      -            x             x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x            x             x
+     Scalar coordinates:
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth_c.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_depth_c.cml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[-1.0, -1.0, -1.0],
+  		[-1.0, -1.0, -1.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[-2.0, -2.0, -2.0],
+  		[-2.0, -2.0, -2.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_eta.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_eta.__str__.txt
@@ -1,0 +1,17 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2; longitude: 3)
+     Dimension coordinates:
+          time                                             x                      -            -             -
+          model_level_number                               -                      x            -             -
+          latitude                                         -                      -            x             -
+          longitude                                        -                      -            -             x
+     Auxiliary coordinates:
+          sigma                                          -                      x            -             -
+          zlev                                           -                      x            -             -
+          depth                                          -                      -            x             x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   -                      x            x             x
+     Scalar coordinates:
+          depth_c: 50.0 m
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_eta.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_eta.cml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[-50.0, -50.0, -50.0],
+ 		[-50.0, -50.0, -50.0]],
+
+		[[-100.0, -100.0, -100.0],
+ 		[-100.0, -100.0, -100.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]],
+
+		[[3.0, 3.0, 3.0],
+ 		[3.0, 3.0, 3.0]],
+
+		[[4.0, 4.0, 4.0],
+ 		[4.0, 4.0, 4.0]]]" shape="(5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_nsigma.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_nsigma.__str__.txt
@@ -1,0 +1,17 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2; longitude: 3)
+     Dimension coordinates:
+          time                                             x                      -            -             -
+          model_level_number                               -                      x            -             -
+          latitude                                         -                      -            x             -
+          longitude                                        -                      -            -             x
+     Auxiliary coordinates:
+          eta                                            x                      -            x             x
+          sigma                                          -                      x            -             -
+          zlev                                           -                      x            -             -
+          depth                                          -                      -            x             x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x            x             x
+     Scalar coordinates:
+          depth_c: 50.0 m
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_nsigma.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_nsigma.cml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[1.0, 1.0, 1.0],
+  		[1.0, 1.0, 1.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[0.0, 0.0, 0.0],
+  		[0.0, 0.0, 0.0]],
+
+ 		[[1.0, 1.0, 1.0],
+  		[1.0, 1.0, 1.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_sigma.__str__.txt
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_sigma.__str__.txt
@@ -1,0 +1,17 @@
+sea_water_potential_temperature                     (time: 2; model_level_number: 5; latitude: 2; longitude: 3)
+     Dimension coordinates:
+          time                                             x                      -            -             -
+          model_level_number                               -                      x            -             -
+          latitude                                         -                      -            x             -
+          longitude                                        -                      -            -             x
+     Auxiliary coordinates:
+          eta                                            x                      -            x             x
+          zlev                                           -                      x            -             -
+          depth                                          -                      -            x             x
+     Derived coordinates:
+          sea_surface_height_above_reference_ellipsoid   x                      x            x             x
+     Scalar coordinates:
+          depth_c: 50.0 m
+          nsigma: 2
+     Attributes:
+          Conventions: CF-1.5

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_sigma.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_remove_sigma.cml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[1.0, 1.0, 1.0],
+  		[1.0, 1.0, 1.0]],
+
+ 		[[1.0, 1.0, 1.0],
+  		[1.0, 1.0, 1.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_save_load.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_save_load.cml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="2c4b8a59" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <dimCoord id="67c7e3fc" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="cc8d401a" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="3131281b" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="566c7ff8" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f0c5855b" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <dimCoord id="87a6b4c" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-101.0, -101.0, -101.0],
+  		[-101.0, -101.0, -101.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-102.0, -102.0, -102.0],
+  		[-102.0, -102.0, -102.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="273ab6c5" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="2fd50af3" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="2c9b0038" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/derived/ocean/ocean_sigma_z_transpose.cml
+++ b/lib/iris/tests/results/derived/ocean/ocean_sigma_z_transpose.cml
@@ -1,0 +1,94 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[1, 0]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[3, 1, 0]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]],
+
+ 		[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]]],
+
+
+		[[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]],
+
+ 		[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]]],
+
+
+		[[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]],
+
+ 		[[-50.0, -50.0],
+  		[-101.0, -102.0],
+  		[2.0, 2.0],
+  		[3.0, 3.0],
+  		[4.0, 4.0]]]]" shape="(3, 2, 5, 2)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[2]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[2]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x7aaf72be" dtype="int32" order="C" shape="(3, 2, 5, 2)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/stock/ocean_sigma_z.cml
+++ b/lib/iris/tests/results/stock/ocean_sigma_z.cml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="sea_water_potential_temperature" units="K" var_name="sea_water_potential_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+    </attributes>
+    <coords>
+      <coord datadims="[2, 3]">
+        <auxCoord id="75d4896e" points="[[100.0, 101.0, 102.0],
+		[103.0, 104.0, 105.0]]" shape="(2, 3)" standard_name="depth" units="Unit('m')" value_type="float32" var_name="depth"/>
+      </coord>
+      <coord>
+        <auxCoord id="13f2f795" long_name="depth_c" points="[50.0]" shape="(1,)" units="Unit('m')" value_type="float64" var_name="depth_c"/>
+      </coord>
+      <coord datadims="[0, 2, 3]">
+        <auxCoord id="88f339a7" long_name="eta" points="[[[1.0, 1.0, 1.0],
+ 		[1.0, 1.0, 1.0]],
+
+		[[2.0, 2.0, 2.0],
+ 		[2.0, 2.0, 2.0]]]" shape="(2, 2, 3)" units="Unit('m')" value_type="float64" var_name="eta"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="c7efdd09" points="[0.0, 1.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="a523d045" points="[0.0, 1.0, 2.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f2bf14cc" points="[0, 1, 2, 3, 4]" shape="(5,)" standard_name="model_level_number" units="Unit('1')" value_type="int32" var_name="model_level_number"/>
+      </coord>
+      <coord>
+        <auxCoord id="8cbc98cf" long_name="nsigma" points="[2]" shape="(1,)" units="Unit('1')" value_type="int64" var_name="nsigma"/>
+      </coord>
+      <coord datadims="[0, 1, 2, 3]">
+        <auxCoord id="5e7bbdc1" points="[[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-101.0, -101.0, -101.0],
+  		[-101.0, -101.0, -101.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]],
+
+
+		[[[-50.0, -50.0, -50.0],
+  		[-50.0, -50.0, -50.0]],
+
+ 		[[-102.0, -102.0, -102.0],
+  		[-102.0, -102.0, -102.0]],
+
+ 		[[2.0, 2.0, 2.0],
+  		[2.0, 2.0, 2.0]],
+
+ 		[[3.0, 3.0, 3.0],
+  		[3.0, 3.0, 3.0]],
+
+ 		[[4.0, 4.0, 4.0],
+  		[4.0, 4.0, 4.0]]]]" shape="(2, 5, 2, 3)" standard_name="sea_surface_height_above_reference_ellipsoid" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[-1.0, -2.0, -3.0, -4.0, -5.0]" shape="(5,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[0.0, 24.0]" shape="(2,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="time"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="affea393" long_name="zlev" points="[0.0, 1.0, 2.0, 3.0, 4.0]" shape="(5,)" units="Unit('m')" value_type="float32" var_name="zlev">
+          <attributes>
+            <attribute name="invalid_standard_name" value="ocean_sigma_z_coordinate"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x268aa64c" dtype="int32" order="C" shape="(2, 5, 2, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_ocean.py
+++ b/lib/iris/tests/test_ocean.py
@@ -1,0 +1,385 @@
+# (C) British Crown Copyright 2010 - 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test the ocean dimesnionless vertical coordinate representations.
+
+"""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import warnings
+
+import numpy as np
+
+import iris
+from iris.aux_factory import OceanSigmaZFactory
+import iris.tests.stock
+
+
+class TestOceanSigmaZ(tests.IrisTest):
+    def setUp(self):
+        self.cube = iris.tests.stock.ocean_sigma_z()
+        self.derived_name = 'sea_surface_height_above_reference_ellipsoid'
+        coords = self.cube.aux_factory().dependencies
+        self.sigma = coords['sigma']
+        self.eta = coords['eta']
+        self.depth = coords['depth']
+        self.depth_c = coords['depth_c']
+        self.nsigma = coords['nsigma']
+        self.zlev = coords['zlev']
+
+    def test_metadata(self):
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.units, 'm')
+        self.assertIsNone(derived.coord_system)
+        self.assertEqual(derived.attributes, dict(positive='up'))
+
+    def test_points(self):
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), -102.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+    def test_bounds(self):
+        self.zlev.guess_bounds()
+        self.sigma.guess_bounds()
+        fname = ('derived', 'ocean', 'ocean_sigma_z_bounds.cml')
+        self.assertCML(self.cube, fname)
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.bounds.min(), -128.0)
+        self.assertEqual(derived.bounds.max(), 4.5)
+
+    def test_transpose(self):
+        self.assertCML(self.cube, ('stock', 'ocean_sigma_z.cml'))
+        self.cube.transpose()
+        fname = ('derived', 'ocean', 'ocean_sigma_z_transpose.cml')
+        self.assertCML(self.cube, fname)
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), -102.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+    def test_indexing(self):
+        cube = self.cube[:, :, :, 0]
+        # Ensure the 3d derived coordinate can be realised.
+        derived = cube.coord(self.derived_name)
+        self.assertCML(cube, ('derived', 'ocean', 'ocean_sigma_z_3d.cml'))
+        self.assertString(str(cube),
+                          ('derived', 'ocean', 'ocean_sigma_z_3d.__str__.txt'))
+
+        cube = self.cube[:, :, 0, 0]
+        # Ensure the 2d derived coordinate can be realised.
+        derived = cube.coord(self.derived_name)
+        self.assertCML(cube, ('derived', 'ocean', 'ocean_sigma_z_2d.cml'))
+        self.assertString(str(cube),
+                          ('derived', 'ocean', 'ocean_sigma_z_2d.__str__.txt'))
+
+        cube = self.cube[:, 0, 0, 0]
+        # Ensure the 1d derived coordinate can be realised.
+        derived = cube.coord(self.derived_name)
+        self.assertCML(cube, ('derived', 'ocean', 'ocean_sigma_z_1d.cml'))
+        self.assertString(str(cube),
+                          ('derived', 'ocean', 'ocean_sigma_z_1d.__str__.txt'))
+
+        cube = self.cube[0, 0, 0, 0]
+        # Ensure the 0d derived coordinate can be realised.
+        derived = cube.coord(self.derived_name)
+        self.assertCML(cube, ('derived', 'ocean', 'ocean_sigma_z_0d.cml'))
+        self.assertString(str(cube),
+                          ('derived', 'ocean', 'ocean_sigma_z_0d.__str__.txt'))
+
+    def test_remove_sigma(self):
+        self.cube.remove_coord('sigma')
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_sigma.cml')
+        self.assertCML(self.cube, fname)
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_sigma.__str__.txt')
+        self.assertString(str(self.cube), fname)
+
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), 1.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+        factory = self.cube.aux_factory()
+        terms = [term for term, coord in factory.dependencies.items()
+                 if coord is not None]
+        self.assertItemsEqual(terms,
+                              ['eta', 'depth', 'depth_c', 'nsigma', 'zlev'])
+
+        dependency_dims = factory._dependency_dims(self.cube.coord_dims)
+        self.assertEqual(dependency_dims, dict(eta=(0, 2, 3),
+                                               depth=(2, 3),
+                                               depth_c=(),
+                                               nsigma=(),
+                                               zlev=(1,)))
+        derived_dims = factory.derived_dims(self.cube.coord_dims)
+        self.assertEqual(derived_dims, (0, 1, 2, 3))
+        nd_points = factory._remap(dependency_dims, derived_dims)
+        nsigma_slice = factory._make_nsigma_slice(dependency_dims,
+                                                  derived_dims,
+                                                  nd_points['nsigma'])
+        self.assertEqual(nsigma_slice, [slice(None),
+                                        slice(0, 2),
+                                        slice(None),
+                                        slice(None)])
+
+    def test_remove_eta(self):
+        self.cube.remove_coord('eta')
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_eta.cml')
+        self.assertCML(self.cube, fname)
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_eta.__str__.txt')
+        self.assertString(str(self.cube), fname)
+
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), -100.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+        factory = self.cube.aux_factory()
+        terms = [term for term, coord in factory.dependencies.items()
+                 if coord is not None]
+        self.assertItemsEqual(terms,
+                              ['sigma', 'depth', 'depth_c', 'nsigma', 'zlev'])
+
+        dependency_dims = factory._dependency_dims(self.cube.coord_dims)
+        self.assertEqual(dependency_dims, dict(sigma=(1,),
+                                               depth=(2, 3),
+                                               depth_c=(),
+                                               nsigma=(),
+                                               zlev=(1,)))
+        derived_dims = factory.derived_dims(self.cube.coord_dims)
+        self.assertEqual(derived_dims, (1, 2, 3))
+        nd_points = factory._remap(dependency_dims, derived_dims)
+        nsigma_slice = factory._make_nsigma_slice(dependency_dims,
+                                                  derived_dims,
+                                                  nd_points['nsigma'])
+        self.assertEqual(nsigma_slice, [slice(0, 2),
+                                        slice(None),
+                                        slice(None)])
+
+    def test_remove_depth(self):
+        self.cube.remove_coord('depth')
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_depth.cml')
+        self.assertCML(self.cube, fname)
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_depth.__str__.txt')
+        self.assertString(str(self.cube), fname)
+
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), -2.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+        factory = self.cube.aux_factory()
+        terms = [term for term, coord in factory.dependencies.items()
+                 if coord is not None]
+        self.assertItemsEqual(terms,
+                              ['sigma', 'eta', 'depth_c', 'nsigma', 'zlev'])
+
+        dependency_dims = factory._dependency_dims(self.cube.coord_dims)
+        self.assertEqual(dependency_dims, dict(sigma=(1,),
+                                               eta=(0, 2, 3),
+                                               depth_c=(),
+                                               nsigma=(),
+                                               zlev=(1,)))
+        derived_dims = factory.derived_dims(self.cube.coord_dims)
+        self.assertEqual(derived_dims, (0, 1, 2, 3))
+        nd_points = factory._remap(dependency_dims, derived_dims)
+        nsigma_slice = factory._make_nsigma_slice(dependency_dims,
+                                                  derived_dims,
+                                                  nd_points['nsigma'])
+        self.assertEqual(nsigma_slice, [slice(None),
+                                        slice(0, 2),
+                                        slice(None),
+                                        slice(None)])
+
+    def test_remove_depth_c(self):
+        self.cube.remove_coord('depth_c')
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_depth_c.cml')
+        self.assertCML(self.cube, fname)
+        fname = ('derived', 'ocean',
+                 'ocean_sigma_z_remove_depth_c.__str__.txt')
+        self.assertString(str(self.cube), fname)
+
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), -2.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+        factory = self.cube.aux_factory()
+        terms = [term for term, coord in factory.dependencies.items()
+                 if coord is not None]
+        self.assertItemsEqual(terms,
+                              ['sigma', 'eta', 'depth', 'nsigma', 'zlev'])
+
+        dependency_dims = factory._dependency_dims(self.cube.coord_dims)
+        self.assertEqual(dependency_dims, dict(sigma=(1,),
+                                               eta=(0, 2, 3),
+                                               depth=(2, 3),
+                                               nsigma=(),
+                                               zlev=(1,)))
+        derived_dims = factory.derived_dims(self.cube.coord_dims)
+        self.assertEqual(derived_dims, (0, 1, 2, 3))
+        nd_points = factory._remap(dependency_dims, derived_dims)
+        nsigma_slice = factory._make_nsigma_slice(dependency_dims,
+                                                  derived_dims,
+                                                  nd_points['nsigma'])
+        self.assertEqual(nsigma_slice, [slice(None),
+                                        slice(0, 2),
+                                        slice(None),
+                                        slice(None)])
+
+    def test_remove_nsigma(self):
+        self.cube.remove_coord('nsigma')
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_nsigma.cml')
+        self.assertCML(self.cube, fname)
+        fname = ('derived', 'ocean', 'ocean_sigma_z_remove_nsigma.__str__.txt')
+        self.assertString(str(self.cube), fname)
+
+        derived = self.cube.coord(self.derived_name)
+        self.assertEqual(derived.points.min(), 0.0)
+        self.assertEqual(derived.points.max(), 4.0)
+
+        factory = self.cube.aux_factory()
+        terms = [term for term, coord in factory.dependencies.items()
+                 if coord is not None]
+        self.assertItemsEqual(terms,
+                              ['sigma', 'eta', 'depth', 'depth_c', 'zlev'])
+
+        dependency_dims = factory._dependency_dims(self.cube.coord_dims)
+        self.assertEqual(dependency_dims, dict(sigma=(1,),
+                                               eta=(0, 2, 3),
+                                               depth=(2, 3),
+                                               depth_c=(),
+                                               zlev=(1,)))
+        derived_dims = factory.derived_dims(self.cube.coord_dims)
+        self.assertEqual(derived_dims, (0, 1, 2, 3))
+        nd_points = factory._remap(dependency_dims, derived_dims)
+        nsigma_slice = factory._make_nsigma_slice(dependency_dims,
+                                                  derived_dims,
+                                                  nd_points['nsigma'])
+        self.assertEqual(nsigma_slice, [slice(None),
+                                        slice(0, 0),
+                                        slice(None),
+                                        slice(None)])
+
+    def test_remove_zlev(self):
+        with self.assertRaises(ValueError):
+            self.cube.remove_coord('zlev')
+
+    def test_derived_coords(self):
+        derived_coords = self.cube.derived_coords
+        self.assertEqual(len(derived_coords), 1)
+        derived, = derived_coords
+        self.assertEqual(derived.standard_name, self.derived_name)
+
+    def test_invalid_no_zlev(self):
+        # Requires a zlev.
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory()
+
+    def test_invalid_no_optional(self):
+        # Requires either a eta, depth, depth_c.
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev)
+
+    def test_invalid_zlev_bounds(self):
+        self.zlev.bounds = np.zeros(self.zlev.shape + (4,))
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev, eta=self.eta)
+
+    def test_invalid_sigma_bounds(self):
+        self.sigma.bounds = np.zeros(self.sigma.shape + (4,))
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               sigma=self.sigma)
+
+    def test_invalid_zlev_sigma_bounds(self):
+        self.zlev.bounds = np.zeros(self.zlev.shape + (4,))
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               sigma=self.sigma)
+
+    def test_invalid_depth_c_non_scalar(self):
+        depth_c = self.depth_c.copy(points=[1, 2])
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               depth_c=depth_c)
+
+    def test_invalid_nsigma_non_scalar(self):
+        nsigma = self.nsigma.copy(points=[1, 2])
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               nsigma=nsigma)
+
+    def test_invalid_zlev_depth_units_match(self):
+        self.depth.units = '1'
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               depth=self.depth)
+
+    def test_invalid_zlev_depth_c_units_match(self):
+        self.depth_c.units = 'K'
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta,
+                               depth_c=self.depth_c)
+
+    def test_invalid_zlev_eta_units_match(self):
+        self.eta.units = 'volts'
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta)
+
+    def test_invalid_zlev_units(self):
+        self.zlev.units = None
+        with self.assertRaises(ValueError):
+            OceanSigmaZFactory(zlev=self.zlev,
+                               eta=self.eta)
+
+    def test_warning_eta_bounds(self):
+        self.eta.bounds = np.zeros(self.eta.shape + (4,))
+        # Ignore eta bounds.
+        with warnings.catch_warnings():
+            # Promote warnings to exception status.
+            warnings.simplefilter('error')
+            with self.assertRaises(UserWarning):
+                OceanSigmaZFactory(zlev=self.zlev,
+                                   eta=self.eta)
+
+    def test_warning_depth_bounds(self):
+        self.depth.bounds = np.zeros(self.depth.shape + (4,))
+        # Ignore depth bounds.
+        with warnings.catch_warnings():
+            # Promote warnings to exception status.
+            warnings.simplefilter('error')
+            with self.assertRaises(UserWarning):
+                OceanSigmaZFactory(zlev=self.zlev,
+                                   eta=self.eta,
+                                   depth=self.depth)
+
+    def test_netcdf_save_load(self):
+        with self.temp_filename(suffix='.nc') as temp:
+            iris.save(self.cube, temp)
+            cube = iris.load_cube(temp)
+            fname = ('derived', 'ocean', 'ocean_sigma_z_save_load.cml')
+            self.assertCML(cube, fname)
+            self.assertEqual(cube, self.cube)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
This PR provides support for the CF **ocean sigma over z** dimensionless vertical coordinate.

As per the CF Metadata Conventions the _standard_name_ of the dimensonless vertical coordinate is **ocean_sigma_z_coordinate**. However, the CF community seem to have failed to register this as a valid _standard_name_ :cry: 

As a follow-on task, I'll communicate this discrepancy and lobby for its definition and inclusion in the official CF Standard Name Table.

I'm also not 100% sure whether the derived coordinate _standard_name_ of **sea_surface_height_above_reference_ellipsoid** is appropriate. Confirmation welcomed.

This PR has been replaced by #1105.
