### PR TITLE
Use array's copy method instead of copy.copy().

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2582,7 +2582,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # of deepcopy on 0-d arrays.
                 new_cube_data = np.asanyarray(self.data)
             else:
-                new_cube_data = copy.copy(self._my_data)
+                if isinstance(self._my_data, biggus.Array):
+                    new_cube_data = copy.copy(self._my_data)
+                else:
+                    new_cube_data = self._my_data.copy()
         else:
             if not isinstance(data, biggus.Array):
                 data = np.asanyarray(data)

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1078,5 +1078,15 @@ class Test_regrid(tests.IrisTest):
         self.assertEqual(result, (scheme, cube, mock.sentinel.TARGET, cube))
 
 
+class Test_copy(tests.IrisTest):
+
+    def test(self):
+        cube = stock.simple_3d_mask()
+        cube_copy = cube.copy()
+        self.assertNotEqual(id(cube), id(cube_copy))
+        self.assertNotEqual(id(cube.data), id(cube_copy.data))
+        self.assertNotEqual(id(cube.data.mask), id(cube_copy.data.mask))
+
+
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
This PR makes the switch to using the `copy()` method of data arrays instead of using `copy.copy()` when performing a copy of a cube. See [this Google Groups thread](https://groups.google.com/forum/?fromgroups#!topic/scitools-iris/kwvKhIYcpfg) for more information.

I'm not entirely sure this is the right thing to do, thoughts welcome.
