### PR TITLE
Nearest neighbour indexing no longer loads the data.

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -320,9 +320,9 @@ def _copy_cube_transformed(src_cube, data, coord_func):
 
 def _curl_change_z(src_cube, z_coord, prototype_diff):
     # New data
-    ind = [slice(None, None)] * src_cube.data.ndim 
-    z_dim = src_cube.coord_dims(z_coord)[0] 
-    ind[z_dim] = slice(-1, None) 
+    ind = [slice(None, None)] * src_cube.ndim
+    z_dim = src_cube.coord_dims(z_coord)[0]
+    ind[z_dim] = slice(-1, None)
     new_data = np.append(src_cube.data, src_cube.data[tuple(ind)], z_dim)
     
     # The existing z_coord doesn't fit the new data so make a

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -130,12 +130,12 @@ def nearest_neighbour_indices(cube, sample_points):
     sample_points = points
     
     # Build up a list of indices to span the cube.
-    indices = [slice(None, None)] * cube.data.ndim
+    indices = [slice(None, None)] * cube.ndim
     
     # Build up a dictionary which maps the cube's data dimensions to a list (which will later
     # be populated by coordinates in the sample points list)
     dim_to_coord_map = {}
-    for i in range(cube.data.ndim):
+    for i in range(cube.ndim):
         dim_to_coord_map[i] = []
         
     # Iterate over all of the specifications provided by sample_points
@@ -222,7 +222,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
     sample_dims = sorted(list(sample_dims))
 
     # Extract a sub cube that lives in just the sampling space.
-    sample_space_slice = [0] * cube.data.ndim
+    sample_space_slice = [0] * cube.ndim
     for sample_dim in sample_dims:
         sample_space_slice[sample_dim] = slice(None, None)
     sample_space_slice = tuple(sample_space_slice)
@@ -270,7 +270,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
 
     # Turn sample_space_ndi into a main cube slice.
     # Map sample cube to main cube dims and leave the rest as a full slice.
-    main_cube_slice = [slice(None, None)] * cube.data.ndim
+    main_cube_slice = [slice(None, None)] * cube.ndim
     for sample_coord, sample_coord_dims in sample_space_coords_and_dims:
         # Find the coord in the main cube
         main_coord = cube.coord(sample_coord.name())
@@ -662,7 +662,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
         # Construct source data & source coordinate values suitable for
         # SciPy's interp1d.
         if getattr(src_coord, 'circular', False):
-            coord_slice_in_cube = [slice(None, None)] * cube.data.ndim
+            coord_slice_in_cube = [slice(None, None)] * cube.ndim
             coord_slice_in_cube[sample_dim] = slice(0, 1)
             modulus = np.array(src_coord.units.modulus or 0,
                                dtype=src_coord.dtype)

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -256,7 +256,7 @@ def _add_subtract_common(operation_function, operation_symbol, operation_noun, o
         points = other.points
 
         if data_dimension is not None:
-            points_shape = [1] * cube.data.ndim
+            points_shape = [1] * cube.ndim
             points_shape[data_dimension] = -1
             points = points.reshape(points_shape)
 
@@ -443,7 +443,7 @@ def _multiply_divide_common(operation_function, operation_symbol,
         # If the axis is defined then shape the provided points so that we can do the
         # division (this is needed as there is no "axis" keyword to numpy's divide/multiply)
         if data_dimension is not None:
-            points_shape = [1] * cube.data.ndim
+            points_shape = [1] * cube.ndim
             points_shape[data_dimension] = -1
             points = points.reshape(points_shape)
         

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -164,7 +164,6 @@ def interpolate(cube, sample_points, method=None):
         for dim in dims:
             squish_my_dims.add(dim)
 
-
     # Derive the new cube's shape by filtering out all the dimensions we're about to sample,
     # and then adding a new dimension to accommodate all the sample points.
     remaining = [(dim, size) for dim, size in enumerate(cube.shape) if dim not in squish_my_dims]

--- a/lib/iris/fileformats/manager.py
+++ b/lib/iris/fileformats/manager.py
@@ -170,13 +170,20 @@ class DataManager(iris.util._OrderedHashable):
                                     for index in deferred_slice])
         
         # Apply the slice to a new data manager (to be deferred)
