### PR TITLE
Changes to raise exceptions when comparing bounded datetime cells

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -186,8 +186,8 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
         Non-Cell vs Cell comparison is used to define Constraint matching.
 
         """
-        if not (isinstance(other, (int, float, np.number, Cell,
-                                   iris.time.PartialDateTime))):
+        if not (isinstance(other, (int, float, np.number, Cell)) or
+                hasattr(other, 'timetuple')):
             raise TypeError("Unexpected type of other "
                             "{}.".format(type(other)))
         if operator_method not in (operator.gt, operator.lt,
@@ -196,11 +196,11 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
 
         # Prevent silent errors resulting from missing netcdftime
         # behaviour.
-        if (isinstance(self.point, netcdftime.datetime) and
-                not isinstance(other, iris.time.PartialDateTime)):
-            raise TypeError("Cannot determine order of {} and {} "
-                            "objects.".format(type(self.point),
-                                              type(other)))
+        if (isinstance(other, netcdftime.datetime) or
+                (isinstance(self.point, netcdftime.datetime) and
+                 not isinstance(other, iris.time.PartialDateTime))):
+            raise TypeError('Cannot determine the order of '
+                            'netcdftime.datetime objects')
 
         if isinstance(other, Cell):
             # Cell vs Cell comparison for providing a strict sort order

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -31,14 +31,14 @@ from iris.time import PartialDateTime
 
 
 class Test___common_cmp__(tests.IrisTest):
-    def assert_raises_on_comparison(self, cell, other, exception_type):
-        with self.assertRaises(exception_type):
+    def assert_raises_on_comparison(self, cell, other, exception_type, regexp):
+        with self.assertRaisesRegexp(exception_type, regexp):
             cell < other
-        with self.assertRaises(exception_type):
+        with self.assertRaisesRegexp(exception_type, regexp):
             cell <= other
-        with self.assertRaises(exception_type):
+        with self.assertRaisesRegexp(exception_type, regexp):
             cell > other
-        with self.assertRaises(exception_type):
+        with self.assertRaisesRegexp(exception_type, regexp):
             cell >= other
 
     def test_netcdftime_cell(self):
@@ -48,9 +48,12 @@ class Test___common_cmp__(tests.IrisTest):
         # results.
         cell = Cell(netcdftime.datetime(2010, 3, 21))
         dt = mock.Mock(timetuple=mock.Mock())
-        self.assert_raises_on_comparison(cell, dt, TypeError)
-        self.assert_raises_on_comparison(cell, 23, TypeError)
-        self.assert_raises_on_comparison(cell, 'hello', TypeError)
+        self.assert_raises_on_comparison(cell, dt, TypeError,
+                                         'determine the order of netcdftime')
+        self.assert_raises_on_comparison(cell, 23, TypeError,
+                                         'determine the order of netcdftime')
+        self.assert_raises_on_comparison(cell, 'hello', TypeError,
+                                         'Unexpected type.*str')
 
     def test_netcdftime_other(self):
         # Check that cell comparison to a netcdftime.datetime object
@@ -58,7 +61,8 @@ class Test___common_cmp__(tests.IrisTest):
         # producing unreliable results.
         dt = netcdftime.datetime(2010, 3, 21)
         cell = Cell(mock.Mock(timetuple=mock.Mock()))
-        self.assert_raises_on_comparison(cell, dt, TypeError)
+        self.assert_raises_on_comparison(cell, dt, TypeError,
+                                         'determine the order of netcdftime')
 
     def test_PartialDateTime_bounded_cell(self):
         # Check that bounded comparisions to a PartialDateTime
@@ -68,7 +72,8 @@ class Test___common_cmp__(tests.IrisTest):
         cell = Cell(datetime.datetime(2010, 1, 1),
                     bound=[datetime.datetime(2010, 1, 1),
                            datetime.datetime(2011, 1, 1)])
-        self.assert_raises_on_comparison(cell, dt, TypeError)
+        self.assert_raises_on_comparison(cell, dt, TypeError,
+                                         'bounded region for datetime')
 
     def test_PartialDateTime_unbounded_cell(self):
         # Check that cell comparison works with PartialDateTimes.
@@ -78,6 +83,16 @@ class Test___common_cmp__(tests.IrisTest):
         self.assertGreater(dt, cell)
         self.assertLessEqual(cell, dt)
         self.assertGreaterEqual(dt, cell)
+
+    def test_datetime_unbounded_cell(self):
+        # Check that cell comparison works with datetimes.
+        dt = datetime.datetime(2000, 6, 15)
+        cell = Cell(datetime.datetime(2000, 1, 1))
+        # Note the absence of the inverse of these
+        # e.g. self.assertGreater(dt, cell).
+        # See http://bugs.python.org/issue8005
+        self.assertLess(cell, dt)
+        self.assertLessEqual(cell, dt)
 
 
 class Test___eq__(tests.IrisTest):
@@ -98,7 +113,7 @@ class Test___eq__(tests.IrisTest):
         cell = Cell(point=object(),
                     bound=[mock.Mock(timetuple=mock.Mock()),
                            mock.Mock(timetuple=mock.Mock())])
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'bounded region for datetime'):
             cell == other
 
     def test_PartialDateTime_other(self):
@@ -115,13 +130,13 @@ class Test_contains_point(tests.IrisTest):
         cell = Cell(point=object(),
                     bound=[mock.Mock(timetuple=mock.Mock()),
                            mock.Mock(timetuple=mock.Mock())])
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'bounded region for datetime'):
             cell.contains_point(point)
 
     def test_datetimelike_point(self):
         point = mock.Mock(timetuple=mock.Mock())
         cell = Cell(point=object(), bound=[object(), object()])
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'bounded region for datetime'):
             cell.contains_point(point)
 
 


### PR DESCRIPTION
This PR is in response to unexpected and highly undesirable behaviour identified by #984. The effect of this PR is to raise an exception when attempting to constrain bounded time coords with the new date time cell comparison feature. This is disappointing, but without calendar information it is not possible to determine whether a PartialDateTime (or any other calendar-agnostic datetime-like object) lies within a bounded region. As Iris currently stands you'll get the wrong answer when performing such constraints and absolutely no indication that something has gone awry. Note that point based datetime constraints (i.e. those in the docs) are fine.

Please also notice that I've put in some special behaviour around `netcdftime.datetime` objects as I can do:

```
>>> import netcdftime
>>> a = netcdftime.datetime(2000, 1, 1)
>>> b = netcdftime.datetime(1990, 1, 1)
>>> a > b
False
>>> a < b
True
```

This fallback to id-based comparison (I think) makes comparing netcdftime.datetime objects to anything other than PartialDateTimes unreliable. I'd rather not put this time-specific/netcdftime-specific logic in `coords.py` but I can't think of a better place without a lot of work.
