### PR TITLE
Added empty what's new 1.6

### DIFF
--- a/docs/iris/src/_templates/index.html
+++ b/docs/iris/src/_templates/index.html
@@ -74,7 +74,7 @@ With Iris you can:
 		<span class="linkdescr">a collection of images produced using Iris</span></p>
 	</li>
 	<li>
-		<p class="biglink"><a class="biglink" href="whatsnew/1.5.html">What's new in Iris 1.5?</a><br/>
+		<p class="biglink"><a class="biglink" href="whatsnew/1.6.html">What's new in Iris 1.6?</a><br/>
 		<span class="linkdescr">recent changes in Iris's capabilities</span></p>
 	</li>
 	</ul>

--- a/docs/iris/src/whatsnew/1.6.rst
+++ b/docs/iris/src/whatsnew/1.6.rst
@@ -1,0 +1,22 @@
+What's new in Iris 1.6
+**********************
+
+:Release: 1.6.0
+:Date: unreleased
+
+
+Iris 1.6 features
+=================
+* N/A
+
+Bugs fixed
+----------
+* N/A
+
+Incompatible changes
+--------------------
+* N/A
+
+Deprecations
+------------
+* N/A

--- a/docs/iris/src/whatsnew/index.rst
+++ b/docs/iris/src/whatsnew/index.rst
@@ -4,6 +4,7 @@ What's new in Iris
 These "What's new" pages describe the important changes between major
 Iris versions.
 
+* :doc:`What's new in Iris 1.6 <1.6>`
 * :doc:`What's new in Iris 1.5 <1.5>`
 * :doc:`What's new in Iris 1.4 <1.4>`
 * :doc:`What's new in Iris 1.3 <1.3>`


### PR DESCRIPTION
This PR adds an empty What's new page for 1.6.
