### PR TITLE
Improved error message on unit conversion failure

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1851,7 +1851,7 @@ class Unit(iris.util._OrderedHashable):
                     self._raise_error('Failed to convert %r to %r' %
                                       (self, other))
         else:
-            raise ValueError("Unable to convert from '%s' to '%s'." %
+            raise ValueError("Unable to convert from '%r' to '%r'." %
                              (self, other))
         return result
 


### PR DESCRIPTION
Currently if unit conversion fails on a time coordinate the error message can be particularly obscure:

``` python
>>> cube.coord('time').units
Unit('hours since 1970-01-01 00:00:00', calendar='360_day')
>>> new_unit = iris.unit.Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')
>>> cube.coord('time').convert_units(new_unit)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  ...
ValueError: Unable to convert from 'hours since 1970-01-01 00:00:00' to 'hours since 1970-01-01 00:00:00'.
```

Changing the error message to print the `repr` of the units rather than the `str` makes it more clear why this unit conversion is failing:

``` python
>>> new_unit = iris.unit.Unit('days since 1970-01-01 00:00:00', 'gregorian')
>>> cube.coord('time').convert_units(new_unit)
Traceback (most recent call last):
  ...
ValueError: Unable to convert from 'Unit('hours since 1970-01-01 00:00:00', calendar='360_day')' to 'Unit('days since 1970-01-01 00:00:00', calendar='gregorian')'.
```
