### PR TITLE
Optimisation of iris.analysis.cartography._quadrant_area

### DIFF
--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -250,6 +250,9 @@ def _quadrant_area(radian_colat_bounds, radian_lon_bounds, radius_of_earth):
     The resulting array will have a shape of
     *(radian_colat_bounds.shape[0], radian_lon_bounds.shape[0])*
 
+    The calculations are done at 64 bit precision and the returned array
+    will be of type numpy.float64.
+
     """
     # ensure pairs of bounds
     if (radian_colat_bounds.shape[-1] != 2 or
@@ -260,16 +263,14 @@ def _quadrant_area(radian_colat_bounds, radian_lon_bounds, radius_of_earth):
 
     # fill in a new array of areas
     radius_sqr = radius_of_earth ** 2
-    areas = np.ndarray((radian_colat_bounds.shape[0],
-                        radian_lon_bounds.shape[0]))
-    # we use abs because backwards bounds (min > max) give negative areas.
-    for j in range(radian_colat_bounds.shape[0]):
-        areas[j, :] = [(radius_sqr * math.cos(radian_colat_bounds[j, 0]) *
-                       (radian_lon_bounds[i, 1] - radian_lon_bounds[i, 0])) -
-                       (radius_sqr * math.cos(radian_colat_bounds[j, 1]) *
-                        (radian_lon_bounds[i, 1] - radian_lon_bounds[i, 0]))
-                       for i in range(radian_lon_bounds.shape[0])]
+    radian_colat_64 = radian_colat_bounds.astype(np.float64)
+    radian_lon_64 = radian_lon_bounds.astype(np.float64)
 
+    ylen = np.cos(radian_colat_64[:, 0]) - np.cos(radian_colat_64[:, 1])
+    xlen = radian_lon_64[:, 1] - radian_lon_64[:, 0]
+    areas = radius_sqr * np.outer(ylen, xlen)
+
+    # we use abs because backwards bounds (min > max) give negative areas.
     return np.abs(areas)
 
 

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -672,46 +672,6 @@ class TestAreaWeights(tests.IrisTest):
         self.assertCML(small_cube, ('analysis', 'areaweights_original.cml'),
                        checksum=False)
 
-    def test_quadrant_area(self):
-
-        degrees = iris.unit.Unit("degrees")
-        radians = iris.unit.Unit("radians")
-
-        def lon2radlon(lons):
-            return [degrees.convert(lon, radians) for lon in lons]
-
-        def lat2radcolat(lats):
-            return [degrees.convert(lat + 90, radians) for lat in lats]
-
-        lats = np.array([lat2radcolat([-80, -70])])
-        lons = np.array([lon2radlon([0, 10])])
-        area = iris.analysis.cartography._quadrant_area(lats, lons, iris.analysis.cartography.DEFAULT_SPHERICAL_EARTH_RADIUS)
-        self.assertAlmostEquals(area, [[319251845980.763671875]])
-
-        lats = np.array([lat2radcolat([0, 10])])
-        lons = np.array([lon2radlon([0, 10])])
-        area = iris.analysis.cartography._quadrant_area(lats, lons, iris.analysis.cartography.DEFAULT_SPHERICAL_EARTH_RADIUS)
-        self.assertAlmostEquals(area, [[1228800593851.443115234375]])
-
-        lats = np.array([lat2radcolat([10, 0])])
-        lons = np.array([lon2radlon([0, 10])])
-        area = iris.analysis.cartography._quadrant_area(lats, lons, iris.analysis.cartography.DEFAULT_SPHERICAL_EARTH_RADIUS)
-        self.assertAlmostEquals(area, [[1228800593851.443115234375]])
-
-        lats = np.array([lat2radcolat([70, 80])])
-        lons = np.array([lon2radlon([0, 10])])
-        area = iris.analysis.cartography._quadrant_area(lats, lons, iris.analysis.cartography.DEFAULT_SPHERICAL_EARTH_RADIUS)
-        self.assertAlmostEquals(area, [[319251845980.7646484375]])
-
-        lats = np.array([lat2radcolat([-80, -70]), lat2radcolat([0, 10]), lat2radcolat([70, 80])])
-        lons = np.array([lon2radlon([0, 10])])
-        area = iris.analysis.cartography._quadrant_area(lats, lons, iris.analysis.cartography.DEFAULT_SPHERICAL_EARTH_RADIUS)
-
-        self.assertAlmostEquals(area[0], [319251845980.763671875])
-        self.assertAlmostEquals(area[1], [1228800593851.443115234375])
-        self.assertAlmostEquals(area[2], [319251845980.7646484375])
-
-
 class TestAreaWeightGeneration(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
+++ b/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
@@ -1,0 +1,114 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for the `iris.analysis.cartography._quadrant_area` function"""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.analysis.cartography import _quadrant_area
+from iris.analysis.cartography import DEFAULT_SPHERICAL_EARTH_RADIUS
+
+
+class TestExampleCases(tests.IrisTest):
+
+    def _radian_bounds(self, coord_list, offset=0):
+        bound_deg = np.array(coord_list) + offset
+        bound_deg = np.atleast_2d(bound_deg)
+        degrees = iris.unit.Unit("degrees")
+        radians = iris.unit.Unit("radians")
+        return degrees.convert(bound_deg, radians)
+
+    def _as_bounded_coords(self, lats, lons):
+        return (self._radian_bounds(lats, offset=90),
+                self._radian_bounds(lons))
+
+    def test_area_in_north(self):
+        lats, lons = self._as_bounded_coords([0, 10], [0, 10])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, [[1228800593851.443115234375]])
+
+    def test_area_in_far_north(self):
+        lats, lons = self._as_bounded_coords([70, 80], [0, 10])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, [[319251845980.7646484375]])
+
+    def test_area_in_far_south(self):
+        lats, lons = self._as_bounded_coords([-80, -70], [0, 10])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, [[319251845980.763671875]])
+
+    def test_area_in_north_with_reversed_lats(self):
+        lats, lons = self._as_bounded_coords([10, 0], [0, 10])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, [[1228800593851.443115234375]])
+
+    def test_area_multiple_lats(self):
+        lats, lons = self._as_bounded_coords([[-80, -70], [0, 10], [70, 80]],
+                                             [0, 10])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+
+        self.assertArrayAllClose(area, [[319251845980.763671875],
+                                        [1228800593851.443115234375],
+                                        [319251845980.7646484375]])
+
+    def test_area_multiple_lats_and_lons(self):
+        lats, lons = self._as_bounded_coords([[-80, -70], [0, 10], [70, 80]],
+                                             [[0, 10], [10, 30]])
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+
+        self.assertArrayAllClose(area, [[3.19251846e+11, 6.38503692e+11],
+                                        [1.22880059e+12, 2.45760119e+12],
+                                        [3.19251846e+11, 6.38503692e+11]])
+
+
+class TestErrorHandling(tests.IrisTest):
+
+    def test_lat_bounds_1d_error(self):
+        self._assert_error_on_malformed_bounds(
+            [0, 10],
+            [[0, 10]])
+
+    def test_lon_bounds_1d_error(self):
+        self._assert_error_on_malformed_bounds(
+            [[0, 10]],
+            [0, 10])
+
+    def test_too_many_lat_bounds_error(self):
+        self._assert_error_on_malformed_bounds(
+            [[0, 10, 20]],
+            [[0, 10]])
+
+    def test_too_many_lon_bounds_error(self):
+        self._assert_error_on_malformed_bounds(
+            [[0, 10]],
+            [[0, 10, 20]])
+
+    def _assert_error_on_malformed_bounds(self, lat_bnds, lon_bnds):
+        with self.assertRaisesRegexp(ValueError,
+                                     'Bounds must be \[n,2\] array'):
+            _quadrant_area(np.array(lat_bnds),
+                           np.array(lon_bnds),
+                           1.)
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Hello,

this isn't really ready for a pull, but I figured it may as well start a pull request.  Could you advise me what needs doing to get this into an acceptable form.

I'm regridding some large (30 second global) data sets using area weighted regridding.  Profiling I noticed quite a bit of time was being spent in _quadrant_area.  I've refactored this routine to use numpy array operations rather than the explicit loops. 

Some sample timeit code and results can be found in the gist: https://gist.github.com/jkettleb/eee213e66b71679c9907.  I think this speed up is worth having - do you agree?  Or are there other factors I need to worry about?  I also, for now, seperated out some tests of _quadrant_area into a stand alone module (it just meant I could run the regression on the unit frequently).  I also changed the assertion to an assert_allclose and added an extra test (to make sure I really was doing the right thing). I can't think of any more obvious test cases - but let me know if you think there are any.

Here's what I think I need to do - but please correct/add as necessary.
1. remove routine _areas_by_loop
2. inline routine _areas_by_products
3. inline the test code (or should this go more into the unittests?)

Thanks for any help you can give over this.  If its easiest I can come and chat to someone.
