### PR TITLE
Make tests compatible with Pillow.

### DIFF
--- a/lib/iris/tests/experimental/test_raster.py
+++ b/lib/iris/tests/experimental/test_raster.py
@@ -32,6 +32,8 @@ class TestGeoTiffExport(tests.IrisTest):
         """
         im = PIL.Image.open(geotiff_fh)
         tiff_header = '\n'.join(str((tag, val))
+                                if not isinstance(val, unicode)
+                                else "(%s, '%s')" % (tag, val)
                                 for tag, val in sorted(im.tag.items()))
 
         reference_path = tests.get_result_path(reference_filename)


### PR DESCRIPTION
Pillow returns Unicode strings instead of str objects, so the tests fail since there's an extra u prefix in the repr.
