### PR TITLE
BF - preserve masked arrays during aggregation

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2403,10 +2403,14 @@ class Cube(CFVariableMixin):
             result = aggregator.aggregate(groupby_sub_cube.data,
                                           axis=dimension_to_groupby,
                                           **kwargs)
+
             # Determine aggregation result data type for the aggregate-by cube
             # data on first pass.
             if i == 0:
-                aggregateby_data = np.zeros(data_shape, dtype=result.dtype)
+                if isinstance(self.data, ma.MaskedArray):
+                    aggregateby_data = ma.zeros(data_shape, dtype=result.dtype)
+                else:
+                    aggregateby_data = np.zeros(data_shape, dtype=result.dtype)
 
             aggregateby_data[tuple(cube_slice)] = result
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -292,6 +292,16 @@ class IrisTest(unittest.TestCase):
     def assertArrayAlmostEqual(self, a, b):
         np.testing.assert_array_almost_equal(a, b)
 
+    def assertMaskedArrayAlmostEqual(self, a, b):
+        """
+        Check that masked arrays are almost equal. This requires the
+        masks to be identical, and the unmasked values to be almost
+        equal.
+
+        """
+        np.testing.assert_array_equal(a.mask, b.mask)
+        np.testing.assert_array_almost_equal(a, b)
+
     def assertArrayAllClose(self, a, b, rtol=1.0e-7, atol=0.0, **kwargs):
         """
         Check arrays are equal, within given relative + absolute tolerances.

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="temperature" units="kelvin">
+    <attributes>
+      <attribute name="history" value="Mean of temperature aggregated over height, level"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="c7be93c8" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="a42bcac2" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="b5d835ec" long_name="level" points="[1, 3, 3, 5, 7, 7, 9, 11, 11]" shape="(9,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="63128986" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+        <coord name="level"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float64" mask_order="C" order="C" shape="(9, 3, 3)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="temperature" units="kelvin">
+    <attributes>
+      <attribute name="history" value="Mean of temperature aggregated over height"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="c7be93c8" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="a42bcac2" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="63128986" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float64" mask_order="C" order="C" shape="(8, 3, 3)" state="loaded"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
During aggregation masked arrays were being converted to numpy arrays. This simple PR prevents this undesirable behaviour by checking the type of the input before constructing the output array.
