### PR TITLE
Cube intersection with split bounds.

### DIFF
--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -693,7 +693,7 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
 
     def test_negative_misaligned_points_outside(self):
         cube = create_cube(0, 360, bounds=True)
-        result = cube.intersection(longitude=(-10.25, 9.75))
+        result = cube.intersection(longitude=(-9.75, 9.75))
         self.assertArrayEqual(result.coord('longitude').bounds[0],
                               [-10.5, -9.5])
         self.assertArrayEqual(result.coord('longitude').bounds[-1],


### PR DESCRIPTION
This PR corrects the behaviour of `cube.intersection` such that it can cope with cell bounds that are split over an intersection wrap point, when a negative wrap point is used.
