### PR TITLE
Bug fix - iris.unit.monotonic return direction value. 

### DIFF
--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -71,10 +71,15 @@ class TestMonotonic(unittest.TestCase):
     def test_monotonic_strict(self):
         b = np.array([3, 5.3, 4])
         self.assertNotMonotonic(b, strict=True)
+        self.assertNotMonotonic(b)
 
         b = np.array([3, 5.3, 5.3])
         self.assertNotMonotonic(b, strict=True)
-        self.assertMonotonic(b)
+        self.assertMonotonic(b, direction=1)
+        
+        b = b[::-1]
+        self.assertNotMonotonic(b, strict=True)
+        self.assertMonotonic(b, direction=-1)
 
         b = np.array([0.0])
         self.assertRaises(ValueError, iris.util.monotonic, b)

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -535,8 +535,9 @@ def monotonic(array, strict=False, return_direction=False):
     # Identify the directions of the largest/most-positive and
     # smallest/most-negative steps.
     d = np.diff(array)
-    sign_max_d = np.sign(d[np.argmax(d)])
-    sign_min_d = np.sign(d[np.argmin(d)])
+
+    sign_max_d = np.sign(np.max(d))
+    sign_min_d = np.sign(np.min(d))
 
     if strict:
         monotonic = sign_max_d == sign_min_d and sign_max_d != 0
@@ -546,10 +547,14 @@ def monotonic(array, strict=False, return_direction=False):
                     (sign_min_d == sign_max_d == 0)
 
     if return_direction:
-        direction = sign_max_d or 1
+        if sign_max_d == 0:
+            direction = sign_min_d
+        else:
+            direction = sign_max_d
+
         return monotonic, direction
-    else:
-        return monotonic
+
+    return monotonic
 
 
 def column_slices_generator(full_slice, ndims):


### PR DESCRIPTION
`iris.unit.monotonic` return direction value was 1 when array elements are descending, and some are identical. Fixed this to be -1. Added some tests for return direction value in TestMonotonic. This fix is for issue #837. 
