### PR TITLE
Make pandas data-sharing check compatible with numpy 1.7

### DIFF
--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -116,14 +116,19 @@ def _as_pandas_coord(coord):
 
 def _assert_shared(np_obj, pandas_obj):
     """Ensure the pandas object shares memory."""
-    if isinstance(pandas_obj, pandas.Series):
-        if not pandas_obj.base is np_obj:
-            raise AssertionError("Pandas Series does not share memory")
-    elif isinstance(pandas_obj, pandas.DataFrame):
-        if not pandas_obj[0].base.base.base is np_obj:
-            raise AssertionError("Pandas DataFrame does not share memory")
+    if hasattr(pandas_obj, 'base'):
+        base = pandas_obj.base
     else:
-        raise ValueError("Expected a Pandas Series or DataFrame")
+        base = pandas_obj[0].base
+    # Chase the stack of NumPy `base` references back to see if any of
+    # them are our original array.
+    while base is not None:
+        if base is np_obj:
+            return
+        # Take the next step up the stack of `base` references.
+        base = base.base
+    msg = 'Pandas {} does not share memory'.format(type(pandas_obj).__name__)
+    raise AssertionError(msg)
 
 
 def as_series(cube, copy=True):


### PR DESCRIPTION
NB. Using NumPy 1.7 results in one less array object in the base.base.... trail for a DataFrame.

This change makes the assertion cope with any length of base references, so it works with both 1.6 and 1.7.

Fixes:
- iris.tests.test_pandas.TestAsDataFrame
  - test_copy_float_false
  - test_copy_int32_false
  - test_copy_int64_false
