### PR TITLE
Specified depth of zero for travis ci clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ language: python
 python:
   - 2.7
 
+git:
+  depth: 0
 
 install:
 


### PR DESCRIPTION
The default depth of the travis CI clone is 50 i.e.

```
git clone --depth=50 --branch=master git://github.com/SciTools/iris.git SciTools/iris
```

This appears to muddle the contents of `git whatchanged` so it appears that changes to files are more recent than they actually are causing the licence check to fail.

This is an educated guess and this PR may fix it. Let's see...
