### PR TITLE
SSL certificate verification workaround.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ install:
   - conda list
   - conda info -a
 
+# Temporary workaround to avoid GitHub SSL verification when downloading
+# Natural Earth shapefiles.
+  - conda install python=2.7.8
+
 # Pre-load Natural Earth data to avoid multiple, overlapping downloads.
 # i.e. There should be no DownloadWarning reports in the log.
   - python -c 'import cartopy; cartopy.io.shapereader.natural_earth()'


### PR DESCRIPTION
Python 2.7.9 performs SSL certificate verification by default (see [issue #22417](https://hg.python.org/cpython/raw-file/v2.7.9/Misc/NEWS) and [PEP 476](https://www.python.org/dev/peps/pep-0476/)). On Travis-CI (and on my local, RHEL 6 machine) the verification is failing for GitHub when attempting to download Natural Earth shapefiles.

This PR is intended to be a _temporary_ workaround which rolls Python back to 2.7.8 where the certificates are unchecked.
