### PR TITLE
Relax NetCDF longitude circularity criteria.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1015,7 +1015,8 @@ fc_extras
 
         # Determine whether the coordinate is circular.
         circular = False
-        if points_data.ndim == 1 and coord_name in [CF_VALUE_STD_NAME_LON, CF_VALUE_STD_NAME_GRID_LON]:
+        if points_data.ndim == 1 and (coord_name is None or
+                coord_name in [CF_VALUE_STD_NAME_LON, CF_VALUE_STD_NAME_GRID_LON]):
             diff = list(set(np.diff(points_data)))
             diff_approx_equal = True
             if len(points_data) > 1:

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -183,6 +183,17 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertCML(cube0, ('netcdf', 'netcdf_units_0.cml'))
         self.assertCML(cube1, ('netcdf', 'netcdf_units_1.cml'))
 
+    def test_circularity(self):
+        data_path = ('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')
+        cube = iris.load_cube(tests.get_data_path(data_path))
+        self.assertTrue(cube.coord('longitude').circular)
+
+        # Check for non-circular longitude.
+        with self.temp_filename(suffix='.nc') as filename:
+            iris.save(cube[..., :-1], filename)
+            non_circular = iris.load_cube(filename)
+            self.assertFalse(non_circular.coord('longitude').circular)
+
 
 class TestSave(tests.IrisTest):
     def test_hybrid(self):


### PR DESCRIPTION
The current criteria for detecting NetCDF longitude circularity is unnecessarily restrictive.

This PR relaxes the current requirement on the candidate coordinate name. This change allows a longitude coordinate that has been identified via the miscellaneous `fc_default_coordinate` PyKE rule (i.e. no `coord_name` is passed to the Python `build_dimension_coordinate` convenience function) to be correctly identified as circular in nature.

Interestingly enough, I did expect unittest failures due to this PR change ... but the CML does not capture the state of the `circular` flag for a `DimCoord`.

Whether we want to do this is another matter, and if we do, I suggest this is the action of a separate PR.

Requires to be rebased once PR https://github.com/SciTools/iris/pull/693 is accepted and merged to upstream/master.
