### PR TITLE
removed workaround to multiple coordinates been present when plotting.

### DIFF
--- a/docs/iris/example_code/graphics/TEC.py
+++ b/docs/iris/example_code/graphics/TEC.py
@@ -30,11 +30,6 @@ def main():
     # Explicitly mask negative electron content.
     cube.data = ma.masked_less(cube.data, 0)
 
-    # Currently require to remove the multi-dimensional
-    # latitude and longitude coordinates for Iris plotting.
-    cube.remove_coord('latitude')
-    cube.remove_coord('longitude')
-
     # Plot the cube using one hundred colour levels.
     qplt.contourf(cube, 100)
     plt.title('Total Electron Content')


### PR DESCRIPTION
This pull request addresses _the second half of_ Iris issue #187.
The workaround to remove latitude and longitude coordinates has been fixed in the latest version of Iris. 
