### PR TITLE
Support for mixed-case calendar strings

### DIFF
--- a/lib/iris/tests/unit/unit/__init__.py
+++ b/lib/iris/tests/unit/unit/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.unit` module."""

--- a/lib/iris/tests/unit/unit/test_Unit.py
+++ b/lib/iris/tests/unit/unit/test_Unit.py
@@ -1,0 +1,76 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.unit.Unit` class."""
+
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+import iris.unit
+from iris.unit import Unit
+
+
+class Test___init__(tests.IrisTest):
+
+    def test_capitalised_calendar(self):
+        calendar = 'GrEgoRian'
+        expected = iris.unit.CALENDAR_GREGORIAN
+        u = Unit('hours since 1970-01-01 00:00:00', calendar=calendar)
+        self.assertEqual(u.calendar, expected)
+
+    def test_not_basestring_calendar(self):
+        with self.assertRaises(TypeError):
+            u = Unit('hours since 1970-01-01 00:00:00', calendar=5)
+
+
+class Test_convert(tests.IrisTest):
+
+    class MyStr(str):
+        pass
+
+    def test_gregorian_calendar_conversion_setup(self):
+        # Reproduces a situation where a unit's gregorian calendar would not
+        # match (using the `is` operator) to the literal string 'gregorian',
+        # causing an `is not` test to return a false negative.
+        cal_str = iris.unit.CALENDAR_GREGORIAN
+        calendar = self.MyStr(cal_str)
+        self.assertIsNot(calendar, cal_str)
+        u1 = Unit('hours since 1970-01-01 00:00:00', calendar=calendar)
+        u2 = Unit('hours since 1969-11-30 00:00:00', calendar=calendar)
+        u1point = np.array([8.], dtype=np.float32)
+        expected = np.array([776.], dtype=np.float32)
+        result = u1.convert(u1point, u2)
+        return expected, result
+
+    def test_gregorian_calendar_conversion_array(self):
+        expected, result = self.test_gregorian_calendar_conversion_setup()
+        self.assertArrayEqual(expected, result)
+
+    def test_gregorian_calendar_conversion_dtype(self):
+        expected, result = self.test_gregorian_calendar_conversion_setup()
+        self.assertEqual(expected.dtype, result.dtype)
+
+    def test_gregorian_calendar_conversion_shape(self):
+        expected, result = self.test_gregorian_calendar_conversion_setup()
+        self.assertEqual(expected.shape, result.shape)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -895,11 +895,16 @@ class Unit(iris.util._OrderedHashable):
             if _OP_SINCE in unit.lower():
                 if calendar is None:
                     calendar_ = CALENDAR_GREGORIAN
-                elif calendar in CALENDARS:
-                    calendar_ = calendar
+                elif isinstance(calendar, basestring):
+                    if calendar.lower() in CALENDARS:
+                        calendar_ = calendar.lower()
+                    else:
+                        msg = '{!r} is an unsupported calendar.'
+                        raise ValueError(msg.format(calendar))
                 else:
-                    raise ValueError('{!r} is an unsupported calendar.'.format(
-                                     calendar))
+                    msg = 'Expected string-like calendar argument, got {!r}.'
+                    raise TypeError(msg.format(type(calendar)))
+
         self._init(category, ut_unit, calendar_, unit)
 
     def _raise_error(self, msg):
@@ -1811,7 +1816,8 @@ class Unit(iris.util._OrderedHashable):
         if self.is_convertible(other):
             # Use utime for converting reference times that are not using a
             # gregorian calendar as it handles these and udunits does not.
-            if self.is_time_reference() and self.calendar is not 'gregorian':
+            if self.is_time_reference() \
+                    and self.calendar != CALENDAR_GREGORIAN:
                 ut1 = self.utime()
                 ut2 = other.utime()
                 result = ut2.date2num(ut1.num2date(value_copy))


### PR DESCRIPTION
Iris currently only supports all-lowercase calendar strings, i.e. `'gregorian'` is supported while `'Gregorian'` would not be. This strictly adheres to the calendar strings quoted in the CF spec in [Section 4.4.1](http://cf-pcmdi.llnl.gov/documents/cf-conventions/1.7-draft1/cf-conventions.html#calendar), where the calendars are all-lowercase strings. However [Section 2.6](http://cf-pcmdi.llnl.gov/documents/cf-conventions/1.7-draft1/cf-conventions.html#idp4850176) of the CF spec states:

> When this standard defines string attributes that may take various prescribed values, the possible values are generally given in lower case. _However, applications programs should not be sensitive to case in these attributes._ (Emphasis added)

Further, the cfchecker tool does not complain about mixed-case calendar strings.

This indicates that Iris is currently being too strict about calendar strings, which is fixed by this PR.

Note that this clarification above may need to be further applied to attributes that are not calendar strings, however determining where this applies is beyond the scope of this particular PR.
