### PR TITLE
BF - allow model level GRIB files to be loaded.

### DIFF
--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -22,7 +22,7 @@ import warnings
 
 import numpy as np
 
-from iris.aux_factory import HybridHeightFactory
+from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
 from iris.fileformats.mosig_cf_map import MOSIG_STASH_TO_CF
 from iris.fileformats.rules import Factory, Reference, ReferenceTarget

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -22,7 +22,7 @@ import warnings
 
 import numpy as np
 
-from iris.aux_factory import HybridHeightFactory
+from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
 from iris.fileformats.mosig_cf_map import MOSIG_STASH_TO_CF
 from iris.fileformats.rules import Factory, Reference, ReferenceTarget
@@ -154,7 +154,8 @@ def convert(f):
     if \
             (len(f.lbcode) == 5) and \
             (f.lbcode.ix == 10) and \
-            (f.bdx != 0 and f.bdx != f.bmdi):
+            (f.bdx != 0) and \
+            (f.bdx != f.bmdi):
         dim_coords_and_dims.append((DimCoord.from_regular(f.bzx, f.bdx, f.lbnpt, standard_name=f._y_coord_name(), units='degrees', coord_system=f.coord_system()), 1))
 
     if \


### PR DESCRIPTION
This PR updates the load rules with newly generated rules that include a previously missing import of `HybridPressureFactory`, see SciTools/iris-code-generators#18.
