### PR TITLE
Future context restores state even when interrupted.

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -199,10 +199,12 @@ class Future(threading.local):
         # Update the state
         for name, value in kwargs.iteritems():
             setattr(self, name, value)
-        yield
-        # Return the state
-        self.__dict__.clear()
-        self.__dict__.update(current_state)
+        try:
+            yield
+        finally:
+            # Return the state
+            self.__dict__.clear()
+            self.__dict__.update(current_state)
 
 
 FUTURE = Future()

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -62,6 +62,19 @@ class Test_context(tests.IrisTest):
                 # exception we're looking for.
                 pass
 
+    def test_exception(self):
+        # Check that an interrupted context block restores the initial state.
+        class LocalTestException(Exception):
+            pass
+
+        future = Future(cell_datetime_objects=False)
+        try:
+            with future.context(cell_datetime_objects=True):
+                raise LocalTestException()
+        except LocalTestException:
+            pass
+        self.assertEqual(future.cell_datetime_objects, False)
+
 
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
iris.FUTURE.context was not safe against exceptions within the block.
The new testcase in test_Future shows the problem (fails for current dev version).
