### PR TITLE
Enhanced guess_bounds docstring.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -938,14 +938,32 @@ class Coord(CFVariableMixin):
 
     def guess_bounds(self, bound_position=0.5):
         """
-        Try to add bounds to this coordinate using the coordinate's points.
+        Add contiguous bounds to a coordinate, calculated from its points.
+
+        Puts a cell boundary at the specified fraction between each point and
+        the next, plus extrapolated lowermost and uppermost bound points, so
+        that each point lies within a cell.
+
+        With regularly spaced points, the resulting bounds will also be
+        regular, and all points lie at the same position within their cell.
+        With irregular points, the first and last cells are given the same
+        widths as the ones next to them.
 
         Kwargs:
 
         * bound_position - The desired position of the bounds relative to the
                            position of the points.
 
-        This method only works for coordinates with ``coord.ndim == 1``.
+        .. note::
+
+            An error is raised if the coordinate already has bounds, is not
+            one-dimensional, or is not monotonic.
+
+        .. note::
+
+            Unevenly spaced values, such from a wrapped longitude range, can
+            produce unexpected results :  In such cases you should assign
+            suitable values directly to the bounds property, instead.
 
         """
         self.bounds = self._guess_bounds(bound_position)


### PR DESCRIPTION
From user-raised issue

> I've got an issue with a guess_bounds call creating garbage bounds data for an extracted cube which crosses the longitude boundary of the original field...
> I'm happy that guess_bounds is behaving as might be expected, but I would argue that the documentation is insufficient; a note describing what happens when guess_bounds is used in a case such as this one would be valuable, along with some indication of how to modify the bounds by hand.

(ref: WO0000000053479 )

I think this needs no CHANGES/WhatsNew entry ?
