### PR TITLE
Fixed tolerance bug in cube.intersection()

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2197,19 +2197,19 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                max_comp(points, maximum)))
         if isinstance(coord, iris.coords.DimCoord):
             delta = coord.points[inside_indices] - points[inside_indices]
-            tolerance = np.finfo(delta.dtype).eps * modulus
-            if np.allclose(delta, delta[0], rtol=tolerance, atol=tolerance):
-                # A single, contiguous block.
-                subsets = [slice(inside_indices[0], inside_indices[-1] + 1)]
-            else:
+            step = np.rint(np.diff(delta) / modulus)
+            non_zero_step_indices = np.nonzero(step)[0]
+            if non_zero_step_indices.size:
                 # A contiguous block at the start and another at the
                 # end. (NB. We can't have more than two blocks
                 # because we've already restricted the coordinate's
                 # range to its modulus).
-                step = np.rint(np.diff(delta) / modulus)
-                end_of_first_chunk = np.nonzero(step)[0][0]
+                end_of_first_chunk = non_zero_step_indices[0]
                 subsets = [slice(inside_indices[end_of_first_chunk + 1], None),
                            slice(None, inside_indices[end_of_first_chunk] + 1)]
+            else:
+                # A single, contiguous block.
+                subsets = [slice(inside_indices[0], inside_indices[-1] + 1)]
         else:
             # An AuxCoord could have its values in an arbitrary
             # order, and hence a range of values can select an

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -872,6 +872,16 @@ class Test_intersection__GlobalSrcModulus(tests.IrisTest):
         self.assertEqual(result.data[0, 0, 0], 303)
         self.assertEqual(result.data[0, 0, -1], 28)
 
+    def test_tolerance_bug(self):
+        # Floating point changes introduced by wrapping mean
+        # the resulting coordinate values are not equal to their
+        # equivalents. This led to a bug that this test checks.
+        cube = create_cube(0, 400)
+        cube.coord('longitude').points = np.linspace(-179.55, 179.55, 400)
+        result = cube.intersection(longitude=(125, 145))
+        self.assertArrayAlmostEqual(result.coord('longitude').points,
+                                    cube.coord('longitude').points[339:361])
+
 
 # Check what happens with a global, points-and-bounds circular
 # intersection coordinate.


### PR DESCRIPTION
As raised by @niallrobinson in the google groups (see https://groups.google.com/forum/#!topic/scitools-iris/jq6mEn32QQo), the current intersection method has some odd behaviour. This turns out to be a tolerance problem which I suspect originates in the wrap_lons helper function. This PR alters the logic in intersection to avoid the issue. I'd love to see @rhattersley and or @bjlittle comment as I believe they know this bit of the code.
