### PR TITLE
Add `--repo` option to testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
   - python setup.py --with-unpack install
 
 script:
-  - python -m iris.tests.runner --example-tests
+  - python -m iris.tests.runner --example-tests --repo-dir=`pwd`
 
   - cd $(pwd)/docs/iris
 # Make html produces an error when run on Travis that does not affect any downstream functionality but causes the build to fail spuriously.

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -39,6 +39,8 @@ class TestRunner():
         ('example-tests', 'e', 'Also run the example code tests.'),
         ('num-processors=', 'p', 'The number of processors used for running '
                                  'the tests.'),
+        ('repo-dir=', 'r', 'The location of the git repository for the '
+                           'iris source code.'),
     ]
     boolean_options = ['no-data', 'system-tests', 'stop', 'example-tests']
 
@@ -48,6 +50,7 @@ class TestRunner():
         self.stop = False
         self.example_tests = False
         self.num_processors = None
+        self.repo_dir = None
 
     def finalize_options(self):
         if self.no_data:
@@ -98,6 +101,11 @@ class TestRunner():
         if self.stop:
             args.append('--stop')
 
+        env = None
+        if self.repo_dir:
+            env = os.environ.copy()
+            env['IRIS_REPO_DIR'] = self.repo_dir
+
         result = True
         for test in tests:
             args[1] = test
@@ -107,6 +115,6 @@ class TestRunner():
             # run the tests at module level i.e. my_module.tests
             # - test must start with test/Test and must not contain the
             #   word Mixin.
-            result &= nose.run(argv=args)
+            result &= nose.run(argv=args, env=env)
         if result is False:
             exit(1)

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -57,6 +57,7 @@ LICENSE_RE = re.compile(LICENSE_RE_PATTERN, re.MULTILINE)
 # Python finding the iris package via a symlink.
 IRIS_DIR = os.path.realpath(os.path.dirname(iris.__file__))
 REPO_DIR = os.path.dirname(os.path.dirname(IRIS_DIR))
+REPO_DIR = os.environ.get('IRIS_REPO_DIR', REPO_DIR)
 DOCS_DIR = os.path.join(REPO_DIR, 'docs', 'iris')
 DOCS_DIR = iris.config.get_option('Resources', 'doc_dir', default=DOCS_DIR)
 exclusion = ['Makefile', 'build']


### PR DESCRIPTION
Allows the specification of the git repo location so the licence header checks can be run.
