### PR TITLE
Added masked version of iris.tests.IrisTest.assertArrayAllClose.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -400,6 +400,31 @@ class IrisTest(unittest.TestCase):
         """
         np.testing.assert_allclose(a, b, rtol=rtol, atol=atol, **kwargs)
 
+    def assertMaskedArrayAllClose(self, a, b, rtol=1.0e-7, atol=0.0, **kwargs):
+        """
+        Check masked arrays are equal, within given relative + absolute
+        tolerances.
+
+        This requires the masks to be equal, and the unmasked array values to
+        be within specified relative and absolute tolerances.
+
+        Args:
+
+        * a, b (array-like):
+            Two arrays to compare.
+
+        Kwargs:
+
+        * rtol, atol (float):
+            Relative and absolute tolerances to apply.
+
+        Any additional kwargs are passed to numpy.testing.assert_allclose.
+        For full details see underlying routine numpy.testing.assert_allclose.
+
+        """
+        np.testing.assert_array_equal(a.mask, b.mask)
+        np.testing.assert_allclose(a[~a.mask].data, b[~b.mask].data)
+
     @contextlib.contextmanager
     def temp_filename(self, suffix=''):
         filename = iris.util.create_temp_filename(suffix)


### PR DESCRIPTION
This change parallels the other assertMaskedXXX routines.
It enables me to fix the problem with the test code in `lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py`, which no longer works (i.e. the test code fails) with numpy v1.7.
( But I'll put that actual fix in an upcoming PR )

Note: this problem was not spotted earlier as these tests are skipped when ESMPy is not installed (so, not in Travis).
