### PR TITLE
Mark a longitude coordinate loaded from netCDF as "circular" if the bounds look right.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1108,8 +1108,8 @@ fc_extras
                 modulus_value = iris.unit.Unit(attr_units).modulus
                 if bounds_data is not None:
                     # set circular if bounds ends are equal
-                    first_bound = bounds_data[0,0] % modulus_value
-                    last_bound = bounds_data[-1,1] % modulus_value
+                    first_bound = bounds_data[0, 0] % modulus_value
+                    last_bound = bounds_data[-1, 1] % modulus_value
                     circular = np.allclose(first_bound, last_bound, rtol=1.0e-5)
                 else:
                     # set circular if points are regular and last+1 ~= first


### PR DESCRIPTION
Data loaded from files with higher-resolution longitudes was not loading as 'circular', owing to floating-point accuracy problems when testing that all coordinate steps are similar.
This adds rules behaviour to test bounds instead, when they exist, which gets around that for some data.
