### PR TITLE
Grib1 - create a time coord when timeRangeIndicator is 2

### DIFF
--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -173,6 +173,11 @@ def convert(grib):
                      points=0.5 * (t_bounds[0] + t_bounds[1]),
                      bounds=t_bounds),
             None))
+
+    if \
+            (grib.edition == 1) and \
+            (grib.timeRangeIndicator == 2):
+        add_bounded_time_coords(aux_coords_and_dims, grib)
 
     if \
             (grib.edition == 1) and \
@@ -390,7 +395,9 @@ def convert(grib):
             (grib.productDefinitionTemplateNumber == 1):
         aux_coords_and_dims.append((DimCoord(points=grib.perturbationNumber, long_name='ensemble_member', units='no_unit'), None))
 
-    if grib.productDefinitionTemplateNumber not in (0, 8):
+    if \
+            (grib.edition == 2) and \
+            grib.productDefinitionTemplateNumber not in (0, 8):
         attributes["GRIB_LOAD_WARNING"] = ("unsupported GRIB%d ProductDefinitionTemplate: #4.%d" % (grib.edition, grib.productDefinitionTemplateNumber))
 
     if \

--- a/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -104,6 +104,9 @@ class TestBoundedTime(TestField):
         self._test_for_coord(message, convert, self.is_time,
                              expected_points=[100],
                              expected_bounds=[[80, 120]])
+
+    def test_time_range_indicator_2(self):
+        self.assert_bounded_message(timeRangeIndicator=2)
 
     def test_time_range_indicator_3(self):
         self.assert_bounded_message(timeRangeIndicator=3)


### PR DESCRIPTION
For Grib1, grib messages with a time range indicator of 2 aren't creating a time coordinate, so I've changed this to do so. 

I've also changed the warning for product definition templates as this is only applicable for grib edition 2.