### PR TITLE
Improve docstrings for interpolator/regridder schemes 

### DIFF
--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -179,6 +179,8 @@ For example, to mask values that lie beyond the range of the original data:
       1155.56      nan]
 
 
+.. _caching_an_interpolator:
+
 Caching an interpolator
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -360,6 +362,8 @@ To visualise the above regrid, let's plot the original data, along with 3 distin
 
 .. plot:: userguide/regridding_plots/regridded_to_global_area_weighted.py
 
+
+.. _caching_a_regridder:
 
 Caching a regridder
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1548,6 +1548,11 @@ class Linear(object):
         given :class:`~iris.cube.Cube` specified by the dimensions of
         the given coordinates.
 
+        Typically you should use :meth:`iris.cube.Cube.interpolate` for
+        interpolating a cube. There are, however, some situations when
+        constructing your own interpolator is preferable. These are detailed
+        in the :ref:`user guide <caching_an_interpolator>`.
+
         Args:
 
         * cube:
@@ -1576,9 +1581,6 @@ class Linear(object):
             sample_points must have the form
             `[new_lat_values, new_lon_values]`.
 
-            This callable would typically be used by
-            :class:`iris.cube.Cube.interpolate`.
-
         """
         return RectilinearInterpolator(cube, coords, 'linear',
                                        self._normalised_extrapolation_mode())
@@ -1587,6 +1589,11 @@ class Linear(object):
         """
         Creates a linear regridder to perform regridding from the source
         grid to the target grid.
+
+        Typically you should use :meth:`iris.cube.Cube.regrid` for
+        regridding a cube. There are, however, some situations when
+        constructing your own regridder is preferable. These are detailed in
+        the :ref:`user guide <caching_a_regridder>`.
 
         Args:
 
@@ -1602,12 +1609,6 @@ class Linear(object):
 
             where `cube` is a cube with the same grid as `src_grid`
             that is to be regridded to the `target_grid`.
