### PR TITLE
Fix Cube.intersection() for descending bounds.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2184,8 +2184,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 indices = inside_indices[split_cell_indices]
                 cells = bounds[indices]
                 cells_delta = np.diff(coord.bounds[indices])
-                cells[:, 0] = cells[:, 1] - cells_delta[:, 0]
-                minimum = np.min(cells[:, 0])
+                # Watch out for ascending/descending bounds
+                if cells_delta[0, 0] > 0:
+                    cells[:, 0] = cells[:, 1] - cells_delta[:, 0]
+                    minimum = np.min(cells[:, 0])
+                else:
+                    cells[:, 1] = cells[:, 0] + cells_delta[:, 0]
+                    minimum = np.min(cells[:, 1])
                 bounds = wrap_lons(coord.bounds, minimum, modulus)
             points = wrap_lons(coord.points, minimum, modulus)
         else:

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -844,6 +844,26 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
         self.assertEqual(result.data[0, 0, 0], 350)
         self.assertEqual(result.data[0, 0, -1], 10)
 
+    def test_decrementing(self):
+        cube = create_cube(360, 0, bounds=True)
+        result = cube.intersection(longitude=(40, 60))
+        self.assertArrayEqual(result.coord('longitude').bounds[0],
+                              [60.5, 59.5])
+        self.assertArrayEqual(result.coord('longitude').bounds[-1],
+                              [40.5, 39.5])
+        self.assertEqual(result.data[0, 0, 0], 300)
+        self.assertEqual(result.data[0, 0, -1], 320)
+
+    def test_decrementing_wrapped(self):
+        cube = create_cube(360, 0, bounds=True)
+        result = cube.intersection(longitude=(-10, 10))
+        self.assertArrayEqual(result.coord('longitude').bounds[0],
+                              [10.5, 9.5])
+        self.assertArrayEqual(result.coord('longitude').bounds[-1],
+                              [-9.5, -10.5])
+        self.assertEqual(result.data[0, 0, 0], 350)
+        self.assertEqual(result.data[0, 0, -1], 10)
+
 
 def unrolled_cube():
     data = np.arange(5, dtype='f4')


### PR DESCRIPTION
This fixes an bug in Cube.intersection() where it fails to operate on a monotonically descending bounded coordinate.

For background, see this [Google groups posting](https://groups.google.com/d/msg/scitools-iris/jq6mEn32QQo/unzl3MYS8bgJ) from pbentley and his corresponding [gist](https://gist.github.com/rockdoc/9cb41bbf85fed08fe42b).
