### PR TITLE
Extract fix

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -153,7 +153,7 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
         compared.
 
         """
-        if isinstance(other, (int, float)):
+        if isinstance(other, (int, float, np.number)):
             if self.bound is not None:
                 return self.contains_point(other)
             else:

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -128,6 +128,21 @@ class TestCells(unittest.TestCase):
         self.assertEquals(self.d.__eq__(Terry()), NotImplemented)
         self.assertEquals(self.d.__ne__(Terry()), NotImplemented)
 
+    def test_numpy_int_equality(self):
+        dtypes = (np.int, np.int16, np.int32, np.int64)
+        for dtype in dtypes:
+            val = dtype(3)
+            cell = iris.coords.Cell(val, None)
+            self.assertEqual(cell, val)
+
+    def test_numpy_float_equality(self):
+        dtypes = (np.float, np.float16, np.float32, np.float64,
+                  np.float128, np.double)
+        for dtype in dtypes:
+            val = dtype(3.2)
+            cell = iris.coords.Cell(val, None)
+            self.assertEqual(cell, val, dtype)
+
     def test_coord_bounds_cmp(self):
         self.e = iris.coords.Cell(0.7, [1.1, 1.9])
         self.assertTrue(self.e == 1.6)


### PR DESCRIPTION
The modification/optimisation of the extract code path using nearest_neighbour_index means that:

``` python
point = cube.coord('model_level_number').points[0]
cube.extract(model_level_number=point)
```

fails with `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`. This is because `__eq__` for Cell is called and it cannot handle numpy floats or ints so the equality falls to the np.int which treats the cell as a tuple (i.e. an iterable) returning a numpy array e.g. `array([False, False])` which cannot be evaluated as a bool.

This PR fixes this bug allowing numpy ints and floats to be handled by `Cell.__eq__()`

**This PR targets 1.5.x and is intended for a 1.5.1 release.**
