### PR TITLE
Show when no masked elements in CML.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -2115,7 +2115,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     # checksum.
                     crc = hex(zlib.crc32(normalise(data.filled(0))))
                     data_xml_element.setAttribute("checksum", crc)
-                    crc = hex(zlib.crc32(normalise(data.mask)))
+                    if ma.is_masked(data):
+                        crc = hex(zlib.crc32(normalise(data.mask)))
+                    else:
+                        crc = 'no-masked-elements'
                     data_xml_element.setAttribute("mask_checksum", crc)
                     data_xml_element.setAttribute('fill_value',
                                                   str(data.fill_value))

--- a/lib/iris/tests/results/analysis/rolling_window/simple_latitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/simple_latitude.cml
@@ -15,6 +15,6 @@
         <coord name="latitude"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="-0x7b25d8b0" dtype="float64" fill_value="1e+20" mask_checksum="0x6522df69" mask_order="C" order="C" shape="(2, 4)"/>
+    <data byteorder="little" checksum="-0x7b25d8b0" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(2, 4)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/rolling_window/simple_longitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/simple_longitude.cml
@@ -16,6 +16,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="-0x72bf1ecf" dtype="float64" fill_value="1e+20" mask_checksum="-0x19f6eb52" mask_order="C" order="C" shape="(3, 3)"/>
+    <data byteorder="little" checksum="-0x72bf1ecf" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/rolling_window/size_4_longitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/size_4_longitude.cml
@@ -14,6 +14,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="-0x7826eaab" dtype="float64" fill_value="1e+20" mask_checksum="-0xbe26ee" mask_order="C" order="C" shape="(3, 1)"/>
+    <data byteorder="little" checksum="-0x7826eaab" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(3, 1)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_datetime_gregorian.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_datetime_gregorian.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="-0x1c75978a" mask_order="C" order="C" shape="(2, 5)"/>
+    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_netcdftime_360.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_netcdftime_360.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="-0x1c75978a" mask_order="C" order="C" shape="(2, 5)"/>
+    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_nonotonic.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_nonotonic.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="-0x1c75978a" mask_order="C" order="C" shape="(2, 5)"/>
+    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_simple.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_simple.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="-0x1c75978a" mask_order="C" order="C" shape="(2, 5)"/>
+    <data byteorder="little" checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_datetime_gregorian.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_datetime_gregorian.cml
@@ -8,6 +8,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="-0x39dd08e3" mask_order="C" order="C" shape="(5,)"/>
+    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_netcdfimte_360.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_netcdfimte_360.cml
@@ -8,6 +8,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="-0x39dd08e3" mask_order="C" order="C" shape="(5,)"/>
+    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_object.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_object.cml
@@ -7,6 +7,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="-0x39dd08e3" mask_order="C" order="C" shape="(5,)"/>
+    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_simple.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_simple.cml
@@ -7,6 +7,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="-0x39dd08e3" mask_order="C" order="C" shape="(5,)"/>
+    <data byteorder="little" checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" mask_order="C" order="C" shape="(5,)"/>
   </cube>
 </cubes>


### PR DESCRIPTION
In cases where Cube.data is a masked array, but where the mask is all False (i.e. no elements have been masked out) this converts the CML representation from an opaque checksum (which is purely dependent on the size of the array) to the string "no-masked-elements".

This has some minor benefit in understanding the existing test results, but is also expected to have a benefit if we switch Cube.data to _always_ be a masked array (as discussed in #900).
