### PR TITLE
Added support for sys.prefix based udunits xml path

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -30,6 +30,8 @@ from __future__ import division
 import copy
 import ctypes
 import ctypes.util
+import os.path
+import sys
 import warnings
 
 import netcdftime
@@ -317,8 +319,14 @@ if not _ud_system:
     _ut_ignore = _func_type((_UT_IGNORE, _lib_ud))
     # ignore standard UDUNITS-2 start-up preamble redirected to stderr stream
     _default_handler = _ut_set_error_message_handler(_ut_ignore)
-    # load the unit-database
+    # Load the unit-database from the default location (modified via
+    # the UDUNITS2_XML_PATH environment variable) and if that fails look
+    # relative to sys.prefix to support environments such as conda.
     _ud_system = _ut_read_xml(None)
+    if _ud_system is None:
+        _alt_xml_path = os.path.join(sys.prefix, 'share',
+                                     'udunits', 'udunits2.xml')
+        _ud_system = _ut_read_xml(_alt_xml_path)
     # reinstate old error handler
     _ut_set_error_message_handler(_default_handler)
     del _func_type


### PR DESCRIPTION
The way we currently use udunits from Iris relies on it to looking in a default location for a set of xml files describing the units. I like this, but if you install Iris (and udunits as one of its dependencies) via conda in a virtual env like location the xml files will not be in this location. This should ideally be fixed in udunits, but they expose an API `ut_read_xml()` to enable user code to look in different locations. This PR adds a fallback if the default lookup fails. It does not break the user's ability to set a custom location via the UDUNITS2_XML_PATH environment var.

See https://github.com/nbren12/conda-recipes/issues/1 and https://groups.google.com/a/continuum.io/forum/#!topic/conda/8yZ3rxED2lk for more discussion.
