### PR TITLE
Fix pandas array order for numpy 1.7

### DIFF
--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -97,7 +97,13 @@ def as_cube(pandas_array, copy=True, calendars=None):
         raise ValueError("Only 1D or 2D Pandas arrays "
                          "can currently be conveted to Iris cubes.")
 
-    cube = Cube(np.ma.masked_invalid(pandas_array, copy=copy))
+    # Make the copy work consistently across NumPy 1.6 and 1.7.
+    # (When 1.7 takes a copy it preserves the C/Fortran ordering, but
+    # 1.6 doesn't. Since we don't care about preserving the order we can
+    # just force it back to C-order.)
+    order = 'C' if copy else 'A'
+    data = np.array(pandas_array, copy=copy, order=order)
+    cube = Cube(np.ma.masked_invalid(data, copy=False))
     _add_iris_coord(cube, "index", pandas_array.index, 0,
                     calendars.get(0, None))
     if pandas_array.ndim == 2:


### PR DESCRIPTION
NumPy 1.7 preserves C/Fortran-order when copying an array, but 1.6 always creates copies as C-order.

This change forces C-order when taking a copy, thus preserving the existing behaviour.

Fixes:
- iris.tests.test_pandas.TestDataFrameAsCube
  - test_data_frame_datetime_gregorian
  - test_data_frame_masked
  - test_data_frame_netcdftime_360
  - test_data_frame_nonotonic
  - test_data_frame_simple
