### PR TITLE
WIP: New binary operations for cubes

### DIFF
--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -484,7 +484,7 @@ def _broadcast_cube_coord_data(cube, other, operation_noun, dim=None):
             except iris.exceptions.CoordinateNotFoundError:
                 raise ValueError(("Could not determine dimension for %s. "
                                   "Use %s(cube, coord, dim=dim)")
-                                 % operation_noun)
+                                 % (operation_noun, operation_noun))
 
     if other.ndim != 1:
         raise iris.exceptions.CoordinateMultiDimError(other)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2265,28 +2265,32 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     __pow__ = iris.analysis.maths.exponentiate
     __rpow__ = iris.analysis.maths.reverse_exponentiate
-    __ipow__ = functools.partial(iris.analysis.maths.exponentiate,
-                                 in_place=True)
+    def __ipow__(self, other):
+        return iris.analysis.maths.exponentiate(self, other, in_place=True)
 
     def __add__(self, other):
         return iris.analysis.maths.add(self, other, ignore=True)
     __radd__ = __add__
-    __iadd__ = functools.partial(iris.analysis.maths.add, in_place=True)
+    def __iadd__(self, other):
+        return iris.analysis.maths.add(self, other, in_place=True)
 
     def __sub__(self, other):
         return iris.analysis.maths.subtract(self, other, ignore=True)
     def __rsub__(self, other):
         return -self + other
-    __isub__ = functools.partial(iris.analysis.maths.subtract, in_place=True)
+    def __isub__(self, other):
+        return iris.analysis.maths.subtract(self, other, in_place=True)
 
     __mul__ = iris.analysis.maths.multiply
     __rmul__ = __mul__
-    __imul__ = functools.partial(iris.analysis.maths.multiply, in_place=True)
+    def __imul__(self, other):
+        return iris.analysis.maths.multiply(self, other, in_place=True)
 
     __div__ = iris.analysis.maths.divide
     def __rdiv__(self, other):
         return iris.analysis.maths.reciprocal(self) * other
-    __idiv__ = functools.partial(iris.analysis.maths.divide, in_place=True)
+    def __idiv__(self, other):
+        return iris.analysis.maths.divide(self, other, in_place=True)
     __truediv__ = iris.analysis.maths.divide
 
     __ge__ = iris.analysis.maths.greater_equal
@@ -2298,17 +2302,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     __and__ = iris.analysis.maths.bitwise_and
     __rand__ = iris.analysis.maths.bitwise_and
-    __iand__ = functools.partial(iris.analysis.maths.bitwise_and,
-                                 in_place=True)
+    def __iand__(self, other):
+        return iris.analysis.maths.bitwise_and(self, other, in_place=True)
 
     __or__ = iris.analysis.maths.bitwise_or
     __ror__ = iris.analysis.maths.bitwise_or
-    __ior__ = functools.partial(iris.analysis.maths.bitwise_or, in_place=True)
+    def __ior__(self, other):
+        return iris.analysis.maths.bitwise_or(self, other, in_place=True)
 
     __xor__ = iris.analysis.maths.bitwise_xor
     __rxor__ = iris.analysis.maths.bitwise_xor
