### PR TITLE
MAINT: Slight refactor.

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -35,6 +35,12 @@ import iris.cube
 import iris.unit
 
 
+_Version = collections.namedtuple('Version',
+                                  ('major', 'minor', 'micro'))
+_NP_VERSION = _Version(*(int(val) for val in
+                         np.version.version.split('.')))
+
+
 def _snapshot_grid(cube):
     """
     Helper function that returns deep copies of lateral dimension coordinates
@@ -1018,11 +1024,7 @@ def _regrid_area_weighted_array(src_data, x_dim, y_dim,
                 # Numpy 1.7 allows the axis keyword arg to be a tuple.
                 # If the version of NumPy is less than 1.7 manipulate the axes
                 # of the data so the x and y dimensions can be flattened.
-                Version = collections.namedtuple('Version',
-                                                 ('major', 'minor', 'micro'))
-                np_version = Version(*(int(val) for val in
-                                       np.version.version.split('.')))
-                if np_version.minor < 7:
+                if _NP_VERSION.minor < 7:
                     if y_dim is not None and x_dim is not None:
                         flattened_shape = list(data.shape)
                         if y_dim > x_dim:


### PR DESCRIPTION
Significant impact on performance due to namedtuple class construction.

http://nbviewer.ipython.org/urls/gist.githubusercontent.com/cpelley/1269dc60c41944d9c504/raw/ab229432ba73b617744339222245334f26494a8d/regrid_performance.ipynb

Currently can cause up to %135 increase in the time it takes to regrid due to redundant namedtuple construction! (restricted to the simpler case where the array is not masked and mdtol=1).  For the case where we deal with masked arrays, nametuple construction accounts for ~23% of the total regrid!  Either way, this is an unnecessary redundancy.

I appreciate that I should really point this to v1.7.x however I would like to have the changes available from master available to me including this one.  Would it be ok for me to make a duplicate PR pointing to v1.7.x to keep everyone happy?
