### PR TITLE
Revert version-specific CF standard-names usage in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,7 @@ install:
 # cfchecker
   - ./.travis_no_output sudo /usr/bin/pip install cdat-lite
   - ./.travis_no_output sudo /usr/bin/pip install cfchecker
-# Using table 23 due to a bug present in the current version
-  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/23/cf-standard-name-table.xml
-#  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml
+  - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml
   - ./.travis_no_output wget http://cf-pcmdi.llnl.gov/documents/cf-standard-names/area-type-table/current/area-type-table.xml
   - echo '#!/usr/bin/env sh' > cfchecker
   - echo "cfchecks -s `pwd`/cf-standard-name-table.xml -a `pwd`/area-type-table.xml -u /usr/share/xml/udunits/udunits2.xml \$1" >> cfchecker


### PR DESCRIPTION
Just reverts https://github.com/cpelley/iris/commit/b4dafb5538ee1f9b3c3d88bd5e1cc6b0c110b7d6,
which was included in https://github.com/SciTools/iris/pull/586

We suspect that the published CF "latest" version has now been fixed 
 -- Since my PR https://github.com/SciTools/iris/pull/589 yesterday checked out ok, it seems that version 24, published 2013-06-28, may have been "quietly" changed since, without assigning a new revision number

So, if **this** PR checks out, it should be okay to merge.
