### PR TITLE
Add new stashcodes for dewpoint and RH.

### DIFF
--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2013, Met Office
 #
 # This file is part of Iris.
 #
@@ -113,6 +113,7 @@ STASH_TO_CF = {
     "m01s03i236" : CFname(cfname="air_temperature", unit="K"),
     "m01s03i238" : CFname(cfname="soil_temperature", unit="K"),
     "m01s03i245" : CFname(cfname="relative_humidity", unit="%"),
+    "m01s03i250" : CFname(cfname="dew_point_temperature", unit="K"),
     "m01s03i313" : CFname(cfname="soil_moisture_content_at_field_capacity", unit="kg m-2"),
     "m01s03i332" : CFname(cfname="toa_outgoing_longwave_flux", unit="W m-2"),
     "m01s03i334" : CFname(cfname="water_potential_evaporation_flux", unit="kg m-2 s-1"),
@@ -314,6 +315,7 @@ STASH_TO_CF = {
     "m02s32i212" : CFname(cfname="tendency_of_sea_ice_thickness_due_to_thermodynamics", unit="m s-1"),
     "m02s32i219" : CFname(cfname="downward_eastward_stress_at_sea_ice_base", unit="Pa"),
     "m02s32i220" : CFname(cfname="downward_northward_stress_at_sea_ice_base", unit="Pa"),
+    "m01s16i256" : CFname(cfname="relative_humidity", unit="%"),
 }
 
 LBFC_TO_CF = {


### PR DESCRIPTION
New PP stashcode translations, needed for local user task (ref: SCIT-240).

NOTE: "m01s03i250" is actually a 1.5-metre height-specific code.
Proper handling of this also needs changes to pp_rules.py (and possibly elsewhere).
These changes must now come through the 'iris-code-generators' project
  -- an issue has been created there to provide this :  https://github.com/SciTools/iris-code-generators/pull/14
