### PR TITLE
Auto promote concatenate.

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -35,17 +35,11 @@ import numpy.ma as ma
 
 import iris.coords
 import iris.cube
-from iris.util import guess_coord_axis, array_equal, unify_time_units
+from iris.util import guess_coord_axis, array_equal, as_compatible_shape
 
 
 #
 # TODO:
-#
-#   * Deal with scalar coordinate promotion to a new dimension
-#     e.g. promote scalar z coordinate in 2D cube (y:m, x:n) to
-#     give the similar 3D cube (z:1, y:m, x:n). These two types
-#     of cubes are one and the same, and as such should concatenate
-#     together.
 #
 #   * Cope with auxiliary coordinate factories.
 #
@@ -266,7 +260,11 @@ def concatenate(cubes, error_on_mismatch=False):
     axis = None
 
     # Register each cube with its appropriate proto-cube.
-    for cube in cubes:
+    # Ensure to seed higher dimensional cubes first. This means that
+    # proto-cubes have a higher dimensionality, allowing them to promote
+    # the dimensionality of candidate cubes containing scalar coordinates,
+    # such that they are compatible for concatenation.
+    for cube in sorted(cubes, key=lambda c: c.ndim, reverse=True):
         # TODO: Remove this when new deferred data mechanism is available.
         # Avoid deferred data/data manager issues, and load the cube data!
         cube.data
@@ -705,6 +703,14 @@ class _ProtoCube(object):
             msg = 'Nominated axis [{}] is not equal ' \
                 'to negotiated axis [{}]'.format(axis, self.axis)
             raise ValueError(msg)
+
+        # Attempt automatic scalar coordinate promotion.
+        if self._cube.ndim > cube.ndim:
+            try:
+                # XXX This loads the cube data payload!
+                cube = as_compatible_shape(cube, self._cube)
+            except ValueError:
+                pass
 
         # Check for compatible cube signatures.
         cube_signature = _CubeSignature(cube)

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -28,7 +28,23 @@ import iris.coords
 from iris._concatenate import concatenate
 import iris.cube
 from iris.exceptions import ConcatenateError
+from iris.tests.stock import realistic_4d
 import iris.unit
+
+
+class TestPromote(tests.IrisTest):
+    def setUp(self):
+        self.cube = realistic_4d()
+
+    def test_auto_promote_single(self):
+        cube = self.cube
+        cl = iris.cube.CubeList([cube[:-1], cube[-1]])
+        self.assertEqual(len(cl.concatenate()), 1)
+
+    def test_auto_promote_multi(self):
+        cube = self.cube
+        cl = iris.cube.CubeList([cube[-1], cube[1:-1], cube[0]])
+        self.assertEqual(len(cl.concatenate()), 1)
 
 
 class TestEpoch(tests.IrisTest):


### PR DESCRIPTION
This PR allows cube concatenation to promote candidate cube dimensionality in an attempt to match that of the proto-cube.

For example, given a 3D time-series, this PR will successfully concatenate the following:

```
iris.cube.CubeList([cube[-1], cube[1:-1], cube[0]]).concatenate_cube()
```

This PR replaces #1434, as it targets upstream/master rather than v1.7.x.