### PR TITLE
grib bounded level save bug fix

### DIFF
--- a/lib/iris/fileformats/grib/grib_save_rules.py
+++ b/lib/iris/fileformats/grib/grib_save_rules.py
@@ -355,17 +355,17 @@ def non_hybrid_surfaces(cube, grib):
         gribapi.grib_set_long(grib, "scaledValueOfSecondFixedSurface", -1)
     else:
         # bounded : set lower+upper surfaces
-        output_v = v_coord.units.convert(v_coord.bounds[0, 0], output_unit)
+        output_v = v_coord.units.convert(v_coord.bounds[0], output_unit)
         if output_v[0] - abs(output_v[0]) or output_v[1] - abs(output_v[1]):
             warnings.warn("Vertical level encoding problem: scaling required.")
         gribapi.grib_set_long(grib, "typeOfFirstFixedSurface", grib_v_code)
-        gribapi.grib_set_long(grib, "scaleFactorOfFirstFixedSurface", 0)
-        gribapi.grib_set_long(grib, "scaledValueOfFirstFixedSurface",
-                              output_v[0])
         gribapi.grib_set_long(grib, "typeOfSecondFixedSurface", grib_v_code)
+        gribapi.grib_set_long(grib, "scaleFactorOfFirstFixedSurface", 0)
         gribapi.grib_set_long(grib, "scaleFactorOfSecondFixedSurface", 0)
+        gribapi.grib_set_long(grib, "scaledValueOfFirstFixedSurface",
+                              int(output_v[0]))
         gribapi.grib_set_long(grib, "scaledValueOfSecondFixedSurface",
-                              output_v[1])
+                              int(output_v[1]))
 
 
 def surfaces(cube, grib):

--- a/lib/iris/tests/unit/fileformats/__init__.py
+++ b/lib/iris/tests/unit/fileformats/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats` package."""

--- a/lib/iris/tests/unit/fileformats/grib/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.grib` package."""

--- a/lib/iris/tests/unit/fileformats/grib/grib_save_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/grib_save_rules/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.grib.grib_save_rules` module."""

--- a/lib/iris/tests/unit/fileformats/grib/grib_save_rules/test_globals.py
+++ b/lib/iris/tests/unit/fileformats/grib/grib_save_rules/test_globals.py
@@ -1,0 +1,49 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for module-level functions."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import gribapi
+import numpy as np
+
+import iris
+import iris.cube
+import iris.coords
+import iris.fileformats.grib.grib_save_rules as grib_save_rules
+
+
+class Test_non_hybrid_surfaces(tests.IrisTest):
+    def test_bounded_altitude_feet(self):
+        cube = iris.cube.Cube([0])
+        cube.add_aux_coord(iris.coords.AuxCoord(
+            1500.0, long_name='altitude', units='ft',
+            bounds=np.array([1000.0, 2000.0])))
+        grib = gribapi.grib_new_from_samples("GRIB2")
+        grib_save_rules.non_hybrid_surfaces(cube, grib)
+        self.assertEqual(
+            gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
+            304.0)
+        self.assertEqual(
+            gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
+            609.0)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This allows us to save bounded levels to GRIB2.
Fixes #674.
