### PR TITLE
Added earth_radius to the grid mapping of saved NetCDF files

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1258,25 +1258,25 @@ class Saver(object):
                     cs.grid_mapping_name, np.int32)
                 cf_var_grid.grid_mapping_name = cs.grid_mapping_name
 
-                def add_ellipsoid():
-                    if cs.ellipsoid:
-                        cf_var_grid.longitude_of_prime_meridian = (
-                            cs.ellipsoid.longitude_of_prime_meridian)
-                        cf_var_grid.semi_major_axis = (
-                            cs.ellipsoid.semi_major_axis)
-                        cf_var_grid.semi_minor_axis = (
-                            cs.ellipsoid.semi_minor_axis)
+                def add_ellipsoid(ellipsoid):
+                    cf_var_grid.longitude_of_prime_meridian = (
+                        ellipsoid.longitude_of_prime_meridian)
+                    semi_major = ellipsoid.semi_major_axis
+                    semi_minor = ellipsoid.semi_minor_axis
+                    if semi_minor == semi_major:
+                        cf_var_grid.earth_radius = semi_major
+                    else:
+                        cf_var_grid.semi_major_axis = semi_major
+                        cf_var_grid.semi_minor_axis = semi_minor
 
                 # latlon
                 if isinstance(cs, iris.coord_systems.GeogCS):
-                    cf_var_grid.longitude_of_prime_meridian = (
-                        cs.longitude_of_prime_meridian)
-                    cf_var_grid.semi_major_axis = cs.semi_major_axis
-                    cf_var_grid.semi_minor_axis = cs.semi_minor_axis
+                    add_ellipsoid(cs)
 
                 # rotated latlon
                 elif isinstance(cs, iris.coord_systems.RotatedGeogCS):
-                    add_ellipsoid()
+                    if cs.ellipsoid:
+                        add_ellipsoid(cs.ellipsoid)
                     cf_var_grid.grid_north_pole_latitude = (
                         cs.grid_north_pole_latitude)
                     cf_var_grid.grid_north_pole_longitude = (
@@ -1286,7 +1286,8 @@ class Saver(object):
 
                 # tmerc
                 elif isinstance(cs, iris.coord_systems.TransverseMercator):
-                    add_ellipsoid()
+                    if cs.ellipsoid:
+                        add_ellipsoid(cs.ellipsoid)
                     cf_var_grid.longitude_of_central_meridian = (
                         cs.longitude_of_central_meridian)
                     cf_var_grid.latitude_of_projection_origin = (

--- a/lib/iris/tests/results/integration/netcdf/TestHybridPressure/save.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestHybridPressure/save.cdl
@@ -13,8 +13,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_and_pressure.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_and_pressure.cdl
@@ -13,8 +13,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_gridmapmulti.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_gridmapmulti.cdl
@@ -12,8 +12,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	int64 longitude(longitude) ;
 		longitude:axis = "X" ;
 		longitude:units = "degrees_east" ;
@@ -30,8 +29,7 @@ variables:
 	int latitude_longitude_0 ;
 		latitude_longitude_0:grid_mapping_name = "latitude_longitude_0" ;
 		latitude_longitude_0:longitude_of_prime_meridian = 0. ;
-		latitude_longitude_0:semi_major_axis = 6371228. ;
-		latitude_longitude_0:semi_minor_axis = 6371228. ;
+		latitude_longitude_0:earth_radius = 6371228. ;
 	int64 longitude_0(longitude_0) ;
 		longitude_0:axis = "X" ;
 		longitude_0:units = "degrees_east" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
@@ -14,8 +14,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_0.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_1.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_1.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_2.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_2.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multiple.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multiple.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_realistic_0d.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_realistic_0d.cdl
@@ -9,8 +9,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_realistic_4d.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_realistic_4d.cdl
@@ -13,8 +13,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_realistic_4d_no_hybrid.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_realistic_4d_no_hybrid.cdl
@@ -13,8 +13,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_single.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_single.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float pressure(pressure) ;
 		pressure:axis = "Z" ;
 		pressure:units = "hPa" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cdl
@@ -12,8 +12,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cdl
@@ -12,8 +12,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float depth(depth) ;
 		depth:axis = "Z" ;
 		depth:units = "m" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	int model_level_number(model_level_number) ;
 		model_level_number:axis = "Z" ;
 		model_level_number:units = "1" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float time(time) ;
 		time:axis = "T" ;
 		time:units = "days since 0000-01-01 00:00:00" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_level_lat_orig.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_level_lat_orig.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_press_orig.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_press_orig.b_0.cdl
@@ -15,8 +15,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_several.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_lon_lat_several.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_n10r13xy.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_n10r13xy.b_0.cdl
@@ -11,8 +11,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_1.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_1.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_2.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abcza_pa19591997_daily_29.b_2.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abxpa_press_lat.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/abxpa_press_lat.b_0.cdl
@@ -13,8 +13,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float pressure(pressure) ;
 		pressure:axis = "Z" ;
 		pressure:units = "hPa" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/integer.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/integer.b_0.cdl
@@ -12,8 +12,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/model.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/model.b_0.cdl
@@ -15,8 +15,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	double time(time) ;
 		time:axis = "T" ;
 		time:bounds = "time_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/ocean_xsect.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/ocean_xsect.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float depth(depth) ;
 		depth:axis = "Z" ;
 		depth:bounds = "depth_bnds" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st0fc699.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st0fc699.b_0.cdl
@@ -12,8 +12,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	float latitude(latitude) ;
 		latitude:axis = "Y" ;
 		latitude:units = "degrees_north" ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st0fc942.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st0fc942.b_0.cdl
@@ -14,8 +14,7 @@ variables:
 	int rotated_latitude_longitude ;
 		rotated_latitude_longitude:grid_mapping_name = "rotated_latitude_longitude" ;
 		rotated_latitude_longitude:longitude_of_prime_meridian = 0. ;
-		rotated_latitude_longitude:semi_major_axis = 6371229. ;
-		rotated_latitude_longitude:semi_minor_axis = 6371229. ;
+		rotated_latitude_longitude:earth_radius = 6371229. ;
 		rotated_latitude_longitude:grid_north_pole_latitude = 0. ;
 		rotated_latitude_longitude:grid_north_pole_longitude = 0. ;
 		rotated_latitude_longitude:north_pole_grid_longitude = 0. ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st30211.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/st30211.b_0.cdl
@@ -16,8 +16,7 @@ variables:
 	int latitude_longitude ;
 		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
 		latitude_longitude:longitude_of_prime_meridian = 0. ;
-		latitude_longitude:semi_major_axis = 6371229. ;
-		latitude_longitude:semi_minor_axis = 6371229. ;
+		latitude_longitude:earth_radius = 6371229. ;
 	int pseudo_level(pseudo_level) ;
 		pseudo_level:units = "1" ;
 		pseudo_level:long_name = "pseudo_level" ;


### PR DESCRIPTION
Note: The loading of the `earth_radius` attribute is already handled in the NetCDF loader, so this is limited to save only.
