### PR TITLE
Fix circular handling in Cube.intersection()

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2077,6 +2077,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # Add copies of the source coordinates, selecting
                 # the appropriate subsets out of coordinates which
                 # share the intersection dimension.
+                preserve_circular = (min_inclusive and max_inclusive and
+                                     abs(maximum - minimum) == modulus)
                 for src_coord in src_coords:
                     dims = self.coord_dims(src_coord)
                     if dim in dims:
@@ -2093,7 +2095,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             bounds = None
                         result_coord = src_coord.copy(points=points,
                                                       bounds=bounds)
-                        if getattr(result_coord, 'circular', False):
+
+                        circular = getattr(result_coord, 'circular', False)
+                        if circular and not preserve_circular:
                             result_coord.circular = False
                     else:
                         result_coord = src_coord.copy()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -371,6 +371,29 @@ class Test_intersection__Metadata(tests.IrisTest):
         self.assertCMLApproxData(result)
 
 
+# Explicitly check the handling of `circular` on the result.
+class Test_intersection__Circular(tests.IrisTest):
+    def test_regional(self):
+        cube = create_cube(0, 360)
+        result = cube.intersection(longitude=(170, 190))
+        self.assertFalse(result.coord('longitude').circular)
+
+    def test_regional_wrapped(self):
+        cube = create_cube(-180, 180)
+        result = cube.intersection(longitude=(170, 190))
+        self.assertFalse(result.coord('longitude').circular)
+
+    def test_global(self):
+        cube = create_cube(-180, 180)
+        result = cube.intersection(longitude=(-180, 180))
+        self.assertTrue(result.coord('longitude').circular)
+
+    def test_global_wrapped(self):
+        cube = create_cube(-180, 180)
+        result = cube.intersection(longitude=(10, 370))
+        self.assertTrue(result.coord('longitude').circular)
+
+
 # Check the various error conditions.
 class Test_intersection__Invalid(tests.IrisTest):
     def test_reversed_min_max(self):


### PR DESCRIPTION
When the requested range wraps around the circular flag is preserved from the source Cube. This PR ensures the circular flag is cleared.
