### PR TITLE
Allow netCDF save to work with non-native byte orders.

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -870,7 +870,7 @@ class Saver(object):
 
             cf_var.bounds = cf_name + '_bnds'
             cf_var_bounds = self._dataset.createVariable(
-                cf_var.bounds, bounds.dtype,
+                cf_var.bounds, bounds.dtype.newbyteorder('='),
                 cf_var.dimensions + (bounds_dimension_name,))
             cf_var_bounds[:] = bounds
 
@@ -1003,8 +1003,8 @@ class Saver(object):
                                               coord)
 
             # Create the CF-netCDF variable.
-            cf_var = self._dataset.createVariable(cf_name, points.dtype,
-                                                  cf_dimensions)
+            cf_var = self._dataset.createVariable(
+                cf_name, points.dtype.newbyteorder('='), cf_dimensions)
 
             # Add the axis attribute for spatio-temporal CF-netCDF coordinates.
             if coord in cf_coordinates:
@@ -1234,7 +1234,8 @@ class Saver(object):
         data = self._ensure_valid_dtype(cube.data, 'cube', cube)
 
         # Create the cube CF-netCDF data variable with data payload.
-        cf_var = self._dataset.createVariable(cf_name, data.dtype,
+        cf_var = self._dataset.createVariable(cf_name,
+                                              data.dtype.newbyteorder('='),
                                               dimension_names,
                                               fill_value=fill_value)
         cf_var[:] = data

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -174,7 +174,7 @@ class IrisTest(unittest.TestCase):
 
         self.assertCML(cubes, reference_filename, checksum=False)
 
-    def assertCDL(self, netcdf_filename, reference_filename):
+    def assertCDL(self, netcdf_filename, reference_filename, flags='-h'):
         """
         Converts the given CF-netCDF file to CDL for comparison with
         the reference CDL file, or creates the reference file if it
@@ -184,8 +184,16 @@ class IrisTest(unittest.TestCase):
         # Convert the netCDF file to CDL file format.
         cdl_filename = iris.util.create_temp_filename(suffix='.cdl')
 
+        if flags is None:
+            flags = []
+        elif isinstance(flags, basestring):
+            flags = flags.split()
+        else:
+            flags = map(str, flags)
+
         with open(cdl_filename, 'w') as cdl_file:
-            subprocess.check_call(['ncdump', '-h', netcdf_filename], stderr=cdl_file, stdout=cdl_file)
+            subprocess.check_call(['ncdump'] + flags + [netcdf_filename],
+                                  stderr=cdl_file, stdout=cdl_file)
 
         # Ingest the CDL for comparison, excluding first line.
         with open(cdl_filename, 'r') as cdl_file:

--- a/lib/iris/tests/results/system/supported_filetype_.nc.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.nc.cml
@@ -40,6 +40,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="-0x3ffe23be" dtype="float32" order="C" shape="(60, 60)"/>
+    <data byteorder="little" checksum="-0x145f5e6f" dtype="float32" order="C" shape="(60, 60)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/endian.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/endian.cdl
@@ -1,0 +1,25 @@
+dimensions:
+	dim0 = UNLIMITED ; // (3 currently)
+	bnds = 2 ;
+	dim1 = 4 ;
+variables:
+	float air_pressure_anomaly(dim0, dim1) ;
+		air_pressure_anomaly:standard_name = "air_pressure_anomaly" ;
+	float dim0(dim0) ;
+		dim0:bounds = "dim0_bnds" ;
+		dim0:units = "1" ;
+	float dim0_bnds(dim0, bnds) ;
+data:
+
+ air_pressure_anomaly =
+  0, 1, 2, 3,
+  4, 5, 6, 7,
+  8, 9, 10, 11 ;
+
+ dim0 = 0, 1, 2 ;
+
+ dim0_bnds =
+  0, 1,
+  2, 3,
+  4, 5 ;
+}


### PR DESCRIPTION
Fixes #768.
