### PR TITLE
Deferred PPField attributes.

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -456,7 +456,8 @@ class FF2PP(object):
 
     def _payload(self, field):
         """Calculate the payload data depth (in bytes) and type."""
-        if field.lbpack.n1 == 0:
+        lbpack_n1 = field.raw_lbpack % 10
+        if lbpack_n1 == 0:
             # Data payload is not packed.
             data_depth = (field.lblrec - field.lbext) * self._word_depth
             # Determine PP field 64-bit payload datatype.
@@ -466,15 +467,15 @@ class FF2PP(object):
             data_type = np.dtype(dtype_name)
         else:
             # Data payload is packed.
-            if field.lbpack.n1 == 1:
+            if lbpack_n1 == 1:
                 # Data packed using WGDOS archive method.
                 data_depth = ((field.lbnrec * 2) - 1) * pp.PP_WORD_DEPTH
-            elif field.lbpack.n1 == 2:
+            elif lbpack_n1 == 2:
                 # Data packed using CRAY 32-bit method.
                 data_depth = (field.lblrec - field.lbext) * pp.PP_WORD_DEPTH
             else:
                 msg = 'PP fields with LBPACK of {} are not supported.'
-                raise NotYetImplementedError(msg.format(field.lbpack))
+                raise NotYetImplementedError(msg.format(field.raw_lbpack))
 
             # Determine PP field payload datatype.
             lookup = pp.LBUSER_DTYPE_LOOKUP
@@ -552,9 +553,8 @@ class FF2PP(object):
                 ff_file, dtype='>f{0}'.format(self._word_depth),
                 count=pp.NUM_FLOAT_HEADERS)
             # In 64-bit words.
-            header_data = tuple(header_integers) + tuple(header_floats)
             # Check whether the current FF LOOKUP table entry is valid.
-            if header_data[0] == _FF_LOOKUP_TABLE_TERMINATE:
+            if header_integers[0] == _FF_LOOKUP_TABLE_TERMINATE:
                 # There are no more FF LOOKUP table entries to read.
                 break
             # Calculate next FF LOOKUP table entry.
@@ -562,25 +562,30 @@ class FF2PP(object):
             # Construct a PPField object and populate using the header_data
             # read from the current FF LOOKUP table.
             # (The PPField sub-class will depend on the header release number.)
-            field = pp.make_pp_field(header_data)
+            field = pp.make_pp_field(header_integers, header_floats)
             # Calculate start address of the associated PP header data.
             data_offset = field.lbegin * self._word_depth
             # Determine PP field payload depth and type.
             data_depth, data_type = self._payload(field)
 
-            stash_entry = STASH_TRANS.get(str(field.stash), None)
+            # Fast stash look-up.
+            stash_s = field.lbuser[3] / 1000
+            stash_i = field.lbuser[3] % 1000
+            stash = 'm{:02}s{:02}i{:03}'.format(field.lbuser[6],
+                                                stash_s, stash_i)
+            stash_entry = STASH_TRANS.get(stash, None)
             if stash_entry is None:
                 subgrid = None
                 warnings.warn('The STASH code {0} was not found in the '
                               'STASH to grid type mapping. Picking the P '
-                              'position as the cell type'.format(field.stash))
+                              'position as the cell type'.format(stash))
             else:
                 subgrid = stash_entry.grid_code
                 if subgrid not in HANDLED_GRIDS:
                     warnings.warn('The stash code {} is on a grid {} which '
                                   'has not been explicitly handled by the '
                                   'fieldsfile loader. Assuming the data is on '
-                                  'a P grid.'.format(field.stash, subgrid))
+                                  'a P grid.'.format(stash, subgrid))
 
             field.x, field.y = grid.vectors(subgrid)
 
@@ -633,9 +638,8 @@ class FF2PP(object):
                                                   data_type)
             else:
                 # Provide enough context to read the data bytes later on.
