### PR TITLE
Allow for variance in netCDF4 behaviour.

### DIFF
--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -167,6 +167,13 @@ class TestNetCDFLoad(tests.IrisTest):
         # can pass by manual sorting...
         cubes = iris.cube.CubeList(sorted(cubes, key=lambda cube: cube.name()))
 
+        # TEST_COMPAT mod - different versions of the Python module
+        # `netCDF4` give different data arrays: MaskedArray vs ndarray
+        # Since we're not interested in the data we can just normalise
+        # to MaskedArray (to minimise the change).
+        for cube in cubes:
+            cube.data = ma.masked_equal(cube.data, -2147483647)
+
         self.assertCML(cubes, ('netcdf', 'netcdf_cell_methods.cml'))
 
     def test_deferred_loading(self):


### PR DESCRIPTION
Before 1.0.8 netCDF4 returned a MaskedArray for the variables in this test file. Since 1.0.8 it returns a plain ndarray. Since this test is focussed on cell methods and doesn't care about the data values at all this PR just normalises to MaskedArray.
