### PR TITLE
Added 'um_version' cube attribute to contain UM version of PP/FF data.

### DIFF
--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -53,7 +53,8 @@ For instance, suppose we have a cube:
               forecast_reference_time: 2009-11-19 04:00:00
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
 
 
 In this case we have a 4 dimensional cube; 
@@ -81,7 +82,8 @@ we can pass the coordinate name and the aggregation definition to the
               sigma: 0.92293, bound=(0.84586, 1.0)
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
          Cell methods:
               mean: model_level_number
 
@@ -139,7 +141,8 @@ These areas can now be passed to the ``collapsed`` method as weights:
               surface_altitude: 399.625 m, bound=(-14.0, 813.25) m
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
          Cell methods:
               mean: grid_longitude, grid_latitude
 

--- a/docs/iris/src/userguide/iris_cubes.rst
+++ b/docs/iris/src/userguide/iris_cubes.rst
@@ -175,7 +175,8 @@ output as this is the quickest way of inspecting the contents of a cube. Here is
               forecast_reference_time: 2009-11-19 04:00:00
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
 
 
 Using this output we can deduce that:

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -94,7 +94,8 @@ list indexing can be used:
               forecast_reference_time: 2009-11-19 04:00:00
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
 
 Notice that the result of printing a **cube** is a little more verbose than 
 it was when printing a **list of cubes**. In addition to the very short summary 

--- a/docs/iris/src/userguide/subsetting_a_cube.rst
+++ b/docs/iris/src/userguide/subsetting_a_cube.rst
@@ -96,7 +96,8 @@ same way as loading with constraints:
               time: 2009-11-19 10:00:00
          Attributes:
               STASH: m01s00i004
-              source: Data from Met Office Unified Model 7.03
+              source: Data from Met Office Unified Model
+              um_version: 7.3
 
 
 Cube iteration

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3042,7 +3042,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                       realization: 10
                  Attributes:
                       STASH: m01s00i024
-                      source: Data from Met Office Unified Model 7.06
+                      source: Data from Met Office Unified Model
+                      um_version: 7.6
                  Cell methods:
                       mean: time (1 hour)
 
@@ -3065,7 +3066,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                       realization: 10
                  Attributes:
                       STASH: m01s00i024
-                      source: Data from Met Office Unified Model 7.06
+                      source: Data from Met Office Unified Model
+                      um_version: 7.6
                  Cell methods:
                       mean: time (1 hour)
                       mean: time

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -39,6 +39,7 @@ THEN
 
 #UM - no version number
 IF
+    not 'um_version' in cm.attributes
     'source' in cm.attributes
     len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)) > 1
     len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) == 0
@@ -47,11 +48,18 @@ THEN
 
 #UM - with version number
 IF
+    not 'um_version' in cm.attributes
     'source' in cm.attributes
     len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)) > 1
     len(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) > 0
 THEN
     pp.lbsrce = int(float(cm.attributes['source'].rsplit("Data from Met Office Unified Model", 1)[1]) * 1000000) + 1111  # UM version
+
+#UM - from 'um_version' attribute
+IF
+    'um_version' in cm.attributes
+THEN
+    pp.lbsrce = 1111 + 10000 * int(cm.attributes['um_version'].split('.')[1]) + 1000000 * int(cm.attributes['um_version'].split('.')[0])
 
 IF
     'STASH' in cm.attributes

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -496,15 +496,13 @@ def convert(f):
         standard_name = "sea_water_potential_temperature"
         units = "Celsius"
 
-    if \
-            ((f.lbsrce % 10000) == 1111) and \
-            ((f.lbsrce / 10000) / 100.0 > 0):
-        attributes['source'] = 'Data from Met Office Unified Model %4.2f' % ((f.lbsrce / 10000) / 100.0)
-
-    if \
-            ((f.lbsrce % 10000) == 1111) and \
-            ((f.lbsrce / 10000) / 100.0 == 0):
+    if (f.lbsrce % 10000) == 1111:
         attributes['source'] = 'Data from Met Office Unified Model'
