### PR TITLE
BUG: Fixed varname setting in aux con.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1159,6 +1159,7 @@ fc_extras
             coord = iris.coords.AuxCoord(points_data,
                                          standard_name=standard_name,
                                          long_name=long_name,
+                                         var_name=var_name,
                                          units=attr_units,
                                          bounds=bounds_data,
                                          attributes=attributes,

--- a/lib/iris/tests/results/netcdf/netcdf_monotonic.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_monotonic.cml
@@ -12,7 +12,7 @@
         <dimCoord id="566c7ff8" points="[10, 20, 30]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="int32" var_name="lon"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="2fd50af3" points="[1, 100, 3]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int32"/>
+        <auxCoord id="2fd50af3" points="[1, 100, 3]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int32" var_name="time3"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -48,7 +48,7 @@
         <dimCoord id="566c7ff8" points="[10, 20, 30]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="int32" var_name="lon"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="2fd50af3" points="[1, 1, 2]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int32"/>
+        <auxCoord id="2fd50af3" points="[1, 1, 2]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int32" var_name="time1"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -24,15 +24,17 @@ fc_rules_cf_fc.build_dimension_coordinate`.
 # importing anything else
 import iris.tests as tests
 
+import warnings
+
 import numpy as np
 import mock
 
-from iris.coords import DimCoord
+from iris.coords import AuxCoord, DimCoord
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_dimension_coordinate
 
 
-class TestBoundsVertexDim(tests.IrisTest):
+class _CommonMockTemplate(tests.IrisTest):
     def setUp(self):
         # Create coordinate cf variables and pyke engine.
         points = np.arange(6)
@@ -64,6 +66,75 @@ class TestBoundsVertexDim(tests.IrisTest):
             'iris.fileformats._pyke_rules.compiled_krb.'
             'fc_rules_cf_fc.deferred_load', new=deferred_load)
 
+
+class TestCoordConstruction(_CommonMockTemplate):
+    # Ensure that the coordinates constructed have all the relevant cf
+    # attributes populated.
+    def test_dim_coord_construction(self):
+        bounds = np.arange(12).reshape(6, 2)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('x', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = DimCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+
+        # Asserts must lie within context manager because of deferred loading.
+        with self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_dimension_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_dim_coord.assert_called_with(
+                expected_coord, [0])
+
+    def test_aux_coord_construction(self):
+        # Use non monotonically increasing coordinates to force aux coord
+        # construction.
+        points = np.array([1, 3, 2, 4, 6, 5])
+        self.cf_coord_var.__getitem__ = lambda self, key: points[key]
+        bounds = np.arange(12).reshape(6, 2)
+        self.cf_bounds_var = mock.Mock(
+            dimensions=('x', 'nv'),
+            cf_name='wibble_bnds',
+            shape=bounds.shape,
+            __getitem__=lambda self, key: bounds[key])
+
+        expected_coord = AuxCoord(
+            self.cf_coord_var[:],
+            long_name=self.cf_coord_var.long_name,
+            var_name=self.cf_coord_var.cf_name,
+            units=self.cf_coord_var.units,
+            bounds=bounds)
+
+        get_cf_bounds_var_patch = mock.patch(
+            'iris.fileformats._pyke_rules.compiled_krb.'
+            'fc_rules_cf_fc.get_cf_bounds_var',
+            return_value=self.cf_bounds_var)
+        warning_patch = mock.patch('warnings.warn')
+
+        # Asserts must lie within context manager because of deferred loading.
+        with warning_patch, self.deferred_load_patch, get_cf_bounds_var_patch:
+            build_dimension_coordinate(self.engine, self.cf_coord_var)
+
+            # Test that expected coord is built and added to cube.
+            self.engine.cube.add_aux_coord.assert_called_with(
+                expected_coord, [0])
+            self.assertIn("creating 'wibble' auxiliary coordinate instead",
+                          warnings.warn.call_args[0][0])
+
+
+class TestBoundsVertexDim(_CommonMockTemplate):
     def test_slowest_varying_vertex_dim(self):
         # Create the bounds cf variable.
         bounds = np.arange(12).reshape(2, 6)


### PR DESCRIPTION
Missing varname when constructing an AuxCoord from `build_dimension_coordinate` within the pyke rules (NetCDF load).
