### PR TITLE
Global unit cache

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -670,6 +670,9 @@ def _Unit(category, ut_unit, calendar=None, origin=None):
     return unit
 
 
+_CACHE = {}
+
+
 def as_unit(unit):
     """
     Returns a Unit corresponding to the given unit.
@@ -679,9 +682,18 @@ def as_unit(unit):
         If the given unit is already a Unit it will be returned unchanged.
 
     """
-    if not isinstance(unit, Unit):
-        unit = Unit(unit)
-    return unit
+    if isinstance(unit, Unit):
+        result = unit
+    else:
+        result = None
+        use_cache = isinstance(unit, basestring) or unit is None
+        if use_cache:
+            result = _CACHE.get(unit)
+        if result is None:
+            result = Unit(unit)
+            if use_cache:
+                _CACHE[unit] = result
+    return result
 
 
 def is_time(unit):


### PR DESCRIPTION
Approx 10% performance boost doing `iris.load_cubes()` on a 17MB PP file containing 2048 fields. (Approx 2% boost running the test suite.)
