### PR TITLE
Cartopy version dependency in INSTALL doc updated

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -64,7 +64,7 @@ PyKE 1.1.1 or later (http://pyke.sourceforge.net/)
 setuptools 0.6c11 or later (http://pypi.python.org/pypi/setuptools/)
     Python package for installing/removing python packages.
 
-cartopy 0.5.0 or later (http://github.com/SciTools/cartopy/)
+cartopy 0.8.0 or later (http://github.com/SciTools/cartopy/)
     Python package which provides cartographic tools for python.
 
 Optional


### PR DESCRIPTION
Version of Cartopy referenced in the Build Requirements section of the INSTALL document updated to v0.8.0.

This addresses #945.
