### PR TITLE
Support for bounds arrays with non-standard dim order

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1022,6 +1022,35 @@ fc_extras
 
 
     ################################################################################
+    def reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var):
+        """
+        Return a bounds_data array with the vertex dimension as the most
+        rapidly varying.
+
+        .. note::
+
+            This function assumes the dimension names of the coordinate
+            variable match those of the bounds variable in order to determine
+            which is the vertex dimension.
+
+
+        """
+        vertex_dim_names = set(cf_bounds_var.dimensions).difference(
+            cf_coord_var.dimensions)
+        if len(vertex_dim_names) != 1:
+            msg = 'Too many dimension names differ between coordinate ' \
+                  'variable {!r} and the bounds variable {!r}. ' \
+                  'Expected 1, got {}.'
+            raise ValueError(msg.format(str(cf_coord_var.cf_name),
+                                        str(cf_bounds_var.cf_name),
+                                        len(vertex_dim_names)))
+        vertex_dim = cf_bounds_var.dimensions.index(*vertex_dim_names)
+        bounds_data = np.rollaxis(bounds_data.view(), vertex_dim,
+                                  len(bounds_data.shape))
+        return bounds_data
+
+
+    ################################################################################
     def build_dimension_coordinate(engine, cf_coord_var, coord_name=None, coord_system=None):
         """Create a dimension coordinate (DimCoord) and add it to the cube."""
 
@@ -1046,6 +1075,12 @@ fc_extras
                 bounds_data = ma.filled(bounds_data)
                 msg = 'Gracefully filling {!r} dimension coordinate masked bounds'
                 warnings.warn(msg.format(str(cf_coord_var.cf_name)))
+            # Handle transposed bounds where the vertex dimension is not
+            # the last one. Test based on shape to support different
+            # dimension names.
+            if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
+                bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
+                                                  cf_coord_var)
         else:
             bounds_data = None
 
@@ -1167,6 +1202,12 @@ fc_extras
             get_values = lambda: deferred_load(filename, nc_bounds_var_name)
             bounds_data = iris.aux_factory.LazyArray(cf_bounds_var.shape,
                                                      get_values)
+            # Handle transposed bounds where the vertex dimension is not
+            # the last one. Test based on shape to support different
+            # dimension names.
+            if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
+                bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
+                                                  cf_coord_var)
         else:
             bounds_data = None
 

