### PR TITLE
Simpler fast-ff interface.

### DIFF
--- a/lib/iris/experimental/fieldsfile.py
+++ b/lib/iris/experimental/fieldsfile.py
@@ -45,27 +45,21 @@ def _collations_from_filename(filename):
     return group_structured_fields(fields)
 
 
-def load(filenames, callback=None):
+def load(filepath):
     """
-    Load the structured FieldsFiles.
+    Load a structured FieldsFile.
 
     Args:
 
-    * filesnames:
-        One or more filenames.
-
-    Kwargs:
-
-    * callback:
-        A modifier/filter function. Please see the module documentation
-        for :mod:`iris`.
+    * filepath (string):
+        Filepath of the input FieldsFile.
 
     Returns:
-        An :class:`iris.cube.CubeList`.
+        A :class:`iris.cube.CubeList`.
 
     """
     loader = Loader(_collations_from_filename, {}, convert_collation, None)
-    return CubeList(load_cubes(filenames, callback, loader, None))
+    return CubeList(load_cubes([filepath], None, loader, None))
 
 
 def _adjust_dims(coords_and_dims, n_dims):

--- a/lib/iris/tests/experimental/test_fieldsfile.py
+++ b/lib/iris/tests/experimental/test_fieldsfile.py
@@ -35,13 +35,6 @@ class TestStructuredLoadFF(tests.IrisTest):
         cube, = load(fname)
         self.assertCML(cube)
 
-    def test_simple_callback(self):
-        def callback(cube, field, filename):
-            cube.attributes['processing'] = 'fast-ff'
-        fname = tests.get_data_path(('FF', 'structured', 'small'))
-        cube, = load(fname, callback=callback)
-        self.assertCML(cube)
-
 
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Removes extra complications that seemed unnecessary and make description harder
(see https://github.com/SciTools/iris/pull/1420  -- can get simpler if we make these changes)

The API seems to contain some unnecessary confusing extras... 
- can pass a group of filenames, but unlike `iris.load()` this can't combine data from multiple files into one cube
- can specify a cube callback, but unlike `iris.load()` this seems a bit pointless, as it only applies it to the result cubes + can't affect the loading process.

So... this proposes to remove both those (but n.b. will need merge with #1420)
