### PR TITLE
Fix iris.util.rolling_window for degenerate masks.

### DIFF
--- a/lib/iris/tests/unit/util/test_rolling_window.py
+++ b/lib/iris/tests/unit/util/test_rolling_window.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -65,6 +65,16 @@ class Test_rolling_window(tests.IrisTest):
                                     [[5, 6, 7], [6, 7, 8], [7, 8, 9]]],
                                    mask=[[[0, 0, 1], [0, 1, 0], [1, 0, 0]],
                                          [[1, 0, 1], [0, 1, 0], [1, 0, 0]]],
+                                   dtype=np.int32)
+        result = rolling_window(a, window=3, axis=1)
+        self.assertMaskedArrayEqual(result, expected_result)
+
+    def test_degenerate_mask(self):
+        a = ma.array([[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]], dtype=np.int32)
+        expected_result = ma.array([[[0, 1, 2], [1, 2, 3], [2, 3, 4]],
+                                    [[5, 6, 7], [6, 7, 8], [7, 8, 9]]],
+                                   mask=[[[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+                                         [[0, 0, 0], [0, 0, 0], [0, 0, 0]]],
                                    dtype=np.int32)
         result = rolling_window(a, window=3, axis=1)
         self.assertMaskedArrayEqual(result, expected_result)

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -353,11 +353,12 @@ def rolling_window(a, window=1, step=1, axis=-1):
                a.strides[axis + 1:])
     rw = np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
     if ma.isMaskedArray(a):
-        strides = (a.mask.strides[:axis] +
-                   (step * a.mask.strides[axis], a.mask.strides[axis]) +
-                   a.mask.strides[axis + 1:])
+        mask = ma.getmaskarray(a)
+        strides = (mask.strides[:axis] +
+                   (step * mask.strides[axis], mask.strides[axis]) +
+                   mask.strides[axis + 1:])
         rw = ma.array(rw, mask=np.lib.stride_tricks.as_strided(
-            a.mask, shape=shape, strides=strides))
+            mask, shape=shape, strides=strides))
     return rw
 
 


### PR DESCRIPTION
Creating a mask array `data` without a mask results in `data.mask` being a single numpy boolean. This breaks the assumption in `iris.util.rolling_window()` that the mask has the same shape as the data resulting in an `IndexError`.

This PR uses `ma.getmaskarray()` to ensure that a genuine mask array (with matching shape) is used instead.
