### PR TITLE
Make matplotlib an optional Iris tests dependency

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,14 +25,17 @@ import iris.tests as tests
 import copy
 import random
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 
 from iris.experimental.regrid import \
     regrid_area_weighted_rectilinear_src_and_grid as regrid_area_weighted
-import iris.quickplot as qplt
 import iris.tests.stock
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    import iris.quickplot as qplt
 
 
 RESULT_DIR = ('experimental', 'regrid',
@@ -359,6 +362,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         res = regrid_area_weighted(src, dest)
         self.assertCMLApproxData(res, RESULT_DIR + ('higher.cml',))
 
+    @tests.skip_plot
     def test_hybrid_height(self):
         src = self.realistic_cube
         dest = _resampled_grid(src, 0.7, 0.8)
@@ -434,6 +438,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
             res = regrid_area_weighted(src, dest)
             self.assertTrue(res, src[indices])
 
+    @tests.skip_plot
     def test_cross_section(self):
         # Slice to get a cross section.
         # Constant latitude
@@ -485,6 +490,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.assertEqual(res.data, src.data)
 
     @tests.skip_data
+    @tests.skip_plot
     def test_global_data_reduce_res(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()
@@ -495,6 +501,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_global_data_increase_res(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()
@@ -505,6 +512,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_global_data_same_res(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()
@@ -514,6 +522,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_global_data_subset(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()
@@ -536,6 +545,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_circular_subset(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()
@@ -558,6 +568,7 @@ class TestAreaWeightedRegrid(tests.GraphicsTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_non_circular_subset(self):
         src = iris.tests.stock.global_pp()
         src.coord('latitude').guess_bounds()

--- a/lib/iris/tests/experimental/regrid/test_regrid_bilinear_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_bilinear_rectilinear_src_and_grid.py
@@ -22,7 +22,6 @@ import iris.tests as tests
 import numpy as np
 
 import iris
-import iris.quickplot as qplt
 from iris.experimental.regrid import \
     regrid_bilinear_rectilinear_src_and_grid as regrid
 from iris.aux_factory import HybridHeightFactory
@@ -30,6 +29,10 @@ from iris.coord_systems import GeogCS, OSGB
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 from iris.tests.stock import global_pp, realistic_4d
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import iris.quickplot as qplt
 
 
 RESULT_DIR = ('experimental', 'regrid',
@@ -377,6 +380,7 @@ class TestCircular(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestVisual(tests.GraphicsTest):
     def test_osgb_to_latlon(self):
         path = tests.get_data_path(

--- a/lib/iris/tests/experimental/test_animate.py
+++ b/lib/iris/tests/experimental/test_animate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,10 +29,14 @@ import numpy as np
 
 import iris
 from iris.coord_systems import GeogCS
-import iris.experimental.animate as animate
-import iris.plot as iplt
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import iris.experimental.animate as animate
+    import iris.plot as iplt
 
 
+@tests.skip_plot
 class IntegrationTest(tests.GraphicsTest):
     def setUp(self):
         cube = iris.cube.Cube(np.arange(36, dtype=np.int32).reshape((3, 3, 4)))

--- a/lib/iris/tests/experimental/test_raster.py
+++ b/lib/iris/tests/experimental/test_raster.py
@@ -22,7 +22,7 @@ import PIL.Image
 
 
 @tests.skip_data
-class TestGeoTiffExport(tests.GraphicsTest):
+class TestGeoTiffExport(tests.IrisTest):
     def check_tiff_header(self, geotiff_fh, reference_filename):
         """
         Checks the given tiff file handle's metadata matches the

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -85,7 +85,8 @@ class SystemInitialTest(tests.IrisTest):
         self.assertEqual(new_result, new_missing_value)
 
     def system_test_imports_general(self):
-        import matplotlib
+        if tests.MPL_AVAILABLE:
+            import matplotlib
         import netCDF4
 
 

--- a/lib/iris/tests/test_abf.py
+++ b/lib/iris/tests/test_abf.py
@@ -26,7 +26,7 @@ import iris.fileformats.abf
 
 
 @tests.skip_data
-class TestAbfLoad(tests.GraphicsTest):
+class TestAbfLoad(tests.IrisTest):
     def setUp(self):
         self.path = tests.get_data_path(('abf', 'AVHRRBUVI01.1985apra.abf'))
 

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -23,8 +23,6 @@ import iris.tests as tests
 import itertools
 
 import cartopy.crs as ccrs
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 import shapely.geometry
@@ -37,6 +35,11 @@ import iris.coord_systems
 import iris.coords
 import iris.cube
 import iris.tests.stock
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib
+    import matplotlib.pyplot as plt
 
 
 class TestAnalysisCubeCoordComparison(tests.IrisTest):
@@ -549,7 +552,8 @@ class TestAggregators(tests.IrisTest):
 
 
 @tests.skip_data
-class TestRotatedPole(tests.IrisTest):
+class TestRotatedPole(tests.GraphicsTest):
+    @tests.skip_plot
     def _check_both_conversions(self, cube):
         rlons, rlats = iris.analysis.cartography.get_xy_grids(cube)
         rcs = cube.coord_system('RotatedGeogCS')
@@ -1118,6 +1122,7 @@ class TestProject(tests.GraphicsTest):
         self.assertEqual(new_cube.shape, self.cube.shape)
 
     @tests.skip_data
+    @tests.skip_plot
     def test_cartopy_projection(self):
         cube = iris.load_cube(tests.get_data_path(('PP', 'aPPglob1',
                                                    'global.pp')))

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,7 +28,6 @@ import numpy as np
 
 import iris.cube
 import iris.coords
-import iris.plot as iplt
 import iris.tests.stock
 import iris.unit
 

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -23,18 +23,22 @@ import datetime
 import os
 
 import gribapi
-import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 import mock
 import numpy as np
 
 import iris
 import iris.exceptions
 import iris.fileformats.grib
-import iris.plot as iplt
-import iris.quickplot as qplt
 import iris.tests.stock
 import iris.util
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
+    import iris.plot as iplt
+    import iris.quickplot as qplt
+
 
 # Construct a mock object to mimic the gribapi for GribWrapper testing.
 _mock_gribapi = mock.Mock(spec=gribapi)
@@ -215,6 +219,7 @@ class TestGribLoad(tests.GraphicsTest):
         cubes = iris.load(gribfile)
         self.assertCML(cubes, ('grib_load', 'missing_values_grib2.cml'))
 
+    @tests.skip_plot
     def test_y_fastest(self):
         cubes = iris.load(tests.get_data_path(("GRIB", "y_fastest",
                                                "y_fast.grib2")))
@@ -224,6 +229,7 @@ class TestGribLoad(tests.GraphicsTest):
         plt.title("y changes fastest")
         self.check_graphic()
 
+    @tests.skip_plot
     def test_ij_directions(self):
 
         def old_compat_load(name):
@@ -331,6 +337,7 @@ class TestGribLoad(tests.GraphicsTest):
         cube = tests.stock.global_grib2()
         self.assertEqual(cube.name(), 'air_temperature')
 
+    @tests.skip_plot
     def test_polar_stereo_grib1(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "polar_stereo", "ST4.2013052210.01h")))
@@ -341,6 +348,7 @@ class TestGribLoad(tests.GraphicsTest):
         plt.title("polar stereo grib1")
         self.check_graphic()
 
+    @tests.skip_plot
     def test_polar_stereo_grib2(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "polar_stereo",
@@ -353,6 +361,7 @@ class TestGribLoad(tests.GraphicsTest):
         plt.title("polar stereo grib2")
         self.check_graphic()
 
+    @tests.skip_plot
     def test_lambert_grib1(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "lambert", "lambert.grib1")))
@@ -364,6 +373,7 @@ class TestGribLoad(tests.GraphicsTest):
         plt.title("lambert grib1")
         self.check_graphic()
 
+    @tests.skip_plot
     def test_lambert_grib2(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "lambert", "lambert.grib2")))
@@ -401,7 +411,7 @@ class TestGribLoad(tests.GraphicsTest):
         self.assertCML(cube, ("grib_load", "reduced_ll_missing_grib1.cml"))
 
 
-class TestGribTimecodes(tests.GraphicsTest):
+class TestGribTimecodes(tests.IrisTest):
     def _run_timetests(self, test_set):
         # Check the unit-handling for given units-codes and editions.
 

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -32,6 +32,7 @@ import iris
 import iris.tests.stock
 
 
+@tests.skip_plot
 class TestRealistic4d(tests.GraphicsTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -22,7 +22,6 @@ Tests map creation.
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.testing as np_testing
 import cartopy.crs as ccrs
@@ -30,11 +29,16 @@ import cartopy.crs as ccrs
 import iris
 import iris.coord_systems
 import iris.cube
-import iris.plot as iplt
 import iris.tests.stock
 
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    import iris.plot as iplt
 
-class TestBasic(tests.IrisTest):
+
+@tests.skip_plot
+class TestBasic(tests.GraphicsTest):
     cube = iris.tests.stock.realistic_4d()
 
     def test_contourf(self):
@@ -65,7 +69,8 @@ class TestBasic(tests.IrisTest):
 
 
 @tests.skip_data
-class TestUnmappable(tests.IrisTest):
+@tests.skip_plot
+class TestUnmappable(tests.GraphicsTest):
     def setUp(self):
         src_cube = iris.tests.stock.global_pp()
 
@@ -84,7 +89,8 @@ class TestUnmappable(tests.IrisTest):
 
 
 @tests.skip_data
-class TestMappingSubRegion(tests.IrisTest):
+@tests.skip_plot
+class TestMappingSubRegion(tests.GraphicsTest):
     def setUp(self):
         cube_path = tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp'))
         cube = iris.load_cube(cube_path)[0]
@@ -129,7 +135,8 @@ class TestMappingSubRegion(tests.IrisTest):
                                              )
 
 @tests.skip_data
-class TestLowLevel(tests.IrisTest):
+@tests.skip_plot
+class TestLowLevel(tests.GraphicsTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
         self.few = 4
@@ -159,7 +166,8 @@ class TestLowLevel(tests.IrisTest):
 
 
 @tests.skip_data
-class TestBoundedCube(tests.IrisTest):
+@tests.skip_plot
+class TestBoundedCube(tests.GraphicsTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
         # Add some bounds to this data (this will actually make the bounds invalid as they
@@ -194,7 +202,8 @@ class TestBoundedCube(tests.IrisTest):
 
 
 @tests.skip_data
-class TestLimitedAreaCube(tests.IrisTest):
+@tests.skip_plot
+class TestLimitedAreaCube(tests.GraphicsTest):
     def setUp(self):
         cube_path = tests.get_data_path(('PP', 'aPProt1', 'rotated.pp'))
         self.cube = iris.load_cube(cube_path)[::20, ::20]

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -24,16 +24,19 @@ from functools import wraps
 import types
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 import iris
 import iris.coords as coords
-import iris.plot as iplt
-import iris.quickplot as qplt
-import iris.symbols
 import iris.tests.stock
-import iris.tests.test_mapping as test_mapping
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    import iris.plot as iplt
+    import iris.quickplot as qplt
+    import iris.symbols
+    import iris.tests.test_mapping as test_mapping
 
 
 def simple_cube():
@@ -43,6 +46,7 @@ def simple_cube():
     return cube
 
 
+@tests.skip_plot
 class TestSimple(tests.GraphicsTest):
     def test_points(self):
         cube = simple_cube()
@@ -55,6 +59,7 @@ class TestSimple(tests.GraphicsTest):
         self.check_graphic()
 
 
+@tests.skip_plot
 class TestMissingCoord(tests.GraphicsTest):
     def _check(self, cube):
         qplt.contourf(cube)
@@ -81,6 +86,7 @@ class TestMissingCoord(tests.GraphicsTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestMissingCS(tests.GraphicsTest):
     @tests.skip_data
     def test_missing_cs(self):
@@ -92,6 +98,7 @@ class TestMissingCS(tests.GraphicsTest):
         self.check_graphic()
 
 
+@tests.skip_plot
 class TestHybridHeight(tests.GraphicsTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()[0, :15, 0, :]
@@ -139,6 +146,7 @@ class TestHybridHeight(tests.GraphicsTest):
             self.check_graphic()
 
 
+@tests.skip_plot
 class Test1dPlotMultiArgs(tests.GraphicsTest):
     # tests for iris.plot using multi-argument calling convention
 
@@ -237,6 +245,7 @@ class Test1dPlotMultiArgs(tests.GraphicsTest):
             self.draw_method(self.cube1d, coords=['time'])
 
 
+@tests.skip_plot
 class Test1dQuickplotPlotMultiArgs(Test1dPlotMultiArgs):
     # tests for iris.plot using multi-argument calling convention
 
@@ -246,6 +255,7 @@ class Test1dQuickplotPlotMultiArgs(Test1dPlotMultiArgs):
 
 
 @tests.skip_data
+@tests.skip_plot
 class Test1dScatter(tests.GraphicsTest):
 
     def setUp(self):
@@ -315,6 +325,7 @@ class Test1dScatter(tests.GraphicsTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class Test1dQuickplotScatter(Test1dScatter):
 
     def setUp(self):
@@ -325,6 +336,7 @@ class Test1dQuickplotScatter(Test1dScatter):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestAttributePositive(tests.GraphicsTest):
     def test_1d_positive_up(self):
         path = tests.get_data_path(('NetCDF', 'ORCA2', 'votemper.nc'))
@@ -421,6 +433,7 @@ def _date_series(src_cube):
     return cube
 
 
+@tests.skip_plot
 class SliceMixin(object):
     """Mixin class providing tests for each 2-dimensional permutation of axes.
 
@@ -595,6 +608,7 @@ class TestPcolormeshNoBounds(tests.GraphicsTest, SliceMixin):
         self.draw_method = iplt.pcolormesh
 
 
+@tests.skip_plot
 class Slice1dMixin(object):
     """Mixin class providing tests for each 1-dimensional permutation of axes.
 
@@ -680,6 +694,7 @@ class LambdaStr(object):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestPlotCoordinatesGiven(tests.GraphicsTest):
     def setUp(self):
         filename = tests.get_data_path(('PP', 'COLPEX',
@@ -808,6 +823,7 @@ class TestPlotCoordinatesGiven(tests.GraphicsTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestPlotDimAndAuxCoordsKwarg(tests.GraphicsTest):
     def setUp(self):
         filename = tests.get_data_path(('NetCDF', 'rotated', 'xy',
@@ -851,6 +867,7 @@ class TestPlotDimAndAuxCoordsKwarg(tests.GraphicsTest):
         self.check_graphic()
 
 
+@tests.skip_plot
 class TestSymbols(tests.GraphicsTest):
     def test_cloud_cover(self):
         iplt.symbols(range(10), [0] * 10, [iris.symbols.CLOUD_COVER[i]
@@ -859,6 +876,7 @@ class TestSymbols(tests.GraphicsTest):
         self.check_graphic()
 
 
+@tests.skip_plot
 class TestPlottingExceptions(tests.IrisTest):
     def setUp(self):
         self.bounded_cube = tests.stock.lat_lon_cube()
@@ -899,6 +917,7 @@ class TestPlottingExceptions(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestPlotOtherCoordSystems(tests.GraphicsTest):
     def test_plot_tmerc(self):
         filename = tests.get_data_path(('NetCDF', 'transverse_mercator',

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -20,14 +20,16 @@ Tests the high-level plotting interface.
 """
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
-
-import matplotlib.pyplot as plt
+import iris.tests.test_plot as test_plot
 
 import iris
-import iris.plot as iplt
-import iris.quickplot as qplt
-import iris.tests.test_plot as test_plot
-import iris.tests.test_mapping as test_mapping
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    import iris.plot as iplt
+    import iris.quickplot as qplt
+    import iris.tests.test_mapping as test_mapping
 
 
 # Caches _load_theta so subsequent calls are faster
@@ -52,6 +54,7 @@ def _load_theta():
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestQuickplotCoordinatesGiven(test_plot.TestPlotCoordinatesGiven):
     def setUp(self):
         filename = tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog_subset.pp'))
@@ -101,6 +104,7 @@ class TestQuickplotCoordinatesGiven(test_plot.TestPlotCoordinatesGiven):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestLabels(tests.GraphicsTest):
     def setUp(self):
         self.theta = _load_theta()
@@ -175,6 +179,7 @@ class TestLabels(tests.GraphicsTest):
 
 
 @tests.skip_data
+@tests.skip_plot
 class TestTimeReferenceUnitsLabels(tests.GraphicsTest):
 
     def setUp(self):

--- a/lib/iris/tests/test_trajectory.py
+++ b/lib/iris/tests/test_trajectory.py
@@ -20,11 +20,14 @@
 import iris.tests as tests
 
 import biggus
-import matplotlib.pyplot as plt
 import numpy as np
 
 import iris.analysis.trajectory
 import iris.tests.stock
+
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
 
 
 class TestSimple(tests.IrisTest):
@@ -52,6 +55,7 @@ class TestTrajectory(tests.IrisTest):
         self.assertEqual(trajectory.sampled_points[31], {'lat': 0.12499999999999989, 'lon': 3.875})
 
     @tests.skip_data
+    @tests.skip_plot
     def test_trajectory_extraction(self):
 
         # Load the COLPEX data => TZYX
@@ -142,6 +146,7 @@ class TestTrajectory(tests.IrisTest):
         self.check_graphic()
 
     @tests.skip_data
+    @tests.skip_plot
     def test_tri_polar(self):
         # load data
         cubes = iris.load(tests.get_data_path(['NetCDF', 'ORCA2', 'votemper.nc']))


### PR DESCRIPTION
This PR allows the Iris test suite to successfully run in an environment where matplotlib is not available. This is achieved by adding a new test decorator (`skip_plot`) that when used to decorate a test class or function means it will be skipped if matplotlib cannot be imported.

To avoid import errors in test modules that use matplotlib (or Iris plotting modules), importing of these modules is wrapped up in a `try` clause.
