### PR TITLE
ENH: Added support for checking netcdf file saving

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -510,8 +510,19 @@ class Saver(object):
         #: A dictionary, listing dimension names and corresponding length
         self._existing_dim = {}
         #: NetCDF dataset
-        self._dataset = netCDF4.Dataset(filename, mode='w',
-                                        format=netcdf_format)
+        try:
+            self._dataset = netCDF4.Dataset(filename, mode='w',
+                                            format=netcdf_format)
+        except RuntimeError:
+            dir_name = os.path.dirname(filename)
+            if not os.path.isdir(dir_name):
+                msg = 'No such file or directory: {}'.format(dir_name)
+                raise IOError(msg)
+            if not os.access(dir_name, os.R_OK | os.W_OK):
+                msg = 'Permission denied: {}'.format(filename)
+                raise IOError(msg)
+            else:
+                raise
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This commit adds permissions checking and path checking to the netcdf
save within iris.  This tackles the generalised runtime error which
results from netCDF4.

_internal ref: WO0000000052833_
