### PR TITLE
Moved to SHA for iris-test-data until we tag the next release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - export CARTOPY_REF="v0.7.0"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF="v1.2"
+  - export IRIS_TEST_DATA_REF="cdcf6dcf4f94be17761b7f951d8d5004f17f59fd"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="v1.0"


### PR DESCRIPTION
PR #520 requires a new file (as stated in the PR description) but its .travis.yml points to a tag of iris-test-data that does not have the file. The PR was merged so the tests on travis are now failing.

This PR changes .travis.yml to get the tests passing again. We'll change back to a tag when we've created one. We could do it now, but there are a few files waiting to go in.
