### PR TITLE
Changed coord_dims to accept a coord name as well as a coord

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1433,7 +1433,7 @@ class ProtoCube(object):
         for factory_defn in self._coord_signature.factory_defns:
             args = {}
             for key, defn in factory_defn.dependency_defns:
-                coord = cube.coord(coord=defn)
+                coord = cube.coord(defn)
                 args[key] = coord
             factory = factory_defn.class_(**args)
             cube.add_aux_factory(factory)

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -278,13 +278,13 @@ def coord_comparison(*cubes):
         # dimension on their respective cubes
         # (None -> group describes a different dimension)
         diff_data_dim_fn = lambda cube, coord: \
-            cube.coord_dims(coord=coord) != first_cube.coord_dims(first_coord)
+            cube.coord_dims(coord) != first_cube.coord_dims(first_coord)
         if coord_group.matches_any(diff_data_dim_fn):
             different_data_dimension.add(coord_group)
 
         # get all coordinate groups which don't describe a dimension
         # (None -> doesn't describe a dimension)
-        no_data_dim_fn = lambda cube, coord: cube.coord_dims(coord=coord) == ()
+        no_data_dim_fn = lambda cube, coord: cube.coord_dims(coord) == ()
         if coord_group.matches_all(no_data_dim_fn):
             no_data_dimension.add(coord_group)
 

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -141,7 +141,7 @@ def cube_delta(cube, coord):
         raise iris.exceptions.CoordinateMultiDimError(coord)
 
     # Try and get a coord dim
-    delta_dims = cube.coord_dims(coord)
+    delta_dims = cube.coord_dims(coord.name())
     if (coord.shape[0] == 1 and not getattr(coord, 'circular', False)) or not delta_dims:
         raise ValueError('Cannot calculate delta over "%s" as it has length of 1.' % coord.name())
     delta_dim = delta_dims[0]
@@ -209,7 +209,7 @@ def differentiate(cube, coord_to_differentiate):
         coord = coord_to_differentiate
 
     delta_coord = _construct_delta_coord(coord)
-    delta_dim = cube.coord_dims(coord)[0]
+    delta_dim = cube.coord_dims(coord.name())[0]
 
     # calculate delta_cube / delta_coord to give the differential.
     delta_cube = iris.analysis.maths.divide(delta_cube, delta_coord, delta_dim)
@@ -317,8 +317,8 @@ def _curl_change_z(src_cube, z_coord, prototype_diff):
 
     # The existing z_coord doesn't fit the new data so make a
     # new cube using the prototype z_coord.
-    local_z_coord = src_cube.coord(coord=z_coord)
-    new_local_z_coord = prototype_diff.coord(coord=z_coord).copy()
+    local_z_coord = src_cube.coord(z_coord)
+    new_local_z_coord = prototype_diff.coord(z_coord).copy()
     def coord_func(coord):
         if coord is local_z_coord:
             new_coord = new_local_z_coord
@@ -545,7 +545,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         # Since prototype_diff == dicos_dtheta we don't need to recalculate dicos_dtheta
         d_j_cube_dphi = _curl_differentiate(j_cube, lon_coord)
         d_j_cube_dphi = _curl_regrid(d_j_cube_dphi, prototype_diff)
-        new_lat_coord = d_j_cube_dphi.coord(name='latitude')
+        new_lat_coord = d_j_cube_dphi.coord('latitude')
         new_lat_cos_coord = _coord_cos(new_lat_coord)
         lat_dim = d_j_cube_dphi.coord_dims(new_lat_coord)[0]
         r_cmpt = iris.analysis.maths.divide(_curl_subtract(dicos_dtheta, d_j_cube_dphi), r * new_lat_cos_coord, dim=lat_dim)

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -131,7 +131,7 @@ def nearest_neighbour_indices(cube, sample_points):
         if isinstance(coord, basestring):
             coord = cube.coord(coord)
         else:
-            coord = cube.coord(coord=coord)
+            coord = cube.coord(coord)
         points.append((coord, values))
     sample_points = points
 
@@ -208,7 +208,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
         if isinstance(coord, basestring):
             coord = cube.coord(coord)
         else:
-            coord = cube.coord(coord=coord)
+            coord = cube.coord(coord)
         if id(coord) not in ok_coord_ids:
             msg = ('Invalid sample coordinate {!r}: derived coordinates are'
                    ' not allowed.'.format(coord.name()))
