### PR TITLE
float64 reg coord if needed

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -36,6 +36,7 @@ import iris.unit
 import iris.util
 
 from iris._cube_coord_common import CFVariableMixin
+from iris.util import is_regular
 
 
 class CoordDefn(collections.namedtuple('CoordDefn',
@@ -1232,6 +1233,10 @@ class DimCoord(Coord):
         points = (zeroth+step) + step*np.arange(count, dtype=np.float32)
         points.flags.writeable = False
         coord._points = points
+        if not is_regular(coord) and count > 1:
+            points = (zeroth+step) + step*np.arange(count, dtype=np.float64)
+            points.flags.writeable = False
+            coord._points = points
 
         if with_bounds:
             delta = 0.5 * step

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -40,6 +40,7 @@ import iris.cube
 import iris.exceptions
 import iris.fileformats.um_cf_map
 import iris.unit
+from iris.util import is_regular, regular_step
 
 RuleResult = collections.namedtuple('RuleResult', ['cube', 'matching_rules', 'factories'])
 Factory = collections.namedtuple('Factory', ['factory_class', 'args'])
@@ -232,33 +233,6 @@ class Reference(iris.util._OrderedHashable):
     A named placeholder for inter-field references.
 
     """
-
-
-# TODO: This function only uses data from a coord, and produces information only pertaining to a coord, so should it be in the coord.
-def is_regular(coord):
-    """Determine if the given coord is regular."""
-    try:
-        regular_step(coord)
-    except iris.exceptions.CoordinateNotRegularError:
-        return False
-    except (TypeError, ValueError):
-        return False
-    return True
-
-
-# TODO: This function only uses data from a coord, and produces information only pertaining to a coord, so should it be in the coord.
-def regular_step(coord):
-    """Return the regular step from a coord or fail."""
-    if coord.ndim != 1:
-        raise iris.exceptions.CoordinateMultiDimError("Expected 1D coord")
-    if coord.shape[0] < 2:
-        raise ValueError("Expected a non-scalar coord")
-
-    diffs = coord.points[1:] - coord.points[:-1]
-    avdiff = np.mean(diffs)
-    if not np.allclose(diffs, avdiff, rtol=0.001):  # TODO: This value is set for test_analysis to pass...
-        raise iris.exceptions.CoordinateNotRegularError("Coord %s is not regular" % coord.name())
-    return avdiff.astype(coord.points.dtype)
 
 
 def calculate_forecast_period(time, forecast_reference_time):

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@
 import iris.tests as tests
 
 import mock
+import numpy as np
 
 import iris.fileformats.pp
 
@@ -79,6 +80,60 @@ class TestVertical(tests.IrisTest):
         # Check the vertical coordinate is as originally specified.
         self.assertEqual(field.lbvc, 19)
         self.assertEqual(field.blev, potm_value)
+
+
+class TestCoordinateForms(tests.IrisTest):
+    def _common(self, x_coord):
+        nx = len(x_coord.points)
+        ny = 2
+        data = np.zeros((ny, nx), dtype=np.float32)
+        test_cube = iris.cube.Cube(data)
+        y0 = np.float32(20.5)
+        dy = np.float32(3.72)
+        y_coord = iris.coords.DimCoord.from_regular(
+            zeroth=y0,
+            step=dy,
+            count=ny,
+            standard_name='latitude',
+            units='degrees_north')
+        test_cube.add_dim_coord(x_coord, 1)
+        test_cube.add_dim_coord(y_coord, 0)
+        # Write to a temporary PP file and read it back as a PPField
+        with self.temp_filename('.pp') as pp_filepath:
+            iris.save(test_cube, pp_filepath)
+            pp_loader = iris.fileformats.pp.load(pp_filepath)
+            pp_field = pp_loader.next()
+        return pp_field
+
+    def test_save_awkward_case_is_regular(self):
+        # Check that specific "awkward" values still save in a regular form.
+        nx = 3
+        x0 = np.float32(355.626)
+        dx = np.float32(0.0135)
+        x_coord = iris.coords.DimCoord.from_regular(
+            zeroth=x0,
+            step=dx,
+            count=nx,
+            standard_name='longitude',
+            units='degrees_east')
+        pp_field = self._common(x_coord)
+        # Check that the result has the regular coordinates as expected.
+        self.assertEqual(pp_field.bzx, x0)
+        self.assertEqual(pp_field.bdx, dx)
+        self.assertEqual(pp_field.lbnpt, nx)
+
+    def test_save_irregular(self):
+        # Check that a non-regular coordinate saves as expected.
+        nx = 3
+        x_values = [0.0, 1.1, 2.0]
+        x_coord = iris.coords.DimCoord(x_values,
+                                       standard_name='longitude',
+                                       units='degrees_east')
+        pp_field = self._common(x_coord)
+        # Check that the result has the regular/irregular Y and X as expected.
+        self.assertEqual(pp_field.bdx, 0.0)
+        self.assertArrayAllClose(pp_field.x, x_values)
+        self.assertEqual(pp_field.lbnpt, nx)
 
 
 if __name__ == "__main__":

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -1247,3 +1247,30 @@ def file_is_newer_than(result_path, source_paths):
         if source_timestamp >= result_timestamp:
             return False
     return True
+
+
+def is_regular(coord):
+    """Determine if the given coord is regular."""
+    try:
+        regular_step(coord)
+    except iris.exceptions.CoordinateNotRegularError:
+        return False
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def regular_step(coord):
+    """Return the regular step from a coord or fail."""
+    if coord.ndim != 1:
+        raise iris.exceptions.CoordinateMultiDimError("Expected 1D coord")
+    if coord.shape[0] < 2:
+        raise ValueError("Expected a non-scalar coord")
+
+    diffs = coord.points[1:] - coord.points[:-1]
+    avdiff = np.mean(diffs)
+    if not np.allclose(diffs, avdiff, rtol=0.001):
+    # TODO: This value is set for test_analysis to pass...
+        msg = "Coord %s is not regular" % coord.name()
+        raise iris.exceptions.CoordinateNotRegularError(msg)
+    return avdiff.astype(coord.points.dtype)


### PR DESCRIPTION
alternative approach to #907

make float64 coord if input is regular and float64 is required to recognise regulatrity
