### PR TITLE
Upgraded RMS to a weighted aggregator.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -465,8 +465,10 @@ def _proportion(array, function, axis, **kwargs):
 
 
 def _rms(array, axis, **kwargs):
-    n_elements = array.shape[axis]
-    return np.sqrt(np.sum(np.square(array), axis=axis) / n_elements)
+    rval = np.sqrt(ma.average(np.square(array), axis=axis, **kwargs))
+    if not ma.isMaskedArray(array):
+        rval = np.asarray(rval)
+    return rval
 
 
 def _sum(array, **kwargs):
@@ -788,15 +790,22 @@ Similarly, the proportion of times precipitation exceeded 10 (in cube data units
 """
 
 
-RMS = Aggregator('Root mean square of {standard_name} {action} {coord_names}',
-                 'root mean square',
-                 _rms)
+RMS = WeightedAggregator(
+    'Root mean square of {standard_name} {action} {coord_names}',
+    'root mean square',
+    _rms)
 """
 The root mean square, as computed by ((x0**2 + x1**2 + ... + xN-1**2) / N) ** 0.5.
 
 For example, to compute zonal root mean square::
 
     result = cube.collapsed('longitude', iris.analysis.RMS)
+
+Additional kwargs available:
+
+* weights
+    Optional array of floats. If supplied, the shape must match the
+    cube. The weights are applied to the squares when taking the mean.
 
 """
 

--- a/lib/iris/tests/results/analysis/rms_weighted_2d.cml
+++ b/lib/iris/tests/results/analysis/rms_weighted_2d.cml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="thingness" units="1">
+    <attributes>
+      <attribute name="history" value="Root mean square of thingness over foo"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 5],
+		[5, 10],
+		[10, 15]]" id="7c9a33bf" long_name="bar" points="[2.5, 7.5, 12.5]" shape="(3,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord>
+        <dimCoord bounds="[[-15, 45]]" id="549be28b" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="root mean square">
+        <coord name="foo"/>
+      </cellMethod>
+    </cellMethods>
+    <data byteorder="little" dtype="float64" order="C" shape="(3,)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -482,6 +482,23 @@ class TestAggregators(tests.IrisTest):
         self.assertCML(result, ('analysis', 'sum_weighted_2d.cml'),
                        checksum=False)
 
+    def test_weighted_rms(self):
+        cube = tests.stock.simple_2d()
+        # modify cube data so that the results are nice numbers
+        cube.data = np.array([[4, 7, 10, 8],
+                              [21, 30, 12, 24],
+                              [14, 16, 20, 8]],
+                             dtype=np.float64)
+        weights = np.array([[1, 4, 3, 2],
+                            [6, 4.5, 1.5, 3],
+                            [2, 1, 1.5, 0.5]],
+                           dtype=np.float64)
+        expected_result = np.array([8.0, 24.0, 16.0])
+        result = cube.collapsed('foo', iris.analysis.RMS, weights=weights)
+        self.assertArrayAlmostEqual(result.data, expected_result)
+        self.assertCML(result, ('analysis', 'rms_weighted_2d.cml'),
+                       checksum=False)
+
 
 @iris.tests.skip_data
 class TestRotatedPole(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/__init__.py
+++ b/lib/iris/tests/unit/analysis/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.analysis` package."""

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -1,0 +1,90 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :class:`iris.analysis.RMS` class instance."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+import numpy.ma as ma
+
+from iris.analysis import RMS
+
+
+class Test_aggregate(tests.IrisTest):
+
+    def test_1d(self):
+        # 1-dimensional input
+        data = np.array([5, 2, 6, 4], dtype=np.float64)
+        rms = RMS.aggregate(data, 0)
+        expected_rms = 4.5
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d(self):
+        # 2-dimensional input
+        data = np.array([[5, 2, 6, 4], [12, 4, 10, 8]], dtype=np.float64)
+        expected_rms = np.array([4.5, 9.0], dtype=np.float64)
+        rms = RMS.aggregate(data, 1)
+        self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_1d_weighted(self):
+        # 1-dimensional input with weights
+        data = np.array([4, 7, 10, 8], dtype=np.float64)
+        weights = np.array([1, 4, 3, 2], dtype=np.float64)
+        expected_rms = 8.0
+        rms = RMS.aggregate(data, 0, weights=weights)
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d_weighted(self):
+        # 2-dimensional input with weights
+        data = np.array([[4, 7, 10, 8], [14, 16, 20, 8]], dtype=np.float64)
+        weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
+        expected_rms = np.array([8.0, 16.0], dtype=np.float64)
+        rms = RMS.aggregate(data, 1, weights=weights)
+        self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_unit_weighted(self):
+        # unit weights should be the same as no weights
+        data = np.array([5, 2, 6, 4], dtype=np.float64)
+        weights = np.ones_like(data)
+        rms = RMS.aggregate(data, 0, weights=weights)
+        expected_rms = 4.5
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked(self):
+        # masked entries should be completely ignored
+        data = ma.array([5, 10, 2, 11, 6, 4],
+                        mask=[False, True, False, True, False, False],
+                        dtype=np.float64)
+        expected_rms = 4.5
+        rms = RMS.aggregate(data, 0)
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked_weighted(self):
+        # weights should work properly with masked arrays
+        data = ma.array([4, 7, 18, 10, 11, 8],
+                        mask=[False, False, True, False, True, False],
+                        dtype=np.float64)
+        weights = np.array([1, 4, 5, 3, 8, 2], dtype=np.float64)
+        expected_rms = 8.0
+        rms = RMS.aggregate(data, 0, weights=weights)
+        self.assertAlmostEqual(rms, expected_rms)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
Changes `iris.analysis.RMS` to a weighted aggregator, fixing #788. This change also ensures that masked arrays are handled properly.

I've used the new unit test structure to provide tests for the aggregator alone. Please let me know if I have done this correctly, I was unsure about the structure of the directories etc. A single integration test is also provided.
