### PR TITLE
Subsection of bugs fixed in v1.7.3

### DIFF
--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -190,6 +190,9 @@ Bugs fixed
 * A fix to allow :meth:`iris.cube.CubeList.concatenate` to deal with descending coordinate order.
 * Add missing NetCDF attribute `varname` when constructing a new :class:`iris.coords.AuxCoord`.
 * The datatype of time arrays converted with :func:`iris.util.unify_time_units` is now preserved.
+
+Bugs fixed in v1.7.3
+^^^^^^^^^^^^^^^^^^^^
 * Scalar dimension coordinates can now be concatenated with :meth:`iris.cube.CubeList.concatenate`.
 * Arbitrary names can no longer be set for elements of a :class:`iris.fileformats.pp.SplittableInt`.
 * Cubes that contain a pseudo-level coordinate can now be saved to PP.


### PR DESCRIPTION
Added subsection to the what's new document for Iris v1.7 that contains the bugs fixed in v1.7.3.
