### PR TITLE
Changed to auto convert from aux to dim coord

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -841,7 +841,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 warnings.warn('converting AuxCoord to DimCoord',
                               stacklevel=2)
             except ValueError as e:
-                raise ValueError('Could not convert coord to DimCoord: '
+                raise ValueError('Could not convert coord to DimCoord. '
                                  + str(e))
 
         # Convert data_dim to a single integer

--- a/lib/iris/tests/test_cube.py
+++ b/lib/iris/tests/test_cube.py
@@ -87,11 +87,10 @@ class Test_Cube_add_dim_coord(tests.IrisTest):
             self.cube.add_dim_coord(coord, 0)
 
     def test_adding_aux_coord(self):
-        try:
-            coord = iris.coords.AuxCoord(np.arange(2), "latitude")
-            self.cube.add_dim_coord(coord, 0)
-        except ValueError as e:
-            self.fail(str(e))
+        coord = iris.coords.AuxCoord(np.arange(2), "latitude")
+        self.cube.add_dim_coord(coord, 0)
+        self.assertIsInstance(self.cube.coord("latitude"),
+                              iris.coords.DimCoord)
 
 
 class TestEquality(tests.IrisTest):


### PR DESCRIPTION
Currently iris raises an error if you try and pass an aux coord to a function that wants a dim coord, even if the aux coord is capable of being converted to a dim coord (i.e. monotonic). This PR attempts to convert aux coords and then raises the current error if that fails.

Note I haven't updated the documentation - not sure what to say: "or an aux_coord that can be converted using DimCoord.from_cube()" or something?