+        # Also define MO-netCDF compliant UM version.
+        um_major = (f.lbsrce / 10000) / 100
+        if um_major != 0:
+            um_minor = (f.lbsrce / 10000) % 100
+            attributes['um_version'] = '{:d}.{:d}'.format(um_major, um_minor)
 
     if f.lbuser[6] != 0 or (f.lbuser[3] / 1000) != 0 or (f.lbuser[3] % 1000) != 0:
         attributes['STASH'] = f.stash

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -21,6 +21,7 @@
 import iris.tests as tests
 
 import iris
+from iris.cube import Cube, CubeList
 import iris.tests.stock as stock
 
 
@@ -88,6 +89,33 @@ class TestSaveMultipleAuxFactories(tests.IrisTest):
         with self.temp_filename(suffix='.nc') as filename, \
                 self.assertRaisesRegexp(ValueError, 'multiple aux factories'):
             iris.save(cube, filename)
+
+
+class TestUmVersionAttribute(tests.IrisTest):
+    def test_single_saves_as_global(self):
+        cube = Cube([1.0], standard_name='air_temperature', units='K',
+                    attributes={'um_version': '4.3'})
+        with self.temp_filename('.nc') as nc_path:
+            iris.save(cube, nc_path)
+            self.assertCDL(nc_path)
+
+    def test_multiple_same_saves_as_global(self):
+        cube_a = Cube([1.0], standard_name='air_temperature', units='K',
+                      attributes={'um_version': '4.3'})
+        cube_b = Cube([1.0], standard_name='air_pressure', units='hPa',
+                      attributes={'um_version': '4.3'})
+        with self.temp_filename('.nc') as nc_path:
+            iris.save(CubeList([cube_a, cube_b]), nc_path)
+            self.assertCDL(nc_path)
+
+    def test_multiple_different_saves_on_variables(self):
+        cube_a = Cube([1.0], standard_name='air_temperature', units='K',
+                      attributes={'um_version': '4.3'})
+        cube_b = Cube([1.0], standard_name='air_pressure', units='hPa',
+                      attributes={'um_version': '4.4'})
+        with self.temp_filename('.nc') as nc_path:
+            iris.save(CubeList([cube_a, cube_b]), nc_path)
+            self.assertCDL(nc_path)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
+++ b/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -494,7 +495,7 @@
 		0.982215, 0.976512, 0.970069, 0.962893, 0.954993]" shape="(10,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="df5b3790" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
+        <auxCoord id="a9e872f8" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
  		85.6042, 53.1264],
 		[146.068, 188.025, 341.338, ..., 117.513,
  		79.4105, 129.535],
@@ -509,7 +510,8 @@
  		84.2878, 118.704]]" shape="(83, 83)" standard_name="surface_altitude" units="Unit('m')" value_type="float32">
           <attributes>
             <attribute name="STASH" value="m01s00i033"/>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>
@@ -524,7 +526,8 @@
   <cube standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -1015,7 +1018,7 @@
 		0.982215, 0.976512, 0.970069, 0.962893, 0.954993]" shape="(10,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="df5b3790" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
+        <auxCoord id="a9e872f8" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
  		85.6042, 53.1264],
 		[146.068, 188.025, 341.338, ..., 117.513,
  		79.4105, 129.535],
@@ -1030,7 +1033,8 @@
  		84.2878, 118.704]]" shape="(83, 83)" standard_name="surface_altitude" units="Unit('m')" value_type="float32">
           <attributes>
             <attribute name="STASH" value="m01s00i033"/>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>
@@ -1045,7 +1049,8 @@
   <cube standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/FF/air_temperature_1.cml
+++ b/lib/iris/tests/results/FF/air_temperature_1.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 8.02"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="8.2"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/FF/air_temperature_2.cml
+++ b/lib/iris/tests/results/FF/air_temperature_2.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 8.02"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="8.2"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/FF/soil_temperature_1.cml
+++ b/lib/iris/tests/results/FF/soil_temperature_1.cml
@@ -3,7 +3,8 @@
   <cube standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
