### PR TITLE
grib2 wind direction (user support issue)

### DIFF
--- a/lib/iris/fileformats/grib/_grib_cf_map.py
+++ b/lib/iris/fileformats/grib/_grib_cf_map.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
This adds phenomnomenon translation between cf and grib2 for _wind (from) direction_.

Todo:
- [x] https://github.com/metarelate/metOcean/pull/6

Note:
The grib2 "parameter code" for _"wind (from) direction"_ can be found in the [WMO spec](http://www.wmo.int/pages/prog/www/WMOCodes/WMO306_vI2/VolumeI.2.html).
Click on the top-left blue X to download the specification.
In the specification, navigate to "PART B. BINARY CODES" --> "b. list of binary codes..." --> "FM 92-XIV GRIB" --> "Code table used in section 4"  and find the code table called, "Product discipline 0 – Meteorological products, parameter category 2: momentum". (Intuitive, huh?!)
