### PR TITLE
Fix bug in comparison with netcdftime.datetime

### DIFF
--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -42,6 +42,25 @@ class Test___init__(tests.IrisTest):
         pd = PartialDateTime(microsecond=10)
         self.assertEqual(pd.year, None)
         self.assertEqual(pd.microsecond, 10)
+
+
+class Test___repr__(tests.IrisTest):
+    def test_full(self):
+        pd = PartialDateTime(*range(7))
+        result = repr(pd)
+        self.assertEqual(result, 'PartialDateTime(year=0, month=1, day=2,'
+                                 ' hour=3, minute=4, second=5,'
+                                 ' microsecond=6)')
+
+    def test_partial(self):
+        pd = PartialDateTime(month=2, day=30)
+        result = repr(pd)
+        self.assertEqual(result, 'PartialDateTime(month=2, day=30)')
+
+    def test_empty(self):
+        pd = PartialDateTime()
+        result = repr(pd)
+        self.assertEqual(result, 'PartialDateTime()')
 
 
 class Test_timetuple(tests.IrisTest):

--- a/lib/iris/time.py
+++ b/lib/iris/time.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -101,6 +101,13 @@ class PartialDateTime(object):
         self.second = second
         #: The microsecond number as an integer, or None.
         self.microsecond = microsecond
+
+    def __repr__(self):
+        attr_pieces = ['{}={}'.format(name, getattr(self, name))
+                       for name in self.__slots__
+                       if getattr(self, name) is not None]
+        result = '{}({})'.format(type(self).__name__, ', '.join(attr_pieces))
+        return result
 
     def __gt__(self, other):
         if isinstance(other, type(self)):


### PR DESCRIPTION
Despite a comment on the PartialDateTime class which specifically mentions the `netcdftime.datetime` class, comparisons against that class currently do not work because it does not have the `microsecond` attribute.

This PR fixes that by making comparison against `microsecond` optional.
