### PR TITLE
test_ff for 32 -bit arch

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -179,7 +179,7 @@ class FFHeader(object):
             Specify the name of the FIXED_LENGTH_HEADER attribute.
 
         Returns:
-            int.
+            A numpy.int64 containing the byte address.
 
         """
 

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -170,7 +170,7 @@ class TestFFHeader(tests.IrisTest):
 
     def test_address_coverage(self):
         for header in self.valid_headers + self.invalid_headers:
-            self.assertIsInstance(self.ff_header.address(header), int)
+            self.assertIsInstance(self.ff_header.address(header), np.int64)
         with self.assertRaises(AttributeError):
             self.ff_header.address('not_a_real_header')
 


### PR DESCRIPTION
This forces a test integer to 64-bit, even on a 32-bit machine.
