### PR TITLE
Resolved pickling issues with deferred loading.

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -63,6 +63,7 @@ class LazyArray(object):
     def _cached_array(self):
         if self._array is None:
             self._array = self._func()
+            del self._func
         return self._array
 
     def reshape(self, *args, **kwargs):

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -213,6 +213,13 @@ class NetCDFDataProxy(object):
         return '%s(%r, %r)' % (self.__class__.__name__, self.path,
                                self.variable_name)
 
+    def __getstate__(self):
+        return {attr: getattr(self, attr) for attr in self.__slots__}
+
+    def __setstate__(self, state):
+        for key, value in state.iteritems():
+            setattr(self, key, value)
+
     def load(self, data_shape, data_type, mdi, deferred_slice):
         """
         Load the corresponding proxy data item and perform any deferred

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -52,6 +52,20 @@ class TestPickle(tests.IrisTest):
             self.assertNotEqual(recon_cube._data_manager, None)
             self.assertEqual(cube._data_manager, recon_cube._data_manager)
             self.assertCML(recon_cube, ('cube_io', 'pickling', 'theta.cml'), checksum=False)
+
+    @iris.tests.skip_data
+    def test_cube_with_deferred_coord_points(self):
+        # Data with 2d lats and lons that when loaded results in points that
+        # are LazyArray objects.
+        filename = tests.get_data_path(('NetCDF',
+                                        'rotated',
+                                        'xy',
+                                        'rotPole_landAreaFraction.nc'))
+        cube = iris.load_cube(filename)
+        # Pickle and unpickle. Do not perform any CML tests
+        # to avoid side effects.
+        _, recon_cube = next(self.pickle_then_unpickle(cube))
+        self.assertEqual(recon_cube, cube)
 
     @iris.tests.skip_data                    
     def test_cubelist_pickle(self):


### PR DESCRIPTION
When attempting to pickle a cube with 2d lats and lons loaded from netcdf I get a PicklingError:

``` python

import pickle

import iris
import iris.tests as tests


filename = tests.get_data_path(('NetCDF',
                                'rotated',
                                'xy',
                                'rotPole_landAreaFraction.nc'))
cube = iris.load_cube(filename)
with open('bob.pkl', 'wb') as fileout:
    pickle.dump(cube,fileout)
```

Leads to:
`pickle.PicklingError: Can't pickle <function <lambda> at 0x10e858578>: it's not found as iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc.<lambda>`

This is because the 2d auxiliary coords are loaded using LazyArrays which do not dispose of a reference to a function object after loading the points. Having fixed this I then hit:
`TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled`
due to an issue with the NetCDFProxy class.

This PR fixes these issues and allows me to pickle and unpickle this cube.
