### PR TITLE
Multiple percentile values processing

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+
 """
 Classes for representing multi-dimensional data with metadata.
 
@@ -2960,10 +2961,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             data_result = aggregator.aggregate(unrolled_data,
                                                axis=-1,
                                                **kwargs)
-
         aggregator.update_metadata(collapsed_cube, coords, axis=collapse_axis,
                                    **kwargs)
-        result = aggregator.post_process(collapsed_cube, data_result, **kwargs)
+        result = aggregator.post_process(collapsed_cube, data_result, coords,
+                                         **kwargs)
         return result
 
     def aggregated_by(self, coords, aggregator, **kwargs):
@@ -3040,11 +3041,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # We can't handle weights
         if isinstance(aggregator, iris.analysis.WeightedAggregator) and \
                 aggregator.uses_weighting(**kwargs):
-            raise ValueError('Invalid Aggregation, aggergated_by() cannot use'
+            raise ValueError('Invalid Aggregation, aggregated_by() cannot use'
                              ' weights.')
 
-        for coord in sorted(self._as_list_of_coords(coords),
-                            key=lambda coord: coord._as_defn()):
+        coords = self._as_list_of_coords(coords)
+        for coord in sorted(coords, key=lambda coord: coord._as_defn()):
             if coord.ndim > 1:
                 msg = 'Cannot aggregate_by coord %s as it is ' \
                       'multidimensional.' % coord.name()
@@ -3070,7 +3071,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         groupby = iris.analysis._Groupby(groupby_coords, shared_coords)
 
         # Create the resulting aggregate-by cube and remove the original
-        # coordinates which are going to be groupedby.
+        # coordinates that are going to be groupedby.
         key = [slice(None, None)] * self.ndim
         # Generate unique index tuple key to maintain monotonicity.
         key[dimension_to_groupby] = tuple(range(len(groupby)))
@@ -3080,7 +3081,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             aggregateby_cube.remove_coord(coord)
 
         # Determine the group-by cube data shape.
+        percentile_rollaxis = False
         data_shape = list(self.shape)
+        if 'percentile' in aggregator.cell_method:
+            try:
+                shape = [len(kwargs['percent'])]
+                percentile_rollaxis = True
+            except TypeError:
+                pass
+            else:
+                data_shape.extend(shape)
         data_shape[dimension_to_groupby] = len(groupby)
 
         # Aggregate the group-by data.
@@ -3098,6 +3108,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                           axis=dimension_to_groupby,
                                           **kwargs)
 
+            if percentile_rollaxis:
+                # Roll the result so its shape matches `data_shape`.
+                result = np.rollaxis(result, 0, start=len(result.shape))
+
             # Determine aggregation result data type for the aggregate-by cube
             # data on first pass.
             if i == 0:
@@ -3107,6 +3121,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     aggregateby_data = np.zeros(data_shape, dtype=result.dtype)
 
             aggregateby_data[tuple(cube_slice)] = result
+
+        if percentile_rollaxis:
+            # Roll `aggregate_by` data so its shape is restored.
+            aggregateby_data = np.rollaxis(aggregateby_data, -1)
 
         # Add the aggregation meta data to the aggregate-by cube.
         aggregator.update_metadata(aggregateby_cube,
@@ -3125,7 +3143,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 aggregateby_cube.add_aux_coord(coord.copy(),
                                                dimension_to_groupby)
         # Attatch the aggregate-by data into the aggregate-by cube.
-        aggregateby_cube.data = aggregateby_data
+        aggregateby_cube = aggregator.post_process(aggregateby_cube,
+                                                   aggregateby_data,
+                                                   coords, **kwargs)
 
         return aggregateby_cube
 
@@ -3304,11 +3324,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 kwargs = dict(kwargs)
                 kwargs['weights'] = iris.util.broadcast_to_shape(
                     weights, rolling_window_data.shape, (dimension + 1,))
-        new_cube.data = aggregator.aggregate(rolling_window_data,
-                                             axis=dimension + 1,
-                                             **kwargs)
-
-        return new_cube
+        data_result = aggregator.aggregate(rolling_window_data,
+                                           axis=dimension + 1,
+                                           **kwargs)
+        result = aggregator.post_process(new_cube, data_result, [coord],
+                                         **kwargs)
+        return result
 
     def interpolate(self, sample_points, scheme, collapse_scalar=True):
         """

