### PR TITLE
Added support for checking coding standards of docs

### DIFF
--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -55,8 +55,7 @@ LICENSE_RE = re.compile(LICENSE_RE_PATTERN, re.MULTILINE)
 #; A guess at the repo directory of Iris.
 REPO_DIR = os.path.dirname(os.path.dirname(os.path.dirname(iris.__file__)))
 DOCS_DIR = os.path.join(REPO_DIR, 'docs')
-# Problem files in build occur under html and build dir not cleared
-# by make clean command.
+# Problem files in build occur under html directory
 DOCS_BUILD_DIR = os.path.join(DOCS_DIR, 'iris', 'build', 'html')
 
 


### PR DESCRIPTION
This is an extension of the work covered in Issue #476, which covered a test of coding standards within Iris. This extension allows Python files within the Iris docs to also be tested.

As docs are not a required part of Iris this extension includes a check to determine whether they are installed or not and sets a flag dependent on the outcome of that check that is referred to later in the test. As many of the docs' Python files are currently not coded to pep8 standards a majority of the changes here adds a second list of files to be skipped by the test, as in the first PR.
