### PR TITLE
Stash Height Constraints

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -27,7 +27,7 @@ from iris.coords import AuxCoord, CellMethod, DimCoord
 from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
                                     ReferenceTarget)
 from iris.fileformats.um_cf_map import (LBFC_TO_CF, STASH_TO_CF,
-                                        _STASHCODE_IMPLIED_HEIGHTS)
+                                        STASHCODE_IMPLIED_HEIGHTS)
 from iris.unit import Unit
 import iris.fileformats.pp
 import iris.unit
@@ -113,14 +113,14 @@ def _convert_vertical_coords(lbcode, lbvc, blev, lblev, stash,
 
     # Height.
     if (lbvc == 1) and \
-            (not (str(stash) in _STASHCODE_IMPLIED_HEIGHTS)) and \
+            (not (str(stash) in STASHCODE_IMPLIED_HEIGHTS)) and \
             (np.all(blev != -1)):
         coord = _dim_or_aux(blev, standard_name='height', units='m',
                             attributes={'positive': 'up'})
         coords_and_dims.append((coord, dim))
 
-    if str(stash) in _STASHCODE_IMPLIED_HEIGHTS:
-        height = _STASHCODE_IMPLIED_HEIGHTS[str(stash)]
+    if str(stash) in STASHCODE_IMPLIED_HEIGHTS:
+        height = STASHCODE_IMPLIED_HEIGHTS[str(stash)]
         coord = DimCoord(height, standard_name='height', units='m',
                          attributes={'positive': 'up'})
         coords_and_dims.append((coord, None))
@@ -626,16 +626,16 @@ def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
 
     if \
             (lbvc == 1) and \
-            (not (str(stash) in _STASHCODE_IMPLIED_HEIGHTS.keys())) and \
+            (not (str(stash) in STASHCODE_IMPLIED_HEIGHTS.keys())) and \
             (blev != -1):
         coords_and_dims.append(
             (DimCoord(blev, standard_name='height', units='m',
                       attributes={'positive': 'up'}),
              None))
 
-    if str(stash) in _STASHCODE_IMPLIED_HEIGHTS.keys():
+    if str(stash) in STASHCODE_IMPLIED_HEIGHTS.keys():
         coords_and_dims.append(
-            (DimCoord(_STASHCODE_IMPLIED_HEIGHTS[str(stash)],
+            (DimCoord(STASHCODE_IMPLIED_HEIGHTS[str(stash)],
                       standard_name='height', units='m',
                       attributes={'positive': 'up'}),
              None))

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -26,7 +26,8 @@ from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
 from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
                                     ReferenceTarget)
-from iris.fileformats.um_cf_map import LBFC_TO_CF, STASH_TO_CF
+from iris.fileformats.um_cf_map import (LBFC_TO_CF, STASH_TO_CF,
+                                        _STASHCODE_IMPLIED_HEIGHTS)
 from iris.unit import Unit
 import iris.fileformats.pp
 import iris.unit
@@ -609,18 +610,6 @@ def _convert_scalar_time_coords(lbcode, lbtim, epoch_hours_unit, t1, t2, lbft):
         coords_and_dims.append((DimCoord(t2_epoch_hours - lbft, standard_name='forecast_reference_time', units=epoch_hours_unit), None))
 
     return coords_and_dims
-
-
-_STASHCODE_IMPLIED_HEIGHTS = {
-    'm01s03i225': 10.0,
-    'm01s03i226': 10.0,
-    'm01s03i236': 1.5,
-    'm01s03i237': 1.5,
-    'm01s03i245': 1.5,
-    'm01s03i247': 1.5,
-    'm01s03i250': 1.5,
-    'm01s03i281': 1.5,
-    'm01s03i463': 10.0}
 
 
 def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,

--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -344,6 +344,7 @@ STASH_TO_CF = {
     'm01s03i237': CFName('specific_humidity', None, '1'),
     'm01s03i238': CFName('soil_temperature', None, 'K'),
     'm01s03i245': CFName('relative_humidity', None, '%'),
+    'm01s03i247': CFName('visibility_in_air', None, 'm'),
     'm01s03i249': CFName('wind_speed', None, 'm s-1'),
     'm01s03i250': CFName('dew_point_temperature', None, 'K'),
     'm01s03i256': CFName(None, 'Heat flux through sea ice', 'W/m^2'),
@@ -398,6 +399,7 @@ STASH_TO_CF = {
     'm01s03i456': CFName(None, 'Dust dry deposition flux division 6 from level 2', 'kg/m^2/s'),
     'm01s03i460': CFName('surface_downward_eastward_stress', None, 'Pa'),
     'm01s03i461': CFName('surface_downward_northward_stress', None, 'Pa'),
+    'm01s03i463': CFName('wind_speed_of_gust', None, 'm s-1'),
     'm01s04i004': CFName('air_temperature', None, 'K'),
     'm01s04i010': CFName('specific_humidity', None, '1'),
     'm01s04i201': CFName('stratiform_rainfall_amount', None, 'kg m-2'),
@@ -813,6 +815,18 @@ STASH_TO_CF = {
     'm02s32i220': CFName('downward_northward_stress_at_sea_ice_base', None, 'Pa'),
     'm03s00i177': CFName(None, 'prescribed_heat_flux_into_slab_ocean', 'W m-2'),
     'm04s06i001': CFName('sea_surface_wind_wave_significant_height', None, 'm'),
+    }
+
+_STASHCODE_IMPLIED_HEIGHTS = {
+    'm01s03i225': (10.0,),
+    'm01s03i226': (10.0,),
+    'm01s03i236': (1.5,),
+    'm01s03i237': (1.5,),
+    'm01s03i245': (1.5,),
+    'm01s03i247': (1.5,),
+    'm01s03i250': (1.5,),
+    'm01s03i281': (1.5,),
+    'm01s03i463': (10.0,),
     }
 
 CF_TO_LBFC = {

--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -817,7 +817,7 @@ STASH_TO_CF = {
     'm04s06i001': CFName('sea_surface_wind_wave_significant_height', None, 'm'),
     }
 
-_STASHCODE_IMPLIED_HEIGHTS = {
+STASHCODE_IMPLIED_HEIGHTS = {
     'm01s03i225': (10.0,),
     'm01s03i226': (10.0,),
     'm01s03i236': (1.5,),

--- a/lib/iris/tests/results/pp_rules/rotated_uk.cml
+++ b/lib/iris/tests/results/pp_rules/rotated_uk.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube standard_name="wind_speed_of_gust" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s03i463"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/tools/gen_translations.py
+++ b/tools/gen_translations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/tools/gen_translations.py
+++ b/tools/gen_translations.py
@@ -29,7 +29,8 @@ from metarelate.fuseki import FusekiServer
 
 from translator import (FORMAT_URIS, FieldcodeCFMappings, StashCFNameMappings,
                         StashCFHeightConstraintMappings,
-                        CFFieldcodeMappings, GRIB1LocalParamCFConstrainedMappings,
+                        CFFieldcodeMappings,
+                        GRIB1LocalParamCFConstrainedMappings,
                         GRIB1LocalParamCFMappings, GRIB2ParamCFMappings,
                         CFConstrainedGRIB1LocalParamMappings,
                         CFGRIB2ParamMappings, CFGRIB1LocalParamMappings)
@@ -197,6 +198,7 @@ def build_grib_cf_map(fuseki, filename):
         fh.writelines(cfcg1.lines(fuseki))
         fh.writelines(cg1.lines(fuseki))
         fh.writelines(cg2.lines(fuseki))
+
 
 def main():
     with FusekiServer() as fuseki:

--- a/tools/gen_translations.py
+++ b/tools/gen_translations.py
@@ -27,7 +27,8 @@ import os.path
 
 from metarelate.fuseki import FusekiServer
 
-from translator import (FORMAT_URIS, FieldcodeCFMappings, StashCFMappings,
+from translator import (FORMAT_URIS, FieldcodeCFMappings, StashCFNameMappings,
+                        StashCFHeightConstraintMappings,
                         CFFieldcodeMappings, GRIB1LocalParamCFConstrainedMappings,
                         GRIB1LocalParamCFMappings, GRIB2ParamCFMappings,
                         CFConstrainedGRIB1LocalParamMappings,
@@ -136,9 +137,11 @@ def build_um_cf_map(fuseki, filename):
         # create the collections, then call lines on each one
         # for thread safety during lines and encode
         fccf = FieldcodeCFMappings(maps)
-        stcf = StashCFMappings(maps)
+        stcf = StashCFNameMappings(maps)
+        stcfhcon = StashCFHeightConstraintMappings(maps)
         fh.writelines(fccf.lines(fuseki))
         fh.writelines(stcf.lines(fuseki))
+        fh.writelines(stcfhcon.lines(fuseki))
 
         # Encode the relevant CF to UM translations.
         maps = _retrieve_mappings(fuseki, FORMAT_URIS['cff'],

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -638,7 +638,7 @@ class StashCFHeightConstraintMappings(Mappings):
         encoding of this metarelate mapping translation.
 
         """
-        return '_STASHCODE_IMPLIED_HEIGHTS'
+        return 'STASHCODE_IMPLIED_HEIGHTS'
 
     @property
     def source_scheme(self):

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -624,7 +624,7 @@ class StashCFHeightConstraintMappings(Mappings):
         encoding of this metarelate mapping translation.
 
         """
-        return ' _STASHCODE_IMPLIED_HEIGHTS'
+        return '_STASHCODE_IMPLIED_HEIGHTS'
 
     @property
     def source_scheme(self):

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -278,18 +278,30 @@ class Mappings(object):
         ftype = FORMAT_URIS['cff']
         result = False
         cffield = hasattr(comp, 'com_type') and comp.com_type == ftype and \
-                  hasattr(comp, 'units') and (hasattr(comp, 'standard_name') or\
-                                              hasattr(comp, 'long_name'))
+            hasattr(comp, 'units') and (hasattr(comp, 'standard_name') or
+                                        hasattr(comp, 'long_name'))
         dimcoord = hasattr(comp, 'dim_coord') and \
-                   isinstance(comp.dim_coord, metarelate.ComponentProperty) and \
-                   comp.dim_coord.component.com_type.notation == 'DimCoord'
+            isinstance(comp.dim_coord, metarelate.ComponentProperty) and \
+            comp.dim_coord.component.com_type.notation == 'DimCoord'
         result = cffield and dimcoord
         return result
 
     def is_cf_height_constrained(self, comp):
-        snprop = metarelate.StatementProperty(metarelate.Item('<http://def.scitools.org.uk/cfdatamodel/standard_name>', 'standard_name'), metarelate.Item('<http://vocab.nerc.ac.uk/standard_name/height>', 'height'))
-        uprop = metarelate.StatementProperty(metarelate.Item('<http://def.scitools.org.uk/cfdatamodel/units>', 'units'), metarelate.Item('"m"', 'm'))
-        pts_pred = metarelate.Item('<http://def.scitools.org.uk/cfdatamodel/points>', 'points')
+        item_sn = metarelate.Item(('<http://def.scitools.org.uk/cfdatamodel/'
+                                   'standard_name>'),
+                                  'standard_name')
+        item_h = metarelate.Item(('<http://vocab.nerc.ac.uk/standard_name/'
+                                  'height>'),
+                                 'height')
+        snprop = metarelate.StatementProperty(item_sn, item_h)
+        item_u = metarelate.Item(('<http://def.scitools.org.uk/cfdatamodel/'
+                                  'units>'),
+                                 'units')
+        uprop = metarelate.StatementProperty(item_u,
+                                             metarelate.Item('"m"', 'm'))
+        pts_pred = metarelate.Item(('<http://def.scitools.org.uk/cfdatamodel/'
+                                    'points>'),
+                                   'points')
         result = False
         if self.is_cf_constrained(comp):
             props = comp.dim_coord.component.properties
@@ -590,8 +602,10 @@ class StashCFNameMappings(Mappings):
             Boolean.
 
         """
-        return self.is_stash(mapping.source) and (self.is_cf(mapping.target) or 
-                                                  self.is_cf_constrained(mapping.target))
+        return (self.is_stash(mapping.source) and
+                (self.is_cf(mapping.target) or
+                 self.is_cf_constrained(mapping.target)))
+
 
 class StashCFHeightConstraintMappings(Mappings):
     """
@@ -659,7 +673,8 @@ class StashCFHeightConstraintMappings(Mappings):
             Boolean.
 
         """
-        return self.is_stash(mapping.source) and self.is_cf_height_constrained(mapping.target)
+        return (self.is_stash(mapping.source) and
+                self.is_cf_height_constrained(mapping.target))
 
 
 class GRIB1LocalParamCFMappings(Mappings):
@@ -675,7 +690,7 @@ class GRIB1LocalParamCFMappings(Mappings):
     def _key(self, line):
         """Provides the sort key of the mappings order."""
         matchstr = ('^    G1LocalParam\(([0-9]+), ([0-9]+), '
-                         '([0-9]+), ([0-9]+)\):.*')
+                    '([0-9]+), ([0-9]+)\):.*')
         match = re.match(matchstr, line)
         if match is None:
             raise ValueError('encoding not sortable')


### PR DESCRIPTION
I have moved the implied stash height constraints our of the PP rules and into the um_cf_map, so that they live alongside the other STASH interpretations

I have updated the translator tools to source this information from the metarelate metOcean knowledge base. 

As the extra information in the knowledge base causes some translations to be lost with the tool on master currently, I have held off the merge of the constraint knowledge awaiting confirmation that these Iris changes are acceptable
https://github.com/metarelate/metOcean/pull/48
