### PR TITLE
Fix vector dims shape for scalar dims

### DIFF
--- a/lib/iris/fileformats/um/_optimal_array_structuring.py
+++ b/lib/iris/fileformats/um/_optimal_array_structuring.py
@@ -168,7 +168,10 @@ def optimal_array_structure(ordering_elements, actual_values_elements=None):
     primary_dimension_elements = set(
         name for (name, _) in target_structure)
 
+    if vector_dims_shape == (1,):
+        shape = ()
+    else:
+        shape = vector_dims_shape
+
     # Return all the information.
-    return (vector_dims_shape,
-            primary_dimension_elements,
-            elements_and_dimensions)
+    return (shape, primary_dimension_elements, elements_and_dimensions)

--- a/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/test_optimal_array_structure.py
+++ b/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/test_optimal_array_structure.py
@@ -57,7 +57,7 @@ class Test_optimal_array_structure(tests.IrisTest):
         # A single value does not make a dimension (no length-1 dims).
         elements = [('a', np.array([1]))]
         shape, primaries, elems_and_dims = optimal_array_structure(elements)
-        self.assertEqual(shape, (1,))
+        self.assertEqual(shape, ())
         self.assertEqual(primaries, set())
         self.assertEqual(elems_and_dims, {})
 


### PR DESCRIPTION
Fix some broken logic in determining the vector dimensions' shape for a `FieldCollation` when a scalar dimension is input.

This caused the data for such dimensions to gain a length-one leading dimension, which was causing errors when building aux factories from fast-loaded structured FF files.
