### PR TITLE
Support 1-D array attributes.  Moved some results files.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -761,7 +761,7 @@ class Coord(CFVariableMixin):
                     ignore = (ignore,)
                 common_keys = common_keys.difference(ignore)
             for key in common_keys:
-                if self.attributes[key] != other.attributes[key]:
+                if np.any(self.attributes[key] != other.attributes[key]):
                     compatible = False
                     break
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -674,7 +674,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     ignore = (ignore,)
                 common_keys = common_keys.difference(ignore)
             for key in common_keys:
-                if self.attributes[key] != other.attributes[key]:
+                if np.any(self.attributes[key] != other.attributes[key]):
                     compatible = False
                     break
 

--- a/lib/iris/tests/results/unit/util/describe_diff/incompatible_array_attrs.str.txt
+++ b/lib/iris/tests/results/unit/util/describe_diff/incompatible_array_attrs.str.txt
@@ -1,0 +1,1 @@
+"test_array" cube_a attribute value "[1 2 3]" is not compatible with cube_b attribute value "[1 7 3]"

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the :class:`iris.coords.Coord`."""
+"""Unit tests for the :class:`iris.coords.Coord` class."""
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -118,6 +118,29 @@ class Test_collapsed(tests.IrisTest):
                     index_slice = (slice(None),) + tuple(index)
                     self.assertArrayEqual(kwargs['bounds'][index_slice],
                                           self._serialize(bounds[index_slice]))
+
+
+class Test_is_compatible(tests.IrisTest):
+    def setUp(self):
+        self.test_coord = AuxCoord([1.])
+        self.other_coord = self.test_coord.copy()
+
+    def test_noncommon_array_attrs_compatible(self):
+        # Non-common array attributes should be ok.
+        self.test_coord.attributes['array_test'] = np.array([1.0, 2, 3])
+        self.assertTrue(self.test_coord.is_compatible(self.other_coord))
+
+    def test_matching_array_attrs_compatible(self):
+        # Matching array attributes should be ok.
+        self.test_coord.attributes['array_test'] = np.array([1.0, 2, 3])
+        self.other_coord.attributes['array_test'] = np.array([1.0, 2, 3])
+        self.assertTrue(self.test_coord.is_compatible(self.other_coord))
+
+    def test_different_array_attrs_incompatible(self):
+        # Differing array attributes should make coords incompatible.
+        self.test_coord.attributes['array_test'] = np.array([1.0, 2, 3])
+        self.other_coord.attributes['array_test'] = np.array([1.0, 2, 777.7])
+        self.assertFalse(self.test_coord.is_compatible(self.other_coord))
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/util/test_describe_diff.py
+++ b/lib/iris/tests/unit/util/test_describe_diff.py
@@ -1,0 +1,65 @@
+# (C) British Crown Copyright 2010 - 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Test function :func:`iris.util.describe_diff`."""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+import StringIO
+
+import iris.cube
+from iris.util import describe_diff
+
+
+class Test(iris.tests.IrisTest):
+    def setUp(self):
+        self.cube_a = iris.cube.Cube([])
+        self.cube_b = self.cube_a.copy()
+
+    def _compare_result(self, cube_a, cube_b):
+        result_strIO = StringIO.StringIO()
+        describe_diff(cube_a, cube_b, output_file=result_strIO)
+        return result_strIO.getvalue()
+
+    def test_noncommon_array_attributes(self):
+        # test non-common array attribute
+        self.cube_a.attributes['test_array'] = np.array([1, 2, 3])
+        return_str = self._compare_result(self.cube_a, self.cube_b)
+        self.assertString(return_str, ['compatible_cubes.str.txt'])
+
+    def test_same_array_attributes(self):
+        # test matching array attribute
+        self.cube_a.attributes['test_array'] = np.array([1, 2, 3])
+        self.cube_b.attributes['test_array'] = np.array([1, 2, 3])
+        return_str = self._compare_result(self.cube_a, self.cube_b)
+        self.assertString(return_str, ['compatible_cubes.str.txt'])
+
+    def test_different_array_attributes(self):
+        # test non-matching array attribute
+        self.cube_a.attributes['test_array'] = np.array([1, 2, 3])
+        self.cube_b.attributes['test_array'] = np.array([1, 7, 3])
+        return_str = self._compare_result(self.cube_a, self.cube_b)
+        self.assertString(
+            return_str,
+            ['unit', 'util', 'describe_diff',
+             'incompatible_array_attrs.str.txt'])
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -246,7 +246,7 @@ def describe_diff(cube_a, cube_b, output_file=None):
     else:
         common_keys = set(cube_a.attributes).intersection(cube_b.attributes)
         for key in common_keys:
-            if cube_a.attributes[key] != cube_b.attributes[key]:
+            if np.any(cube_a.attributes[key] != cube_b.attributes[key]):
                 output_file.write('"%s" cube_a attribute value "%s" is not '
                                   'compatible with cube_b '
                                   'attribute value "%s"\n'


### PR DESCRIPTION
Although netcdf allows for attributes to be 1-D arrays, some Iris code would choke on that because the equality tests for numpy arrays do not produce simple booleans (i.e. `a == b` is not a truth value, but an array of them).
Simple examples :

```
>>> c1 = iris.cube.Cube([])
>>> c2 = c.copy()
>>> c1.attributes['a'] = np.array([1,2,3])
>>> c2.attributes['a'] = np.array([1,2,5])
>>> c1.is_compatible(c2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/cube.py", line 674, in is_compatible
    if self.attributes[key] != other.attributes[key]:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
>>> 
>>> iris.util.describe_diff(c1, c2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/util.py", line 230, in describe_diff
    if cube_a.is_compatible(cube_b):
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/cube.py", line 674, in is_compatible
    if self.attributes[key] != other.attributes[key]:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
>>> 
```

Following a global code search, I identified and fixed 3 places where this seems to act, and extended the related test routines.
