### PR TITLE
Setting doctests and extests running automatically in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ install:
   - ./.travis_no_output /usr/bin/python setup.py pyke_rules
 
 script:
-  - /usr/bin/python setup.py test
+  - /usr/bin/python setup.py test --example-tests
 
   - cd $(pwd)/docs/iris
 # Make html produces an error when run on Travis that does not affect any downstream functionality but causes the build to fail spuriously.
@@ -130,4 +130,3 @@ script:
   - echo `make clean html`
 
   - make doctest
-  - make extest

--- a/setup.py
+++ b/setup.py
@@ -63,14 +63,16 @@ class TestRunner(setuptools.Command):
                                           'system tests.'),
                     ('stop', 'x', 'Stop running tests after the first '
                                   'error or failure'),
+                    ('example-tests', 'e', 'Also run the example code tests.')
                    ]
 
-    boolean_options = ['no-data', 'system-tests', 'stop']
+    boolean_options = ['no-data', 'system-tests', 'stop', 'example-tests']
     
     def initialize_options(self):
         self.no_data = False
         self.system_tests = False
         self.stop = False
+        self.example_tests = False
     
     def finalize_options(self):
         if self.no_data:
@@ -95,6 +97,9 @@ class TestRunner(setuptools.Command):
             path = os.path.join(lib_dir, mod)
             if mod != '.svn' and os.path.exists(os.path.join(path, 'tests')):
                 tests.append('%s.tests' % mod)
+        if self.example_tests:
+            tests.append(os.path.join(script_path, 'docs', 'iris',
+                                      'example_tests'))
 
         if not tests:
             raise CommandError('No tests found in %s/*/tests' % lib_dir)


### PR DESCRIPTION
An edit of the Travis-CI build control file to cause the Iris doctests and extests to also automatically run when a new PR is submitted to SciTools/Iris. Overall this is a trivial change; simply a case of adding a directory change and three make commands (make clean html, make doctest, make extest) to the `script` section of `.travis.yml.`

There are, however, two caveats:
- For the doctests to pass, two items of documentation had to be updated to reflect a change to one of the sample data files. Further, the Iris sample data ref in `.travis.yml` has been pulled up to the most recent.
- The `make html` command is consistently erroring when run on Travis, causing builds to fail even when all build and test elements have passed. As a fix to this specific problem is outside of the scope of this PR, a workaround is employed in `.travis.yml`.
