### PR TITLE
Clarified user guide on loading Brewer palettes.

### DIFF
--- a/docs/iris/src/userguide/plotting_a_cube.rst
+++ b/docs/iris/src/userguide/plotting_a_cube.rst
@@ -313,7 +313,8 @@ Plotting with Brewer
 ====================
 
 To plot a cube using a Brewer colour palette, simply select one of the Iris 
-registered Brewer colour palettes and plot the cube as normal.
+registered Brewer colour palettes and plot the cube as normal. The Brewer palettes
+become available once :mod:`iris.plot` or :mod:`iris.quickplot` are imported.
 
 .. plot:: userguide/plotting_examples/cube_brewer_contourf.py
    :include-source:


### PR DESCRIPTION
Adds a short sentence describing how to get the Brewer palettes loaded. I know that the palettes are actually loaded when `iris.palette` is imported, but I think just mentioning `iris.plot` and `iris.quickplot` is more appropriate for the user guide.
