### PR TITLE
Transverse Mercator from netCDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export CARTOPY_REF="1fe7438b8f203a19b5855c2491622ee9001bb62c"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
-  - export IRIS_TEST_DATA_REF="89bb2ce50e5f407614f097cd47927eac0bdcd50b"
+  - export IRIS_TEST_DATA_REF="37b937e46f059e1dce4b78a80b323646b8c9ca4c"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="2f279384eab2dcdef1728331ce1b22c95f775437"

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -722,6 +722,8 @@ fc_extras
     CF_ATTR_GRID_FALSE_EASTING = 'false_easting'
     CF_ATTR_GRID_FALSE_NORTHING = 'false_northing'
     CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN = 'scale_factor_at_projection_origin'
+    CF_ATTR_GRID_SCALE_FACTOR_AT_CENT_MERIDIAN = 'scale_factor_at_central_meridian'
+    CF_ATTR_GRID_LON_OF_CENT_MERIDIAN = 'longitude_of_central_meridian'
     CF_ATTR_POSITIVE = 'positive'
     CF_ATTR_STD_NAME = 'standard_name'
     CF_ATTR_LONG_NAME = 'long_name'
@@ -864,14 +866,23 @@ fc_extras
 
         latitude_of_projection_origin = getattr(
             cf_grid_var, CF_ATTR_GRID_LAT_OF_PROJ_ORIGIN, None)
-        longitude_of_projection_origin = getattr(
-            cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        longitude_of_central_meridian = getattr(
+            cf_grid_var, CF_ATTR_GRID_LON_OF_CENT_MERIDIAN, None)
         false_easting = getattr(
             cf_grid_var, CF_ATTR_GRID_FALSE_EASTING, None)
         false_northing = getattr(
             cf_grid_var, CF_ATTR_GRID_FALSE_NORTHING, None)
-        scale_factor_at_projection_origin = getattr(
-            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
+        scale_factor_at_central_meridian = getattr(
+            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_CENT_MERIDIAN, None)
+
+        # The following accounts for the inconsistancy in the transverse
+        # mercator description within the CF spec.
+        if longitude_of_central_meridian is None:
+            longitude_of_central_meridian = getattr(
+                cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        if scale_factor_at_central_meridian is None:
+            scale_factor_at_central_meridian = getattr(
+                cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
 
         ellipsoid = None
         if major is not None or minor is not None or \
@@ -880,8 +891,9 @@ fc_extras
                                                   inverse_flattening)
 
         cs = iris.coord_systems.TransverseMercator(
-            latitude_of_projection_origin, longitude_of_projection_origin,
-            false_easting, false_northing, scale_factor_at_projection_origin)
+            latitude_of_projection_origin, longitude_of_central_meridian,
+            false_easting, false_northing, scale_factor_at_central_meridian,
+            ellipsoid)
 
         return cs
 

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -50,15 +50,15 @@
  		1.99301683617]]" shape="(290, 180)" standard_name="longitude" units="Unit('degrees')" value_type="float64" var_name="lon"/>
       </coord>
       <coord datadims="[2]">
-        <dimCoord id="8dd36522" long_name="projection_x_coordinate" points="[-197500.0, -192500.0, -187500.0, ..., 687500.0,
+        <dimCoord id="9cb7f900" long_name="projection_x_coordinate" points="[-197500.0, -192500.0, -187500.0, ..., 687500.0,
 		692500.0, 697500.0]" shape="(180,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64" var_name="x">
-          <transverseMercator ellipsoid="None" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <transverseMercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.91)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="4daf6692" long_name="projection_y_coordinate" points="[1247500.0, 1242500.0, 1237500.0, ..., -187500.0,
+        <dimCoord id="3da32419" long_name="projection_y_coordinate" points="[1247500.0, 1242500.0, 1237500.0, ..., -187500.0,
 		-192500.0, -197500.0]" shape="(290,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64" var_name="y">
-          <transverseMercator ellipsoid="None" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
+          <transverseMercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.91)" false_easting="400000.0" false_northing="-100000.0" latitude_of_projection_origin="49.0" longitude_of_central_meridian="-2.0" scale_factor_at_central_meridian="0.9996012717"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -121,6 +121,28 @@ class TestNetCDFLoad(tests.IrisTest):
                                  'tmean_1910_1910.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_tmerc_and_climatology.cml'))
 
+    def test_load_tmerc_grid_with_projection_origin(self):
+        # Test loading a single CF-netCDF file with a transverse Mercator
+        # grid_mapping that uses longitude_of_projection_origin and
+        # scale_factor_at_projection_origin instead of
+        # longitude_of_central_meridian and scale_factor_at_central_meridian.
+        cube = iris.load_cube(
+            tests.get_data_path(('NetCDF', 'transverse_mercator',
+                                 'projection_origin_attributes.nc')))
+
+        expected = icoord_systems.TransverseMercator(
+            latitude_of_projection_origin=49.0,
+            longitude_of_central_meridian=-2.0,
+            false_easting=400000.0,
+            false_northing=-100000.0,
+            scale_factor_at_central_meridian=0.9996012717,
+            ellipsoid=icoord_systems.GeogCS(
+                semi_major_axis=6377563.396, semi_minor_axis=6356256.91))
+        self.assertEqual(cube.coord('projection_x_coordinate').coord_system,
+                         expected)
+        self.assertEqual(cube.coord('projection_y_coordinate').coord_system,
+                         expected)
+
     def test_missing_climatology(self):
         # Check we can cope with a missing climatology variable.
         with self.temp_filename(suffix='nc') as filename:


### PR DESCRIPTION
This PR replaces #752, fixing my initial error in the pyke rules whereby longitude_of_projection_origin was used instead of longitude_of_central_meridian (same applies to scale_factor). Both forms can now be accepted as both can be found in the cf spec document.
