### PR TITLE
rolling_window on masked cubes

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -308,6 +308,16 @@ class IrisTest(unittest.TestCase):
     def assertArrayEqual(self, a, b, err_msg=''):
         np.testing.assert_array_equal(a, b, err_msg=err_msg)
 
+    def assertMaskedArrayEqual(self, a, b):
+        """
+        Check that masked arrays are equal. This requires the
+        unmasked values and masks to be identical.
+
+        """
+        np.testing.assert_array_equal(a, b)
+        np.testing.assert_array_equal(a.mask, b.mask)
+
+
     def assertArrayAlmostEqual(self, a, b):
         np.testing.assert_array_almost_equal(a, b)
 

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -903,6 +903,25 @@ class TestRollingWindow(tests.IrisTest):
 
         self.assertRaises(ValueError, self.cube.rolling_window, 'longitude', iris.analysis.MEAN, window=0)
 
+    def test_longitude_masked(self):
+        self.cube.data = ma.array(self.cube.data,
+                                  mask=[[True, True, True, True],
+                                        [True, False, True, True],
+                                        [False, False, False, False]])
+        res_cube = self.cube.rolling_window('longitude',
+                                            iris.analysis.MEAN,
+                                            window=2)
+
+        expected_result = np.ma.array([[-99., -99., -99.],
+                                       [12., 12., -99.],
+                                       [15., 11., 8.]],
+                                      mask=[[True, True, True],
+                                            [False, False, True],
+                                            [False, False, False]],
+                                      dtype=np.float64)
+
+        self.assertMaskedArrayEqual(expected_result, res_cube.data)
+
     def test_longitude_circular(self):
         cube = self.cube
         cube.coord('longitude').circular = True

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -335,7 +335,14 @@ def rolling_window(a, window=1, step=1, axis=-1):
     num_windows = (a.shape[axis] - window + step) / step
     shape = a.shape[:axis] + (num_windows, window) + a.shape[axis + 1:]
     strides = a.strides[:axis] + (step * a.strides[axis], a.strides[axis]) + a.strides[axis + 1:]
-    return np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
+    rw = np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
+    if ma.isMaskedArray(a):
+        strides = (a.mask.strides[:axis] +
+                   (step * a.mask.strides[axis], a.mask.strides[axis]) +
+                   a.mask.strides[axis + 1:])
+        rw = ma.array(rw, mask=np.lib.stride_tricks.as_strided(
+            a.mask, shape=shape, strides=strides))
+    return rw
 
 
 def array_equal(array1, array2):


### PR DESCRIPTION
Rolling window didn't seem to deal with masked cubes so I added a check. I haven't compared with any cml in the unit test because I didn't know how.
