### PR TITLE
Clarify Cube methods which do not support lazy evaluation.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2839,6 +2839,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Returns:
             :class:`iris.cube.Cube`.
 
+        .. note::
+
+            This operation does not yet have support for lazy evaluation.
+
         For example:
 
             >>> import iris
@@ -2992,6 +2996,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         Returns:
             :class:`iris.cube.Cube`.
+
+        .. note::
+
+            This operation does not yet have support for lazy evaluation.
 
         For example:
 


### PR DESCRIPTION
Adds a note to the docstrings of `Cube.aggregated_by()` and `Cube.rolling_window()` to highlight that they do not currently support lazy evaluation.