-    __ixor__ = functools.partial(iris.analysis.maths.bitwise_xor,
-                                 in_place=True)
+    def __ixor__(self, other):
+        return iris.analysis.maths.bitwise_xor(self, other, in_place=True)
     # END OPERATOR OVERLOADS
 
     def add_history(self, string):

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -36,14 +36,14 @@ class TestBasicMaths(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
         self.cube.data = self.cube.data - 260
-    
-    def test_abs(self):  
-        a = self.cube                      
-        
+
+    def test_abs(self):
+        a = self.cube
+
         b = iris.analysis.maths.abs(a, in_place=False)
         self.assertCML(a, ('analysis', 'maths_original.cml'))
         self.assertCML(b, ('analysis', 'abs.cml'))
-        
+
         iris.analysis.maths.abs(a, in_place=True)
         self.assertCML(b, ('analysis', 'abs.cml'))
         self.assertCML(a, ('analysis', 'abs.cml'))
@@ -60,20 +60,20 @@ class TestBasicMaths(tests.IrisTest):
 
         # Check that the subtraction has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         c = iris.analysis.maths.subtract(e, e)
         self.assertCML(c, ('analysis', 'subtract.cml'))
-                        
+
         # Check that the subtraction has had no effect on the original
         self.assertCML(e, ('analysis', 'maths_original.cml'))
-        
+
     def test_minus_in_need_of_transpose(self):
         a = self.cube
         e = self.cube.copy()
         e.transpose([1, 0])
         self.assertRaises(ValueError, iris.analysis.maths.subtract, a, e)
-        
-        
+
+
     def test_minus_with_data_describing_coordinate(self):
         a = self.cube
         e = self.cube.copy()
@@ -85,23 +85,23 @@ class TestBasicMaths(tests.IrisTest):
 
     def test_minus_scalar(self):
         a = self.cube
-        
+
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = a - 200
         self.assertCML(b, ('analysis', 'subtract_scalar.cml'))
         # Check that the subtraction has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_minus_array(self):
         a = self.cube
         data_array = self.cube.copy().data
-        
+
         # check that the file has not changed (avoids false positives by failing early)
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         # subtract an array of exactly the same shape as the original
-        b = a - data_array        
+        b = a - data_array
         self.assertArrayEqual(b.data, np.array(0, dtype=np.float32))
         self.assertCML(b, ('analysis', 'subtract_array.cml'), checksum=False)
 
@@ -114,64 +114,64 @@ class TestBasicMaths(tests.IrisTest):
         b = a - data_array[0, :]
         self.assertArrayEqual(b.data[0, :], np.array(0, dtype=np.float32))
         self.assertArrayEqual(b.data[:, 1:2], b.data[:, 1:2])
-        
+
         # subtract an array of 1 dimension more than the cube
         d_array = data_array.reshape(data_array.shape[0], data_array.shape[1], 1)
         self.assertRaises(ValueError, iris.analysis.maths.subtract, a, d_array)
-                        
+
         # Check that the subtraction has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_minus_coord(self):
         a = self.cube
 
-        xdim = a.ndim-1 
+        xdim = a.ndim-1
         ydim = a.ndim-2
-        c_x = iris.coords.DimCoord(points=range(a.shape[xdim]), long_name='x_coord', units=self.cube.units) 
-        c_y = iris.coords.AuxCoord(points=range(a.shape[ydim]), long_name='y_coord', units=self.cube.units) 
-        
+        c_x = iris.coords.DimCoord(points=range(a.shape[xdim]), long_name='x_coord', units=self.cube.units)
+        c_y = iris.coords.AuxCoord(points=range(a.shape[ydim]), long_name='y_coord', units=self.cube.units)
+
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = iris.analysis.maths.subtract(a, c_x, dim=1)
         self.assertCML(b, ('analysis', 'subtract_coord_x.cml'))
         # Check that the subtraction has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = iris.analysis.maths.subtract(a, c_y, dim=0)
         self.assertCML(b, ('analysis', 'subtract_coord_y.cml'))
         # Check that the subtraction has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_addition_scalar(self):
         a = self.cube
-        
+
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = a + 200
         self.assertCML(b, ('analysis', 'addition_scalar.cml'))
         # Check that the addition has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_addition_coord(self):
         a = self.cube
 
-        xdim = a.ndim-1 
+        xdim = a.ndim-1
         ydim = a.ndim-2
-        c_x = iris.coords.DimCoord(points=range(a.shape[xdim]), long_name='x_coord', units=self.cube.units) 
-        c_y = iris.coords.AuxCoord(points=range(a.shape[ydim]), long_name='y_coord', units=self.cube.units) 
-        
+        c_x = iris.coords.DimCoord(points=range(a.shape[xdim]), long_name='x_coord', units=self.cube.units)
+        c_y = iris.coords.AuxCoord(points=range(a.shape[ydim]), long_name='y_coord', units=self.cube.units)
+
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = iris.analysis.maths.add(a, c_x, dim=1)
         self.assertCML(b, ('analysis', 'addition_coord_x.cml'))
         # Check that the addition has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
         b = iris.analysis.maths.add(a, c_y, dim=0)
         self.assertCML(b, ('analysis', 'addition_coord_y.cml'))
         # Check that the addition has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-    
+
     def test_addition(self):
         a = self.cube
 
@@ -179,21 +179,21 @@ class TestBasicMaths(tests.IrisTest):
         self.assertCML(c, ('analysis', 'addition.cml'))
         # Check that the addition has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_addition_different_standard_name(self):
         a = self.cube.copy()
         b = self.cube.copy()
         b.rename('my cube data')
-        c = a + b        
+        c = a + b
         self.assertCML(c, ('analysis', 'addition_different_std_name.cml'), checksum=False)
-        
+
     def test_addition_fail(self):
         a = self.cube
-        
-        xdim = a.ndim-1 
-        ydim = a.ndim-2 
-        c_axis_length_fail = iris.coords.DimCoord(points=range(a.shape[ydim]), long_name='x_coord', units=self.cube.units) 
-        c_unit_fail = iris.coords.AuxCoord(points=range(a.shape[xdim]), long_name='x_coord', units='volts') 
+
+        xdim = a.ndim-1
+        ydim = a.ndim-2
+        c_axis_length_fail = iris.coords.DimCoord(points=range(a.shape[ydim]), long_name='x_coord', units=self.cube.units)
+        c_unit_fail = iris.coords.AuxCoord(points=range(a.shape[xdim]), long_name='x_coord', units='volts')
 
         self.assertRaises(ValueError, iris.analysis.maths.add, a, c_axis_length_fail)
         self.assertRaises(iris.exceptions.NotYetImplementedError, iris.analysis.maths.add, a, c_unit_fail)
@@ -212,12 +212,12 @@ class TestBasicMaths(tests.IrisTest):
         b = iris.analysis.maths.add(a, 1000, in_place=True)
         self.assertTrue(b is a)
         self.assertCML(a, ('analysis', 'addition_in_place_coord.cml'))
-        
+
     def test_addition_different_attributes(self):
         a = self.cube.copy()
         b = self.cube.copy()
         b.attributes['my attribute'] = 'foobar'
-        c = a + b        
+        c = a + b
         self.assertIsNone(c.standard_name)
         self.assertEqual(c.attributes, {})
 
@@ -232,18 +232,18 @@ class TestDivideAndMultiply(tests.IrisTest):
         a = self.cube
 
         c = a / a
-        
+
         np.testing.assert_array_almost_equal(a.data / a.data, c.data)
         self.assertCML(c, ('analysis', 'division.cml'), checksum=False)
 
         # Check that the division has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_divide_by_scalar(self):
         a = self.cube
 
         c = a / 10
-        
+
         np.testing.assert_array_almost_equal(a.data / 10, c.data)
         self.assertCML(c, ('analysis', 'division_scalar.cml'), checksum=False)
 
@@ -252,63 +252,63 @@ class TestDivideAndMultiply(tests.IrisTest):
 
     def test_divide_by_coordinate(self):
         a = self.cube
-                
+
         c = a / a.coord('latitude')
         self.assertCML(c, ('analysis', 'division_by_latitude.cml'))
-        
+
         # Check that the division has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
-        
+
     def test_divide_by_array(self):
         a = self.cube
         data_array = self.cube.copy().data
-        
+
         # test division by exactly the same shape data
-        c = a / data_array 
+        c = a / data_array
         self.assertArrayEqual(c.data, np.array(1, dtype=np.float32))
         self.assertCML(c, ('analysis', 'division_by_array.cml'), checksum=False)
-        
+
         # test division by array of fewer dimensions
-        c = a / data_array[0, :] 
+        c = a / data_array[0, :]
         self.assertArrayEqual(c.data[0, :], np.array(1, dtype=np.float32))
-        
+
         # test division by array of more dimensions
         d_array = data_array.reshape(-1, data_array.shape[1], 1, 1)
-        self.assertRaises(ValueError, iris.analysis.maths.divide, c, d_array) 
-                
+        self.assertRaises(ValueError, iris.analysis.maths.divide, c, d_array)
+
         # Check that the division has had no effect on the original
-        self.assertCML(a, ('analysis', 'maths_original.cml'))    
-        
+        self.assertCML(a, ('analysis', 'maths_original.cml'))
+
     def test_divide_by_coordinate_dim2(self):
         a = self.cube
 
         # Prevent divide-by-zero warning
-        a.coord('longitude').points = a.coord('longitude').points + 0.5 
+        a.coord('longitude').points = a.coord('longitude').points + 0.5
 
         c = a / a.coord('longitude')
         self.assertCML(c, ('analysis', 'division_by_longitude.cml'))
 
         # Reset to allow comparison with original
-        a.coord('longitude').points = a.coord('longitude').points - 0.5 
+        a.coord('longitude').points = a.coord('longitude').points - 0.5
 
         # Check that the division has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
 
     def test_divide_by_singluar_coordinate(self):
         a = self.cube
-        
+
         coord = iris.coords.DimCoord(points=2, long_name='foo', units='1')
         c = iris.analysis.maths.divide(a, coord)
         self.assertCML(c, ('analysis', 'division_by_singular_coord.cml'))
-        
-        # Check that the division is equivalent to dividing the whole of the data by 2 
+
+        # Check that the division is equivalent to dividing the whole of the data by 2
         self.assertArrayEqual(c.data, a.data/2.)
-        
+
     def test_divide_by_different_len_coord(self):
         a = self.cube
-        
-        coord = iris.coords.DimCoord(points=np.arange(10) * 2 + 5, standard_name='longitude', units='degrees') 
-        
+
+        coord = iris.coords.DimCoord(points=np.arange(10) * 2 + 5, standard_name='longitude', units='degrees')
+
         self.assertRaises(ValueError, iris.analysis.maths.divide, a, coord)
 
     def test_divide_in_place(self):
@@ -320,13 +320,13 @@ class TestDivideAndMultiply(tests.IrisTest):
         a = self.cube.copy()
         b = iris.analysis.maths.divide(a, 5, in_place=False)
         self.assertIsNot(a, b)
-        
+
     def test_multiply(self):
         a = self.cube
-        
+
         c = a * a
         self.assertCML(c, ('analysis', 'multiply.cml'))
-        
+
         # Check that the multiplication has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
 
@@ -334,14 +334,14 @@ class TestDivideAndMultiply(tests.IrisTest):
         a = self.cube.copy()
         b = self.cube.copy()
         b.rename('my cube data')
-        c = a * b        
+        c = a * b
         self.assertCML(c, ('analysis', 'multiply_different_std_name.cml'), checksum=False)
-        
+
     def test_multiplication_different_attributes(self):
         a = self.cube.copy()
         b = self.cube.copy()
         b.attributes['my attribute'] = 'foobar'
-        c = a * b        
+        c = a * b
         self.assertIsNone(c.standard_name)
         self.assertEqual(c.attributes, {})
 
@@ -420,36 +420,37 @@ class TestMaskedArrays(tests.IrisTest):
     def setUp(self):
         self.data1 = ma.MaskedArray([[9,9,9],[8,8,8,]],mask=[[0,1,0],[0,0,1]])
         self.data2 = ma.MaskedArray([[3,3,3],[2,2,2,]],mask=[[0,1,0],[0,1,1]])
-        
-        self.cube1 = iris.cube.Cube(self.data1) 
-        self.cube2 = iris.cube.Cube(self.data2) 
+
+        self.cube1 = iris.cube.Cube(self.data1)
+        self.cube2 = iris.cube.Cube(self.data2)
 
     def test_operator(self):
         for test_op in self.ops:
             result1 = test_op(self.cube1, self.cube2)
             result2 = test_op(self.data1, self.data2)
-        
+
             np.testing.assert_array_equal(result1.data, result2)
 
     def test_operator_in_place(self):
         for test_op in self.iops:
+            data1 = self.data1.copy()
             test_op(self.cube1, self.cube2)
-            test_op(self.data1, self.data2)
+            test_op(data1, self.data2)
 
-            np.testing.assert_array_equal(self.cube1.data, self.data1)
-    
+            np.testing.assert_array_equal(self.cube1.data, data1)
+
     def test_operator_scalar(self):
         for test_op in self.ops:
             result1 = test_op(self.cube1, 2)
             result2 = test_op(self.data1, 2)
-        
+
             np.testing.assert_array_equal(result1.data, result2)
 
     def test_operator_array(self):
         for test_op in self.ops:
             result1 = test_op(self.cube1, self.data2)
             result2 = test_op(self.data1, self.data2)
-    
+
             np.testing.assert_array_equal(result1.data, result2)
 
     def test_incompatible_dimensions(self):
@@ -461,9 +462,9 @@ class TestMaskedArrays(tests.IrisTest):
     def test_increase_cube_dimensionality(self):
         with self.assertRaises(ValueError):
             # This would increase the dimensionality of the cube due to auto broadcasting
-            cubex = iris.cube.Cube(ma.MaskedArray([[9,]],mask=[[0]])) 
-            cubex + ma.MaskedArray([[3,3,3,3]],mask=[[0,1,0,1]]) 
-            
-    
+            cubex = iris.cube.Cube(ma.MaskedArray([[9,]],mask=[[0]]))
+            cubex + ma.MaskedArray([[3,3,3,3]],mask=[[0,1,0,1]])
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
To begin, I refactored iris.analysis.maths to reduce redundant code. It should
be much more straightforward to write a new operation now. I believe all
related tests are still passing.

`iris.analysis.maths.exponentiate` can now take cubes or coordinates as
arguments for the exponent, as long as the units still make sense.

I also added comparison operations `>=`, `<=`, `>` and `<` to
iris.analysis.maths and to cubes. These operators do the cube equivalent of
the standard numpy operations, except with "cube aware" broadcasting.

I would like to change the cube operators `==` and `!=` to match my new
comparison operators but this would change the current API so it definitely
needs to be discussed.

I haven't added much in the way of new tests because the current tests for
numerical operations look very awkward to write, relying on separate test
data. I imagine new tests should go in tests/unit/analysis but I would
appreciate some guidance here.
