### PR TITLE
First attempt at merging duplicate cubes on merge

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -337,7 +337,7 @@ class CubeList(list):
 
         return self.extract(iris.Constraint(coord_values=coord_values))
 
-    def merge_cube(self):
+    def merge_cube(self, merge_duplicates=False):
         """
         Return the merged contents of the :class:`CubeList` as a single
         :class:`Cube`.
@@ -371,10 +371,10 @@ class CubeList(list):
             proto_cube.register(cube, error_on_mismatch=True)
 
         # Extract the merged cube from the ProtoCube.
-        merged_cube, = proto_cube.merge()
+        merged_cube, = proto_cube.merge(merge_duplicates=merge_duplicates)
         return merged_cube
 
-    def merge(self, unique=True):
+    def merge(self, unique=True, merge_duplicates=False):
         """
         Returns the :class:`CubeList` resulting from merging this
         :class:`CubeList`.
@@ -454,7 +454,7 @@ class CubeList(list):
         merged_cubes = CubeList()
         for name in sorted(proto_cubes_by_name):
             for proto_cube in proto_cubes_by_name[name]:
-                merged_cubes.extend(proto_cube.merge(unique=unique))
+                merged_cubes.extend(proto_cube.merge(unique=unique, merge_duplicates=merge_duplicates))
 
         return merged_cubes
 


### PR DESCRIPTION
'real world' data files can often contain duplicate data within files, or sets of files, which iris currently fails to load. As a user of iris, I need to be able to load and deal with files and data streams which have these sorts of issues.

A workaround, provided by @marqh,  is to load the data as load_raw and attempt to merge the cube. On an exception, the merge is re-attmpted with unique=False and a set of simple tests attempt to check that the merge is sensibe.

This branch replicates the process within the merge method. The tests are definitely not perfect and will probably not be appropriate in all cases, but by having the tests within the iris codebase, rather than as a set of working practices in many user's routines, then the tests can be maintained and improved upon for the edge cases.

Thanks,

Malcolm