--- a/lib/iris/tests/unit/fileformats/pyke_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.fileformats._pyke_rules` module."""

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/__init__.py
@@ -1,0 +1,20 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the :mod:`iris.fileformats._pyke_rules.compiled_krb` module.
+
+"""

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris.fileformats.fc_rules_cf_fc` module."""

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -1,0 +1,177 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.build_auxilliary_coordinate`.
+
+"""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+import mock
+
+from iris.coords import AuxCoord
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    build_auxiliary_coordinate
+
+
+class TestBoundsVertexDim(tests.IrisTest):
+    def setUp(self):
+        # Create coordinate cf variables and pyke engine.
+        points = np.arange(6).reshape(2, 3)
+        self.cf_coord_var = mock.Mock(
+            dimensions=('foo', 'bar'),
+            cf_name='wibble',
+            standard_name=None,
+            long_name='wibble',
+            units='m',
+            shape=points.shape,
+            dtype=points.dtype,
+            __getitem__=lambda self, key: points[key])
+
+        self.engine = mock.Mock(
+            cube=mock.Mock(),
+            cf_var=mock.Mock(dimensions=('foo', 'bar')),
+            filename='DUMMY',
+            provides=dict(coordinates=[]))
+
+        # Create patch for deferred loading that prevents attempted
+        # file access. This assumes that self.cf_bounds_var is
+        # defined in the test case.
+        def deferred_load(filename, var_name):
+            for var in (self.cf_coord_var, self.cf_bounds_var):
+                if var_name == var.cf_name:
+                    return var[:]
+
+        self.deferred_load_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.deferred_load', new=deferred_load)
+
+    def test_slowest_varying_vertex_dim(self):
+        # Create the bounds cf variable.
+        bounds = np.arange(24).reshape(4, 2, 3)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('nv', 'foo', 'bar'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        # Expected bounds on the resulting coordinate should be rolled so that
+        # the vertex dimension is at the end.
+        expected_bounds = np.rollaxis(bounds, 0, bounds.ndim)
+        expected_coord = AuxCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=expected_bounds)
+
+        # Patch the helper function that retrieves the bounds cf variable.
+        # This avoids the need for setting up further mocking of cf objects.
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_aux_coord.assert_called_with(
+                expected_coord, [0, 1])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+    def test_fastest_varying_vertex_dim(self):
+        bounds = np.arange(24).reshape(2, 3, 4)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('foo', 'bar', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = AuxCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_aux_coord.assert_called_with(
+                expected_coord, [0, 1])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+    def test_fastest_with_different_dim_names(self):
+        # Despite the dimension names ('x', and 'y') differing from the coord's
+        # which are 'foo' and 'bar' (as permitted by the cf spec),
+        # this should still work because the vertex dim is the fastest varying.
+        bounds = np.arange(24).reshape(2, 3, 4)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('x', 'y', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = AuxCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_aux_coord.assert_called_with(
+                expected_coord, [0, 1])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -1,0 +1,177 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.build_dimension_coordinate`.
+
+"""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+import mock
+
+from iris.coords import DimCoord
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    build_dimension_coordinate
+
+
+class TestBoundsVertexDim(tests.IrisTest):
+    def setUp(self):
+        # Create coordinate cf variables and pyke engine.
+        points = np.arange(6)
+        self.cf_coord_var = mock.Mock(
+            dimensions=('foo',),
+            cf_name='wibble',
+            standard_name=None,
+            long_name='wibble',
+            units='m',
+            shape=points.shape,
+            dtype=points.dtype,
+            __getitem__=lambda self, key: points[key])
+
+        self.engine = mock.Mock(
+            cube=mock.Mock(),
+            cf_var=mock.Mock(dimensions=('foo', 'bar')),
+            filename='DUMMY',
+            provides=dict(coordinates=[]))
+
+        # Create patch for deferred loading that prevents attempted
+        # file access. This assumes that self.cf_bounds_var is
+        # defined in the test case.
+        def deferred_load(filename, var_name):
+            for var in (self.cf_coord_var, self.cf_bounds_var):
+                if var_name == var.cf_name:
+                    return var[:]
+
+        self.deferred_load_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.deferred_load', new=deferred_load)
+
+    def test_slowest_varying_vertex_dim(self):
+        # Create the bounds cf variable.
+        bounds = np.arange(12).reshape(2, 6)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('nv', 'foo'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        # Expected bounds on the resulting coordinate should be rolled so that
+        # the vertex dimension is at the end.
+        expected_bounds = bounds.transpose()
+        expected_coord = DimCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=expected_bounds)
+
+        # Patch the helper function that retrieves the bounds cf variable.
+        # This avoids the need for setting up further mocking of cf objects.
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_dimension_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_dim_coord.assert_called_with(
+                expected_coord, [0])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+    def test_fastest_varying_vertex_dim(self):
+        bounds = np.arange(12).reshape(6, 2)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('foo', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = DimCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_dimension_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_dim_coord.assert_called_with(
+                expected_coord, [0])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+    def test_fastest_with_different_dim_names(self):
+        # Despite the dimension names 'x' differing from the coord's
+        # which is 'foo' (as permitted by the cf spec),
+        # this should still work because the vertex dim is the fastest varying.
+        bounds = np.arange(12).reshape(6, 2)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('x', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = DimCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_dimension_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_dim_coord.assert_called_with(
+                expected_coord, [0])
+
+            # Test that engine.provides container is correctly populated.
+            expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
+            self.assertEqual(self.engine.provides['coordinates'],
+                             expected_list)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -1,0 +1,79 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.reorder_bounds_data`.
+
+"""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+import mock
+
+from iris.aux_factory import LazyArray
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    reorder_bounds_data
+
+
+class Test(tests.IrisTest):
+    def test_fastest_varying(self):
+        bounds_data = np.arange(24).reshape(2, 3, 4)
+        cf_bounds_var = mock.Mock(dimensions=('foo', 'bar', 'nv'),
+                                  cf_name='wibble_bnds')
+        cf_coord_var = mock.Mock(dimensions=('foo', 'bar'))
+
+        res = reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
+        # Vertex dimension (nv) is already at the end.
+        self.assertArrayEqual(res, bounds_data)
+
+    def test_slowest_varying(self):
+        bounds_data = np.arange(24).reshape(4, 2, 3)
+        cf_bounds_var = mock.Mock(dimensions=('nv', 'foo', 'bar'))
+        cf_coord_var = mock.Mock(dimensions=('foo', 'bar'))
+
+        res = reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
+        # Move zeroth dimension (nv) to the end.
+        expected = np.rollaxis(bounds_data, 0, bounds_data.ndim)
+        self.assertArrayEqual(res, expected)
+
+    def test_slowest_varying_lazy(self):
+        bounds_data = np.arange(24).reshape(4, 2, 3)
+        func = lambda: bounds_data
+        lazy_bounds_data = LazyArray(bounds_data.shape, func)
+        cf_bounds_var = mock.Mock(dimensions=('nv', 'foo', 'bar'))
+        cf_coord_var = mock.Mock(dimensions=('foo', 'bar'))
+
+        res = reorder_bounds_data(lazy_bounds_data, cf_bounds_var,
+                                  cf_coord_var)
+        # Move zeroth dimension (nv) to the end.
+        expected = np.rollaxis(bounds_data, 0, bounds_data.ndim)
+        self.assertArrayEqual(res, expected)
+
+    def test_different_dim_names(self):
+        bounds_data = np.arange(24).reshape(2, 3, 4)
+        cf_bounds_var = mock.Mock(dimensions=('foo', 'bar', 'nv'),
+                                  cf_name='wibble_bnds')
+        cf_coord_var = mock.Mock(dimensions=('x', 'y'), cf_name='wibble')
+        with self.assertRaisesRegexp(ValueError, 'dimension names'):
+            reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
This PR fixes #1104. It allows Iris to load cf-netcdf data with bounded coords where the bounds data arrays do not have a vertex dimension at the end. Currently Iris assumes the vertex dimension is the fastest varying (the last one). If this is not the case an exception will be raised as the array shape will not be compatible with the points array when constructing the coord.
