### PR TITLE
Support for LBLEV of 9999

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -970,11 +970,6 @@ class PPField(object):
             calendar = iris.unit.CALENDAR_365_DAY
         return calendar
 
-    @property
-    def model_level_number(self):
-        """The model level number of the field."""
-        return 0 if self.lblev == 9999 else self.lblev
-
     def _read_extra_data(self, pp_file, file_reader, extra_len):
         """Read the extra data section and update the self appropriately."""
 

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -31,6 +31,30 @@ import iris.fileformats.pp
 import iris.unit
 
 
+def _model_level_number(field):
+    """
+    Return the model level number of a field.
+
+    Args:
+
+    * field (:class:`iris.fileformats.pp.PPField`)
+        PP field to inspect.
+
+    Returns:
+        Model level number (integer).
+
+    """
+    # See Word no. 33 (LBLEV) in section 4 of UM Model Docs (F3).
+    SURFACE_AND_ZEROTH_RHO_LEVEL_LBLEV = 9999
+
+    if field.lblev == SURFACE_AND_ZEROTH_RHO_LEVEL_LBLEV:
+        model_level_number = 0
+    else:
+        model_level_number = field.lblev
+
+    return model_level_number
+
+
 def convert(f):
     factories = []
     references = []
@@ -301,7 +325,7 @@ def convert(f):
     if \
             (len(f.lbcode) != 5) and \
             (f.lbvc == 2):
-        aux_coords_and_dims.append((DimCoord(f.model_level_number, standard_name='model_level_number', attributes={'positive': 'down'}), None))
+        aux_coords_and_dims.append((DimCoord(_model_level_number(f), standard_name='model_level_number', attributes={'positive': 'down'}), None))
 
     if \
             (len(f.lbcode) != 5) and \
@@ -317,7 +341,7 @@ def convert(f):
 
     # soil level
     if len(f.lbcode) != 5 and f.lbvc == 6:
-        aux_coords_and_dims.append((DimCoord(f.model_level_number, long_name='soil_model_level_number', attributes={'positive': 'down'}), None))
+        aux_coords_and_dims.append((DimCoord(_model_level_number(f), long_name='soil_model_level_number', attributes={'positive': 'down'}), None))
 
     if \
             (f.lbvc == 8) and \
@@ -331,7 +355,7 @@ def convert(f):
 
     # Hybrid pressure coordinate
     if f.lbvc == 9:
-        model_level_number = DimCoord(f.model_level_number,
+        model_level_number = DimCoord(_model_level_number(f),
                                       standard_name='model_level_number',
                                       attributes={'positive': 'up'})
         # The following match the hybrid height scheme, but data has the
@@ -359,7 +383,7 @@ def convert(f):
                                   Reference('surface_air_pressure')]))
 
     if f.lbvc == 65:
-        aux_coords_and_dims.append((DimCoord(f.model_level_number, standard_name='model_level_number', attributes={'positive': 'up'}), None))
+        aux_coords_and_dims.append((DimCoord(_model_level_number(f), standard_name='model_level_number', attributes={'positive': 'up'}), None))
         aux_coords_and_dims.append((DimCoord(f.blev, long_name='level_height', units='m', bounds=[f.brlev, f.brsvd[0]], attributes={'positive': 'up'}), None))
         aux_coords_and_dims.append((AuxCoord(f.bhlev, long_name='sigma', bounds=[f.bhrlev, f.brsvd[1]]), None))
         factories.append(Factory(HybridHeightFactory, [{'long_name': 'level_height'}, {'long_name': 'sigma'}, Reference('orography')]))

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -46,7 +46,7 @@ class TestVertical(tests.IrisTest):
         # NB. Use MagicMock so that SplittableInt header items, such as
         # LBCODE, support len().
         soil_level = 1234
