### PR TITLE
Resolve PP save rule bug.

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -637,6 +637,7 @@ IF
     scalar_coord(cm, 'depth') is None
     scalar_coord(cm, 'height') is None
     scalar_coord(cm, 'pressure') is None
+    cm.standard_name is not None
     'soil' in cm.standard_name
 THEN
     pp.lbvc = 6


### PR DESCRIPTION
This PR resolves the PP save rule exception `TypeError: argument of type 'NoneType' is not iterable` when attempting to save a cube with a `standard_name` of `None`.
