### PR TITLE
Added basic support for climatology cell methods

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -868,7 +868,7 @@ fc_extras
 
     CM_PARSE = re.compile(  r'''
                                 (?P<name>([\w_]+:\s+)+)
-                                (?P<method>[\w_]+)\s*
+                                (?P<method>[\w_\s]+(?![\w_]*:))\s*
                                 (?:
                                     \(\s*
                                     (?P<extra>[^\)]+)
@@ -1487,8 +1487,17 @@ fc_extras
         if nc_cell_methods is not None:
             for m in CM_PARSE.finditer(nc_cell_methods):
                 d = m.groupdict()
-                if d[CM_METHOD].lower() not in CM_KNOWN_METHODS:
-                    warnings.warn('NetCDF variable {!r} contains unknown cell method {!r}'.format('{}'.format(cf_var_name), '{}'.format(d[CM_METHOD])))
+                method = d[CM_METHOD]
+                method = method.strip()
+                # Check validity of method, allowing for multi-part methods
+                # e.g. mean over years.
+                method_words = method.split()
+                if method_words[0].lower() not in CM_KNOWN_METHODS:
+                    msg = 'NetCDF variable {!r} contains unknown cell ' \
+                          'method {!r}'
+                    warnings.warn(msg.format('{}'.format(cf_var_name),
+                                             '{}'.format(method_words[0])))
+                d[CM_METHOD] = method
                 name = d[CM_NAME]
                 name = name.replace(' ', '')
                 name = name.rstrip(':')

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -66,10 +66,10 @@
       </coord>
     </coords>
     <cellMethods>
-      <cellMethod method="mean">
+      <cellMethod method="mean within years">
         <coord name="time"/>
       </cellMethod>
-      <cellMethod method="mean">
+      <cellMethod method="mean over years">
         <coord name="time"/>
       </cellMethod>
     </cellMethods>

--- a/lib/iris/tests/results/netcdf/save_load_traj.cml
+++ b/lib/iris/tests/results/netcdf/save_load_traj.cml
@@ -29,10 +29,10 @@
       </coord>
     </coords>
     <cellMethods>
-      <cellMethod method="mean">
+      <cellMethod method="mean within years">
         <coord name="time"/>
       </cellMethod>
-      <cellMethod method="mean">
+      <cellMethod method="mean over years">
         <coord name="time"/>
       </cellMethod>
     </cellMethods>

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
@@ -1,0 +1,97 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc._parse_cell_methods`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import mock
+
+from iris.coords import CellMethod
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    _parse_cell_methods
+
+
+class Test(tests.IrisTest):
+    def test_simple(self):
+        cell_method_str = 'time: mean'
+        expected = (CellMethod(method='mean', coords='time'),)
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_with_interval(self):
+        cell_method_str = 'time: variance (interval: 1 hr)'
+        expected = (CellMethod(method='variance', coords='time',
+                               intervals='1 hr'),)
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_multiple(self):
+        cell_method_str = 'time: maximum (interval: 1 hr) ' \
+                          'time: mean (interval: 1 day)'
+        expected = (CellMethod(method='maximum', coords='time',
+                               intervals='1 hr'),
+                    CellMethod(method='mean', coords='time',
+                               intervals='1 day'))
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_comment(self):
+        cell_method_str = 'time: maximum (interval: 1 hr comment: first bit) ' \
+                          'time: mean (interval: 1 day comment: second bit)'
+        expected = (CellMethod(method='maximum', coords='time',
+                               intervals='1 hr', comments='first bit'),
+                    CellMethod(method='mean', coords='time',
+                               intervals='1 day', comments='second bit'))
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_portions_of_cells(self):
+        cell_method_str = 'area: mean where sea_ice over sea'
+        expected = (CellMethod(method='mean where sea_ice over sea',
+                               coords='area'),)
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_climatology(self):
+        cell_method_str = 'time: minimum within days time: mean over days'
+        expected = (CellMethod(method='minimum within days', coords='time'),
+                    CellMethod(method='mean over days', coords='time'))
+        res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertEqual(res, expected)
+
+    def test_climatology_with_unknown_method(self):
+        cell_method_str = 'time: min within days time: mean over days'
+        expected = (CellMethod(method='min within days', coords='time'),
+                    CellMethod(method='mean over days', coords='time'))
+        with mock.patch('warnings.warn') as warn:
+            res = _parse_cell_methods('test_var', cell_method_str)
+        self.assertIn("NetCDF variable 'test_var' contains unknown "
+                      "cell method 'min'",
+                      warn.call_args[0][0])
+        self.assertEqual(res, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import setuptools
 sys.path.append('lib/iris/tests/runner')
 from _runner import TestRunner
 
-exclude_dirs = ['compiled_krb']
 
 # Returns the package and all its sub-packages
 def find_package_tree(root_path, root_package):
@@ -30,7 +29,10 @@ def find_package_tree(root_path, root_package):
             contains_init_file = os.path.isfile(os.path.join(dir_path,
                                                              dir_name,
                                                              '__init__.py'))
-            if dir_name in exclude_dirs or not contains_init_file:
+            if not contains_init_file:
+                dir_names.remove(dir_name)
+            # Exclude compiled PyKE rules, but keep associated unit tests.
+            if dir_name == 'compiled_krb' and 'tests' not in dir_path:
                 dir_names.remove(dir_name)
         if dir_names:
             prefix = dir_path.split('/')[root_count:]


### PR DESCRIPTION
This PR addresses #1438 allowing loading of CF-netCDF files with rich cell methods like `time: mean within years time: mean over years` that express climatologies. I've not enhance the `CellMethod` to give atomic access to the components of the multi word method, but I still check the first part of the method is a known. I'm not good at regular expressions so any advice is welcomed.