### PR TITLE
Extending masked array comparison

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -351,27 +351,58 @@ class IrisTest(unittest.TestCase):
     def assertArrayEqual(self, a, b, err_msg=''):
         np.testing.assert_array_equal(a, b, err_msg=err_msg)
 
-    def assertMaskedArrayEqual(self, a, b):
+    def _assertMaskedArray(self, assertion, a, b, strict):
+        a_mask, b_mask = ma.getmaskarray(a), ma.getmaskarray(b)
+        np.testing.assert_array_equal(a_mask, b_mask)
+        if strict:
+            assertion(a.data, b.data)
+        else:
+            assertion(a[~a_mask].data, b[~b_mask].data)
+
+    def assertMaskedArrayEqual(self, a, b, strict=False):
         """
         Check that masked arrays are equal. This requires the
         unmasked values and masks to be identical.
 
+        Args:
+
+        * a, b (array-like):
+            Two arrays to compare.
+
+        Kwargs:
+
+        * strict (bool):
+            If True, perform a complete mask and data array equality check.
+            If False (default), the data array equality considers only unmasked
+            elements.
+
         """
-        np.testing.assert_array_equal(a.mask, b.mask)
-        np.testing.assert_array_equal(a[~a.mask].data, b[~b.mask].data)
+        self._assertMaskedArray(np.testing.assert_array_equal, a, b, strict)
 
     def assertArrayAlmostEqual(self, a, b):
         np.testing.assert_array_almost_equal(a, b)
 
-    def assertMaskedArrayAlmostEqual(self, a, b):
+    def assertMaskedArrayAlmostEqual(self, a, b, strict=False):
         """
         Check that masked arrays are almost equal. This requires the
         masks to be identical, and the unmasked values to be almost
         equal.
 
+        Args:
+
+        * a, b (array-like):
+            Two arrays to compare.
+
+        Kwargs:
+
+        * strict (bool):
+            If True, perform a complete mask and data array equality check.
+            If False (default), the data array equality considers only unmasked
+            elements.
+
         """
-        np.testing.assert_array_equal(a.mask, b.mask)
-        np.testing.assert_array_almost_equal(a[~a.mask].data, b[~b.mask].data)
+        self._assertMaskedArray(np.testing.assert_array_almost_equal, a, b,
+                                strict)
 
     def assertArrayAllClose(self, a, b, rtol=1.0e-7, atol=0.0, **kwargs):
         """

--- a/lib/iris/tests/unit/tests/__init__.py
+++ b/lib/iris/tests/unit/tests/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.tests` package."""

--- a/lib/iris/tests/unit/tests/test_IrisTest.py
+++ b/lib/iris/tests/unit/tests/test_IrisTest.py
@@ -1,0 +1,94 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.tests.IrisTest` class."""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+from abc import ABCMeta, abstractproperty
+
+import numpy as np
+
+
+class _MaskedArrayEquality(object):
+    __metaclass__ = ABCMeta
+
+    def setUp(self):
+        self.arr1 = np.ma.array([1, 2, 3, 4], mask=[False, True, True, False])
+        self.arr2 = np.ma.array([1, 3, 2, 4], mask=[False, True, True, False])
+
+    @abstractproperty
+    def _func(self):
+        pass
+
+    def test_strict_comparison(self):
+        # Comparing both mask and data array completely.
+        with self.assertRaises(AssertionError):
+            self._func(self.arr1, self.arr2, strict=True)
+
+    def test_non_strict_comparison(self):
+        # Checking masked array equality and all unmasked array data values.
+        self._func(self.arr1, self.arr2, strict=False)
+
+    def test_default_strict_arg_comparison(self):
+        self._func(self.arr1, self.arr2)
+
+    def test_nomask(self):
+        # Test that an assertion is raised when comparing a masked array
+        # containing masked and unmasked values with a masked array with
+        # 'nomask'.
+        arr1 = np.ma.array([1, 2, 3, 4])
+        with self.assertRaises(AssertionError):
+            self._func(arr1, self.arr2, strict=False)
+
+    def test_nomask_unmasked(self):
+        # Ensure that a masked array with 'nomask' can compare with an entirely
+        # unmasked array.
+        arr1 = np.ma.array([1, 2, 3, 4])
+        arr2 = np.ma.array([1, 2, 3, 4], mask=False)
+        self._func(arr1, arr2, strict=False)
+
+    def test_different_mask_strict(self):
+        # Differing masks, equal data
+        arr2 = self.arr1.copy()
+        arr2[0] = np.ma.masked
+        with self.assertRaises(AssertionError):
+            self._func(self.arr1, arr2, strict=True)
+
+    def test_different_mask_nonstrict(self):
+        # Differing masks, equal data
+        arr2 = self.arr1.copy()
+        arr2[0] = np.ma.masked
+        with self.assertRaises(AssertionError):
+            self._func(self.arr1, arr2, strict=False)
+
+
+class Test_assertMaskedArrayEqual(_MaskedArrayEquality, tests.IrisTest):
+    @property
+    def _func(self):
+        return self.assertMaskedArrayEqual
+
+
+class Test_assertMaskedArrayAlmostEqual(_MaskedArrayEquality, tests.IrisTest):
+    @property
+    def _func(self):
+        return self.assertMaskedArrayAlmostEqual
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Work completed in #1074 only to go into v1.6.x
Required for a bugfix.
