### PR TITLE
Removed patch awareness from grib save test

### DIFF
--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -85,22 +85,11 @@ class TestLoadSave(tests.IrisTest):
 
     def test_time_mean(self):
         # This test for time-mean fields also tests negative forecast time.
-        # Because the results depend on the presence of our api patch,
-        # we currently have results for both a patched and unpatched api.
-        # If the api ever allows -ve ft, we should revert to a single result.
         source_grib = tests.get_data_path(("GRIB", "time_processed",
                                            "time_bound.grib2"))
         reference_text = tests.get_result_path(("grib_save",
                                                 "time_mean.grib_compare.txt"))
-        # TODO: It's not ideal to have grib patch awareness here...
-        import unittest
-        try:
-            self.save_and_compare(source_grib, reference_text)
-        except unittest.TestCase.failureException:
-            reference_text = tests.get_result_path((
-                                        "grib_save",
-                                        "time_mean.grib_compare.FT_PATCH.txt"))
-            self.save_and_compare(source_grib, reference_text)
+        self.save_and_compare(source_grib, reference_text)
 
 
 @tests.skip_data


### PR DESCRIPTION
There is such a thing as a hindcast, which is effectively a negative forecast. This description is especially accurate in terms of the value of the hindcast's "forecast reference time". As such, the forecast time can be a negative number, which causes a problem in GRIB, which does not deal with negative numbers meaning that any hindcast reference times would overflow to become very large positive integers, to be re-interpreted as a negative number by a 3rd-party library (such as Iris) on GRIB file load.

Initially Iris worked around this issue by patching part of gribapi so that the `forecastTime` key was cast as a signed int rather than an unsigned int. However the scope of deployment of this patched version of gribapi was inevitably limited, so the `iris.tests.test_grib_save` needed to be aware of both versions of gribapi (unpatched and patched).

However, for reasons as mentioned above (scope of patch availability), a hindcast workaround was added to `iris.fileformats.grib` and referenced by both the Iris GRIB load and save rules. This mean a GRIB file containing hindcast data could always be loaded into Iris without the presence of the gribapi patch. Further, this loaded cube would have the appropriate negative forecast time and could then also be saved to GRIB again without any change to the `forecastTime` key after the load-save round trip.

At approximately the same time the local-scope gribapi patch was removed so that no Iris users would be using a patched version of gribapi, but the patch awareness in the grib save test was not removed (see #308) and has remained there since. 

As such, the very long description above serves as a justification for the prior presence of the patch-aware test and the removal of it in this pull request; a removal motivated by changing the patch-aware test in #1250.

**TL;DR** - the test patch removed here is obsolete, so we don't need it any more.
