### PR TITLE
Support FieldsFile grid code 11

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -321,6 +321,15 @@ class FF2PP(object):
 
         return x_p, y_p, x_u, y_v
 
+    def _select_grid(self, grid, x_p, x_u, y_p, y_v):
+        x = x_p
+        y = y_p
+        if grid in X_COORD_U_GRID:
+            x = x_u
+        if grid in Y_COORD_V_GRID:
+            y = y_v
+        return x, y
+
     def _extract_field(self):
         # FF table pointer initialisation based on FF LOOKUP table
         # configuration.
@@ -395,12 +404,7 @@ class FF2PP(object):
                               'loader. Assuming the data is on a P grid.'
                               ''.format(field.stash, grid))
 
-            field.x = x_p
-            field.y = y_p
-            if grid in X_COORD_U_GRID:
-                field.x = x_u
-            if grid in Y_COORD_V_GRID:
-                field.y = y_v
+            field.x, field.y = self._select_grid(grid, x_p, x_u, y_p, y_v)
 
             if is_boundary_packed:
                 name_mapping = dict(rim_width=slice(4, 6), y_halo=slice(2, 4),

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -26,6 +26,7 @@ import mock
 import numpy as np
 import warnings
 
+from iris.fileformats.ff import FF2PP
 import iris.fileformats.ff as ff
 import iris.fileformats.pp as pp
 
@@ -364,6 +365,32 @@ class Test__extract_field__grid_staggering(tests.IrisTest):
         res.next()
         self.assertFalse(ff.FF2PP._det_typeC_grid_coord.called)
         ff.FF2PP._det_typeC_vpole_grid_coord.assert_called_once_with()
+
+
+class Test__select_grid(tests.IrisTest):
+    def setUp(self):
+        self.xp = mock.sentinel.xp
+        self.xu = mock.sentinel.xu
+        self.yp = mock.sentinel.yp
+        self.yv = mock.sentinel.yv
+
+    def _test(self, grid, expected):
+        with mock.patch('iris.fileformats.ff.FFHeader'):
+            ff2pp = FF2PP('dummy')
+        result = ff2pp._select_grid(grid, self.xp, self.xu, self.yp, self.yv)
+        self.assertEqual(result, expected)
+
+    def test_pp(self):
+        self._test(1, (self.xp, self.yp))
+
+    def test_pu(self):
+        self._test(18, (self.xu, self.yp))
+
+    def test_up(self):
+        self._test(19, (self.xp, self.yv))
+
+    def test_uu(self):
+        self._test(11, (self.xu, self.yv))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Reviewer: cpelley**

Grid type code 11 is defined as: "Data on atmospheric uv points"

From the UM systems team:

> The phrase "Data on atmospheric uv points" for grid type 11 is, I guess, a little bit ambiguous, but means "data on the same common set of B-grid wind points, not the distinct u and v points of the C-grid" 
