### PR TITLE
Added non-standard calendar support for add_day_of_year

### DIFF
--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -164,7 +164,10 @@ def add_day_of_year(cube, coord, name='day_of_year'):
     (1..366 in leap years).
 
     """
-    # Note: tm_yday has index 7 in timetuples.
+    # Note: netcdftime.datetime objects return a normal tuple from timetuple(),
+    # unlike datetime.datetime objects that return a namedtuple.
+    # Index the time tuple (element 7 is day of year) instead of using named
+    # element tm_yday.
     add_categorised_coord(
         cube, name, coord,
         lambda coord, x: _pt_date(coord, x).timetuple()[7])

--- a/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
+++ b/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
@@ -115,7 +115,9 @@ class Test_add_day_of_year(tests.IrisTest):
             add_day_of_year(cube, 'time')
             points = cube.coord('day_of_year').points
             expected_points = self.expected[calendar]
-            self.assertArrayEqual(points, expected_points)
+            msg = 'Test failed for the following calendar: {}.'
+            self.assertArrayEqual(points, expected_points,
+                                  err_msg=msg.format(calendar))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `iris.coord_categorisation` function `add_day_of_year` now supports all calendars in `iris.unit.CALENDARS`. This was achieved by indexing into the tuple of time values using the index of year-day instead of the namedtuple index `tm_yday`, which is only available in `time.struct_time` instances as generated when the time unit's calendar is standard. Such value-based indexing is supported by all calendars.

Added unit test for confirming all calendars now work as expected with this coord categorisation.
