### PR TITLE
Added skip_data decorator to two tests using test data without it

### DIFF
--- a/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
+++ b/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
@@ -132,12 +132,14 @@ class TestEqualiseAttributes(tests.IrisTest):
         cubes = [self.cube_a1b5v1, self.cube_a1b6v1]
         self._test(cubes, {'a': 1, 'v': self.v1})
 
+    @tests.skip_data
     def test_complex_nonecommon(self):
         # Example with cell methods and factories, but no common attributes.
         cubes = [iris.tests.stock.global_pp(),
                  iris.tests.stock.hybrid_height()]
         self._test(cubes, {})
 
+    @tests.skip_data
     def test_complex_somecommon(self):
         # Example with cell methods and factories, plus some common attributes.
         cubes = [iris.tests.stock.global_pp(), iris.tests.stock.simple_pp()]


### PR DESCRIPTION
Seriously small PR this - I happened to be running the Iris tests in an environment without test data and the two tests altered below errored because they were referencing test data with out a `tests.skip_data` decorator.
