### PR TITLE
Normalise array order from ABF loader.

### DIFF
--- a/lib/iris/tests/results/abf/load.cml
+++ b/lib/iris/tests/results/abf/load.cml
@@ -34,6 +34,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="-0x40a15839" dtype="uint8" fill_value="255" mask_checksum="-0x6f99a5a9" mask_order="F" order="C" shape="(2160, 4320)"/>
+    <data checksum="-0x40a15839" dtype="uint8" fill_value="255" mask_checksum="-0x6f99a5a9" mask_order="C" order="C" shape="(2160, 4320)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/test_abf.py
+++ b/lib/iris/tests/test_abf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2013, Met Office
+# (C) British Crown Copyright 2012 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,9 @@ class TestAbfLoad(tests.GraphicsTest):
         time_coord = cubes[0].coord("time")
         time_coord.points = np.array(time_coord.points, dtype=np.int64)
         time_coord.bounds = np.array(time_coord.bounds, dtype=np.int64)
+        # Normalise the different array orders returned by version 1.6
+        # and 1.7 of NumPy.
+        cubes[0].data = cubes[0].data.copy(order='C')
         self.assertCML(cubes, ("abf", "load.cml"))
 
     def test_fill_value(self):


### PR DESCRIPTION
This change forces the test results to have C-order.

Fixes:
- iris.tests.test_abf.TestAbfLoad
  - test_load
