### PR TITLE
Force iris.tests to use TkAgg backend when called by idiff.py

### DIFF
--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ Currently relies on matplotlib for image processing so limited to PNG format.
 
 import os.path
 import shutil
+import sys
 
 import matplotlib.pyplot as plt
 import matplotlib.image as mimg
@@ -80,4 +81,9 @@ def step_over_diffs():
 
 
 if __name__ == '__main__':
+    # Force iris.tests to use the ```tkagg``` backend by using the '-d'
+    # command-line argument as idiff is an interactive tool that requires a
+    # gui interface.
+    sys.argv.append('-d')
+
     step_over_diffs()


### PR DESCRIPTION
This small change forces the use of the TkAgg backend by matplotlib in `iris.tests` when this is called by `idiff.py`. This is accomplished by adding the `-d` flag to `sys.argv` within `idiff.py`, which is then picked up when `iris.tests` is imported.

When a large number of test images differ (typical settings mean >20 images) and the backend is set to agg (as is the `iris.tests` default) then `idiff.py` will attempt to load all images simultaneously, leading to memory issues. The benefit of this change then is that forcing `iris.tests` to use TkAgg as the backend in this case avoids the problem.
