### PR TITLE
fix travis ref to new sample data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ install:
 # cfchecker
   - ./.travis_no_output sudo /usr/bin/pip install cdat-lite
   - ./.travis_no_output sudo /usr/bin/pip install cfchecker
-  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml
+# Using table 23 due to a bug present in the current version
+  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/23/cf-standard-name-table.xml
+#  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml
   - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/area-type-table/current/area-type-table.xml
   - echo '#!/usr/bin/env sh' > cfchecker
   - echo "cfchecks -s `pwd`/cf-standard-name-table.xml -a `pwd`/area-type-table.xml -u /usr/share/xml/udunits/udunits2.xml \$1" >> cfchecker


### PR DESCRIPTION
Travis is currently pointing to the wrong sample data commit (tag),
which results in numerous doctest and extest failures.

Fix for bug introduced in #570
