### PR TITLE
Gracefully accept either NetCDF longitude std name.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1182,7 +1182,8 @@ fc_extras
             if attr_units == 'degrees':
                 attr_std_name = getattr(cf_var, CF_ATTR_STD_NAME, None)
                 if attr_std_name is not None:
-                    is_valid = attr_std_name.lower() == std_name_grid
+                    # Graceful acceptance of either CF longitude standard name.
+                    is_valid = attr_std_name.lower() in [std_name, std_name_grid]
                 else:
                     is_valid = False
                     # TODO: check that this interpretation of axis is correct.


### PR DESCRIPTION
See #669 and #703 for further details and discussion.

Relaxing the standard name condition given the units of `degrees` for a longitude coordinate is exercised by multiple existing unit tests, so I don't see the benefit of including an explicit test for this PR.

This PR relaxes the standard name criteria for identifying a longitude coordinate with units of `degrees`.

The CF specification implies that **only** a standard name of `grid_longitude` should be associated with a rotated pole units of `degrees`.
