### PR TITLE
Changed cube string repr

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1446,8 +1446,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Add the dim_coord names that participate in the associated data
         # dimensions.
         for dim in xrange(len(self.shape)):
-            for coord in self.coords(contains_dimension=dim, dim_coords=True):
-                dim_names[dim].add(coord.name())
+            dim_coords = self.coords(contains_dimension=dim, dim_coords=True)
+            if dim_coords:
+                dim_names[dim].add(dim_coords[0].name())
+            else:
+                dim_names[dim].add('-- ')
 
         # Convert axes sets to lists and sort.
         dim_names = [sorted(names, key=sorted_axes) for names in dim_names]
@@ -1457,7 +1460,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             dimension_header = 'scalar cube'
         else:
             dimension_header = '; '.join(
-                [', '.join(dim_names[dim] or ['*ANONYMOUS*']) +
+                [', '.join(dim_names[dim]) +
                  ': %d' % dim_shape for dim, dim_shape in
                  enumerate(self.shape)])
 

--- a/lib/iris/tests/results/cdm/str_repr/missing_coords_cube.repr.txt
+++ b/lib/iris/tests/results/cdm/str_repr/missing_coords_cube.repr.txt
@@ -1,0 +1,1 @@
+<iris 'Cube' of air_potential_temperature / (K) (-- : 6; -- : 70; grid_latitude: 100; grid_longitude: 100)>

--- a/lib/iris/tests/results/cdm/str_repr/missing_coords_cube.str.txt
+++ b/lib/iris/tests/results/cdm/str_repr/missing_coords_cube.str.txt
@@ -1,0 +1,14 @@
+air_potential_temperature / (K)     (-- : 6; -- : 70; grid_latitude: 100; grid_longitude: 100)
+     Dimension coordinates:
+          grid_latitude                 -       -                  x                    -
+          grid_longitude                -       -                  -                    x
+     Auxiliary coordinates:
+          level_height                  -       x                  -                    -
+          sigma                         -       x                  -                    -
+          surface_altitude              -       -                  x                    x
+     Derived coordinates:
+          altitude                      -       x                  x                    x
+     Scalar coordinates:
+          forecast_period: 0.0 hours
+     Attributes:
+          source: Iris test case

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -256,7 +256,16 @@ class TestCubeStringRepresentations(IrisDotTest):
     def test_dot_4d(self):
         cube = iris.tests.stock.realistic_4d()
         self.check_dot(cube, ('file_load', '4d_pp.dot'))
-        
+
+    def test_missing_coords(self):
+        cube = iris.tests.stock.realistic_4d()
+        cube.remove_coord('time')
+        cube.remove_coord('model_level_number')
+        self.assertString(repr(cube),
+                          ('cdm', 'str_repr', 'missing_coords_cube.repr.txt'))
+        self.assertString(str(cube),
+                          ('cdm', 'str_repr', 'missing_coords_cube.str.txt'))
+
     def test_cubelist_string(self):
         cube_list = iris.cube.CubeList([iris.tests.stock.realistic_4d(),
                                         iris.tests.stock.global_pp()])


### PR DESCRIPTION
Changed cube string representation so that dim names are `@` if only aux coords are present and `?` if no coords are present, as opposed to the current system, which uses `*ANONYMOUS*`.  In reaction to discussion here
https://groups.google.com/forum/?fromgroups#!topic/scitools-iris/i0-GHVNcpVc
and here
https://groups.google.com/forum/#!topic/scitools-iris-dev/DothjG_MUzA
