### PR TITLE
Add PartialDateTime

### DIFF
--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -1,0 +1,206 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.time.PartialDateTime` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import datetime
+import operator
+
+import mock
+
+from iris.time import PartialDateTime
+
+
+class Test___init__(tests.IrisTest):
+    def test_positional(self):
+        # Test that we can define PartialDateTimes with positional arguments.
+        pd = PartialDateTime(1066, None, 10)
+        self.assertEqual(pd.year, 1066)
+        self.assertEqual(pd.month, None)
+        self.assertEqual(pd.day, 10)
+
+    def test_keyword_args(self):
+        # Test that we can define PartialDateTimes with keyword arguments.
+        pd = PartialDateTime(microsecond=10)
+        self.assertEqual(pd.year, None)
+        self.assertEqual(pd.microsecond, 10)
+
+
+class Test_timetuple(tests.IrisTest):
+    def test_exists(self):
+        # Check that the PartialDateTime class implements a timetuple (needed
+        # because of http://bugs.python.org/issue8005).
+        pd = PartialDateTime(*range(7))
+        self.assertTrue(hasattr(pd, 'timetuple'))
+
+
+class _Test_operator(object):
+    def test_invalid_type(self):
+        pdt = PartialDateTime()
+        with self.assertRaises(TypeError):
+            self.op(pdt, 1)
+
+    def _test(self, pdt, other, name):
+        expected = self.expected_value[name]
+        if isinstance(expected, type):
+            with self.assertRaises(expected):
+                result = self.op(pdt, other)
+        else:
+            result = self.op(pdt, other)
+            self.assertIs(result, expected)
+
+    def _test_dt(self, pdt, name):
+        other = mock.Mock(name='datetime', spec=datetime.datetime,
+                          year=2013, month=3, day=20, second=2)
+        self._test(pdt, other, name)
+
+    def test_no_difference(self):
+        self._test_dt(PartialDateTime(year=2013, month=3, day=20, second=2),
+                      'no_difference')
+
+    def test_null(self):
+        self._test_dt(PartialDateTime(), 'null')
+
+    def test_item1_lo(self):
+        self._test_dt(PartialDateTime(year=2011, month=3, second=2),
+                      'item1_lo')
+
+    def test_item1_hi(self):
+        self._test_dt(PartialDateTime(year=2015, month=3, day=24), 'item1_hi')
+
+    def test_item2_lo(self):
+        self._test_dt(PartialDateTime(year=2013, month=1, second=2),
+                      'item2_lo')
+
+    def test_item2_hi(self):
+        self._test_dt(PartialDateTime(year=2013, month=5, day=24), 'item2_hi')
+
+    def test_item3_lo(self):
+        self._test_dt(PartialDateTime(year=2013, month=3, second=1),
+                      'item3_lo')
+
+    def test_item3_hi(self):
+        self._test_dt(PartialDateTime(year=2013, month=3, second=42),
+                      'item3_hi')
+
+    def test_mix_hi_lo(self):
+        self._test_dt(PartialDateTime(year=2015, month=1, day=24), 'mix_hi_lo')
+
+    def test_mix_lo_hi(self):
+        self._test_dt(PartialDateTime(year=2011, month=5, day=24), 'mix_lo_hi')
+
+    def _test_pdt(self, other, name):
+        pdt = PartialDateTime(year=2013, day=24)
+        self._test(pdt, other, name)
+
+    def test_pdt_same(self):
+        self._test_pdt(PartialDateTime(year=2013, day=24), 'pdt_same')
+
+    def test_pdt_diff(self):
+        self._test_pdt(PartialDateTime(year=2013, day=25), 'pdt_diff')
+
+    def test_pdt_diff_fewer_fields(self):
+        self._test_pdt(PartialDateTime(year=2013), 'pdt_diff_fewer')
+
+    def test_pdt_diff_more_fields(self):
+        self._test_pdt(PartialDateTime(year=2013, day=24, hour=12),
+                       'pdt_diff_more')
+
+    def test_pdt_diff_no_fields(self):
+        pdt1 = PartialDateTime()
+        pdt2 = PartialDateTime(month=3, day=24)
+        self._test(pdt1, pdt2, 'pdt_empty')
+
+
+def negate_expectations(expectations):
+    def negate(expected):
+        if not isinstance(expected, type):
+            expected = not expected
+        return expected
+
+    return {name: negate(value) for name, value in expectations.iteritems()}
+
+
+EQ_EXPECTATIONS = {'no_difference': True, 'item1_lo': False, 'item1_hi': False,
+                   'item2_lo': False, 'item2_hi': False, 'item3_lo': False,
+                   'item3_hi': False, 'mix_hi_lo': False, 'mix_lo_hi': False,
+                   'null': True, 'pdt_same': True, 'pdt_diff': False,
+                   'pdt_diff_fewer': False, 'pdt_diff_more': False,
+                   'pdt_empty': False}
+
+GT_EXPECTATIONS = {'no_difference': False, 'item1_lo': False, 'item1_hi': True,
+                   'item2_lo': False, 'item2_hi': True, 'item3_lo': False,
+                   'item3_hi': True, 'mix_hi_lo': True, 'mix_lo_hi': False,
+                   'null': False, 'pdt_same': TypeError, 'pdt_diff': TypeError,
+                   'pdt_diff_fewer': TypeError, 'pdt_diff_more': TypeError,
+                   'pdt_empty': TypeError}
+
+LT_EXPECTATIONS = {'no_difference': False, 'item1_lo': True, 'item1_hi': False,
+                   'item2_lo': True, 'item2_hi': False, 'item3_lo': True,
+                   'item3_hi': False, 'mix_hi_lo': False, 'mix_lo_hi': True,
+                   'null': False, 'pdt_same': TypeError, 'pdt_diff': TypeError,
+                   'pdt_diff_fewer': TypeError, 'pdt_diff_more': TypeError,
+                   'pdt_empty': TypeError}
+
+
+class Test___eq__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.eq
+        self.expected_value = EQ_EXPECTATIONS
+
+
+class Test___ne__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.ne
+        self.expected_value = negate_expectations(EQ_EXPECTATIONS)
+
+
+class Test___gt__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.gt
+        self.expected_value = GT_EXPECTATIONS
+
+
+class Test___le__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.le
+        self.expected_value = negate_expectations(GT_EXPECTATIONS)
+
+
+class Test___lt__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.lt
+        self.expected_value = LT_EXPECTATIONS
+
+
+class Test___ge__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.ge
+        self.expected_value = negate_expectations(LT_EXPECTATIONS)
+
+
+class Test___le__(tests.IrisTest, _Test_operator):
+    def setUp(self):
+        self.op = operator.le
+        self.expected_value = negate_expectations(GT_EXPECTATIONS)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/time.py
+++ b/lib/iris/time.py
@@ -1,0 +1,152 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Time handling.
+
+"""
+import collections
+import datetime
+import functools
+import operator
+
+import netcdftime
+
+
+@functools.total_ordering
+class PartialDateTime(object):
+    """
+    A :class:`PartialDateTime` object specifies values for some subset of
+    the calendar/time fields (year, month, hour, etc.) for comparing
+    with :class:`datetime.datetime`-like instances.
+
+    Comparisons are defined against any other class with all of the
+    attributes: year, month, day, hour, minute, second, microsecond.
+    Notably, this includes :class:`datetime.datetime` and
+    :class:`netcdftime.datetime`.
+
+    A :class:`PartialDateTime` object is not limited to any particular
+    calendar, so no restriction is placed on the range of values
+    allowed in its component fields. Thus, it is perfectly legitimate to
+    create an instance as: `PartialDateTime(month=2, day=30)`.
+
+    """
+
+    __slots__ = ('year', 'month', 'day', 'hour', 'minute', 'second',
+                 'microsecond')
+
+    #: A dummy value provided as a workaround to allow comparisons with
+    #: :class:`datetime.datetime`.
+    #: See http://bugs.python.org/issue8005.
+    # NB. It doesn't even matter what this value is.
+    timetuple = None
+
+    def __init__(self, year=None, month=None, day=None, hour=None,
+                 minute=None, second=None, microsecond=None):
+        """
+        Allows partial comparisons against datetime-like objects.
+
+        Args:
+
+        * year (int):
+        * month (int):
+        * day (int):
+        * hour (int):
+        * minute (int):
+        * second (int):
+        * microsecond (int):
+
+        For example, to select any days of the year after the 3rd of April:
+
+        >>> from iris.time import PartialDateTime
+        >>> import datetime
+        >>> pdt = PartialDateTime(month=4, day=3)
+        >>> datetime.datetime(2014, 4, 1) > pdt
+        False
+        >>> datetime.datetime(2014, 4, 5) > pdt
+        True
+        >>> datetime.datetime(2014, 5, 1) > pdt
+        True
+        >>> datetime.datetime(2015, 2, 1) > pdt
+        False
+
+        """
+
+        #: The year number as an integer, or None.
+        self.year = year
+        #: The month number as an integer, or None.
+        self.month = month
+        #: The day number as an integer, or None.
+        self.day = day
+        #: The hour number as an integer, or None.
+        self.hour = hour
+        #: The minute number as an integer, or None.
+        self.minute = minute
+        #: The second number as an integer, or None.
+        self.second = second
+        #: The microsecond number as an integer, or None.
+        self.microsecond = microsecond
+
+    def __gt__(self, other):
+        if isinstance(other, type(self)):
+            raise TypeError('Cannot order PartialDateTime instances.')
+        result = False
+        try:
+            for attr_name in self.__slots__:
+                attr = getattr(self, attr_name)
+                other_attr = getattr(other, attr_name)
+                if attr is not None and attr != other_attr:
+                    result = attr > other_attr
+                    break
+        except AttributeError:
+            result = NotImplemented
+        return result
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            slots = self.__slots__
+            self_tuple = tuple(getattr(self, name) for name in slots)
+            other_tuple = tuple(getattr(other, name) for name in slots)
+            result = self_tuple == other_tuple
+        else:
+            result = True
+            try:
+                for attr_name in self.__slots__:
+                    attr = getattr(self, attr_name)
+                    other_attr = getattr(other, attr_name)
+                    if attr is not None and attr != other_attr:
+                        result = False
+                        break
+            except AttributeError:
+                result = NotImplemented
+        return result
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is not NotImplemented:
+            result = not result
+        return result
+
+    def __cmp__(self, other):
+        # Since we've defined all the rich comparison operators (via
+        # functools.total_ordering), we can only reach this point if
+        # neither this class nor the other class had a rich comparison
+        # that could handle the type combination.
+        # We don't want Python to fall back to the default `object`
+        # behaviour (which compares using object IDs), so we raise an
+        # exception here instead.
+        fmt = 'unable to compare PartialDateTime with {}'
+        raise TypeError(fmt.format(type(other)))


### PR DESCRIPTION
A follow-up to #883.

Adds `iris.time.PartialDateTime` which gives "sloppy" comparisons with "datetime-like" objects.
Thus allowing things like:

``` python
Constraint(time=lambda cell: cell.point == PartialDateTime(...))
```

NB. The Cell class has _not_ been extended in this PR to allow Cell-PartialDateTime comparisons. So it is **not** possible to do: `Constraint(time=PartialDateTime(...))`. This can be added in a subsequent PR.
