### PR TITLE
Normalise array order after curl.

### DIFF
--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -31,6 +31,7 @@ import iris.coords
 import iris.tests.stock
 
 from iris.coords import DimCoord
+from iris.tests.test_interpolation import normalise_order
 
 
 class TestCubeDelta(tests.IrisTest):
@@ -470,6 +471,7 @@ class TestCalculusWKnownSolutions(tests.IrisTest):
         result.data = result.data * 0  + 1
         np.testing.assert_array_almost_equal(result.data, r[2].data, decimal=4)
 
+        normalise_order(r[1])
         self.assertCML(r, ('analysis', 'calculus', 'curl_contrived_cartesian2.cml'), checksum=False)
 
     def test_contrived_spherical_curl1(self):


### PR DESCRIPTION
The NumPy 1.6 vs. 1.7 change to np.append behaviour rears its head once again!

This change forces the affected test result to have C-order.

Fixes:
- iris.tests.test_analysis_calculus.TestCalculusWKnownSolutions
  - test_contrived_non_spherical_curl2

NB. This is the last change for NumPy 1.7! \o/
