### PR TITLE
moved to v0.11.0 of cartopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - export BIGGUS_REF="aab46da45f65d2225e0aef9cdde675e435ea255f"
   - export BIGGUS_SUFFIX=$(echo "${BIGGUS_REF}" | sed "s/^v//")
 
-  - export CARTOPY_REF="0a0b548a08d445427bef834cf5bdb19cbee4202a"
+  - export CARTOPY_REF="v0.11.0"
   - export CARTOPY_SUFFIX=$(echo "${CARTOPY_REF}" | sed "s/^v//")
 
   - export IRIS_TEST_DATA_REF="3378fe68c00ca7f31895ab6630a59a39ccef94e3"


### PR DESCRIPTION
This moves Iris up to using the latest release of cartopy.
