### PR TITLE
(tiny) Constraint warns of coord not found

### DIFF
--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -20,6 +20,7 @@ Provides objects for building up expressions useful for pattern matching.
 """
 import collections
 import operator
+import warnings
 
 import numpy as np
 
@@ -238,6 +239,8 @@ class _CoordConstraint(object):
         try:
             coord = cube.coord(self.coord_name)
         except iris.exceptions.CoordinateNotFoundError:
+            warnings.warn(
+                "Constrained coord {} not found".format(self.coord_name))
             cube_cim.all_false()
             return cube_cim
         dims = cube.coord_dims(coord)


### PR DESCRIPTION
I had no idea why my constrained loading was failing, with some cryptic error message coming from merge.
This PR tells the user they mi-spelled their coordinate name! :grinning: 
