### PR TITLE
Allow setting of negative LBPROC

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -673,7 +673,7 @@ class _LBProc(BitwiseInt):
 
         """
         if value < 0:
-            msg = 'Setting LBPROC with a negative value of {}'
+            msg = 'Negative values of LBPROC {} are not supported.'
             warnings.warn(msg.format(value))
         self._value = int(value)
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -673,8 +673,8 @@ class _LBProc(BitwiseInt):
 
         """
         if value < 0:
-            raise ValueError('Negative numbers not supported with '
-                             'splittable integers object')
+            msg = 'Setting LBPROC with a negative value of {}'
+            warnings.warn(msg.format(value))
         self._value = int(value)
 
     def __len__(self):

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -35,8 +35,10 @@ class Test___init__(tests.IrisTest):
         _LBProc('245')
 
     def test_negative(self):
-        with self.assertRaises(ValueError):
-            _LBProc(-1)
+        with mock.patch('warnings.warn') as warn:
+            lbproc = _LBProc(-1)
+        self.assertEqual(warn.call_count, 1)
+        self.assertEqual(lbproc, -1)
 
     def test_invalid_str(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This change to `iris.fileformats.pp._LBproc` means Iris can load FieldsFile-like data with a negative LBPROC value.

Traditionally Iris did not allow negative values for LBPROC, apparently because the UM F3 document does not explicitly state that such is allowed. However with LBPROC = 0 indicating that no processing has been done, it seems that often negative values of LBPROC are used to indicate that processing is missing or unknown. This change allows Iris to support such data.