### PR TITLE
Additive agg

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -932,10 +932,14 @@ def _percentile(data, axis, percent, **kwargs):
         if not isinstance(percent, collections.Iterable):
             percent = [percent]
         percent = np.array(percent)
-        # Account for the additive dimensin.
+        # Account for the additive dimension.
         if percent.shape > (1,):
             shape += percent.shape
         result = result.reshape(shape)
+    # Check whether to reduce to a scalar result, as per the behaviour
+    # of other aggregators.
+    if result.shape == (1,) and quantiles.ndim == 0:
+        result = result[0]
 
     return result
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -545,7 +545,7 @@ class _Aggregator(object):
           keyword from a standard deviation aggregator).
 
         Returns:
-            The collapsed cube with it's aggregated data payload.
+            The collapsed cube with its aggregated data payload.
 
         """
         if isinstance(data_result, biggus.Array):
@@ -557,7 +557,7 @@ class _Aggregator(object):
 
     def aggregate_shape(self, **kwargs):
         """
-        The shape of the additive dimension created by the aggregator.
+        The shape of the new dimension/s created by the aggregator.
 
         Kwargs:
 
@@ -565,7 +565,7 @@ class _Aggregator(object):
           and should be passed the same keywords.
 
         Returns:
-            A tuple of the additive dimension shape.
+            A tuple of the aggregate shape.
 
         """
         return ()

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+
 """
 Classes for representing multi-dimensional data with metadata.
 
@@ -2960,10 +2961,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             data_result = aggregator.aggregate(unrolled_data,
                                                axis=-1,
                                                **kwargs)
-
         aggregator.update_metadata(collapsed_cube, coords, axis=collapse_axis,
                                    **kwargs)
-        result = aggregator.post_process(collapsed_cube, data_result, **kwargs)
+        result = aggregator.post_process(collapsed_cube, data_result, coords,
+                                         **kwargs)
         return result
 
     def aggregated_by(self, coords, aggregator, **kwargs):
@@ -3040,11 +3041,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # We can't handle weights
         if isinstance(aggregator, iris.analysis.WeightedAggregator) and \
                 aggregator.uses_weighting(**kwargs):
-            raise ValueError('Invalid Aggregation, aggergated_by() cannot use'
+            raise ValueError('Invalid Aggregation, aggregated_by() cannot use'
                              ' weights.')
 
-        for coord in sorted(self._as_list_of_coords(coords),
-                            key=lambda coord: coord._as_defn()):
+        coords = self._as_list_of_coords(coords)
+        for coord in sorted(coords, key=lambda coord: coord._as_defn()):
             if coord.ndim > 1:
                 msg = 'Cannot aggregate_by coord %s as it is ' \
                       'multidimensional.' % coord.name()
@@ -3070,7 +3071,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         groupby = iris.analysis._Groupby(groupby_coords, shared_coords)
 
         # Create the resulting aggregate-by cube and remove the original
-        # coordinates which are going to be groupedby.
+        # coordinates that are going to be groupedby.
         key = [slice(None, None)] * self.ndim
         # Generate unique index tuple key to maintain monotonicity.
         key[dimension_to_groupby] = tuple(range(len(groupby)))
@@ -3080,7 +3081,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             aggregateby_cube.remove_coord(coord)
 
         # Determine the group-by cube data shape.
+        percentile_rollaxis = False
         data_shape = list(self.shape)
+        if 'percentile' in aggregator.cell_method:
+            try:
+                shape = [len(kwargs['percent'])]
+                percentile_rollaxis = True
+            except TypeError:
+                pass
+            else:
+                data_shape.extend(shape)
         data_shape[dimension_to_groupby] = len(groupby)
 
         # Aggregate the group-by data.
@@ -3098,6 +3108,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                           axis=dimension_to_groupby,
                                           **kwargs)
 
+            if percentile_rollaxis:
+                # Roll the result so its shape matches `data_shape`.
+                result = np.rollaxis(result, 0, start=len(result.shape))
+
             # Determine aggregation result data type for the aggregate-by cube
             # data on first pass.
             if i == 0:
@@ -3107,6 +3121,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     aggregateby_data = np.zeros(data_shape, dtype=result.dtype)
 
             aggregateby_data[tuple(cube_slice)] = result
