### PR TITLE
Raise warning when cube masked array re-cast to numpy array

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1930,6 +1930,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # We can turn a masked array into a normal array if it's full.
         if isinstance(data, ma.core.MaskedArray):
             if ma.count_masked(data) == 0:
+                msg = 'Casting full masked array to NumPy array.'
+                warnings.warn(msg)
                 data = data.filled()
 
         # Make the new cube slice

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -23,6 +23,7 @@ from __future__ import (absolute_import, division, print_function)
 import iris.tests as tests
 
 import itertools
+import warnings
 
 import biggus
 import mock
@@ -63,6 +64,21 @@ class Test___init___data(tests.IrisTest):
         cube = Cube(data)
         self.assertEqual(type(cube.data), np.ndarray)
         self.assertArrayEqual(cube.data, data)
+
+
+class Test___getitem__(tests.IrisTest):
+    def test_full_masked_array_warning(self):
+        # Check that a warning is raised when a cube's data that is a
+        # full masked array is cast to a numpy array.
+        # This happens when such a cube is indexed.
+        data = np.ma.array(np.arange(12).reshape(3, 4))
+        cube = Cube(data)
+        self.assertEqual(type(cube.data), np.ma.MaskedArray)
+        with warnings.catch_warnings():
+            # Cause all warnings to raise Exceptions.
+            warnings.simplefilter('error')
+            with self.assertRaisesRegexp(UserWarning, 'Casting full masked'):
+                cube[:2]
 
 
 class Test_extract(tests.IrisTest):


### PR DESCRIPTION
Added a warning when subsetting a cube will cast a masked array to a numpy array.

This will happen when a cube's data attribute is a filled (i.e. no unmasked points) masked array. This currently happens silently, which is undesirable if not expected.

