### PR TITLE
Install Travis libgdalh1 v1.10.0-1~precise1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 # add repo
   - ./.travis_no_output sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192
-  - yes | ./.travis_no_output sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+  - yes | ./.travis_no_output sudo add-apt-repository ppa:ubuntugis/ppa
   - ./.travis_no_output sudo apt-get update
 
 # install deps
@@ -47,7 +47,7 @@ install:
   - ./.travis_no_output sudo /usr/bin/pip install netCDF4==1.0.2
   - ./.travis_no_output sudo /usr/bin/pip install pyke pandas
   - ./.travis_no_output sudo apt-get install openjdk-7-jre
-  - ./.travis_no_output sudo apt-get install python-gdal
+  - sudo apt-get install python-gdal
   - export LD_LIBRARY_PATH=/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH
 
 # cfchecker

--- a/lib/iris/experimental/constraints.py
+++ b/lib/iris/experimental/constraints.py
@@ -58,9 +58,9 @@ class TimeRangeConstraint(Constraint):
         """
         Convenience method to extract the day of the year from either a
         :class:`datetime.datetime` or a :class:`netcdftime.datetime`.
-        
+
         Caution: See also :func:`iris.util._fix_netcdftime_datetime`.
-        
+
         """
         # netcdf.datetime?
         if hasattr(dt, 'dayofyr'):


### PR DESCRIPTION
This PR fixes the Travis build of GDAL given the change in dependency of `python-gdal` on `libgdal1` to `libgdal1h`.  
