### PR TITLE
Increased git depth to 10000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
   - ./.travis_no_output wget https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.9.16.tar.gz --no-check-certificate
   - ./.travis_no_output tar -xvf grib_api-1.9.16.tar.gz
   - cd grib_api-1.9.16/
-  - ../.travis_no_output CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
+  - ../.travis_no_output PYTHON="/usr/bin/python" CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
   - ../.travis_no_output make
   - ../.travis_no_output sudo make install
   - cd python


### PR DESCRIPTION
Cloning the Iris repo on Travis CI has recently started failing with the following error:

`The command "git clone --depth=0 git://github.com/SciTools/iris.git SciTools/iris" failed.`

The simple fix is to increase the git depth to significantly greater (in this case 10000 commits) than the total number of Iris commits. This will give time for a fix to requiring all the git history to be determined.