-      <attribute name="source" value="Data from Met Office Unified Model 8.02"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="8.2"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/FF/surface_altitude_1.cml
+++ b/lib/iris/tests/results/FF/surface_altitude_1.cml
@@ -3,7 +3,8 @@
   <cube standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
-      <attribute name="source" value="Data from Met Office Unified Model 8.02"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="8.2"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/original.cml
+++ b/lib/iris/tests/results/analysis/original.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_10_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -53,7 +54,8 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -103,7 +105,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -154,7 +157,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -55,7 +56,8 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -107,7 +109,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -160,7 +163,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/attribute_constraint.cml
+++ b/lib/iris/tests/results/constrained_load/attribute_constraint.cml
@@ -4,7 +4,8 @@
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="my_attribute" value="foobar"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -53,7 +54,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -53,7 +54,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -142,7 +143,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -192,7 +194,8 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -242,7 +245,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -293,7 +297,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -142,7 +143,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -142,7 +143,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -142,7 +143,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_match.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/constrained_load/theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_strict.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cube_io/pickling/cubelist.cml
+++ b/lib/iris/tests/results/cube_io/pickling/cubelist.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -488,7 +489,7 @@
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="df5b3790" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
+        <auxCoord id="a9e872f8" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
  		324.58],
 		[386.476, 390.813, 393.15, ..., 316.098,
  		321.788, 330.007],
@@ -502,7 +503,8 @@
  		300.34]]" shape="(100, 100)" standard_name="surface_altitude" units="Unit('m')" value_type="float32">
           <attributes>
             <attribute name="STASH" value="m01s00i033"/>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>
@@ -517,7 +519,8 @@
   <cube standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cube_io/pickling/single_cube.cml
+++ b/lib/iris/tests/results/cube_io/pickling/single_cube.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -488,7 +489,7 @@
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="df5b3790" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
+        <auxCoord id="a9e872f8" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
  		324.58],
 		[386.476, 390.813, 393.15, ..., 316.098,
  		321.788, 330.007],
@@ -502,7 +503,8 @@
  		300.34]]" shape="(100, 100)" standard_name="surface_altitude" units="Unit('m')" value_type="float32">
           <attributes>
             <attribute name="STASH" value="m01s00i033"/>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/results/cube_io/pickling/theta.cml
