### PR TITLE
Preserve the datatype of time arrays converted with Unit.

### DIFF
--- a/lib/iris/tests/unit/unit/test_Unit.py
+++ b/lib/iris/tests/unit/unit/test_Unit.py
@@ -71,6 +71,13 @@ class Test_convert(tests.IrisTest):
         expected, result = self.test_gregorian_calendar_conversion_setup()
         self.assertEqual(expected.shape, result.shape)
 
+    def test_non_gregorian_calendar_conversion_dtype(self):
+        data = np.arange(4, dtype=np.float32)
+        u1 = Unit('hours since 2000-01-01 00:00:00', calendar='360_day')
+        u2 = Unit('hours since 2000-01-02 00:00:00', calendar='360_day')
+        result = u1.convert(data, u2)
+        self.assertEqual(result.dtype, np.float32)
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1829,6 +1829,10 @@ class Unit(iris.util._OrderedHashable):
                 ut1 = self.utime()
                 ut2 = other.utime()
                 result = ut2.date2num(ut1.num2date(value_copy))
+                # Preserve the datatype of the input array if it was float32.
+                if (isinstance(value, np.ndarray)
+                        and value.dtype == np.float32):
+                    result = result.astype(np.float32)
             else:
                 ut_converter = _ut_get_converter(self.ut_unit, other.ut_unit)
                 if ut_converter:


### PR DESCRIPTION
The symptom was that people have been using iris.util.unify_time_units to unify their 360_day calendar epochs and the resulting cubes wouldn't merge/concatenate due to the data type being different.

Replaces #1384.
