### PR TITLE
BUG: Fixed typo in OSGB definition

### DIFF
--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -410,7 +410,7 @@ class TransverseMercator(CoordSystem):
 class OSGB(TransverseMercator):
     """A Specific transverse mercator projection on a specific ellipsoid."""
     def __init__(self):
-        TransverseMercator.__init__(self, 49, -2, -400000, 100000, 0.9996012717,
+        TransverseMercator.__init__(self, 49, -2, 400000, -100000, 0.9996012717,
                                     GeogCS(6377563.396, 6356256.909))
 
     def as_cartopy_crs(self):

--- a/lib/iris/tests/results/nimrod/load_2flds.cml
+++ b/lib/iris/tests/results/nimrod/load_2flds.cml
@@ -20,15 +20,15 @@
         </dimCoord>
       </coord>
       <coord datadims="[2]">
-        <dimCoord id="a7509aee" points="[-238000.015625, -236000.015625, -234000.015625,
+        <dimCoord id="7edfa6e5" points="[-238000.015625, -236000.015625, -234000.015625,
 		..., 851999.984375, 853999.984375, 855999.984375]" shape="(548,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
-          <oSGB ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="-400000.0" false_northing="100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <oSGB ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="8762255b" points="[-184000.0, -182000.0, -180000.0, ..., 1218000.0,
+        <dimCoord id="5eed1950" points="[-184000.0, -182000.0, -180000.0, ..., 1218000.0,
 		1220000.0, 1222000.0]" shape="(704,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
-          <oSGB ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="-400000.0" false_northing="100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <oSGB ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">


### PR DESCRIPTION
This bug results in an incorrectly interpreted cube and thus incorrectly saved result, however this is not noticed when plotted, since these parameters are not sent to cartopy, cartopy OSGB class in simply instantiated on plotting.