@@ -640,7 +640,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
         if isinstance(coord, basestring):
             coord = cube.coord(coord)
         else:
-            coord = cube.coord(coord=coord)
+            coord = cube.coord(coord)
         points.append((coord, values))
     sample_points = points
 

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -86,7 +86,7 @@ def intersection_of_cubes(cube, other_cube):
 
     # cubes must have matching coordinates
     for coord in cube.coords():
-        other_coord = other_cube.coord(coord=coord)
+        other_coord = other_cube.coord(coord)
 
         # Only intersect coordinates which are different, single values coordinates may differ.
         if coord.shape[0] > 1 and coord != other_coord:
@@ -226,8 +226,8 @@ def _add_subtract_common(operation_function, operation_noun,
             coord_dims_equal = True
             for coord_group in coord_comp['transposable']:
                 cube_coord, other_coord = coord_group.coords
-                cube_coord_dims = cube.coord_dims(coord=cube_coord)
-                other_coord_dims = other.coord_dims(coord=other_coord)
+                cube_coord_dims = cube.coord_dims(cube_coord)
+                other_coord_dims = other.coord_dims(other_coord)
                 other_coord_dims_broadcasted = tuple(
                     [dim + broadcast_padding for dim in other_coord_dims])
                 if cube_coord_dims != other_coord_dims_broadcasted:

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -174,7 +174,7 @@ def cube_text(cube):
         relationships += '\n    ":Cube" -> "%s"' % coord_label
 
         # Are there any relationships to data dimensions?
-        dims = cube.coord_dims(coord=coord)
+        dims = cube.coord_dims(coord)
         for dim in dims:
             relationships_association += '\n    "%s" -> "CubeDimension_%s":w' % (coord_label, dim)
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -717,10 +717,7 @@ class Saver(object):
         else:
             for coord in unlimited_dimensions:
                 try:
-                    if isinstance(coord, basestring):
-                        coord = cube.coord(name=coord, dim_coords=True)
-                    else:
-                        coord = cube.coord(coord=coord, dim_coords=True)
+                    coord = cube.coord(name_or_coord=coord, dim_coords=True)
                 except iris.exceptions.CoordinateNotFoundError:
                     # coordinate isn't used for this cube, but it might be
                     # used for a different one

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -565,7 +565,7 @@ class RulesContainer(object):
 def scalar_coord(cube, coord_name):
     """Try to find a single-valued coord with the given name."""
     found_coord = None
-    for coord in cube.coords(name=coord_name):
+    for coord in cube.coords(coord_name):
         if coord.shape == (1,):
             found_coord = coord
             break
@@ -575,7 +575,7 @@ def scalar_coord(cube, coord_name):
 def vector_coord(cube, coord_name):
     """Try to find a one-dimensional, multi-valued coord with the given name."""
     found_coord = None
-    for coord in cube.coords(name=coord_name):
+    for coord in cube.coords(coord_name):
         if len(coord.shape) == 1 and coord.shape[0] > 1:
             found_coord = coord
             break
@@ -588,7 +588,7 @@ def scalar_cell_method(cube, method, coord_name):
     for cell_method in cube.cell_methods:
         if cell_method.method == method and len(cell_method.coord_names) == 1:
             name = cell_method.coord_names[0]
-            coords = cube.coords(name=name)
+            coords = cube.coords(name)
             if len(coords) == 1:
                 found_cell_method = cell_method
     return found_cell_method
@@ -693,7 +693,7 @@ def _ensure_aligned(regrid_cache, src_cube, target_cube):
     try:
         target_coords = []
         for dim_coord in src_cube.dim_coords:
-            target_coords.append(target_cube.coord(coord=dim_coord))
+            target_coords.append(target_cube.coord(dim_coord))
     except iris.exceptions.CoordinateNotFoundError:
         # One of the src_cube's dim_coords didn't exist on the
         # target_cube... so we can't regrid (i.e. just return None).

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -56,10 +56,7 @@ PlotDefn = collections.namedtuple('PlotDefn', ('coords', 'transpose'))
 
 def _get_plot_defn_custom_coords_picked(cube, coords, mode, ndims=2):
     def as_coord(coord):
-        if isinstance(coord, basestring):
-            coord = cube.coord(name=coord)
-        else:
-            coord = cube.coord(coord=coord)
+        coord = cube.coord(coord)
         return coord
     coords = map(as_coord, coords)
 
@@ -826,10 +823,7 @@ def _1d_coords_deprecation_handler(func):
             if isinstance(args[0], iris.cube.Cube):
                 if len(args) < 2 or not isinstance(args[1], (iris.cube.Cube,
                                                    iris.coords.Coord)):
-                    if isinstance(coords[0], basestring):
-                        coord = args[0].coord(name=coords[0])
-                    else:
-                        coord = args[0].coord(coord=coords[0])
+                    coord = args[0].coord(coords[0])
                     if not args[0].coord_dims(coord):
                         raise ValueError("The coordinate {!r} doesn't "
                                          "span a data dimension."

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -57,8 +57,8 @@ class TestCubeDelta(tests.IrisTest):
         delta = iris.analysis.calculus.cube_delta(cube,
                                                   'projection_x_coordinate')
         delta_coord = delta.coord('projection_x_coordinate')
-        self.assertEqual(delta_coord, delta.coord(coord=coord))
-        self.assertEqual(coord, cube.coord(coord=delta_coord))
+        self.assertEqual(delta_coord, delta.coord(coord))
+        self.assertEqual(coord, cube.coord(delta_coord))
 
 
 class TestDeltaAndMidpoint(tests.IrisTest):

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -385,19 +385,19 @@ class TestQueryCoord(tests.IrisTest):
         self.t = iris.tests.stock.simple_2d_w_multidim_and_scalars()
 
     def test_name(self):
-        coords = self.t.coords(name='dim1')
+        coords = self.t.coords('dim1')
         self.assertEqual([coord.name() for coord in coords], ['dim1'])
         
-        coords = self.t.coords(name='dim2')
+        coords = self.t.coords('dim2')
         self.assertEqual([coord.name() for coord in coords], ['dim2'])
         
-        coords = self.t.coords(name='an_other')
+        coords = self.t.coords('an_other')
         self.assertEqual([coord.name() for coord in coords], ['an_other'])
 
-        coords = self.t.coords(name='air_temperature')
+        coords = self.t.coords('air_temperature')
         self.assertEqual([coord.name() for coord in coords], ['air_temperature'])
 
-        coords = self.t.coords(name='wibble')
+        coords = self.t.coords('wibble')
         self.assertEqual(coords, [])
 
     def test_long_name(self):
@@ -481,12 +481,12 @@ class TestQueryCoord(tests.IrisTest):
         self.assertEqual(set([coord.name() for coord in coords]), {'dim1', 'dim2', 'an_other', 'my_multi_dim_coord', 'air_temperature'})
     
     def test_coord(self):
-        coords = self.t.coords(coord=self.t.coord('dim1'))
+        coords = self.t.coords(self.t.coord('dim1'))
         self.assertEqual([coord.name() for coord in coords], ['dim1'])
         # check for metadata look-up by modifying points
         coord = self.t.coord('dim1').copy()
         coord.points = np.arange(5) * 1.23
-        coords = self.t.coords(coord=coord)
+        coords = self.t.coords(coord)
         self.assertEqual([coord.name() for coord in coords], ['dim1'])
         
     def test_str_repr(self):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1068,10 +1068,7 @@ def new_axis(src_cube, scalar_coord=None):
 
     """
     if scalar_coord is not None:
-        if isinstance(scalar_coord, basestring):
-            scalar_coord = src_cube.coord(name=scalar_coord)
-        else:
-            scalar_coord = src_cube.coord(coord=scalar_coord)
+        scalar_coord = src_cube.coord(scalar_coord)
 
     # Indexing numpy arrays requires loading deferred data here returning a
     # copy of the data with a new leading dimension.
@@ -1178,7 +1175,7 @@ def as_compatible_shape(src_cube, target_cube):
         new_coord = coord.copy(points=points, bounds=bounds)
         # If originally in dim_coords, add to dim_coords, otherwise add to
         # aux_coords.
-        if target_cube.coords(coord=coord, dim_coords=True):
+        if target_cube.coords(coord, dim_coords=True):
             try:
                 new_cube.add_dim_coord(new_coord, dims)
             except ValueError:


### PR DESCRIPTION
Minor change so that iris.cube.Cube.coord_dims() can accept a coordinate object, or a coord name string, like most of (all?) the other coordinate accepting functions.

UPDATE: This is being achieved by changing the behaviour of `Cube.coord` and `Cube.coords` to accept a `name_or_coord` which is then type checked, rather than the separate `name` and `coord` kwargs
