### PR TITLE
Explicitly set version of gribapi in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - conda install pep8
   - conda install sphinx
   # Optional iris dependencies
-  - conda install ecmwf_grib
+  - conda install ecmwf_grib=1.9.16
   - conda install gdal
   - conda install libmo_unpack
   - conda install pandas=0.12.0


### PR DESCRIPTION
Explicitly set version of gribapi for Conda to install on Travis to v1.9.16. This will ease the process of adding a conda recipe for v1.12.1 to binstar.org/SciTools without the risk of conda retrieving the wrong version and so causing a number of test failures on Travis.
