### PR TITLE
Default CF spherical earth radius.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -72,7 +72,7 @@ fc_provides_grid_mapping_latitude_longitude
         check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_LAT_LON)
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
-        python coordinate_system = build_coordinate_system(engine, cf_grid_var)
+        python coordinate_system = build_coordinate_system(cf_grid_var)
         python engine.provides['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, latitude_longitude)
         python engine.rule_triggered.add(rule.name)
@@ -449,9 +449,9 @@ fc_build_coordinate_latitude_nocs
     foreach
         facts_cf.provides(coordinate, latitude, $coordinate)
         notany
-        	facts_cf.provides(coordinate_system, latitude_longitude)
+            facts_cf.provides(coordinate_system, latitude_longitude)
         notany
-        	facts_cf.provides(coordinate_system, rotated_latitude_longitude)
+            facts_cf.provides(coordinate_system, rotated_latitude_longitude)
     assert
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
@@ -472,9 +472,9 @@ fc_build_coordinate_longitude_nocs
     foreach
         facts_cf.provides(coordinate, longitude, $coordinate)
         notany
-	        facts_cf.provides(coordinate_system, latitude_longitude)
+            facts_cf.provides(coordinate_system, latitude_longitude)
         notany
-	        facts_cf.provides(coordinate_system, rotated_latitude_longitude)
+            facts_cf.provides(coordinate_system, rotated_latitude_longitude)
     assert
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
@@ -711,6 +711,7 @@ fc_extras
     CF_ATTR_CALENDAR = 'calendar'
     CF_ATTR_CLIMATOLOGY = 'climatology'
     CF_ATTR_GRID_INVERSE_FLATTENING = 'inverse_flattening'
+    CF_ATTR_GRID_EARTH_RADIUS = 'earth_radius'
     CF_ATTR_GRID_MAPPING_NAME = 'grid_mapping_name'
     CF_ATTR_GRID_NORTH_POLE_LAT = 'grid_north_pole_latitude'
     CF_ATTR_GRID_NORTH_POLE_LON = 'grid_north_pole_longitude'
@@ -813,56 +814,63 @@ fc_extras
                 cube.attributes[str(attr_name)] = attr_value
 
 
+
     ################################################################################
-    def build_coordinate_system(engine, cf_grid_var):
-        """Create a coordinate system from the CF-netCDF grid mapping variable."""
+    def _get_ellipsoid(cf_grid_var):
+        """Return the ellipsoid definition."""
         major = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MAJOR_AXIS, None)
         minor = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MINOR_AXIS, None)
         inverse_flattening = getattr(cf_grid_var, CF_ATTR_GRID_INVERSE_FLATTENING, None)
-        # Avoid over-specification exception
+
+        # Avoid over-specification exception.
         if major is not None and minor is not None:
-        	inverse_flattening = None
+            inverse_flattening = None
+
+        # Check for a default spherical earth.
+        if major is None and minor is None and inverse_flattening is None:
+            major = getattr(cf_grid_var, CF_ATTR_GRID_EARTH_RADIUS, None) 
+
+        return major, minor, inverse_flattening
+
+
+    ################################################################################
+    def build_coordinate_system(cf_grid_var):
+        """Create a coordinate system from the CF-netCDF grid mapping variable."""
+        major, minor, inverse_flattening = _get_ellipsoid(cf_grid_var)
 
         return iris.coord_systems.GeogCS(major, minor, inverse_flattening)
 
+
+    ################################################################################
     def build_rotated_coordinate_system(engine, cf_grid_var):
         """Create a rotated coordinate system from the CF-netCDF grid mapping variable."""
-        
-        major = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MAJOR_AXIS, None)
-        minor = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MINOR_AXIS, None)
-        inverse_flattening = getattr(cf_grid_var, CF_ATTR_GRID_INVERSE_FLATTENING, None)
-        # Avoid over-specification exception
-        if major is not None and minor is not None:
-        	inverse_flattening = None
+        major, minor, inverse_flattening = _get_ellipsoid(cf_grid_var)
 
         north_pole_latitude = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_LAT, 90.0)
         north_pole_longitude = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_LON, 0.0)
         if north_pole_latitude is None or north_pole_longitude is None:
-        	warnings.warn('Rotated pole position is not fully specified')
+            warnings.warn('Rotated pole position is not fully specified')
 
         north_pole_grid_lon = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_GRID_LON, 0.0)
-        
+
         ellipsoid = None
         if major is not None or minor is not None or inverse_flattening is not None:
-        	ellipsoid = iris.coord_systems.GeogCS(major, minor, inverse_flattening)
-        
+            ellipsoid = iris.coord_systems.GeogCS(major, minor, inverse_flattening)
+
         rcs = iris.coord_systems.RotatedGeogCS(north_pole_latitude, north_pole_longitude,
-        						north_pole_grid_lon, ellipsoid)
-                
+                                               north_pole_grid_lon, ellipsoid)
+
         return rcs
 
+
+    ################################################################################
     def build_transverse_mercator_coordinate_system(engine, cf_grid_var):
         """
         Create a transverse Mercator coordinate system from the CF-netCDF
         grid mapping variable.
 
         """
-        major = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MAJOR_AXIS, None)
-        minor = getattr(cf_grid_var, CF_ATTR_GRID_SEMI_MINOR_AXIS, None)
-        inverse_flattening = getattr(cf_grid_var, CF_ATTR_GRID_INVERSE_FLATTENING, None)
-        # Avoid over-specification exception
-        if major is not None and minor is not None:
-            inverse_flattening = None
+        major, minor, inverse_flattening = _get_ellipsoid(cf_grid_var)
 
         latitude_of_projection_origin = getattr(
             cf_grid_var, CF_ATTR_GRID_LAT_OF_PROJ_ORIGIN, None)

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -35,6 +35,7 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
+import iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc as pyke_rules
 import iris.fileformats.netcdf
 import iris.std_names
 import iris.util
@@ -209,6 +210,28 @@ class TestNetCDFLoad(tests.IrisTest):
 
         self.assertCML(cube0, ('netcdf', 'netcdf_units_0.cml'))
         self.assertCML(cube1, ('netcdf', 'netcdf_units_1.cml'))
+
+
+class TestNetCDFCRS(tests.IrisTest):
+    def setUp(self):
+        class Var(object):
+            pass
+
+        self.grid = Var()
+
+    def test_lat_lon_major_minor(self):
+        major = 63781370
+        minor = 63567523
+        self.grid.semi_major_axis = major
+        self.grid.semi_minor_axis = minor
+        crs = pyke_rules.build_coordinate_system(self.grid)
+        self.assertEqual(crs, icoord_systems.GeogCS(major, minor))
+
+    def test_lat_lon_earth_radius(self):
+        earth_radius = 63700000
+        self.grid.earth_radius = earth_radius
+        crs = pyke_rules.build_coordinate_system(self.grid)
+        self.assertEqual(crs, icoord_systems.GeogCS(earth_radius))
 
 
 class SaverPermissions(tests.IrisTest):


### PR DESCRIPTION
This PR performs some PyKE convenience function rationalisation for building NetCDF loader coordinate systems.

Common code for determining the underlying grid mapping ellipsoid has been re-factored into a single function, which also additionally checks for the CF `earth_radius` grid mapping attribute, which defines a spherical earth.
