### PR TITLE
DOC: Clarification notes for (apparently) merge-related tools

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -662,11 +662,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             :meth:`iris.util.describe_diff()`
 
-        .. Note::
-            
-            Compatibility as defined by this function does not guarantee that
-            the two cubes are able to be merged, instead it checks only the
-            four items quoted above for equality between the two cubes.
+        .. note::
+
+            This function does not indicate whether the two cubes can be
+            merged, instead it checks only the four items quoted above for
+            equality. Determining whether two cubes will merge requires
+            additional logic that is beyond the scope of this method.
 
         """
         compatible = (self.name() == other.name() and

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -235,12 +235,13 @@ def describe_diff(cube_a, cube_b, output_file=None):
 
         :meth:`iris.cube.Cube.is_compatible()`
 
-    .. Note::
-        
-        Compatibility does not guarantee that the two cubes are able to be
-        merged. Instead, this function is designed to provide a verbose
-        description of compatibility (a concept different to merging) between
-        the two cubes.
+    .. note::
+
+        Compatibility does not guarantee that two cubes can be merged.
+        Instead, this function is designed to provide a verbose description
+        of the differences in metadata between two cubes. Determining whether
+        two cubes will merge requires additional logic that is beyond the
+        scope of this function.
 
     """
 


### PR DESCRIPTION
This adds a note to the docstring for each of `iris.cube.Cube.is_compatible()` and `iris.util.describe_diff()` to clarify that neither of these functions are designed as merge reporting tools and that a return value of `True` does not guarantee the two cubes will merge.
