### PR TITLE
Class to allow interactive exploration in cube plots

### DIFF
--- a/lib/iris/experimental/cube_explorer.py
+++ b/lib/iris/experimental/cube_explorer.py
@@ -258,13 +258,13 @@ class CubeExplorer(object):
                 picker_plot_dims = [i for i, v in
                                     enumerate(self.current_slice)
                                     if type(v) is slice]
-    
+
                 xpt = event.mouseevent.xdata
                 s[picker_plot_dims[0]] = int(xpt)
                 if len(picker_plot_dims) == 2:
                     ypt = event.mouseevent.ydata
                     s[picker_plot_dims[1]] = int(ypt)
-    
+
                 plt.figure(num=None)
                 plot_func(self.cube[tuple(s)], *args, **kwargs)
                 if hook is not None:
@@ -279,7 +279,7 @@ class CubeExplorer(object):
         Masks off the region selected by clicking a polygon
         (over all other dimensions). Selection is ended with
         a double-click.
-        
+
         """
         # add picker option to plot
         self._plot_kwargs['picker'] = kwargs.pop('picker', True)
@@ -297,7 +297,7 @@ class CubeExplorer(object):
             picker_plot_dims = [i for i, v
                                 in enumerate(self.current_slice)
                                 if type(v) is slice]
-            
+
             x_size = self.cube.shape[picker_plot_dims[-1]]
 
             if event.mouseevent.ydata is None:
@@ -305,8 +305,8 @@ class CubeExplorer(object):
                 self._poly_verts.append(i)
             else:
                 self.current_slice
-                i = event.ind[-1]/x_size
-                j = event.ind[-1]%x_size
+                i = event.ind[-1] / x_size
+                j = event.ind[-1] % x_size
                 self._poly_verts.append([i, j])
 
             if event.mouseevent.dblclick:


### PR DESCRIPTION
Recovery from mystery cockup here
https://github.com/SciTools/iris/pull/623

INITIAL PR FOR FEEDBACK - DO NOT MERGE

Interactive plot features:
- Navigation through other dims of cube
- Animations
- Popup plots of other dims of cube by ctrl+clicking
- Masking regions by clicking a polygon (finish with double click)
- Adjusting colour range

Problems/questions:
- It takes quite a long time to render a full 145x192 grid. I did a version using matplotlib rather than the iris plot functions and it was much snappier. Not sure what `iplt` does to is slowing it up so much. Can `iplt` processed images be cached somehow?
- Have I just rewritten the matplotlib animate function by mistake? I've never used it. Would it be useful here?
- I can't figure out how to integrate with `iris.quickplot`. In particular, the `_refresh_plot()` method keeps re-plotting the colour bar.
- I suspect I can streamline some of the matplotlib stuff but this is the first time I've played with the widgets. Do I need to save the buttons in a dictionary, for instance.
- I was experimenting with using two cube_explorer plots simultaneously and it got a little buggy. I think I need to more explicitly tell the plot function which axes to plot to. Unfortunately, I can't find the plot function as a method of the (geo) axes, and I can't figure out how to pass an axes instance to the iplt function.

Here is an example of usage

``` python
    import iris 
    import iris.plot as iplt
    import iris.quickplot as qplt

    cube = iris.load_cube(iris.sample_data_path('', 'uk_hires.pp'), 'air_potential_temperature')

    def hook_main(ce):
        ce.ax.coastlines()
        mln = ce.cube[tuple(ce.current_slice)].coord('model_level_number').points[0]
        t = ce.cube[tuple(ce.current_slice)].coord('time')

        ce.ax.set_title('Time: %s, model_level: %d' % (str(t.points), mln))

    def hook_picker(popup_ax, ce):
        popup_ax.set_title('The other two dims at this pt')

    sub_cube = cube[:, :, :30, :60].copy()
    ce = CubeExplorer(sub_cube, iplt.pcolormesh, [0, 0, slice(None), slice(None)] , hook=hook_main, vmin=286, vmax=290)
    ce.add_nav_buttons(1, ("Up", "Down"), slot=0)
    ce.add_animate_buttons(0, ("Play", "Stop"), slot=1)
    ce.add_color_range_buttons(("+","-"), 0.25, slot=2)
    ce.add_picker(qplt.pcolormesh, hook=hook_picker)
    ce.add_poly_picker(qplt.pcolormesh, hook=hook_picker)
    ce.show()
```
