### PR TITLE
Fixed issue with time triple merging with realizations

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -21,7 +21,7 @@ Typically the cube merge process is handled by
 :method:`iris.cube.CubeList.merge`.
 
 """
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from copy import deepcopy
 
 import numpy as np
@@ -1144,9 +1144,14 @@ class ProtoCube(object):
             if space[name] is None:
                 if _is_combination(name):
                     members = name.split(_COMBINATION_JOIN)
-                    cells = sorted(set(tuple(
-                        position[int(member) if member.isdigit() else member]
-                        for member in members) for position in positions))
+                    # Create list of unique tuples from all combinations of
+                    # scalars for each source cube. The keys of an OrderedDict
+                    # are used to retain the ordering of source cubes but to
+                    # remove any duplicate tuples.
+                    cells = OrderedDict(
+                        (tuple(position[int(member) if member.isdigit() else
+                                        member] for member in members), None)
+                        for position in positions).keys()
                     dim_by_name[name] = len(self._shape)
                     self._nd_names.append(name)
                     self._shape.append(len(cells))

--- a/lib/iris/tests/results/cdm/masked_cube.cml
+++ b/lib/iris/tests/results/cdm/masked_cube.cml
@@ -7,7 +7,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="73141289" points="[0.0, 0.0, 0.0, 3.0, 3.0, 6.0, 6.0, 6.0]" shape="(8,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <auxCoord id="73141289" points="[0.0, 3.0, 6.0, 0.0, 3.0, 6.0, 0.0, 6.0]" shape="(8,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[999.999999996]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -27,15 +27,15 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="8d07ce7a" long_name="pressure" points="[800.0, 900.0, 1000.0, 800.0, 1000.0, 800.0,
-		900.0, 1000.0]" shape="(8,)" units="Unit('hPa')" value_type="float32"/>
+        <auxCoord id="8d07ce7a" long_name="pressure" points="[1000.0, 1000.0, 1000.0, 800.0, 800.0, 800.0,
+		900.0, 900.0]" shape="(8,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="6a1b3c16" points="[999.999999996, 999.999999996, 999.999999996,
-		1003.0, 1003.0, 1006.0, 1006.0, 1006.0]" shape="(8,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+        <auxCoord id="6a1b3c16" points="[999.999999996, 1003.0, 1006.0, 999.999999996,
+		1003.0, 1006.0, 999.999999996, 1006.0]" shape="(8,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>
-    <data byteorder="little" checksum="-0x4c30a3b1" dtype="float32" fill_value="1e-09" mask_checksum="0x5a209acb" shape="(8, 20, 20)"/>
+    <data byteorder="little" checksum="-0xb7e918a" dtype="float32" fill_value="1e-09" mask_checksum="0x54a64fdc" shape="(8, 20, 20)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/merge/separable_combination.cml
+++ b/lib/iris/tests/results/merge/separable_combination.cml
@@ -3,23 +3,31 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="9c870e8e" long_name="a" points="[2002, 2002, 2005, 2026, 2502, 2502, 2502, 2502,
-		2502, 2502, 2502, 2502, 2502, 2002, 2002, 2005,
-		2026, 2002, 2002, 2005, 2026]" shape="(21,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="9c870e8e" long_name="a" points="[2005, 2005, 2005, 2026, 2026, 2026, 2002, 2002,
+		2002, 2002, 2002, 2002, 2502, 2502, 2502, 2502,
+		2502, 2502, 2502, 2502, 2502]" shape="(21,)" units="Unit('1')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="c499a7a6" long_name="b" points="[CERFACS, IFM-GEOMAR, ECMWF, UK Met Office,
+        <auxCoord id="c499a7a6" long_name="b" points="[ECMWF, ECMWF, ECMWF, UK Met Office,
+		UK Met Office, UK Met Office, CERFACS, CERFACS,
+		CERFACS, IFM-GEOMAR, IFM-GEOMAR, IFM-GEOMAR,
 		UK Met Office, UK Met Office, UK Met Office,
 		UK Met Office, UK Met Office, UK Met Office,
-		UK Met Office, UK Met Office, UK Met Office,
-		CERFACS, IFM-GEOMAR, ECMWF, UK Met Office,
-		CERFACS, IFM-GEOMAR, ECMWF, UK Met Office]" shape="(21,)" units="Unit('1')" value_type="string"/>
+		UK Met Office, UK Met Office, UK Met Office]" shape="(21,)" units="Unit('1')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="45bcc281" long_name="c" points="[GELATO, Sys 0, Met 1, ENSEMBLES,
-		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+        <auxCoord id="45bcc281" long_name="c" points="[HOPE-E, Sys 1, Met 1, ENSEMBLES,
+		HOPE-E, Sys 1, Met 1, ENSEMBLES,
 		HOPE-E, Sys 1, Met 1, ENSEMBLES,
 		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		HadGEM2, Sys 1, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		GELATO, Sys 0, Met 1, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
+		ECHAM5, Sys 1, Met 10, ENSEMBLES,
 		HadCM3, Sys 51, Met 10, ENSEMBLES,
 		HadCM3, Sys 51, Met 11, ENSEMBLES,
 		HadCM3, Sys 51, Met 12, ENSEMBLES,
@@ -28,20 +36,12 @@
 		HadCM3, Sys 51, Met 15, ENSEMBLES,
 		HadCM3, Sys 51, Met 16, ENSEMBLES,
 		HadCM3, Sys 51, Met 17, ENSEMBLES,
-		HadCM3, Sys 51, Met 18, ENSEMBLES,
-		GELATO, Sys 0, Met 1, ENSEMBLES,
-		ECHAM5, Sys 1, Met 10, ENSEMBLES,
-		HOPE-E, Sys 1, Met 1, ENSEMBLES,
-		HadGEM2, Sys 1, Met 1, ENSEMBLES,
-		GELATO, Sys 0, Met 1, ENSEMBLES,
-		ECHAM5, Sys 1, Met 10, ENSEMBLES,
-		HOPE-E, Sys 1, Met 1, ENSEMBLES,
-		HadGEM2, Sys 1, Met 1, ENSEMBLES]" shape="(21,)" units="Unit('1')" value_type="string"/>
+		HadCM3, Sys 51, Met 18, ENSEMBLES]" shape="(21,)" units="Unit('1')" value_type="string"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="74a4f5f6" long_name="d" points="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0,
-		2.0, 2.0, 2.0]" shape="(21,)" units="Unit('1')" value_type="float32"/>
+        <auxCoord id="74a4f5f6" long_name="d" points="[0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0,
+		0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0]" shape="(21,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2]">
         <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_non_expanding.cml
+++ b/lib/iris/tests/results/merge/time_triple_non_expanding.cml
@@ -9,7 +9,7 @@
         <auxCoord id="fe82bc89" points="[10, 20, 20]" shape="(3,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int32"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="c2f882b5" points="[0, 0, 1]" shape="(3,)" standard_name="time" units="Unit('1')" value_type="int32"/>
+        <auxCoord id="c2f882b5" points="[0, 1, 0]" shape="(3,)" standard_name="time" units="Unit('1')" value_type="int32"/>
       </coord>
       <coord datadims="[2]">
         <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_realization.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_realization.cml
@@ -3,19 +3,19 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="ca4300da" points="[0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1,
-		1]" shape="(17,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="ca4300da" points="[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,
+		0]" shape="(17,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="fe82bc89" points="[10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 10, 10,
-		10, 11, 11, 11, 11]" shape="(17,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="fe82bc89" points="[10, 10, 11, 11, 10, 10, 11, 11, 10, 10, 11, 11,
+		10, 10, 11, 11, 10]" shape="(17,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="cfd5ae8c" points="[1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 3, 1, 2, 1, 2, 1,
-		2]" shape="(17,)" standard_name="realization" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="cfd5ae8c" points="[1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2,
+		3]" shape="(17,)" standard_name="realization" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="c2f882b5" points="[1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2,
+        <auxCoord id="c2f882b5" points="[1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
 		2]" shape="(17,)" standard_name="time" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[2]">

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_triple.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_triple.cml
@@ -3,19 +3,19 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="ca4300da" points="[0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1,
+        <auxCoord id="ca4300da" points="[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,
 		1]" shape="(17,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="fe82bc89" points="[10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 10, 10,
-		11, 11, 11, 11, 11]" shape="(17,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="fe82bc89" points="[10, 10, 11, 11, 10, 10, 11, 11, 10, 10, 11, 11,
+		10, 10, 11, 11, 11]" shape="(17,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="cfd5ae8c" points="[1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
+        <auxCoord id="cfd5ae8c" points="[1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2,
 		2]" shape="(17,)" standard_name="realization" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="c2f882b5" points="[1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2,
+        <auxCoord id="c2f882b5" points="[1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
 		3]" shape="(17,)" standard_name="time" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[2]">

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_realization.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_realization.cml
@@ -3,7 +3,7 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[1]">
-        <auxCoord id="ca4300da" points="[0, 1, 0, 1, 0, 1, 1, 0]" shape="(8,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="ca4300da" points="[0, 0, 0, 0, 1, 1, 1, 1]" shape="(8,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[1]">
         <auxCoord id="fe82bc89" points="[10, 10, 11, 11, 10, 10, 11, 11]" shape="(8,)" standard_name="forecast_reference_time" units="Unit('1')" value_type="int64"/>
@@ -12,7 +12,7 @@
         <dimCoord id="cfd5ae8c" points="[1, 2]" shape="(2,)" standard_name="realization" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[1]">
-        <auxCoord id="c2f882b5" points="[1, 1, 1, 1, 2, 2, 2, 3]" shape="(8,)" standard_name="time" units="Unit('1')" value_type="int64"/>
+        <auxCoord id="c2f882b5" points="[1, 2, 1, 3, 1, 2, 1, 2]" shape="(8,)" standard_name="time" units="Unit('1')" value_type="int64"/>
       </coord>
       <coord datadims="[3]">
         <dimCoord id="b0c4282a" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int64"/>

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1164,7 +1164,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
 
         # Test the slicing before deferred loading
         full_slice = cube[3]
-        partial_slice = cube[2]
+        partial_slice = cube[0]
         self.assertIsInstance(full_slice.data, np.ndarray)
         self.assertIsInstance(partial_slice.data, ma.core.MaskedArray)
         self.assertEqual(ma.count_masked(partial_slice._data), 25)
@@ -1172,7 +1172,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
         # Test the slicing is consistent after deferred loading
         cube.data
         full_slice = cube[3]
-        partial_slice = cube[2]
+        partial_slice = cube[0]
         self.assertIsInstance(full_slice.data, np.ndarray)
         self.assertIsInstance(partial_slice.data, ma.core.MaskedArray)
         self.assertEqual(ma.count_masked(partial_slice._data), 25)
@@ -1181,7 +1181,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
         cube = self._load_3d_cube()
 
         # extract the 2d field that has SOME missing values
-        masked_slice = cube[2]
+        masked_slice = cube[0]
         masked_slice.data.fill_value = 123456
         
         # test saving masked data


### PR DESCRIPTION
This PR fixes a serious problem in merge. When attempting to merge a complex set of data with various times forecast periods and forecast reference times, merge is amazingly clever at turning this into a multidimensional cube with the different coordinates along different dimensions. When some data is missing or just doesn't quite fit the pattern, merge does the sensible thing and stacks everything up, forming so-called combinations. All is well so far. However, in this second case where the time like coordinates all lie along a single dimension things go wrong with the process if there are groups of the time-like scalars that correspond to another scalar. For example, if there is a sequence of time, forecast period and forecast reference time that repeats for a number of realisations. A bug means that the size of the time-like dimension is multiplied by the number of realisations and garbage is found in the extra uninitialised bits of the coords/data array.

~~The fix is easy, use a set to get the unique combinations of time-like tuples. I've also sorted this set of unique cells to fix the order. This fix has changed the order of lat-lon slices in some of the results as you can see in the diffs.~~The fix is to remove duplicate combinations. I've used an OrderedDict to achieve this so that the ordering of slices in datasets unaffected by this bug are not affected by this fix.

I've put the testing into integration rather then modifying the old style test_merge.py file.
