### PR TITLE
Fix to link in colorbar example

### DIFF
--- a/docs/iris/example_code/graphics/anomaly_log_colouring.py
+++ b/docs/iris/example_code/graphics/anomaly_log_colouring.py
@@ -13,7 +13,7 @@ magnitude may be considered "not significant", so we put these into a separate
 
 To do this, we create a custom value mapping function (normalization) using
 the matplotlib Norm class `matplotlib.colours.SymLogNorm
-<http://matplotlib.org/api/colors_api.html#matplotlib.colors.BoundaryNorm>`_.
+<http://matplotlib.org/api/colors_api.html#matplotlib.colors.SymLogNorm>`_.
 We use this to make a cell-filled pseudocolour plot with a colorbar.
 
 NOTE: By "pseudocolour", we mean that each data point is drawn as a "cell"


### PR DESCRIPTION
This PR corrects a link in the doctstring of the new anomaly colouring example to point to SymLogNorm (as used in the code) rather than BoundaryNorm.
