### PR TITLE
LinearRegridder rebrand.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -59,7 +59,7 @@ import scipy.stats.mstats
 from iris.analysis._area_weighted import AreaWeightedRegridder
 from iris.analysis._interpolation import (EXTRAPOLATION_MODES,
                                           RectilinearInterpolator)
-from iris.analysis._linear import LinearRegridder
+from iris.analysis._linear import RectilinearRegridder
 import iris.coords
 from iris.exceptions import LazyAggregatorError
 
@@ -1600,8 +1600,8 @@ class Linear(object):
             which is to be regridded to the `target_grid`.
 
         """
-        return LinearRegridder(src_grid, target_grid,
-                               self._normalised_extrapolation_mode())
+        return RectilinearRegridder(src_grid, target_grid,
+                                    self._normalised_extrapolation_mode())
 
 
 class AreaWeighted(object):

--- a/lib/iris/analysis/_linear.py
+++ b/lib/iris/analysis/_linear.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/_linear.py
+++ b/lib/iris/analysis/_linear.py
@@ -25,7 +25,7 @@ import iris.cube
 import iris.experimental.regrid as eregrid
 
 
-class LinearRegridder(object):
+class RectilinearRegridder(object):
     """
     This class provides support for performing regridding via linear
     interpolation.
@@ -87,10 +87,10 @@ class LinearRegridder(object):
     def __call__(self, cube):
         """
         Regrid this :class:`~iris.cube.Cube` on to the target grid of
-        this :class:`LinearRegridder`.
+        this :class:`RectilinearRegridder`.
 
         The given cube must be defined with the same grid as the source
-        grid used to create this :class:`LinearRegridder`.
+        grid used to create this :class:`RectilinearRegridder`.
 
         Args:
 

--- a/lib/iris/tests/unit/analysis/linear/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/linear/test_RectilinearRegridder.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/linear/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/linear/test_RectilinearRegridder.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for :class:`iris.analysis._linear.LinearRegridder`."""
+"""Unit tests for :class:`iris.analysis._linear.RectilinearRegridder`."""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -25,7 +25,7 @@ import iris.tests as tests
 import mock
 import numpy as np
 
-from iris.analysis._linear import LinearRegridder
+from iris.analysis._linear import RectilinearRegridder
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord
 from iris.cube import Cube
@@ -52,14 +52,14 @@ class Test(tests.IrisTest):
     def check_mode(self, mode):
         src_grid, target_grid = self.grids()
         kwargs = {'extrapolation_mode': mode}
-        regridder = LinearRegridder(src_grid, target_grid, **kwargs)
+        regridder = RectilinearRegridder(src_grid, target_grid, **kwargs)
         # Make a new cube to regrid with different data so we can
         # distinguish between regridding the original src grid
         # definition cube and the cube passed to the regridder.
         src = src_grid.copy()
         src.data += 10
 
-        # To avoid duplicating tests, just check the LinearRegridder
+        # To avoid duplicating tests, just check the RectilinearRegridder
         # defers to the experimental regrid function with the correct
         # arguments (and honouring the return value!)
         with mock.patch('iris.experimental.regrid.'
@@ -92,7 +92,7 @@ class Test(tests.IrisTest):
     def test_invalid_mode(self):
         src, target = self.grids()
         with self.assertRaises(ValueError):
-            LinearRegridder(src, target, 'magic')
+            RectilinearRegridder(src, target, 'magic')
 
     def test_mismatched_src_coord_systems(self):
         src = Cube(np.zeros((3, 4)))
@@ -103,7 +103,7 @@ class Test(tests.IrisTest):
         src.add_dim_coord(lon, 1)
         target = mock.Mock()
         with self.assertRaises(ValueError):
-            LinearRegridder(src, target, 'extrapolate')
+            RectilinearRegridder(src, target, 'extrapolate')
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -112,9 +112,9 @@ class Test_regridder(tests.IrisTest):
         linear = create_scheme(mode)
 
         # Check that calling `linear.regridder(...)` returns an instance
-        # of LinearRegridder which has been created using the correct
+        # of RectilinearRegridder which has been created using the correct
         # arguments.
-        with mock.patch('iris.analysis.LinearRegridder',
+        with mock.patch('iris.analysis.RectilinearRegridder',
                         return_value=mock.sentinel.regridder) as lr:
             regridder = linear.regridder(mock.sentinel.src,
                                          mock.sentinel.target)


### PR DESCRIPTION
First baby step forward to incorporating nearest neighbour regrid via the new API.

Rebrand the `LinearRegridder` as `RectilinearRegridder` akin to `RectilinearInterpolator`, so that we have a consistent API.