### PR TITLE
Standardize Cartopy CRS imports.

### DIFF
--- a/docs/iris/src/whatsnew/1.0.rst
+++ b/docs/iris/src/whatsnew/1.0.rst
@@ -280,15 +280,15 @@ This functionality is provided by :func:`iris.analysis.cartography.project()`.
 For example::
 
     import iris
-    import cartopy
+    import cartopy.crs as ccrs
     import matplotlib.pyplot as plt
 
     # Load data
     cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
 
     # Transform cube to target projection
-    target_proj = cartopy.crs.RotatedPole(pole_longitude=177.5,
-                                          pole_latitude=37.5)
+    target_proj = ccrs.RotatedPole(pole_longitude=177.5,
+                                   pole_latitude=37.5)
     new_cube, extent = iris.analysis.cartography.project(cube, target_proj)
 
     # Plot

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -23,7 +23,7 @@ from __future__ import division
 from abc import ABCMeta, abstractmethod
 import warnings
 
-import cartopy.crs
+import cartopy.crs as ccrs
 
 
 class CoordSystem(object):
@@ -222,17 +222,17 @@ class GeogCS(CoordSystem):
         return CoordSystem.xml_element(self, doc, attrs)
 
     def as_cartopy_crs(self):
-        return cartopy.crs.Geodetic(self.as_cartopy_globe())
+        return ccrs.Geodetic(self.as_cartopy_globe())
 
     def as_cartopy_projection(self):
-        return cartopy.crs.PlateCarree()
+        return ccrs.PlateCarree()
 
     def as_cartopy_globe(self):
         # Explicitly set `ellipse` to None as a workaround for
         # Cartopy setting WGS84 as the default.
-        return cartopy.crs.Globe(semimajor_axis=self.semi_major_axis,
-                                 semiminor_axis=self.semi_minor_axis,
-                                 ellipse=None)
+        return ccrs.Globe(semimajor_axis=self.semi_major_axis,
+                          semiminor_axis=self.semi_minor_axis,
+                          ellipse=None)
 
 
 class RotatedGeogCS(CoordSystem):
@@ -314,12 +314,12 @@ class RotatedGeogCS(CoordSystem):
         return CoordSystem.xml_element(self, doc, self._pretty_attrs())
 
     def as_cartopy_crs(self):
-        return cartopy.crs.RotatedGeodetic(self.grid_north_pole_longitude,
-                                           self.grid_north_pole_latitude)
+        return ccrs.RotatedGeodetic(self.grid_north_pole_longitude,
+                                    self.grid_north_pole_latitude)
 
     def as_cartopy_projection(self):
-        return cartopy.crs.RotatedPole(self.grid_north_pole_longitude,
-                                       self.grid_north_pole_latitude)
+        return ccrs.RotatedPole(self.grid_north_pole_longitude,
+                                self.grid_north_pole_latitude)
 
 
 class TransverseMercator(CoordSystem):
@@ -405,7 +405,7 @@ class TransverseMercator(CoordSystem):
         else:
             globe = None
 
