### PR TITLE
Support PP cross-section height.

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -192,6 +192,12 @@ def convert(f):
 
     if \
             (len(f.lbcode) == 5) and \
+            (f.lbcode.iy == 2) and \
+            (f.bdy == 0 or f.bdy == f.bmdi):
+        dim_coords_and_dims.append((DimCoord(f.y, standard_name='height', units='km', bounds=f.y_bounds, attributes={'positive': 'up'}), 0))
+
+    if \
+            (len(f.lbcode) == 5) and \
             (f.lbcode[-1] == 1) and \
             (f.lbcode.iy == 4):
         dim_coords_and_dims.append((DimCoord(f.y, standard_name='depth', units='m', bounds=f.y_bounds, attributes={'positive': 'down'}), 0))

--- a/lib/iris/tests/unit/fileformats/__init__.py
+++ b/lib/iris/tests/unit/fileformats/__init__.py
@@ -27,7 +27,8 @@ class TestField(tests.IrisTest):
          aux_coords_and_dims) = convert(field)
 
         # Check for one and only one matching coordinate.
-        matching_coords = [coord for coord, _ in aux_coords_and_dims if
+        coords_and_dims = dim_coords_and_dims + aux_coords_and_dims
+        matching_coords = [coord for coord, _ in coords_and_dims if
                            coord_predicate(coord)]
         self.assertEqual(len(matching_coords), 1, str(matching_coords))
         coord = matching_coords[0]

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -33,6 +33,36 @@ import iris.tests.unit.fileformats
 import iris.unit
 
 
+class TestLBCODE(iris.tests.unit.fileformats.TestField):
+    @staticmethod
+    def _is_cross_section_height_coord(coord):
+        return (coord.standard_name == 'height' and
+                coord.units == 'km' and
+                coord.attributes['positive'] == 'up')
+
+    def test_cross_section_height_bdy_zero(self):
+        lbcode = SplittableInt(19902, {'iy': slice(0, 2), 'ix': slice(2, 4)})
+        points = np.array([10, 20, 30, 40])
+        bounds = np.array([[0, 15], [15, 25], [25, 35], [35, 45]])
+        field = mock.MagicMock(lbcode=lbcode, bdy=0, y=points, y_bounds=bounds)
+        self._test_for_coord(field, convert,
+                             TestLBCODE._is_cross_section_height_coord,
+                             expected_points=points,
+                             expected_bounds=bounds)
+
+    def test_cross_section_height_bdy_bmdi(self):
+        lbcode = SplittableInt(19902, {'iy': slice(0, 2), 'ix': slice(2, 4)})
+        points = np.array([10, 20, 30, 40])
+        bounds = np.array([[0, 15], [15, 25], [25, 35], [35, 45]])
+        bmdi = -1.07374e+09
+        field = mock.MagicMock(lbcode=lbcode, bdy=bmdi, bmdi=bmdi,
+                               y=points, y_bounds=bounds)
+        self._test_for_coord(field, convert,
+                             TestLBCODE._is_cross_section_height_coord,
+                             expected_points=points,
+                             expected_bounds=bounds)
+
+
 class TestLBVC(iris.tests.unit.fileformats.TestField):
     @staticmethod
     def _is_potm_level_coord(coord):


### PR DESCRIPTION
This PR adds an additional PP load rule to correctly translate cross-section height as a dimensional coordinate into an Iris cube.

Given a fully specified `lbcode` with a `iy` of `02` meaning `height above sea level` with units of `km` (see UMDP F3, section 4.2, 16 LBCODE) the associated point and bounds data is expected within the extra data PP payload.