+
+        if percentile_rollaxis:
+            # Roll `aggregate_by` data so its shape is restored.
+            aggregateby_data = np.rollaxis(aggregateby_data, -1)
 
         # Add the aggregation meta data to the aggregate-by cube.
         aggregator.update_metadata(aggregateby_cube,
@@ -3125,7 +3143,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 aggregateby_cube.add_aux_coord(coord.copy(),
                                                dimension_to_groupby)
         # Attatch the aggregate-by data into the aggregate-by cube.
-        aggregateby_cube.data = aggregateby_data
+        aggregateby_cube = aggregator.post_process(aggregateby_cube,
+                                                   aggregateby_data,
+                                                   coords, **kwargs)
 
         return aggregateby_cube
 
@@ -3304,11 +3324,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 kwargs = dict(kwargs)
                 kwargs['weights'] = iris.util.broadcast_to_shape(
                     weights, rolling_window_data.shape, (dimension + 1,))
-        new_cube.data = aggregator.aggregate(rolling_window_data,
-                                             axis=dimension + 1,
-                                             **kwargs)
-
-        return new_cube
+        data_result = aggregator.aggregate(rolling_window_data,
+                                           axis=dimension + 1,
+                                           **kwargs)
+        result = aggregator.post_process(new_cube, data_result, [coord],
+                                         **kwargs)
+        return result
 
     def interpolate(self, sample_points, scheme, collapse_scalar=True):
         """

--- a/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
@@ -5,12 +5,11 @@
       <coord>
         <dimCoord bounds="[[0, 11]]" id="549be28b" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data dtype="float64" shape="(1,)" state="loaded"/>
+    <data dtype="float64" shape="()" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
@@ -10,12 +10,11 @@
       <coord>
         <dimCoord bounds="[[-15, 45]]" id="549be28b" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
@@ -13,6 +13,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data dtype="float64" shape="(1,)" state="loaded"/>
+    <data dtype="float64" shape="()" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
@@ -8,13 +8,11 @@
       <coord>
         <dimCoord bounds="[[-15, 45]]" id="549be28b" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
       </coord>
+      <coord>
+        <dimCoord id="38918495" long_name="percentile_over_foo_bar" points="[25]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (25%)">
-        <coord name="foo"/>
-        <coord name="bar"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
@@ -9,14 +9,13 @@
         <dimCoord circular="True" id="a523d045" points="[-180, -90, 0, 90]" shape="(4,)" standard_name="longitude" units="Unit('degrees')" value_type="int64"/>
       </coord>
       <coord>
+        <dimCoord id="8d9dcec2" long_name="percentile_over_wibble" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord>
         <dimCoord bounds="[[10.0, 30.0]]" id="a2260f1f" long_name="wibble" points="[20.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="wibble"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3, 4)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
@@ -9,14 +9,13 @@
         <dimCoord circular="True" id="a523d045" points="[-180, -90, 0, 90]" shape="(4,)" standard_name="longitude" units="Unit('degrees')" value_type="int64"/>
       </coord>
       <coord>
+        <dimCoord id="8d9dcec2" long_name="percentile_over_wibble" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord>
         <dimCoord bounds="[[10.0, 30.0]]" id="a2260f1f" long_name="wibble" points="[20.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>
       </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="wibble"/>
-      </cellMethod>
-    </cellMethods>
+    <cellMethods/>
     <data dtype="float64" shape="(3, 4)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data dtype="float64" shape="(1,)" state="loaded"/>
+    <data dtype="float64" shape="()" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
@@ -5,12 +5,11 @@
       <coord>
         <dimCoord bounds="[[0, 11]]" id="549be28b" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
       </coord>
+      <coord>
+        <dimCoord id="88f09ece" long_name="percentile_over_foo" points="[75]" shape="(1,)" units="Unit('1')" value_type="int64"/>
+      </coord>
     </coords>
-    <cellMethods>
-      <cellMethod method="percentile (75%)">
-        <coord name="foo"/>
-      </cellMethod>
-    </cellMethods>
-    <data dtype="float64" shape="()" state="loaded"/>
+    <cellMethods/>
+    <data dtype="float64" shape="(1,)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/unit/analysis/test_AdditiveAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_AdditiveAggregator.py
@@ -1,0 +1,144 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the :class:`iris.analysis.AdditiveAggregator` class instance.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from mock import sentinel
+import numpy as np
+
+from iris.analysis import AdditiveAggregator
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+
+
+class Test(tests.IrisTest):
+    def test_required_missing(self):
+        name = 'percentile'
+        emsg = '{} aggregator requires a mandatory keyword argument.'
+        with self.assertRaisesRegexp(ValueError, emsg.format(name)):
+            AdditiveAggregator(name, None, None)
+        name = 'unknown'
+        with self.assertRaisesRegexp(ValueError, emsg.format(name)):
+            AdditiveAggregator(None, None, None)
+
+    def test_complete(self):
+        name = 'one two three'
+        call_func = sentinel.call_func
+        required = 'dummy'
+        units_func = sentinel.units_func
+        lazy_func = sentinel.lazy_func
+        aggregator = AdditiveAggregator(name, call_func, required,
+                                        units_func=units_func,
+                                        lazy_func=lazy_func)
+        self.assertEqual(aggregator.name(), 'one_two_three')
+        self.assertIs(aggregator.call_func, call_func)
+        self.assertEqual(aggregator.required, required)
+        self.assertIs(aggregator.units_func, units_func)
+        self.assertIs(aggregator.lazy_func, lazy_func)
+        self.assertIsNone(aggregator.cell_method)
+
+
+class Test_post_process(tests.IrisTest):
+    def setUp(self):
+        shape = (2, 5)
+        data = np.arange(np.prod(shape))
+
+        self.coord_simple = DimCoord(data, 'time')
+        self.cube_simple = Cube(data)
+        self.cube_simple.add_dim_coord(self.coord_simple, 0)
+
+        self.coord_multi_0 = DimCoord(range(shape[0]), 'time')
+        self.coord_multi_1 = DimCoord(range(shape[1]), 'height')
+        self.cube_multi = Cube(data.reshape(shape))
+        self.cube_multi.add_dim_coord(self.coord_multi_0, 0)
+        self.cube_multi.add_dim_coord(self.coord_multi_1, 1)
+
+    def test_simple_single_point(self):
+        aggregator = AdditiveAggregator('way', None, 'point')
+        point = 50
+        kwargs = dict(point=point)
+        data = np.empty(self.cube_simple.shape)
+        coords = [self.coord_simple]
+        actual = aggregator.post_process(self.cube_simple, data, coords,
+                                         **kwargs)
+        self.assertEqual(actual.shape, self.cube_simple.shape)
+        self.assertIs(actual.data, data)
+        name = 'way_over_time'
+        coord = actual.coord(name)
+        expected = AuxCoord(point, long_name=name)
+        self.assertEqual(coord, expected)
+
+    def test_simple_multiple_points(self):
+        aggregator = AdditiveAggregator('just', None, 'points')
+        points = np.array([10, 20, 50, 90])
+        kwargs = dict(points=points)
+        shape = self.cube_simple.shape + points.shape
+        data = np.empty(shape)
+        coords = [self.coord_simple]
+        actual = aggregator.post_process(self.cube_simple, data, coords,
+                                         **kwargs)
+        self.assertEqual(actual.shape, points.shape + self.cube_simple.shape)
+        expected = np.rollaxis(data, -1)
+        self.assertArrayEqual(actual.data, expected)
+        name = 'just_over_time'
+        coord = actual.coord(name)
+        expected = AuxCoord(points, long_name=name)
+        self.assertEqual(coord, expected)
+
+    def test_multi_single_point(self):
+        aggregator = AdditiveAggregator('nearly', None, 'point')
+        point = 70
+        kwargs = dict(point=point)
+        data = np.empty(self.cube_multi.shape)
+        coords = [self.coord_multi_0]
+        actual = aggregator.post_process(self.cube_multi, data, coords,
+                                         **kwargs)
+        self.assertEqual(actual.shape, self.cube_multi.shape)
+        self.assertIs(actual.data, data)
+        name = 'nearly_over_time'
+        coord = actual.coord(name)
+        expected = AuxCoord(point, long_name=name)
+        self.assertEqual(coord, expected)
+
+    def test_multi_multiple_points(self):
+        aggregator = AdditiveAggregator('hardly', None, 'points')
+        points = np.array([17, 29, 81])
+        kwargs = dict(points=points)
+        shape = self.cube_multi.shape + points.shape
+        data = np.empty(shape)
+        coords = [self.coord_multi_0]
+        actual = aggregator.post_process(self.cube_multi, data, coords,
+                                         **kwargs)
+        self.assertEqual(actual.shape, points.shape + self.cube_multi.shape)
+        expected = np.rollaxis(data, -1)
+        self.assertArrayEqual(actual.data, expected)
+        name = 'hardly_over_time'
+        coord = actual.coord(name)
+        expected = AuxCoord(points, long_name=name)
+        self.assertEqual(coord, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/analysis/test_COUNT.py
+++ b/lib/iris/tests/unit/analysis/test_COUNT.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -45,6 +45,26 @@ class Test_masked(tests.IrisTest):
     def test_ma(self):
         cube = self.cube.collapsed("foo", COUNT, function=self.func)
         self.assertArrayEqual(cube.data, [2])
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNotNone(COUNT.required)
+        self.assertEqual(COUNT.required, 'function')
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(COUNT.name(), 'count')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(COUNT.aggregate_shape(**kwargs), shape)
+        kwargs = dict(wibble='wobble')
+        self.assertTupleEqual(COUNT.aggregate_shape(**kwargs), shape)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_COUNT.py
+++ b/lib/iris/tests/unit/analysis/test_COUNT.py
@@ -47,12 +47,6 @@ class Test_masked(tests.IrisTest):
         self.assertArrayEqual(cube.data, [2])
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNotNone(COUNT.required)
-        self.assertEqual(COUNT.required, 'function')
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(COUNT.name(), 'count')

--- a/lib/iris/tests/unit/analysis/test_MEAN.py
+++ b/lib/iris/tests/unit/analysis/test_MEAN.py
@@ -55,11 +55,6 @@ class Test_lazy_aggregate(tests.IrisTest):
         self.assertMaskedArrayAlmostEqual(result, expected)
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNone(MEAN.required)
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(MEAN.name(), 'mean')

--- a/lib/iris/tests/unit/analysis/test_MEAN.py
+++ b/lib/iris/tests/unit/analysis/test_MEAN.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -53,6 +53,25 @@ class Test_lazy_aggregate(tests.IrisTest):
         result = agg.masked_array()
         expected = ma.mean(self.data, axis=self.axis)
         self.assertMaskedArrayAlmostEqual(result, expected)
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(MEAN.required)
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(MEAN.name(), 'mean')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(MEAN.aggregate_shape(**kwargs), shape)
+        kwargs = dict(one=1, two=2)
+        self.assertTupleEqual(MEAN.aggregate_shape(**kwargs), shape)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -38,7 +38,7 @@ class Test_aggregate(tests.IrisTest):
         data = np.arange(11)
         actual = PERCENTILE.aggregate(data, axis=0, percent=50)
         expected = 5
-        self.assertTupleEqual(actual.shape, (1,))
+        self.assertTupleEqual(actual.shape, ())
         self.assertEqual(actual, expected)
 
     def test_masked_1d_single(self):
@@ -46,7 +46,7 @@ class Test_aggregate(tests.IrisTest):
         data[3:7] = ma.masked
         actual = PERCENTILE.aggregate(data, axis=0, percent=50)
         expected = 7
-        self.assertTupleEqual(actual.shape, (1,))
+        self.assertTupleEqual(actual.shape, ())
         self.assertEqual(actual, expected)
 
     def test_1d_multi(self):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -1,0 +1,155 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :data:`iris.analysis.PERCENTILE` aggregator."""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+import numpy.ma as ma
+
+from iris.analysis import PERCENTILE
+
+
+class Test_aggregate(tests.IrisTest):
+    def test_missing_mandatory_kwarg(self):
+        emsg = "percentile aggregator requires .* keyword argument 'percent'"
+        with self.assertRaisesRegexp(ValueError, emsg):
+            PERCENTILE.aggregate('dummy', axis=0)
+
+    def test_1d_single(self):
+        data = np.arange(11)
+        actual = PERCENTILE.aggregate(data, axis=0, percent=50)
+        expected = 5
+        self.assertTupleEqual(actual.shape, (1,))
+        self.assertEqual(actual, expected)
+
+    def test_masked_1d_single(self):
+        data = ma.arange(11)
+        data[3:7] = ma.masked
+        actual = PERCENTILE.aggregate(data, axis=0, percent=50)
+        expected = 7
+        self.assertTupleEqual(actual.shape, (1,))
+        self.assertEqual(actual, expected)
+
+    def test_1d_multi(self):
+        data = np.arange(11)
+        percent = np.array([20, 50, 90])
+        actual = PERCENTILE.aggregate(data, axis=0, percent=percent)
+        expected = [2, 5, 9]
+        self.assertTupleEqual(actual.shape, percent.shape)
+        self.assertArrayEqual(actual, expected)
+
+    def test_masked_1d_multi(self):
+        data = ma.arange(11)
+        data[3:9] = ma.masked
+        percent = np.array([25, 50, 75])
+        actual = PERCENTILE.aggregate(data, axis=0, percent=percent)
+        expected = [1, 2, 9]
+        self.assertTupleEqual(actual.shape, percent.shape)
+        self.assertArrayEqual(actual, expected)
+
+    def test_2d_single(self):
+        shape = (2, 11)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        actual = PERCENTILE.aggregate(data, axis=0, percent=50)
+        self.assertTupleEqual(actual.shape, shape[-1:])
+        expected = np.arange(shape[-1]) + 5.5
+        self.assertArrayEqual(actual, expected)
+
+    def test_masked_2d_single(self):
+        shape = (2, 11)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        data[1, 1::2] = ma.masked
+        actual = PERCENTILE.aggregate(data, axis=0, percent=50)
+        self.assertTupleEqual(actual.shape, shape[-1:])
+        expected = np.empty(shape[-1:])
+        expected[1::2] = data[0, 1::2]
+        expected[::2] = data[1, ::2]
+        self.assertArrayEqual(actual, expected)
+
+    def test_2d_multi(self):
+        shape = (2, 10)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        percent = np.array([10, 50, 90, 100])
+        actual = PERCENTILE.aggregate(data, axis=0, percent=percent)
+        self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
+        expected = np.array(range(shape[-1]) * percent.size)
+        expected = expected.reshape(percent.size, shape[-1]).T + 1
+        expected = expected + (percent / 10 - 1)
+        self.assertArrayAlmostEqual(actual, expected)
+
+    def test_masked_2d_multi(self):
+        shape = (3, 10)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[1] = ma.masked
+        percent = np.array([10, 50, 70, 80])
+        actual = PERCENTILE.aggregate(data, axis=0, percent=percent)
+        self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
+        expected = np.array(range(shape[-1]) * percent.size)
+        expected = expected.reshape(percent.size, shape[-1]).T
+        expected = expected + (percent / 10 * 2)
+        self.assertArrayAlmostEqual(actual, expected)
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNotNone(PERCENTILE.required)
+        self.assertEqual(PERCENTILE.required, 'percent')
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(PERCENTILE.name(), 'percentile')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test_missing_mandatory_kwarg(self):
+        emsg = "percentile aggregator requires .* keyword argument 'percent'"
+        with self.assertRaisesRegexp(ValueError, emsg):
+            PERCENTILE.aggregate_shape()
+        with self.assertRaisesRegexp(ValueError, emsg):
+            kwargs = dict()
+            PERCENTILE.aggregate_shape(**kwargs)
+        with self.assertRaisesRegexp(ValueError, emsg):
+            kwargs = dict(point=10)
+            PERCENTILE.aggregate_shape(**kwargs)
+
+    def test_mandatory_kwarg_no_shape(self):
+        kwargs = dict(percent=50)
+        self.assertTupleEqual(PERCENTILE.aggregate_shape(**kwargs), ())
+        kwargs = dict(percent=[50])
+        self.assertTupleEqual(PERCENTILE.aggregate_shape(**kwargs), ())
+
+    def test_mandatory_kwarg_shape(self):
+        kwargs = dict(percent=(10, 20))
+        self.assertTupleEqual(PERCENTILE.aggregate_shape(**kwargs), (2,))
+        kwargs = dict(percent=range(13))
+        self.assertTupleEqual(PERCENTILE.aggregate_shape(**kwargs), (13,))
+
+
+class Test_cell_method(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(PERCENTILE.cell_method)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -110,12 +110,6 @@ class Test_aggregate(tests.IrisTest):
         self.assertArrayAlmostEqual(actual, expected)
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNotNone(PERCENTILE.required)
-        self.assertEqual(PERCENTILE.required, 'percent')
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(PERCENTILE.name(), 'percentile')

--- a/lib/iris/tests/unit/analysis/test_PROPORTION.py
+++ b/lib/iris/tests/unit/analysis/test_PROPORTION.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -46,6 +46,26 @@ class Test_masked(tests.IrisTest):
     def test_ma(self):
         cube = self.cube.collapsed("foo", PROPORTION, function=self.func)
         self.assertArrayEqual(cube.data, [0.5])
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNotNone(PROPORTION.required)
+        self.assertEqual(PROPORTION.required, 'function')
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(PROPORTION.name(), 'proportion')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(PROPORTION.aggregate_shape(**kwargs), shape)
+        kwargs = dict(captain='caveman', penelope='pitstop')
+        self.assertTupleEqual(PROPORTION.aggregate_shape(**kwargs), shape)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_PROPORTION.py
+++ b/lib/iris/tests/unit/analysis/test_PROPORTION.py
@@ -48,12 +48,6 @@ class Test_masked(tests.IrisTest):
         self.assertArrayEqual(cube.data, [0.5])
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNotNone(PROPORTION.required)
-        self.assertEqual(PROPORTION.required, 'function')
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(PROPORTION.name(), 'proportion')

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the :class:`iris.analysis.AdditiveAggregator` class instance.
+Unit tests for the :class:`iris.analysis.PercentileAggregator` class instance.
 
 """
 
@@ -28,33 +28,21 @@ import iris.tests as tests
 from mock import sentinel
 import numpy as np
 
-from iris.analysis import AdditiveAggregator
+from iris.analysis import PercentileAggregator, _percentile
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 
 
 class Test(tests.IrisTest):
-    def test_required_missing(self):
+    def test_init(self):
         name = 'percentile'
-        emsg = '{} aggregator requires a mandatory keyword argument.'
-        with self.assertRaisesRegexp(ValueError, emsg.format(name)):
-            AdditiveAggregator(name, None, None)
-        name = 'unknown'
-        with self.assertRaisesRegexp(ValueError, emsg.format(name)):
-            AdditiveAggregator(None, None, None)
-
-    def test_complete(self):
-        name = 'one two three'
-        call_func = sentinel.call_func
-        required = 'dummy'
+        call_func = _percentile
         units_func = sentinel.units_func
         lazy_func = sentinel.lazy_func
-        aggregator = AdditiveAggregator(name, call_func, required,
-                                        units_func=units_func,
-                                        lazy_func=lazy_func)
-        self.assertEqual(aggregator.name(), 'one_two_three')
+        aggregator = PercentileAggregator(units_func=units_func,
+                                          lazy_func=lazy_func)
+        self.assertEqual(aggregator.name(), name)
         self.assertIs(aggregator.call_func, call_func)
-        self.assertEqual(aggregator.required, required)
         self.assertIs(aggregator.units_func, units_func)
         self.assertIs(aggregator.lazy_func, lazy_func)
         self.assertIsNone(aggregator.cell_method)
@@ -75,68 +63,74 @@ class Test_post_process(tests.IrisTest):
         self.cube_multi.add_dim_coord(self.coord_multi_0, 0)
         self.cube_multi.add_dim_coord(self.coord_multi_1, 1)
 
+    def test_missing_mandatory_kwarg(self):
+        aggregator = PercentileAggregator()
+        emsg = "percentile aggregator requires .* keyword argument 'percent'"
+        with self.assertRaisesRegexp(ValueError, emsg):
+            aggregator.aggregate('dummy', axis=0)
+
     def test_simple_single_point(self):
-        aggregator = AdditiveAggregator('way', None, 'point')
-        point = 50
-        kwargs = dict(point=point)
+        aggregator = PercentileAggregator()
+        percent = 50
+        kwargs = dict(percent=percent)
         data = np.empty(self.cube_simple.shape)
         coords = [self.coord_simple]
         actual = aggregator.post_process(self.cube_simple, data, coords,
                                          **kwargs)
         self.assertEqual(actual.shape, self.cube_simple.shape)
         self.assertIs(actual.data, data)
-        name = 'way_over_time'
+        name = 'percentile_over_time'
         coord = actual.coord(name)
-        expected = AuxCoord(point, long_name=name)
+        expected = AuxCoord(percent, long_name=name)
         self.assertEqual(coord, expected)
 
     def test_simple_multiple_points(self):
-        aggregator = AdditiveAggregator('just', None, 'points')
-        points = np.array([10, 20, 50, 90])
-        kwargs = dict(points=points)
-        shape = self.cube_simple.shape + points.shape
+        aggregator = PercentileAggregator()
+        percent = np.array([10, 20, 50, 90])
+        kwargs = dict(percent=percent)
+        shape = self.cube_simple.shape + percent.shape
         data = np.empty(shape)
         coords = [self.coord_simple]
         actual = aggregator.post_process(self.cube_simple, data, coords,
                                          **kwargs)
-        self.assertEqual(actual.shape, points.shape + self.cube_simple.shape)
+        self.assertEqual(actual.shape, percent.shape + self.cube_simple.shape)
         expected = np.rollaxis(data, -1)
         self.assertArrayEqual(actual.data, expected)
-        name = 'just_over_time'
+        name = 'percentile_over_time'
         coord = actual.coord(name)
-        expected = AuxCoord(points, long_name=name)
+        expected = AuxCoord(percent, long_name=name)
         self.assertEqual(coord, expected)
 
     def test_multi_single_point(self):
-        aggregator = AdditiveAggregator('nearly', None, 'point')
-        point = 70
-        kwargs = dict(point=point)
+        aggregator = PercentileAggregator()
+        percent = 70
+        kwargs = dict(percent=percent)
         data = np.empty(self.cube_multi.shape)
         coords = [self.coord_multi_0]
         actual = aggregator.post_process(self.cube_multi, data, coords,
                                          **kwargs)
         self.assertEqual(actual.shape, self.cube_multi.shape)
         self.assertIs(actual.data, data)
-        name = 'nearly_over_time'
+        name = 'percentile_over_time'
         coord = actual.coord(name)
-        expected = AuxCoord(point, long_name=name)
+        expected = AuxCoord(percent, long_name=name)
         self.assertEqual(coord, expected)
 
     def test_multi_multiple_points(self):
-        aggregator = AdditiveAggregator('hardly', None, 'points')
-        points = np.array([17, 29, 81])
-        kwargs = dict(points=points)
-        shape = self.cube_multi.shape + points.shape
+        aggregator = PercentileAggregator()
+        percent = np.array([17, 29, 81])
+        kwargs = dict(percent=percent)
+        shape = self.cube_multi.shape + percent.shape
         data = np.empty(shape)
         coords = [self.coord_multi_0]
         actual = aggregator.post_process(self.cube_multi, data, coords,
                                          **kwargs)
-        self.assertEqual(actual.shape, points.shape + self.cube_multi.shape)
+        self.assertEqual(actual.shape, percent.shape + self.cube_multi.shape)
         expected = np.rollaxis(data, -1)
         self.assertArrayEqual(actual.data, expected)
-        name = 'hardly_over_time'
+        name = 'percentile_over_time'
         coord = actual.coord(name)
-        expected = AuxCoord(points, long_name=name)
+        expected = AuxCoord(percent, long_name=name)
         self.assertEqual(coord, expected)
 
 

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -29,7 +29,6 @@ from iris.analysis import RMS
 
 
 class Test_aggregate(tests.IrisTest):
-
     def test_1d(self):
         # 1-dimensional input
         data = np.array([5, 2, 6, 4], dtype=np.float64)
@@ -86,11 +85,6 @@ class Test_aggregate(tests.IrisTest):
         expected_rms = 8.0
         rms = RMS.aggregate(data, 0, weights=weights)
         self.assertAlmostEqual(rms, expected_rms)
-
-
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNone(RMS.required)
 
 
 class Test_name(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -88,5 +88,24 @@ class Test_aggregate(tests.IrisTest):
         self.assertAlmostEqual(rms, expected_rms)
 
 
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(RMS.required)
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(RMS.name(), 'root_mean_square')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(RMS.aggregate_shape(**kwargs), shape)
+        kwargs = dict(tom='jerry', calvin='hobbes')
+        self.assertTupleEqual(RMS.aggregate_shape(**kwargs), shape)
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/analysis/test_STD_DEV.py
+++ b/lib/iris/tests/unit/analysis/test_STD_DEV.py
@@ -46,11 +46,6 @@ class Test_lazy_aggregate(tests.IrisTest):
         self.assertArrayAlmostEqual(var.ndarray(), np.array(2.291287))
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNone(STD_DEV.required)
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(STD_DEV.name(), 'standard_deviation')

--- a/lib/iris/tests/unit/analysis/test_STD_DEV.py
+++ b/lib/iris/tests/unit/analysis/test_STD_DEV.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -44,6 +44,25 @@ class Test_lazy_aggregate(tests.IrisTest):
         array = biggus.NumpyArrayAdapter(np.arange(8))
         var = STD_DEV.lazy_aggregate(array, axis=0, ddof=0)
         self.assertArrayAlmostEqual(var.ndarray(), np.array(2.291287))
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(STD_DEV.required)
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(STD_DEV.name(), 'standard_deviation')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(STD_DEV.aggregate_shape(**kwargs), shape)
+        kwargs = dict(forfar=5, fife=4)
+        self.assertTupleEqual(STD_DEV.aggregate_shape(**kwargs), shape)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -88,11 +88,6 @@ class Test_lazy_aggregate(tests.IrisTest):
         self.assertArrayAlmostEqual(var.ndarray(), np.array(5.25))
 
 
-class Test_required(tests.IrisTest):
-    def test(self):
-        self.assertIsNone(VARIANCE.required)
-
-
 class Test_name(tests.IrisTest):
     def test(self):
         self.assertEqual(VARIANCE.name(), 'variance')

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -86,6 +86,25 @@ class Test_lazy_aggregate(tests.IrisTest):
         array = biggus.NumpyArrayAdapter(np.arange(8))
         var = VARIANCE.lazy_aggregate(array, axis=0, ddof=0)
         self.assertArrayAlmostEqual(var.ndarray(), np.array(5.25))
+
+
+class Test_required(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(VARIANCE.required)
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(VARIANCE.name(), 'variance')
+
+
+class Test_aggregate_shape(tests.IrisTest):
+    def test(self):
+        shape = ()
+        kwargs = dict()
+        self.assertTupleEqual(VARIANCE.aggregate_shape(**kwargs), shape)
+        kwargs = dict(bat='man', wonder='woman')
+        self.assertTupleEqual(VARIANCE.aggregate_shape(**kwargs), shape)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -327,6 +327,7 @@ class Test_aggregated_by(tests.IrisTest):
         self.mock_agg.cell_method = []
         self.mock_agg.aggregate = mock.Mock(
             return_value=mock.Mock(dtype='object'))
+        self.mock_agg.aggregate_shape = mock.Mock(return_value=())
         post_process_func = lambda x, y, z: x
         self.mock_agg.post_process = mock.Mock(side_effect=post_process_func)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -324,8 +324,11 @@ class Test_aggregated_by(tests.IrisTest):
         self.cube.add_aux_coord(val_coord, 0)
         self.cube.add_aux_coord(label_coord, 0)
         self.mock_agg = mock.Mock(spec=Aggregator)
+        self.mock_agg.cell_method = []
         self.mock_agg.aggregate = mock.Mock(
             return_value=mock.Mock(dtype='object'))
+        post_process_func = lambda x, y, z: x
+        self.mock_agg.post_process = mock.Mock(side_effect=post_process_func)
 
     def test_string_coord_agg_by_label(self):
         # Aggregate a cube on a string coordinate label where label
@@ -376,6 +379,8 @@ class Test_rolling_window(tests.IrisTest):
         self.mock_agg = mock.Mock(spec=Aggregator)
         self.mock_agg.aggregate = mock.Mock(
             return_value=np.empty([4]))
+        post_process_func = lambda x, y, z: x
+        self.mock_agg.post_process = mock.Mock(side_effect=post_process_func)
 
     def test_string_coord(self):
         # Rolling window on a cube that contains a string coordinate.


### PR DESCRIPTION
This PR is a re-factor of #1564. 

This PR extends the capability of the `PERCENTILE` aggregator such that it can calculate more than one percentile at a time, but it also addresses the issues of that functionality bleeding-thru to the `Cube` methods `aggregated_by`, `collapsed` and `rolling_window`, as per #1564.

The bleed-thru issues have pretty much melted away due to re-organising the aggregator class hierarchy, however in doing so, some minor changes to the API were necessary, namely:
 * Explicit enforcement of any mandatory aggregator call keyword arguments i.e. the `function` keyword for `PROPORTION` and `COUNT`, and `percent` for `PERCENTILE`.
 * The introduction of a `aggregator_shape` method, which is used by the `Cube.aggregated_by` method.

Thoughts on `aggregator_shape` are welcomed, as are alternatives ...

Closes #1564.