### PR TITLE
Add show to quickplot. Closes #607.

### DIFF
--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -233,3 +233,7 @@ def plot(*args, **kwargs):
     result = iplt.plot(*args, **kwargs)
     _label_1d_plot(*args)
     return result
+
+
+# Provide a convenience show method from pyplot.
+show = plt.show


### PR DESCRIPTION
Adds a convenience show method to `iris.quickplot`. This prevents quickplot users from having to import another module to display their plot.
