### PR TITLE
Convert iris.analysis.SUM to a weighted aggregator.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Features added
   arguments, which may be cubes or coordinates, allowing the user to have full
   control over what is plotted on each axis. The coords keyword argument is now
   deprecated for these functions.
+* `iris.analysis.SUM` is now a weighted aggregator, allowing it to take a
+  weights keyword argument.
 
 Bugs fixed
 ----------

--- a/docs/iris/src/whatsnew/1.5.rst
+++ b/docs/iris/src/whatsnew/1.5.rst
@@ -15,6 +15,8 @@ A summary of the main features added with version 1.5:
   up to two arguments, which may be cubes or coordinates, allowing the user to
   have full control over what is plotted on each axis. The coords keyword argument
   is now deprecated for these functions.
+* class:`iris.analysis.SUM` is now a weighted aggregator, allowing it to take a
+  weights keyword argument.
 
 Bugs fixed
 ----------

--- a/lib/iris/tests/results/analysis/sum_weighted_1d.cml
+++ b/lib/iris/tests/results/analysis/sum_weighted_1d.cml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="thingness" units="1">
+    <attributes>
+      <attribute name="history" value="Sum of thingness over foo"/>
+    </attributes>
+    <coords>
+      <coord>
+        <dimCoord bounds="[[0, 11]]" id="549be28b" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="sum">
+        <coord name="foo"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float64" order="C" shape="(1,)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/sum_weighted_2d.cml
+++ b/lib/iris/tests/results/analysis/sum_weighted_2d.cml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="thingness" units="1">
+    <attributes>
+      <attribute name="history" value="Sum of thingness over bar"/>
+    </attributes>
+    <coords>
+      <coord>
+        <dimCoord bounds="[[0, 15]]" id="7c9a33bf" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-15, 0],
+		[0, 15],
+		[15, 30],
+		[30, 45]]" id="549be28b" long_name="foo" points="[-7.5, 7.5, 22.5, 37.5]" shape="(4,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="sum">
+        <coord name="bar"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float64" order="C" shape="(4,)" state="loaded"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
This PR converts `iris.analysis.SUM` to a weighted aggregator. The implementation is designed to be consistent with the only existing built-in weighted aggregator which is `iris.analysis.MEAN`.
