### PR TITLE
Remove obsolete and unwanted import

### DIFF
--- a/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
+++ b/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
@@ -21,16 +21,15 @@
 import iris.tests as tests
 
 import numpy as np
-from osgeo import gdal
 try:
     from osgeo import gdal
+    from iris.experimental.raster import export_geotiff
 except ImportError:
     gdal = None
 
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord
 from iris.cube import Cube
-from iris.experimental.raster import export_geotiff
 
 
 @tests.skip_gdal


### PR DESCRIPTION
Follow up to #1191 which removes a left-over import.
