### PR TITLE
Backed out unify_time_units call in concatenate

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -219,8 +219,6 @@ def concatenate(cubes):
         This routine will load your data payload!
 
     """
-    if len(cubes) > 1:
-        unify_time_units(cubes)
     proto_cubes_by_name = defaultdict(list)
     # Initialise the nominated axis (dimension) of concatenation
     # which requires to be negotiated.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -397,6 +397,13 @@ class CubeList(list):
         Contrast this with :meth:`iris.cube.CubeList.concatenate`, which joins
         cubes along an existing dimension.
 
+        .. note::
+
+            If time coordinates in the list of cubes have differing epochs then
+            the cubes will not be able to be merged. If this occurs, use
+            :func:`iris.util.unify_time_units` to normalise the epochs of the
+            time coordinates so that the cubes can be merged.
+
         """
         # Register each of our cubes with its appropriate ProtoCube.
         proto_cubes_by_name = {}
@@ -477,6 +484,13 @@ class CubeList(list):
 
         Contrast this with :meth:`iris.cube.CubeList.merge`, which makes a new
         dimension from values of an auxiliary scalar coordinate.
+
+        .. note::
+
+            If time coordinates in the list of cubes have differing epochs then
+            the cubes will not be able to be concatenated. If this occurs, use
+            :func:`iris.util.unify_time_units` to normalise the epochs of the
+            time coordinates so that the cubes can be concatenated.
 
         .. warning::
 

--- a/lib/iris/tests/integration/concatenate/__init__.py
+++ b/lib/iris/tests/integration/concatenate/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for the :mod:`iris._concatenate` package."""

--- a/lib/iris/tests/integration/concatenate/test_concatenate.py
+++ b/lib/iris/tests/integration/concatenate/test_concatenate.py
@@ -1,0 +1,65 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Integration tests for concatenating cubes with differing time coord epochs
+using :func:`iris.util.unify_time_units`.
+
+"""
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris.coords
+from iris._concatenate import concatenate
+import iris.cube
+import iris.unit
+from iris.util import unify_time_units
+
+
+class Test_concatenate__epoch(tests.IrisTest):
+    def simple_1d_time_cubes(self, reftimes, coords_points):
+        cubes = []
+        data_points = [273, 275, 278, 277, 274]
+        for reftime, coord_points in zip(reftimes, coords_points):
+            cube = iris.cube.Cube(np.array(data_points, dtype=np.float32),
+                                  standard_name='air_temperature',
+                                  units='K')
+            unit = iris.unit.Unit(reftime, calendar='gregorian')
+            coord = iris.coords.DimCoord(points=np.array(coord_points,
+                                                         dtype=np.float32),
+                                         standard_name='time',
+                                         units=unit)
+            cube.add_dim_coord(coord, 0)
+            cubes.append(cube)
+        return cubes
+
+    def test_concat_1d_with_differing_time_units(self):
+        reftimes = ['hours since 1970-01-01 00:00:00',
+                    'hours since 1970-01-02 00:00:00']
+        coords_points = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]
+        cubes = self.simple_1d_time_cubes(reftimes, coords_points)
+        unify_time_units(cubes)
+        result = concatenate(cubes)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (10,))
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/concatenate/__init__.py
+++ b/lib/iris/tests/unit/concatenate/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris._concatenate` package."""

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the :mod:`iris._concatenate` package."""
+"""Test function :func:`iris._concatenate.concatenate.py`."""
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.
@@ -49,15 +49,6 @@ class Test_concatenate__epoch(tests.IrisTest):
         reftimes = ['hours since 1970-01-01 00:00:00',
                     'hours since 1970-01-01 00:00:00']
         coords_points = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
-        cubes = self.simple_1d_time_cubes(reftimes, coords_points)
-        result = concatenate(cubes)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].shape, (10,))
-
-    def test_concat_1d_with_differing_time_units(self):
-        reftimes = ['hours since 1970-01-01 00:00:00',
-                    'hours since 1970-01-02 00:00:00']
-        coords_points = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]
         cubes = self.simple_1d_time_cubes(reftimes, coords_points)
         result = concatenate(cubes)
         self.assertEqual(len(result), 1)

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1291,7 +1291,7 @@ def unify_time_units(cubes):
     Arg:
 
     * cubes:
-        An iterable of :class:`iris.cube.Cube`s.
+        An iterable containing :class:`iris.cube.Cube` instances.
 
     """
     epochs = {}


### PR DESCRIPTION
In #1003 an `iris.util` function, namely `unify_time_units` was added to Iris, and called within `iris._concatenate.concatenate` as a helper function for occasions when concatenation would fail due to differing epochs in the time coords of the cubes to be merged. However this (as discussed post-merge in the comments of #1003) has had the undesirable side-effects of:
- enforcing unifying time coord epochs when concatenating CubeLists, which may not be the wish of the user, and
- meaning that even if the concatenate operation still fails the CubeList is irreversibly and inescapably changed.

As such it is considered that it would be much better to remove the automatic call of the util function from concatenate and add a note in the documentation for concatenate (and merge, which benefits in the same way from the provision of this util function) pointing users toward the util function.

Removing the util function call from concatenate means the epoch tests for concatenate no longer pass. As such the failing test is moved to a new integration test that explicitly calls the util function.
