### PR TITLE
Graceful identification of longitude.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1182,7 +1182,8 @@ fc_extras
             if attr_units == 'degrees':
                 attr_std_name = getattr(cf_var, CF_ATTR_STD_NAME, None)
                 if attr_std_name is not None:
-                    is_valid = attr_std_name.lower() == std_name_grid
+                    # Graceful acceptance of either longitude standard name.
+                    is_valid = attr_std_name.lower() in (std_name, std_name_grid)
                 else:
                     is_valid = False
                     # TODO: check that this interpretation of axis is correct.

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -183,6 +183,17 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertCML(cube0, ('netcdf', 'netcdf_units_0.cml'))
         self.assertCML(cube1, ('netcdf', 'netcdf_units_1.cml'))
 
+    def test_circularity_cycle(self):
+        data_path = ('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')
+        cube = iris.load_cube(tests.get_data_path(data_path))
+        self.assertTrue(cube.coord('longitude').circular)
+
+        # Check still circular after save-load-cycle.
+        with self.temp_filename(suffix='.nc') as filename:
+            iris.save(cube, filename)
+            recycle = iris.load_cube(filename)
+            self.assertTrue(recycle.coord('longitude').circular)
+
 
 class TestSave(tests.IrisTest):
     def test_hybrid(self):


### PR DESCRIPTION
The PR is a follow on from the aborted #669. See the final comment https://github.com/SciTools/iris/pull/669#issuecomment-22766373

It relaxes the identification of a longitude coordinate when it has a units value of `degrees`, which implies rotated pole data.
