### PR TITLE
Fixed mpl 1.3.1 issue with derived_phenomena example

### DIFF
--- a/docs/iris/example_code/graphics/deriving_phenomena.py
+++ b/docs/iris/example_code/graphics/deriving_phenomena.py
@@ -24,7 +24,14 @@ def limit_colorbar_ticks(contour_object):
     number of ticks on the colorbar to 4.
 
     """
-    colorbar = contour_object.colorbar[0]
+    # Under Matplotlib v1.2.x the colorbar attribute of a contour object is
+    # a tuple containing the colorbar and an axes object, whereas under
+    # Matplotlib v1.3.x it is simply the colorbar.
+    try:
+        colorbar = contour_object.colorbar[0]
+    except AttributeError:
+        colorbar = contour_object.colorbar
+
     colorbar.locator = matplotlib.ticker.MaxNLocator(4)
     colorbar.update_ticks()
 


### PR DESCRIPTION
`cont = iris.quickplot.contourf(cube)` returns a tuple `(<matplotlib.colorbar.Colorbar instance at 0x10fd15a28>, <matplotlib.axes.AxesSubplot object at 0x10fcfcc10>)` under mpl 1.2.1, but just the colorbar object `<matplotlib.colorbar.Colorbar instance at 0x1124819e0>` under mpl 1.3.1. This workaround in the derived_phonomena.py example ensures the code works with both versions. Note there may be a image change when we bump to mpl 1.3.1, but that can be handled separately.
