### PR TITLE
Fixed RPM typo in what's new page

### DIFF
--- a/docs/iris/src/whatsnew/1.6.rst
+++ b/docs/iris/src/whatsnew/1.6.rst
@@ -245,12 +245,12 @@ consuming processing, or to reap the benefit of fast-loading a pickled cube.
 
 .. _rms:
 
-The RPM aggregator supports weights
+The RMS aggregator supports weights
 ===================================
-A :data:`iris.analysis.RMS` aggregator has been extended to allow the use of
+The :data:`iris.analysis.RMS` aggregator has been extended to allow the use of
 weights using the new keyword argument :data:`weights`.
 
-For example, a RMS weighted cube collapse is performed as follows:
+For example, an RMS weighted cube collapse is performed as follows:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR fixes #1038 and a couple of other typos in that section.
