### PR TITLE
Added dtype property to iris.cube.Cube class

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1399,11 +1399,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     @property
     def dtype(self):
-        """
-        Return the data type of this cube without causing the data payload
-        to be loaded into memory, which would happen if the cube.data.dtype
-        attribute was queried.
-        """
+        """The :class:`numpy.dtype` of the data of this cube."""
         return self.lazy_data().dtype
 
     @property

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1398,6 +1398,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         return shape
 
     @property
+    def dtype(self):
+        """
+        Return the data type of this cube without causing the data payload
+        to be loaded into memory, which would happen if the cube.data.dtype
+        attribute was queried.
+        """
+        return self.lazy_data().dtype
+
+    @property
     def ndim(self):
         """The number of dimensions in the data of this cube."""
         return len(self.shape)

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -1154,6 +1154,17 @@ class Test_copy(tests.IrisTest):
     def test__lazy(self):
         cube = Cube(biggus.NumpyArrayAdapter(np.array([1, 0])))
         self._check_copy(cube, cube.copy())
+
+
+class Test_properties(tests.IrisTest):
+    def setUp(self):
+        self.cube_i8 = iris.cube.Cube(np.array([0,1], dtype=np.int8))
+        self.cube_f32 = iris.cube.Cube(np.array([0,1], dtype=np.float32))
+
+    def test_dtype(self):
+        # Check that the dtype property returns the correct numpy.dtype object.
+        self.assertEqual(self.cube_i8.dtype, np.int8)
+        self.assertEqual(self.cube_f32.dtype, np.float32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This small pull request is intended to facilitate the situation wherein one wishes to query the data type of a cube without causing the cube's data payload to be loaded into memory, which can be an undesirable side effect for very large datasets which one intends to process later perhaps on a tile-by-tile basis (i.e. domain decomposition).

The current alternative - querying `cube.data.dtype` - appears to suffer from the aforementioned side effect (though with the obvious proviso that no additional time penalty is incurred if the data has already been loaded into memory).