### PR TITLE
Update whatsnew doc for v1.7.1

### DIFF
--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -181,8 +181,6 @@ Bugs fixed
 * Aggregate_by may now be passed single-value coordinates.
 * Making a copy of a :class:`iris.coords.DimCoord` no longer results in the writeable
   flag on the copied points and bounds arrays being set to True.
-* Fixed a bug that prevented regridding of a cube that has coordinates with
-  no :class:`iris.coord_systems.CoordSystem`.
 * Can now save to PP a cube that has vertical levels but no orography.
 
 Incompatible changes


### PR DESCRIPTION
Updated to include changes added to v1.7.x for the v1.7.1 release. 

A replacement for #1245, this branch tracks v1.7.x so has a sensible commit history.
