### PR TITLE
BF - handle missing values from grib messages

### DIFF
--- a/lib/iris/fileformats/grib_save_rules.py
+++ b/lib/iris/fileformats/grib_save_rules.py
@@ -454,6 +454,7 @@ def data(cube, grib):
 
     # mdi
     if isinstance(cube.data, ma.core.MaskedArray):
+        gribapi.grib_set(grib, "bitmapPresent", 1)
         gribapi.grib_set_double(grib, "missingValue", float(cube.data.fill_value))
         data = cube.data.filled()
     else:
@@ -475,4 +476,3 @@ def run(cube, grib):
     grid_template(cube, grib)
     product_template(cube, grib)
     data(cube, grib)
-    

--- a/lib/iris/tests/results/grib_load/missing_values_grib2.cml
+++ b/lib/iris/tests/results/grib_load/missing_values_grib2.cml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="x_wind" units="m s-1">
+    <coords>
+      <coord>
+        <dimCoord id="73141289" points="[0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="a42bcac2" points="[90.0, 87.5, 85.0, 82.5, 80.0, 77.5, 75.0, 72.5,
+		70.0, 67.5, 65.0, 62.5, 60.0, 57.5, 55.0, 52.5,
+		50.0, 47.5, 45.0, 42.5, 40.0, 37.5, 35.0, 32.5,
+		30.0, 27.5, 25.0, 22.5, 20.0, 17.5, 15.0, 12.5,
+		10.0, 7.5, 5.0, 2.5, 0.0, -2.5, -5.0, -7.5,
+		-10.0, -12.5, -15.0, -17.5, -20.0, -22.5, -25.0,
+		-27.5, -30.0, -32.5, -35.0, -37.5, -40.0, -42.5,
+		-45.0, -47.5, -50.0, -52.5, -55.0, -57.5, -60.0,
+		-62.5, -65.0, -67.5, -70.0, -72.5, -75.0, -77.5,
+		-80.0, -82.5, -85.0, -87.5, -90.0]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="63128986" points="[0.0, 2.5, 5.0, ..., 352.5, 355.0, 357.5]" shape="(144,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <auxCoord id="64f42873" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[380304.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="0x6b19167f" dtype="float64" mask_checksum="-0x646a97b2" mask_order="C" order="C" shape="(73, 144)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -195,6 +195,13 @@ class TestGribLoad(tests.GraphicsTest):
         cubes = iris.load(tests.get_data_path(('GRIB', "3_layer_viz", "3_layer.grib2")))
         cubes = iris.cube.CubeList([cubes[1], cubes[0], cubes[2]])
         self.assertCML(cubes, ("grib_load", "3_layer.cml"))
+
+    def test_load_masked(self):
+
+        gribfile = tests.get_data_path(
+            ('GRIB', 'missing_values', 'missing_values.grib2'))
+        cubes = iris.load(gribfile)
+        self.assertCML(cubes, ('grib_load', 'missing_values_grib2.cml'))
         
     def test_y_fastest(self):
         cubes = iris.load(tests.get_data_path(("GRIB", "y_fastest", "y_fast.grib2")))

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -68,7 +68,8 @@ class Test_data(tests.IrisTest):
     
     @mock.patch.object(gribapi, "grib_set_double_array")
     @mock.patch.object(gribapi, "grib_set_double")
-    def test_masked_array(self, mock_set_double, grib_set_double_array):
+    @mock.patch.object(gribapi, "grib_set")
+    def test_masked_array(self, mock_set, mock_set_double, grib_set_double_array):
         grib = None
         cube = iris.cube.Cube(ma.MaskedArray([1,2,3,4,5], fill_value=54321)) 
 


### PR DESCRIPTION
This PR implements missing value handling for data read from GRIB messages.

There has already been some discussion in #516 regarding the specifics. I decided to implement this in a way that means only messages that contain missing values will be stored in masked arrays, messages that don't will be stored in numpy arrays as previously.

The additional test requires a new data file in [this PR](https://github.com/SciTools/iris-test-data/issues/6).
