### PR TITLE
Fixed use of undefined exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class TestRunner(setuptools.Command):
                                       'example_tests'))
 
         if not tests:
-            raise CommandError('No tests found in %s/*/tests' % lib_dir)
+            raise RuntimeError('No tests found in %s/*/tests' % lib_dir)
 
         if self.system_tests:
             regexp_pat = r'--match=^[Ss]ystem'


### PR DESCRIPTION
This PR fixes #1099 by simply changing an undefined exception to a builtin. This is in setup.py so a simple generic RuntimeError rather than a custom one seemed the simplest solution.
