### PR TITLE
BUG: Extraction of scalar cubes

### DIFF
--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2013, Met Office
+# (C) British Crown Copyright 2010 - 2014, Met Office
 #
 # This file is part of Iris.
 #
@@ -144,14 +144,25 @@ class Constraint(object):
         else return None.
 
         """
+        result = None
+        # Account for a scalar cube.  Make an indexable so that we can use a
+        # common code path as the non-scalar cubes.
+        reshaped = False
+        if cube.ndim == 0:
+            reshaped = True
+            orig_cube = cube
+            cube = orig_cube.copy()
+            cube.data = cube.data[None]
+
         resultant_CIM = self._CIM_extract(cube)
         slice_tuple = resultant_CIM.as_slice()
-        result = None
         if slice_tuple is not None:
             # Slicing the cube is an expensive operation.
             if all([item == slice(None) for item in slice_tuple]):
-                # Don't perform a full slice, just return the cube.
+                # Don't perform a full slice, just return the original cube.
                 result = cube
+                if reshaped:
+                    result = orig_cube
             else:
                 # Performing the partial slice.
                 result = cube[slice_tuple]

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -75,17 +75,35 @@ class Test_extract(tests.IrisTest):
         res = constraint.extract(cube)
         self.assertIs(res, None)
 
+    def test_scalar_cube_coord_match(self):
+        # Ensure that extract is able to extract a scalar cube according to
+        # constrained scalar coordinate.
+        constraint = iris.Constraint(scalar_coord=0)
+        cube = Cube(1, long_name='a1')
+        coord = iris.coords.AuxCoord(0, long_name='scalar_coord')
+        cube.add_aux_coord(coord, None)
+        res = constraint.extract(cube)
+        self.assertIs(res, cube)
+
+    def test_scalar_cube_coord_nomatch(self):
+        # Ensure that extract is not extracting a scalar cube with scalar
+        # coordinate that does not match the constraint.
+        constraint = iris.Constraint(scalar_coord=1)
+        cube = Cube(1, long_name='a1')
+        coord = iris.coords.AuxCoord(0, long_name='scalar_coord')
+        cube.add_aux_coord(coord, None)
+        res = constraint.extract(cube)
+        self.assertIs(res, None)
+
     def test_1d_cube_exists(self):
-        # Ensure that extract is able to extract from a cube with dimension
-        # mapping.
+        # Ensure that extract is able to extract from a cube with shape.
         constraint = iris.Constraint(name='a1')
         cube = Cube([1], long_name='a1')
         res = constraint.extract(cube)
         self.assertIs(res, cube)
 
     def test_1d_cube_noexists(self):
-        # Ensure that extract does not return a non-matching cube with
-        # dimension mapping.
+        # Ensure that extract does not return a non-matching cube with shape.
         constraint = iris.Constraint(name='a2')
         cube = Cube([1], long_name='a1')
         res = constraint.extract(cube)

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -165,5 +165,17 @@ class Test_xml(tests.IrisTest):
         self.assertIn('byteorder', self.cubes.xml(byteorder=True))
 
 
+class Test_extract(tests.IrisTest):
+    def test_scalar_cube_test(self):
+        # Ensure that extraction of a CubeList containing scalar cubes is
+        # successful i.e. extracts the correct number and the correct ones.
+        cubes = CubeList()
+        for i in range(5):
+            for letter in 'abcd':
+                cubes.append(Cube(1, long_name=letter))
+        target = CubeList([Cube(1, long_name='a') for i in range(5)])
+        self.assertEqual(cubes.extract('a'), target)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Fixes the issue with performing extraction on scalar cubes or cube lists containing scalar cubes.

**Approach taken:**  Utilise existing index based code (_ColumnIndexManager) by taking a copy of the original cube and reshaping it (ndim=1).  Taking this copy allows us to return the original scalar cube (this is consistent with the current behaviour of non scalar cubes where the constraint matches the entire cube).

**Note:**  The approach taken copies the scalar cube and also touches the data in reshaping it.  We don't have to make a copy if we are content with not returning the same cube object.
