### PR TITLE
Fix problem arising in ESMPy tests with numpy v1.7.

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -409,12 +409,10 @@ class TestConservativeRegrid(tests.IrisTest):
         c1x1 = regrid_conservative_via_esmpy(c1, c1x1_gridcube)
         c1x1_areasum = _cube_area_sum(c1x1)
         # Check the total area sum is still the same
-        # NOTE: at present, this causes an error inside ESMF ...
-        context = self.assertRaises(AssertionError)
         condense_to_1x1_supported = False
+        # NOTE: currently disabled (ESMF gets this wrong)
+        # NOTE ALSO: call hits numpy 1.7 bug in testing.assert_array_compare.
         if condense_to_1x1_supported:
-            context = _donothing_context_manager()
-        with context:
             self.assertArrayAllClose(c1x1_areasum, c1_areasum)
 
         # Condense entire region onto a single cell covering the area of 'c2'


### PR DESCRIPTION
Replaces https://github.com/SciTools/iris/pull/1023
(now targetting 1.6.x)

See discussions on earlier PR
