### PR TITLE
Sphinx data documenter for instances.

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -67,6 +67,9 @@ extensions = ['sphinx.ext.autodoc',
 
               # better class documentation
               'custom_class_autodoc',
+
+              # Data instance __repr__ filter.
+              'custom_data_autodoc',
 
               'gen_example_directory',
               'generate_package_rst',

--- a/docs/iris/src/sphinxext/custom_data_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_data_autodoc.py
@@ -1,0 +1,57 @@
+# (C) British Crown Copyright 2010 - 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from sphinx.ext.autodoc import DataDocumenter, ModuleLevelDocumenter
+from sphinx.util.inspect import safe_repr
+
+from iris.analysis import Aggregator
+
+
+class IrisDataDocumenter(DataDocumenter):
+    priority = 0
+
+    def add_directive_header(self, sig):
+        ModuleLevelDocumenter.add_directive_header(self, sig)
+        if not self.options.annotation:
+            try:
+                objrepr = safe_repr(self.object)
+            except ValueError:
+                pass
+            else:
+                if not (objrepr.startswith('<') and objrepr.endswith('>')):
+                    self.add_line(u'   :annotation: = ' + objrepr, '<autodoc>')
+                else:
+                    self.add_line(u'   :annotation:', '<autodoc>')
+        elif self.options.annotation is object():
+            pass
+        else:
+            self.add_line(u'   :annotation: %s' % self.options.annotation,
+                          '<autodoc>')
+
+
+def handler(app, what, name, obj, options, signature, return_annotation):
+    if what == 'data':
+        if isinstance(obj, object) and issubclass(obj.__class__, Aggregator):
+            signature = '()'
+            return_annotation = '{} instance.'.format(obj.__class__.__name__)
+    return signature, return_annotation
+
+
+def setup(app):
+    app.add_autodocumenter(IrisDataDocumenter)
+    app.connect('autodoc-process-signature', handler)

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -42,9 +42,10 @@ import scipy.stats.mstats
 import iris.coords
 from iris.exceptions import LazyAggregatorError
 
+
 __all__ = ('COUNT', 'GMEAN', 'HMEAN', 'MAX', 'MEAN', 'MEDIAN', 'MIN',
            'PEAK', 'PERCENTILE', 'PROPORTION', 'RMS', 'STD_DEV', 'SUM',
-           'VARIANCE', 'coord_comparison', 'Aggregator',
+           'VARIANCE', 'coord_comparison', 'Aggregator', 'WeightedAggregator',
            'clear_phenomenon_identity')
 
 
@@ -332,7 +333,7 @@ class Aggregator(object):
     def __init__(self, cell_method, call_func, units_func=None,
                  lazy_func=None, **kwargs):
         """
-        Create an aggregator for the given call_func.
+        Create an aggregator for the given :data:`call_func`.
 
         Args:
 
@@ -346,11 +347,11 @@ class Aggregator(object):
         * units_func (callable):
             Units conversion function.
         * lazy_func (callable):
-            An alternative to 'call_func' implementing a lazy aggregation.
-            (Note:  need not support all features of the main operation, but
-            should raise an error in unhandled cases.)
+            An alternative to :data:`call_func` implementing a lazy
+            aggregation. Note that, it need not support all features of the
+            main operation, but should raise an error in unhandled cases.
         * kwargs:
-            Passed through to call_func.
+            Passed through to :data:`call_func`.
 
         """
         #: Cube cell method string.
@@ -526,15 +527,54 @@ class Aggregator(object):
 
 
 class WeightedAggregator(Aggregator):
+    """
+    Convenience class that supports common weighted aggregation functionality.
 
-    def __init__(self, cell_method, call_func, **kwargs):
-        Aggregator.__init__(self, cell_method, call_func, **kwargs)
+    """
+    def __init__(self, cell_method, call_func, units_func=None,
+                 lazy_func=None, **kwargs):
+        """
+        Create a weighted aggregator for the given :data:`call_func`.
+
+        Args:
+
+        * cell_method (string):
+            Cell method string that supports string format substitution.
+        * call_func (callable):
+            Data aggregation function. Call signature (data, axis, **kwargs).
+
+        Kwargs:
+
+        * units_func (callable):
+            Units conversion function.
+        * lazy_func (callable):
+            An alternative to :data:`call_func` implementing a lazy
+            aggregation. Note that, it need not support all features of the
+            main operation, but should raise an error in unhandled cases.
+        * kwargs:
+            Passed through to :data:`call_func`.
+
+        """
+        Aggregator.__init__(self, cell_method, call_func,
+                            units_func=units_func, lazy_func=lazy_func,
+                            **kwargs)
 
         #: A list of keywords that trigger weighted behaviour.
         self._weighting_keywords = ["returned", "weights"]
 
     def uses_weighting(self, **kwargs):
-        """Does this aggregator use weighting with the given keywords?"""
+        """
+        Determine whether this aggregator uses weighting.
+
+        Kwargs:
+
+        * kwargs:
+            Arguments to filter of weighted keywords.
+
+        Returns:
+            Boolean.
+
+        """
         result = False
         for kwarg in kwargs.keys():
             if kwarg in self._weighting_keywords:


### PR DESCRIPTION
This PR adds a custom Sphinx data documenter that avoids the following instance variables being rendered by default as `iris.analysis.COUNT = <iris.analysis.Aggregator object at 0x2877210>`

Instead, the example will be rendered as `iris.analysis.COUNT -> Aggregator instance`.
