### PR TITLE
Normalise array order after circular interpolation.

### DIFF
--- a/lib/iris/tests/analysis/test_interpolate.py
+++ b/lib/iris/tests/analysis/test_interpolate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ import numpy as np
 import iris.analysis.interpolate as interpolate
 from iris.coords import DimCoord
 from iris.cube import Cube
+from iris.tests.test_interpolation import normalise_order
 
 
 class Test_linear__circular_wrapping(tests.IrisTest):
@@ -44,6 +45,7 @@ class Test_linear__circular_wrapping(tests.IrisTest):
         cube = self._create_cube([-180, -90, 0, 90])
         samples = [('longitude', range(-360, 720, 45))]
         result = interpolate.linear(cube, samples)
+        normalise_order(result)
         self.assertCMLApproxData(result, ('analysis', 'interpolation',
                                           'linear', 'circular_wrapping',
                                           'symmetric'))
@@ -53,6 +55,7 @@ class Test_linear__circular_wrapping(tests.IrisTest):
         cube = self._create_cube([0, 90, 180, 270])
         samples = [('longitude', range(-360, 720, 45))]
         result = interpolate.linear(cube, samples)
+        normalise_order(result)
         self.assertCMLApproxData(result, ('analysis', 'interpolation',
                                           'linear', 'circular_wrapping',
                                           'positive'))

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -137,6 +137,6 @@
         <coord interval="1 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="-0x45409a9" dtype="float32" order="F" shape="(38, 145)"/>
+    <data byteorder="little" checksum="-0x45409a9" dtype="float32" order="C" shape="(38, 145)"/>
   </cube>
 </cubes>


### PR DESCRIPTION
When appending to an array, NumPy 1.7 always returns the same C/Fortran order independent of the axis:

``` python
>>> import numpy as np
>>> np.__version__
'1.7.2'
>>> a = np.arange(60).reshape(3,4,5)
>>> np.append(a, a[:1], axis=0).flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
>>> np.append(a, a[:, :1], axis=1).flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
>>> np.append(a, a[:, :, :1], axis=2).flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
```

But 1.6 has varying order depending on the append axis:

``` python
>>> import numpy as np
>>> np.__version__
'1.6.0'
>>> a = np.arange(60).reshape(3,4,5)
>>> np.append(a, a[:1], axis=0).flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
>>> np.append(a, a[:, :1], axis=1).flags
  C_CONTIGUOUS : False
  F_CONTIGUOUS : False
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
>>> np.append(a, a[:, :, :1], axis=2).flags
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  UPDATEIFCOPY : False
```

This change forces the relevant test results to have C-order.

Fixes:
- iris.tests.analysis.test_interpolate.Test_linear__circular_wrapping
  - test_positive
  - test_symmetric
- iris.tests.test_interpolation.TestLinear1dInterpolation
  - test_circular_vs_non_circular_coord
  - test_simple_multiple_points_circular
- iris.tests.test_interpolation.TestNearestLinearInterpolRealData
  - test_circular
