### PR TITLE
Add Cube.regrid()

### DIFF
--- a/lib/iris/analysis/_interpolator.py
+++ b/lib/iris/analysis/_interpolator.py
@@ -25,6 +25,7 @@ from iris.analysis._scipy_interpolate import _RegularGridInterpolator
 from iris.analysis.cartography import wrap_lons as wrap_circular_points
 from iris.coords import DimCoord, AuxCoord
 import iris.cube
+import iris.experimental.regrid as eregrid
 
 
 _DEFAULT_DTYPE = np.float16
@@ -118,9 +119,9 @@ class LinearInterpolator(object):
             Must be one of the following strings:
 
               * 'linear' - The extrapolation points will be calculated by
-                extending the gradient of closest two points.
+                extending the gradient of the closest two points.
               * 'nan' - The extrapolation points will be be set to NaN.
-              * 'error' - An exception will be raised, notifying an
+              * 'error' - A ValueError exception will be raised, notifying an
                 attempt to extrapolate.
               * 'mask' - The extrapolation points will always be masked, even
                 if the source data is not a MaskedArray.
@@ -573,3 +574,99 @@ class LinearInterpolator(object):
             new_cube = new_cube[tuple(dim_slices)]
 
         return new_cube
+
+
+class LinearRegridder(object):
+    """
+    This class provides support for performing regridding via linear
+    interpolation.
+
+    """
+    def __init__(self, src_grid_cube, target_grid_cube,
+                 extrapolation_mode='linear'):
+        """
+        Create a linear regridder for conversions between the source
+        and target grids.
+
+        Args:
+
+        * src_grid_cube:
+            The :class:`~iris.cube.Cube` providing the source grid.
+        * target_grid_cube:
+            The :class:`~iris.cube.Cube` providing the target grid.
+
+        Kwargs:
+
+        * extrapolation_mode:
+            Must be one of the following strings:
+
+              * 'linear' - The extrapolation points will be calculated by
+                extending the gradient of closest two points.
+              * 'nan' - The extrapolation points will be be set to NaN.
+              * 'error' - An exception will be raised, notifying an
+                attempt to extrapolate.
+              * 'mask' - The extrapolation points will always be masked, even
+                if the source data is not a MaskedArray.
+              * 'nanmask' - If the source data is a MaskedArray the
+                extrapolation points will be masked. Otherwise they will be
+                set to NaN.
+
+            Default mode of extrapolation is 'linear'
+
+        """
+        # Snapshot the state of the cubes to ensure that the regridder
+        # is impervious to external changes to the original source cubes.
+        self._src_grid = self._snapshot_grid(src_grid_cube)
+        self._target_grid = self._snapshot_grid(target_grid_cube)
+        # The extrapolation mode.
+        if extrapolation_mode not in _LINEAR_EXTRAPOLATION_MODES:
+            msg = 'Extrapolation mode {!r} not supported.'
+            raise ValueError(msg.format(extrapolation_mode))
+        self._extrapolation_mode = extrapolation_mode
+
+        # The need for an actual Cube is an implementation quirk
+        # caused by the current usage of the experimental regrid
+        # function.
+        self._target_grid_cube_cache = None
+
+    def _snapshot_grid(self, cube):
+        x, y = eregrid._get_xy_dim_coords(cube)
+        return x.copy(), y.copy()
+
+    @property
+    def _target_grid_cube(self):
+        if self._target_grid_cube_cache is None:
+            x, y = self._target_grid
+            data = np.empty((y.points.size, x.points.size))
+            cube = iris.cube.Cube(data)
+            cube.add_dim_coord(y, 0)
+            cube.add_dim_coord(x, 1)
+            self._target_grid_cube_cache = cube
+        return self._target_grid_cube_cache
+
+    def __call__(self, cube):
+        """
+        Regrid this :class:`~iris.cube.Cube` on to the target grid of
+        this :class:`LinearRegridder`.
+
+        The given cube must be defined with the same grid as the source
+        grid used to create this :class:`LinearRegridder`.
+
+        Args:
+
+        * cube:
+            A :class:`~iris.cube.Cube` to be regridded.
+
+        Returns:
+            A cube defined with the horizontal dimensions of the target
+            and the other dimensions from this cube. The data values of
+            this cube will be converted to values on the new grid using
+            linear interpolation.
+
+        """
+        if eregrid._get_xy_dim_coords(cube) != self._src_grid:
+            raise ValueError('The given cube is not defined on the same '
+                             'source grid as this regridder.')
+        return eregrid.regrid_bilinear_rectilinear_src_and_grid(
+            cube, self._target_grid_cube,
+            extrapolation_mode=self._extrapolation_mode)

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -401,6 +401,10 @@ def regrid(source_cube, grid_cube, mode='bilinear', **kwargs):
         for regrid support with mask awareness.
 
     """
+    if mode == 'bilinear':
+        scheme = iris.analysis.Linear(**kwargs)
+        return source_cube.regrid(grid_cube, scheme)
+
     # Condition 1
     source_cs = source_cube.coord_system(iris.coord_systems.CoordSystem)
     grid_cs = grid_cube.coord_system(iris.coord_systems.CoordSystem)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3198,6 +3198,29 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         interp = scheme.interpolator(self, coords)
         return interp(points, collapse_scalar=collapse_scalar)
 
+    def regrid(self, grid, scheme):
+        """
+        Regrid this :class:`~iris.cube.Cube` on to the given `grid`
+        using the provided regridding scheme.
+
+        Args:
+
+        * grid:
+            A :class:`~iris.cube.Cube` which defines the target grid.
+        * scheme:
+            A :class:`~iris.analysis.Linear` instance, which defines the
+            interpolator scheme.
+
+        Returns:
+            A cube defined with the horizontal dimensions of the target
+            and the other dimensions from this cube. The data values of
+            this cube will be converted to values on the new grid
+            according to the given scheme.
+
+        """
+        regridder = scheme.regridder(self, grid)
+        return regridder(self)
+
 
 class ClassDict(object, UserDict.DictMixin):
     """

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -28,9 +28,8 @@ import numpy.ma as ma
 from scipy.sparse import csc_matrix
 
 import iris.analysis.cartography
