### PR TITLE
Fix cube.copy() for scalar cubes.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2615,16 +2615,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def _deepcopy(self, memo, data=None):
         if data is None:
-            if not self.has_lazy_data() and self.ndim == 0:
-                # Cope with NumPy's asymmetric (aka. "annoying!") behaviour
-                # of deepcopy on 0-d arrays.
-                new_cube_data = np.asanyarray(self.data)
+            # Use a copy of the source cube data.
+            if self.has_lazy_data():
+                # Use copy.copy, as lazy arrays don't have a copy method.
+                new_cube_data = copy.copy(self.lazy_data())
             else:
-                try:
-                    new_cube_data = self._my_data.copy()
-                except AttributeError:
-                    new_cube_data = copy.copy(self._my_data)
+                # Do *not* use copy.copy, as NumPy 0-d arrays do that wrong.
+                new_cube_data = self.data.copy()
         else:
+            # Use the provided data (without copying it).
             if not isinstance(data, biggus.Array):
                 data = np.asanyarray(data)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1100,12 +1100,42 @@ class Test_regrid(tests.IrisTest):
 
 
 class Test_copy(tests.IrisTest):
-    def test(self):
-        cube = stock.simple_3d_mask()
-        cube_copy = cube.copy()
+    def _check_copy(self, cube, cube_copy):
+        self.assertEqual(cube, cube_copy)
         self.assertNotEqual(id(cube), id(cube_copy))
+        if isinstance(cube.data, np.ma.MaskedArray):
+            self.assertMaskedArrayEqual(cube.data, cube_copy.data)
+        else:
+            self.assertArrayEqual(cube.data, cube_copy.data)
         self.assertNotEqual(id(cube.data), id(cube_copy.data))
-        self.assertNotEqual(id(cube.data.mask), id(cube_copy.data.mask))
+
+    def test(self):
+        cube = stock.simple_3d()
+        self._check_copy(cube, cube.copy())
+
+    def test__masked_emptymask(self):
+        cube = Cube(np.ma.array([0, 1]))
+        self._check_copy(cube, cube.copy())
+
+    def test__masked_arraymask(self):
+        cube = Cube(np.ma.array([0, 1], mask=[True, False]))
+        self._check_copy(cube, cube.copy())
+
+    def test__scalar(self):
+        cube = Cube(0)
+        self._check_copy(cube, cube.copy())
+
+    def test__masked_scalar_emptymask(self):
+        cube = Cube(np.ma.array(0))
+        self._check_copy(cube, cube.copy())
+
+    def test__masked_scalar_arraymask(self):
+        cube = Cube(np.ma.array(0, mask=False))
+        self._check_copy(cube, cube.copy())
+
+    def test__lazy(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.array([1, 0])))
+        self._check_copy(cube, cube.copy())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Problem as mentioned https://github.com/SciTools/iris/pull/1403#issuecomment-59939103

```
>>> cube = iris.cube.Cube(0)
>>> cube.copy().data is cube.data
True
>>> 
```

Basically, with cube.copy(**data=None**), the array never got actually copied.
The proposed new code is now actually a bit simpler, from using array copy method.
