### PR TITLE
as_compatible_shape() utility function

### DIFF
--- a/lib/iris/tests/results/util/as_compatible_shape_collapsed.cml
+++ b/lib/iris/tests/results/util/as_compatible_shape_collapsed.cml
@@ -1,0 +1,145 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="air_potential_temperature" units="K">
+    <attributes>
+      <attribute name="history" value="Mean of air_potential_temperature over model_level_number"/>
+      <attribute name="source" value="Iris test case"/>
+    </attributes>
+    <coords>
+      <coord datadims="[1, 2, 3]">
+        <auxCoord bounds="[[[[0.0, 42491.4],
+  		[0.0, 42495.3],
+  		[0.0, 42489.8],
+  		..., 
+  		[0.0, 42390.2],
+  		[0.0, 42395.4],
+  		[0.0, 42402.1]],
+
+ 		[[0.0, 42464.0],
+  		[0.0, 42468.3],
+  		[0.0, 42470.6],
+  		..., 
+  		[0.0, 42393.6],
+  		[0.0, 42399.3],
+  		[0.0, 42407.5]],
+
+ 		[[0.0, 42437.4],
+  		[0.0, 42438.2],
+  		[0.0, 42441.0],
+  		..., 
+  		[0.0, 42390.1],
+  		[0.0, 42398.2],
+  		[0.0, 42405.7]],
+
+ 		..., 
+ 		[[0.0, 42477.0],
+  		[0.0, 42469.4],
+  		[0.0, 42461.0],
+  		..., 
+  		[0.0, 42359.2],
+  		[0.0, 42375.3],
+  		[0.0, 42387.4]],
+
+ 		[[0.0, 42479.0],
+  		[0.0, 42469.6],
+  		[0.0, 42460.4],
+  		..., 
+  		[0.0, 42364.2],
+  		[0.0, 42379.4],
+  		[0.0, 42387.8]],
+
+ 		[[0.0, 42485.4],
+  		[0.0, 42476.3],
+  		[0.0, 42467.1],
+  		..., 
+  		[0.0, 42358.5],
+  		[0.0, 42371.5],
+  		[0.0, 42377.8]]]]" id="c56f646c" points="[[[21245.7, 21247.7, 21244.9, ..., 21195.1,
+  		21197.7, 21201.0],
+ 		[21232.0, 21234.2, 21235.3, ..., 21196.8,
+  		21199.6, 21203.8],
+ 		[21218.7, 21219.1, 21220.5, ..., 21195.1,
+  		21199.1, 21202.9],
+ 		..., 
+ 		[21238.5, 21234.7, 21230.5, ..., 21179.6,
+  		21187.6, 21193.7],
+ 		[21239.5, 21234.8, 21230.2, ..., 21182.1,
+  		21189.7, 21193.9],
+ 		[21242.7, 21238.1, 21233.6, ..., 21179.2,
+  		21185.8, 21188.9]]]" shape="(1, 100, 100)" standard_name="altitude" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord>
+        <dimCoord id="73141289" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord bounds="[[-0.12825, -0.12735],
+		[-0.12735, -0.12645],
+		[-0.12645, -0.12555],
+		..., 
+		[-0.04095, -0.04005],
+		[-0.04005, -0.03915],
+		[-0.03915, -0.03825]]" id="3b3f362e" points="[-0.1278, -0.1269, -0.126, ..., -0.0405, -0.0396,
+		-0.0387]" shape="(100,)" standard_name="grid_latitude" units="Unit('degrees')" value_type="float32">
+          <rotatedGeogCS ellipsoid="GeogCS(6371229.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="177.5"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord bounds="[[359.579, 359.58],
+		[359.58, 359.581],
+		[359.581, 359.582],
+		..., 
+		[359.666, 359.667],
+		[359.667, 359.668],
+		[359.668, 359.669]]" id="5036c64b" points="[359.58, 359.581, 359.581, ..., 359.667, 359.668,
+		359.669]" shape="(100,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float32">
+          <rotatedGeogCS ellipsoid="GeogCS(6371229.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="177.5"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[0.0, 42077.5]]" id="218bea13" long_name="level_height" points="[21038.8]" shape="(1,)" units="Unit('m')" value_type="float32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[1, 70]]" id="af0092b8" points="[35]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord bounds="[[0.0, 1.0]]" id="5f88ebd6" long_name="sigma" points="[0.5]" shape="(1,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+      <coord datadims="[2, 3]">
+        <auxCoord id="4471545e" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
+ 		324.58],
+		[386.476, 390.813, 393.15, ..., 316.098,
+ 		321.788, 330.007],
+		[359.94, 360.696, 363.495, ..., 312.63, 320.699,
+ 		328.22],
+		..., 
+		[399.5, 391.9, 383.5, ..., 281.7, 297.76, 309.88],
+		[401.5, 392.12, 382.88, ..., 286.75, 301.9,
+ 		310.3],
+		[407.9, 398.78, 389.6, ..., 281.0, 294.04,
+ 		300.34]]" shape="(100, 100)" standard_name="surface_altitude" units="Unit('m')" value_type="float32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="6a1b3c16" points="[347921.166667, 347921.333333, 347921.5,
+		347921.666667, 347921.833333, 347922.0]" shape="(6,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="model_level_number"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float32" mask_order="C" order="C" shape="(6, 1, 100, 100)" state="loaded"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
This PR contains a workaround to an issue affecting a number of users. When collapsing/aggregating/slicing a cube the dimensionality of the resultant cube is often reduced when one or more dimensions are reduced to length one and the associated coordinates become scalar coordinates. This is not always desirable. In the case of slicing one can use slice notation to obtain the desired behaviour. For example:

``` python
>>> import iris
>>> cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
>>> print cube.shape
(73, 96)
>>> print cube[0].shape
(96,)
>>> print cube[0:1].shape
(1, 96)
```

However when collapsing a cube using `cube.collapsed()`, there is no way to preserve the dimensionality of the cube.

This PR adds a helper function called `iris.util.as_compatible_shape()` that figures out which dimensions have been collapsed through an examination of the coordinates on the two cubes. It then reshapes a copy of the cube data and the point/bounds of any coordinates adding in length one dimensions where necessary.