-                field._data = pp.DeferredArrayBytes(self._filename,
-                                                    data_offset, data_depth,
-                                                    data_type)
+                field._data = (self._filename, data_offset,
+                               data_depth, data_type)
             yield field
         ff_file.close()
 

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -36,8 +36,7 @@ import iris.fileformats.pp as pp
 
 
 _MockField = collections.namedtuple('_MockField',
-                                    'lbext,lblrec,lbnrec,lbpack,lbuser')
-_MockLbpack = collections.namedtuple('_MockLbpack', 'n1')
+                                    'lbext lblrec lbnrec raw_lbpack lbuser')
 
 # PP-field: LBPACK N1 values.
 _UNPACKED = 0
@@ -188,8 +187,8 @@ class TestFFVariableResolutionGrid(tests.IrisTest):
 
         self.orig_make_pp_field = pp.make_pp_field
 
-        def new_make_pp_field(header_values):
-            field = self.orig_make_pp_field(header_values)
+        def new_make_pp_field(header_longs, header_floats):
+            field = self.orig_make_pp_field(header_longs, header_floats)
             field.stash = self.ff2pp._custom_stash
             field.bdx = field.bdy = field.bmdi
             return field
@@ -236,7 +235,7 @@ class TestFFPayload(tests.IrisTest):
 
     def test_payload_unpacked_real(self):
         mock_field = _MockField(lbext=0, lblrec=100, lbnrec=-1,
-                                lbpack=_MockLbpack(_UNPACKED),
+                                raw_lbpack=_UNPACKED,
                                 lbuser=[_REAL])
         expected_type = ff._LBUSER_DTYPE_LOOKUP[_REAL].format(word_depth=8)
         expected_type = np.dtype(expected_type)
@@ -244,7 +243,7 @@ class TestFFPayload(tests.IrisTest):
 
     def test_payload_unpacked_real_ext(self):
         mock_field = _MockField(lbext=50, lblrec=100, lbnrec=-1,
-                                lbpack=_MockLbpack(_UNPACKED),
+                                raw_lbpack=_UNPACKED,
                                 lbuser=[_REAL])
         expected_type = ff._LBUSER_DTYPE_LOOKUP[_REAL].format(word_depth=8)
         expected_type = np.dtype(expected_type)
@@ -252,7 +251,7 @@ class TestFFPayload(tests.IrisTest):
 
     def test_payload_unpacked_integer(self):
         mock_field = _MockField(lbext=0, lblrec=200, lbnrec=-1,
-                                lbpack=_MockLbpack(_UNPACKED),
+                                raw_lbpack=_UNPACKED,
                                 lbuser=[_INTEGER])
         expected_type = ff._LBUSER_DTYPE_LOOKUP[_INTEGER].format(word_depth=8)
         expected_type = np.dtype(expected_type)
@@ -260,7 +259,7 @@ class TestFFPayload(tests.IrisTest):
 
     def test_payload_unpacked_integer_ext(self):
         mock_field = _MockField(lbext=100, lblrec=200, lbnrec=-1,
-                                lbpack=_MockLbpack(_UNPACKED),
+                                raw_lbpack=_UNPACKED,
                                 lbuser=[_INTEGER])
         expected_type = ff._LBUSER_DTYPE_LOOKUP[_INTEGER].format(word_depth=8)
         expected_type = np.dtype(expected_type)
@@ -268,49 +267,49 @@ class TestFFPayload(tests.IrisTest):
 
     def test_payload_wgdos_real(self):
         mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=100,
