### PR TITLE
replaced mdtol docstring with area based one

### DIFF
--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -151,7 +151,7 @@ Iris 1.7 features
 * A speed improvement in calculation of :func:`iris.analysis.geometry.geometry_area_weights`.
 * The mdtol keyword was added to area-weighted regridding to allow control of the
   tolerance for missing data. For a further description of this concept, see
-  :data:`iris.analysis.MEAN`.
+  :class:`iris.analysis.AreaWeighted`.
 * Handling for patching of the CF conventions global attribute via a defined
   cf_patch_conventions function.
 * Deferred GRIB data loading has been introduced for reduced memory consumption when

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1602,11 +1602,12 @@ class AreaWeighted(object):
 
         * mdtol (float):
             Tolerance of missing data. The value returned in each element of
-            the returned array will be masked if the fraction of masked data
-            exceeds mdtol. mdtol=0 means no missing data is tolerated while
-            mdtol=1 will mean the resulting element will be masked if and only
-            if all the contributing elements of data are masked.
-            Defaults to 1.
+            the returned array will be masked if the fraction of missing data
+            exceeds mdtol. This fraction is calculated based on the area of
+            masked cells within each target cell. mdtol=0 means no masked
+            data is tolerated while mdtol=1 will mean the resulting element
+            will be masked if and only if all the overlapping elements of the
+            source grid are masked. Defaults to 1.
 
         """
         if not (0 <= mdtol <= 1):


### PR DESCRIPTION
The `mdtol` description for `AreaWeighted` was taken from `iris.analysis.MEAN` rather than the area weighted regridding function in experimental. The latter is based on area and the docs as they stood did not reflect this.
