### PR TITLE
Load raw reduced grids from GRIB files.

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -745,7 +745,8 @@ def _regularise(grib_message):
 
 def grib_generator(filename, auto_regularise=True):
     """
-    Returns a generator of GribWrapper fields from the given filename.
+    Returns a generator of :class:`~iris.fileformats.grib.GribWrapper`
+    fields from the given filename.
 
     Args:
 
@@ -802,6 +803,7 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
         reduced grid to an equivalent regular grid.
 
     .. note::
+
        To make use of the *auto_regularise* keyword the normal Iris loading
        pipeline cannot be used, the loading must be performed manually::
 

--- a/lib/iris/tests/results/unit/fileformats/grib/load_cubes/reduced_gg_raw.cml
+++ b/lib/iris/tests/results/unit/fileformats/grib/load_cubes/reduced_gg_raw.cml
@@ -20,17 +20,17 @@
         </auxCoord>
       </coord>
       <coord>
-        <dimCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
+        <auxCoord id="af0092b8" points="[1]" shape="(1,)" standard_name="model_level_number" units="Unit('1')" value_type="int32">
           <attributes>
             <attribute name="positive" value="up"/>
           </attributes>
-        </dimCoord>
+        </auxCoord>
       </coord>
       <coord>
         <auxCoord id="64f42873" long_name="originating_centre" points="[	European Centre for Medium Range Weather Forecasts]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord>
-        <dimCoord id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+        <auxCoord id="5f88ebd6" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="6a1b3c16" points="[377688.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -400,13 +400,6 @@ class TestGribLoad(tests.GraphicsTest):
             ("GRIB", "reduced", "reduced_ll_missing.grib1")))
         self.assertCML(cube, ("grib_load", "reduced_ll_missing_grib1.cml"))
 
-    def test_reduced_raw(self):
-        gribfile = tests.get_data_path(("GRIB", "reduced", "reduced_gg.grib2"))
-        grib_generator = iris.fileformats.grib.load_cubes(
-            gribfile, auto_regularise=False)
-        cube = iris.cube.CubeList(grib_generator).merge_cube()
-        self.assertCML(cube, ("grib_load", "reduced_gg_raw.cml"))
-
 
 class TestGribTimecodes(tests.GraphicsTest):
     def _run_timetests(self, test_set):

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -1,0 +1,34 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.grib.load_cubes` function."""
+import iris.tests as tests
+
+from iris.fileformats.grib import load_cubes
+
+
+@tests.skip_data
+class Test_load_cubes(tests.IrisTest):
+
+    def test_reduced_raw(self):
+        # Loading a GRIB message defined on a reduced grid without
+        # interpolating to a regular grid.
+        gribfile = tests.get_data_path(
+            ("GRIB", "reduced", "reduced_gg.grib2"))
+        grib_generator = load_cubes(gribfile, auto_regularise=False)
+        self.assertCML(next(grib_generator),
+                       ("unit", "fileformats", "grib", "load_cubes",
+                        "reduced_gg_raw.cml"))


### PR DESCRIPTION
Adds the ability to load reduced grids from GRIB files in raw form, i.e. without automatically interpolating to a regular grid. The change is made at a fairly low level in the API so one needs to do extra work to use it, but I think it is important that the ability to do this at all arrives first, and we can decide if/how it should be integrated into the load procedure at a later time.

Current usage:

``` python
import iris
cube_generator = iris.fileformats.grib.load_cubes("reduced.grib",
                                                  auto_regularise=False)
cubes = iris.cube.CubeList(cube_generator).merge()
```

Pinging @PAGWatson since he asked for this feature, feel free to comment here.
