### PR TITLE
Define pp.UMVersion helper for pp rules.

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -45,7 +45,8 @@ iris.proxy.apply_proxy('iris.fileformats.pp_packing', globals())
 
 __all__ = ['load', 'save', 'load_cubes', 'PPField',
            'add_load_rules', 'reset_load_rules',
-           'add_save_rules', 'reset_save_rules', 'STASH', 'EARTH_RADIUS']
+           'add_save_rules', 'reset_save_rules', 'STASH', 'UMVersion',
+           'EARTH_RADIUS']
 
 
 EARTH_RADIUS = 6371229.0
@@ -339,6 +340,118 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+
+class UMVersion(collections.namedtuple('UMVersion', ('major', 'minor'))):
+    """A class representing a UM version."""
+
+    __slots__ = ()
+
+    def __new__(cls, major=None, minor=None):
+        """
+        Create a UMVersion object.
+
+        Args:
+
+        * major, minor (integer):
+            Major and minor version codes: major>=0, 0<=minor<=99.
+            If either is None (the default), the version is regarded as
+            unknown.
+
+        """
+        if major is not None:
+            UMVersion.check_major(major)
+            major = int(np.round(major))
+
+        if minor is not None:
+            UMVersion.check_minor(minor)
+            minor = int(np.round(minor))
+
+        return super(UMVersion, cls).__new__(cls, major, minor)
+
+    @staticmethod
+    def check_major(major):
+        """
+        Raise an exception if the provided argument does not meet
+        criteria for a :class:`UVVersion` major component.
+
+        """
+        UMVersion.check_int(major)
+        if major < 0:
+            raise ValueError('UMVersion major component must satisfy: 0 <= major')
+
+    @staticmethod
+    def check_minor(minor):
+        """
+        Raise an exception if the provided argument does not meet
+        criteria for a :class:`UVVersion` minor component.
+
+        """
+        UMVersion.check_int(minor)
+        if minor < 0 or minor > 99:
+            raise ValueError('UMVersion minor component must satisfy: 0 <= minor <= 99')
+
+    @staticmethod
+    def check_int(val):
+        """
+        Raise an exception if the provided value is not sufficiently close
+        to an integer value.
+
+        """
+        if abs(val - np.round(val)) > 1e-5:
+            raise ValueError('UMVersion components must be integers')
+
+    @classmethod
+    def from_lbsrce(cls, lbsrce):
+        """
+        Return an instance of :class:`UMVersion` from an LBSRCE value.
+
+        Returns an "unknown" version if the lower four digits are not '1111'.
+
+        """
+        if lbsrce % 10000 != 1111:
+            major, minor = None, None
+        else:
+            lbsrce /= 10000
+            major, minor = lbsrce / 100, lbsrce % 100
+        return cls(major, minor)
+
+    def is_unknown(self):
+        """
+        Return whether the version is unknown.
+
+        The version is regarded as unknown if either of the major or minor
+        components is set to None.
+
+        """
+        return self.major is None or self.minor is None
+
+    def lbsrce(self):
+        """
+        Calculate an LBSRCE value.
+
+        Result is 0 for unknown version.
+
+        """
+        if self.is_unknown():
+            result = 0
+        else:
+            code = self.major * 100 + self.minor
+            result = code * 10000 + 1111
+        return result
+
+    def __str__(self):
+        """
+        Return a string representation of a :class:`UMVersion`.
+
+        Result is '' (an empty string) for an unknown version.
+
+        """
+        if self.is_unknown():
+            result = ''
+        else:
+            result = '{}.{}'.format(self.major, self.minor)
+        return result
 
 
 class SplittableInt(object):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -398,7 +398,7 @@ class UMVersion(collections.namedtuple('UMVersion', ('major', 'minor'))):
         to an integer value.
 
         """
-        if abs(val - np.round(val)) > 1e-5:
+        if val != np.round(val):
             raise ValueError('UMVersion components must be integers')
 
     @classmethod

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -496,13 +496,11 @@ def convert(f):
         standard_name = "sea_water_potential_temperature"
         units = "Celsius"
 
-    if (f.lbsrce % 10000) == 1111:
+    um_ver = iris.fileformats.pp.UMVersion.from_lbsrce(f.lbsrce)
+    if not um_ver.is_unknown():
         attributes['source'] = 'Data from Met Office Unified Model'
-        # Also define MO-netCDF compliant UM version.
-        um_major = (f.lbsrce / 10000) / 100
-        if um_major != 0:
-            um_minor = (f.lbsrce / 10000) % 100
-            attributes['um_version'] = '{:d}.{:d}'.format(um_major, um_minor)
+        if um_ver.major != 0:
+            attributes['um_version'] = str(um_ver)
 
     if f.lbuser[6] != 0 or (f.lbuser[3] / 1000) != 0 or (f.lbuser[3] % 1000) != 0:
         attributes['STASH'] = f.stash

--- a/lib/iris/tests/unit/fileformats/pp/test_UMVersion.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_UMVersion.py
@@ -1,0 +1,182 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for :class:`iris.fileformats.pp.UMVersion`."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from iris.fileformats.pp import UMVersion
+
+
+class Test___init__(tests.IrisTest):
+    def _check_init(self, umver, *content):
+        major, minor, unknown = content
+        self.assertEqual(umver.major, major)
+        self.assertEqual(umver.minor, minor)
+        self.assertEqual(umver.is_unknown(), unknown)
+
+    def test_simple(self):
+        umver = UMVersion(2, 5)
+        self._check_init(umver, 2, 5, False)
+
+    def test_unknown(self):
+        umver = UMVersion(None, None)
+        self._check_init(umver, None, None, True)
+
+    def test_unknown__noargs(self):
+        umver = UMVersion()
+        self._check_init(umver, None, None, True)
+
+    def test_unknown__nomajor(self):
+        umver = UMVersion(1)
+        self._check_init(umver, 1, None, True)
+
+    def test_unknown__nominor(self):
+        umver = UMVersion(None, 1)
+        self._check_init(umver, None, 1, True)
+
+    def test_float(self):
+        umver = UMVersion(2.0000001, 4.9999999)
+        self._check_init(umver, 2, 5, False)
+
+    def test_zeros(self):
+        umver = UMVersion(0, 0)
+        self._check_init(umver, 0, 0, False)
+
+    def test_fail_float_major(self):
+        with self.assertRaises(ValueError) as err_context:
+            umver = UMVersion(2.3, 4)
+        msg = err_context.exception.message
+        self.assertIn('integers', msg)
+
+    def test_fail_float_minor(self):
+        with self.assertRaises(ValueError) as err_context:
+            umver = UMVersion(2, 4.1)
+        msg = err_context.exception.message
+        self.assertIn('integers', msg)
+
+    def test_fail_negative_major(self):
+        with self.assertRaises(ValueError) as err_context:
+            umver = UMVersion(-2, 4)
+        msg = err_context.exception.message
+        self.assertIn('0 <= major', msg)
+
+    def test_fail_negative_minor(self):
+        with self.assertRaises(ValueError) as err_context:
+            umver = UMVersion(2, -4)
+        msg = err_context.exception.message
+        self.assertIn('0 <= minor', msg)
+
+    def test_fail_minor_range(self):
+        with self.assertRaises(ValueError) as err_context:
+            umver = UMVersion(2, 105)
+        msg = err_context.exception.message
+        self.assertIn('minor <= 99', msg)
+
+
+class Test___slots__(tests.IrisTest):
+    def check_fails_attr_write(self, attr_name):
+        with self.assertRaises(AttributeError) as err_context:
+            umver = UMVersion(1, 1)
+            attr_value = getattr(umver, attr_name)
+            setattr(umver, attr_name, attr_value)
+        msg = err_context.exception.message
+        self.assertEqual(msg, "can't set attribute")
+
+    def test_major_no_write(self):
+        self.check_fails_attr_write('major')
+
+    def test_minor_no_write(self):
+        self.check_fails_attr_write('minor')
+
+
+class Test___str__(tests.IrisTest):
+    def test_simple(self):
+        self.assertEqual(str(UMVersion(2, 5)), '2.5')
+
+    def test_zeros(self):
+        self.assertEqual(str(UMVersion(0, 0)), '0.0')
+
+    def test_unknown(self):
+        self.assertEqual(str(UMVersion()), '')
+
+
+class Test_lbsrce(tests.IrisTest):
+    def test_simple(self):
+        self.assertEqual(UMVersion(2, 5).lbsrce(), 2051111)
+
+    def test_zeros(self):
+        self.assertEqual(UMVersion(0, 0).lbsrce(), 1111)
+
+    def test_unknown(self):
+        self.assertEqual(UMVersion().lbsrce(), 0)
+
+
+class Test_from_lbsrce(tests.IrisTest):
+    def _check_lbsrce(self, umver, content, string, lbsrce):
+        major, minor, unknown = content
+        self.assertEqual(umver.major, major)
+        self.assertEqual(umver.minor, minor)
+        self.assertEqual(umver.is_unknown(), unknown)
+        self.assertEqual(str(umver), string)
+        self.assertEqual(umver.lbsrce(), lbsrce)
+
+    def test_simple(self):
+        umver = UMVersion.from_lbsrce(2051111)
+        self._check_lbsrce(umver,
+                           (2, 5, False),
+                           '2.5',
+                           2051111)
+
+    def test_no_version(self):
+        umver = UMVersion.from_lbsrce(1111)
+        self._check_lbsrce(umver,
+                           (0, 0, False),
+                           '0.0',
+                           1111)
+
+    def test_unknown(self):
+        umver = UMVersion.from_lbsrce(123)
+        self._check_lbsrce(umver,
+                           (None, None, True),
+                           '',
+                           0)
+
+
+class Test__comparisons(tests.IrisTest):
+    def test_eq(self):
+        self.assertEqual(UMVersion(2, 5), UMVersion(2, 5))
+
+    def test_eq__unknown(self):
+        self.assertEqual(UMVersion(), UMVersion())
+
+    def test_ne__minor(self):
+        self.assertNotEqual(UMVersion(2, 5), UMVersion(2, 6))
+
+    def test_ne__major(self):
+        self.assertNotEqual(UMVersion(1, 5), UMVersion(2, 5))
+
+    def test_ne__both(self):
+        self.assertNotEqual(UMVersion(1, 5), UMVersion(2, 5))
+
+    def test_ne__unknown(self):
+        self.assertNotEqual(UMVersion(1, 5), UMVersion(None, None))
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test_UMVersion.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_UMVersion.py
@@ -51,7 +51,7 @@ class Test___init__(tests.IrisTest):
         self._check_init(umver, None, 1, True)
 
     def test_float(self):
-        umver = UMVersion(2.0000001, 4.9999999)
+        umver = UMVersion(2.0, 5.0)
         self._check_init(umver, 2, 5, False)
 
     def test_zeros(self):


### PR DESCRIPTION
Enables writing rules without referring to the rules of encoding in LBSRCE.
