### PR TITLE
allow calculation of forecast period from forecast ref time

### DIFF
--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
@@ -64,7 +64,7 @@ class Test(TestGribSimple):
             reference_time(cube, grib)
 
         mock_gribapi.assert_has_calls(
-            [mock.call.grib_set_long(grib, "significanceOfReferenceTime", 2),
+            [mock.call.grib_set_long(grib, "significanceOfReferenceTime", 3),
              mock.call.grib_set_long(grib, "dataDate", '19941201'),
              mock.call.grib_set_long(grib, "dataTime", '0000')])
 


### PR DESCRIPTION
The current grib save code makes no use of a `forecast_reference_time` coordinate. If a cube has no `forecast_period` the forecast time is set to zero rather than calculating it from the other coordinates. This PR adds logic so that in the case of a missing forecast period, it checks for the presence of a forecast reference time and determines the appropriate forecast time.

I've also changed the case of no forecast period and no forecast reference time so that the `significanceOfReferenceTime` value is set to 3 (Observation time) rather than the current 2 (Verifying time of forecast).
