### PR TITLE
Remove obsolete Coord.index() stub

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -805,14 +805,6 @@ class Coord(CFVariableMixin):
         # a deferred load unnecessarily.
         return self._points.shape
 
-    def index(self, cell):
-        """
-        Return the index of a given Cell in this Coord.
-
-        """
-        raise IrisError('Coord.index() is no longer available.'
-                        ' Use Coord.nearest_neighbour_index() instead.')
-
     def cell(self, index):
         """
         Return the single :class:`Cell` instance which results from slicing the


### PR DESCRIPTION
This has been deprecated since at least [v0.9](https://github.com/SciTools/iris/blob/v0.9/lib/iris/coords.py#L603)... and it hasn't even worked properly all that time!

NB. This was spotted during #871.
