### PR TITLE
Remove nearest_neighbour_indices circular warning.

### DIFF
--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -164,9 +164,6 @@ def nearest_neighbour_indices(cube, sample_points):
         #calculate the nearest neighbour
         min_index = coord.nearest_neighbour_index(point)
 
-        if getattr(coord, 'circular', False):
-            warnings.warn("Nearest neighbour on a circular coordinate may not be picking the nearest point.", DeprecationWarning)
-
         # If the dimension has already been interpolated then assert that the index from this coordinate
         # agrees with the index already calculated, otherwise we have a contradicting specification
         if indices[data_dim] != slice(None, None) and min_index != indices[data_dim]:


### PR DESCRIPTION
Raised on google group... https://groups.google.com/d/msg/scitools-iris/qXdxsuWf7NE/s4H157kU20IJ

**NB.** It turns out there _is_ a problem when bounds are involved, so either the warning needs to be more specific or we just fix the issue with bounds.
