### PR TITLE
BF - Correct Earth radius when saving GRIB2 files, fixes #690.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export CARTOPY_REF="fcec835d18fc5f6b6994b6f230e17dd3c6a4dc23"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF="07d756b2d9ad3bdd28d877dcc60cb2e45af1eb08"
+  - export IRIS_TEST_DATA_REF="cbf0c72955f3c5a4c52aa6389f30fba0f5329a02"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="2f279384eab2dcdef1728331ce1b22c95f775437"

--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,9 @@ Features added
 
 Bugs fixed
 ----------
-* N/A
+* Shape of the Earth scale factors are now correctly interpreted by the GRIB
+  loader. They were previously used as a multiplier for the given value but
+  should have been used as a decimal shift.
 
 Incompatible changes
 --------------------

--- a/docs/iris/src/whatsnew/1.5.rst
+++ b/docs/iris/src/whatsnew/1.5.rst
@@ -23,7 +23,9 @@ A summary of the main features added with version 1.5:
 
 Bugs fixed
 ----------
-* N/A
+* Shape of the Earth scale factors are now correctly interpreted by the GRIB
+  loader. They were previously used as a multiplier for the given value but
+  should have been used as a decimal shift.
 
 Incompatible changes
 --------------------

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -382,9 +382,9 @@ class GribWrapper(object):
             
         #custom sphere
         elif self.shapeOfTheEarth == 1:
-            geoid = \
-                coord_systems.GeogCS(self.scaledValueOfRadiusOfSphericalEarth * \
-                                     self.scaleFactorOfRadiusOfSphericalEarth)
+            geoid = coord_systems.GeogCS(
+                self.scaledValueOfRadiusOfSphericalEarth *
+                10 ** -self.scaleFactorOfRadiusOfSphericalEarth)
                     
         #IAU65 oblate sphere
         elif self.shapeOfTheEarth == 2:
@@ -393,8 +393,10 @@ class GribWrapper(object):
         #custom oblate spheroid (km)
         elif self.shapeOfTheEarth == 3:
             geoid = coord_systems.GeogCS(
-                semi_major_axis=self.scaledValueOfEarthMajorAxis * self.scaleFactorOfEarthMajorAxis * 1000.0,
-                semi_minor_axis=self.scaledValueOfEarthMinorAxis * self.scaleFactorOfEarthMinorAxis * 1000.0)
+                semi_major_axis=self.scaledValueOfEarthMajorAxis *
+                10 ** -self.scaleFactorOfEarthMajorAxis * 1000.,
+                semi_minor_axis=self.scaledValueOfEarthMinorAxis *
+                10 ** -self.scaleFactorOfEarthMinorAxis * 1000.)
             
         #IAG-GRS80 oblate spheroid
         elif self.shapeOfTheEarth == 4:
@@ -412,8 +414,10 @@ class GribWrapper(object):
         #custom oblate spheroid (m)
         elif self.shapeOfTheEarth == 7:
             geoid = coord_systems.GeogCS(
-                semi_major_axis=self.scaledValueOfEarthMajorAxis * self.scaleFactorOfEarthMajorAxis,
-                semi_minor_axis=self.scaledValueOfEarthMinorAxis * self.scaleFactorOfEarthMinorAxis)
+                semi_major_axis=self.scaledValueOfEarthMajorAxis *
+                10 ** -self.scaleFactorOfEarthMajorAxis,
+                semi_minor_axis=self.scaledValueOfEarthMinorAxis *
+                10 ** -self.scaleFactorOfEarthMinorAxis)
         
         elif self.shapeOfTheEarth == 8:
             raise ValueError("unhandled shape of earth : grib earth shape = 8")

--- a/lib/iris/tests/results/system/supported_filetype_.grib2.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.grib2.cml
@@ -6,7 +6,7 @@
         <dimCoord id="73141289" points="[9]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="22c278de" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+        <dimCoord id="a42bcac2" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
 		9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
 		17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0,
 		25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0,
@@ -14,11 +14,11 @@
 		41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0,
 		49.0, 50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0,
 		57.0, 58.0, 59.0]" shape="(60,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
-          <geogCS earth_radius="0.0"/>
+          <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="a03d4e5f" points="[30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
+        <dimCoord id="63128986" points="[30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
 		38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0,
 		46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 52.0, 53.0,
 		54.0, 55.0, 56.0, 57.0, 58.0, 59.0, 60.0, 61.0,
@@ -26,7 +26,7 @@
 		70.0, 71.0, 72.0, 73.0, 74.0, 75.0, 76.0, 77.0,
 		78.0, 79.0, 80.0, 81.0, 82.0, 83.0, 84.0, 85.0,
 		86.0, 87.0, 88.0, 89.0]" shape="(60,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
-          <geogCS earth_radius="0.0"/>
+          <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
       <coord>


### PR DESCRIPTION
This PR fixes a problem where the Earth's radius in the coordinate system was accidentally set to 0 when saving GRIB2 files. This turned out to be due to an issue when loading files where the scale factor was interpreted incorrectly.

To-do:
- [x] update test data reference when SciTools/iris-test-data#20 is merged
- [x] update change log and what's new when accepted in principle
