### PR TITLE
Remove docstrings from tests.

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
+++ b/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
Get rid of unwanted docstrings which cause the test output to be:

```
Test FieldsFile to PPFields cube load. ... ok
```

instead of:

```
test_unit_pass_0 (iris.tests.test_ff.TestFF2PP2Cube) ... ok
```

Also, get rid of an unnecessary/duplicate docstring.
