### PR TITLE
ENH: Cached cropped_bounds within regrid

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -676,10 +676,11 @@ def _within_bounds(src_bounds, tgt_bounds, orderswap=False):
 
 def _cropped_bounds(bounds, lower, upper):
     """
-    Return a new bounds array and corresponding slice object (or indices)
-    that result from cropping the provided bounds between the specified lower
-    and upper values. The bounds at the extremities will be truncated so that
-    they start and end with lower and upper.
+    Return a new bounds array and corresponding slice object (or indices) of
+    the original data array, resulting from cropping the provided bounds
+    between the specified lower and upper values. The bounds at the
+    extremities will be truncated so that they start and end with lower and
+    upper.
 
     This function will return an empty NumPy array and slice if there is no
     overlap between the region covered by bounds and the region from lower to


### PR DESCRIPTION
See https://github.com/SciTools/iris/pull/1431 for further details.

Going from 30second (21600, 43200) source to N96 (145, 192):
Unoptimised: 43s
Optimised: 26s (does not include #1431)

Combined with #1431, offers a double in performance of regrid for the above.

When regriding from a 15seconds field to N2048 (decomposed to 30 pieces on multiple hosts using MPI) the combined optimisation of these PRs takes this from **20minutes to 3.7minutes!**
