### PR TITLE
reordered args in new cube.interpolate() api

### DIFF
--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -637,7 +637,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
         raise TypeError('Expecting the sample points to be a list of tuple pairs representing (coord, points), got a list of %s.' % type(sample_points[0]))
 
     scheme = Linear(extrapolation_mode)
-    return cube.interpolate(scheme, sample_points)
+    return cube.interpolate(sample_points, scheme)
 
 
 def _interp1d_rolls_y():

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3187,18 +3187,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return new_cube
 
-    def interpolate(self, scheme, sample_points, collapse_scalar=True):
+    def interpolate(self, sample_points, scheme, collapse_scalar=True):
         """
-        Interpolate over the :class:`~iris.cube.Cube` using the provided
-        interpolation scheme and specified sample points.
+        Interpolate over the :class:`~iris.cube.Cube` using the specified
+        sample points and provided interpolation scheme.
 
         Args:
 
+        * sample_points:
+            A sequence of (coordinate, points) pairs over which to interpolate.
         * scheme:
             A :class:`~iris.analysis.Linear` instance, which defines the
             interpolator scheme.
-        * sample_points:
-            A sequence of (coordinate, points) pairs over which to interpolate.
 
         Kwargs:
 

--- a/lib/iris/tests/unit/analysis/interpolate/test_linear.py
+++ b/lib/iris/tests/unit/analysis/interpolate/test_linear.py
@@ -44,7 +44,7 @@ class Test(tests.IrisTest):
 
         linear_patch.assert_called_once_with(self.extrapolation)
 
-        cinterp_patch.assert_called_once_with(self.scheme, sample_points_call)
+        cinterp_patch.assert_called_once_with(sample_points_call, self.scheme)
 
     def test_sample_point_dict(self):
         # Passing sample_points in the form of a dictionary.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -812,7 +812,7 @@ class Test_interpolate(tests.IrisTest):
 
     def test_api(self):
         sample_points = (('foo', 0.5), ('bar', 0.6))
-        result = self.cube.interpolate(self.scheme, sample_points,
+        result = self.cube.interpolate(sample_points, self.scheme,
                                        self.collapse_coord)
         self.scheme.interpolator.assert_called_once_with(
             self.cube, ('foo', 'bar'))


### PR DESCRIPTION
`cube.regrid` and `cube.interpolate`, both take a target grid/sample_points and a scheme, however, the order of those objects in the signature is not consistent. This PR changes `cube.interpolate` to match that of `cube.regrid` i.e.

`cube.interpolate(sample_points, Linear())`

matching:

`cube.regrid(grid_cube, Linear())`
