### PR TITLE
Missing import

### DIFF
--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -21,6 +21,7 @@ Definitions of coordinate systems.
 
 from __future__ import division
 from abc import ABCMeta, abstractmethod
+import warnings
 
 import cartopy.crs
 


### PR DESCRIPTION
The following lines need the `warnings` module.
https://github.com/SciTools/iris/blob/master/lib/iris/coord_systems.py#L385-389

This PR adds the missing import.
