### PR TITLE
assertString auto path

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -218,23 +218,27 @@ class IrisTest(unittest.TestCase):
 
         Args:
         
-        * netcdf_filename - The filename under investigation. 
+        * netcdf_filename (string):
+            The filename under investigation. 
         
         Kwargs:
         
-        * reference_filename - Relative subpath in the results folder.
-                               If omitted, the result path is generated 
-                               automatically from the calling method's name
-                               and module heirarchy using
-                               :meth:`~IrisTest.reference_filename`.
+        * reference_filename (string):
+            Relative subpath in the results folder.
+            If omitted, the result path is generated 
+            automatically from the calling method's name
+            and module heirarchy using
+            :meth:`~IrisTest.reference_filename`.
                                 
-        * basename - If *reference_filename* is not specified, causing the
-                     result path to be generated automatically, this
-                     keyword can be used to force a particular filename.
-                     Used when multiple tests in a test class wish to
-                     share a single result file.
+        * basename (string):
+            If *reference_filename* is not specified, causing the
+            result path to be generated automatically, this
+            keyword can be used to force a particular filename.
+            Used when multiple tests in a test class wish to
+            share a single result file.
                        
-        * flags - arguments to *ncdump*.
+        * flags (string):
+            arguments to *ncdump*.
 
         """
         if reference_filename is None:
@@ -278,23 +282,28 @@ class IrisTest(unittest.TestCase):
 
         Args:
         
-        * cubes - The cubes under investigation. 
+        * cubes (:class:`iris.cube.CubeList` or iterable of \
+        :class:`iris.cube.Cube`s):
+            The cubes under investigation. 
         
         Kwargs:
         
-        * reference_filename - Relative subpath in the results folder.
-                               If omitted, the result path is generated 
-                               automatically from the calling method's name
-                               and module heirarchy using
-                               :meth:`~IrisTest.reference_filename`.
+        * reference_filename (string):
+            Relative subpath in the results folder.
+            If omitted, the result path is generated 
+            automatically from the calling method's name
+            and module heirarchy using
+            :meth:`~IrisTest.reference_filename`.
                                 
-        * basename - If *reference_filename* is not specified, causing the
-                     result path to be generated automatically, this
-                     keyword can be used to force a particular filename.
-                     Used when multiple tests in a test class wish to
-                     share a single result file.
+        * basename (string):
+            If *reference_filename* is not specified, causing the
+            result path to be generated automatically, this
+            keyword can be used to force a particular filename.
+            Used when multiple tests in a test class wish to
+            share a single result file.
                        
-        * checksum - Passed through to :meth:`iris.cube.CubeList.xml`. 
+        * checksum (bool):
+            Passed through to :meth:`iris.cube.CubeList.xml`. 
 
         """
         if isinstance(cubes, iris.cube.Cube):
@@ -357,21 +366,24 @@ class IrisTest(unittest.TestCase):
         """
         Args:
         
-        * string - The string under investigation. 
+        * string (string):
+            The string under investigation. 
         
         Kwargs:
         
-        * reference_filename - Relative subpath in the results folder.
-                               If omitted, the result path is generated 
-                               automatically from the calling method's name
-                               and module heirarchy using
-                               :meth:`~IrisTest.reference_filename`.
+        * reference_filename (string):
+            Relative subpath in the results folder.
+            If omitted, the result path is generated 
+            automatically from the calling method's name
+            and module heirarchy using
+            :meth:`~IrisTest.reference_filename`.
                                 
-        * basename - If *reference_filename* is not specified, causing the
-                     result path to be generated automatically, this
-                     keyword can be used to force a particular filename.
-                     Used when multiple tests in a test class wish to
-                     share a single result file.
+        * basename (string):
+            If *reference_filename* is not specified, causing the
+            result path to be generated automatically, this
+            keyword can be used to force a particular filename.
+            Used when multiple tests in a test class wish to
+            share a single result file.
 
         """
         if reference_filename is None:


### PR DESCRIPTION
To test this, I added some _temporary_ tests to `Test_GribLevels``:

```
    def test_assertString1(self):
        self.assertString("12345")

    def test_assertString2(self):
        self.assertString("12345", basename="second_temporary_test")

    def test_assertString3(self):
        self.assertString("67890", basename="second_temporary_test")
```

As expected, this produced two new result files:

```
$ l lib/iris/tests/results/unit/fileformats/grib/load_rules/convert/GribLevels/
assertString1.txt  second_temporary_test.txt

$ cat lib/iris/tests/results/unit/fileformats/grib/load_rules/convert/GribLevels/assertString1.txt
12345

$ cat lib/iris/tests/results/unit/fileformats/grib/load_rules/convert/GribLevels/second_temporary_test.txt
12345
```

And a failure:

```
FAIL: test_assertString3 (__main__.Test_GribLevels)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/iris/git/iris/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py", line 38, in test_assertString3
    self.assertString("67890", basename="second_temporary_test")
  File "/home/iris/.local/lib/python2.7/site-packages/iris/tests/__init__.py", line 326, in assertString
    type_comparison_name='Strings')
  File "/home/iris/.local/lib/python2.7/site-packages/iris/tests/__init__.py", line 334, in _check_same
    self._assert_str_same(reference, item, reference_filename, type_comparison_name)
  File "/home/iris/.local/lib/python2.7/site-packages/iris/tests/__init__.py", line 159, in _assert_str_same
    self.fail("%s do not match: %s\n%s" % (type_comparison_name, reference_filename, diff))
AssertionError: Strings do not match: /home/iris/.local/lib/python2.7/site-packages/iris/tests/results/unit/fileformats/grib/load_rules/convert/GribLevels/second_temporary_test.txt
--- Reference
+++ Test result
@@ -1 +1 @@
-12345+67890
```
