### PR TITLE
Add ConversionMetadata named tuple.

### DIFF
--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -34,7 +34,7 @@ import iris.coord_systems as icoord_systems
 from iris.coords import AuxCoord, DimCoord, CellMethod
 from iris.exceptions import TranslationError
 from iris.fileformats.grib import grib_phenom_translation as itranslation
-from iris.fileformats.rules import Factory, Reference
+from iris.fileformats.rules import ConversionMetadata, Factory, Reference
 from iris.unit import CALENDAR_GREGORIAN, date2num, Unit
 from iris.util import _is_circular
 
@@ -1544,11 +1544,7 @@ def convert(field):
         GRIB message to be translated.
 
     Returns:
-        Translated cube metadata tuple containing factories list, references
-        list, standard_name, long_name, units, attributes dictionary, cell
-        methods list, list containing dimension coordinate and associated
-        dimension tuple pairs, and a list containing auxiliary coordinate and
-        associated dimensions tuple pairs.
+        A :class:`iris.fileformats.rules.ConversionMetadata` object.
 
     """
     editionNumber = field.sections[0]['editionNumber']
@@ -1571,4 +1567,4 @@ def convert(field):
     # Convert GRIB2 message to cube metadata.
     grib2_convert(field, metadata)
 
-    return tuple(metadata.values())
+    return ConversionMetadata._make(metadata.values())

--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -24,11 +24,24 @@ import numpy as np
 
 from iris.aux_factory import HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
-from iris.fileformats.rules import Factory, Reference, ReferenceTarget
+from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
+                                    ReferenceTarget)
 from iris.unit import CALENDAR_GREGORIAN, Unit
 
 
 def convert(grib):
+    """
+    Converts a GRIB message into the corresponding items of Cube metadata.
+
+    Args:
+
+    * grib:
+        A :class:`~iris.fileformats.grib.GribWrapper` object.
+
+    Returns:
+        A :class:`iris.fileformats.rules.ConversionMetadata` object.
+
+    """
     factories = []
     references = []
     standard_name = None
@@ -387,5 +400,6 @@ def convert(grib):
             (grib.typeOfFirstFixedSurface == 105):
         references.append(ReferenceTarget('surface_air_pressure', lambda cube: {'standard_name': 'surface_air_pressure', 'units': 'Pa', 'data': np.exp(cube.data)}))
 
-    return (factories, references, standard_name, long_name, units, attributes,
-            cell_methods, dim_coords_and_dims, aux_coords_and_dims)
+    return ConversionMetadata(factories, references, standard_name, long_name,
+                              units, attributes, cell_methods,
+                              dim_coords_and_dims, aux_coords_and_dims)

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -22,7 +22,8 @@ import numpy as np
 
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
-from iris.fileformats.rules import Factory, Reference, ReferenceTarget
+from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
+                                    ReferenceTarget)
 from iris.fileformats.um_cf_map import LBFC_TO_CF, STASH_TO_CF
 from iris.unit import Unit
 import iris.fileformats.pp
@@ -254,6 +255,18 @@ def _convert_scalar_pseudo_level_coords(lbuser5):
 
 
 def convert(f):
+    """
+    Converts a PP field into the corresponding items of Cube metadata.
+
+    Args:
+
+    * f:
+        A :class:`iris.fileformats.pp.PPField` object.
+
+    Returns:
+        A :class:`iris.fileformats.rules.ConversionMetadata` object.
+
+    """
     factories = []
     aux_coords_and_dims = []
 
@@ -294,8 +307,9 @@ def convert(f):
         dim_coords_and_dims, other_aux_coords_and_dims = _all_other_rules(f)
     aux_coords_and_dims.extend(other_aux_coords_and_dims)
 
-    return (factories, references, standard_name, long_name, units, attributes,
-            cell_methods, dim_coords_and_dims, aux_coords_and_dims)
+    return ConversionMetadata(factories, references, standard_name, long_name,
+                              units, attributes, cell_methods,
+                              dim_coords_and_dims, aux_coords_and_dims)
 
 
 def _all_other_rules(f):

--- a/lib/iris/tests/test_rules.py
+++ b/lib/iris/tests/test_rules.py
@@ -25,8 +25,9 @@ import types
 
 from iris.aux_factory import HybridHeightFactory
 from iris.cube import Cube
-from iris.fileformats.rules import ConcreteReferenceTarget, Factory, Loader, \
-                                   Reference, ReferenceTarget, load_cubes
+from iris.fileformats.rules import (ConcreteReferenceTarget,
+                                    ConversionMetadata, Factory, Loader,
+                                    Reference, ReferenceTarget, load_cubes)
 import iris.tests.stock as stock
 
 
@@ -105,7 +106,8 @@ class TestLoadCubes(tests.IrisTest):
         factory.factory_class = lambda *args: \
             setattr(aux_factory, 'fake_args', args) or aux_factory
         def converter(field):
-            return ([factory], [], '', '', '', {}, [], [], [])
+            return ConversionMetadata([factory], [], '', '', '', {}, [], [],
+                                      [])
         # Finish by making a fake Loader
         fake_loader = Loader(field_generator, {}, converter, None)
         cubes = load_cubes(['fake_filename'], None, fake_loader)
@@ -175,9 +177,10 @@ class TestLoadCubes(tests.IrisTest):
                                    for coord in src.dim_coords]
             aux_coords_and_dims = [(coord, src.coord_dims(coord))
                                    for coord in src.aux_coords]
-            return (factories, references, src.standard_name, src.long_name,
-                    src.units, src.attributes, src.cell_methods,
-                    dim_coords_and_dims, aux_coords_and_dims)
+            return ConversionMetadata(factories, references, src.standard_name,
+                                      src.long_name, src.units, src.attributes,
+                                      src.cell_methods, dim_coords_and_dims,
+                                      aux_coords_and_dims)
         # Finish by making a fake Loader
         fake_loader = Loader(field_generator, {}, converter, None)
         cubes = load_cubes(['fake_filename'], None, fake_loader)

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -23,6 +23,7 @@ import iris.tests as tests
 import mock
 
 from iris.fileformats.rules import _make_cube
+import iris.fileformats.rules
 
 
 class Test(tests.IrisTest):
@@ -38,15 +39,10 @@ class Test(tests.IrisTest):
         cell_methods = None
         dim_coords_and_dims = None
         aux_coords_and_dims = None
-        converter = mock.Mock(return_value=(factories,
-                                            references,
-                                            standard_name,
-                                            long_name,
-                                            units,
-                                            attributes,
-                                            cell_methods,
-                                            dim_coords_and_dims,
-                                            aux_coords_and_dims))
+        metadata = iris.fileformats.rules.ConversionMetadata(
+            factories, references, standard_name, long_name, units, attributes,
+            cell_methods, dim_coords_and_dims, aux_coords_and_dims)
+        converter = mock.Mock(return_value=metadata)
 
         field = mock.Mock()
         with mock.patch('warnings.warn') as warn:


### PR DESCRIPTION
The `iris.fileformats.rules` converter interface currently relies on an anonymous tuple to transfer the nine separate pieces of metadata which define the translation. This PR switches to a `namedtuple` which simplifies documenting the interface.
