### PR TITLE
Added likely location of test images to git ignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ lib/iris/std_names.py
 
 # Iris test result files
 lib/iris/tests/result_image_comparison/
+iris_image_test_output/
 
 # Pydev/Eclipse files
 .project


### PR DESCRIPTION
I'm hitting a scenario where running tests creates a directory called `iris_image_test_output` in the directory I run the tests from, which is mostly the iris source directory. I guess this shouldn't happen because the preferred location (and the one already ignored) is writeable, but for some reason `os.access()` doesn't think so (perhaps something weird with NFS setup). Anyway, this seemed like the most obvious shortest path to resolving this annoyance while I get on with other tasks!
