### PR TITLE
Allowed >f8 data arrays to be saved to pp

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1072,6 +1072,11 @@ class PPField(object):
         # populate lbuser[0] to have the data's datatype
         if data.dtype == np.dtype('>f4'):
             lb[HEADER_DICT['lbuser'][0]] = 1
+        elif data.dtype == np.dtype('>f8'):
+            warnings.warn("Downcasting array precision from float64 to float32 for save."
+                          "If float64 precision is required then please save in a different format")
+            data = data.astype('>f4')
+            lb[HEADER_DICT['lbuser'][0]] = 1
         elif data.dtype == np.dtype('>i4'):
             # NB: there is no physical difference between lbuser[0] of 2 or 3 so we encode just 2
             lb[HEADER_DICT['lbuser'][0]] = 2

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -100,6 +100,7 @@ class TestSavePP(TestSaveMethods):
         with self.assertRaises(ValueError):
             save_by_filehandle(self.temp_filename1, self.temp_filename2, self.cube1, pp.save, binary_mode = False)
 
+
 class TestSaveDot(TestSaveMethods):
     """Test saving cubes to DOT format"""
     ext = ".dot"

--- a/lib/iris/tests/unit/fileformats/pp/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pp/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.fileformats.pp` module."""

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -1,0 +1,89 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.PPField` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import warnings
+
+import mock
+import numpy as np
+
+from iris.fileformats.pp import PPField
+
+
+# The PPField class is abstract, so to test we define a minimal,
+# concrete subclass with the `t1` and `t2` properties.
+#
+# NB. We define dummy header items to allow us to zero the unused header
+# items when written to disk and get consistent results.
+class TestPPField(PPField):
+
+    HEADER_DEFN = [
+        ('dummy1', (0, 13)),
+        ('lblrec', (14,)),
+        ('dummy2', (15, 18)),
+        ('lbext',  (19,)),
+        ('lbpack', (20,)),
+        ('dummy3', (21, 37)),
+        ('lbuser', (38, 39, 40, 41, 42, 43, 44,)),
+        ('dummy4', (45, 63)),
+    ]
+
+    @property
+    def t1(self):
+        return netcdftime.datetime(2013, 10, 14, 10, 4)
+
+    @property
+    def t2(self):
+        return netcdftime.datetime(2013, 10, 14, 10, 5)
+
+
+class Test_save(tests.IrisTest):
+    def test_float64(self):
+        # Tests down-casting of >f8 data to >f4.
+
+        def field_checksum(data):
+            field = TestPPField()
+            field.dummy1 = 0
+            field.dummy2 = 0
+            field.dummy3 = 0
+            field.dummy4 = 0
+            field.lblrec = 0
+            field.lbext = 0
+            field.lbpack = 0
+            field.lbuser = 0
+            field.data = data
+            with self.temp_filename('.pp') as temp_filename:
+                with open(temp_filename, 'wb') as pp_file:
+                    field.save(pp_file)
+                checksum = self.file_checksum(temp_filename)
+            return checksum
+
+        data_64 = np.linspace(0, 1, num=10, endpoint=False).reshape(2, 5)
+        checksum_32 = field_checksum(data_64.astype('>f4'))
+        with mock.patch('warnings.warn') as warn:
+            checksum_64 = field_checksum(data_64.astype('>f8'))
+
+        self.assertEquals(checksum_32, checksum_64)
+        warn.assert_called()
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
Change the way pps are saved so that they can write >f8 data. I suspect it might not be as simple as I'm making out to fix - I couldn't find documentation on how lbuser is set. However, I can now save my data and open it again, so that's a good sign!

Issue first raised here
https://groups.google.com/forum/#!topic/scitools-iris/aWWk_5QpdjI
Seems to happen particularly when saving cubes resulting from some kind of aggregation.
