### PR TITLE
BUG: Fix pandas test for version update

### DIFF
--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -214,8 +214,9 @@ class TestAsDataFrame(tests.IrisTest):
         self.assertArrayEqual(data_frame, cube.data)
         nanoseconds_per_day = 24 * 60 * 60 * 1000000000
         days_to_2000 = 365 * 30 + 7
-        timestamps = [pandas.Timestamp(nanoseconds_per_day *
-                                       (days_to_2000 + day_offset))
+        # pandas Timestamp class cannot handle floats in pandas <v0.12
+        timestamps = [pandas.Timestamp(int(nanoseconds_per_day *
+                                       (days_to_2000 + day_offset)))
                       for day_offset in day_offsets]
         self.assertTrue(all(data_frame.columns == timestamps))
         self.assertTrue(all(data_frame.index == [0, 1]))


### PR DESCRIPTION
Iris pandas unit test currently fails due to a dtype mismatch between
what pandas Timestamp class can handle with v.11 compared to v.12  This
commit converts the input argument which instantiation this class
to an integer, which is commonly accepted by both versions of pandas.

Should now pass for v0.11 and v0.12 (latest) tested

Relates to the changes introduced in #648 

``` Python
======================================================================
ERROR: test_time_gregorian (iris.tests.test_pandas.TestAsDataFrame)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/h05/cpelley/git/iris/lib/iris/tests/test_pandas.py", line 219, in test_time_gregorian
    for day_offset in day_offsets]
  File "tslib.pyx", line 140, in pandas.tslib.Timestamp.__new__ (pandas/tslib.c:4955)

```
