### PR TITLE
Added support for bool array indexing on a cube.

### DIFF
--- a/lib/iris/fileformats/manager.py
+++ b/lib/iris/fileformats/manager.py
@@ -121,7 +121,10 @@ class DataManager(iris.util._OrderedHashable):
                     count = len(range(start, stop, step))
                     resultant_shape.append(count)
                 elif isinstance(key, tuple):
-                    resultant_shape.append(len(key))
+                    if key and isinstance(key[0], (bool, np.bool_)):
+                        resultant_shape.append(sum(key))
+                    else:
+                        resultant_shape.append(len(key))
                 elif isinstance(key, int):
                     pass
                 else:
@@ -226,8 +229,12 @@ class DataManager(iris.util._OrderedHashable):
         
                     # Sample the merged slice item with the index item.
                     if isinstance(index_item, tuple):
+                        if index_item and isinstance(index_item[0], (bool, np.bool_)):
+                            index_item = np.where(index_item)[0]
+
                         # Sample for each tuple item.
-                        merged_slice[i] = tuple([merged_slice_item[index] for index in index_item])
+                        merged_slice[i] = tuple([merged_slice_item[index]
+                                                 for index in index_item])
                     else:
                         # Sample with a slice or single scalar index.
                         merged_slice[i] = merged_slice_item[index_item]

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -941,8 +941,7 @@ class TestDataManagerIndexing(TestCube2d):
     def check_consecutive(self, keys1, keys2):
         self._check_consecutive(keys1, keys2)
         self._check_consecutive(keys2, keys1)
-            
-    
+
     def check_indexing_error(self, keys):
         self.assertRaises(IndexError, self.dm.getitem, self.pa, keys)
         
@@ -1023,6 +1022,15 @@ class TestDataManagerIndexing(TestCube2d):
 
         self.assertRaises(IndexError, self.cube.__getitem__, ((0, 4, 5, 2), (3, 5, 5), 0, 0, 4) )
         self.assertRaises(IndexError, self.cube.__getitem__, (Ellipsis, Ellipsis, Ellipsis, Ellipsis, Ellipsis, Ellipsis) )
+
+    def test_fancy_indexing_bool_array(self):
+        cube = self.cube
+        cube.data = np.ma.masked_array(cube.data, mask=cube.data > 100000)
+        r = cube[:, cube.coord('grid_latitude').points > 1]
+        self.assertEqual(r.shape, (10, 218, 720))
+        data = cube.data[:, self.cube.coord('grid_latitude').points > 1, :]
+        np.testing.assert_array_equal(data, r.data)
+        np.testing.assert_array_equal(data.mask, r.data.mask)
 
 
 class TestCubeCollapsed(tests.IrisTest):


### PR DESCRIPTION
I was surprised to learn that the data manager didn't handle boolean arrays when indexing (obviously numpy does, so when the data is loaded, this type of indexing works).

With this change, you can now do:

```
import iris

fname = iris.sample_data_path('air_temp.pp')
temperature = iris.load_cube(fname)

temperature[temperature.coord('latitude').points > 0]
```

Which before would have needed the data to be loaded to function correctly.

**PLEASE NOTE**: Whilst adding this functionality is a good idea, the Constraints mechanism are still the prefered means to do such a query. My example would be written as `temperature.extract(iris.Constraint(latitude=lambda v: v>0)))` which does not rely on the latitude being the first dimension of the cube to extract.
