### PR TITLE
Extract fix for Cell comparison

### DIFF
--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -23,6 +23,7 @@ import operator
 
 import numpy as np
 
+import iris.coords
 import iris.exceptions
 
 
@@ -248,11 +249,13 @@ class _CoordConstraint(object):
         if callable(self._coord_thing):
             call_func = self._coord_thing
         elif (isinstance(self._coord_thing, collections.Iterable) and
-              not isinstance(self._coord_thing, basestring)):
+                not isinstance(self._coord_thing,
+                               (basestring, iris.coords.Cell))):
             call_func = lambda cell: cell in list(self._coord_thing)
         else:
             call_func = lambda c: c == self._coord_thing
-            try_quick = isinstance(coord, iris.coords.DimCoord)
+            try_quick = (isinstance(coord, iris.coords.DimCoord) and
+                         not isinstance(self._coord_thing, iris.coords.Cell))
 
         # Simple, yet dramatic, optimisation for the monotonic case.
         if try_quick:

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -78,6 +78,18 @@ class TestSimple(tests.IrisTest):
         sub_list = self.slices.extract(constraint)
         self.assertEqual(len(sub_list), 6)
 
+    def test_cell_equal_bounds(self):
+        cell = self.slices[0].coord('level_height').cell(0)
+        constraint = iris.Constraint(level_height=cell)
+        sub_list = self.slices.extract(constraint)
+        self.assertEqual(len(sub_list), 6)
+
+    def test_cell_different_bounds(self):
+        cell = iris.coords.Cell(10, bound=(9, 11))
+        constraint = iris.Constraint(model_level_number=cell)
+        sub_list = self.slices.extract(constraint)
+        self.assertEqual(len(sub_list), 0)
+
 
 class TestMixin(object):
     """


### PR DESCRIPTION
When doing:

``` python
cube.extract(model_level_number=Cell(10))
```

an unexpected code path is followed as the Cell is an instance of collections.Iterable. It is therefore converted to a list (e.g. `[10, None]`) and each cell in the coord is compared element-wise via `call_func = lambda cell: cell in [10, None]`.

This PR fixes this so that cell equality is used.

**This PR targets 1.5.x and is intended for a 1.5.1 release.**
