### PR TITLE
MAINT: Remove iris changelog.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,48 +1,9 @@
-Release 1.5 (unreleased)
-========================
+This file is no longer updated and is provided for historical purposes only.
+Please see docs/iris/src/whatsnew/ for a changelog.
 
 
-Features added
---------------
-* Scatter plots can now be produced using `iris.plot.scatter` and
-  `iris.quickplot.scatter`.
-* The functions `iris.plot.plot` and `iris.quickplot.plot` now take up to two
-  arguments, which may be cubes or coordinates, allowing the user to have full
-  control over what is plotted on each axis. The coords keyword argument is now
-  deprecated for these functions.
-* `iris.analysis.SUM` is now a weighted aggregator, allowing it to take a
-  weights keyword argument.
-* Grib2 translations added for standard_name 'soil_temperature'.
-* :meth:`iris.cube.Cube.slices` can now handle passing dimension index as well
-  as the currently supported types (string, coordinate), in order to slice in
-  cases where there is no coordinate associated with a dimension.
-* :mod:`iris.experimental.animate` now provides experimental animation support.
-
-Bugs fixed
-----------
-* Shape of the Earth scale factors are now correctly interpreted by the GRIB
-  loader. They were previously used as a multiplier for the given value but
-  should have been used as a decimal shift.
-
-Incompatible changes
---------------------
-* N/A
-
-Deprecations
-------------
-* The coords keyword argument for `iris.plot.plot` and `iris.quickplot.plot`
-  has been deprecated due to the new API which accepts multiple cubes or
-  coordinates.
-
-
-----------------------------
-
-
-Release 1.4 (unreleased)
-========================
-
-:Release: 1.4.0
-:Date: 14 June 2013
+Release 1.4 (14 June 2013)
+==========================
 
 * Saving multiple cubes to netcdf
   https://github.com/SciTools/iris/pull/367


### PR DESCRIPTION
Currently the iris whatsnew purpose overlaps with the changelog and
thus the changelog has no clear purpose.  For developers it has been
agreed that for them to analyse the commit history would serve the
intended use of a changelog.

refer to #755
