### PR TITLE
added packaged grib support

### DIFF
--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -71,6 +71,12 @@ FORMAT_AGENT.add_spec(FormatSpec('GRIB',
                                  priority=5))
 
 
+FORMAT_AGENT.add_spec(FormatSpec('WMO GRIB Bulletin',
+                                 fp.MAGIC_NUMBER_32_BIT_WMO_BULLETIN,
+                                 0x47524942,
+                                 grib.load_cubes,
+                                 priority=3))
+
 #
 # netCDF files.
 #

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -253,23 +253,28 @@ class FileElement(object):
         return 'FileElement(%r, %r)' % (self._name, self._element_getter_fn)
 
 
-def _read_n(fh, fmt, n):
+def _read_n(fh, fmt, n, offset=None):
+    if offset is not None:
+        fh.seek(offset)
     bytes_read = fh.read(n)
     if len(bytes_read) != n:
         raise EOFError(fh.name)
     return struct.unpack(fmt, bytes_read)[0]
 
 
-MAGIC_NUMBER_32_BIT = FileElement('32-bit magic number', lambda filename, fh: 
+MAGIC_NUMBER_32_BIT = FileElement('32-bit magic number', lambda filename, fh:
                                   _read_n(fh, '>L', 4))
-MAGIC_NUMBER_64_BIT = FileElement('64-bit magic number', lambda filename, fh: 
+
+WMO_BULLETIN_HEADER_LENGTH = 21
+MAGIC_NUMBER_32_BIT_WMO_BULLETIN = FileElement(
+    '32-bit magic number with byte offset', lambda filename,
+    fh: _read_n(fh, '>L', 4, WMO_BULLETIN_HEADER_LENGTH))
+
+MAGIC_NUMBER_64_BIT = FileElement('64-bit magic number', lambda filename, fh:
                                   _read_n(fh, '>Q', 8))
-
-
 FILE_EXTENSION = FileElement('File extension', lambda basename,
                              fh: os.path.splitext(basename)[1])
 LEADING_LINE = FileElement('Leading line', lambda filename, fh: fh.readline())
 URI_PROTOCOL = FileElement('URI protocol',
                            lambda uri, _: decode_uri(uri)[0],
                            requires_fh=False)
-

--- a/lib/iris/tests/results/file_load/known_loaders.txt
+++ b/lib/iris/tests/results/file_load/known_loaders.txt
@@ -7,6 +7,7 @@
  * NAME III (priority 5)
  * UM Fieldsfile (FF) post v5.2 (priority 4)
  * UM Post Processing file (PP) little-endian (priority 3)
+ * WMO GRIB Bulletin (priority 3)
  * UM Fieldsfile (FF) pre v3.1 (priority 3)
  * UM Fieldsfile (FF) ancillary (priority 3)
  * UM Fieldsfile (FF) converted with ieee to 32 bit (priority 3)

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -22,8 +22,10 @@ Test the io/__init__.py module.
 import iris.tests as tests
 
 import unittest
+from io import BytesIO
 
 import iris.fileformats as iff
+import iris.io.format_picker as fp
 import iris.io
 
 
@@ -92,6 +94,20 @@ class TestFileFormatPicker(tests.IrisTest):
             with open(test_path, 'r') as test_file:
                 a = iff.FORMAT_AGENT.get_spec(test_path, test_file)
                 self.assertEqual(a.name, expected_format_name)
+
+    def test_format_picker_nodata(self):
+        # The following is to replace the above at some point as no real files
+        # are required.
+        # (Used binascii.unhexlify() to convert from hex to binary)
+
+        # Packaged grib, magic number offset by set length, this length is
+        # specific to WMO bulletin headers
+        binary_string = fp.WMO_BULLETIN_HEADER_LENGTH * '\x00' + 'GRIB'
+        with BytesIO('rw') as bh:
+            bh.write(binary_string)
+            bh.name = 'fake_file_handle'
+            a = iff.FORMAT_AGENT.get_spec(bh.name, bh)
+        self.assertEqual(a.name, 'WMO GRIB Bulletin')
 
     def test_open_dap(self):
         # tests that *ANY* http or https URL is seen as an OPeNDAP service.


### PR DESCRIPTION
This is an enhancement to support packaged grib files.
Packaged grib files have extra header information, meaning that the signature (magic number) is offset by a specific number of bytes.

This PR adds support by recognising this type of "grib" file for which the grib api can handle.
closes #332

_internal ref: WO49559_
