### PR TITLE
fixed bug when comparing string fill values

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -381,11 +381,18 @@ class _CubeSignature(namedtuple('CubeSignature',
         if self.data_type != other.data_type:
             msgs.append('cube data dtype differs: {} != {}'.format(
                 self.data_type, other.data_type))
-        if not (np.isnan(self.fill_value) and np.isnan(other.fill_value)) and \
-                self.fill_value != other.fill_value:
-            msg = 'cube data fill_value differs: ' \
-                '{!r} != {!r}'.format(self.fill_value, other.fill_value)
-            msgs.append(msg)
+        # Compare fill values noting that two np.nans do not compare equal
+        # and np.isnan() raises a TypeError on strings.
+        if self.fill_value != other.fill_value:
+            try:
+                both_nan = (np.isnan(self.fill_value) and
+                            np.isnan(other.fill_value))
+            except TypeError:
+                both_nan = False
+            if not both_nan:
+                msg = 'cube data fill_value differs: ' \
+                    '{!r} != {!r}'.format(self.fill_value, other.fill_value)
+                msgs.append(msg)
         match = not bool(msgs)
         if error_on_mismatch and not match:
             raise iris.exceptions.MergeError(msgs)

--- a/lib/iris/tests/unit/merge/test__CubeSignature.py
+++ b/lib/iris/tests/unit/merge/test__CubeSignature.py
@@ -74,6 +74,24 @@ class Test_match__fill_value(tests.IrisTest):
             sig2.match(sig1, True)
         self.assertFalse(sig2.match(sig1, False))
 
+    def test_str_fill_value_equal(self):
+        sig1 = CubeSig(self.defn, self.data_shape, self.data_type, ' ')
+        sig2 = CubeSig(self.defn, self.data_shape, self.data_type, ' ')
+        self.assertTrue(sig1.match(sig2, True))
+        self.assertTrue(sig1.match(sig2, False))
+        self.assertTrue(sig2.match(sig1, True))
+        self.assertTrue(sig2.match(sig1, False))
+
+    def test_str_fill_value_unequal(self):
+        sig1 = CubeSig(self.defn, self.data_shape, self.data_type, ' ')
+        sig2 = CubeSig(self.defn, self.data_shape, self.data_type, '_')
+        with self.assertRaises(iris.exceptions.MergeError):
+            sig1.match(sig2, True)
+        self.assertFalse(sig1.match(sig2, False))
+        with self.assertRaises(iris.exceptions.MergeError):
+            sig2.match(sig1, True)
+        self.assertFalse(sig2.match(sig1, False))
+
 
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
This PR fixes a bug introduced by #1152 that prevents Iris being able to load certain files it used to have not issues with. The problem arises with netcdf files with variables containing strings. If the fill values are strings calling `np.isnan(fill_value)` raises a TypeError. #1152 added an `np.isnan()` because `np.nan`s do not compare equal. This PR covers both cases.
