### PR TITLE
Deprecate default unlimited dimension on netCDF save

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -781,6 +781,10 @@ class Saver(object):
                     dim_name = self._get_coord_variable_name(cube, coord)
                     unlimited_dim_names.append(dim_name)
 
+        if unlimited_dim_names is not None:
+            warnings.warn('The behaviour for making the outermost dimension '
+                          'unlimited is to be removed in a future release.')
+
         for dim_name in dimension_names:
             if dim_name not in self._dataset.dimensions:
                 if dim_name in unlimited_dim_names:

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -118,11 +118,15 @@ class Test_write(tests.IrisTest):
         cube = self._simple_cube('>f4')
         with self.temp_filename('.nc') as nc_path:
             with Saver(nc_path, 'NETCDF4') as saver:
-                saver.write(cube)
+                with mock.patch('warnings.warn') as warn:
+                    saver.write(cube)
             ds = nc.Dataset(nc_path)
             self.assertTrue(ds.dimensions['dim0'].isunlimited())
             self.assertFalse(ds.dimensions['dim1'].isunlimited())
             ds.close()
+        msg = ('The behaviour for making the outermost dimension unlimited is '
+               'to be removed in a future release.')
+        warn.assert_called_once_with(msg)
 
     def test_no_unlimited_dimensions(self):
         cube = self._simple_cube('>f4')


### PR DESCRIPTION
Warns of the future removal of the iris default behaviour with NetCDF
'UNLIMITED' dimensions.