### PR TITLE
small correction to documentation in iris.cub

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -582,13 +582,17 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             :mod:`iris.aux_factory`.
 
         For example::
-
-            latitude = DimCoord(range(-85, 105, 10), standard_name='latitude',
-                                units='degrees')
-            longitude = DimCoord(range(0, 360, 10), standard_name='longitude',
-                                 units='degrees')
-            cube = Cube(np.zeros((18, 36), np.float32),
-                        dim_coords_and_dims=[(latitude, 0), (longitude, 1)])
+            >>> from iris.coords import DimCoord
+            >>> from iris.cube import Cube
+            >>> latitude = DimCoord(np.linspace(-90, 90, 4),
+            ...                     standard_name='latitude',
+            ...                     units='degrees')
+            >>> longitude = DimCoord(np.linspace(45, 360, 8),
+            ...                      standard_name='longitude',
+            ...                      units='degrees')
+            >>> cube = Cube(np.zeros((4, 8), np.float32),
+            ...             dim_coords_and_dims=[(latitude, 0),
+            ...                                  (longitude, 1)])
 
         """
         # Temporary error while we transition the API.


### PR DESCRIPTION
I know this is small. When I cut and paste an example from the iris.cube documentation it fails.   This commit fixes that.

This could be elaborated on - for instance should an example generate a latitude that goes above 90 degrees, or should it do something more 'realistic'?  (I'm happy to make this change if you think it would be helpful)

What's considered best practice to make things like this less fragile?  Should the 19 be replaced with `len(latitude.points)`?

Should this example be a doctest example?