-from iris.analysis._interpolator import (_extend_circular_coord_and_data,
-                                         _LINEAR_EXTRAPOLATION_MODES)
 from iris.analysis._scipy_interpolate import _RegularGridInterpolator
+import iris.analysis._interpolator
 import iris.coord_systems
 import iris.cube
 import iris.unit
@@ -280,8 +279,8 @@ def _regrid_bilinear_array(src_data, x_dim, y_dim, src_x_coord, src_y_coord,
     src_data = src_data[tuple(flip_index)]
 
     if src_x_coord.circular:
-        x_points, src_data = _extend_circular_coord_and_data(src_x_coord,
-                                                             src_data, x_dim)
+        extend = iris.analysis._interpolator._extend_circular_coord_and_data
+        x_points, src_data = extend(src_x_coord, src_data, x_dim)
     else:
         x_points = src_x_coord.points
 
@@ -303,7 +302,8 @@ def _regrid_bilinear_array(src_data, x_dim, y_dim, src_x_coord, src_y_coord,
     # some unnecessary checks on these values, so we set them
     # afterwards instead. Sneaky. ;-)
     try:
-        mode = _LINEAR_EXTRAPOLATION_MODES[extrapolation_mode]
+        modes = iris.analysis._interpolator._LINEAR_EXTRAPOLATION_MODES
+        mode = modes[extrapolation_mode]
     except KeyError:
         raise ValueError('Invalid extrapolation mode.')
     interpolator.bounds_error = mode.bounds_error
@@ -585,7 +585,8 @@ def regrid_bilinear_rectilinear_src_and_grid(src, grid,
                                                  grid_x_coord, grid_y_coord)):
         raise ValueError("Unsupported units: must be 'degrees' or 'm'.")
 
-    if extrapolation_mode not in _LINEAR_EXTRAPOLATION_MODES:
+    modes = iris.analysis._interpolator._LINEAR_EXTRAPOLATION_MODES
+    if extrapolation_mode not in modes:
         raise ValueError('Invalid extrapolation mode.')
 
     # Convert the grid to a 2D sample grid in the src CRS.

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -1,0 +1,82 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for :class:`iris.analysis.Linear`."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+
+from iris.analysis import Linear
+
+
+class TestModes(tests.IrisTest):
+    def check_mode(self, mode=None):
+        kwargs = {}
+        if mode is not None:
+            kwargs['extrapolation_mode'] = mode
+        linear = Linear(**kwargs)
+        if mode is None:
+            mode = 'linear'
+        self.assertEqual(linear.extrapolation_mode, mode)
+
+        # To avoid duplicating tests, just check that creating an
+        # interpolator defers to the LinearInterpolator with the
+        # correct arguments (and honouring the return value!)
+        with mock.patch('iris.analysis.LinearInterpolator',
+                        return_value=mock.sentinel.interpolator) as li:
+            interpolator = linear.interpolator(mock.sentinel.cube,
+                                               mock.sentinel.coords)
+        li.assert_called_once_with(mock.sentinel.cube, mock.sentinel.coords,
+                                   extrapolation_mode=mode)
+        self.assertIs(interpolator, mock.sentinel.interpolator)
+
+        # As above, check method defers to LinearRegridder.
+        with mock.patch('iris.analysis.LinearRegridder',
+                        return_value=mock.sentinel.regridder) as lr:
+            regridder = linear.regridder(mock.sentinel.src,
+                                         mock.sentinel.target)
+        lr.assert_called_once_with(mock.sentinel.src, mock.sentinel.target,
+                                   extrapolation_mode=mode)
+        self.assertIs(regridder, mock.sentinel.regridder)
+
+    def test_default(self):
+        self.check_mode()
+
+    def test_linear(self):
+        self.check_mode('linear')
+
+    def test_nan(self):
+        self.check_mode('nan')
+
+    def test_error(self):
+        self.check_mode('error')
+
+    def test_mask(self):
+        self.check_mode('mask')
+
+    def test_nanmask(self):
+        self.check_mode('nanmask')
+
+    def test_invalid(self):
+        with self.assertRaisesRegexp(ValueError, 'Extrapolation mode'):
+            Linear('bogus')
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -789,5 +789,31 @@ class Test_interpolate(tests.IrisTest):
             (0.5, 0.6), collapse_scalar=self.collapse_coord)
         self.assertIs(result, mock.sentinel.RESULT)
 
