### PR TITLE
Remove external use of `_data` attribute.

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -636,12 +636,12 @@ class FF2PP(object):
                 # Read the actual bytes. This can then be converted to a
                 # numpy array at a higher level.
                 ff_file_seek(data_offset, os.SEEK_SET)
-                field._data = pp.LoadedArrayBytes(ff_file.read(data_depth),
-                                                  data_type)
+                field._my_data = pp.LoadedArrayBytes(ff_file.read(data_depth),
+                                                     data_type)
             else:
                 # Provide enough context to read the data bytes later on.
-                field._data = (self._filename, data_offset,
-                               data_depth, data_type)
+                field._my_data = (self._filename, data_offset,
+                                  data_depth, data_type)
             yield field
         ff_file.close()
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -229,9 +229,25 @@ class GribWrapper(object):
                                   grib_fh.name,
                                   offset - message_length,
                                   auto_regularise)
-            self._data = biggus.NumpyArrayAdapter(proxy)
+            self._my_data = biggus.NumpyArrayAdapter(proxy)
         else:
-            self.data = _message_values(grib_message, shape)
+            self._my_data = _message_values(grib_message, shape)
+
+    def lazy_data(self):
+        array = self._my_data
+        if not isinstance(array, biggus.Array):
+            array = biggus.NumpyArrayAdapter(array)
+        return array
+
+    @property
+    def data(self):
+        data = self._my_data
+        if not isinstance(data, np.ndarray):
+            data = data.masked_array()
+            if ma.count_masked(data) == 0:
+                data = data.data
+            self._my_data = data
+        return data
 
     @staticmethod
     def _regularise_shape(grib_message):

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -76,8 +76,7 @@ class _GribMessage(object):
     def sections(self):
         return self._raw_message.sections
 
