### PR TITLE
Added unify_time_units call to merge

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -332,6 +332,7 @@ class CubeList(list):
               Coordinate-to-dimension mapping differs for cube.dim_coords.
 
         """
+        iris.util.unify_time_units(self)
         if not self:
             raise ValueError("can't merge an empty CubeList")
 
@@ -398,6 +399,7 @@ class CubeList(list):
 
         """
         # Register each of our cubes with its appropriate ProtoCube.
+        iris.util.unify_time_units(self)
         proto_cubes_by_name = {}
         for cube in self:
             name = cube.standard_name

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -30,6 +30,20 @@ class Test_merge_cube(tests.IrisTest):
         self.cube1 = Cube([1, 2, 3], "air_temperature", units="K")
         self.cube1.add_aux_coord(AuxCoord([0], "height", units="m"))
 
+    def differing_epochs_cubes(self):
+        cubes = CubeList()
+        reftimes = ['hours since 1970-01-01 00:00:00',
+                    'hours since 1970-01-02 00:00:00']
+        calendar = 'gregorian'
+        for reftime in reftimes:
+            units = iris.unit.Unit(reftime, calendar='gregorian')
+            cube = self.cube1.copy()
+            frt_aux = AuxCoord(0, standard_name='forecast_reference_time',
+                               units=units)
+            cube.add_aux_coord(frt_aux)
+            cubes.append(cube)
+        return cubes
+
     def test_pass(self):
         cube2 = self.cube1.copy()
         cube2.coord("height").points = [1]
@@ -54,6 +68,10 @@ class Test_merge_cube(tests.IrisTest):
     def test_repeated_cube(self):
         with self.assertRaises(iris.exceptions.MergeError):
             CubeList([self.cube1, self.cube1]).merge_cube()
+
+    def test_differing_epochs_cubes(self):
+        result = self.differing_epochs_cubes().merge_cube()
+        self.assertIsInstance(result, Cube)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a call to the `iris.util` function `unify_time_units()` introduced in #1003 to CubeList merge methods. This allows merge to run successfully on CubeLists whose time coordinates' epochs differ.