-if __name__ == "__main__":
+
+class Test_regrid(tests.IrisTest):
+    def test(self):
+        # Test that Cube.regrid() just defers to the regridder of the
+        # given scheme.
+
+        # Define a fake scheme and its associated regridder which just
+        # capture their arguments and return them in place of the
+        # regridded cube.
+        class FakeRegridder(object):
+            def __init__(self, *args):
+                self.args = args
+
+            def __call__(self, cube):
+                return self.args + (cube,)
+
+        class FakeScheme(object):
+            def regridder(self, src, target):
+                return FakeRegridder(self, src, target)
+
+        cube = Cube(0)
+        scheme = FakeScheme()
+        result = cube.regrid(mock.sentinel.TARGET, scheme)
+        self.assertEqual(result, (scheme, cube, mock.sentinel.TARGET, cube))
+
+
+if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
Notable features:
- Adds a `regridder()` method to the `iris.analysis.Linear` scheme.
- Adds `Cube.regrid()`.
- Switches `iris.analysis.interpolate.regrid()` to use the new Cube.regrid() method when in linear mode.

NB. The "meat" of the linear regridder is provided by `iris.experimental.regrid.regrid_bilinear_rectilinear_src_and_grid()`. Once we're happy with the state of play, future work is needed to deprecate/remove this experimental function and shift all the functionality/tests into the main code base.
