### PR TITLE
Opt-in to Coord.cell returning time objects

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -137,12 +137,12 @@ class Future(threading.local):
     To adjust the values simply update the relevant attribute from
     within your code. For example::
 
-        iris.FUTURE.cell_time_objects = True
+        iris.FUTURE.cell_datetime_objects = True
 
     If Iris code is executed with multiple threads, note the values of
     these options are thread-specific.
 
-    Currently, the only option available is `cell_time_objects` which
+    Currently, the only option available is `cell_datetime_objects` which
     controls whether the :meth:`iris.coords.Coord.cell()` method returns
     time coordinate values as simple numbers or as time objects with
     attributes for year, month, day, etc. In particular, this allows one
@@ -158,12 +158,13 @@ class Future(threading.local):
 
     """
 
-    def __init__(self, cell_time_objects=False):
+    def __init__(self, cell_datetime_objects=False):
         """This one's for the init"""
-        self.__dict__['cell_time_objects'] = cell_time_objects
+        self.__dict__['cell_datetime_objects'] = cell_datetime_objects
 
     def __repr__(self):
-        return 'Future(cell_time_objects={})'.format(self.cell_time_objects)
+        return 'Future(cell_datetime_objects={})'.format(
+            self.cell_datetime_objects)
 
     def __setattr__(self, name, value):
         if name not in self.__dict__:
@@ -184,12 +185,12 @@ class Future(threading.local):
         For example::
 
             with iris.FUTURE.context():
-                iris.FUTURE.cell_time_objects = True
+                iris.FUTURE.cell_datetime_objects = True
                 # ... code which expects time objects
 
         Or more concisely::
 
-            with iris.FUTURE.context(cell_time_objects=True):
+            with iris.FUTURE.context(cell_datetime_objects=True):
                 # ... code which expects time objects
 
         """

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -812,7 +812,7 @@ class Coord(CFVariableMixin):
 
         .. note::
 
-            If `iris.FUTURE.cell_time_objects` is True, then this
+            If `iris.FUTURE.cell_datetime_objects` is True, then this
             method will return Cell objects whose `points` and `bounds`
             attributes contain either datetime.datetime instances or
             netcdftime.datetime instances (depending on the calendar).
@@ -829,7 +829,7 @@ class Coord(CFVariableMixin):
         if self.bounds is not None:
             bound = tuple(np.array(self.bounds[index], ndmin=1).flatten())
 
-        if iris.FUTURE.cell_time_objects:
+        if iris.FUTURE.cell_datetime_objects:
             if self.units.is_time_reference():
                 point = self.units.num2date(point)
                 if bound is not None:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1612,7 +1612,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
                     # Format cell depending on type of point and whether it
                     # has a bound
-                    with iris.FUTURE.context(cell_time_objects=False):
+                    with iris.FUTURE.context(cell_datetime_objects=False):
                         coord_cell = coord.cell(0)
                     if isinstance(coord_cell.point, basestring):
                         # Indent string type coordinates

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -50,7 +50,7 @@ class Test_cell(tests.IrisTest):
                           (mock.sentinel.lower, mock.sentinel.upper))
 
     def test_time_as_object(self):
-        # When iris.FUTURE.cell_time_objects is True, ensure
+        # When iris.FUTURE.cell_datetime_objects is True, ensure
         # Coord.cell() converts the point/bound values to "datetime"
         # objects.
         coord = self._mock_coord()
@@ -58,7 +58,7 @@ class Test_cell(tests.IrisTest):
             side_effect=[mock.sentinel.datetime,
                          (mock.sentinel.datetime_lower,
                           mock.sentinel.datetime_upper)])
-        with mock.patch('iris.FUTURE', cell_time_objects=True):
+        with mock.patch('iris.FUTURE', cell_datetime_objects=True):
             cell = Coord.cell(coord, 0)
         self.assertIs(cell.point, mock.sentinel.datetime)
         self.assertEquals(cell.bound,

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -142,12 +142,12 @@ class Test_collapsed__warning(tests.IrisTest):
 
 
 class Test_summary(tests.IrisTest):
-    def test_cell_time_objects(self):
+    def test_cell_datetime_objects(self):
         # Check the scalar coordinate summary still works even when
-        # iris.FUTURE.cell_time_objects is True.
+        # iris.FUTURE.cell_datetime_objects is True.
         cube = Cube(0)
         cube.add_aux_coord(iris.coords.AuxCoord(42, units='hours since epoch'))
-        with iris.FUTURE.context(cell_time_objects=True):
+        with iris.FUTURE.context(cell_datetime_objects=True):
             summary = cube.summary()
         self.assertIn('1970-01-02 18:00:00', summary)
 

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -26,9 +26,9 @@ from iris import Future
 class Test___setattr__(tests.IrisTest):
     def test_valid_attribute(self):
         future = Future()
-        new_value = not future.cell_time_objects
-        future.cell_time_objects = new_value
-        self.assertEqual(future.cell_time_objects, new_value)
+        new_value = not future.cell_datetime_objects
+        future.cell_datetime_objects = new_value
+        self.assertEqual(future.cell_datetime_objects, new_value)
 
     def test_invalid_attribute(self):
         future = Future()
@@ -38,20 +38,20 @@ class Test___setattr__(tests.IrisTest):
 
 class Test_context(tests.IrisTest):
     def test_no_args(self):
-        future = Future(cell_time_objects=False)
-        self.assertFalse(future.cell_time_objects)
+        future = Future(cell_datetime_objects=False)
+        self.assertFalse(future.cell_datetime_objects)
         with future.context():
-            self.assertFalse(future.cell_time_objects)
-            future.cell_time_objects = True
-            self.assertTrue(future.cell_time_objects)
-        self.assertFalse(future.cell_time_objects)
+            self.assertFalse(future.cell_datetime_objects)
+            future.cell_datetime_objects = True
+            self.assertTrue(future.cell_datetime_objects)
+        self.assertFalse(future.cell_datetime_objects)
 
     def test_with_arg(self):
-        future = Future(cell_time_objects=False)
-        self.assertFalse(future.cell_time_objects)
-        with future.context(cell_time_objects=True):
-            self.assertTrue(future.cell_time_objects)
-        self.assertFalse(future.cell_time_objects)
+        future = Future(cell_datetime_objects=False)
+        self.assertFalse(future.cell_datetime_objects)
+        with future.context(cell_datetime_objects=True):
+            self.assertTrue(future.cell_datetime_objects)
+        self.assertFalse(future.cell_datetime_objects)
 
     def test_invalid_arg(self):
         future = Future()


### PR DESCRIPTION
This PR allows one to set `iris.FUTURE.cell_time_objects` to True in order to obtain time objects(*) from `Coord.cell()` (and hence `Coord.cells()` as well).

This allows one to defined certain time constraints via access to the year, month, day, etc. fields:

``` python
# To select all data defined at midday.
Constraint(time=lambda cell: cell.point.hour == 12)

# To ignore the 29th of February.
Constraint(time=lambda cell: cell.point.day != 29 and cell.point.month != 2)
```

*) `datetime.datetime` or `netcdftime.datetime`, depending on the calendar, as produced by `iris.unit.num2date()`.

NB. This is an alternative to #871 which avoids the need for doppelgänger classes and allows a step-by-step accumulation of capabilities.

Next steps might include:
- Add PartialDateTime
- Upgrade netcdftime.datetime to allow comparison operations.
- Upgrade netcdftime.datetime to allow timedelta calculations.
