### PR TITLE
Support 3 stashcodes with implied 10m height.

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -117,6 +117,17 @@ def _convert_scalar_time_coords(lbcode, lbtim, epoch_hours_unit, t1, t2, lbft):
     return coords_and_dims
 
 
+_stashcode_implied_heights = {
+    'm01s03i236': 1.5,
+    'm01s03i237': 1.5,
+    'm01s03i245': 1.5,
+    'm01s03i247': 1.5,
+    'm01s03i250': 1.5,
+    'm01s03i225': 10.0,
+    'm01s03i226': 10.0,
+    'm01s03i463': 10.0}
+
+
 def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
                                     bhlev, bhrlev, brsvd1, brsvd2, brlev):
     """
@@ -128,14 +139,22 @@ def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
     factories = []
     coords_and_dims = []
     model_level_number = _model_level_number(lblev)
+
     if \
             (lbvc == 1) and \
-            (not (str(stash) in ['m01s03i236', 'm01s03i237', 'm01s03i245', 'm01s03i247', 'm01s03i250'])) and \
+            (not (str(stash) in _stashcode_implied_heights.keys())) and \
             (blev != -1):
-        coords_and_dims.append((DimCoord(blev, standard_name='height', units='m', attributes={'positive': 'up'}), None))
+        coords_and_dims.append(
+            (DimCoord(blev, standard_name='height', units='m',
+                      attributes={'positive': 'up'}),
+             None))
 
-    if str(stash) in ['m01s03i236', 'm01s03i237', 'm01s03i245', 'm01s03i247', 'm01s03i250']:
-        coords_and_dims.append((DimCoord(1.5, standard_name='height', units='m', attributes={'positive': 'up'}), None))
+    if str(stash) in _stashcode_implied_heights.keys():
+        coords_and_dims.append(
+            (DimCoord(_stashcode_implied_heights[str(stash)],
+                      standard_name='height', units='m',
+                      attributes={'positive': 'up'}),
+             None))
 
     if \
             (len(lbcode) != 5) and \

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
@@ -46,7 +46,7 @@ def _lbcode(value=None, ix=None, iy=None):
 
 class TestLBVC001_Height(TestField):
     def _check_height(self, blev, stash,
-                      expect_normal=True, expect_fixed=False):
+                      expect_normal=True, expect_fixed_height=None):
         lbvc = 1
         lbcode = _lbcode(0)  # effectively unused in this case
         lblev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
@@ -60,10 +60,10 @@ class TestLBVC001_Height(TestField):
                 (DimCoord(blev, standard_name='height', units='m',
                           attributes={'positive': 'up'}),
                  None)]
-        elif expect_fixed:
+        elif expect_fixed_height:
             expect_result = [
-                (DimCoord([1.5], standard_name='height', units='m',
-                          attributes={'positive': 'up'}),
+                (DimCoord([expect_fixed_height], standard_name='height',
+                          units='m', attributes={'positive': 'up'}),
                  None)]
         else:
             expect_result = []
@@ -77,9 +77,13 @@ class TestLBVC001_Height(TestField):
         self._check_height(blev=-1, stash=STASH(1, 1, 1),
                            expect_normal=False)
 
-    def test_implied_height(self):
+    def test_implied_height_1m5(self):
         self._check_height(blev=75.2, stash=STASH(1, 3, 236),
-                           expect_normal=False, expect_fixed=True)
+                           expect_normal=False, expect_fixed_height=1.5)
+
+    def test_implied_height_10m(self):
+        self._check_height(blev=75.2, stash=STASH(1, 3, 225),
+                           expect_normal=False, expect_fixed_height=10.0)
 
 
 class TestLBVC002_Depth(TestField):


### PR DESCRIPTION
There are other '10m stashcodes', but these 3 are specifically requested for the present.
New support mechanism integrates the existing 1.5m cases.