-    @property
-    def data(self):
+    def lazy_data(self):
         """
         The data array from the GRIB message as a biggus Array.
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -751,12 +751,7 @@ def _make_cube(field, converter):
     # Convert the field to a Cube.
     metadata = converter(field)
 
-    try:
-        data = field._data
-    except AttributeError:
-        data = field.data
-
-    cube = iris.cube.Cube(data,
+    cube = iris.cube.Cube(field.lazy_data(),
                           attributes=metadata.attributes,
                           cell_methods=metadata.cell_methods,
                           dim_coords_and_dims=metadata.dim_coords_and_dims,

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -35,14 +35,14 @@ class TestGribMessage(tests.IrisTest):
             with open(filename, 'wb') as f:
                 pickle.dump(message, f)
 
-    def test_data(self):
-        # Check that _GribMessage.data pickles without errors.
+    def test_lazy_data(self):
+        # Check that _GribMessage.lazy_data() pickles without errors.
         path = tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2'))
         messages = _GribMessage.messages_from_filename(path)
         message = next(messages)
         with self.temp_filename('.pkl') as filename:
             with open(filename, 'wb') as f:
-                pickle.dump(message.data, f)
+                pickle.dump(message.lazy_data(), f)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -100,7 +100,8 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
+            data = np.arange(1200).reshape(y, x) * scale
+            field = mock.MagicMock(lazy_data=lambda: data,
                                    lbcode=[1], lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)
@@ -179,7 +180,8 @@ class TestVertical(tests.IrisTest):
     def test_hybrid_pressure_with_duplicate_references(self):
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
+            data = np.arange(1200).reshape(y, x) * scale
+            field = mock.MagicMock(lazy_data=lambda: data,
                                    lbcode=[1], lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)
@@ -292,7 +294,8 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
+            data = np.arange(1200).reshape(y, x) * scale
+            field = mock.MagicMock(lazy_data=lambda: data,
                                    lbcode=[1], lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -41,7 +41,7 @@ class TestPPCopy(tests.IrisTest):
     def test_copy_field_deferred(self):
         field = next(pp.load(self.filename))
         clone = field.copy()
-        self.assertIsInstance(clone._data, biggus.Array)
+        self.assertIsInstance(clone._my_data, biggus.Array)
         self.assertEqual(field, clone)
         clone.lbyr = 666
         self.assertNotEqual(field, clone)
@@ -49,7 +49,7 @@ class TestPPCopy(tests.IrisTest):
     def test_deepcopy_field_deferred(self):
         field = next(pp.load(self.filename))
         clone = deepcopy(field)
-        self.assertIsInstance(clone._data, biggus.Array)
+        self.assertIsInstance(clone._my_data, biggus.Array)
         self.assertEqual(field, clone)
         clone.lbyr = 666
         self.assertNotEqual(field, clone)

--- a/lib/iris/tests/test_rules.py
+++ b/lib/iris/tests/test_rules.py
@@ -96,7 +96,7 @@ class TestLoadCubes(tests.IrisTest):
 
         # The fake PPField which will be supplied to our converter.
         field = Mock()
-        field.data = None
+        field.lazy_data = lambda: None
         field_generator = lambda filename: [field]
         # A fake conversion function returning:
         #   1) A parameter cube needing a simple factory construction.
@@ -156,9 +156,9 @@ class TestLoadCubes(tests.IrisTest):
 
         # The fake PPFields which will be supplied to our converter.
         press_field = Mock()
-        press_field.data = param_cube.data
+        press_field.lazy_data = lambda: param_cube.data
         orog_field = Mock()
-        orog_field.data = orog_cube.data
+        orog_field.lazy_data = lambda: orog_cube.data
         field_generator = lambda filename: [press_field, orog_field]
         # A fake rule set returning:
         #   1) A parameter cube needing an "orography" reference

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -49,18 +49,18 @@ class Test_sections(tests.IrisTest):
         self.assertIs(message.sections, mock.sentinel.SECTIONS)
 
 
-class Test_data__unsupported(tests.IrisTest):
+class Test_lazy_data__unsupported(tests.IrisTest):
     def test_unsupported_grid_definition(self):
         message = _make_test_message({3: {'sourceOfGridDefinition': 1}})
         with self.assertRaisesRegexp(TranslationError, 'source'):
-            message.data
+            message.lazy_data()
 
     def test_unsupported_quasi_regular__number_of_octets(self):
         message = _make_test_message(
             {3: {'sourceOfGridDefinition': 0,
                  'numberOfOctectsForNumberOfPoints': 1}})
         with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
-            message.data
+            message.lazy_data()
 
     def test_unsupported_quasi_regular__interpretation(self):
         message = _make_test_message(
@@ -68,7 +68,7 @@ class Test_data__unsupported(tests.IrisTest):
                  'numberOfOctectsForNumberOfPoints': 0,
                  'interpretationOfNumberOfPoints': 1}})
         with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
-            message.data
+            message.lazy_data()
 
     def test_unsupported_template(self):
         message = _make_test_message(
@@ -77,10 +77,10 @@ class Test_data__unsupported(tests.IrisTest):
                  'interpretationOfNumberOfPoints': 0,
                  'gridDefinitionTemplateNumber': 2}})
         with self.assertRaisesRegexp(TranslationError, 'template'):
-            message.data
+            message.lazy_data()
 
 
-class Test_data__grid_template_0(tests.IrisTest):
+class Test_lazy_data__grid_template_0(tests.IrisTest):
     def test_unsupported_scanning_mode(self):
         message = _make_test_message(
             {3: {'sourceOfGridDefinition': 0,
@@ -89,7 +89,7 @@ class Test_data__grid_template_0(tests.IrisTest):
                  'gridDefinitionTemplateNumber': 0,
                  'scanningMode': 1}})
         with self.assertRaisesRegexp(TranslationError, 'scanning mode'):
-            message.data
+            message.lazy_data()
 
     def _test(self, scanning_mode):
         def make_raw_message():
@@ -104,7 +104,7 @@ class Test_data__grid_template_0(tests.IrisTest):
             raw_message = mock.Mock(sections=sections)
             return raw_message
         message = _GribMessage(make_raw_message(), make_raw_message, False)
-        data = message.data
+        data = message.lazy_data()
         self.assertIsInstance(data, biggus.Array)
         self.assertEqual(data.shape, (3, 4))
         self.assertEqual(data.dtype, np.floating)

--- a/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
@@ -86,8 +86,8 @@ class Test_deferred(tests.IrisTest):
         grib_message = 'regular_ll'
         for i, _ in enumerate(tell_tale):
             gw = GribWrapper(grib_message, grib_fh, auto_regularise)
-            self.assertIsInstance(gw._data, NumpyArrayAdapter)
-            proxy = gw._data.concrete
+            self.assertIsInstance(gw.lazy_data(), NumpyArrayAdapter)
+            proxy = gw.lazy_data().concrete
             self.assertIsInstance(proxy, GribDataProxy)
             self.assertEqual(proxy.shape, (10, 20))
             self.assertEqual(proxy.dtype, np.float)
@@ -104,8 +104,8 @@ class Test_deferred(tests.IrisTest):
         grib_message = 'regular_ll'
         for offset in expected:
             gw = GribWrapper(grib_message, grib_fh, auto_regularise)
-            self.assertIsInstance(gw._data, NumpyArrayAdapter)
-            proxy = gw._data.concrete
+            self.assertIsInstance(gw.lazy_data(), NumpyArrayAdapter)
+            proxy = gw.lazy_data().concrete
             self.assertIsInstance(proxy, GribDataProxy)
             self.assertEqual(proxy.shape, (10, 20))
             self.assertEqual(proxy.dtype, np.float)
@@ -121,8 +121,8 @@ class Test_deferred(tests.IrisTest):
         grib_message = 'reduced_gg'
         for i, _ in enumerate(tell_tale):
             gw = GribWrapper(grib_message, grib_fh, auto_regularise)
-            self.assertIsInstance(gw._data, NumpyArrayAdapter)
-            proxy = gw._data.concrete
+            self.assertIsInstance(gw.lazy_data(), NumpyArrayAdapter)
+            proxy = gw.lazy_data().concrete
             self.assertIsInstance(proxy, GribDataProxy)
             self.assertEqual(proxy.shape, (200,))
             self.assertEqual(proxy.dtype, np.float)
@@ -139,8 +139,8 @@ class Test_deferred(tests.IrisTest):
         grib_message = 'reduced_gg'
         for offset in expected:
             gw = GribWrapper(grib_message, grib_fh, auto_regularise)
-            self.assertIsInstance(gw._data, NumpyArrayAdapter)
-            proxy = gw._data.concrete
+            self.assertIsInstance(gw.lazy_data(), NumpyArrayAdapter)
+            proxy = gw.lazy_data().concrete
             self.assertIsInstance(proxy, GribDataProxy)
             self.assertEqual(proxy.shape, (200,))
             self.assertEqual(proxy.dtype, np.float)

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -28,10 +28,10 @@ import iris.fileformats.pp as pp
 
 class Test__create_field_data(tests.IrisTest):
     def test_loaded_bytes(self):
-        # Check that a field with LoadedArrayBytes in _data gets the
+        # Check that a field with LoadedArrayBytes in _my_data gets the
         # result of a suitable call to _data_bytes_to_shaped_array().
         mock_loaded_bytes = mock.Mock(spec=pp.LoadedArrayBytes)
-        field = mock.Mock(_data=mock_loaded_bytes)
+        field = mock.Mock(_my_data=mock_loaded_bytes)
         data_shape = mock.Mock()
         land_mask = mock.Mock()
         with mock.patch('iris.fileformats.pp._data_bytes_to_shaped_array') as \
@@ -39,14 +39,14 @@ class Test__create_field_data(tests.IrisTest):
             convert_bytes.return_value = mock.sentinel.array
             pp._create_field_data(field, data_shape, land_mask)
 
-        self.assertIs(field._data, mock.sentinel.array)
+        self.assertIs(field._my_data, mock.sentinel.array)
         convert_bytes.assert_called_once_with(mock_loaded_bytes.bytes,
                                               field.lbpack, data_shape,
                                               mock_loaded_bytes.dtype,
                                               field.bmdi, land_mask)
 
     def test_deferred_bytes(self):
-        # Check that a field with deferred array bytes in _data gets a
+        # Check that a field with deferred array bytes in _my_data gets a
         # biggus array.
         fname = mock.sentinel.fname
         position = mock.sentinel.position
@@ -54,7 +54,7 @@ class Test__create_field_data(tests.IrisTest):
         newbyteorder = mock.Mock(return_value=mock.sentinel.dtype)
         dtype = mock.Mock(newbyteorder=newbyteorder)
         deferred_bytes = (fname, position, n_bytes, dtype)
-        field = mock.Mock(_data=deferred_bytes)
+        field = mock.Mock(_my_data=deferred_bytes)
         data_shape = (mock.sentinel.lat, mock.sentinel.lon)
         land_mask = mock.Mock()
         proxy = mock.Mock(dtype=mock.sentinel.dtype, shape=data_shape)
@@ -66,9 +66,9 @@ class Test__create_field_data(tests.IrisTest):
             PPDataProxy.return_value = proxy
             pp._create_field_data(field, data_shape, land_mask)
         # Does the biggus array look OK from the outside?
-        self.assertIsInstance(field._data, biggus.Array)
-        self.assertEqual(field._data.shape, data_shape)
-        self.assertEqual(field._data.dtype, mock.sentinel.dtype)
+        self.assertIsInstance(field._my_data, biggus.Array)
+        self.assertEqual(field._my_data.shape, data_shape)
+        self.assertEqual(field._my_data.dtype, mock.sentinel.dtype)
         # Is it making use of a correctly configured proxy?
         # NB. We know it's *using* the result of this call because
         # that's where the dtype came from above.

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -79,7 +79,7 @@ class Test__field_gen(tests.IrisTest):
             np.fromfile.assert_has_calls(calls)
         expected_deferred_bytes = ('mocked', open_fh.tell(),
                                    4, np.dtype('>f4'))
-        self.assertEqual(pp_field._data, expected_deferred_bytes)
+        self.assertEqual(pp_field._my_data, expected_deferred_bytes)
 
     def test_read_data_call(self):
         # Checks that data is read if read_data is True.
@@ -92,7 +92,7 @@ class Test__field_gen(tests.IrisTest):
             next(pp._field_gen('mocked', read_data_bytes=True))
         expected_loaded_bytes = pp.LoadedArrayBytes(open_fh.read(),
                                                     np.dtype('>f4'))
-        self.assertEqual(pp_field._data, expected_loaded_bytes)
+        self.assertEqual(pp_field._my_data, expected_loaded_bytes)
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -33,13 +33,13 @@ class Test__interpret_fields__land_packed_fields(tests.IrisTest):
         self.pp_field = mock.Mock(lblrec=1, lbext=0, lbuser=[0] * 7,
                                   lbrow=0, lbnpt=0,
                                   raw_lbpack=20,
-                                  _data=('dummy', 0, 0, 0))
+                                  _my_data=('dummy', 0, 0, 0))
         # The field specifying the land/seamask.
         lbuser = [None, None, None, 30, None, None, 1]  # m01s00i030
         self.land_mask_field = mock.Mock(lblrec=1, lbext=0, lbuser=lbuser,
                                          lbrow=3, lbnpt=4,
                                          raw_lbpack=0,
-                                         _data=('dummy', 0, 0, 0))
+                                         _my_data=('dummy', 0, 0, 0))
 
     def test_non_deferred_fix_lbrow_lbnpt(self):
         # Checks the fix_lbrow_lbnpt is applied to fields which are not
@@ -51,7 +51,7 @@ class Test__interpret_fields__land_packed_fields(tests.IrisTest):
         self.assertEqual(f1.lbrow, 3)
         self.assertEqual(f1.lbnpt, 4)
         # Check the data's shape has been updated too.
-        self.assertEqual(f1._data.shape, (3, 4))
+        self.assertEqual(f1._my_data.shape, (3, 4))
 
     def test_fix_lbrow_lbnpt_no_mask_available(self):
         # Check a warning is issued when loading a land masked field


### PR DESCRIPTION
The data API of the 2D field formats is currently a bit of a mess, with `_data` being accessed from outside the classes in order to provide to deferred loading. This PR attempts to improve matters by borrowing the `data`/`lazy_data()` API from the `Cube` class.
