### PR TITLE
Improve handling of LBCODE=3xxxx

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ import numpy as np
 
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
+from iris.exceptions import TranslationError
 from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
                                     ReferenceTarget)
 from iris.fileformats.um_cf_map import LBFC_TO_CF, STASH_TO_CF
@@ -608,6 +609,16 @@ def _convert_scalar_time_coords(lbcode, lbtim, epoch_hours_unit, t1, t2, lbft):
             None))
         coords_and_dims.append((DimCoord(t2_epoch_hours - lbft, standard_name='forecast_reference_time', units=epoch_hours_unit), None))
 
+    if \
+            (len(lbcode) == 5) and \
+            (lbcode[-1] == 3) and \
+            (lbtim.ib == 2) and  (lbtim.ic == 2):
+        coords_and_dims.append((
+            DimCoord(standard_name='forecast_reference_time',
+                     units=epoch_hours_unit,
+                     points=t2_epoch_hours - lbft),
+            None))
+
     return coords_and_dims
 
 
@@ -766,6 +777,7 @@ def convert(f):
     aux_coords_and_dims = []
 
     # "Normal" (non-cross-sectional) Time values (--> scalar coordinates)
+    # Our spurious scalar time coord gets introduced by this call...
     time_coords_and_dims = _convert_scalar_time_coords(
         lbcode=f.lbcode, lbtim=f.lbtim,
         epoch_hours_unit=f.time_unit('hours'),
@@ -968,30 +980,78 @@ def _all_other_rules(f):
 
     # Cross-sectional time values (--> vector coordinates)
     if (len(f.lbcode) == 5 and f.lbcode[-1] == 1 and f.lbcode.iy == 23):
+        epoch_hours_unit = f.time_unit('hours')
         dim_coords_and_dims.append(
             (DimCoord(
                 f.y,
                 standard_name='time',
-                units=Unit('days since 0000-01-01 00:00:00',
+                units=Unit(epoch_hours_unit,
                            calendar=iris.unit.CALENDAR_360_DAY),
                 bounds=f.y_bounds),
              0))
 
     if (len(f.lbcode) == 5 and f.lbcode[-1] == 1 and f.lbcode.ix == 23):
+        epoch_hours_unit = f.time_unit('hours')
         dim_coords_and_dims.append(
             (DimCoord(
                 f.x,
                 standard_name='time',
-                units=Unit('days since 0000-01-01 00:00:00',
+                units=Unit(epoch_hours_unit,
                            calendar=iris.unit.CALENDAR_360_DAY),
                 bounds=f.x_bounds),
              1))
 
-    # Site number (--> scalar coordinate)
-    if (len(f.lbcode) == 5 and f.lbcode[-1] == 1 and f.lbcode.ix == 13 and
-            f.bdx != 0):
+    # Check for cross-section over-specification.
+    if (len(f.lbcode) == 5 and
+            f.lbcode[-1] == 3 and
+            f.lbcode.ix == 23 and
+            hasattr(f, 'x')):
+        epoch_hours_unit = f.time_unit('hours')
+        t1_epoch_hours = epoch_hours_unit.date2num(f.t1)
+        if t1_epoch_hours != f.x[0]:
+            msg = ('PP cross-section file is over-specified for '
+                   'the time dimension, but the sets of values do not match.')
+            raise TranslationError(msg)
+
+    if (len(f.lbcode) == 5 and
+            f.lbcode[-1] == 3 and
+            f.lbcode.iy == 23 and
+            hasattr(f, 'y')):
+        epoch_hours_unit = f.time_unit('hours')
+        t1_epoch_hours = epoch_hours_unit.date2num(f.t1)
+        if t1_epoch_hours != f.y[0]:
+            msg = ('PP cross-section file is over-specified for '
+                   'the time dimension, but the sets of values do not match.')
+            raise TranslationError(msg)
+
+    # More cross-sectional time values (--> vector coordinates)
+    if (len(f.lbcode) == 5 and f.lbcode[-1] == 3 and f.lbcode.iy == 23):
+        epoch_hours_unit = f.time_unit('hours')
+        t1_epoch_hours = epoch_hours_unit.date2num(f.t1)
+        t2_epoch_hours = epoch_hours_unit.date2num(f.t2)
+        # The end time is exclusive, not inclusive.
+        hours_from_t1_to_t2 = t2_epoch_hours - t1_epoch_hours
+        timestep = hours_from_t1_to_t2 / f.lbrow
+        t2_epoch_hours -= timestep
         dim_coords_and_dims.append(
-            (DimCoord.from_regular(f.bzx, f.bdx, f.lbnpt,
+            (DimCoord(
+                np.linspace(t1_epoch_hours, t2_epoch_hours, f.lbrow),
+                standard_name='time',
+                units=Unit(epoch_hours_unit,
+                           calendar=iris.unit.CALENDAR_360_DAY),
+                bounds=f.y_bounds),
+             0))
+
+    # Site number (--> scalar coordinate)
+    if (len(f.lbcode) == 5 and f.lbcode.ix == 13):
+        if f.bdx != 0.0:
+            point_zero = f.bzx
+            point_spacing = f.bdx
+        else:
+            point_zero = 0.0
+            point_spacing = 1.0
+        dim_coords_and_dims.append(
+            (DimCoord.from_regular(point_zero, point_spacing, f.lbnpt,
                                    long_name='site_number', units='1'),
              1))
 

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
@@ -18,10 +18,10 @@
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="6bc2e82a" points="[681540.0, 683340.0, 685140.0, 686940.0,
+        <dimCoord id="2789ad5b" points="[681540.0, 683340.0, 685140.0, 686940.0,
 		688740.0, 690540.0, 692340.0, 694140.0,
 		695940.0, 697740.0, 699540.0, 701340.0,
-		703140.0, 704940.0, 706740.0, 708540.0]" shape="(16,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
+		703140.0, 704940.0, 706740.0, 708540.0]" shape="(16,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
@@ -24,8 +24,8 @@
         <dimCoord id="2718ad80" long_name="site_number" points="[1.0, 2.0, 3.0]" shape="(3,)" units="Unit('1')" value_type="float32" var_name="site_number"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="6bc2e82a" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,
-		755700.0, 756060.0]" shape="(240,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
+        <dimCoord id="2789ad5b" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,
+		755700.0, 756060.0]" shape="(240,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
@@ -13,7 +13,7 @@
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32" var_name="pressure"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="6bc2e82a" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
+        <dimCoord id="2789ad5b" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
@@ -18,7 +18,7 @@
         <dimCoord id="2718ad80" long_name="site_number" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32" var_name="site_number"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="6bc2e82a" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
+        <dimCoord id="2789ad5b" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32" var_name="time"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
@@ -17,10 +17,10 @@
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="9be2c77a" points="[681540.0, 683340.0, 685140.0, 686940.0,
+        <dimCoord id="4c12dc80" points="[681540.0, 683340.0, 685140.0, 686940.0,
 		688740.0, 690540.0, 692340.0, 694140.0,
 		695940.0, 697740.0, 699540.0, 701340.0,
-		703140.0, 704940.0, 706740.0, 708540.0]" shape="(16,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
+		703140.0, 704940.0, 706740.0, 708540.0]" shape="(16,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
@@ -27,8 +27,8 @@
         <dimCoord id="8f406936" long_name="site_number" points="[1.0, 2.0, 3.0]" shape="(3,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="9be2c77a" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,
-		755700.0, 756060.0]" shape="(240,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
+        <dimCoord id="4c12dc80" points="[670020.0, 670380.0, 670740.0, ..., 755340.0,
+		755700.0, 756060.0]" shape="(240,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
@@ -12,7 +12,7 @@
 		1000.0]" shape="(15,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="9be2c77a" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
+        <dimCoord id="4c12dc80" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
@@ -17,7 +17,7 @@
         <dimCoord id="8f406936" long_name="site_number" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="9be2c77a" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('days since 0000-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
+        <dimCoord id="4c12dc80" points="[756690.0, 763890.0, 771090.0, 778290.0]" shape="(4,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float32"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cdl
@@ -12,7 +12,7 @@ variables:
 		depth:positive = "down" ;
 	float time(time) ;
 		time:axis = "T" ;
-		time:units = "days since 0000-01-01 00:00:00" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
 		time:standard_name = "time" ;
 		time:calendar = "360_day" ;
 

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cdl
@@ -16,7 +16,7 @@ variables:
 		latitude_longitude:earth_radius = 6371229. ;
 	float time(time) ;
 		time:axis = "T" ;
-		time:units = "days since 0000-01-01 00:00:00" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
 		time:standard_name = "time" ;
 		time:calendar = "360_day" ;
 	float site_number(site_number) ;

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_time_press.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_time_press.b_0.cdl
@@ -13,7 +13,7 @@ variables:
 		pressure:long_name = "pressure" ;
 	float time(time) ;
 		time:axis = "T" ;
-		time:units = "days since 0000-01-01 00:00:00" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
 		time:standard_name = "time" ;
 		time:calendar = "360_day" ;
 

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_tseries.b_0.cdl
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/to_netcdf/aaxzc_tseries.b_0.cdl
@@ -10,7 +10,7 @@ variables:
 		air_temperature:coordinates = "height" ;
 	float time(time) ;
 		time:axis = "T" ;
-		time:units = "days since 0000-01-01 00:00:00" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
 		time:standard_name = "time" ;
 		time:calendar = "360_day" ;
 	float site_number(site_number) ;


### PR DESCRIPTION
Adjust the PP rules to better account for `f.lbcode` in range `10000` or `30000`. As the time unit epochs have been brought into line with other time unit epochs (see, for example, the epoch used in the change to [pp_rules.py:L618](https://github.com/dkillick/iris/compare/SciTools:master...dkillick:pp_lbcode_31323?expand=1#diff-15f5603f73cf0cbabbc6a3a1ef893489R618)) some CML has been changed to reflect these changes.