### PR TITLE
Fix to prevent unnecessary rebuild of pyke rules.

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -189,7 +189,7 @@ def _pyke_kb_engine():
             rule_age = os.path.getmtime(
                 os.path.join(pyke_dir, _PYKE_RULE_BASE + '.krb'))
 
-            if oldest_pyke_compile_file > rule_age:
+            if oldest_pyke_compile_file >= rule_age:
                 # Initialise the pyke inference engine.
                 engine = knowledge_engine.engine(
                     (None, 'iris.fileformats._pyke_rules.compiled_krb'))


### PR DESCRIPTION
If I `sudo python setup.py install` Iris the resulting compiled pyke rules (`compiled_krb/*`) and the source (`fc_rules_cf.krb`) that are copied into the install location end up having the same modification date. The result is that when a user attempts to load a netcdf file the rules are compiled again. This fails due to permission issues.

This PR fixes this problem by changing the criteria for regeneration from 'greater than' to 'greater than or equal to'.
