### PR TITLE
Expose Nearest.regridder

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1666,7 +1666,8 @@ class Nearest(object):
     """
     This class describes the nearest-neighbour interpolation scheme for
     interpolating over one or more orthogonal coordinates, typically for
-    use with :meth:`iris.cube.Cube.interpolate()`.
+    use with :meth:`iris.cube.Cube.interpolate()` or
+    :meth:`iris.cube.Cube.regrid()`.
 
     """
     def __init__(self, extrapolation_mode='extrapolate'):
@@ -1738,3 +1739,27 @@ class Nearest(object):
         """
         return RectilinearInterpolator(cube, coords, 'nearest',
                                        self.extrapolation_mode)
+
+    def regridder(self, src_grid, target_grid):
+        """
+        Creates a nearest-neighbour regridder to perform regridding from the
+        source grid to the target grid.
+
+        Args:
+
+        * src_grid:
+            The :class:`~iris.cube.Cube` defining the source grid.
+        * target_grid:
+            The :class:`~iris.cube.Cube` defining the target grid.
+
+        Returns:
+            A callable with the interface:
+
+                `callable(cube)`
+
+            where `cube` is a cube with the same grid as `src_grid
+            which is to be regridded to the `target_grid`.
+
+        """
+        return RectilinearRegridder(src_grid, target_grid, 'nearest',
+                                    self.extrapolation_mode)

--- a/lib/iris/tests/unit/analysis/test_Nearest.py
+++ b/lib/iris/tests/unit/analysis/test_Nearest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -83,6 +83,40 @@ class Test_interpolator(tests.IrisTest):
         ri.assert_called_once_with(mock.sentinel.cube, mock.sentinel.coords,
                                    'nearest', expected_mode)
         self.assertIs(interpolator, mock.sentinel.interpolator)
+
+    def test_default(self):
+        self.check_mode()
+
+    def test_extrapolate(self):
+        self.check_mode('extrapolate')
+
+    def test_nan(self):
+        self.check_mode('nan')
+
+    def test_error(self):
+        self.check_mode('error')
+
+    def test_mask(self):
+        self.check_mode('mask')
+
+    def test_nanmask(self):
+        self.check_mode('nanmask')
+
+
+class Test_regridder(tests.IrisTest):
+    def check_mode(self, mode=None):
+        scheme = create_scheme(mode)
+
+        with mock.patch('iris.analysis.RectilinearRegridder',
+                        return_value=mock.sentinel.regridder) as rr:
+            regridder = scheme.regridder(mock.sentinel.src_grid,
+                                         mock.sentinel.tgt_grid)
+
+        expected_mode = 'extrapolate' if mode is None else mode
+        rr.assert_called_once_with(mock.sentinel.src_grid,
+                                   mock.sentinel.tgt_grid,
+                                   'nearest', expected_mode)
+        self.assertIs(regridder, mock.sentinel.regridder)
 
     def test_default(self):
         self.check_mode()

--- a/lib/iris/tests/unit/analysis/test_Nearest.py
+++ b/lib/iris/tests/unit/analysis/test_Nearest.py
@@ -107,6 +107,9 @@ class Test_regridder(tests.IrisTest):
     def check_mode(self, mode=None):
         scheme = create_scheme(mode)
 
+        # Ensure that calling the regridder results in an instance of
+        # RectilinearRegridder being returned, which has been created with
+        # the expected arguments.
         with mock.patch('iris.analysis.RectilinearRegridder',
                         return_value=mock.sentinel.regridder) as rr:
             regridder = scheme.regridder(mock.sentinel.src_grid,


### PR DESCRIPTION
This PR exposes the `Nearest.regridder` method, thus hooking up the underlying implementation to the new API.