### PR TITLE
Correction to MDI handling.

### DIFF
--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
@@ -26,7 +26,7 @@ import datetime
 
 import mock
 
-from iris.fileformats.grib._load_convert import _GRIBAPI_MDI_UNSIGNED as MDI
+from iris.fileformats.grib._load_convert import _MDI as MDI
 
 from iris.fileformats.grib._load_convert import data_cutoff
 

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
@@ -32,7 +32,7 @@ from iris.fileformats.grib._load_convert import vertical_coords
 
 from iris.fileformats.grib._load_convert import \
     _FIXED_SURFACE_MISSING as MISSING_SURFACE, \
-    _GRIBAPI_MDI_SIGNED as MISSING_LEVEL
+    _MDI as MISSING_LEVEL
 
 
 class Test(tests.IrisTest):


### PR DESCRIPTION
Thanks to @bjlittle reporting some unexpected behaviour, further investigation into the handling of missing values by the ECMWF GRIB API has highlighted a misunderstanding:
- Keys with signed values return 2**32-1, and **not** -(2**31-1) as previously thought.

Happily, this makes things simpler. \o/