+++ b/lib/iris/tests/results/cube_io/pickling/theta.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
+++ b/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/file_load/theta_levels.cml
+++ b/lib/iris/tests/results/file_load/theta_levels.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -53,7 +54,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -103,7 +105,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -153,7 +156,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -203,7 +207,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -253,7 +258,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -303,7 +309,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -353,7 +360,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -403,7 +411,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -453,7 +462,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -503,7 +513,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -553,7 +564,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -603,7 +615,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -653,7 +666,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -703,7 +717,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -753,7 +768,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -803,7 +819,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -853,7 +870,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -903,7 +921,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -953,7 +972,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1003,7 +1023,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1053,7 +1074,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1103,7 +1125,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1153,7 +1176,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1203,7 +1227,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1253,7 +1278,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1303,7 +1329,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1353,7 +1380,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1403,7 +1431,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1453,7 +1482,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1503,7 +1533,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1553,7 +1584,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1603,7 +1635,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1653,7 +1686,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1703,7 +1737,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1753,7 +1788,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1803,7 +1839,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1853,7 +1890,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/file_load/u_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/u_wind_levels.cml
@@ -3,7 +3,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -54,7 +55,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -105,7 +107,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -156,7 +159,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -207,7 +211,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -258,7 +263,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -309,7 +315,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -360,7 +367,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -411,7 +419,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -462,7 +471,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -513,7 +523,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -564,7 +575,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -615,7 +627,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -666,7 +679,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -717,7 +731,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -768,7 +783,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -819,7 +835,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -870,7 +887,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -921,7 +939,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -972,7 +991,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1023,7 +1043,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1074,7 +1095,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1125,7 +1147,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1176,7 +1199,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1227,7 +1251,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1278,7 +1303,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1329,7 +1355,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1380,7 +1407,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1431,7 +1459,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1482,7 +1511,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1533,7 +1563,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1584,7 +1615,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1635,7 +1667,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1686,7 +1719,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1737,7 +1771,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1788,7 +1823,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1839,7 +1875,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1890,7 +1927,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/file_load/v_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/v_wind_levels.cml
@@ -3,7 +3,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -54,7 +55,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -105,7 +107,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -156,7 +159,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -207,7 +211,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -258,7 +263,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -309,7 +315,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -360,7 +367,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -411,7 +419,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -462,7 +471,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -513,7 +523,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -564,7 +575,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -615,7 +627,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -666,7 +679,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -717,7 +731,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -768,7 +783,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -819,7 +835,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -870,7 +887,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -921,7 +939,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -972,7 +991,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1023,7 +1043,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1074,7 +1095,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1125,7 +1147,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1176,7 +1199,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1227,7 +1251,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1278,7 +1303,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1329,7 +1355,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1380,7 +1407,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1431,7 +1459,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1482,7 +1511,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1533,7 +1563,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1584,7 +1615,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1635,7 +1667,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1686,7 +1719,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1737,7 +1771,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1788,7 +1823,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1839,7 +1875,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1890,7 +1927,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/file_load/wind_levels.cml
+++ b/lib/iris/tests/results/file_load/wind_levels.cml
@@ -3,7 +3,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -54,7 +55,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -105,7 +107,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -156,7 +159,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -207,7 +211,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -258,7 +263,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -309,7 +315,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -360,7 +367,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -411,7 +419,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -462,7 +471,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -513,7 +523,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -564,7 +575,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -615,7 +627,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -666,7 +679,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -717,7 +731,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -768,7 +783,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -819,7 +835,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -870,7 +887,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -921,7 +939,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -972,7 +991,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1023,7 +1043,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1074,7 +1095,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1125,7 +1147,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1176,7 +1199,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1227,7 +1251,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1278,7 +1303,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1329,7 +1355,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1380,7 +1407,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1431,7 +1459,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1482,7 +1511,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1533,7 +1563,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1584,7 +1615,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1635,7 +1667,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1686,7 +1719,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1737,7 +1771,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1788,7 +1823,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1839,7 +1875,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1890,7 +1927,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1941,7 +1979,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -1992,7 +2031,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2043,7 +2083,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2094,7 +2135,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2145,7 +2187,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2196,7 +2239,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2247,7 +2291,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2298,7 +2343,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2349,7 +2395,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2400,7 +2447,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2451,7 +2499,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2502,7 +2551,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2553,7 +2603,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2604,7 +2655,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2655,7 +2707,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2706,7 +2759,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2757,7 +2811,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2808,7 +2863,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2859,7 +2915,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2910,7 +2967,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -2961,7 +3019,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3012,7 +3071,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3063,7 +3123,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3114,7 +3175,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3165,7 +3227,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3216,7 +3279,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3267,7 +3331,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3318,7 +3383,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3369,7 +3435,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3420,7 +3487,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3471,7 +3539,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3522,7 +3591,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3573,7 +3643,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3624,7 +3695,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3675,7 +3747,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3726,7 +3799,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3777,7 +3851,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -3828,7 +3903,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/multiple_different_saves_on_variables.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/multiple_different_saves_on_variables.cdl
@@ -1,0 +1,15 @@
+dimensions:
+	dim0 = UNLIMITED ; // (1 currently)
+variables:
+	double air_temperature(dim0) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_version = "4.3" ;
+	double air_pressure(dim0) ;
+		air_pressure:standard_name = "air_pressure" ;
+		air_pressure:units = "hPa" ;
+		air_pressure:um_version = "4.4" ;
+
+// global attributes:
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/multiple_same_saves_as_global.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/multiple_same_saves_as_global.cdl
@@ -1,0 +1,14 @@
+dimensions:
+	dim0 = UNLIMITED ; // (1 currently)
+variables:
+	double air_temperature(dim0) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+	double air_pressure(dim0) ;
+		air_pressure:standard_name = "air_pressure" ;
+		air_pressure:units = "hPa" ;
+
+// global attributes:
+		:um_version = "4.3" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/single_saves_as_global.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestUmVersionAttribute/single_saves_as_global.cdl
@@ -1,0 +1,11 @@
+dimensions:
+	dim0 = UNLIMITED ; // (1 currently)
+variables:
+	double air_temperature(dim0) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+
+// global attributes:
+		:um_version = "4.3" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/merge/dec.cml
+++ b/lib/iris/tests/results/merge/dec.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -142,7 +143,8 @@
   <cube standard_name="specific_humidity" units="1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -281,7 +283,8 @@
   <cube standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>
