### PR TITLE
Fixed aggregate_by bug for single values coordinates.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1401,7 +1401,11 @@ class _Groupby(object):
                     new_points = []
                     new_bounds = None
                     for key_slice in self._slices_by_key.itervalues():
-                        new_pt = '|'.join(coord.points[i] for i in key_slice)
+                        if isinstance(key_slice, slice):
+                            indices = key_slice.indices(coord.points.shape[0])
+                            key_slice = range(*indices)
+                        new_pt = '|'.join([coord.points[i]
+                                           for i in key_slice])
                         new_points.append(new_pt)
                 else:
                     msg = ('collapsing the bounded string coordinate {0!r}'

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -23,28 +23,26 @@ import iris.tests as tests
 import iris
 from iris.analysis import MEAN
 from iris.aux_factory import LazyArray
-from iris.coords import AuxCoord, CellMethod
 
 
-@tests.skip_data
 class Test_aggregated_by(tests.IrisTest):
-    def setUp(self):
+    @tests.skip_data
+    def test_agg_by_aux_coord(self):
         problem_test_file = tests.get_data_path(('NetCDF', 'testing',
                                                 'small_theta_colpex.nc'))
-        self.cube = iris.load_cube(problem_test_file)
+        cube = iris.load_cube(problem_test_file)
 
-    def test_agg_by_aux_coord(self):
         # Test aggregating by aux coord, notably the `forecast_period` aux
-        # coord on `self.cube`, whose `_points` attribute is of type
+        # coord on `cube`, whose `_points` attribute is of type
         # :class:`iris.aux_factory.LazyArray`. This test then ensures that
         # aggregating using `points` instead is successful.
 
         # First confirm we've got a `LazyArray`.
-        forecast_period_coord = self.cube.coord('forecast_period')
+        forecast_period_coord = cube.coord('forecast_period')
         self.assertIsInstance(forecast_period_coord._points, LazyArray)
 
         # Now confirm we can aggregate along this coord.
-        res_cube = self.cube.aggregated_by('forecast_period', MEAN)
+        res_cube = cube.aggregated_by('forecast_period', MEAN)
         res_cell_methods = res_cube.cell_methods[0]
         self.assertEqual(res_cell_methods.coord_names, ('forecast_period',))
         self.assertEqual(res_cell_methods.method, 'mean')

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -299,6 +299,16 @@ class Test_aggregated_by(tests.IrisTest):
         self.assertEqual(res_cube.coord('val'), val_coord)
         self.assertEqual(res_cube.coord('label'), label_coord)
 
+    def test_single_string_aggregation(self):
+        aux_coords = [(AuxCoord(['a', 'b', 'a'], long_name='foo'), 0),
+                      (AuxCoord(['a', 'a', 'a'], long_name='bar'), 0)]
+        cube = iris.cube.Cube(np.arange(12).reshape(3, 4),
+                              aux_coords_and_dims=aux_coords)
+        result = cube.aggregated_by('foo', MEAN)
+        self.assertEqual(result.shape, (2, 4))
+        self.assertEqual(result.coord('bar'),
+                         AuxCoord(['a|a', 'a'], long_name='bar'))
+
 
 class Test_rolling_window(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
Follows on from #1203.
