### PR TITLE
BUG FIX: Only do string serialization of collapsed AuxCoords

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -853,7 +853,7 @@ class Coord(CFVariableMixin):
             raise ValueError('Cannot partially collapse a coordinate (%s).'
                              % self.name())
 
-        if self.units in ['no_unit', 'unknown']:
+        if np.issubdtype(self.dtype, np.str):
             # Collapse the coordinate by serializing the points and
             # bounds as strings.
             serialize = lambda x: '|'.join([str(i) for i in x.flatten()])


### PR DESCRIPTION
This fixes a bug introduced by #847, which is encountered when attempting to collapse along a dimension coordinate with unknown units. In such a case, the coordinate value is converted into a string, which fails for dimension coordinates because dimension coordinates must be numeric.

Apologies for the spurious lines in the diff -- it's just removing extraneous whitespace, which my editor does by default on save.
