### PR TITLE
Default NetCDF dimensionless unit.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -924,7 +924,7 @@ fc_extras
 
     ################################################################################
     def get_attr_units(cf_var, attributes):
-        attr_units = getattr(cf_var, CF_ATTR_UNITS, iris.unit._UNKNOWN_UNIT_STRING)
+        attr_units = getattr(cf_var, CF_ATTR_UNITS, iris.unit._UNIT_DIMENSIONLESS)
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="cube_axes_0" units="unknown" var_name="cube_axes_0">
+  <cube long_name="cube_axes_0" units="1" var_name="cube_axes_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -20,7 +20,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_1" units="unknown" var_name="cube_axes_1">
+  <cube long_name="cube_axes_1" units="1" var_name="cube_axes_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -41,7 +41,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_2" units="unknown" var_name="cube_axes_2">
+  <cube long_name="cube_axes_2" units="1" var_name="cube_axes_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -66,7 +66,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_3" units="unknown" var_name="cube_axes_3">
+  <cube long_name="cube_axes_3" units="1" var_name="cube_axes_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -89,7 +89,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_4" units="unknown" var_name="cube_axes_4">
+  <cube long_name="cube_axes_4" units="1" var_name="cube_axes_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -112,7 +112,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_0" units="unknown" var_name="cube_comment_0">
+  <cube long_name="cube_comment_0" units="1" var_name="cube_comment_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -131,7 +131,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_1" units="unknown" var_name="cube_comment_1">
+  <cube long_name="cube_comment_1" units="1" var_name="cube_comment_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -150,7 +150,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_2" units="unknown" var_name="cube_comment_2">
+  <cube long_name="cube_comment_2" units="1" var_name="cube_comment_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -170,7 +170,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_3" units="unknown" var_name="cube_comment_3">
+  <cube long_name="cube_comment_3" units="1" var_name="cube_comment_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -190,7 +190,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_4" units="unknown" var_name="cube_comment_4">
+  <cube long_name="cube_comment_4" units="1" var_name="cube_comment_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -213,7 +213,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_0" units="unknown" var_name="cube_interval_0">
+  <cube long_name="cube_interval_0" units="1" var_name="cube_interval_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -232,7 +232,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_1" units="unknown" var_name="cube_interval_1">
+  <cube long_name="cube_interval_1" units="1" var_name="cube_interval_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -252,7 +252,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_2" units="unknown" var_name="cube_interval_2">
+  <cube long_name="cube_interval_2" units="1" var_name="cube_interval_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -272,7 +272,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_3" units="unknown" var_name="cube_interval_3">
+  <cube long_name="cube_interval_3" units="1" var_name="cube_interval_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -295,7 +295,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_4" units="unknown" var_name="cube_interval_4">
+  <cube long_name="cube_interval_4" units="1" var_name="cube_interval_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -320,7 +320,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_maximum" units="unknown" var_name="cube_maximum">
+  <cube long_name="cube_maximum" units="1" var_name="cube_maximum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -333,7 +333,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mean" units="unknown" var_name="cube_mean">
+  <cube long_name="cube_mean" units="1" var_name="cube_mean">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -346,7 +346,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_median" units="unknown" var_name="cube_median">
+  <cube long_name="cube_median" units="1" var_name="cube_median">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -359,7 +359,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mid_range" units="unknown" var_name="cube_mid_range">
+  <cube long_name="cube_mid_range" units="1" var_name="cube_mid_range">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -372,7 +372,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_minimum" units="unknown" var_name="cube_minimum">
+  <cube long_name="cube_minimum" units="1" var_name="cube_minimum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -385,7 +385,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mix_0" units="unknown" var_name="cube_mix_0">
+  <cube long_name="cube_mix_0" units="1" var_name="cube_mix_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -404,7 +404,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mix_1" units="unknown" var_name="cube_mix_1">
+  <cube long_name="cube_mix_1" units="1" var_name="cube_mix_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -424,7 +424,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mix_2" units="unknown" var_name="cube_mix_2">
+  <cube long_name="cube_mix_2" units="1" var_name="cube_mix_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="3131281b" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -447,7 +447,7 @@
     </cellMethods>
     <data byteorder="little" checksum="-0x1344b4ab" dtype="int32" fill_value="-2147483647" mask_checksum="-0x9d92c67" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mode" units="unknown" var_name="cube_mode">
+  <cube long_name="cube_mode" units="1" var_name="cube_mode">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -460,7 +460,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_point" units="unknown" var_name="cube_point">
+  <cube long_name="cube_point" units="1" var_name="cube_point">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -473,7 +473,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_standard_deviation" units="unknown" var_name="cube_standard_deviation">
+  <cube long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -486,7 +486,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_sum" units="unknown" var_name="cube_sum">
+  <cube long_name="cube_sum" units="1" var_name="cube_sum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -499,7 +499,7 @@
     </cellMethods>
     <data byteorder="little" checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="-0x5afa20e5" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_variance" units="unknown" var_name="cube_variance">
+  <cube long_name="cube_variance" units="1" var_name="cube_variance">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="2f67da18" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="4c86d57a" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="2038b66d" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="295d7d37" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="26a96851" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -39,11 +39,11 @@
         <dimCoord circular="True" id="4c86d57a" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="2038b66d" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="295d7d37" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="26a96851" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="4c86d57a" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="2038b66d" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="295d7d37" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="26a96851" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="4c86d57a" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="2038b66d" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="295d7d37" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="26a96851" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown" var_name="unknown">
+  <cube units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown" var_name="unknown">
+  <cube units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown" var_name="unknown">
+  <cube units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown" var_name="unknown">
+  <cube units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown" var_name="unknown">
+  <cube units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>


### PR DESCRIPTION
This PR corrects the NetCDF loader such that it honours the CF convention that states quantities with no `units` are deemed as `dimensionless`, rather than `unknown` as currently implemented i.e.

```
Units are not required for dimensionless quantities. A variable with no units attribute is assumed to be
dimensionless. However, a units attribute specifying a dimensionless unit may optionally be included.
```

See http://cf-convention.github.io/1.6.html#units for further clarification.

Fixes #935.