--- a/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
@@ -5,12 +5,11 @@
       <coord>
         <dimCoord bounds="[[0, 11]]" id="549be28b" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
@@ -10,12 +10,11 @@
       <coord>
         <dimCoord bounds="[[-15, 45]]" id="549be28b" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
@@ -8,13 +8,11 @@
       <coord>
         <dimCoord bounds="[[-15, 45]]" id="549be28b" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
       </coord>
+      <coord>
+        <dimCoord id="38918495" long_name="percentile_over_foo_bar" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-        <coord name="bar"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
@@ -9,14 +9,13 @@
         <dimCoord circular="True" id="a523d045" points="[-180, -90, 0, 90]" shape="(4,)" standard_name="longitude" units="Unit('degrees')" value_type="int64"/>
       </coord>
       <coord>
+        <dimCoord id="8d9dcec2" long_name="percentile_over_wibble" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord>
         <dimCoord bounds="[[10.0, 30.0]]" id="a2260f1f" long_name="wibble" points="[20.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="wibble"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3, 4)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
@@ -9,14 +9,13 @@
         <dimCoord circular="True" id="a523d045" points="[-180, -90, 0, 90]" shape="(4,)" standard_name="longitude" units="Unit('degrees')" value_type="int64"/>
       </coord>
       <coord>
+        <dimCoord id="8d9dcec2" long_name="percentile_over_wibble" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord>
         <dimCoord bounds="[[10.0, 30.0]]" id="a2260f1f" long_name="wibble" points="[20.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="wibble"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3, 4)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
@@ -5,12 +5,11 @@
       <coord>
         <dimCoord bounds="[[0, 11]]" id="549be28b" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -324,8 +324,11 @@ class Test_aggregated_by(tests.IrisTest):
         self.cube.add_aux_coord(val_coord, 0)
         self.cube.add_aux_coord(label_coord, 0)
         self.mock_agg = mock.Mock(spec=Aggregator)
+        self.mock_agg.cell_method = []
         self.mock_agg.aggregate = mock.Mock(
             return_value=mock.Mock(dtype='object'))
+        post_process_func = lambda x, y, z: x
+        self.mock_agg.post_process = mock.Mock(side_effect=post_process_func)
 
     def test_string_coord_agg_by_label(self):
         # Aggregate a cube on a string coordinate label where label
@@ -376,6 +379,8 @@ class Test_rolling_window(tests.IrisTest):
         self.mock_agg = mock.Mock(spec=Aggregator)
         self.mock_agg.aggregate = mock.Mock(
             return_value=np.empty([4]))
+        post_process_func = lambda x, y, z: x
+        self.mock_agg.post_process = mock.Mock(side_effect=post_process_func)
 
     def test_string_coord(self):
         # Rolling window on a cube that contains a string coordinate.


### PR DESCRIPTION
Adds the option to calculate multiple percentiles in a single `PERCENTILE` aggregator call. For example:

```python
result = cube.collapsed('time', iris.analysis.PERCENTILE, percent=[50, 75])
```

The updated percentile aggregator works for `cube.collapsed`, `cube.aggregated_by` and `cube.rolling_window`.

The improvements are gained simply by changing the underlying function call from `scipy.stats.mstats.scoreatpercentile` to `scipy.stats.mstats.mquantiles`, which accepts multiple input percentiles without raising an error.

This adds the obvious functionality of being able to calculate multiple percentiles in a single cube method call but also provides efficiency gains as the setup and ordering processing necessary need only be done once for all percentile calculations, rather than once per percentile as would be the case if each percentile calculation were carried out in its own collapsed call.

