### PR TITLE
Vectorise convertion of vertical coordinates

### DIFF
--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
@@ -16,13 +16,16 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
 Unit tests for
-:func:`iris.fileformats.pp_rules._convert_scalar_vertical_coords`.
+:func:`iris.fileformats.pp_rules._convert_vertical_coords`.
 
 """
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+
+from collections import Iterable
+import numpy as np
 
 from iris.coords import DimCoord, AuxCoord
 from iris.aux_factory import HybridPressureFactory, HybridHeightFactory
@@ -31,7 +34,7 @@ from iris.fileformats.pp_rules import Reference
 from iris.tests.unit.fileformats import TestField
 
 
-from iris.fileformats.pp_rules import _convert_scalar_vertical_coords
+from iris.fileformats.pp_rules import _convert_vertical_coords
 
 
 def _lbcode(value=None, ix=None, iy=None):
@@ -46,25 +49,28 @@ def _lbcode(value=None, ix=None, iy=None):
 
 class TestLBVC001_Height(TestField):
     def _check_height(self, blev, stash,
-                      expect_normal=True, expect_fixed_height=None):
+                      expect_normal=True, expect_fixed_height=None, dim=None):
         lbvc = 1
         lbcode = _lbcode(0)  # effectively unused in this case
         lblev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
             None, None, None, None, None, None
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_normal:
             expect_result = [
                 (DimCoord(blev, standard_name='height', units='m',
                           attributes={'positive': 'up'}),
-                 None)]
+                 dim)]
         elif expect_fixed_height:
+            klass = DimCoord
+            if isinstance(expect_fixed_height, Iterable):
+                klass = AuxCoord
             expect_result = [
-                (DimCoord([expect_fixed_height], standard_name='height',
-                          units='m', attributes={'positive': 'up'}),
-                 None)]
+                (klass(expect_fixed_height, standard_name='height',
+                       units='m', attributes={'positive': 'up'}),
+                 dim)]
         else:
             expect_result = []
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
@@ -73,58 +79,112 @@ class TestLBVC001_Height(TestField):
     def test_normal_height__present(self):
         self._check_height(blev=12.3, stash=STASH(1, 1, 1))
 
+    def test_normal_height__present_vector(self):
+        blev = [12.3, 123.4, 1234.5]
+        self._check_height(blev=blev, stash=STASH(1, 1, 1), dim=1)
+
     def test_normal_height__absent(self):
         self._check_height(blev=-1, stash=STASH(1, 1, 1),
+                           expect_normal=False)
+
+    def test_normal_height__absent_vector(self):
+        blev = [-1, -1, -1]
+        self._check_height(blev=blev, stash=STASH(1, 1, 1),
+                           expect_normal=False, dim=2)
+
+    def test_normal_height__absent_mixed_vector(self):
+        blev = [-1, 12.3, -1, 123.4]
+        self._check_height(blev=blev, stash=STASH(1, 1, 1),
                            expect_normal=False)
 
     def test_implied_height_1m5(self):
         self._check_height(blev=75.2, stash=STASH(1, 3, 236),
                            expect_normal=False, expect_fixed_height=1.5)
 
+    def test_implied_height_1m5__vector(self):
+        blev = np.array([1, 2, 3, 4])
+        expected = [1.5] * blev.size
+        self._check_height(blev=blev, stash=STASH(1, 3, 236),
+                           expect_normal=False, expect_fixed_height=expected,
+                           dim=1)
+
     def test_implied_height_10m(self):
         self._check_height(blev=75.2, stash=STASH(1, 3, 225),
                            expect_normal=False, expect_fixed_height=10.0)
 
+    def test_implied_height_10m__vector(self):
+        blev = np.arange(10)
+        expected = [10.0] * blev.size
+        self._check_height(blev=blev, stash=STASH(1, 3, 225),
+                           expect_normal=False, expect_fixed_height=expected,
+                           dim=2)
+
 
 class TestLBVC002_Depth(TestField):
-    def _check_depth(self, lbcode, lblev, brlev=0.0, brsvd1=0.0,
-                     expect_bounds=True, expect_match=True):
+    def _check_depth(self, lbcode, lblev=23.0, blev=123.4, brlev=0.0,
+                     brsvd1=0.0, expect_bounds=True, expect_match=True,
+                     expect_depth=True, dim=None):
         lbvc = 2
-        lblev = 23.0
-        blev = 123.4
         stash = STASH(1, 1, 1)
         bhlev, bhrlev, brsvd2 = None, None, None
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_result = [
-                (DimCoord([lblev],
+                (DimCoord(lblev,
                           standard_name='model_level_number',
-                          attributes={'positive': 'down'}), None)]
-            if expect_bounds:
-                expect_result.append(
-                    (DimCoord(blev, standard_name='depth',
-                              units='m',
-                              bounds=[brsvd1, brlev],
-                              attributes={'positive': 'down'}), None))
-            else:
-                expect_result.append(
-                    (DimCoord(blev, standard_name='depth', units='m',
-                              attributes={'positive': 'down'}), None))
+                          attributes={'positive': 'down'}), dim)]
+            if expect_depth:
+                if expect_bounds:
+                    brsvd1 = np.array(brsvd1, ndmin=1)
+                    brlev = np.array(brlev, ndmin=1)
+                    bounds = np.vstack((brsvd1, brlev)).T
+                    expect_result.append(
+                        (DimCoord(blev, standard_name='depth',
+                                  units='m',
+                                  bounds=bounds,
+                                  attributes={'positive': 'down'}), dim))
+                else:
+                    expect_result.append(
+                        (DimCoord(blev, standard_name='depth', units='m',
+                                  attributes={'positive': 'down'}), dim))
         else:
             expect_result = []
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
         self.assertEqual(factories, [])
 
     def test_unbounded(self):
-        self._check_depth(_lbcode(1), lblev=23.0,
-                          expect_bounds=False)
+        self._check_depth(_lbcode(1), lblev=23.0, expect_bounds=False)
+
+    def test_unbounded__vector(self):
+        lblev = [1, 2, 3]
+        blev = [10, 20, 30]
+        brsvd1 = [5, 15, 25]
+        brlev = [5, 15, 25]
+        self._check_depth(_lbcode(1), lblev=lblev, blev=blev, brsvd1=brsvd1,
+                          brlev=brlev, expect_bounds=False, dim=1)
+
+    def test_unbounded__vector_no_depth(self):
+        lblev = [1, 2, 3]
+        blev = [10, 20, 30]
+        brsvd1 = [5, 15, 25]
+        brlev = [5, 15, 666]  # not all equal or all unequal!
+        self._check_depth(_lbcode(1), lblev=lblev, blev=blev, brsvd1=brsvd1,
+                          brlev=brlev, expect_depth=False, dim=0)
 
     def test_bounded(self):
         self._check_depth(_lbcode(1), lblev=23.0, brlev=22.5, brsvd1=23.5,
                           expect_bounds=True)
+
+    def test_bounded__vector(self):
+        lblev = [1, 2, 3]
+        blev = [10, 20, 30]
+        brsvd1 = [5, 15, 25]
+        brlev = [15, 25, 35]
+        self._check_depth(_lbcode(1), lblev=lblev, blev=blev, brsvd1=brsvd1,
+                          brlev=brlev, expect_bounds=True, dim=1)
 
     def test_cross_section(self):
         self._check_depth(_lbcode(ix=1, iy=2), lblev=23.0,
@@ -132,20 +192,20 @@ class TestLBVC002_Depth(TestField):
 
 
 class TestLBVC006_SoilLevel(TestField):
-    def _check_soil_level(self, lbcode, expect_match=True):
+    def _check_soil_level(self, lbcode, lblev=12.3, expect_match=True,
+                          dim=None):
         lbvc = 6
-        lblev = 12.3
         stash = STASH(1, 1, 1)
         blev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
             None, None, None, None, None, None
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_result = [
-                (DimCoord([lblev], long_name='soil_model_level_number',
-                          attributes={'positive': 'down'}), None)]
+                (DimCoord(lblev, long_name='soil_model_level_number',
+                          attributes={'positive': 'down'}), dim)]
         else:
             expect_result = []
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
@@ -154,24 +214,27 @@ class TestLBVC006_SoilLevel(TestField):
     def test_normal(self):
         self._check_soil_level(_lbcode(0))
 
+    def test_normal__vector(self):
+        lblev = np.arange(10)
+        self._check_soil_level(_lbcode(0), lblev=lblev, dim=0)
+
     def test_cross_section(self):
         self._check_soil_level(_lbcode(ix=1, iy=2), expect_match=False)
 
 
 class TestLBVC008_Pressure(TestField):
-    def _check_pressure(self, lbcode, expect_match=True):
+    def _check_pressure(self, lbcode, blev=250.3, expect_match=True, dim=None):
         lbvc = 8
-        blev = 250.3
         stash = STASH(1, 1, 1)
         lblev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
             None, None, None, None, None, None
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_result = [
-                (DimCoord([blev], long_name='pressure', units='hPa'), None)]
+                (DimCoord(blev, long_name='pressure', units='hPa'), dim)]
         else:
             expect_result = []
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
@@ -180,28 +243,39 @@ class TestLBVC008_Pressure(TestField):
     def test_normal(self):
         self._check_pressure(_lbcode(0))
 
+    def test_normal__vector(self):
+        blev = [10, 100, 1000, 10000]
+        self._check_pressure(_lbcode(0), blev=blev, dim=2)
+
     def test_non_pressure_cross_section(self):
         self._check_pressure(_lbcode(ix=10, iy=11))
+
+    def test_non_pressure_cross_section__vector(self):
+        blev = np.arange(10)
+        self._check_pressure(_lbcode(ix=10, iy=11), blev=blev, dim=0)
 
     def test_pressure_cross_section(self):
         self._check_pressure(_lbcode(ix=10, iy=1), expect_match=False)
 
+    def test_pressure_cross_section__vector(self):
+        blev = np.arange(10)
+        self._check_pressure(_lbcode(ix=10, iy=1), expect_match=False)
+
 
 class TestLBVC019_PotentialTemperature(TestField):
-    def _check_potm(self, lbcode, expect_match=True):
+    def _check_potm(self, lbcode, blev=130.6, expect_match=True, dim=None):
         lbvc = 19
-        blev = 130.6
         stash = STASH(1, 1, 1)
         lblev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
             None, None, None, None, None, None
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_result = [
-                (DimCoord([blev], standard_name='air_potential_temperature',
-                          units='K', attributes={'positive': 'up'}), None)]
+                (DimCoord(blev, standard_name='air_potential_temperature',
+                          units='K', attributes={'positive': 'up'}), dim)]
         else:
             expect_result = []
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
@@ -210,36 +284,49 @@ class TestLBVC019_PotentialTemperature(TestField):
     def test_normal(self):
         self._check_potm(_lbcode(0))
 
+    def test_normal__vector(self):
+        blev = range(10)
+        self._check_potm(_lbcode(0), blev=blev, dim=0)
+
     def test_cross_section(self):
+        self._check_potm(_lbcode(ix=10, iy=11), expect_match=False)
+
+    def test_cross_section(self):
+        blev = np.arange(5) + 100
         self._check_potm(_lbcode(ix=10, iy=11), expect_match=False)
 
 
 class TestLBVC009_HybridPressure(TestField):
-    def test_valid(self, expect_match=True):
+    def _check(self, lblev=37.0,
+               bhlev=850.1, bhrlev=810.0, brsvd2=875.0,
+               blev=0.15, brlev=0.11, brsvd1=0.19,
+               expect_match=True, dim=None):
         lbvc = 9
-        lblev = 37.0
-        bhlev = 850.1  # pressure
-        bhrlev, brsvd2 = 810.0, 875.0  # pressure bounds
-        blev = 0.15  # sigma
-        brlev, brsvd1 = 0.11, 0.19  # sigma bounds
         lbcode = _lbcode(0)  # unused
         stash = STASH(1, 1, 1)  # unused
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_coords_and_dims = [
-                (DimCoord([37.0],
+                (DimCoord(lblev,
                           standard_name='model_level_number',
-                          attributes={'positive': 'up'}), None),
-                (DimCoord([850.1],
+                          attributes={'positive': 'up'}), dim)]
+
+            bhrlev = np.array(bhrlev, ndmin=1)
+            brsvd2 = np.array(brsvd2, ndmin=1)
+            expect_coords_and_dims.append(
+                (DimCoord(bhlev,
                           long_name='level_pressure',
                           units='Pa',
-                          bounds=[810.0, 875.0]), None),
-                (AuxCoord([0.15],
+                          bounds=np.vstack((bhrlev, brsvd2)).T), dim))
+            brlev = np.array(brlev, ndmin=1)
+            brsvd1 = np.array(brsvd1, ndmin=1)
+            expect_coords_and_dims.append(
+                (AuxCoord(blev,
                           long_name='sigma',
-                          bounds=[brlev, brsvd1]), None)]
+                          bounds=np.vstack((brlev, brsvd1)).T), dim))
             expect_factories = [(HybridPressureFactory,
                                  [{'long_name': 'level_pressure'},
                                   {'long_name': 'sigma'},
@@ -251,32 +338,51 @@ class TestLBVC009_HybridPressure(TestField):
                                            expect_coords_and_dims)
         self.assertEqual(factories, expect_factories)
 
+    def test_normal(self):
+        self._check()
+
+    def test_normal__vector(self):
+        lblev = range(3)
+        bhlev = [10, 20, 30]
+        bhrlev = [5, 15, 25]
+        brsvd2 = [15, 25, 35]
+        blev = [100, 200, 300]
+        brlev = [50, 150, 250]
+        brsvd1 = [150, 250, 350]
+        self._check(lblev=lblev, bhlev=bhlev, bhrlev=bhrlev, brsvd2=brsvd2,
+                    blev=blev, brlev=brlev, brsvd1=brsvd1, dim=0)
+
 
 class TestLBVC065_HybridHeight(TestField):
-    def test_valid(self, expect_match=True):
+    def _check(self, lblev=37.0,
+               blev=9596.3, brlev=9500.0, brsvd1=9800.0,
+               bhlev=0.35, bhrlev=0.31, brsvd2=0.39,
+               expect_match=True, dim=None):
         lbvc = 65
-        lblev = 37.0
-        bhlev = 0.35  # sigma
-        bhrlev, brsvd2 = 0.31, 0.39  # sigma bounds
-        blev = 9596.3  # level_height
-        brlev, brsvd1 = 9500.0, 9800.0  # level_height bounds
         lbcode = _lbcode(0)  # unused
         stash = STASH(1, 1, 1)  # unused
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
-            brlev=brlev)
+            brlev=brlev, dim=dim)
         if expect_match:
             expect_coords_and_dims = [
-                (DimCoord([37.0],
+                (DimCoord(lblev,
                           standard_name='model_level_number',
-                          attributes={'positive': 'up'}), None),
-                (DimCoord([9596.3],
+                          attributes={'positive': 'up'}), dim)]
+            brlev = np.array(brlev, ndmin=1)
+            brsvd1 = np.array(brsvd1, ndmin=1)
+            expect_coords_and_dims.append(
+                (DimCoord(blev,
                           long_name='level_height', units='m',
-                          bounds=[brlev, brsvd1],
-                          attributes={'positive': 'up'}), None),
-                (AuxCoord([0.35],
-                          long_name='sigma', bounds=[bhrlev, brsvd2]), None)]
+                          bounds=np.vstack((brlev, brsvd1)).T,
+                          attributes={'positive': 'up'}), dim))
+            bhrlev = np.array(bhrlev, ndmin=1)
+            brsvd2 = np.array(brsvd2, ndmin=1)
+            expect_coords_and_dims.append(
+                (AuxCoord(bhlev,
+                          long_name='sigma',
+                          bounds=np.vstack((bhrlev, brsvd2)).T), dim))
             expect_factories = [(HybridHeightFactory,
                                  [{'long_name': 'level_height'},
                                   {'long_name': 'sigma'},
@@ -288,6 +394,21 @@ class TestLBVC065_HybridHeight(TestField):
                                            expect_coords_and_dims)
         self.assertEqual(factories, expect_factories)
 
+    def test_normal(self):
+        self._check()
+
+    def test_normal__vector(self):
+        npts = 5
+        lblev = np.arange(npts)
+        blev = np.arange(npts) + 10
+        brlev = np.arange(npts) + 5
+        brsvd1 = np.arange(npts) + 15
+        bhlev = np.arange(npts) + 12
+        bhrlev = np.arange(npts) + 6
+        brsvd2 = np.arange(npts) + 18
+        self._check(lblev=lblev, blev=blev, brlev=brlev, brsvd1=brsvd1,
+                    bhlev=bhlev, bhrlev=bhrlev, brsvd2=brsvd2, dim=1)
+
 
 class TestLBVCxxx_Unhandled(TestField):
     def test_unknown_lbvc(self):
@@ -296,7 +417,7 @@ class TestLBVCxxx_Unhandled(TestField):
             None, None, None, None, None, None, None
         lbcode = _lbcode(0)  # unused
         stash = STASH(1, 1, 1)  # unused
-        coords_and_dims, factories = _convert_scalar_vertical_coords(
+        coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
             brlev=brlev)

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
@@ -20,18 +20,36 @@
 # importing anything else.
 import iris.tests as tests
 
+import numpy as np
+
 from iris.fileformats.pp_rules import _model_level_number
 
 
 class Test_9999(tests.IrisTest):
-    def test(self):
-        self.assertEqual(_model_level_number(9999), 0)
+    def test_scalar(self):
+        expected = np.array(0, ndmin=1)
+        result = _model_level_number(9999)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vector(self):
+        lblev = [1, 2, 9999, 4, 5, 9999]
+        expected = np.array([1, 2, 0, 4, 5, 0])
+        result = _model_level_number(lblev)
+        np.testing.assert_array_equal(result, expected)
 
 
 class Test_lblev(tests.IrisTest):
-    def test(self):
+    def test_scalar(self):
         for val in xrange(9999):
-            self.assertEqual(_model_level_number(val), val)
+            expected = np.array(val, ndmin=1)
+            result = _model_level_number(val)
+            np.testing.assert_array_equal(result, expected)
+
+    def test_vector(self):
+        lblev = range(9999)
+        expected = np.arange(9999)
+        result = _model_level_number(lblev)
+        np.testing.assert_array_equal(result, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR extends the capability of the `pp_rules._convert_scalar_vertical_coords` function to cope with array data rather than scalar values.

Re-brands `_convert_scalar_vertical_coords` as `_convert_vertical_coords`.

Assumes that the following arguments will remain as scalar:
- lbcode
- lbvc
- stash

Assumes that the following arguments may be either scalar or array:
- blev
- lblev
- bhlev
- bhrlev
- brsvd1
- brsvd2
- brlev 
