### PR TITLE
Update gitignore file to ignore example test results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ docs/iris/src/_templates/gallery.html
 docs/iris/src/examples/
 docs/iris/src/iris/
 
+# Example test results
+docs/iris/iris_image_test_output/
+
 # Created by editiors
 *~
 \#*


### PR DESCRIPTION
Add the directory of test images produced by `make extest` to the gitignore file.
