### PR TITLE
Fixed PEP8 issues in netcdf.py

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -129,7 +129,7 @@ class CFNameCoordMap(object):
     def name(self, coord):
         """
         Return the CF name, given a coordinate
-        
+
         Args:
 
         * coord:
@@ -578,7 +578,8 @@ class Saver(object):
                 self._dataset.createDimension(dimension_names[0], None)
         for dim_name in dimension_names[1:]:
             if dim_name not in self._dataset.dimensions:
-                self._dataset.createDimension(dim_name, self._existing_dim[dim_name])
+                self._dataset.createDimension(dim_name,
+                                              self._existing_dim[dim_name])
 
     def _add_aux_coords(self, cube, cf_var_cube, dimension_names,
                         factory_defn):
@@ -692,7 +693,8 @@ class Saver(object):
                     dimension_names.append(dim_name)
                     self._dim_coords.append(coord)
                 else:
-                    # Return the dim_name associated with the existing coordinate
+                    # Return the dim_name associated with the existing
+                    # coordinate.
                     dim_name = self._name_coord_map.name(coord)
                     dimension_names.append(dim_name)
 

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -89,7 +89,6 @@ class StandardReportWithExclusions(pep8.StandardReport):
         '*/iris/fileformats/grib_save_rules.py',
         '*/iris/fileformats/manager.py',
         '*/iris/fileformats/mosig_cf_map.py',
-        '*/iris/fileformats/netcdf.py',
         '*/iris/fileformats/pp.py',
         '*/iris/fileformats/rules.py',
         '*/iris/fileformats/um_cf_map.py',


### PR DESCRIPTION
This PR fixes a few PEP8 issues that slipped into netcdf.py recently and removes it from the PEP8 exclusion list.
