### PR TITLE
More tolerant coordinate loading for GDT12.

### DIFF
--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_12.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_12.py
@@ -129,6 +129,18 @@ class Test(tests.IrisTest):
         expected = self.expected(1, 0)
         self.assertEqual(metadata, expected)
 
+    def test_di_tolerance(self):
+        # Even though Ni * Di doesn't exactly match X1 to X2 it should
+        # be close enough to allow the translation.
+        section = self.section_3()
+        section['X2'] += 1
+        metadata = empty_metadata()
+        grid_definition_template_12(section, metadata)
+        expected = self.expected(0, 1)
+        x = expected['dim_coords_and_dims'][1][0]
+        x.points = np.linspace(293000, 299000.01, 4)
+        self.assertEqual(metadata, expected)
+
     def test_incompatible_grid_extent(self):
         section = self.section_3()
         section['X2'] += 100


### PR DESCRIPTION
Allows a GRIB message to load even if the centimetre resolution of the message prevents a consistent representation of start, end, and step.
