### PR TITLE
Support masked arrays in broadcast_to_shape.

### DIFF
--- a/lib/iris/tests/unit/util/test_broadcast_to_shape.py
+++ b/lib/iris/tests/unit/util/test_broadcast_to_shape.py
@@ -62,6 +62,15 @@ class Test_broadcast_to_shape(tests.IrisTest):
             for j in xrange(4):
                 self.assertMaskedArrayEqual(b[i, :, j, :].T, m)
 
+    def test_masked_degenerate(self):
+        # masked arrays can have degenerate masks too
+        a = np.random.random([2, 3])
+        m = ma.array(a)
+        b = broadcast_to_shape(m, (5, 3, 4, 2), (3, 1))
+        for i in xrange(5):
+            for j in xrange(4):
+                self.assertMaskedArrayEqual(b[i, :, j, :].T, m)
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -131,27 +131,26 @@ def broadcast_to_shape(array, shape, dim_map):
         # correct length, we might just get a segfault.
         raise ValueError('dim_map must have an entry for every '
                          'dimension of the input array')
-    strides = [0] * len(shape)
-    for idim, dim in enumerate(dim_map):
-        if shape[dim] != array.shape[idim]:
-            # We'll get garbage values if the dimensions of array are not
-            # those indicated by shape.
-            raise ValueError('shape and array are not compatible')
-        strides[dim] = array.strides[idim]
-    array_view = np.lib.stride_tricks.as_strided(array,
-                                                 shape=shape,
-                                                 strides=strides)
-    if ma.isMaskedArray(array):
-        # If the input array is a masked array we must apply the same
-        # technique to the mask as well as the values, but using the
-        # knowledge that the mask is the same shape as the array.
-        mstrides = [0] * len(shape)
+
+    def _broadcast_helper(a):
+        strides = [0] * len(shape)
         for idim, dim in enumerate(dim_map):
-            mstrides[dim] = array.mask.strides[idim]
-        mask = np.lib.stride_tricks.as_strided(array.mask,
-                                               shape=shape,
-                                               strides=mstrides)
-        array_view = ma.array(array_view, mask=mask)
+            if shape[dim] != a.shape[idim]:
+                # We'll get garbage values if the dimensions of array are not
+                # those indicated by shape.
+                raise ValueError('shape and array are not compatible')
+            strides[dim] = a.strides[idim]
+        return np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
+
+    array_view = _broadcast_helper(array)
+    if ma.isMaskedArray(array):
+        if array.mask is ma.nomask:
+            # Degenerate masks can be applied as-is.
+            mask_view = array.mask
+        else:
+            # Mask arrays need to be handled in the same way as the data array.
+            mask_view = _broadcast_helper(array.mask)
+        array_view = ma.array(array_view, mask=mask_view)
     return array_view
 
 


### PR DESCRIPTION
This PR adds support for masked arrays to `iris.util.broadcast_to_shape`. The striding trick needed to be applied independently to the mask of masked arrays, otherwise the result is a plain numpy array including the masked values.
