### PR TITLE
BUG: Provided workaround for numpy ufunc.

### DIFF
--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -22,7 +22,7 @@ import numpy as np
 from iris.cube import Cube
 
 
-class TestArithmetic(object):
+class Arithmetic(object):
     # This class ensures that the behaviour of cube arithmetic follows that of
     # numpy via operator.xx
     __metaclass__ = ABCMeta

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -23,10 +23,10 @@ import iris.tests as tests
 import operator
 
 from iris.analysis.maths import add
-from iris.tests.unit.analysis.maths import TestArithmetic
+from iris.tests.unit.analysis.maths import Arithmetic
 
 
-class TestValue(tests.IrisTest, TestArithmetic):
+class TestValue(tests.IrisTest, Arithmetic):
     @property
     def op(self):
         return operator.add

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -26,10 +26,10 @@ import numpy as np
 
 import iris
 from iris.analysis.maths import divide
-from iris.tests.unit.analysis.maths import TestArithmetic
+from iris.tests.unit.analysis.maths import Arithmetic
 
 
-class TestValue(tests.IrisTest, TestArithmetic):
+class TestValue(tests.IrisTest, Arithmetic):
     @property
     def op(self):
         return operator.div

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -23,10 +23,10 @@ import iris.tests as tests
 import operator
 
 from iris.analysis.maths import multiply
-from iris.tests.unit.analysis.maths import TestArithmetic
+from iris.tests.unit.analysis.maths import Arithmetic
 
 
-class TestValue(tests.IrisTest, TestArithmetic):
+class TestValue(tests.IrisTest, Arithmetic):
     @property
     def op(self):
         return operator.mul

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -23,10 +23,10 @@ import iris.tests as tests
 import operator
 
 from iris.analysis.maths import subtract
-from iris.tests.unit.analysis.maths import TestArithmetic
+from iris.tests.unit.analysis.maths import Arithmetic
 
 
-class TestValue(tests.IrisTest, TestArithmetic):
+class TestValue(tests.IrisTest, Arithmetic):
     @property
     def op(self):
         return operator.sub


### PR DESCRIPTION
This effects binary operators (add, subtract, division and multiply)
onlt.
Replaces messy #1052
