### PR TITLE
Add GRIB save GDT12 (Transverse Mercator) 

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -960,14 +960,13 @@ def save_grib2(cube, target, append=False, **kwargs):
     else:
         raise ValueError("Can only save grib to filename or writable")
 
-    lon_coords = cube.coords(axis='x', dim_coords=True)
-    lat_coords = cube.coords(axis='y', dim_coords=True)
-    if len(lat_coords) != 1 or len(lon_coords) != 1:
-        raise TranslationError("Did not find one (and only one) "
-                               "latitude or longitude coord")
+    x_coords = cube.coords(axis='x', dim_coords=True)
+    y_coords = cube.coords(axis='y', dim_coords=True)
+    if len(x_coords) != 1 or len(y_coords) != 1:
+        raise TranslationError("Did not find one (and only one) x or y coord")
 
     # Save each latlon slice2D in the cube
-    for slice2D in cube.slices([lat_coords[0], lon_coords[0]]):
+    for slice2D in cube.slices([y_coords[0], x_coords[0]]):
 
         # Save this slice to the grib file
         grib_message = gribapi.grib_new_from_samples("GRIB2")

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
@@ -44,7 +44,6 @@ class GdtTestMixin(object):
         self.mock_gribapi.grib_set_float = grib_set_trap
         self.mock_gribapi.grib_set_double = grib_set_trap
         self.mock_gribapi.grib_set_long_array = grib_set_trap
-        self.mock_gribapi.grib_set = grib_set_trap
         self.mock_gribapi.grib_set_array = grib_set_trap
 
         # Create a mock 'grib message id', with a 'keys' dict for settings.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_12.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_12.py
@@ -43,8 +43,7 @@ class Test(tests.IrisTest, GdtTestMixin):
     def setUp(self):
         self.default_ellipsoid = GeogCS(semi_major_axis=6377563.396,
                                         semi_minor_axis=6356256.909)
-        self.default_cs = self._default_coord_system()
-        self.test_cube = self._make_test_cube(cs=self.default_cs)
+        self.test_cube = self._make_test_cube()
 
         GdtTestMixin.setUp(self)
 
@@ -72,16 +71,14 @@ class Test(tests.IrisTest, GdtTestMixin):
 
     def test__grid_shape(self):
         test_cube = self._make_test_cube(x_points=np.arange(13),
-                                         y_points=np.arange(6),
-                                         cs=self.default_cs)
+                                         y_points=np.arange(6))
         grid_definition_template_12(test_cube, self.mock_grib)
         self._check_key('Ni', 13)
         self._check_key('Nj', 6)
 
     def test__grid_points(self):
         test_cube = self._make_test_cube(x_points=[1, 3, 5, 7],
-                                         y_points=[4, 9],
-                                         cs=self.default_cs)
+                                         y_points=[4, 9])
         grid_definition_template_12(test_cube, self.mock_grib)
         self._check_key("X1", 100)
         self._check_key("X2", 700)
@@ -93,6 +90,7 @@ class Test(tests.IrisTest, GdtTestMixin):
     def test__negative_grid_points_gribapi_broken(self):
         self.mock_gribapi.GribInternalError = FakeGribError
 
+        # Force the test to run the signed int --> unsigned int workaround.
         def set(grib, key, value):
             if key in ["X1", "X2", "Y1", "Y2"] and value < 0:
                 raise self.mock_gribapi.GribInternalError()
@@ -100,8 +98,7 @@ class Test(tests.IrisTest, GdtTestMixin):
         self.mock_gribapi.grib_set = set
 
         test_cube = self._make_test_cube(x_points=[-1, 1, 3, 5, 7],
-                                         y_points=[-4, 9],
-                                         cs=self.default_cs)
+                                         y_points=[-4, 9])
         grid_definition_template_12(test_cube, self.mock_grib)
         self._check_key("X1", 0x80000064)
         self._check_key("X2", 700)
@@ -110,8 +107,7 @@ class Test(tests.IrisTest, GdtTestMixin):
 
     def test__negative_grid_points_gribapi_fixed(self):
         test_cube = self._make_test_cube(x_points=[-1, 1, 3, 5, 7],
-                                         y_points=[-4, 9],
-                                         cs=self.default_cs)
+                                         y_points=[-4, 9])
         grid_definition_template_12(test_cube, self.mock_grib)
         self._check_key("X1", -100)
         self._check_key("X2", 700)


### PR DESCRIPTION
This adds functionality to Iris that allows cubes on a Transverse Mercator grid to be saved to a GRIB2 message. This functionality is contained in a new `_save_rules` function called `grid_definition_template_12`.

**Please note** however that this _does not currently work_ due to a bug in GRIBAPI that means the only key in GDT12 that is specified as being a `float32` by the GRIB spec is set as a signed int by the GRIBAPI template. On account of this, `_save_rules` raises a `TranslationError` when trying to save a cube with a Transverse Mercator grid to GRIB.

The other changes I've made to get this "working" are:
- This would appear to be the first grid we've saved to GRIB that is not on a simple lat/lon grid. As such I've improved the section of `fileformats/grib/__init__` that locates the horizontal dim coords of the cubes to find _any_ horizontal dim coords rather than only `Latitude` and `Longitude`.
- The logic for locating the `ellipsoid` that defines the shape of the earth for the saved GRIB message has been improved. This was done because the previous logic did not cater for a non-Rotated Pole coord system with an ellipsoid defined.
- I've also removed two function calls from `latlon_common` as it turned out they weren't common to GDT12. Specifically, GDT12 does not define lat/lon for first and last grid points or dx/dy.
- As this PR introduces using only `gribapi.grib_set` for writing GRIB message key values, I've added a trap for calling this function to the grib save rules tests `__init__`. The test module itself for this change is very short as calling `grid_definition_template_12` will currently always result in a `TranslationError`.