-        new_data_manager = DataManager( data_shape=deepcopy(self._orig_data_shape),
+        defered_slices = self.deferred_slices + (new_deferred_slice, )
+        new_data_manager = self.new_data_manager(defered_slices)
+
+        return new_proxy_array, new_data_manager
+
+    def new_data_manager(self, deferred_slices=Ellipsis):
+        """
+        Creates a new data manager instance with the given deferred slice.
+
+        """
+        return self.__class__(data_shape=deepcopy(self._orig_data_shape),
                               data_type=deepcopy(self.data_type),
                               mdi=deepcopy(self.mdi),
-                              deferred_slices=self.deferred_slices + (new_deferred_slice, ),
-                              )
-        
-        return new_proxy_array, new_data_manager
+                              deferred_slices=deferred_slices)
 
     def _deferred_slice_merge(self):
         """Determine the single slice that is equivalent to all the accumulated deferred slices."""

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -123,7 +123,7 @@ def _get_plot_defn(cube, mode, ndims=2):
     """
     if cube.ndim != ndims:
         msg = 'Cube must be %s-dimensional. Got %s dimensions.'
-        raise ValueError(msg % (ndims, cube.data.ndim))
+        raise ValueError(msg % (ndims, cube.ndim))
 
     # Start by taking the DimCoords from each dimension.
     coords = [None] * ndims

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -371,6 +371,7 @@ def hybrid_height():
                           aux_factories=[hybrid_height])
     return cube
 
+
 def simple_4d_with_hybrid_height():
     cube = iris.cube.Cube(np.arange(3*4*5*6, dtype='i8').reshape(3,4,5,6), 
                           "air_temperature", units="K")

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -162,7 +162,7 @@ class TestAnalysisWeights(tests.IrisTest):
         f, collapsed_area_weights = e.collapsed('latitude', iris.analysis.MEAN, weights=area_weights, returned=True)
         g = f.collapsed('longitude', iris.analysis.MEAN, weights=collapsed_area_weights)
         # check it's a 1D, scalar cube (actually, it should really be 0D)!
-        self.assertEquals(g.data.shape, (1,))
+        self.assertEquals(g.shape, (1,))
         # check the value - pp_area_avg's result of 287.927 differs by factor of 1.00002959
         np.testing.assert_approx_equal(g.data[0], 287.935, significant=5)
 

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -879,7 +879,7 @@ class TestCubeEquality(TestCube2d):
         r.remove_coord('dim1')
         self.assertTrue(self.t.is_compatible(r))
         # Different data.
-        r.data = np.zeros(r.data.shape)
+        r.data = np.zeros(r.shape)
         self.assertTrue(self.t.is_compatible(r))
         # Different var_names (but equal name()).
         r.var_name = 'foo'

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -554,6 +554,11 @@ class TestNearestNeighbour(tests.IrisTest):
         self.assertEqual(indices, (20, 10))
         
         b = iris.analysis.interpolate.extract_nearest_neighbour(self.cube, point_spec) 
+
+        # Check that the data has not been loaded on either the original cube,
+        # nor the interpolated one.
+        self.assertIsNotNone(b._data_manager)
+        self.assertIsNotNone(self.cube._data_manager)
         self.assertCML(b, ('analysis', 'interpolation', 'nearest_neighbour_extract_latitude_longitude.cml'))
         
         value = iris.analysis.interpolate.nearest_neighbour_data_value(self.cube, point_spec)


### PR DESCRIPTION
Fixes a question raised at http://stackoverflow.com/questions/18313916/interpolate-cube-data-to-a-given-list-of-points about nearest neighbour interpolation without actually loading the data first.

I haven't looked at whether nearest neighbour regridding can do this, but in principle, that too should be perfectly possible.
