### PR TITLE
BUG: creating coordinate from another crs copy

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -21,8 +21,8 @@ Definitions of coordinates.
 from __future__ import division
 
 from abc import ABCMeta, abstractproperty
-from copy import deepcopy
 import collections
+import copy
 from itertools import chain, izip_longest
 import operator
 import warnings
@@ -413,7 +413,7 @@ class Coord(CFVariableMixin):
             raise ValueError('If bounds are specified, points must also be '
                              'specified')
 
-        new_coord = deepcopy(self)
+        new_coord = copy.deepcopy(self)
         if points is not None:
             # Explicitly not using the points property as we don't want the
             # shape the new points to be constrained by the shape of
@@ -1176,7 +1176,7 @@ class DimCoord(Coord):
                         long_name=coord.long_name, var_name=coord.var_name,
                         units=coord.units, bounds=coord.bounds,
                         attributes=coord.attributes,
-                        coord_system=coord.coord_system,
+                        coord_system=copy.deepcopy(coord.coord_system),
                         circular=getattr(coord, 'circular', False))
 
     def __init__(self, points, standard_name=None, long_name=None,
@@ -1317,7 +1317,7 @@ class AuxCoord(Coord):
                              var_name=coord.var_name,
                              units=coord.units, bounds=coord.bounds,
                              attributes=coord.attributes,
-                             coord_system=coord.coord_system)
+                             coord_system=copy.deepcopy(coord.coord_system))
 
         return new_coord
 

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -311,6 +311,14 @@ class TestAuxCoordCreation(unittest.TestCase):
         b = iris.coords.AuxCoord(['Jan', 'Feb', 'March'], units='no_unit')
         c = iris.coords.AuxCoord(['Jan', 'Feb', 'March'], units='no_unit')
         self.assertEqual(b, c)
+
+    def test_AuxCoord_fromcoord(self):
+        # Check the coordinate returned by `from_coord` doesn't reference the
+        # same coordinate system as the source coordinate.
+        crs = iris.coord_systems.GeogCS(6370000)
+        a = iris.coords.DimCoord(10, coord_system=crs)
+        b = iris.coords.AuxCoord.from_coord(a)
+        self.assertIsNot(a.coord_system, b.coord_system)
   
   
 class TestDimCoordCreation(unittest.TestCase):
@@ -377,6 +385,14 @@ class TestDimCoordCreation(unittest.TestCase):
         b = iris.coords.AuxCoord.from_coord(a)
         # Note - circular attribute is not a factor in equality comparison
         self.assertEqual(a, b)
+
+    def test_DimCoord_fromcoord(self):
+        # Check the coordinate returned by `from_coord` doesn't reference the
+        # same coordinate system as the source coordinate.
+        crs = iris.coord_systems.GeogCS(6370000)
+        a = iris.coords.AuxCoord(10, coord_system=crs)
+        b = iris.coords.DimCoord.from_coord(a)
+        self.assertIsNot(a.coord_system, b.coord_system)
 
 
 class TestCoordMaths(tests.IrisTest):


### PR DESCRIPTION
Currently, creating a coordinate from another using the coordinates
from_coord static method, passes the coordinate system through by
reference.
