### PR TITLE
Add missing travis_no_output for gdal build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - ./.travis_no_output sudo /usr/bin/pip install netCDF4==1.0.2
   - ./.travis_no_output sudo /usr/bin/pip install pyke pandas
   - ./.travis_no_output sudo apt-get install openjdk-7-jre
-  - sudo apt-get install python-gdal
+  - ./.travis_no_output sudo apt-get install python-gdal
   - export LD_LIBRARY_PATH=/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH
 
 # cfchecker


### PR DESCRIPTION
This PR includes a minor change to the `travis.yml` missed in #857.