-        field = mock.MagicMock(lbvc=6, model_level_number=soil_level,
+        field = mock.MagicMock(lbvc=6, lblev=soil_level,
                                stash=iris.fileformats.pp.STASH(1, 0, 9),
                                lbuser=[0] * 7, lbrsvd=[0] * 4)
         load = mock.Mock(return_value=iter([field]))
@@ -119,7 +119,7 @@ class TestVertical(tests.IrisTest):
         sigma_lower, sigma, sigma_upper = 0.85, 0.9, 0.95
         delta_lower, delta, delta_upper = 0.05, 0.1, 0.15
         data_field = field_with_data()
-        data_field.configure_mock(lbvc=9, model_level_number=model_level,
+        data_field.configure_mock(lbvc=9, lblev=model_level,
                                   bhlev=delta, bhrlev=delta_lower,
                                   blev=sigma, brlev=sigma_lower,
                                   brsvd=[sigma_upper, delta_upper])
@@ -198,7 +198,7 @@ class TestVertical(tests.IrisTest):
         sigma_lower, sigma, sigma_upper = 0.85, 0.9, 0.95
         delta_lower, delta, delta_upper = 0.05, 0.1, 0.15
         data_field = field_with_data()
-        data_field.configure_mock(lbvc=9, model_level_number=model_level,
+        data_field.configure_mock(lbvc=9, lblev=model_level,
                                   bhlev=delta, bhrlev=delta_lower,
                                   blev=sigma, brlev=sigma_lower,
                                   brsvd=[sigma_upper, delta_upper])

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -104,18 +104,5 @@ class Test_calendar(tests.IrisTest):
         self.assertEqual(field.calendar, '365_day')
 
 
-class Test_model_level_number(tests.IrisTest):
-    def test_9999(self):
-        field = TestPPField()
-        field.lblev = 9999
-        self.assertEqual(field.model_level_number, 0)
-
-    def test_lblev(self):
-        field = TestPPField()
-        for val in xrange(9999):
-            field.lblev = val
-            self.assertEqual(field.model_level_number, val)
-
-
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
@@ -1,0 +1,42 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for :func:`iris.fileformats.pp_rules._model_level_number`."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+
+from iris.fileformats.pp_rules import _model_level_number
+
+
+class Test_9999(tests.IrisTest):
+    def test(self):
+        field = mock.Mock(lblev=9999)
+        self.assertEqual(_model_level_number(field), 0)
+
+
+class Test_lblev(tests.IrisTest):
+    def test(self):
+        for val in xrange(9999):
+            field = mock.Mock(lblev=val)
+            self.assertEqual(_model_level_number(field), val)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -63,7 +63,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_soil_levels(self):
         level = 1234
-        field = mock.MagicMock(lbvc=6, model_level_number=level)
+        field = mock.MagicMock(lbvc=6, lblev=level)
         self._test_for_coord(field, convert,
                              TestLBVC._is_soil_model_level_number_coord,
                              expected_points=[level],
@@ -71,7 +71,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_hybrid_pressure_model_level_number(self):
         level = 5678
-        field = mock.MagicMock(lbvc=9, model_level_number=level,
+        field = mock.MagicMock(lbvc=9, lblev=level,
                                blev=20, brlev=23, bhlev=42,
                                bhrlev=45, brsvd=[17, 40])
         self._test_for_coord(field, convert,
@@ -83,7 +83,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
         delta_point = 12.0
         delta_lower_bound = 11.0
         delta_upper_bound = 13.0
-        field = mock.MagicMock(lbvc=9, model_level_number=5678,
+        field = mock.MagicMock(lbvc=9, lblev=5678,
                                blev=20, brlev=23, bhlev=delta_point,
                                bhrlev=delta_lower_bound,
                                brsvd=[17, delta_upper_bound])
@@ -97,7 +97,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
         sigma_point = 0.5
         sigma_lower_bound = 0.6
         sigma_upper_bound = 0.4
-        field = mock.MagicMock(lbvc=9, model_level_number=5678,
+        field = mock.MagicMock(lbvc=9, lblev=5678,
                                blev=sigma_point, brlev=sigma_lower_bound,
                                bhlev=12, bhrlev=11,
                                brsvd=[sigma_upper_bound, 13])


### PR DESCRIPTION
Within PP/fields files the spec indicates that an lblev of 9999 should be interpreted as a model level number of 0. This came to light when loading a fields file and finding the surface field at the top rather than the bottom of a cube since the model level number coord is monotonic.

This PR ensures an lblev of 9999 leads to a model level of zero in the lbvc cases where we generate a model level number coordinate. I implemented it in a couple of ways, initially putting all the logic (`level = 0 if f.lblev == 9999 else f.lblev`) in the pp_rules.py file but the replication of code bothered me (easy to miss for future pp rules) and led me put it in a function that I then shifted to a property on the field. I'm still not certain where the best place is so I'd welcome any thoughts. As a result of this choice I also had to modify some of the mocked fields in the tests and I uncovered and fixed a bug (second commit) with `iris.tests.unit.fileformats.TestField._test_for_coord` where a scalar point was not being suitably compared to an empty array.
