### PR TITLE
Standardised interface to self.x and self.y in analysis.interpolate.Linear1dExtrapolator

### DIFF
--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
References to `y` in `iris.analysis.interpolate.Linear1dExtrapolator` now use `self.y`, as defined in the `__init__` for this class, rather than using the value of y as found in the SciPy `interp1d` object; that is, `self._interpolator.y`.

The benefit of this change is that it standardises the interface to `self.x` and `self.y` within this class. It will also simplify further changes that are necessary to make this class work with SciPy 0.13.x.
