### PR TITLE
Add ability to pass data dimensions for slicing cube

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Features added
 * `iris.analysis.SUM` is now a weighted aggregator, allowing it to take a
   weights keyword argument.
 * Grib2 translations added for standard_name 'soil_temperature'.
+* Method `iris.cube.Cube.slices` can now handle passing dimension index as well
+  as the currently supported types (string, coordinate), in order to slice in
+  cases where there is no coordinate associated with a dimension.
 
 Bugs fixed
 ----------

--- a/docs/iris/src/whatsnew/1.5.rst
+++ b/docs/iris/src/whatsnew/1.5.rst
@@ -20,6 +20,9 @@ A summary of the main features added with version 1.5:
 * class:`iris.analysis.SUM` is now a weighted aggregator, allowing it to take a
   weights keyword argument.
 * Grib2 translations added for standard_name 'soil_temperature'.
+* Method `iris.cube.Cube.slices` can now handle passing dimension index as well
+  as the currently supported types (string, coordinate), in order to slice in
+  cases where there is no coordinate associated with a dimension.
 
 Bugs fixed
 ----------

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -546,6 +546,7 @@ class TestIteration(TestCube2d):
         for subcube in subcubes:
             self.assertEqual(subcube.shape, self.t.shape[1:])
 
+
 class Test2dSlicing(TestCube2d):
     def test_cube_slice_all_dimensions(self):
         for cube in self.t.slices(['dim1', 'dim2']):
@@ -554,20 +555,73 @@ class Test2dSlicing(TestCube2d):
     def test_cube_slice_with_transpose(self):
         for cube in self.t.slices(['dim2', 'dim1']):
             self.assertCML(cube, ('cube_slice', '2d_transposed.cml'))
+
+    def test_cube_slice_without_transpose(self):
+        for cube in self.t.slices(['dim2', 'dim1'], ordered=False):
+            self.assertCML(cube, ('cube_slice', '2d_orig.cml'))
             
     def test_cube_slice_1dimension(self):
+        # Result came from the equivalent test test_cube_indexing_1d which
+        # does self.t[0, 0:]
         slices = [res for res in self.t.slices(['dim2'])]
-        # Result came from the equivalent test test_cube_indexing_1d which does self.t[0, 0:]
         self.assertCML(slices[0], ('cube_slice', '2d_to_1d_cube_slice.cml'))
     
     def test_cube_slice_zero_len_slice(self):
         self.assertRaises(IndexError, self.t.__getitem__, (slice(0, 0)))
     
     def test_cube_slice_with_non_existant_coords(self):
-        self.assertRaises(iris.exceptions.CoordinateNotFoundError, self.t.slices, ['dim2', 'dim1', 'doesnt exist'])
-        
+        with self.assertRaises(iris.exceptions.CoordinateNotFoundError):
+            self.t.slices(['dim2', 'dim1', 'doesnt exist'])
+
     def test_cube_extract_coord_with_non_describing_coordinates(self):
-        self.assertRaises(ValueError, self.t.slices, ['an_other'])
+        with self.assertRaises(ValueError):
+            self.t.slices(['an_other'])
+
+
+class Test2dSlicing_ByDim(TestCube2d):
+    def test_cube_slice_all_dimensions(self):
+        for cube in self.t.slices([0, 1]):
+            self.assertCML(cube, ('cube_slice', '2d_orig.cml'))
+            
+    def test_cube_slice_with_transpose(self):
+        for cube in self.t.slices([1, 0]):
+            self.assertCML(cube, ('cube_slice', '2d_transposed.cml'))
+
+    def test_cube_slice_without_transpose(self):
+        for cube in self.t.slices([1, 0], ordered=False):
+            self.assertCML(cube, ('cube_slice', '2d_orig.cml'))
+            
+    def test_cube_slice_1dimension(self):
+        # Result came from the equivalent test test_cube_indexing_1d which
+        # does self.t[0, 0:]
+        slices = [res for res in self.t.slices([1])]
+        self.assertCML(slices[0], ('cube_slice', '2d_to_1d_cube_slice.cml'))
+
+    def test_cube_slice_nodimension(self):
+        slices = [res for res in self.t.slices([])]
+        self.assertCML(slices[0], ('cube_slice', '2d_to_0d_cube_slice.cml'))
+    
+    def test_cube_slice_with_non_existant_dims(self):
+        with self.assertRaises(IndexError):
+            self.t.slices([1, 0, 2])
+
+    def test_cube_slice_duplicate_dimensions(self):
+        with self.assertRaises(ValueError):
+            self.t.slices([1, 1])
+
+
+class Test2dSlicing_ByMix(TestCube2d):
+    def test_cube_slice_all_dimensions(self):
+        for cube in self.t.slices([0, 'dim2']):
+            self.assertCML(cube, ('cube_slice', '2d_orig.cml'))
+            
+    def test_cube_slice_with_transpose(self):
+        for cube in self.t.slices(['dim2', 0]):
+            self.assertCML(cube, ('cube_slice', '2d_transposed.cml'))
+
+    def test_cube_slice_with_non_existant_dims(self):
+        with self.assertRaises(ValueError):
+            self.t.slices([1, 0, 'an_other'])
 
 
 class Test2dExtraction(TestCube2d):


### PR DESCRIPTION
This PR is a result of a support request, making it easier to slice a cube when there are missing dimension coordinates.  This situation currently makes slicing the cube more difficult.

(internal ref: WO49150)
