### PR TITLE
Cosmetic reformat of GRIB/CF map.

### DIFF
--- a/lib/iris/fileformats/grib/_grib_cf_map.py
+++ b/lib/iris/fileformats/grib/_grib_cf_map.py
@@ -27,7 +27,7 @@ Notes:
 * The format here will surely change in future.
 * This file is currently not pep8 compliant.
 * Only the tables actually *used* have been manually modified, i.e.
-GRIB1Local_TO_CF, GRIB2_TO_CF and CF_TO_GRIB2.  The other tables may now be
+GRIB1_LOCAL_TO_CF, GRIB2_TO_CF and CF_TO_GRIB2.  The other tables may now be
 inconsistent with these changes.
 
 This file is currently *not* actual Metarelate output, so these translations
@@ -37,7 +37,7 @@ should be made.
 
 """
 
-import collections
+from collections import namedtuple
 
 # LIST OF CHANGES:
 # Differences from the current Metarelate output.
@@ -57,156 +57,153 @@ import collections
 
 # OUTSTANDING QUESTIONS:
 # Remarks regarding the Metarelate output format
-# * Why do G1Lparam and G2param contain an "edition" attribute ?
+# * Why do G1LocalParam and G2Param contain an "edition" attribute ?
 #     -- this seems already implied in the names
 # * It would seem preferable to combine the tables GRIB1Local_TO_CF and
-#     GRIB1LocalConstrained_TO_CF, if possible
+#     GRIB1_LOCAL_TO_CF_CONSTRAINED, if possible
 
-G2param = collections.namedtuple('G2param', ['edition', 'discipline',
-                                             'category', 'number'])
-G1Lparam = collections.namedtuple('G1Lparam', ['edition', 't2version', 'centre',
-                                               'iParam'])
-DimensionCoordinate = collections.namedtuple('DimensionCoordinate',
-                                            ['standard_name', 'units', 'points'])
+G2Param = namedtuple('G2Param', 'edition discipline category number')
+G1LocalParam = namedtuple('G1LocalParam', 'edition t2version centre iParam')
+DimensionCoordinate = namedtuple('DimensionCoordinate',
+                                 'standard_name units points')
 
-CFname = collections.namedtuple('CFname', ['standard_name', 'long_name',
-                                           'unit'])
+CFName = namedtuple('CFName', 'standard_name long_name units')
 
-GRIB1LocalConstrained_TO_CF = {
-	G1Lparam(1, 128, 98, 165): (CFname("x_wind", None, "m s-1"), DimensionCoordinate("height", "m", (10,))),
-	G1Lparam(1, 128, 98, 166): (CFname("y_wind", None, "m s-1"), DimensionCoordinate("height", "m", (10,))),
-    G1Lparam(1, 128, 98, 167): (CFname("air_temperature", None, "K"), DimensionCoordinate("height", "m", (2,))),
-    G1Lparam(1, 128, 98, 168): (CFname("dew_point_temperature", None, "K"), DimensionCoordinate("height", "m", (2,))),
+GRIB1_LOCAL_TO_CF_CONSTRAINED = {
+	G1LocalParam(1, 128, 98, 165): (CFName('x_wind', None, 'm s-1'), DimensionCoordinate('height', 'm', (10,))),
+	G1LocalParam(1, 128, 98, 166): (CFName('y_wind', None, 'm s-1'), DimensionCoordinate('height', 'm', (10,))),
+    G1LocalParam(1, 128, 98, 167): (CFName('air_temperature', None, 'K'), DimensionCoordinate('height', 'm', (2,))),
+    G1LocalParam(1, 128, 98, 168): (CFName('dew_point_temperature', None, 'K'), DimensionCoordinate('height', 'm', (2,))),
 	}
 
-GRIB1Local_TO_CF = {
-	G1Lparam(1, 128, 98, 129): CFname("geopotential", None, "m2 s-2"),
-	G1Lparam(1, 128, 98, 130): CFname("air_temperature", None, "K"),
-	G1Lparam(1, 128, 98, 131): CFname("x_wind", None, "m s-1"),
-	G1Lparam(1, 128, 98, 132): CFname("y_wind", None, "m s-1"),
-	G1Lparam(1, 128, 98, 135): CFname("lagrangian_tendency_of_air_pressure", None, "Pa s-1"),
-	G1Lparam(1, 128, 98, 141): CFname("thickness_of_snowfall_amount", None, "m"),
-	G1Lparam(1, 128, 98, 151): CFname("air_pressure_at_sea_level", None, "Pa"),
-	G1Lparam(1, 128, 98, 157): CFname("relative_humidity", None, "%"),
-	G1Lparam(1, 128, 98, 164): CFname("cloud_area_fraction", None, 1),
-	G1Lparam(1, 128, 98, 173): CFname("surface_roughness_length", None, "m"),
-	G1Lparam(1, 128, 98, 174): CFname(None, "grib_physical_atmosphere_albedo", 1),
-	G1Lparam(1, 128, 98, 186): CFname("low_type_cloud_area_fraction", None, 1),
-	G1Lparam(1, 128, 98, 187): CFname("medium_type_cloud_area_fraction", None, 1),
-	G1Lparam(1, 128, 98, 188): CFname("high_type_cloud_area_fraction", None, 1),
-	G1Lparam(1, 128, 98, 235): CFname(None, "grib_skin_temperature", "K"),
-	G1Lparam(1, 128, 98, 31): CFname("sea_ice_area_fraction", None, 1),
-	G1Lparam(1, 128, 98, 34): CFname("sea_surface_temperature", None, "K"),
-	G1Lparam(1, 128, 98, 59): CFname("atmosphere_specific_convective_available_potential_energy", None, "J kg-1"),
+GRIB1_LOCAL_TO_CF = {
+	G1LocalParam(1, 128, 98, 129): CFName('geopotential', None, 'm2 s-2'),
+	G1LocalParam(1, 128, 98, 130): CFName('air_temperature', None, 'K'),
+	G1LocalParam(1, 128, 98, 131): CFName('x_wind', None, 'm s-1'),
+	G1LocalParam(1, 128, 98, 132): CFName('y_wind', None, 'm s-1'),
+	G1LocalParam(1, 128, 98, 135): CFName('lagrangian_tendency_of_air_pressure', None, 'Pa s-1'),
+	G1LocalParam(1, 128, 98, 141): CFName('thickness_of_snowfall_amount', None, 'm'),
+	G1LocalParam(1, 128, 98, 151): CFName('air_pressure_at_sea_level', None, 'Pa'),
+	G1LocalParam(1, 128, 98, 157): CFName('relative_humidity', None, '%'),
+	G1LocalParam(1, 128, 98, 164): CFName('cloud_area_fraction', None, 1),
+	G1LocalParam(1, 128, 98, 173): CFName('surface_roughness_length', None, 'm'),
+	G1LocalParam(1, 128, 98, 174): CFName(None, 'grib_physical_atmosphere_albedo', 1),
+	G1LocalParam(1, 128, 98, 186): CFName('low_type_cloud_area_fraction', None, 1),
+	G1LocalParam(1, 128, 98, 187): CFName('medium_type_cloud_area_fraction', None, 1),
+	G1LocalParam(1, 128, 98, 188): CFName('high_type_cloud_area_fraction', None, 1),
+	G1LocalParam(1, 128, 98, 235): CFName(None, 'grib_skin_temperature', 'K'),
+	G1LocalParam(1, 128, 98, 31): CFName('sea_ice_area_fraction', None, 1),
+	G1LocalParam(1, 128, 98, 34): CFName('sea_surface_temperature', None, 'K'),
+	G1LocalParam(1, 128, 98, 59): CFName('atmosphere_specific_convective_available_potential_energy', None, 'J kg-1'),
 	}
 
 GRIB2_TO_CF = {
-	G2param(2, 0, 0, 0): CFname("air_temperature", None, "K"),
-	G2param(2, 0, 0, 17): CFname(None, "grib_skin_temperature", "K"),
-	G2param(2, 0, 0, 2): CFname("air_potential_temperature", None, "K"),
-	G2param(2, 0, 1, 0): CFname("specific_humidity", None, "kg kg-1"),
-	G2param(2, 0, 1, 1): CFname("relative_humidity", None, "%"),
-	G2param(2, 0, 1, 11): CFname("thickness_of_snowfall_amount", None, "m"),
-	G2param(2, 0, 1, 13): CFname("liquid_water_content_of_surface_snow", None, "kg m-2"),
-	G2param(2, 0, 1, 22): CFname(None, "cloud_mixing_ratio", "kg kg-1"),
-	G2param(2, 0, 1, 3): CFname(None, "precipitable_water", "kg m-2"),
-	G2param(2, 0, 14, 0): CFname("atmosphere_mole_content_of_ozone", None, "Dobson"),
-	G2param(2, 0, 19, 1): CFname(None, "grib_physical_atmosphere_albedo", "%"),
-	G2param(2, 0, 2, 1): CFname("wind_speed", None, "m s-1"),
-	G2param(2, 0, 2, 10): CFname("atmosphere_absolute_vorticity", None, "s-1"),
-	G2param(2, 0, 2, 2): CFname("x_wind", None, "m s-1"),
-	G2param(2, 0, 2, 3): CFname("y_wind", None, "m s-1"),
-	G2param(2, 0, 2, 8): CFname("lagrangian_tendency_of_air_pressure", None, "Pa s-1"),
-	G2param(2, 0, 3, 0): CFname("air_pressure", None, "Pa"),
-	G2param(2, 0, 3, 1): CFname("air_pressure_at_sea_level", None, "Pa"),
-	G2param(2, 0, 3, 3): CFname(None, "icao_standard_atmosphere_reference_height", "m"),
-	G2param(2, 0, 3, 4): CFname("geopotential", None, "m2 s-2"),
-	G2param(2, 0, 3, 5): CFname("geopotential_height", None, "m"),
-	G2param(2, 0, 3, 9): CFname("geopotential_height_anomaly", None, "m"),
-	G2param(2, 0, 6, 1): CFname("cloud_area_fraction", None, "%"),
-	G2param(2, 0, 6, 3): CFname("low_type_cloud_area_fraction", None, "%"),
-	G2param(2, 0, 6, 4): CFname("medium_type_cloud_area_fraction", None, "%"),
-	G2param(2, 0, 6, 5): CFname("high_type_cloud_area_fraction", None, "%"),
-	G2param(2, 0, 6, 6): CFname("atmosphere_mass_content_of_cloud_liquid_water", None, "kg m-2"),
-	G2param(2, 0, 6, 7): CFname("cloud_area_fraction_in_atmosphere_layer", None, "%"),
-	G2param(2, 0, 7, 6): CFname("atmosphere_specific_convective_available_potential_energy", None, "J kg-1"),
-	G2param(2, 0, 7, 7): CFname(None, "convective_inhibition", "J kg-1"),
-	G2param(2, 0, 7, 8): CFname(None, "storm_relative_helicity", "J kg-1"),
-	G2param(2, 10, 2, 0): CFname("sea_ice_area_fraction", None, 1),
-	G2param(2, 10, 3, 0): CFname("sea_surface_temperature", None, "K"),
-	G2param(2, 2, 0, 0): CFname("land_area_fraction", None, 1),
-	G2param(2, 2, 0, 1): CFname("surface_roughness_length", None, "m"),
-    G2param(2, 2, 0, 2): CFname("soil_temperature", None, "K"),
-    G2param(2, 0, 1, 64): CFname("atmosphere_mass_content_of_water_vapor", None, "kg m-2"),
-    G2param(2, 2, 0, 7): CFname("surface_altitude", None, "m"),
+	G2Param(2, 0, 0, 0): CFName('air_temperature', None, 'K'),
+	G2Param(2, 0, 0, 17): CFName(None, 'grib_skin_temperature', 'K'),
+	G2Param(2, 0, 0, 2): CFName('air_potential_temperature', None, 'K'),
+	G2Param(2, 0, 1, 0): CFName('specific_humidity', None, 'kg kg-1'),
+	G2Param(2, 0, 1, 1): CFName('relative_humidity', None, '%'),
+	G2Param(2, 0, 1, 11): CFName('thickness_of_snowfall_amount', None, 'm'),
+	G2Param(2, 0, 1, 13): CFName('liquid_water_content_of_surface_snow', None, 'kg m-2'),
+	G2Param(2, 0, 1, 22): CFName(None, 'cloud_mixing_ratio', 'kg kg-1'),
+	G2Param(2, 0, 1, 3): CFName(None, 'precipitable_water', 'kg m-2'),
+	G2Param(2, 0, 14, 0): CFName('atmosphere_mole_content_of_ozone', None, 'Dobson'),
+	G2Param(2, 0, 19, 1): CFName(None, 'grib_physical_atmosphere_albedo', '%'),
+	G2Param(2, 0, 2, 1): CFName('wind_speed', None, 'm s-1'),
+	G2Param(2, 0, 2, 10): CFName('atmosphere_absolute_vorticity', None, 's-1'),
+	G2Param(2, 0, 2, 2): CFName('x_wind', None, 'm s-1'),
+	G2Param(2, 0, 2, 3): CFName('y_wind', None, 'm s-1'),
+	G2Param(2, 0, 2, 8): CFName('lagrangian_tendency_of_air_pressure', None, 'Pa s-1'),
+	G2Param(2, 0, 3, 0): CFName('air_pressure', None, 'Pa'),
+	G2Param(2, 0, 3, 1): CFName('air_pressure_at_sea_level', None, 'Pa'),
+	G2Param(2, 0, 3, 3): CFName(None, 'icao_standard_atmosphere_reference_height', 'm'),
+	G2Param(2, 0, 3, 4): CFName('geopotential', None, 'm2 s-2'),
+	G2Param(2, 0, 3, 5): CFName('geopotential_height', None, 'm'),
+	G2Param(2, 0, 3, 9): CFName('geopotential_height_anomaly', None, 'm'),
+	G2Param(2, 0, 6, 1): CFName('cloud_area_fraction', None, '%'),
+	G2Param(2, 0, 6, 3): CFName('low_type_cloud_area_fraction', None, '%'),
+	G2Param(2, 0, 6, 4): CFName('medium_type_cloud_area_fraction', None, '%'),
+	G2Param(2, 0, 6, 5): CFName('high_type_cloud_area_fraction', None, '%'),
+	G2Param(2, 0, 6, 6): CFName('atmosphere_mass_content_of_cloud_liquid_water', None, 'kg m-2'),
+	G2Param(2, 0, 6, 7): CFName('cloud_area_fraction_in_atmosphere_layer', None, '%'),
+	G2Param(2, 0, 7, 6): CFName('atmosphere_specific_convective_available_potential_energy', None, 'J kg-1'),
+	G2Param(2, 0, 7, 7): CFName(None, 'convective_inhibition', 'J kg-1'),
+	G2Param(2, 0, 7, 8): CFName(None, 'storm_relative_helicity', 'J kg-1'),
+	G2Param(2, 10, 2, 0): CFName('sea_ice_area_fraction', None, 1),
+	G2Param(2, 10, 3, 0): CFName('sea_surface_temperature', None, 'K'),
+	G2Param(2, 2, 0, 0): CFName('land_area_fraction', None, 1),
+	G2Param(2, 2, 0, 1): CFName('surface_roughness_length', None, 'm'),
+    G2Param(2, 2, 0, 2): CFName('soil_temperature', None, 'K'),
+    G2Param(2, 0, 1, 64): CFName('atmosphere_mass_content_of_water_vapor', None, 'kg m-2'),
+    G2Param(2, 2, 0, 7): CFName('surface_altitude', None, 'm'),
 	}
 
-CFConstrained_TO_GRIB1Local = {
-(CFname("air_temperature", None, "K"), DimensionCoordinate("height", "m", (2,))): G1Lparam(1, 128, 98, 167),
-(CFname("x_wind", None, "m s-1"), DimensionCoordinate("height", "m", (10,))): G1Lparam(1, 128, 98, 165),
-(CFname("y_wind", None, "m s-1"), DimensionCoordinate("height", "m", (10,))): G1Lparam(1, 128, 98, 166),
+CF_CONSTRAINED_TO_GRIB1_LOCAL = {
+    (CFName('air_temperature', None, 'K'), DimensionCoordinate('height', 'm', (2,))): G1LocalParam(1, 128, 98, 167),
+    (CFName('x_wind', None, 'm s-1'), DimensionCoordinate('height', 'm', (10,))): G1LocalParam(1, 128, 98, 165),
+    (CFName('y_wind', None, 'm s-1'), DimensionCoordinate('height', 'm', (10,))): G1LocalParam(1, 128, 98, 166),
 	}
 
-CF_TO_GRIB1Local = {
-	CFname("air_pressure_at_sea_level", None, "Pa"):G1Lparam(1, 128, 98, 151),
-	CFname("air_temperature", None, "K"):G1Lparam(1, 128, 98, 130),
-	CFname("atmosphere_specific_convective_available_potential_energy", None, "J Kg-1"):G1Lparam(1, 128, 98, 59),
-	CFname("cloud_area_fraction", None, 1):G1Lparam(1, 128, 98, 164),
-	CFname("geopotential", None, "m2 s-2"):G1Lparam(1, 128, 98, 129),
-	CFname("high_type_cloud_area_fraction", None, 1):G1Lparam(1, 128, 98, 188),
-	CFname("lagrangian_tendency_of_air_pressure", None, "Pa s-1"):G1Lparam(1, 128, 98, 135),
-	CFname("low_type_cloud_area_fraction", None, 1):G1Lparam(1, 128, 98, 186),
-	CFname("medium_type_cloud_area_fraction", None, 1):G1Lparam(1, 128, 98, 187),
-	CFname("relative_humidity", None, "%"):G1Lparam(1, 128, 98, 157),
-	CFname("sea_ice_area_fraction", None, 1):G1Lparam(1, 128, 98, 31),
-	CFname("sea_surface_temperature", None, "K"):G1Lparam(1, 128, 98, 34),
-	CFname("surface_roughness_length", None, "m"):G1Lparam(1, 128, 98, 173),
-	CFname("thickness_of_snowfall_amount", None, "m"):G1Lparam(1, 128, 98, 141),
-	CFname("x_wind", None, "m s-1"):G1Lparam(1, 128, 98, 131),
-	CFname("y_wind", None, "m s-1"):G1Lparam(1, 128, 98, 132),
-	CFname(None, "grib_physical_atmosphere_albedo", 1):G1Lparam(1, 128, 98, 174),
-	CFname(None, "grib_skin_temperature", "K"):G1Lparam(1, 128, 98, 235),
+CF_TO_GRIB1_LOCAL = {
+	CFName('air_pressure_at_sea_level', None, 'Pa'): G1LocalParam(1, 128, 98, 151),
+	CFName('air_temperature', None, 'K'): G1LocalParam(1, 128, 98, 130),
+	CFName('atmosphere_specific_convective_available_potential_energy', None, 'J Kg-1'): G1LocalParam(1, 128, 98, 59),
+	CFName('cloud_area_fraction', None, 1): G1LocalParam(1, 128, 98, 164),
+	CFName('geopotential', None, 'm2 s-2'): G1LocalParam(1, 128, 98, 129),
+	CFName('high_type_cloud_area_fraction', None, 1): G1LocalParam(1, 128, 98, 188),
+	CFName('lagrangian_tendency_of_air_pressure', None, 'Pa s-1'): G1LocalParam(1, 128, 98, 135),
+	CFName('low_type_cloud_area_fraction', None, 1): G1LocalParam(1, 128, 98, 186),
+	CFName('medium_type_cloud_area_fraction', None, 1): G1LocalParam(1, 128, 98, 187),
+	CFName('relative_humidity', None, '%'): G1LocalParam(1, 128, 98, 157),
+	CFName('sea_ice_area_fraction', None, 1): G1LocalParam(1, 128, 98, 31),
+	CFName('sea_surface_temperature', None, 'K'): G1LocalParam(1, 128, 98, 34),
+	CFName('surface_roughness_length', None, 'm'): G1LocalParam(1, 128, 98, 173),
+	CFName('thickness_of_snowfall_amount', None, 'm'): G1LocalParam(1, 128, 98, 141),
+	CFName('x_wind', None, 'm s-1'): G1LocalParam(1, 128, 98, 131),
+	CFName('y_wind', None, 'm s-1'): G1LocalParam(1, 128, 98, 132),
+	CFName(None, 'grib_physical_atmosphere_albedo', 1): G1LocalParam(1, 128, 98, 174),
+	CFName(None, 'grib_skin_temperature', 'K'): G1LocalParam(1, 128, 98, 235),
 	}
 
-CF_TO_GRIB2 = {	CFname("x_wind", None, "m s-1"):G2param(2, 0, 2, 2),
-
- 	CFname("air_potential_temperature", None, "K"):G2param(2, 0, 0, 2),
- 	CFname("air_pressure", None, "Pa"):G2param(2, 0, 3, 0),
- 	CFname("air_pressure_at_sea_level", None, "Pa"):G2param(2, 0, 3, 1),
- 	CFname("air_temperature", None, "K"):G2param(2, 0, 0, 0),
- 	CFname("atmosphere_absolute_vorticity", None, "s-1"):G2param(2, 0, 2, 10),
- 	CFname("atmosphere_mass_content_of_cloud_liquid_water", None, "kg m-2"):G2param(2, 0, 6, 6),
- 	CFname("atmosphere_mole_content_of_ozone", None, "Dobson"):G2param(2, 0, 14, 0),
- 	CFname("atmosphere_specific_convective_available_potential_energy", None, "J kg-1"):G2param(2, 0, 7, 6),
- 	CFname("cloud_area_fraction", None, "%"):G2param(2, 0, 6, 1),
- 	CFname("cloud_area_fraction_in_atmosphere_layer", None, "%"):G2param(2, 0, 6, 7),
- 	CFname("geopotential", None, "m2 s-2"):G2param(2, 0, 3, 4),
- 	CFname("geopotential_height", None, "m"):G2param(2, 0, 3, 5),
- 	CFname("geopotential_height_anomaly", None, "m"):G2param(2, 0, 3, 9),
- 	CFname("high_type_cloud_area_fraction", None, "%"):G2param(2, 0, 6, 5),
- 	CFname("lagrangian_tendency_of_air_pressure", None, "Pa s-1"):G2param(2, 0, 2, 8),
- 	CFname("land_area_fraction", None, 1):G2param(2, 2, 0, 0),
- 	CFname("liquid_water_content_of_surface_snow", None, "kg m-2"):G2param(2, 0, 1, 13),
- 	CFname("low_type_cloud_area_fraction", None, "%"):G2param(2, 0, 6, 3),
- 	CFname("medium_type_cloud_area_fraction", None, "%"):G2param(2, 0, 6, 4),
- 	CFname("relative_humidity", None, "%"):G2param(2, 0, 1, 1),
- 	CFname("sea_ice_area_fraction", None, 1):G2param(2, 10, 2, 0),
- 	CFname("sea_surface_temperature", None, "K"):G2param(2, 10, 3, 0),
-    CFname("soil_temperature", None, "K"):G2param(2, 2, 0, 2),
-    CFname("specific_humidity", None, "kg kg-1"):G2param(2, 0, 1, 0),
- 	CFname("surface_roughness_length", None, "m"):G2param(2, 2, 0, 1),
- 	CFname("thickness_of_snowfall_amount", None, "m"):G2param(2, 0, 1, 11),
- 	CFname("wind_speed", None, "m s-1"):G2param(2, 0, 2, 1),
- 	CFname("y_wind", None, "m s-1"):G2param(2, 0, 2, 3),
- 	CFname(None, "cloud_mixing_ratio", "kg kg-1"):G2param(2, 0, 1, 22),
- 	CFname(None, "convective_inhibition", "J kg-1"):G2param(2, 0, 7, 7),
- 	CFname(None, "grib_physical_atmosphere_albedo", "%"):G2param(2, 0, 19, 1),
- 	CFname(None, "grib_skin_temperature", "K"):G2param(2, 0, 0, 17),
- 	CFname(None, "icao_standard_atmosphere_reference_height", "m"):G2param(2, 0, 3, 3),
- 	CFname(None, "precipitable_water", "kg m-2"):G2param(2, 0, 1, 3),
- 	CFname(None, "storm_relative_helicity", "J kg-1"):G2param(2, 0, 7, 8),
-    CFname("dew_point_temperature", None, "K"):G2param(2, 0, 0, 6),
-    CFname("atmosphere_mass_content_of_water_vapor", None, "kg m-2"):G2param(2, 0, 1, 64),
-    CFname("surface_altitude", None, "m"):G2param(2, 2, 0, 7),
-    CFname("land_binary_mask", None, 1):G2param(2, 2, 0, 0),
+CF_TO_GRIB2 = {
+	CFName('x_wind', None, 'm s-1'): G2Param(2, 0, 2, 2),
+ 	CFName('air_potential_temperature', None, 'K'): G2Param(2, 0, 0, 2),
+ 	CFName('air_pressure', None, 'Pa'): G2Param(2, 0, 3, 0),
+ 	CFName('air_pressure_at_sea_level', None, 'Pa'): G2Param(2, 0, 3, 1),
+ 	CFName('air_temperature', None, 'K'): G2Param(2, 0, 0, 0),
+ 	CFName('atmosphere_absolute_vorticity', None, 's-1'): G2Param(2, 0, 2, 10),
+ 	CFName('atmosphere_mass_content_of_cloud_liquid_water', None, 'kg m-2'): G2Param(2, 0, 6, 6),
+ 	CFName('atmosphere_mole_content_of_ozone', None, 'Dobson'): G2Param(2, 0, 14, 0),
+ 	CFName('atmosphere_specific_convective_available_potential_energy', None, 'J kg-1'): G2Param(2, 0, 7, 6),
+ 	CFName('cloud_area_fraction', None, '%'): G2Param(2, 0, 6, 1),
+ 	CFName('cloud_area_fraction_in_atmosphere_layer', None, '%'): G2Param(2, 0, 6, 7),
+ 	CFName('geopotential', None, 'm2 s-2'): G2Param(2, 0, 3, 4),
+ 	CFName('geopotential_height', None, 'm'): G2Param(2, 0, 3, 5),
+ 	CFName('geopotential_height_anomaly', None, 'm'): G2Param(2, 0, 3, 9),
+ 	CFName('high_type_cloud_area_fraction', None, '%'): G2Param(2, 0, 6, 5),
+ 	CFName('lagrangian_tendency_of_air_pressure', None, 'Pa s-1'): G2Param(2, 0, 2, 8),
+ 	CFName('land_area_fraction', None, 1): G2Param(2, 2, 0, 0),
+ 	CFName('liquid_water_content_of_surface_snow', None, 'kg m-2'): G2Param(2, 0, 1, 13),
+ 	CFName('low_type_cloud_area_fraction', None, '%'): G2Param(2, 0, 6, 3),
+ 	CFName('medium_type_cloud_area_fraction', None, '%'): G2Param(2, 0, 6, 4),
+ 	CFName('relative_humidity', None, '%'): G2Param(2, 0, 1, 1),
+ 	CFName('sea_ice_area_fraction', None, 1): G2Param(2, 10, 2, 0),
+ 	CFName('sea_surface_temperature', None, 'K'): G2Param(2, 10, 3, 0),
+    CFName('soil_temperature', None, 'K'): G2Param(2, 2, 0, 2),
+    CFName('specific_humidity', None, 'kg kg-1'): G2Param(2, 0, 1, 0),
+ 	CFName('surface_roughness_length', None, 'm'): G2Param(2, 2, 0, 1),
+ 	CFName('thickness_of_snowfall_amount', None, 'm'): G2Param(2, 0, 1, 11),
+ 	CFName('wind_speed', None, 'm s-1'): G2Param(2, 0, 2, 1),
+ 	CFName('y_wind', None, 'm s-1'): G2Param(2, 0, 2, 3),
+ 	CFName(None, 'cloud_mixing_ratio', 'kg kg-1'): G2Param(2, 0, 1, 22),
+ 	CFName(None, 'convective_inhibition', 'J kg-1'): G2Param(2, 0, 7, 7),
+ 	CFName(None, 'grib_physical_atmosphere_albedo', '%'): G2Param(2, 0, 19, 1),
+ 	CFName(None, 'grib_skin_temperature', 'K'): G2Param(2, 0, 0, 17),
+ 	CFName(None, 'icao_standard_atmosphere_reference_height', 'm'): G2Param(2, 0, 3, 3),
+ 	CFName(None, 'precipitable_water', 'kg m-2'): G2Param(2, 0, 1, 3),
+ 	CFName(None, 'storm_relative_helicity', 'J kg-1'): G2Param(2, 0, 7, 8),
+    CFName('dew_point_temperature', None, 'K'): G2Param(2, 0, 0, 6),
+    CFName('atmosphere_mass_content_of_water_vapor', None, 'kg m-2'): G2Param(2, 0, 1, 64),
+    CFName('surface_altitude', None, 'm'): G2Param(2, 2, 0, 7),
+    CFName('land_binary_mask', None, 1): G2Param(2, 2, 0, 0),
 	}

--- a/lib/iris/fileformats/grib/grib_phenom_translation.py
+++ b/lib/iris/fileformats/grib/grib_phenom_translation.py
@@ -109,7 +109,7 @@ def _make_grib1_cf_table():
         return (grib1_key, cf_data)
 
     # Interpret the imported Grib1-to-CF table.
-    for (grib1data, cfdata) in grcf.GRIB1Local_TO_CF.iteritems():
+    for (grib1data, cfdata) in grcf.GRIB1_LOCAL_TO_CF.iteritems():
         assert grib1data.edition == 1
         association_entry = _make_grib1_cf_entry(
             table2_version=grib1data.t2version,
@@ -117,14 +117,14 @@ def _make_grib1_cf_table():
             param_number=grib1data.iParam,
             standard_name=cfdata.standard_name,
             long_name=cfdata.long_name,
-            units=cfdata.unit)
+            units=cfdata.units)
         if association_entry is not None:
             key, value = association_entry
             table[key] = value
 
     # Do the same for special Grib1 codes that include an implied height level.
     for (grib1data, (cfdata, extra_dimcoord)) \
-            in grcf.GRIB1LocalConstrained_TO_CF.iteritems():
+            in grcf.GRIB1_LOCAL_TO_CF_CONSTRAINED.iteritems():
         assert grib1data.edition == 1
         if extra_dimcoord.standard_name != 'height':
             raise ValueError('Got implied dimension coord of "{}", '
@@ -144,7 +144,7 @@ def _make_grib1_cf_table():
             param_number=int(grib1data.iParam),
             standard_name=cfdata.standard_name,
             long_name=cfdata.long_name,
-            units=cfdata.unit,
+            units=cfdata.units,
             set_height=extra_dimcoord.points[0])
         if association_entry is not None:
             key, value = association_entry
@@ -204,7 +204,7 @@ def _make_grib2_to_cf_table():
             param_number=grib2data.number,
             standard_name=cfdata.standard_name,
             long_name=cfdata.long_name,
-            units=cfdata.unit)
+            units=cfdata.units)
         if association_entry is not None:
             key, value = association_entry
             table[key] = value
@@ -258,7 +258,7 @@ def _make_cf_to_grib2_table():
     # Interpret the imported CF-to-Grib2 table into a lookup table
     for cfdata, grib2data in grcf.CF_TO_GRIB2.iteritems():
         assert grib2data.edition == 2
-        iris_units = iris.unit.Unit(cfdata.unit)
+        iris_units = iris.unit.Unit(cfdata.units)
         association_entry = _make_cf_grib2_entry(
             standard_name=cfdata.standard_name,
             long_name=cfdata.long_name,


### PR DESCRIPTION
This PR includes minor format changes to the `_grib_cf_map.py` file. There are **no** data changes.

These changes pave the way (eases the pain) for a following PR which incorporates the new GRIB/CF translations as generated by MetaRelate.

The summary of main format changes:
- `CFname` to `CFName`,
- `unit` to `units` (within the `CFName` namedtuple),
- `:` to `:<space>` (addition of trailing space after colon in dictionary key/value pairs),
- `"` to `'`,
- `G2parm` to `G2Param`,
- `G1Lparam` to `G1LocalParam`,
- `GRIB1LocalConstrained_TO_CF` to `GRIB1_LOCAL_TO_CF_CONSTRAINED`,
- `GRIB1Local_TO_CF` to `GRIB1_LOCAL_TO_CF`,
- `CFConstrained_TO_GRIB1Local` to `CF_CONSTRAINED_TO_GRIB1_LOCAL`, and
- `CF_TO_GRIB1Local` to `CF_TO_GRIB1_LOCAL`.

This PR must be merged before #853.
