### PR TITLE
Revised for ESMPy version 620_01b.

### DIFF
--- a/docs/iris/src/whatsnew/1.6.rst
+++ b/docs/iris/src/whatsnew/1.6.rst
@@ -4,12 +4,6 @@ What's new in Iris 1.6
 :Release: 1.6.0
 :Date: unreleased
 
-Incompatible changes
---------------------
-* The previously experimental 'concatenate' function is now a method of a
-  :class:`iris.cube.CubeList`, see :meth:`iris.cube.CubeList.concatenate`.  The
-  functionality is unchanged.
-
 Iris 1.6 features
 =================
 * A new utility function makes it easy to "shortcut" slow calculations or
@@ -18,7 +12,9 @@ Iris 1.6 features
 * A new experimental function removes any non-matching attributes from a group
   of cubes.  This can assist in merging cubes which only differ in their
   attributes.  See
-  :meth:`iris.experimental.equalise_cubes.equalise_attributes`.
+  :func:`iris.experimental.equalise_cubes.equalise_attributes`.
+* :func:iris.experimental.regrid_conservative_via_esmpy upgraded to work with
+  ESMPy version "ESMPy_620_01b".
 * Staggered grid support for Fieldsfiles extended to type 6 (Arakawa C grid
   with v at poles).
 * A new utility function is now available for creating a new cube axis as the
@@ -51,6 +47,9 @@ Incompatible changes
   use :meth:`iris.cube.Cube.slices()`.
 * The following boolean methods/properties on the
   :class:`~iris.unit.Unit` class have been removed.
+* The previously experimental 'concatenate' function is now a method of a
+  :class:`iris.cube.CubeList`, see :meth:`iris.cube.CubeList.concatenate`.  The
+  functionality is unchanged.
 
   ====================================== ===========================================
   Removed property/method                New method

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -373,7 +373,7 @@ class TestConservativeRegrid(tests.IrisTest):
         c2.add_dim_coord(x_coord_2, 1)
 
         # NOTE: at present, this causes an error inside ESMF ...
-        context = self.assertRaises(NameError)
+        context = self.assertRaises(ValueError)
         global_cell_supported = False
         if global_cell_supported:
             context = _donothing_context_manager()


### PR DESCRIPTION
Addresses
- #685 'Upgrade regrid_conservative_via_esmpy to latest ESMPy version'
- #686 'Explain how to make "regrid_conservative_via_esmpy" work.'

NOTE: The functions aren't tested in Travis, as it doesn't install ESMPy/ESMF.
Tested locally ok with ESMPY version version 620_01b.

Reviewer: cpelley

TODOs:
- [x] move whatsnew item from 1.5 to 1.6 whatsnew list
- [x] final rebase
