### PR TITLE
What's new for v1.7.4.

### DIFF
--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -1,8 +1,8 @@
 What's new in Iris 1.7
 **********************
 
-:Release: 1.7.3
-:Date: ???
+:Release: 1.7.4
+:Date: 17th March 2015
 
 Iris 1.7 features
 =================
@@ -197,6 +197,13 @@ Bugs fixed in v1.7.3
 * Arbitrary names can no longer be set for elements of a :class:`iris.fileformats.pp.SplittableInt`.
 * Cubes that contain a pseudo-level coordinate can now be saved to PP.
 * Fixed a bug in the FieldsFile loader that prevented it always loading all available fields.
+
+Bugs fixed in v1.7.4
+^^^^^^^^^^^^^^^^^^^^
+* Several minor fixes to allow use of Iris on Windows.
+* Made use of the new standard_parallels keyword in Cartopy's LambertConformal
+  projection (Cartopy v0.12). Older versions of Iris will not be able to create LambertConformal
+  coordinate systems with with Cartopy >= 0.12.
 
 Incompatible changes
 ====================

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -108,7 +108,7 @@ import iris.io
 
 
 # Iris revision.
-__version__ = '1.7.4-DEV'
+__version__ = '1.7.4'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',


### PR DESCRIPTION
Based on https://github.com/SciTools/iris/compare/v1.7.3...v1.7.x.

There is just one PR against v1.7.x (according to https://api.github.com/repos/scitools/iris/pulls?base=v1.7.x), and it is not likely that it will be mergeable in short order.

Once this is merged, I will use the github interface to create the v1.7.4 tag.