### PR TITLE
Prevent arbitrary SplittableInt in lbtim.

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -976,17 +976,16 @@ class PPField(object):
         self.lbuser[6] = self._stash.lbuser6()
         self.lbuser[3] = self._stash.lbuser3()
 
-    # lbtim
-    def _lbtim_setter(self, new_value):
-        if not isinstance(new_value, SplittableInt):
-            self.raw_lbtim = new_value
-            # add the ia/ib/ic values for lbtim
-            new_value = SplittableInt(new_value, {'ia':slice(2, None), 'ib':1, 'ic':0})
-        else:
-            self.raw_lbtim = new_value._value
-        self._lbtim = new_value
+    @property
+    def lbtim(self):
+        return self._lbtim
 
-    lbtim = property(lambda self: self._lbtim, _lbtim_setter)
+    @lbtim.setter
+    def lbtim(self, value):
+        value = int(value)
+        self.raw_lbtim = value
+        self._lbtim = SplittableInt(value, {'ia': slice(2, None), 'ib': 1,
+                                            'ic': 0})
 
     # lbcode
     def _lbcode_setter(self, new_value):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -232,5 +232,44 @@ class Test__getattr__(tests.IrisTest):
             TestPPField().x
 
 
+class Test_lbtim(tests.IrisTest):
+    def test_get_splittable(self):
+        headers = [0] * 64
+        headers[12] = 12345
+        field = TestPPField(headers)
+        self.assertIsInstance(field.lbtim, SplittableInt)
+        self.assertEqual(field.lbtim.ia, 123)
+        self.assertEqual(field.lbtim.ib, 4)
+        self.assertEqual(field.lbtim.ic, 5)
+
+    def test_set_int(self):
+        headers = [0] * 64
+        headers[12] = 12345
+        field = TestPPField(headers)
+        field.lbtim = 34567
+        self.assertIsInstance(field.lbtim, SplittableInt)
+        self.assertEqual(field.lbtim.ia, 345)
+        self.assertEqual(field.lbtim.ib, 6)
+        self.assertEqual(field.lbtim.ic, 7)
+        self.assertEqual(field.raw_lbtim, 34567)
+
+    def test_set_splittable(self):
+        # Check that assigning a SplittableInt to lbtim uses the integer
+        # value. In other words, check that you can't assign an
+        # arbitrary SplittableInt with crazy named attributes.
+        headers = [0] * 64
+        headers[12] = 12345
+        field = TestPPField(headers)
+        si = SplittableInt(34567, {'foo': 0})
+        field.lbtim = si
+        self.assertIsInstance(field.lbtim, SplittableInt)
+        with self.assertRaises(AttributeError):
+            field.lbtim.foo
+        self.assertEqual(field.lbtim.ia, 345)
+        self.assertEqual(field.lbtim.ib, 6)
+        self.assertEqual(field.lbtim.ic, 7)
+        self.assertEqual(field.raw_lbtim, 34567)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Fixes a bug where it is possible to assign a SplittableInt with arbitrary named digit ranges to `PPField.lbtim`. For example:

```
>>> field.lbtim = SplittableInt(1234, {'foo': 0, 'bar': slice(1, None)})
>>> field.lbtim.foo
4
```

NB. If this gets merged then I'd do the same for `lbcode` and `lbpack`, and similar for `lbproc`.
