### PR TITLE
PP soil level

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -618,8 +618,8 @@ THEN
 
 # single depth level (Non-dimensional soil model level)
 IF
-    scalar_coord(cm, 'model_level_number') is not None
-    not scalar_coord(cm, 'model_level_number').bounds
+    scalar_coord(cm, 'soil_model_level_number') is not None
+    not scalar_coord(cm, 'soil_model_level_number').bounds
     # The following `is None` checks ensure this rule does not get run
     # if any of the previous LBVC setting rules have run. It gives these
     # rules something of an IF-THEN-ELSE structure.
@@ -631,8 +631,8 @@ IF
     'soil' in cm.standard_name
 THEN
     pp.lbvc = 6
-    pp.lblev = scalar_coord(cm, 'model_level_number').points[0]
-    pp.blev = scalar_coord(cm, 'model_level_number').points[0]
+    pp.lblev = scalar_coord(cm, 'soil_model_level_number').points[0]
+    pp.blev = pp.lblev
 
 # single potential-temperature level
 IF

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -293,10 +293,9 @@ def convert(f):
             (f.brsvd[0] != f.brlev):
         aux_coords_and_dims.append((DimCoord(f.blev, standard_name='depth', units='m', bounds=[f.brsvd[0], f.brlev], attributes={'positive': 'down'}), None))
 
-    if \
-            (len(f.lbcode) != 5) and \
-            (f.lbvc == 6):
-        aux_coords_and_dims.append((DimCoord(f.blev, standard_name='model_level_number', attributes={'positive': 'down'}), None))
+    # soil level
+    if len(f.lbcode) != 5 and f.lbvc == 6:
+        aux_coords_and_dims.append((DimCoord(f.lblev, long_name='soil_model_level_number', attributes={'positive': 'down'}), None))
 
     if \
             (f.lbvc == 8) and \

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -32,7 +32,7 @@ class TestVertical(tests.IrisTest):
         # NB. Use MagicMock so that SplittableInt header items, such as
         # LBCODE, support len().
         soil_level = 1234
-        field = mock.MagicMock(lbvc=6, blev=soil_level,
+        field = mock.MagicMock(lbvc=6, lblev=soil_level,
                                stash=iris.fileformats.pp.STASH(1, 0, 9),
                                lbuser=[0] * 7, lbrsvd=[0] * 4)
         load = mock.Mock(return_value=iter([field]))
@@ -40,8 +40,9 @@ class TestVertical(tests.IrisTest):
             cube = next(iris.fileformats.pp.load_cubes('DUMMY'))
 
         self.assertIn('soil', cube.standard_name)
-        self.assertEqual(len(cube.coords('model_level_number')), 1)
-        self.assertEqual(cube.coord('model_level_number').points, soil_level)
+        self.assertEqual(len(cube.coords('soil_model_level_number')), 1)
+        self.assertEqual(cube.coord('soil_model_level_number').points,
+                         soil_level)
 
         # Now use the save rules to convert the Cube back into a PPField.
         field = iris.fileformats.pp.PPField3()
@@ -52,7 +53,7 @@ class TestVertical(tests.IrisTest):
 
         # Check the vertical coordinate is as originally specified.
         self.assertEqual(field.lbvc, 6)
-        self.assertEqual(field.blev, soil_level)
+        self.assertEqual(field.lblev, soil_level)
 
     def test_potential_temperature_level_round_trip(self):
         """Check save+load for data on 'potential temperature' levels."""

--- a/lib/iris/tests/results/FF/soil_temperature_1.cml
+++ b/lib/iris/tests/results/FF/soil_temperature_1.cml
@@ -32,7 +32,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <dimCoord id="acd2e4a5" points="[1.0]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="float64">
+        <dimCoord id="2eb202d2" long_name="soil_model_level_number" points="[1]" shape="(1,)" units="Unit('1')" value_type="int64">
           <attributes>
             <attribute name="positive" value="down"/>
           </attributes>

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -32,16 +32,17 @@ import iris.unit
 
 class TestLBVC(tests.IrisTest):
     def test_soil_levels(self):
-        field = mock.MagicMock(lbvc=6, blev=1234)
+        field = mock.MagicMock(lbvc=6, lblev=1234)
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,
          aux_coords_and_dims) = convert(field)
 
-        def is_model_level_coord(coord_and_dims):
+        def is_soil_model_level_coord(coord_and_dims):
             coord, dims = coord_and_dims
-            return coord.standard_name == 'model_level_number'
+            return coord.long_name == 'soil_model_level_number'
 
-        coords_and_dims = filter(is_model_level_coord, aux_coords_and_dims)
+        coords_and_dims = filter(is_soil_model_level_coord,
+                                 aux_coords_and_dims)
         self.assertEqual(len(coords_and_dims), 1)
         coord, dims = coords_and_dims[0]
         self.assertEqual(coord.points, 1234)


### PR DESCRIPTION
Soil model level can now be taken from lblev when not in blev, as found in a data set from a user support issue.