@@ -421,7 +424,8 @@
   <cube standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/merge/theta.cml
+++ b/lib/iris/tests/results/merge/theta.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.06"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.6"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/merge/theta_two_times.cml
+++ b/lib/iris/tests/results/merge/theta_two_times.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -487,7 +488,7 @@
 		0.0, 0.0]" shape="(70,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="df5b3790" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
+        <auxCoord id="a9e872f8" points="[[413.937, 417.817, 412.334, ..., 312.72, 317.89,
  		324.58],
 		[386.476, 390.813, 393.15, ..., 316.098,
  		321.788, 330.007],
@@ -501,7 +502,8 @@
  		300.34]]" shape="(100, 100)" standard_name="surface_altitude" units="Unit('m')" value_type="float32">
           <attributes>
             <attribute name="STASH" value="m01s00i033"/>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
@@ -65,9 +65,11 @@ variables:
 		surface_altitude:units = "m" ;
 		surface_altitude:standard_name = "surface_altitude" ;
 		surface_altitude:um_stash_source = "m01s00i033" ;
-		surface_altitude:source = "Data from Met Office Unified Model 7.04" ;
+		surface_altitude:source = "Data from Met Office Unified Model" ;
+		surface_altitude:um_version = "7.4" ;
 
 // global attributes:
-		:source = "Data from Met Office Unified Model 7.04" ;
+		:source = "Data from Met Office Unified Model" ;
+		:um_version = "7.4" ;
 		:Conventions = "CF-1.5" ;
 }

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
@@ -4,7 +4,8 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord datadims="[1, 2, 3]">
@@ -495,7 +496,7 @@
 		0.982215, 0.976512, 0.970069, 0.962893, 0.954993]" shape="(10,)" units="Unit('1')" value_type="float32" var_name="sigma"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="dac4e29e" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
+        <auxCoord id="a3171b4c" points="[[99.1904, 305.988, 313.866, ..., 67.0949,
  		85.6042, 53.1264],
 		[146.068, 188.025, 341.338, ..., 117.513,
  		79.4105, 129.535],
@@ -509,8 +510,9 @@
 		[317.526, 437.432, 293.445, ..., 127.839,
  		84.2878, 118.704]]" shape="(83, 83)" standard_name="surface_altitude" units="Unit('m')" value_type="float32" var_name="surface_altitude">
           <attributes>
-            <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+            <attribute name="source" value="Data from Met Office Unified Model"/>
             <attribute name="um_stash_source" value="m01s00i033"/>
+            <attribute name="um_version" value="7.4"/>
           </attributes>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
+++ b/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.8"/>
     </attributes>
     <coords>
       <coord>
@@ -39,7 +40,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.8"/>
     </attributes>
     <coords>
       <coord>
@@ -79,7 +81,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.8"/>
     </attributes>
     <coords>
       <coord>
@@ -119,7 +122,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.8"/>
     </attributes>
     <coords>
       <coord>
@@ -159,7 +163,8 @@
   <cube standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.08"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.8"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/pp_rules/rotated_uk.cml
