### PR TITLE
BUG: Do not filter surface altitude/pressure fields

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1678,6 +1678,9 @@ def reset_save_rules():
     _save_rules = None
 
 
+_STASH_ALLOW = [STASH(1, 0, 33), STASH(1, 0, 1)]
+
+
 def _convert_constraints(constraints):
     """
     Converts known constraints from Iris semantics to PP semantics
@@ -1699,7 +1702,7 @@ def _convert_constraints(constraints):
             ## only keep the pp constraints set if they are all handled as
             ## pp constraints
             unhandled_constraints = True
-                
+ 
     def pp_filter(field):
         """
         return True if field is to be kept,
@@ -1708,7 +1711,8 @@ def _convert_constraints(constraints):
         """
         res = True
         if pp_constraints.get('stash'):
-            if field.stash not in pp_constraints['stash']:
+            if (field.stash not in _STASH_ALLOW and field.stash not in
+                    pp_constraints['stash']):
                 res = False
         return res
 

--- a/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
@@ -28,11 +28,26 @@ from iris.fileformats.pp import STASH
 
 
 class Test_convert_constraints(tests.IrisTest):
-    def test_single_stash(self):
-        stcube = mock.Mock(stash=STASH.from_msi('m01s03i236'))
+    def _single_stash(self):
         constraint = iris.AttributeConstraint(STASH='m01s03i236')
-        pp_filter = _convert_constraints(constraint)
+        return _convert_constraints(constraint)
+
+    def test_single_stash(self):
+        pp_filter = self._single_stash()
+        stcube = mock.Mock(stash=STASH.from_msi('m01s03i236'))
         self.assertTrue(pp_filter(stcube))
+
+    def test_surface_altitude(self):
+        # Ensure that surface altitude fields are not filtered.
+        pp_filter = self._single_stash()
+        orography_cube = mock.Mock(stash=STASH.from_msi('m01s00i033'))
+        self.assertTrue(pp_filter(orography_cube))
+
+    def test_surface_pressure(self):
+        # Ensure that surface pressure fields are not filtered.
+        pp_filter = self._single_stash()
+        pressure_cube = mock.Mock(stash=STASH.from_msi('m01s00i001'))
+        self.assertTrue(pp_filter(pressure_cube))
 
     def test_double_stash(self):
         stcube236 = mock.Mock(stash=STASH.from_msi('m01s03i236'))


### PR DESCRIPTION
Currently, surface altitude and surface pressure pp fields will be thrown away if specifying a stash constraint (unless including the reference fields stash code also).  This is a change in behaviour from before the pp load optimisation work took place which translated iris constraints to lower level pp constraints (stash only constraint).  Context: https://github.com/SciTools/iris/pull/1243

``` Python
phenom = 'phenom.pp'
orography = 'orography.pp'

stash_constraint = iris.AttributeConstraint(STASH='m01s00i010')
cube = iris.load_cube([um_dat, orography_dat], stash_constraint)
```

The resulting cube has no surface altitude coordinate.

Workaround:

``` Python
cube, _ = iris.load_cubes([um_dat, orography_dat], [stash_constraint, 'surface_altitude'])
```

The bugfix in this PR is applicable to both surface altitude and surface pressure fields.
