### PR TITLE
Fix netCDF4 python package at version 1.0.2 for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
   - ./.travis_no_output sudo apt-get install libgeos-dev libproj-dev
   - ./.travis_no_output sudo apt-get install libudunits2-dev libhdf5-serial-dev netcdf-bin libnetcdf-dev
   - ./.travis_no_output sudo apt-get install make unzip python-sphinx graphviz
-  - ./.travis_no_output sudo /usr/bin/pip install pyke netCDF4 pandas
+  - ./.travis_no_output sudo /usr/bin/pip install netCDF4==1.0.2
+  - ./.travis_no_output sudo /usr/bin/pip install pyke pandas
   - ./.travis_no_output sudo apt-get install openjdk-7-jre
   - ./.travis_no_output sudo apt-get install python-gdal
   - export LD_LIBRARY_PATH=/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH


### PR DESCRIPTION
This PR forces travis to use netCDF4 (python package) version 1.0.2 rather than the latest (1.0.5). The latest version appears to install cleanly but cannot be imported on travis. Further investigation is required, but this workaround should get travis CI going again.
