### PR TITLE
Updated docs to use latest what's new.

### DIFF
--- a/docs/iris/src/_templates/index.html
+++ b/docs/iris/src/_templates/index.html
@@ -74,7 +74,7 @@ With Iris you can:
 		<span class="linkdescr">a collection of images produced using Iris</span></p>
 	</li>
 	<li>
-		<p class="biglink"><a class="biglink" href="whatsnew/1.4.html">What's new in Iris 1.4?</a><br/>
+		<p class="biglink"><a class="biglink" href="whatsnew/1.5.html">What's new in Iris 1.5?</a><br/>
 		<span class="linkdescr">recent changes in Iris's capabilities</span></p>
 	</li>
 	</ul>

--- a/docs/iris/src/whatsnew/index.rst
+++ b/docs/iris/src/whatsnew/index.rst
@@ -4,6 +4,7 @@ What's new in Iris
 These "What's new" pages describe the important changes between major
 Iris versions.
 
+* :doc:`What's new in Iris 1.5 <1.5>`
 * :doc:`What's new in Iris 1.4 <1.4>`
 * :doc:`What's new in Iris 1.3 <1.3>`
 * :doc:`What's new in Iris 1.2 <1.2>`


### PR DESCRIPTION
This PR updates the front page of the docs to point at version 1.5 of what's new so one build the docs and easily view the rendered "What's new in Iris 1.5" page when modifying what's new for new PRs.