+++ b/lib/iris/tests/results/pp_rules/rotated_uk.cml
@@ -3,7 +3,8 @@
   <cube units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s03i463"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/trajectory/big_cube.cml
+++ b/lib/iris/tests/results/trajectory/big_cube.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/trajectory/constant_latitude.cml
+++ b/lib/iris/tests/results/trajectory/constant_latitude.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/trajectory/single_point.cml
+++ b/lib/iris/tests/results/trajectory/single_point.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/trajectory/zigzag.cml
+++ b/lib/iris/tests/results/trajectory/zigzag.cml
@@ -3,7 +3,8 @@
   <cube standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
-      <attribute name="source" value="Data from Met Office Unified Model 7.04"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="7.4"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
@@ -4,7 +4,8 @@
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s12i187"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
@@ -3,7 +3,8 @@
   <cube standard_name="tendency_of_upward_air_velocity_due_to_advection" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s12i187"/>
-      <attribute name="source" value="Data from Met Office Unified Model 6.01"/>
+      <attribute name="source" value="Data from Met Office Unified Model"/>
+      <attribute name="um_version" value="6.1"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/12187.b_0.cdl
@@ -56,6 +56,7 @@ variables:
 	double time_bnds(bnds) ;
 
 // global attributes:
-		:source = "Data from Met Office Unified Model 6.01" ;
+		:source = "Data from Met Office Unified Model" ;
+		:um_version = "6.1" ;
 		:Conventions = "CF-1.5" ;
 }

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -71,5 +71,35 @@ class TestLbfcProduction(tests.IrisTest):
         self.check_cube_stash_yields_lbfc(None, 0)
 
 
+class TestLbsrceProduction(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.lat_lon_cube()
+
+    def check_cube_um_source_yields_lbsrce(
+            self, source_str=None, um_version_str=None, lbsrce_expected=None):
+        if source_str is not None:
+            self.cube.attributes['source'] = source_str
+        if um_version_str is not None:
+            self.cube.attributes['um_version'] = um_version_str
+        lbsrce_produced = _pp_save_ppfield_values(self.cube).lbsrce
+        self.assertEqual(lbsrce_produced, lbsrce_expected)
+
+    def test_none(self):
+        self.check_cube_um_source_yields_lbsrce(
+            None, None, 0)
+
+    def test_source_only_no_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model', None, 1111)
+
+    def test_source_only_with_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model 12.17', None, 12171111)
+
+    def test_um_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model 12.17', '25.36', 25361111)
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -249,5 +249,38 @@ class TestLBRSVD(iris.tests.unit.fileformats.TestField):
                              expected_bounds=bounds)
 
 
+class TestLBSRCE(iris.tests.IrisTest):
+    def check_um_source_attrs(self, lbsrce,
+                              source_str=None, um_version_str=None):
+        field = mock.MagicMock(lbsrce=lbsrce)
+        (factories, references, standard_name, long_name, units,
+         attributes, cell_methods, dim_coords_and_dims,
+         aux_coords_and_dims) = convert(field)
+        if source_str is not None:
+            self.assertEqual(attributes['source'], source_str)
+        else:
+            self.assertNotIn('source', attributes)
+        if um_version_str is not None:
+            self.assertEqual(attributes['um_version'], um_version_str)
+        else:
+            self.assertNotIn('um_version', attributes)
+
+    def test_none(self):
+        self.check_um_source_attrs(lbsrce=8123,
+                                   source_str=None, um_version_str=None)
+
+    def test_no_um_version(self):
+        self.check_um_source_attrs(
+            lbsrce=1111,
+            source_str='Data from Met Office Unified Model',
+            um_version_str=None)
+
+    def test_um_version(self):
+        self.check_um_source_attrs(
+            lbsrce=12071111,
+            source_str='Data from Met Office Unified Model',
+            um_version_str='12.7')
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Supported by pp (and FF) load and save.
See also newer suggestions in https://github.com/SciTools/iris/pull/1141, which could make this neater.

The change messes up a lot of CDL/CML result files, and a few doctest and examples, so I've left those fixes in separate commits for now.
