### PR TITLE
Fix nearest-neighbour interpolation.

### DIFF
--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -328,8 +328,8 @@ class RectilinearInterpolator(object):
             # some unnecessary checks on the fill_value parameter,
             # so we set it afterwards instead. Sneaky. ;-)
             self._interpolator = _RegularGridInterpolator(
-                self._src_points, data, bounds_error=mode.bounds_error,
-                fill_value=None)
+                self._src_points, data, method=self.method,
+                bounds_error=mode.bounds_error, fill_value=None)
         else:
             self._interpolator.values = data
 

--- a/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
@@ -498,7 +498,7 @@ class Test___call___time(tests.IrisTest):
     def interpolator(self, method=LINEAR):
         data = np.arange(12).reshape(4, 3)
         cube = iris.cube.Cube(data)
-        time_coord = iris.coords.DimCoord(range(0, 48, 12), 'time',
+        time_coord = iris.coords.DimCoord(np.arange(0.0, 48.0, 12.0), 'time',
                                           units='hours since epoch')
         height_coord = iris.coords.DimCoord(range(3), 'altitude', units='m')
         cube.add_dim_coord(time_coord, 0)


### PR DESCRIPTION
By using integer coordinate values the tests of nearest-neighbour interpolation were hiding a bug - the underlying SciPy interpolator wasn't being told to operate in nearest-neighbour mode!

This was discovered thanks to #1374.
