### PR TITLE
update to latest biggus to get mdtol handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ git:
 
 install:
 
-  - export BIGGUS_REF="v0.5.0"
+  - export BIGGUS_REF="aab46da45f65d2225e0aef9cdde675e435ea255f"
   - export BIGGUS_SUFFIX=$(echo "${BIGGUS_REF}" | sed "s/^v//")
 
   - export CARTOPY_REF="0a0b548a08d445427bef834cf5bdb19cbee4202a"

--- a/lib/iris/tests/unit/analysis/test_MEAN.py
+++ b/lib/iris/tests/unit/analysis/test_MEAN.py
@@ -1,0 +1,57 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :data:`iris.analysis.MEAN` aggregator."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import biggus
+import numpy.ma as ma
+
+from iris.analysis import MEAN
+
+
+class Test_lazy_aggregate(tests.IrisTest):
+    def setUp(self):
+        self.data = ma.arange(12).reshape(3, 4)
+        self.data[2, 1:] = ma.masked
+        self.array = biggus.NumpyArrayAdapter(self.data)
+        self.axis = 0
+
+    def test_mdtol_default(self):
+        agg = MEAN.lazy_aggregate(self.array, axis=self.axis)
+        result = agg.masked_array()
+        expected = ma.mean(self.data, axis=self.axis)
+        self.assertArrayAlmostEqual(result, expected)
+
+    def test_mdtol_below(self):
+        agg = MEAN.lazy_aggregate(self.array, axis=self.axis, mdtol=0.3)
+        result = agg.masked_array()
+        expected = ma.mean(self.data, axis=self.axis)
+        expected.mask = [False, True, True, True]
+        self.assertMaskedArrayAlmostEqual(result, expected)
+
+    def test_mdtol_above(self):
+        agg = MEAN.lazy_aggregate(self.array, axis=self.axis, mdtol=0.4)
+        result = agg.masked_array()
+        expected = ma.mean(self.data, axis=self.axis)
+        self.assertMaskedArrayAlmostEqual(result, expected)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This PR moves us to the latest and greatest biggus so the mdtol keyword arg is handled by `iris.analysis.MEAN.lazy_aggregate()`
