### PR TITLE
Remove last usage of duplicate test data file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="3378fe68c00ca7f31895ab6630a59a39ccef94e3"
+  - export IRIS_TEST_DATA_REF="dc405c98f45b9d5fdc753b4a01cd501a2d82165b"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="1ed3e26606366717e2053bacc12bf5e8d8fa2704"

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -268,7 +268,7 @@ class TestPPFileExtraXData(IrisPPTest):
 @tests.skip_data
 class TestPPFileWithExtraCharacterData(IrisPPTest):
     def setUp(self):
-        self.original_pp_filepath = tests.get_data_path(('PP', 'model_comp', 'dec_subset.pp'))
+        self.original_pp_filepath = tests.get_data_path(('PP', 'globClim1', 'dec_subset.pp'))
         self.r = pp.load(self.original_pp_filepath)
         self.r_loaded_data = pp.load(self.original_pp_filepath, read_data=True)
         


### PR DESCRIPTION
This means the iris-test-data tarball can be a little smaller.

See #1244.
