### PR TITLE
Added support for loading regular gaussian grids from GRIB files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export CARTOPY_REF="fcec835d18fc5f6b6994b6f230e17dd3c6a4dc23"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF="cbf0c72955f3c5a4c52aa6389f30fba0f5329a02"
+  - export IRIS_TEST_DATA_REF="89bb2ce50e5f407614f097cd47927eac0bdcd50b"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="2f279384eab2dcdef1728331ce1b22c95f775437"

--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -56,6 +56,18 @@ def convert(grib):
         dim_coords_and_dims.append((DimCoord(grib._x_points, grib._x_coord_name, units='degrees', coord_system=grib._coord_system, circular=grib._x_circular), 0))
 
     if \
+            (grib.gridType=="regular_gg") and \
+            (grib.jPointsAreConsecutive == 0):
+        dim_coords_and_dims.append((DimCoord(grib._y_points, grib._y_coord_name, units='degrees', coord_system=grib._coord_system), 0))
+        dim_coords_and_dims.append((DimCoord(grib._x_points, grib._x_coord_name, units='degrees', coord_system=grib._coord_system, circular=grib._x_circular), 1))
+
+    if \
+            (grib.gridType=="regular_gg") and \
+            (grib.jPointsAreConsecutive == 1):
+        dim_coords_and_dims.append((DimCoord(grib._y_points, grib._y_coord_name, units='degrees', coord_system=grib._coord_system), 1))
+        dim_coords_and_dims.append((DimCoord(grib._x_points, grib._x_coord_name, units='degrees', coord_system=grib._coord_system, circular=grib._x_circular), 0))
+
+    if \
             (grib.gridType=="rotated_ll") and \
             (grib.jPointsAreConsecutive == 0):
         dim_coords_and_dims.append((DimCoord(grib._y_points, grib._y_coord_name, units='degrees', coord_system=grib._coord_system), 0))

--- a/lib/iris/tests/results/grib_load/regular_gg_grib1.cml
+++ b/lib/iris/tests/results/grib_load/regular_gg_grib1.cml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="x_wind" units="m s-1">
+    <coords>
+      <coord>
+        <dimCoord id="73141289" points="[0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="a42bcac2" points="[88.572168514, 86.7225309547, 84.861970292, ...,
+		-84.861970292, -86.7225309547, -88.572168514]" shape="(96,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord circular="True" id="63128986" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <auxCoord id="64f42873" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord>
+        <dimCoord id="8d07ce7a" long_name="pressure" points="[850]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[300240.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="-0x415d9176" dtype="float64" order="C" shape="(96, 192)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/grib_load/regular_gg_grib2.cml
+++ b/lib/iris/tests/results/grib_load/regular_gg_grib2.cml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="geopotential_height" units="m">
+    <coords>
+      <coord>
+        <dimCoord id="73141289" points="[69]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="a42bcac2" points="[88.572168514, 86.7225309547, 84.861970292, ...,
+		-84.861970292, -86.7225309547, -88.572168514]" shape="(96,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord circular="True" id="63128986" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <auxCoord id="64f42873" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord>
+        <dimCoord id="5b34144a" long_name="pressure" points="[52500.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[382389.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data byteorder="little" checksum="0x5750956d" dtype="float64" order="C" shape="(96, 192)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -375,6 +375,16 @@ class TestGribLoad(tests.GraphicsTest):
         plt.title("lambert grib2")
         self.check_graphic()
 
+    def test_regular_gg_grib1(self):
+        cube = iris.load_cube(tests.get_data_path(
+            ('GRIB', 'gaussian', 'regular_gg.grib1')))
+        self.assertCML(cube, ('grib_load', 'regular_gg_grib1.cml'))
+
+    def test_regular_gg_grib2(self):
+        cube = iris.load_cube(tests.get_data_path(
+            ('GRIB', 'gaussian', 'regular_gg.grib2')))
+        self.assertCML(cube, ('grib_load', 'regular_gg_grib2.cml'))
+
 
 class TestGribTimecodes(tests.GraphicsTest):
     def _run_timetests(self, test_set):


### PR DESCRIPTION
This PR adds the ability to load data defined on the `regular_gg` (regular gaussian) grid type from GRIB files. These changes only make it possible to load such data, saving back to grib2 format is somewhat non-trivial so I propose to leave it for a separate PR.

Related PRs:
SciTools/iris-code-generators#12
SciTools/iris-test-data#18

Remaining tasks:
- [x] update iris-test-data reference when SciTools/iris-test-data#18 is merged
- [x] rebase once #691 is merged (the iris-test-data reference will include new files that need #691 or tests will fail)
