### PR TITLE
Updating Iris' handled grids to include grid 21

### DIFF
--- a/lib/iris/fileformats/_ff_cross_references.py
+++ b/lib/iris/fileformats/_ff_cross_references.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -202,6 +202,7 @@ STASH_TRANS = {
     "m01s00i203": Stash(19, 57),
     "m01s00i204": Stash(1, 19),
     "m01s00i205": Stash(1, 36),
+    "m01s00i207": Stash(21, 1381),
     "m01s00i208": Stash(21, 1382),
     "m01s00i209": Stash(21, 1383),
     "m01s00i211": Stash(1, 218),

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -113,7 +113,7 @@ Y_COORD_V_GRID = (11, 19, 28)
 #: Grid codes found in the STASH master which are currently known to be
 #: handled correctly. A warning is issued if a grid is found which is not
 #: handled.
-HANDLED_GRIDS = (1, 2, 3, 4, 5, 26, 29) + X_COORD_U_GRID + Y_COORD_V_GRID
+HANDLED_GRIDS = (1, 2, 3, 4, 5, 21, 26, 29) + X_COORD_U_GRID + Y_COORD_V_GRID
 
 # REAL constants header names as described by UM documentation paper F3.
 # NB. These are zero-based indices as opposed to the one-based indices

--- a/lib/iris/tests/integration/test_ff.py
+++ b/lib/iris/tests/integration/test_ff.py
@@ -31,6 +31,7 @@ import iris
 import iris.experimental.um as um
 
 
+@tests.skip_data
 class TestLBC(tests.IrisTest):
     def setUp(self):
         # Load multiple cubes from a test file.

--- a/lib/iris/tests/integration/test_ff.py
+++ b/lib/iris/tests/integration/test_ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,9 +22,13 @@ from __future__ import (absolute_import, division, print_function)
 # importing anything else.
 import iris.tests as tests
 
+import shutil
+
+import mock
 import numpy as np
 
 import iris
+import iris.experimental.um as um
 
 
 class TestLBC(tests.IrisTest):
@@ -80,6 +84,22 @@ class TestLBC(tests.IrisTest):
         mask = np.zeros((2, 4, 16, 16), dtype=bool)
         mask[:, :, 7:9, 5:11] = True
         self.assertArrayEqual(cube.data.mask, mask)
+
+
+class TestFFGrid(tests.IrisTest):
+    @tests.skip_data
+    def test_unhandled_grid_type(self):
+        self.filename = tests.get_data_path(('FF', 'n48_multi_field'))
+        with self.temp_filename() as temp_path:
+            shutil.copyfile(self.filename, temp_path)
+            ffv = um.FieldsFileVariant(temp_path,
+                                       mode=um.FieldsFileVariant.UPDATE_MODE)
+            ffv.fields[3].lbuser4 = 60
+            ffv.close()
+            with mock.patch('warnings.warn') as warn_fn:
+                iris.load(temp_path)
+            self.assertIn("Assuming the data is on a P grid.",
+                          warn_fn.call_args[0][0])
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -224,12 +224,6 @@ class TestFFVariableResolutionGrid(tests.IrisTest):
 
     def test_v(self):
         self._check_stash('m01s00i003', self.P_grid_x, self.V_grid_y)
-
-    def test_unhandled_grid_type(self):
-        with mock.patch('warnings.warn') as warn_fn:
-            self._check_stash('m01s00i005', self.P_grid_x, self.P_grid_y)
-            self.assertIn("Assuming the data is on a P grid.",
-                          warn_fn.call_args[0][0])
 
 
 class TestFFPayload(tests.IrisTest):


### PR DESCRIPTION
Grid 21 is being handled correctly by Iris, it should be on a P grid. The documentation isn't clear but this has been decided as the land sea mask used for the compressing is on unstaggered theta points.

Stash item m01s00i207 wasn't in the STASH to grid type mapping so was getting a warning.