### PR TITLE
DOC: Added 'top' buttons to top level object separators in documentation.

### DIFF
--- a/docs/iris/src/_static/style.css
+++ b/docs/iris/src/_static/style.css
@@ -1,3 +1,32 @@
 .sidebar { z-index: 10; }
 
-.highlight { background: none; } 
+.highlight { background: none; }
+
+p.hr_p {
+    overflow: hidden;
+    text-align: center;
+}
+p.hr_p a {
+    font-size: small;
+    color: #1C86EE;
+}
+p.hr_p:before,
+p.hr_p:after {
+    background-color: #abc;
+    border: 1px solid #abc;
+    content: "";
+    display: inline-block;
+    height: 1px;
+    position: relative;
+    vertical-align: middle;
+    width: 50%;
+}
+p.hr_p:before {
+    right: 0.5em;
+    margin-left: -50%;
+}
+p.hr_p:after {
+    left: 0.5em;
+    margin-right: -50%;
+}
+ 

--- a/docs/iris/src/sphinxext/generate_package_rst.py
+++ b/docs/iris/src/sphinxext/generate_package_rst.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -46,6 +46,20 @@ document_dict = {
 '''}
 
 
+horizontal_sep = """
+.. raw:: html
+
+    <p class="hr_p"><a href="#">&uarr;&#32&#32 top &#32&#32&uarr;</a></p>
+    <!--
+-----------
+
+.. raw:: html
+
+    -->
+
+"""
+
+
 def lookup_object_type(obj):
         if inspect.isclass(obj):
             return 'class'
@@ -74,11 +88,10 @@ def auto_doc_module(file_path, import_name, root_package, package_toc=None, titl
 
     tmp = ''
     for element, obj in document_these:
-        tmp += '----------\n' + document_dict[lookup_object_type(obj)] % {'object_name': import_name + '.' + element,
+        tmp += horizontal_sep + document_dict[lookup_object_type(obj)] % {'object_name': import_name + '.' + element,
                                                          'object_name_header_line':'+' * len(import_name + '.' + element),
                                                          'object_docstring': inspect.getdoc(obj),
                                                          }
-
 
     module_elements = '\n'.join([' * :py:obj:`%s`' % (element) for element, obj in document_these])
 


### PR DESCRIPTION
Adds "top" links after each top level item in the reference docs.
