### PR TITLE
Ensure consistent memory layout for checksums.

### DIFF
--- a/lib/iris/tests/results/abf/load.cml
+++ b/lib/iris/tests/results/abf/load.cml
@@ -34,6 +34,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x53c948b8" dtype="uint8" mask_checksum="-0x4c701678" mask_order="C" order="C" shape="(2160, 4320)"/>
+    <data checksum="0x53c948b8" dtype="uint8" mask_checksum="-0x6f99a5a9" mask_order="F" order="C" shape="(2160, 4320)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/dim_to_aux.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/dim_to_aux.cml
@@ -16,6 +16,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x7b6fee44" dtype="float32" order="F" shape="(3, 3)"/>
+    <data byteorder="little" checksum="0x49ca1082" dtype="float32" order="F" shape="(3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -137,6 +137,6 @@
         <coord interval="1 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="-0x5744027d" dtype="float32" order="F" shape="(38, 145)"/>
+    <data byteorder="little" checksum="-0x45409a9" dtype="float32" order="F" shape="(38, 145)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint1.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint1.cml
@@ -13,6 +13,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x77b4c96c" dtype="float32" order="F" shape="(4, 3)"/>
+    <data byteorder="little" checksum="0x68358ab9" dtype="float32" order="F" shape="(4, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint2.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint2.cml
@@ -13,6 +13,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x255cdf1c" dtype="float32" order="F" shape="(2, 3)"/>
+    <data byteorder="little" checksum="0x6aa57114" dtype="float32" order="F" shape="(2, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points.cml
@@ -13,6 +13,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="-0x6ecdb347" dtype="float32" order="F" shape="(2, 3)"/>
+    <data byteorder="little" checksum="0x59bb663b" dtype="float32" order="F" shape="(2, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_shared_axis.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_shared_axis.cml
@@ -16,6 +16,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x55f98e79" dtype="float32" order="F" shape="(4, 2)"/>
+    <data byteorder="little" checksum="-0x2585c19" dtype="float32" order="F" shape="(4, 2)"/>
   </cube>
 </cubes>


### PR DESCRIPTION
This de-couples the checksums from their corresponding memory order attributes. With this change, if the memory order is changed but the logical values are unchanged the order attribute will reflect the change but the checksum will be unchanged.

NB. It also fixes a bug in the `mask_order` attribute so it now correctly reports the memory order of the mask, instead of just repeating the memory order of the data.
