### PR TITLE
Search for dot executable in the PATH.

### DIFF
--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -32,7 +32,7 @@ _SUBGRAPH_INDENT = ' ' * 8
 _DOT_EXECUTABLE_PATH = iris.config.get_option('System', 'dot_path',
                                               default='dot')
 if not os.path.exists(_DOT_EXECUTABLE_PATH):
-    if not _DOT_EXECUTABLE_PATH.startswith('/'):
+    if not os.path.isabs(_DOT_EXECUTABLE_PATH):
         try:
             # Check PATH
             subprocess.check_output([_DOT_EXECUTABLE_PATH, '-V'],


### PR DESCRIPTION
Current code checks if the path exists, but not if it exists in the user's PATH somewhere. This needlessly requires the site.cfg to be modified, even though we can run `dot` just fine.
