### PR TITLE
Fix to tests._check_same unicode strings handling.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -282,8 +282,9 @@ class IrisTest(unittest.TestCase):
         else:
             self._ensure_folder(reference_path)
             logger.warning('Creating result file: %s', reference_path)
-            open(reference_path, 'w').writelines(line.encode('utf-8') for
-                                                 line in item)
+            open(reference_path, 'w').writelines(
+                part.encode('utf-8') if isinstance(part, unicode) else part
+                for part in item)
 
     def assertXMLElement(self, obj, reference_filename):
         """


### PR DESCRIPTION
Fixes https://github.com/SciTools/iris/issues/769

Explain:
Types 'str' and 'unicode' both support method "encode"
Applying unicode.encode('utf-8') gives you a plain 'str' with escape chars coding the unicode extension characters.
You can't generally _re-encode_ that, because any escapes character are themselves **invalid** characters to encode.

So when writing testfiles, only call ".encode('utf-8')" for unicode input, leave plain str data alone.