-            Thus for the callable returned by
-            `Linear().regridder(src_grid, target_grid)`, cube must
-            be on the same grid as src_grid.
-
-            This callable would typically be used by
-            :class:`iris.cube.Cube.regrid`.
 
         """
         return RectilinearRegridder(src_grid, target_grid, 'linear',
@@ -1652,6 +1653,11 @@ class AreaWeighted(object):
         Creates an area-weighted regridder to perform regridding from the
         source grid to the target grid.
 
+        Typically you should use :meth:`iris.cube.Cube.regrid` for
+        regridding a cube. There are, however, some situations when
+        constructing your own regridder is preferable. These are detailed in
+        the :ref:`user guide <caching_a_regridder>`.
+
         Args:
 
         * src_grid_cube:
@@ -1666,12 +1672,6 @@ class AreaWeighted(object):
 
             where `cube` is a cube with the same grid as `src_grid_cube`
             that is to be regridded to the grid of `target_grid_cube`.
-            Thus for the callable returned by
-            `AreaWeighted().regridder(src_grid, target_grid)`, cube must
-            be on the same grid as src_grid.
-
-            This callable would typically be used by
-            :class:`iris.cube.Cube.regrid`.
 
         """
         return AreaWeightedRegridder(src_grid_cube, target_grid_cube,
@@ -1724,12 +1724,17 @@ class Nearest(object):
         interpolation over the given :class:`~iris.cube.Cube` specified
         by the dimensions of the specified coordinates.
 
+        Typically you should use :meth:`iris.cube.Cube.interpolate` for
+        interpolating a cube. There are, however, some situations when
+        constructing your own interpolator is preferable. These are detailed
+        in the :ref:`user guide <caching_an_interpolator>`.
+
         Args:
 
         * cube:
             The source :class:`iris.cube.Cube` to be interpolated.
         * coords:
-            The names or coordinate instances which are to be
+            The names or coordinate instances that are to be
             interpolated over.
 
         Returns:
@@ -1752,9 +1757,6 @@ class Nearest(object):
             sample_points must have the form
             `[new_lat_values, new_lon_values]`.
 
-            This callable would typically be used by
-            :class:`iris.cube.Cube.interpolate`.
-
         """
         return RectilinearInterpolator(cube, coords, 'nearest',
                                        self.extrapolation_mode)
@@ -1763,6 +1765,11 @@ class Nearest(object):
         """
         Creates a nearest-neighbour regridder to perform regridding from the
         source grid to the target grid.
+
+        Typically you should use :meth:`iris.cube.Cube.regrid` for
+        regridding a cube. There are, however, some situations when
+        constructing your own regridder is preferable. These are detailed in
+        the :ref:`user guide <caching_a_regridder>`.
 
         Args:
 
@@ -1776,8 +1783,8 @@ class Nearest(object):
 
                 `callable(cube)`
 
-            where `cube` is a cube with the same grid as `src_grid
-            which is to be regridded to the `target_grid`.
+            where `cube` is a cube with the same grid as `src_grid`
+            that is to be regridded to the `target_grid`.
 
         """
         return RectilinearRegridder(src_grid, target_grid, 'nearest',

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1494,9 +1494,10 @@ def clear_phenomenon_identity(cube):
 
 class Linear(object):
     """
-    This class describes the linear interpolation scheme for interpolating over
-    one or more orthogonal coordinates, typically for use with
-    :meth:`iris.cube.Cube.interpolate()` or :meth:`iris.cube.Cube.regrid()`.
+    This class describes the linear interpolation and regridding scheme for
+    interpolating or regridding over one or more orthogonal coordinates,
+    typically for use with :meth:`iris.cube.Cube.interpolate()` or
+    :meth:`iris.cube.Cube.regrid()`.
 
     """
 
@@ -1504,8 +1505,8 @@ class Linear(object):
 
     def __init__(self, extrapolation_mode='linear'):
         """
-        Linear interpolation scheme suitable for interpolating over one or
-        more orthogonal coordinates.
+        Linear interpolation and regridding scheme suitable for interpolating
+        or regridding over one or more orthogonal coordinates.
 
         Kwargs:
 
@@ -1545,14 +1546,14 @@ class Linear(object):
         """
         Creates a linear interpolator to perform interpolation over the
         given :class:`~iris.cube.Cube` specified by the dimensions of
-        the specified coordinates.
+        the given coordinates.
 
         Args:
 
         * cube:
             The source :class:`iris.cube.Cube` to be interpolated.
         * coords:
-            The names or coordinate instances which are to be
+            The names or coordinate instances that are to be
             interpolated over.
 
         Returns:
@@ -1566,7 +1567,7 @@ class Linear(object):
             dimensions in the result cube caused by scalar values in
             `sample_points`.
 
-            The values for coordinates which correspond to date/times
+            The values for coordinates that correspond to date/times
             may optionally be supplied as datetime.datetime or
             netcdftime.datetime instances.
 
@@ -1574,6 +1575,9 @@ class Linear(object):
             `Linear().interpolator(cube, ['latitude', 'longitude'])`,
             sample_points must have the form
             `[new_lat_values, new_lon_values]`.
+
+            This callable would typically be used by
+            :class:`iris.cube.Cube.interpolate`.
 
         """
         return RectilinearInterpolator(cube, coords, 'linear',
@@ -1597,7 +1601,13 @@ class Linear(object):
                 `callable(cube)`
 
             where `cube` is a cube with the same grid as `src_grid`
-            which is to be regridded to the `target_grid`.
+            that is to be regridded to the `target_grid`.
+            Thus for the callable returned by
+            `Linear().regridder(src_grid, target_grid)`, cube must
+            be on the same grid as src_grid.
+
+            This callable would typically be used by
+            :class:`iris.cube.Cube.regrid`.
 
         """
         return RectilinearRegridder(src_grid, target_grid, 'linear',
@@ -1654,8 +1664,14 @@ class AreaWeighted(object):
 
                 `callable(cube)`
 
-            where `cube` is a cube with the same grid as `src_grid_cube`, which
-            is to be regridded to the grid of `target_grid_cube`.
+            where `cube` is a cube with the same grid as `src_grid_cube`
+            that is to be regridded to the grid of `target_grid_cube`.
+            Thus for the callable returned by
+            `AreaWeighted().regridder(src_grid, target_grid)`, cube must
+            be on the same grid as src_grid.
+
+            This callable would typically be used by
+            :class:`iris.cube.Cube.regrid`.
 
         """
         return AreaWeightedRegridder(src_grid_cube, target_grid_cube,
@@ -1664,16 +1680,16 @@ class AreaWeighted(object):
 
 class Nearest(object):
     """
-    This class describes the nearest-neighbour interpolation scheme for
-    interpolating over one or more orthogonal coordinates, typically for
-    use with :meth:`iris.cube.Cube.interpolate()` or
-    :meth:`iris.cube.Cube.regrid()`.
+    This class describes the nearest-neighbour interpolation and regridding
+    scheme for interpolating or regridding over one or more orthogonal
+    coordinates, typically for use with :meth:`iris.cube.Cube.interpolate()`
+    or :meth:`iris.cube.Cube.regrid()`.
 
     """
     def __init__(self, extrapolation_mode='extrapolate'):
         """
-        Nearest-neighbour interpolation scheme suitable for
-        interpolating over one or more orthogonal coordinates.
+        Nearest-neighbour interpolation and regridding scheme suitable for
+        interpolating or regridding over one or more orthogonal coordinates.
 
         Kwargs:
 
@@ -1727,7 +1743,7 @@ class Nearest(object):
             dimensions in the result cube caused by scalar values in
             `sample_points`.
 
-            The values for coordinates which correspond to date/times
+            The values for coordinates that correspond to date/times
             may optionally be supplied as datetime.datetime or
             netcdftime.datetime instances.
 
@@ -1735,6 +1751,9 @@ class Nearest(object):
             `Nearest().interpolator(cube, ['latitude', 'longitude'])`,
             sample_points must have the form
             `[new_lat_values, new_lon_values]`.
+
+            This callable would typically be used by
+            :class:`iris.cube.Cube.interpolate`.
 
         """
         return RectilinearInterpolator(cube, coords, 'nearest',


### PR DESCRIPTION
Improves the docstrings for the interpolator and regridder schemes `Linear`, `AreaWeighted` and `Nearest` in `iris.analysis`. This adds:
 * the word "regridding" into the docstrings where these schemes have been extended to be used as a regridding scheme as well as an interpolation scheme,
 * usage examples to each schemes' `regridder` method, and
 * a comment on typical usage of the `callable` returned by each scheme's `interpolator` and `regridder` methods to the docstrings of these methods. 