### PR TITLE
Fixed travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-#
-# Based on pelson's travis work for cartopy.
-#
 # Please update the cartopy, test data, and sample data git references below if appropriate.
 #
 # Note: Contrary to the travis documentation,
@@ -35,7 +32,7 @@ install:
 
 # add repo
   - ./.travis_no_output sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192
-  - ./.travis_no_output sudo add-apt-repository -y ppa:ubuntugis/ppa
+  - ./.travis_no_output sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 # access to scipy 0.12.0 https://launchpad.net/~pylab/+archive/stable
   - sudo add-apt-repository -y ppa:pylab/stable
   - ./.travis_no_output sudo apt-get update


### PR DESCRIPTION
It seems the stable PPA for ubuntugis has been broken, so I've moved it to the unstable build, which fixes it...

Cartopy has been using the unstable build for a few months without any noticeable interruptions (though obviously bandwidth is lower), and it is easy enough to revert back to the sable build once it has been fixed.
