### PR TITLE
Select last reference cube.

### DIFF
--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -68,7 +68,7 @@ class ConcreteReferenceTarget(object):
             if len(src_cubes) > 1:
                 # Merge the reference cubes to allow for
                 # time-varying surface pressure in hybrid-presure.
-                src_cubes = src_cubes.merge()
+                src_cubes = src_cubes.merge(unique=False)
                 if len(src_cubes) > 1:
                     warnings.warn('Multiple reference cubes for {}'
                                   .format(self.name))


### PR DESCRIPTION
This PR corrects an oversight.

Normally, after merging there should only be one reference cube e.g. orography for hybrid height, but there can be instances when the data-feed may contain multiple versions.

The PR allows such a data-feed to be loaded, an appropriate warning message issued and the last reference cube selected by default.

By setting `unique=False` merge will return multiple cubes when constructing the higher dimensionality and there are more than one candidate cube that wants to occupy a specific index in the higher dimensionality space. 

If the default merge `unique=True` behaviour is maintained, then an `iris.exceptions.DuplicateDataError` will be raised, and the data-feed cannot be loaded by the user.
