### PR TITLE
Auto promote concatenate.

### DIFF
--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -26,7 +26,23 @@ import iris.coords
 from iris._concatenate import concatenate
 import iris.cube
 from iris.exceptions import ConcatenateError
+from iris.tests.stock import realistic_4d
 import iris.unit
+
+
+class TestPromote(tests.IrisTest):
+    def setUp(self):
+        self.cube = realistic_4d()
+
+    def test_auto_promote_single(self):
+        cube = self.cube
+        cl = iris.cube.CubeList([cube[:-1], cube[-1]])
+        self.assertEqual(len(cl.concatenate()), 1)
+
+    def test_auto_promote_multi(self):
+        cube = self.cube
+        cl = iris.cube.CubeList([cube[-1], cube[1:-1], cube[0]])
+        self.assertEqual(len(cl.concatenate()), 1)
 
 
 class TestEpoch(tests.IrisTest):


### PR DESCRIPTION
This PR allows cube concatenation to promote candidate cube dimensionality in an attempt to match that of the proto-cube.

For example, given a 3D time-series, this PR will successfully concatenate the following:

```
iris.cube.CubeList([cube[-1], cube[1:-1], cube[0]]).concatenate_cube()
```
