### PR TITLE
PP save default gridded polar axis.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1048,23 +1048,33 @@ class Cube(CFVariableMixin):
 
         return coords[0]
 
-    def coord_system(self, spec):
-        """Return the CoordSystem of the given type - or None.
+    def coord_system(self, spec=None):
+        """
+        Find the coordinate system of the given type.
 
-        Args:
+        If no target coordinate system is provided then find
+        any available coordinate system.
 
-        * spec
-            The the name or type of a CoordSystem subclass. E.g. ::
+        Kwargs:
+
+        * spec:
+            The the name or type of a coordinate system subclass.
+            E.g. ::
 
                 cube.coord_system("GeogCS")
                 cube.coord_system(iris.coord_systems.GeogCS)
 
-        If spec is provided as a type it can be a superclass of any
-        CoordSystems found.
+            If spec is provided as a type it can be a superclass of
+            any coordinate system found.
+
+            If spec is None, then find any available coordinate
+            systems within the :class:`iris.cube.Cube`.
+
+        Returns:
+            The :class:`iris.coord_systems.CoordSystem` or None.
 
         """
-        # Was a string or a type provided?
-        if isinstance(spec, basestring):
+        if isinstance(spec, basestring) or spec is None:
             spec_name = spec
         else:
             msg = "type %s is not a subclass of CoordSystem" % spec
@@ -1077,7 +1087,15 @@ class Cube(CFVariableMixin):
             if coord.coord_system:
                 coord_systems.add(coord.coord_system, replace=True)
 
-        return coord_systems.get(spec_name)
+        result = None
+        if spec_name is None:
+            for key in sorted(coord_systems.keys()):
+                result = coord_systems[key]
+                break
+        else:
+            result = coord_systems.get(spec_name)
+
+        return result
 
     @property
     def cell_methods(self):
@@ -2606,7 +2624,7 @@ class ClassDict(object, UserDict.DictMixin):
         if not isinstance(object_, self._superclass):
             msg = "Only subclasses of {!r} are allowed as values.".format(
                 self._superclass.__name__)
-            raise TypeError()
+            raise TypeError(msg)
         # Find all the superclasses of the given object, starting with the
         # object's class.
         superclasses = type.mro(type(object_))

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,7 +25,7 @@ THEN
     pp.lbproc = 0                # Processing. Start at 0.
 
 IF
-    cm.coord_system("GeogCS") is not None
+    cm.coord_system("GeogCS") is not None or cm.coord_system(None) is None
 THEN
     pp.bplat = 90
     pp.bplon = 0

--- a/lib/iris/tests/results/cube_to_pp/default_coord_system.txt
+++ b/lib/iris/tests/results/cube_to_pp/default_coord_system.txt
@@ -1,0 +1,57 @@
+[PP Field
+   lbyr: 0
+   lbmon: 0
+   lbdat: 0
+   lbhr: 0
+   lbmin: 0
+   lbsec: 0
+   lbyrd: 0
+   lbmond: 0
+   lbdatd: 0
+   lbhrd: 0
+   lbmind: 0
+   lbsecd: 0
+   lbtim: 0
+   lbft: 0
+   lblrec: 12
+   lbcode: 1
+   lbhem: 3
+   lbrow: 3
+   lbnpt: 4
+   lbext: 0
+   lbpack: 0
+   lbrel: 3
+   lbfc: 0
+   lbcfc: 0
+   lbproc: 0
+   lbvc: 0
+   lbrvc: 0
+   lbexp: 0
+   lbegin: 0
+   lbnrec: 0
+   lbproj: 0
+   lbtyp: 0
+   lblev: 0
+   lbrsvd: (0, 0, 0, 0)
+   lbsrce: 0
+   lbuser: (2, 0, 0, 0, 0, 0, 0)
+   brsvd: (0.0, 0.0, 0.0, 0.0)
+   bdatum: 0.0
+   bacc: 0.0
+   blev: 0.0
+   brlev: 0.0
+   bhlev: 0.0
+   bhrlev: 0.0
+   bplat: 90.0
+   bplon: 0.0
+   bgor: 0.0
+   bzy: -2.0
+   bdy: 1.0
+   bzx: -2.0
+   bdx: 1.0
+   bmdi: -1e+30
+   bmks: 1.0
+   data: [[ 0  1  2  3]
+ [ 4  5  6  7]
+ [ 8  9 10 11]]
+]

--- a/lib/iris/tests/results/cube_to_pp/depth.time.pp.txt
+++ b/lib/iris/tests/results/cube_to_pp/depth.time.pp.txt
@@ -42,7 +42,7 @@
    brlev: 0.0
    bhlev: 0.0
    bhrlev: 0.0
-   bplat: 0.0
+   bplat: 90.0
    bplon: 0.0
    bgor: 0.0
    bzy: 0.0

--- a/lib/iris/tests/results/cube_to_pp/pressure.time.pp.txt
+++ b/lib/iris/tests/results/cube_to_pp/pressure.time.pp.txt
@@ -42,7 +42,7 @@
    brlev: 0.0
    bhlev: 0.0
    bhrlev: 0.0
-   bplat: 0.0
+   bplat: 90.0
    bplon: 0.0
    bgor: 0.0
    bzy: 0.0

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ import iris.tests as tests
 import logging
 
 import iris.coords
+import iris.tests.stock
 import iris.unit
 
 from iris.coord_systems import *
@@ -38,6 +39,38 @@ def osgb():
                               scale_factor_at_central_meridian=0.9996012717,
                               ellipsoid=GeogCS(6377563.396, 6356256.909))
 
+
+class TestCoordSystemLookup(tests.IrisTest):
+    def setUp(self):
+        self.cube = iris.tests.stock.lat_lon_cube()
+
+    def test_hit_name(self):
+        self.assertIsInstance(self.cube.coord_system('GeogCS'),
+                              GeogCS)
+
+    def test_hit_type(self):
+        self.assertIsInstance(self.cube.coord_system(GeogCS),
+                              GeogCS)
+
+    def test_miss(self):
+        self.assertIsNone(self.cube.coord_system(RotatedGeogCS))
+
+    def test_empty(self):
+        self.assertIsInstance(self.cube.coord_system(GeogCS),
+                              GeogCS)
+        self.assertIsNotNone(self.cube.coord_system(None))
+        self.assertIsInstance(self.cube.coord_system(None),
+                              GeogCS)
+        self.assertIsNotNone(self.cube.coord_system())
+        self.assertIsInstance(self.cube.coord_system(),
+                              GeogCS)
+
+        for coord in self.cube.coords():
+            coord.coord_system = None
+
+        self.assertIsNone(self.cube.coord_system(GeogCS))
+        self.assertIsNone(self.cube.coord_system(None))
+        self.assertIsNone(self.cube.coord_system())
 
 
 class TestCoordSystemSame(tests.IrisTest):


### PR DESCRIPTION
This PR defaults the polar axis to the North Pole, when a cube with no coordinate system is saved to the PP file-format.

This ensures that when the saved PP file is reloaded back into Iris, the resultant cube has a `GeogCS` coordinate system, and not a `RotatedGeogCS` caused by the `bplat` and `bplon` fields not been written to by the PP saver and defaulting to a value of zero.
