### PR TITLE
Load empty string as dimensionless.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -947,6 +947,8 @@ fc_extras
     ################################################################################
     def get_attr_units(cf_var, attributes):
         attr_units = getattr(cf_var, CF_ATTR_UNITS, iris.unit._UNIT_DIMENSIONLESS)
+        if not attr_units:
+            attr_units = '1'
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:


### PR DESCRIPTION
@rhattersley in order to implement phase one of #1164 (and to be fully CF compliant) we need to interpret empty strings as dimensionless.  This PR implements this at the loading level.  However, `iris.unit.Unit("")` still translates to `unknown` as shown in the example below:

http://nbviewer.ipython.org/gist/ocefpaf/5fa5dc8b81a072389e61/staggered_grid_units_issue.ipynb
