### PR TITLE
BUG: Fixed pyke rules for transverse mercator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export CARTOPY_REF="1fe7438b8f203a19b5855c2491622ee9001bb62c"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF="89bb2ce50e5f407614f097cd47927eac0bdcd50b"
+  - export IRIS_TEST_DATA_REF="277a889ddfef06349c8d03de15cf3b1ee5d0e7cf"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="2f279384eab2dcdef1728331ce1b22c95f775437"

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -722,6 +722,8 @@ fc_extras
     CF_ATTR_GRID_FALSE_EASTING = 'false_easting'
     CF_ATTR_GRID_FALSE_NORTHING = 'false_northing'
     CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN = 'scale_factor_at_projection_origin'
+    CF_ATTR_GRID_SCALE_FACTOR_AT_CENT_MERIDIAN = 'scale_factor_at_central_meridian'
+    CF_ATTR_GRID_LON_OF_CENT_MERIDIAN = 'longitude_of_central_meridian'
     CF_ATTR_POSITIVE = 'positive'
     CF_ATTR_STD_NAME = 'standard_name'
     CF_ATTR_LONG_NAME = 'long_name'
@@ -864,14 +866,23 @@ fc_extras
 
         latitude_of_projection_origin = getattr(
             cf_grid_var, CF_ATTR_GRID_LAT_OF_PROJ_ORIGIN, None)
-        longitude_of_projection_origin = getattr(
-            cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        longitude_of_central_meridian = getattr(
+            cf_grid_var, CF_ATTR_GRID_LON_OF_CENT_MERIDIAN, None)
         false_easting = getattr(
             cf_grid_var, CF_ATTR_GRID_FALSE_EASTING, None)
         false_northing = getattr(
             cf_grid_var, CF_ATTR_GRID_FALSE_NORTHING, None)
-        scale_factor_at_projection_origin = getattr(
-            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
+        scale_factor_at_central_meridian = getattr(
+            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_CENT_MERIDIAN, None)
+
+        # The following accounts for the inconsistancy in the transverse
+        # mercator description within the CF spec.
+        if longitude_of_central_meridian is None:
+            longitude_of_central_meridian = getattr(
+                cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        if scale_factor_at_central_meridian is None:
+            scale_factor_at_central_meridian = getattr(
+                cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
 
         ellipsoid = None
         if major is not None or minor is not None or \
@@ -880,8 +891,9 @@ fc_extras
                                                   inverse_flattening)
 
         cs = iris.coord_systems.TransverseMercator(
-            latitude_of_projection_origin, longitude_of_projection_origin,
-            false_easting, false_northing, scale_factor_at_projection_origin)
+            latitude_of_projection_origin, longitude_of_central_meridian,
+            false_easting, false_northing, scale_factor_at_central_meridian,
+            ellipsoid)
 
         return cs
 

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -4,7 +4,15 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.6"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>
-      <attribute name="history" value="Conversion from ESRI grid"/>
+      <attribute name="history" value="Thu Sep  5 10:17:53 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_central_meridian,crs,m,d,-2
+Wed Sep  4 16:47:15 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a scale_factor_at_central_meridian,crs,c,d,0.9996012717
+Wed Sep  4 16:46:53 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a scale_factor_at_projection_origin,crs,d,d,0.9996012717
+Wed Sep  4 16:45:54 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_central_meridian,crs,c,d,49.
+Wed Sep  4 16:45:36 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_central_meridian,crs,d,f,49.
+Wed Sep  4 16:45:27 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_central_meridian,crs,c,f,49.
+Wed Sep  4 16:44:10 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_central_meridian,crs,c,float,49.
+Wed Sep  4 16:43:20 2013: /project/ukmo/rhel6/nco/bin/ncatted tmean_1910_1910.nc -a longitude_of_projection_origin,crs,d,float,49.
+Conversion from ESRI grid"/>
       <attribute name="institution" value="Met Office"/>
       <attribute name="source" value="EWB2"/>
       <attribute name="title" value="UK annual mean tmean"/>
@@ -50,15 +58,15 @@
  		1.99301683617]]" shape="(290, 180)" standard_name="longitude" units="Unit('degrees')" value_type="float64" var_name="lon"/>
       </coord>
       <coord datadims="[2]">
-        <dimCoord id="8dd36522" long_name="projection_x_coordinate" points="[-197500.0, -192500.0, -187500.0, ..., 687500.0,
+        <dimCoord id="9cb7f900" long_name="projection_x_coordinate" points="[-197500.0, -192500.0, -187500.0, ..., 687500.0,
 		692500.0, 697500.0]" shape="(180,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64" var_name="x">
-          <transverseMercator ellipsoid="None" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <transverseMercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.91)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="4daf6692" long_name="projection_y_coordinate" points="[1247500.0, 1242500.0, 1237500.0, ..., -187500.0,
+        <dimCoord id="3da32419" long_name="projection_y_coordinate" points="[1247500.0, 1242500.0, 1237500.0, ..., -187500.0,
 		-192500.0, -197500.0]" shape="(290,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64" var_name="y">
-          <transverseMercator ellipsoid="None" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <transverseMercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.91)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">


### PR DESCRIPTION
This PR fixes two of the attributes of the grid mapping variable changing longitude_of_projection_origin to longitude_of_central_meridian and the same for the scale_factor.