-        return cartopy.crs.TransverseMercator(
+        return ccrs.TransverseMercator(
             central_longitude=self.longitude_of_central_meridian,
             central_latitude=self.latitude_of_projection_origin,
             false_easting=self.false_easting,
@@ -425,10 +425,10 @@ class OSGB(TransverseMercator):
                                     GeogCS(6377563.396, 6356256.909))
 
     def as_cartopy_crs(self):
-        return cartopy.crs.OSGB()
+        return ccrs.OSGB()
 
     def as_cartopy_projection(self):
-        return cartopy.crs.OSGB()
+        return ccrs.OSGB()
 
 
 class Orthographic(CoordSystem):
@@ -496,12 +496,12 @@ class Orthographic(CoordSystem):
         if self.ellipsoid is not None:
             globe = self.ellipsoid.as_cartopy_globe()
         else:
-            globe = cartopy.crs.Globe()
+            globe = ccrs.Globe()
 
         warnings.warn('Discarding false_easting and false_northing that are '
                       'not used by Cartopy.')
 
-        return cartopy.crs.Orthographic(
+        return ccrs.Orthographic(
             central_longitude=self.longitude_of_projection_origin,
             central_latitude=self.latitude_of_projection_origin,
             globe=globe)
@@ -590,9 +590,9 @@ class VerticalPerspective(CoordSystem):
         if self.ellipsoid is not None:
             globe = self.ellipsoid.as_cartopy_globe()
         else:
-            globe = cartopy.crs.Globe()
+            globe = ccrs.Globe()
 
-        return cartopy.crs.Geostationary(
+        return ccrs.Geostationary(
             central_longitude=self.longitude_of_projection_origin,
             satellite_height=self.perspective_point_height,
             false_easting=self.false_easting,
@@ -673,8 +673,8 @@ class Stereographic(CoordSystem):
         if self.ellipsoid is not None:
             globe = self.ellipsoid.as_cartopy_globe()
         else:
-            globe = cartopy.crs.Globe()
-        return cartopy.crs.Stereographic(
+            globe = ccrs.Globe()
+        return ccrs.Stereographic(
             self.central_lat, self.central_lon,
             self.false_easting, self.false_northing,
             self.true_scale_lat, globe)
@@ -761,9 +761,9 @@ class LambertConformal(CoordSystem):
         if self.ellipsoid is not None:
             globe = self.ellipsoid.as_cartopy_globe()
         else:
-            globe = cartopy.crs.Globe()
+            globe = ccrs.Globe()
 
-        return cartopy.crs.LambertConformal(
+        return ccrs.LambertConformal(
             self.central_lon, self.central_lat,
             self.false_easting, self.false_northing,
             self.secant_latitudes, globe, cutoff)

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -27,7 +27,7 @@ import os
 import warnings
 
 import biggus
-import cartopy
+import cartopy.crs as ccrs
 import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
@@ -592,7 +592,7 @@ class GribWrapper(object):
             x1, y1 = cartopy_crs.transform_point(
                                 self.longitudeOfFirstGridPointInDegrees,
                                 self.latitudeOfFirstGridPointInDegrees,
-                                cartopy.crs.Geodetic())
+                                ccrs.Geodetic())
 
             if not np.all(np.isfinite([x1, y1])):
                 raise TranslationError("Could not determine the first latitude"

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -24,7 +24,7 @@ See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 import collections
 import datetime
 
-import cartopy.crs
+import cartopy.crs as ccrs
 import cartopy.mpl.geoaxes
 import matplotlib.axes
 import matplotlib.collections as mpl_collections
@@ -523,7 +523,7 @@ def _ensure_cartopy_axes_and_determine_kwargs(x_coord, y_coord, kwargs):
     if cs is not None:
         cartopy_proj = cs.as_cartopy_projection()
     else:
-        cartopy_proj = cartopy.crs.PlateCarree()
+        cartopy_proj = ccrs.PlateCarree()
 
     # Ensure the current axes are a cartopy.mpl.GeoAxes instance.
     _replace_axes_with_cartopy_axes(cartopy_proj)

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -23,7 +23,7 @@ import iris.tests as tests
 
 import logging
 
-import cartopy.crs
+import cartopy.crs as ccrs
 import numpy as np
 
 import iris.cube
@@ -182,9 +182,9 @@ class Test_GeogCS_as_cartopy_crs(tests.IrisTest):
     def test_as_cartopy_crs(self):
         cs = GeogCS(6543210, 6500000)
         res = cs.as_cartopy_crs()
-        globe = cartopy.crs.Globe(semimajor_axis=6543210.0,
-                                  semiminor_axis=6500000.0, ellipse=None)
-        expected = cartopy.crs.Geodetic(globe)
+        globe = ccrs.Globe(semimajor_axis=6543210.0,
+                           semiminor_axis=6500000.0, ellipse=None)
+        expected = ccrs.Geodetic(globe)
         self.assertEqual(res, expected)
 
 
@@ -265,14 +265,14 @@ class Test_TransverseMercator_as_cartopy_crs(tests.IrisTest):
             scale_factor_at_central_meridian,
             ellipsoid=ellipsoid)
 
-        expected = cartopy.crs.TransverseMercator(
+        expected = ccrs.TransverseMercator(
             central_longitude=longitude_of_central_meridian,
             central_latitude=latitude_of_projection_origin,
             false_easting=false_easting,
             false_northing=false_northing,
             scale_factor=scale_factor_at_central_meridian,
-            globe=cartopy.crs.Globe(semimajor_axis=6377563.396,
-                                    semiminor_axis=6356256.909, ellipse=None))
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
 
         res = tmerc_cs.as_cartopy_crs()
         self.assertEqual(res, expected)
@@ -296,14 +296,14 @@ class Test_TransverseMercator_as_cartopy_projection(tests.IrisTest):
             scale_factor_at_central_meridian,
             ellipsoid=ellipsoid)
 
-        expected = cartopy.crs.TransverseMercator(
+        expected = ccrs.TransverseMercator(
             central_longitude=longitude_of_central_meridian,
             central_latitude=latitude_of_projection_origin,
             false_easting=false_easting,
             false_northing=false_northing,
             scale_factor=scale_factor_at_central_meridian,
-            globe=cartopy.crs.Globe(semimajor_axis=6377563.396,
-                                    semiminor_axis=6356256.909, ellipse=None))
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
 
         res = tmerc_cs.as_cartopy_projection()
         self.assertEqual(res, expected)

--- a/lib/iris/tests/unit/coord_systems/test_Orthographic.py
+++ b/lib/iris/tests/unit/coord_systems/test_Orthographic.py
@@ -20,7 +20,7 @@
 # importing anything else.
 import iris.tests as tests
 
-import cartopy.crs
+import cartopy.crs as ccrs
 from iris.coord_systems import GeogCS, Orthographic
 
 
@@ -37,10 +37,10 @@ class Test_as_cartopy_crs(tests.IrisTest):
 
     def test_crs_creation(self):
         res = self.ortho_cs.as_cartopy_crs()
-        globe = cartopy.crs.Globe(semimajor_axis=self.semi_major_axis,
-                                  semiminor_axis=self.semi_minor_axis,
-                                  ellipse=None)
-        expected = cartopy.crs.Orthographic(
+        globe = ccrs.Globe(semimajor_axis=self.semi_major_axis,
+                           semiminor_axis=self.semi_minor_axis,
+                           ellipse=None)
+        expected = ccrs.Orthographic(
             self.latitude_of_projection_origin,
             self.longitude_of_projection_origin,
             globe=globe)
@@ -60,10 +60,10 @@ class Test_as_cartopy_projection(tests.IrisTest):
 
     def test_projection_creation(self):
         res = self.ortho_cs.as_cartopy_projection()
-        globe = cartopy.crs.Globe(semimajor_axis=self.semi_major_axis,
-                                  semiminor_axis=self.semi_minor_axis,
-                                  ellipse=None)
-        expected = cartopy.crs.Orthographic(
+        globe = ccrs.Globe(semimajor_axis=self.semi_major_axis,
+                           semiminor_axis=self.semi_minor_axis,
+                           ellipse=None)
+        expected = ccrs.Orthographic(
             self.latitude_of_projection_origin,
             self.longitude_of_projection_origin,
             globe=globe)

--- a/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
+++ b/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
@@ -20,7 +20,7 @@
 # importing anything else.
 import iris.tests as tests
 
-import cartopy.crs
+import cartopy.crs as ccrs
 from iris.coord_systems import GeogCS, VerticalPerspective
 
 
@@ -39,10 +39,10 @@ class Test_cartopy_crs(tests.IrisTest):
 
     def test_crs_creation(self):
         res = self.vp_cs.as_cartopy_crs()
-        globe = cartopy.crs.Globe(semimajor_axis=self.semi_major_axis,
-                                  semiminor_axis=self.semi_minor_axis,
-                                  ellipse=None)
-        expected = cartopy.crs.Geostationary(
+        globe = ccrs.Globe(semimajor_axis=self.semi_major_axis,
+                           semiminor_axis=self.semi_minor_axis,
+                           ellipse=None)
+        expected = ccrs.Geostationary(
             self.longitude_of_projection_origin,
             self.perspective_point_height,
             globe=globe)
@@ -64,10 +64,10 @@ class Test_cartopy_projection(tests.IrisTest):
 
     def test_projection_creation(self):
         res = self.vp_cs.as_cartopy_projection()
-        globe = cartopy.crs.Globe(semimajor_axis=self.semi_major_axis,
-                                  semiminor_axis=self.semi_minor_axis,
-                                  ellipse=None)
-        expected = cartopy.crs.Geostationary(
+        globe = ccrs.Globe(semimajor_axis=self.semi_major_axis,
+                           semiminor_axis=self.semi_minor_axis,
+                           ellipse=None)
+        expected = ccrs.Geostationary(
             self.longitude_of_projection_origin,
             self.perspective_point_height,
             globe=globe)


### PR DESCRIPTION
The "Cartopy in a nutshell" notebook suggests as a standard:

```
import cartopy.crs as ccrs
```

which is implemented here.

There are other imports of `cartopy.<something>`, but I did not change them.
