### PR TITLE
BUG: Intersection points are no longer contiguous

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2160,6 +2160,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         max_comp = np.less_equal if max_inclusive else np.less
         if coord.has_bounds():
             bounds = wrap_lons(coord.bounds, minimum, modulus)
+
+            # Do not wrap around values which are within a tolerance of base +
+            # period as this makes points originally contiguous no longer
+            # contiguous.
+            tol = 1e-12
+            mask = ((coord.bounds < (minimum + modulus) + tol) *
+                    (coord.bounds > (minimum + modulus) - tol))
+            bounds[mask] = coord.bounds[mask]
+
             inside = np.logical_and(min_comp(minimum, bounds),
                                     max_comp(bounds, maximum))
             inside_indices, = np.where(np.any(inside, axis=1))

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2145,6 +2145,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def _intersect_modulus(self, coord, minimum, maximum, min_inclusive,
                            max_inclusive):
+        # Point tolerance for wrap_lons comparison
+        tol = 1e-12
         modulus = coord.units.modulus
         if maximum > minimum + modulus:
             raise ValueError("requested range greater than coordinate's"
@@ -2164,7 +2166,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # Do not wrap around values which are within a tolerance of base +
             # period as this makes points originally contiguous no longer
             # contiguous.
-            tol = 1e-12
             mask = ((coord.bounds < (minimum + modulus) + tol) *
                     (coord.bounds > (minimum + modulus) - tol))
             bounds[mask] = coord.bounds[mask]
@@ -2203,8 +2204,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 bounds = wrap_lons(coord.bounds, minimum, modulus)
             points = wrap_lons(coord.points, minimum, modulus)
         else:
+            # Do not wrap around values which are within a tolerance of base +
+            # period as this makes points originally contiguous no longer
+            # contiguous.
             points = iris.analysis.cartography.wrap_lons(coord.points, minimum,
                                                          modulus)
+            mask = ((coord.points < (minimum + modulus) + tol) *
+                    (coord.points > (minimum + modulus) - tol))
+            points[mask] = coord.points[mask]
             bounds = None
             inside_indices, = np.where(
                 np.logical_and(min_comp(minimum, points),

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -32,7 +32,6 @@ from iris.analysis import WeightedAggregator, Aggregator
 from iris.analysis import MEAN
 from iris.cube import Cube
 from iris.coords import AuxCoord, DimCoord
-from iris.exceptions import LazyAggregatorError
 import iris.tests.stock as stock
 
 
@@ -612,6 +611,14 @@ class Test_intersection__RegionalSrcModulus(tests.IrisTest):
 # Check what happens with a global, points-only circular intersection
 # coordinate.
 class Test_intersection__GlobalSrcModulus(tests.IrisTest):
+    def test_global_wrapped_extreme(self):
+        # Ensure that we can correctly handle points defined at (base + period)
+        cube = create_cube(-180., 180.)
+        lons = cube.coord('longitude')
+        result = cube.intersection(longitude=(lons.points.min(),
+                                              lons.points.max()))
+        self.assertArrayEqual(result.data, cube.data)
+
     def test_global(self):
         cube = create_cube(0, 360)
         result = cube.intersection(longitude=(0, 360))
@@ -777,6 +784,14 @@ class Test_intersection__GlobalSrcModulus(tests.IrisTest):
 # Check what happens with a global, points-and-bounds circular
 # intersection coordinate.
 class Test_intersection__ModulusBounds(tests.IrisTest):
+    def test_global_wrapped_extreme(self):
+        # Ensure that we can correctly handle bounds defined at (base + period)
+        cube = create_cube(-180., 180., bounds=True)
+        lons = cube.coord('longitude')
+        result = cube.intersection(longitude=(lons.bounds.min(),
+                                              lons.bounds.max()))
+        self.assertArrayEqual(result.data, cube.data)
+
     def test_misaligned_points_inside(self):
         cube = create_cube(0, 360, bounds=True)
         result = cube.intersection(longitude=(169.75, 190.25))


### PR DESCRIPTION
BUG: Intersection for points at period + base

Currently while intersecting points/bounds which coincide at (period + base)
these are wrapped around which results in a once contiguous coordinate
being not contiguous any more.

I have yet to add unittests as it would be good to get confirmation as to whether I am correct in modifying `cube.intersection` and not `iris.analysis.cartography.wrap_lons`.
My feeling is that `wrap_lons` is neither correct or incorrect.  Also, modifying wrap_lons would have a greater impact reliant on its current behaviour.
However, when utilising `wrap_lons` within `cube.intersection`, this clearly identifies itself as a bug within this specific context (i.e. its an issue with how `cube.intersection` uses these points).

**DO NOT MERGE: once I get confirmation of the above, I'll be happy to write some unittests.**

```Python
>>> import numpy as np
>>> from iris.analysis.cartography import wrap_lons
>>> lons = np.array([-180., -90., 0., 90., 180.])
>>> res = wrap_lons(lons, -180., 360.)
>>> res == lons
array([ True,  True,  True,  True, False], dtype=bool)
>>> print res
[-180.  -90.    0.   90. -180.]
>>> assert np.all(lons == res)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```

Here is the gist when attempting an intersection:
https://gist.github.com/cpelley/05cde98a251d467e9cd2

When running on 1.7.x:
```Python
[...]$  python2.7 intersection_bug.py 

Traceback (most recent call last):
  File "intersection_bug.py", line 50, in <module>
    overlap = source.intersection(x_ext, y_ext)
  File "/.../git/iris/lib/iris/cube.py", line 2051, in intersection
    result = result._intersect(*arg)
  File "/.../git/iris/lib/iris/cube.py", line 2090, in _intersect
    chunks = [make_chunk(key) for key in subsets]
  File "/.../git/iris/lib/iris/cube.py", line 2085, in make_chunk
    chunk_coord.bounds = bounds[(key,)]
  File "/.../git/iris/lib/iris/coords.py", line 1447, in bounds
    raise ValueError('The bounds array must be strictly '
ValueError: The bounds array must be strictly monotonic.
```

When running on master: - we can see that the coordinates and the corresponding data has been unexpectedly wrapped, but now at least the monotonic bounds except is not raised.
```Python
Traceback (most recent call last):
  File "intersection_bug.py", line 52, in <module>
    assert source == overlap
AssertionError

print source.coord('longitude')
DimCoord(array([-135.,  -45.,   45.,  135.]), bounds=array([[-180.,  -90.],
       [ -90.,    0.],
       [   0.,   90.],
       [  90.,  180.]]), standard_name='longitude', units=Unit('degree_east'), coord_system=GeogCS(6371229.0), circular=True)
print overlap.coord('longitude')
DimCoord(array([-225., -135.,  -45.,   45.]), bounds=array([[-270., -180.],
       [-180.,  -90.],
       [ -90.,    0.],
       [   0.,   90.]]), standard_name='longitude', units=Unit('degree_east'), coord_system=GeogCS(6371229.0), circular=True)
```

I believe the common cause to both these problems lies in the correct handling of points that lie at the (base + period).  The issue is that this base moves as a result of the extended minimum.

**I should point out that I have mistakenly pointed this to master, I will change to 1.7.x after confirmation.**