### PR TITLE
trigger loading of source data during interpolation to avoid multiple loads

### DIFF
--- a/lib/iris/analysis/_interpolator.py
+++ b/lib/iris/analysis/_interpolator.py
@@ -132,8 +132,13 @@ class LinearInterpolator(object):
             Default mode of extrapolation is 'linear'
 
         """
-        # Snapshot the state of the cube to ensure that the interpolator
-        # is impervious to external changes to the original source cube.
+        # Trigger any deferred loading of the source cube's data and snapshot
+        # its state to ensure that the interpolator is impervious to external
+        # changes to the original source cube. The data is loaded to prevent
+        # the snaphot having lazy data, avoiding the potential for the
+        # same data to be loaded again and again.
+        if src_cube.has_lazy_data():
+            src_cube.data
         self._src_cube = src_cube.copy()
         # Coordinates defining the dimensions to be interpolated.
         self._src_coords = [self._src_cube.coord(coord) for coord in coords]


### PR DESCRIPTION
`LinearInterpolator` creates a snapshot of the source cube. If the source cube has lazy data, using the interpolator won't ever make this source cube's data concrete. Instead the data for the snapshot is loaded. So what? Well, the problem is that repeated calls to cube.interpolate() will cause the data to be loaded from disk over and over again. This can be demonstrated by:

``` python
>>> import iris
>>> cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
>>> cube.has_lazy_data()
True
>>> res = cube.interpolate([('latitude', [1,2,3])], iris.analysis.Linear())
>>> cube.has_lazy_data()
True
```

This PR fixes the issue by triggering deferred loading prior to making a snapshot of the source cube.
