### PR TITLE
Show full reference file path on test failure.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -329,7 +329,8 @@ class IrisTest(unittest.TestCase):
     def _check_same(self, item, reference_path, reference_filename, type_comparison_name='CML'):
         if os.path.isfile(reference_path):
             reference = ''.join(open(reference_path, 'r').readlines())
-            self._assert_str_same(reference, item, reference_filename, type_comparison_name)
+            self._assert_str_same(reference, item, reference_path,
+                                  type_comparison_name)
         else:
             self._ensure_folder(reference_path)
             logger.warning('Creating result file: %s', reference_path)


### PR DESCRIPTION
When a test fails, instead of seeing:

```
AssertionError: CML do not match: ('pp_rules', 'lbtim_2.cml')
```

This PR lets you see:

```
AssertionError: CML do not match: /the/full/path/to/my/iris/lib/iris/tests/results/pp_rules/lbtim_2.cml
```

So you can actually load the file, etc. :expressionless: 
