### PR TITLE
Correct dim coord behaviour for aggregated by.

### DIFF
--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -223,7 +223,7 @@ These two coordinates can now be used to aggregate by season and climate-year:
     ...     ['clim_season', 'season_year'], 
     ...     iris.analysis.MEAN)
     >>> print repr(annual_seasonal_mean)
-    <iris 'Cube' of surface_temperature / (K) (*ANONYMOUS*: 19; latitude: 18; longitude: 432)>
+    <iris 'Cube' of surface_temperature / (K) (time: 19; latitude: 18; longitude: 432)>
     
 The primary change in the cube is that the cube's data has been 
 reduced in the 'time' dimension by aggregation (taking means, in this case). 
@@ -264,7 +264,7 @@ do not cover a three month period (note: judged here as > 3*28 days):
     >>> three_months_bound = iris.Constraint(time=spans_three_months)
     >>> full_season_means = annual_seasonal_mean.extract(three_months_bound)
     >>> full_season_means
-    <iris 'Cube' of surface_temperature / (K) (*ANONYMOUS*: 17; latitude: 18; longitude: 432)>
+    <iris 'Cube' of surface_temperature / (K) (time: 17; latitude: 18; longitude: 432)>
 
 The final result now represents the seasonal mean temperature for 17 seasons 
 from jja-2006 to jja-2010:

--- a/lib/iris/tests/results/analysis/aggregated_by/multi.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi.cml
@@ -21,6 +21,17 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="f2bf14cc" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -21,6 +21,17 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="f2bf14cc" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_shared.cml
@@ -41,6 +41,17 @@
 		[10, 11],
 		[12, 14],
 		[15, 15],
+		[16, 17]]" id="f2bf14cc" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
 		[16, 17]]" id="5f88ebd6" long_name="sigma" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>

--- a/lib/iris/tests/results/analysis/aggregated_by/single.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single.cml
@@ -18,6 +18,16 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="f2bf14cc" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">

--- a/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
@@ -18,6 +18,16 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="f2bf14cc" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">

--- a/lib/iris/tests/results/analysis/aggregated_by/single_rms.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_rms.cml
@@ -18,6 +18,16 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="f2bf14cc" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="root mean square">

--- a/lib/iris/tests/results/analysis/aggregated_by/single_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_shared.cml
@@ -19,6 +19,16 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="f2bf14cc" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
         <auxCoord bounds="[[0, 0],
 		[1, 2],
 		[3, 5],
@@ -26,7 +36,7 @@
 		[10, 14],
 		[15, 20],
 		[21, 27],
-		[28, 35]]" id="8b0ef2bd" long_name="model_level" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" units="Unit('1')" value_type="float64"/>
+		[28, 35]]" id="a2260f1f" long_name="wibble" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_shared_circular.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_shared_circular.cml
@@ -29,6 +29,16 @@
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="f2bf14cc" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -62,7 +62,11 @@ class TestAggregateBy(tests.IrisTest):
                                                    long_name='height',
                                                    units='m')
 
+        model_level = iris.coords.DimCoord(range(z_points.size),
+                                           standard_name='model_level_number')
+
         self.cube_single.add_aux_coord(self.coord_z_single, 0)
+        self.cube_single.add_dim_coord(model_level, 0)
         self.cube_single.add_dim_coord(coord_lon, 1)
         self.cube_single.add_dim_coord(coord_lat, 2)
 
@@ -89,8 +93,12 @@ class TestAggregateBy(tests.IrisTest):
                                                    long_name='level',
                                                    units='1')
 
+        model_level = iris.coords.DimCoord(range(z1_points.size),
+                                           standard_name='model_level_number')
+
         self.cube_multi.add_aux_coord(self.coord_z1_multi, 0)
         self.cube_multi.add_aux_coord(self.coord_z2_multi, 0)
+        self.cube_multi.add_dim_coord(model_level, 0)
         self.cube_multi.add_dim_coord(coord_lon.copy(), 1)
         self.cube_multi.add_dim_coord(coord_lat.copy(), 2)
 
@@ -184,7 +192,7 @@ class TestAggregateBy(tests.IrisTest):
 
     def test_single_shared(self):
         z2_points = np.arange(36, dtype=np.int32)
-        coord_z2 = iris.coords.AuxCoord(z2_points, long_name='model_level',
+        coord_z2 = iris.coords.AuxCoord(z2_points, long_name='wibble',
                                         units='1')
         self.cube_single.add_aux_coord(coord_z2, 0)
 


### PR DESCRIPTION
This PR ensures that a cube containing a CF dimension coordinate that is being aggregated over, results in an aggregated cube with the CF dimension coordinate maintained, if possible i.e. the aggregation operation can cause a `DimCoord` to be demoted to an `AuxCoord` due to the aggregation sampling applied.

Previously, the CF dimension coordinate once aggregated was **always** grouped as an auxiliary coordinate, regardless of whether it maintained its `DimCoord` status.
