### PR TITLE
Extended the env variables for Iris's travis-ci testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 
 env:
   - TEST_TARGET=default
-  - TEST_TARGET=coding_and_system
+  - TEST_TARGET=coding
   - TEST_TARGET=example
   - TEST_TARGET=doctest
 
@@ -79,7 +79,7 @@ install:
   
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib
-  - if [[ $TEST_TARGET -ne 'coding_and_system' ]]; then
+  - if [[ $TEST_TARGET -ne 'coding' ]]; then
       IRIS=$(ls -d1 build/lib*/iris);
       mkdir $IRIS/etc;
     else
@@ -97,7 +97,7 @@ install:
 
   # The coding standards tests expect all the standard names and PyKE
   # modules to be present.
-  - if [[ $TEST_TARGET == 'coding_and_system' ]]; then
+  - if [[ $TEST_TARGET == 'coding' ]]; then
       python setup.py std_names;
       PYTHONPATH=lib python setup.py pyke_rules;
     fi
@@ -108,7 +108,7 @@ install:
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests;
+      python -m iris.tests.runner --default-tests --system-tests;
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
       python -m iris.tests.runner --example-tests;
@@ -122,6 +122,6 @@ script:
       echo `make clean html`;
       make doctest;
     fi
-  - if [[ $TEST_TARGET == 'coding_and_system' ]]; then
-      python setup.py test --coding-tests --system-tests;
+  - if [[ $TEST_TARGET == 'coding' ]]; then
+      python setup.py test --coding-tests;
     fi


### PR DESCRIPTION
Splits the tests up further in travis-ci. Adds the system tests to the mix.

Example before: https://travis-ci.org/SciTools/iris/builds/38275701
Example after: https://travis-ci.org/pelson/iris/builds/38798350

Max run-time drops from 11m50s to 9m10. A finger in the air measurement suggests that the total install time is around 3 mins currently.