-                                lbpack=_MockLbpack(_WGDOS),
+                                raw_lbpack=_WGDOS,
                                 lbuser=[_REAL])
         self._test_payload(mock_field, 796, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_wgdos_real_ext(self):
         mock_field = _MockField(lbext=50, lblrec=-1, lbnrec=100,
-                                lbpack=_MockLbpack(_WGDOS),
+                                raw_lbpack=_WGDOS,
                                 lbuser=[_REAL])
         self._test_payload(mock_field, 796, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_wgdos_integer(self):
         mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=200,
-                                lbpack=_MockLbpack(_WGDOS),
+                                raw_lbpack=_WGDOS,
                                 lbuser=[_INTEGER])
         self._test_payload(mock_field, 1596, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
     def test_payload_wgdos_integer_ext(self):
         mock_field = _MockField(lbext=100, lblrec=-1, lbnrec=200,
-                                lbpack=_MockLbpack(_WGDOS),
+                                raw_lbpack=_WGDOS,
                                 lbuser=[_INTEGER])
         self._test_payload(mock_field, 1596, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
     def test_payload_cray_real(self):
         mock_field = _MockField(lbext=0, lblrec=100, lbnrec=-1,
-                                lbpack=_MockLbpack(_CRAY),
+                                raw_lbpack=_CRAY,
                                 lbuser=[_REAL])
         self._test_payload(mock_field, 400, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_cray_real_ext(self):
         mock_field = _MockField(lbext=50, lblrec=100, lbnrec=-1,
-                                lbpack=_MockLbpack(_CRAY),
+                                raw_lbpack=_CRAY,
                                 lbuser=[_REAL])
         self._test_payload(mock_field, 200, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_cray_integer(self):
         mock_field = _MockField(lbext=0, lblrec=200, lbnrec=-1,
-                                lbpack=_MockLbpack(_CRAY),
+                                raw_lbpack=_CRAY,
                                 lbuser=[_INTEGER])
         self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
     def test_payload_cray_integer_ext(self):
         mock_field = _MockField(lbext=100, lblrec=200, lbnrec=-1,
-                                lbpack=_MockLbpack(_CRAY),
+                                raw_lbpack=_CRAY,
                                 lbuser=[_INTEGER])
         self._test_payload(mock_field, 400, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -76,9 +76,11 @@ class Test__extract_field__LBC_format(tests.IrisTest):
 
     def test_LBC_header(self):
         bzx, bzy = -10, 15
-        field = mock.Mock(lbegin=0, stash='m01s00i001',
+        # stash m01s00i001
+        lbuser = [None, None, 121416, 1, None, None, 1]
+        field = mock.Mock(lbegin=0,
                           lbrow=10, lbnpt=12, bdx=1, bdy=1, bzx=bzx, bzy=bzy,
-                          lbuser=[None, None, 121416])
+                          lbuser=lbuser)
         with self.mock_for_extract_field([field]) as ff2pp:
             ff2pp._ff_header.dataset_type = 5
             result = list(ff2pp._extract_field())
@@ -97,10 +99,10 @@ class Test__extract_field__LBC_format(tests.IrisTest):
 
     def check_non_trivial_coordinate_warning(self, field):
         field.lbegin = 0
-        field.stash = 'm01s31i020'
         field.lbrow = 10
         field.lbnpt = 12
-        field.lbuser = [None, None, 121416]
+        # stash m01s31i020
+        field.lbuser = [None, None, 121416, 20, None, None, 1]
         orig_bdx, orig_bdy = field.bdx, field.bdy
 
         x = np.array([1, 2, 6])
@@ -151,7 +153,8 @@ class Test__extract_field__LBC_format(tests.IrisTest):
         # Check a warning is raised when bdy is negative,
         # we don't yet know what "north" means in this case.
         field = mock.Mock(bdx=10, bdy=-10, bzx=10, bzy=10, lbegin=0,
-                          lbuser=[0, 0, 121416], lbrow=10, lbnpt=12)
+                          lbuser=[0, 0, 121416, 0, None, None, 0],
+                          lbrow=10, lbnpt=12)
         with self.mock_for_extract_field([field]) as ff2pp:
             ff2pp._ff_header.dataset_type = 5
             with mock.patch('warnings.warn') as warn:

--- a/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
@@ -1,0 +1,50 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.PPDataProxy` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+
+from iris.fileformats.pp import PPDataProxy, SplittableInt
+
+
+class Test_lbpack(tests.IrisTest):
+    def test_lbpack_SplittableInt(self):
+        lbpack = mock.Mock(spec_set=SplittableInt)
+        proxy = PPDataProxy(None, None, None, None,
+                            None, lbpack, None, None)
+        self.assertEqual(proxy.lbpack, lbpack)
+        self.assertIs(proxy.lbpack, lbpack)
+
+    def test_lnpack_raw(self):
+        lbpack = 4321
+        proxy = PPDataProxy(None, None, None, None,
+                            None, lbpack, None, None)
+        self.assertEqual(proxy.lbpack, lbpack)
+        self.assertIsNot(proxy.lbpack, lbpack)
+        self.assertIsInstance(proxy.lbpack, SplittableInt)
+        self.assertEqual(proxy.lbpack.n1, lbpack % 10)
+        self.assertEqual(proxy.lbpack.n2, lbpack / 10 % 10)
+        self.assertEqual(proxy.lbpack.n3, lbpack / 100 % 10)
+        self.assertEqual(proxy.lbpack.n4, lbpack / 1000 % 10)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -35,18 +35,21 @@ from iris.fileformats.pp import SplittableInt
 # items when written to disk and get consistent results.
 
 
+DUMMY_HEADER = [('dummy1', (0, 13)),
+                ('lblrec', (14,)),
+                ('dummy2', (15, 18)),
+                ('lbext',  (19,)),
+                ('lbpack', (20,)),
+                ('dummy3', (21, 37)),
+                ('lbuser', (38, 39, 40, 41, 42, 43, 44,)),
+                ('dummy4', (45, 63)),
+                ]
+
+
 class TestPPField(PPField):
 
-    HEADER_DEFN = [
-        ('dummy1', (0, 13)),
-        ('lblrec', (14,)),
-        ('dummy2', (15, 18)),
-        ('lbext',  (19,)),
-        ('lbpack', (20,)),
-        ('dummy3', (21, 37)),
-        ('lbuser', (38, 39, 40, 41, 42, 43, 44,)),
-        ('dummy4', (45, 63)),
-    ]
+    HEADER_DEFN = DUMMY_HEADER
+    HEADER_DICT = dict(DUMMY_HEADER)
 
     @property
     def t1(self):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField2.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField2.py
@@ -1,0 +1,120 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.PPField2` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+import numpy as np
+
+import iris.fileformats.pp as pp
+from iris.fileformats.pp import PPField2, SplittableInt
+
+
+class Test__init__(tests.IrisTest):
+    def setUp(self):
+        self.header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
+        self.header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+
+    def test_no_headers(self):
+        field = PPField2()
+        self.assertIsNone(field._header_longs)
+        self.assertIsNone(field._header_floats)
+        self.assertIsNone(field.raw_lbpack)
+
+    def test_lbpack_lookup(self):
+        self.assertEqual(PPField2.HEADER_DICT['lbpack'], (20,))
+
+    def test_raw_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField2.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField2(header_longs=self.header_longs)
+        self.assertEqual(field.raw_lbpack, raw_lbpack)
+
+
+class Test__getattr__(tests.IrisTest):
+    def setUp(self):
+        self.header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
+        self.header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+
+    def test_attr_singular_long(self):
+        lbrow = 1234
+        loc, = PPField2.HEADER_DICT['lbrow']
+        self.header_longs[loc] = lbrow
+        field = PPField2(header_longs=self.header_longs)
+        self.assertEqual(field.lbrow, lbrow)
+
+    def test_attr_multi_long(self):
+        lbuser = (100, 101, 102, 103, 104, 105, 106)
+        loc = PPField2.HEADER_DICT['lbuser']
+        self.header_longs[loc[0]:loc[-1] + 1] = lbuser
+        field = PPField2(header_longs=self.header_longs)
+        self.assertEqual(field.lbuser, lbuser)
+
+    def test_attr_singular_float(self):
+        bdatum = 1234
+        loc, = PPField2.HEADER_DICT['bdatum']
+        self.header_floats[loc - pp.NUM_LONG_HEADERS] = bdatum
+        field = PPField2(header_floats=self.header_floats)
+        self.assertEqual(field.bdatum, bdatum)
+
+    def test_attr_multi_float(self):
+        brsvd = (100, 101, 102, 103)
+        loc = PPField2.HEADER_DICT['brsvd']
+        start = loc[0] - pp.NUM_LONG_HEADERS
+        stop = loc[-1] + 1 - pp.NUM_LONG_HEADERS
+        self.header_floats[start:stop] = brsvd
+        field = PPField2(header_floats=self.header_floats)
+        self.assertEqual(field.brsvd, brsvd)
+
+    def test_attr_special_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField2.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField2(header_longs=self.header_longs)
+        result = field._lbpack
+        self.assertEqual(result, raw_lbpack)
+        self.assertIsInstance(result, SplittableInt)
+
+    def test_attr_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField2.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField2(header_longs=self.header_longs)
+        result = field.lbpack
+        self.assertEqual(result, raw_lbpack)
+        self.assertIsInstance(result, SplittableInt)
+
+    def test_attr_raw_lbpack_assign(self):
+        field = PPField2(header_longs=self.header_longs)
+        self.assertEqual(field.raw_lbpack, 0)
+        self.assertEqual(field.lbpack, 0)
+        raw_lbpack = 4321
+        field.lbpack = raw_lbpack
+        self.assertEqual(field.raw_lbpack, raw_lbpack)
+        self.assertNotIsInstance(field.raw_lbpack, SplittableInt)
+
+    def test_attr_unknown(self):
+        with self.assertRaises(AttributeError):
+            PPField2().x
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField3.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField3.py
@@ -1,0 +1,120 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.PPField3` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+import numpy as np
+
+import iris.fileformats.pp as pp
+from iris.fileformats.pp import PPField3, SplittableInt
+
+
+class Test__init__(tests.IrisTest):
+    def setUp(self):
+        self.header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
+        self.header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+
+    def test_no_headers(self):
+        field = PPField3()
+        self.assertIsNone(field._header_longs)
+        self.assertIsNone(field._header_floats)
+        self.assertIsNone(field.raw_lbpack)
+
+    def test_lbpack_lookup(self):
+        self.assertEqual(PPField3.HEADER_DICT['lbpack'], (20,))
+
+    def test_raw_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField3.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField3(header_longs=self.header_longs)
+        self.assertEqual(field.raw_lbpack, raw_lbpack)
+
+
+class Test__getattr__(tests.IrisTest):
+    def setUp(self):
+        self.header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
+        self.header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+
+    def test_attr_singular_long(self):
+        lbrow = 1234
+        loc, = PPField3.HEADER_DICT['lbrow']
+        self.header_longs[loc] = lbrow
+        field = PPField3(header_longs=self.header_longs)
+        self.assertEqual(field.lbrow, lbrow)
+
+    def test_attr_multi_long(self):
+        lbuser = (100, 101, 102, 103, 104, 105, 106)
+        loc = PPField3.HEADER_DICT['lbuser']
+        self.header_longs[loc[0]:loc[-1] + 1] = lbuser
+        field = PPField3(header_longs=self.header_longs)
+        self.assertEqual(field.lbuser, lbuser)
+
+    def test_attr_singular_float(self):
+        bdatum = 1234
+        loc, = PPField3.HEADER_DICT['bdatum']
+        self.header_floats[loc - pp.NUM_LONG_HEADERS] = bdatum
+        field = PPField3(header_floats=self.header_floats)
+        self.assertEqual(field.bdatum, bdatum)
+
+    def test_attr_multi_float(self):
+        brsvd = (100, 101, 102, 103)
+        loc = PPField3.HEADER_DICT['brsvd']
+        start = loc[0] - pp.NUM_LONG_HEADERS
+        stop = loc[-1] + 1 - pp.NUM_LONG_HEADERS
+        self.header_floats[start:stop] = brsvd
+        field = PPField3(header_floats=self.header_floats)
+        self.assertEqual(field.brsvd, brsvd)
+
+    def test_attr_special_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField3.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField3(header_longs=self.header_longs)
+        result = field._lbpack
+        self.assertEqual(result, raw_lbpack)
+        self.assertIsInstance(result, SplittableInt)
+
+    def test_attr_lbpack(self):
+        raw_lbpack = 4321
+        loc, = PPField3.HEADER_DICT['lbpack']
+        self.header_longs[loc] = raw_lbpack
+        field = PPField3(header_longs=self.header_longs)
+        result = field.lbpack
+        self.assertEqual(result, raw_lbpack)
+        self.assertIsInstance(result, SplittableInt)
+
+    def test_attr_raw_lbpack_assign(self):
+        field = PPField3(header_longs=self.header_longs)
+        self.assertEqual(field.raw_lbpack, 0)
+        self.assertEqual(field.lbpack, 0)
+        raw_lbpack = 4321
+        field.lbpack = raw_lbpack
+        self.assertEqual(field.raw_lbpack, raw_lbpack)
+        self.assertNotIsInstance(field.raw_lbpack, SplittableInt)
+
+    def test_attr_unknown(self):
+        with self.assertRaises(AttributeError):
+            PPField3().x
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -47,10 +47,14 @@ class Test__create_field_data(tests.IrisTest):
                                               field.bmdi, land_mask)
 
     def test_deferred_bytes(self):
-        # Check that a field with DeferredArrayBytes in _data gets a
+        # Check that a field with deferred array bytes in _data gets a
         # biggus array.
-        deferred_bytes = mock.Mock(spec=pp.DeferredArrayBytes)
-        deferred_bytes.dtype.newbyteorder.return_value = mock.sentinel.dtype
+        fname = mock.sentinel.fname
+        position = mock.sentinel.position
+        n_bytes = mock.sentinel.n_bytes
+        newbyteorder = mock.Mock(return_value=mock.sentinel.dtype)
+        dtype = mock.Mock(newbyteorder=newbyteorder)
+        deferred_bytes = (fname, position, n_bytes, dtype)
         field = mock.Mock(_data=deferred_bytes)
         data_shape = (mock.sentinel.lat, mock.sentinel.lon)
         land_mask = mock.Mock()
@@ -69,11 +73,10 @@ class Test__create_field_data(tests.IrisTest):
         # Is it making use of a correctly configured proxy?
         # NB. We know it's *using* the result of this call because
         # that's where the dtype came from above.
-        PPDataProxy.assert_called_once_with((data_shape), deferred_bytes.dtype,
-                                            deferred_bytes.fname,
-                                            deferred_bytes.position,
-                                            deferred_bytes.n_bytes,
-                                            field.lbpack, field.bmdi,
+        PPDataProxy.assert_called_once_with((data_shape), dtype,
+                                            fname, position,
+                                            n_bytes,
+                                            field.raw_lbpack, field.bmdi,
                                             land_mask)
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -77,9 +77,8 @@ class Test__field_gen(tests.IrisTest):
             calls = [mock.call(open_fh, count=45, dtype='>i4'),
                      mock.call(open_fh, count=19, dtype='>f4')]
             np.fromfile.assert_has_calls(calls)
-        expected_deferred_bytes = pp.DeferredArrayBytes('mocked',
-                                                        open_fh.tell(),
-                                                        4, np.dtype('>f4'))
+        expected_deferred_bytes = ('mocked', open_fh.tell(),
+                                   4, np.dtype('>f4'))
         self.assertEqual(pp_field._data, expected_deferred_bytes)
 
     def test_read_data_call(self):

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -31,14 +31,16 @@ import iris.fileformats.pp as pp
 class Test__interpret_fields__land_packed_fields(tests.IrisTest):
     def setUp(self):
         # A field packed using a land/sea mask.
-        self.pp_field = mock.Mock(lblrec=1, lbext=0, lbuser=[0],
+        self.pp_field = mock.Mock(lblrec=1, lbext=0, lbuser=[0] * 7,
                                   lbrow=0, lbnpt=0,
-                                  lbpack=mock.Mock(n2=2))
+                                  raw_lbpack=20,
+                                  _data=('dummy', 0, 0, 0))
         # The field specifying the land/seamask.
-        self.land_mask_field = mock.Mock(lblrec=1, lbext=0, lbuser=[0],
+        lbuser = [None, None, None, 30, None, None, 1]  # m01s00i030
+        self.land_mask_field = mock.Mock(lblrec=1, lbext=0, lbuser=lbuser,
                                          lbrow=3, lbnpt=4,
-                                         stash='m01s00i030',
-                                         data=np.empty((3, 4)))
+                                         raw_lbpack=0,
+                                         _data=('dummy', 0, 0, 0))
 
     def test_non_deferred_fix_lbrow_lbnpt(self):
         # Checks the fix_lbrow_lbnpt is applied to fields which are not


### PR DESCRIPTION
This PR provides a performance optimisation to the PP and FF loading pipeline up to the point where a `PPField` is created.

It offers a loading speed-up of approximately 75% by implementing deferred `PPField` attribute creation and avoids the use of expensive convenience PP attributes such as `stash` and `lbpack` where possible. 
