### PR TITLE
Treat um fields with BPLAT=90, BPLON=180 as unrotated.

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1254,12 +1254,31 @@ class PPField(object):
         """Return a CoordSystem for this PPField.
 
         Returns:
-            Currently, a :class:`~iris.coord_systems.GeogCS` or :class:`~iris.coord_systems.RotatedGeogCS`.
+            Currently, a :class:`~iris.coord_systems.GeogCS` or
+            :class:`~iris.coord_systems.RotatedGeogCS`.
 
         """
-        geog_cs =  iris.coord_systems.GeogCS(EARTH_RADIUS)
-        if self.bplat != 90.0 or self.bplon != 0.0:
-            geog_cs = iris.coord_systems.RotatedGeogCS(self.bplat, self.bplon, ellipsoid=geog_cs)
+        geog_cs = iris.coord_systems.GeogCS(EARTH_RADIUS)
+
+        def degrees_ne(angle, ref_angle):
+            """
+            Return whether an angle differs significantly from a set value.
+
+            The inputs are in degrees.
+            The difference is judged significant if more than 0.0001 degrees.
+
+            """
+            return abs(angle - ref_angle) > 0.0001
+
+        if (degrees_ne(self.bplat, 90.0) or (degrees_ne(self.bplon, 0.0) and
+                                             degrees_ne(self.bplon, 180.0))):
+            # NOTE: when bplat,bplon=90,0 this encodes an unrotated system.
+            # However, the rotated system which is *equivalent* to an unrotated
+            # one actually has blat,bplon=90,180, due to a quirk in the
+            # definition equations.
+            # So we accept BPLON of 0 *or* 180 to mean 'unrotated'.
+            geog_cs = iris.coord_systems.RotatedGeogCS(
+                self.bplat, self.bplon, ellipsoid=geog_cs)
 
         return geog_cs
 


### PR DESCRIPTION
Sample UM data from a mesoscale model was encountered with header values BPLAT=90 , BPLON=180.
This data then loads with a rotated pole coordinate system.
In fact, though, a rotated pole system with these settings is *identical* to normal plain lat-lon coordinates (unrotated).

A user complained that when this data was loaded in Iris and saved as GRIB, the resulting grid template was not as expected.
**This change allows Iris to recognise that this kind of data is 'unrotated'.**

Presumably the source of this data produces ouput in an arbitrary rotated system, of which this is the "degenerate case".  This only causes problems because of an oddity in the UM fields encoding :
For some odd reason (presumably historical), the UM fields use BPLAT,BPLON=90,0 as a signature meaning 'unrotated', despite the fact that an *actual* rotated-pole system with these settings (at least in the current definition) is *not* the same as a simple latlon system, but instead one whose longitudes are 180 degrees rotated.
