### PR TITLE
Use array's copy method instead of copy.copy().

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2526,7 +2526,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # of deepcopy on 0-d arrays.
                 new_cube_data = np.asanyarray(self.data)
             else:
-                new_cube_data = copy.copy(self._my_data)
+                try:
+                    new_cube_data = self._my_data.copy()
+                except AttributeError:
+                    new_cube_data = copy.copy(self._my_data)
         else:
             if not isinstance(data, biggus.Array):
                 data = np.asanyarray(data)

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -946,5 +946,15 @@ class Test_regrid(tests.IrisTest):
         self.assertEqual(result, (scheme, cube, mock.sentinel.TARGET, cube))
 
 
+class Test_copy(tests.IrisTest):
+
+    def test(self):
+        cube = stock.simple_3d_mask()
+        cube_copy = cube.copy()
+        self.assertNotEqual(id(cube), id(cube_copy))
+        self.assertNotEqual(id(cube.data), id(cube_copy.data))
+        self.assertNotEqual(id(cube.data.mask), id(cube_copy.data.mask))
+
+
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
[version of #1331 with target v1.7.x]

This PR makes the switch to using the copy() method of data arrays instead of using copy.copy() when performing a copy of a cube. See this Google Groups thread for more information.
