### PR TITLE
Name vertical level interpretation

### DIFF
--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -314,12 +314,11 @@ def _cf_height_from_name(z_coord):
         match = pattern.match(z_coord)
         if match:
             match = match.groupdict()
+            # Do not interpret if there is additional information to the match
+            if match['extra']:
+                break
             units = match['type'].replace(' ', '')
             name = type_name[units]
-            if match['extra']:
-                raise iris.exceptions.TranslationError(
-                    'Unable to interpret z-coordinate due to extra '
-                    'information: {}'.format(match))
 
             # Interpret points if present.
             if 'point' in match:
@@ -330,6 +329,7 @@ def _cf_height_from_name(z_coord):
                                    float(match['upper_bound'])])
                 points = bounds.sum() / 2.
 
+            long_name = None
             if name in ['height', 'altitude']:
                 units = units[0]
                 standard_name = name

--- a/lib/iris/tests/results/name/NAMEII_field.cml
+++ b/lib/iris/tests/results/name/NAMEII_field.cml
@@ -20,7 +20,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord bounds="[[0.0, 100.0]]" id="5b5327e7" long_name="z" points="[50.0]" shape="(1,)" standard_name="height" units="Unit('m')" value_type="float64"/>
+        <dimCoord bounds="[[0.0, 100.0]]" id="f4f30ef" points="[50.0]" shape="(1,)" standard_name="height" units="Unit('m')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[52.36655, 52.3676555276],
@@ -74,7 +74,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord bounds="[[0.0, 100.0]]" id="5b5327e7" long_name="z" points="[50.0]" shape="(1,)" standard_name="height" units="Unit('m')" value_type="float64"/>
+        <dimCoord bounds="[[0.0, 100.0]]" id="f4f30ef" points="[50.0]" shape="(1,)" standard_name="height" units="Unit('m')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[52.36655, 52.3676555276],

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__cf_height_from_name.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__cf_height_from_name.py
@@ -27,18 +27,26 @@ import iris.tests as tests
 import numpy as np
 
 from iris.coords import AuxCoord
-from iris.exceptions import TranslationError
 from iris.fileformats.name_loaders import _cf_height_from_name
 
 
-class TestAll_NAMEII(tests.IrisTest):
+class TestAll(tests.IrisTest):
+    def _default_coord(self, data):
+        # This private method returns a coordinate with values expected
+        # when no interpretation is made of the field header string.
+        return AuxCoord(
+            units='no-unit', points=data, bounds=None, standard_name=None,
+            long_name='z')
+
+
+class TestAll_NAMEII(TestAll):
     # NAMEII formats are defined by bounds, not points
     def test_bounded_height_above_ground(self):
         data = 'From     0 -   100m agl'
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=np.array([0., 100.]),
-            standard_name='height', long_name='z')
+            standard_name='height', long_name=None)
         self.assertEqual(com, res)
 
     def test_bounded_flight_level(self):
@@ -54,29 +62,32 @@ class TestAll_NAMEII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=np.array([0., 100.]),
-            standard_name='altitude', long_name='z')
+            standard_name='altitude', long_name=None)
         self.assertEqual(com, res)
 
     def test_malformed_height_above_ground(self):
         # Parse height above ground level with additional stuff on the end of
         # the string (agl).
         data = 'From     0 -   100m agl and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_malformed_height_above_sea_level(self):
         # Parse height above ground level with additional stuff on the end of
         # the string (agl).
         data = 'From     0 -   100m asl and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_malformed_flight_level(self):
         # Parse height above ground level with additional stuff on the end of
         # the string (agl).
         data = 'From FL0 - FL100 and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_float_bounded_height_above_ground(self):
         # Parse height above ground level when its a float.
@@ -84,7 +95,7 @@ class TestAll_NAMEII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=np.array([0., 100.]),
-            standard_name='height', long_name='z')
+            standard_name='height', long_name=None)
         self.assertEqual(com, res)
 
     def test_float_bounded_height_flight_level(self):
