### PR TITLE
pinning pep8 to v1.5.7

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -17,7 +17,7 @@ setuptools
 cfchecker
 mock
 nose
-pep8
+pep8=1.5.7
 sphinx
 
 # Optional iris dependencies


### PR DESCRIPTION
An update to pep8 to 1.6.1 is causing test failures due to assignment of lambda functions etc. This is a short term fix.