### PR TITLE
Missing iris.analysis.trajectory import in test_netcdf

### DIFF
--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -35,6 +35,7 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
+import iris.analysis.trajectory
 import iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc as pyke_rules
 import iris.fileformats.netcdf
 import iris.std_names


### PR DESCRIPTION
NB. This error only cropped up when running test_netcdf.py in isolation.