@@ -102,7 +113,7 @@ class TestAll_NAMEII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=np.array([0., 100.]),
-            standard_name='altitude', long_name='z')
+            standard_name='altitude', long_name=None)
         self.assertEqual(com, res)
 
     def test_no_match(self):
@@ -110,9 +121,7 @@ class TestAll_NAMEII(tests.IrisTest):
         # No interpretation, just returns default values.
         data = 'Vertical integral'
         res = _cf_height_from_name(data)
-        com = AuxCoord(
-            units='no-unit', points='Vertical integral', bounds=None,
-            standard_name=None, long_name='z')
+        com = self._default_coord(data)
         self.assertEqual(com, res)
 
     def test_pressure(self):
@@ -121,18 +130,18 @@ class TestAll_NAMEII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='Pa', points=50.0, bounds=np.array([0., 100.]),
-            standard_name='air_pressure', long_name='z')
+            standard_name='air_pressure', long_name=None)
         self.assertEqual(com, res)
 
 
-class TestAll_NAMEIII(tests.IrisTest):
-    # NAMEII formats are defined by points, not boudns.
+class TestAll_NAMEIII(TestAll):
+    # NAMEIII formats are defined by points, not bounds.
     def test_height_above_ground(self):
         data = 'Z = 50.00000 m agl'
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=None,
-            standard_name='height', long_name='z')
+            standard_name='height', long_name=None)
         self.assertEqual(com, res)
 
     def test_height_flight_level(self):
@@ -148,29 +157,32 @@ class TestAll_NAMEIII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=None,
-            standard_name='altitude', long_name='z')
+            standard_name='altitude', long_name=None)
         self.assertEqual(com, res)
 
     def test_malformed_height_above_ground(self):
         # Parse height above ground level, with additonal stuff at the string
         # end (agl).
         data = 'Z = 50.00000 m agl and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_malformed_height_above_sea_level(self):
         # Parse height above ground level, with additional stuff at string
         # end (agl).
         data = 'Z = 50.00000 m asl and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_malformed_flight_level(self):
         # Parse height above ground level (agl), with additional stuff at
         # string end.
         data = 'Z = 50.00000 FL and stuff'
-        with self.assertRaises(TranslationError):
-            _cf_height_from_name(data)
+        res = _cf_height_from_name(data)
+        com = self._default_coord(data)
+        self.assertEqual(com, res)
 
     def test_integer_height_above_ground(self):
         # Parse height above ground level when its an integer.
@@ -178,7 +190,7 @@ class TestAll_NAMEIII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=None,
-            standard_name='height', long_name='z')
+            standard_name='height', long_name=None)
         self.assertEqual(com, res)
 
     def test_integer_height_flight_level(self):
@@ -196,7 +208,7 @@ class TestAll_NAMEIII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='m', points=50.0, bounds=None,
-            standard_name='altitude', long_name='z')
+            standard_name='altitude', long_name=None)
         self.assertEqual(com, res)
 
     def test_pressure(self):
@@ -205,7 +217,7 @@ class TestAll_NAMEIII(tests.IrisTest):
         res = _cf_height_from_name(data)
         com = AuxCoord(
             units='Pa', points=50.0, bounds=None,
-            standard_name='air_pressure', long_name='z')
+            standard_name='air_pressure', long_name=None)
         self.assertEqual(com, res)
 
 


### PR DESCRIPTION
This PR parses NAME 'z column heading' using regular expressions.
Result is a versatile (whitespace agnostic, integer/float agnostic).
It is also strict, in the sense that it does not consider anything other than a match that can differ by only whitespace.

Still to be decided whether bounds are to be automatically guessed for NAMEIII files, since points are defined not bounds, while bounds are defined not points for NAMEII.  Guessing bounds will allow cubes from the two formats to be merged.
