### PR TITLE
Limit unit calendar argument

### DIFF
--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -60,6 +60,19 @@ class TestCreation(TestUnit):
         u = Unit('   meter   ')
         self.assertTrue(u.name, 'meter')
 
+    def test_calendar(self):
+        calendar = unit.CALENDAR_365_DAY
+        u = Unit('hours since 1970-01-01 00:00:00', calendar=calendar)
+        self.assertEqual(u.calendar, calendar)
+
+    def test_no_calendar(self):
+        u = Unit('hours since 1970-01-01 00:00:00')
+        self.assertEqual(u.calendar, unit.CALENDAR_GREGORIAN)
+
+    def test_unknown_calendar(self):
+        with self.assertRaises(ValueError):
+            u = Unit('hours since 1970-01-01 00:00:00', calendar='wibble')
+
 
 class TestModulus(TestUnit):
     #
@@ -682,7 +695,7 @@ class TestConvert(TestUnit):
         # Test converting from one reference time to another between different
         # calendars raises an error.
         u1 = Unit('seconds since 1978-09-01 00:00:00', calendar='360_day')
-        u2 = Unit('seconds since 1979-04-01 00:00:00', calendar='georgian')
+        u2 = Unit('seconds since 1979-04-01 00:00:00', calendar='gregorian')
         u1point = np.array([ 54432000.], dtype=np.float32)
         with self.assertRaises(ValueError):
             u1.convert(u1point, u2)

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -848,8 +848,11 @@ class Unit(iris.util._OrderedHashable):
             if _OP_SINCE in unit.lower():
                 if calendar is None:
                     calendar_ = CALENDAR_GREGORIAN
-                else:
+                elif calendar in CALENDARS:
                     calendar_ = calendar
+                else:
+                    raise ValueError('{!r} is an unsupported calendar.'.format(
+                                     calendar))
         self._init(category, ut_unit, calendar_, unit)
 
     def _raise_error(self, msg):


### PR DESCRIPTION
This PR fixes the bug mentioned in #666 and prevents silent errors through the creation of units with unsupported calendars.

I'd be interested in the performance impact this change has. Can you comment @pp-mo?
