### PR TITLE
Fix netcdf load on windows

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -182,7 +182,7 @@ def load_files(filenames, callback, constraints=None):
     # Create default dict mapping iris format handler to its associated filenames
     handler_map = collections.defaultdict(list)
     for fn in all_file_paths:
-        with open(fn) as fh:
+        with open(fn, 'rb') as fh:
             handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), fh)
             handler_map[handling_format_spec].append(fn)
 


### PR DESCRIPTION
On windows loading of netcdf (and possibly other formats) fails with an EOFError. This is because the open() call in the load code does not specify the mode as binary. In the format picker code: https://github.com/SciTools/iris/blob/master/lib/iris/io/format_picker.py#L265-L267 the `read` call hits a newline and returns a string shorter than the requested 8 bytes (I get 5 when attempting to load E1_north_america.nc from the sample data). Changing to `'rb'` fixes the problem. I believe this is covered by existing tests.