### PR TITLE
MAINT: Version references packages __init__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,9 +243,22 @@ class BuildPyWithExtras(build_py.build_py):
             MakePykeRules._pyke_rule_compile()
 
 
+def extract_version():
+    version = None
+    fdir = os.path.dirname(__file__)
+    fnme = os.path.join(fdir, 'lib', 'iris', '__init__.py')
+    with open(fnme) as fd:
+        for line in fd:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                version = version.strip()[1:-1]  # Remove quotation characters
+                break
+    return version
+
+
 setup(
     name='Iris',
-    version='1.7.4-DEV',
+    version=extract_version(),
     url='http://scitools.org.uk/iris/',
     author='UK Met Office',
 


### PR DESCRIPTION
Removes unnecessary conflict between setup version reference of
multiple branches.  Also Pep8 setup.

**Context:** Working from master and merging v1.7.x branch(es) (PRs yet to be merged) results in annoying conflicts with the version referenced in setup.py.  This PR simply makes setup.py reference the version identifier from the package directly.