### PR TITLE
Remove cube deprecations

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2083,15 +2083,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return summary
 
-    def assert_valid(self):
-        """
-        Does nothing and returns None.
-
-        .. deprecated:: 0.8
-
-        """
-        warn_deprecated('Cube.assert_valid() has been deprecated.')
-
     def __str__(self):
         # six has a decorator for this bit, but it doesn't do errors='replace'.
         if six.PY3:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3111,29 +3111,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     __pow__ = iris.analysis.maths.exponentiate
     # END OPERATOR OVERLOADS
 
-    def add_history(self, string):
-        """
-        Add the given string to the cube's history.
-        If the history coordinate does not exist, then one will be created.
-
-        .. deprecated:: 1.6
-            Add/modify history metadata within
-            :attr:`~iris.cube.Cube.attributes` as needed.
-
-        """
-        warn_deprecated("Cube.add_history() has been deprecated - "
-                        "please modify/create cube.attributes['history'] "
-                        "as needed.")
-
-        timestamp = datetime.datetime.now().strftime("%d/%m/%y %H:%M:%S")
-        string = '%s Iris: %s' % (timestamp, string)
-
-        try:
-            history = self.attributes['history']
-            self.attributes['history'] = '%s\n%s' % (history, string)
-        except KeyError:
-            self.attributes['history'] = string
-
     # START ANALYSIS ROUTINES
 
     regridded = iris.util._wrap_function_for_method(

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1231,8 +1231,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def coords(self, name_or_coord=None, standard_name=None,
                long_name=None, var_name=None, attributes=None, axis=None,
-               contains_dimension=None, dimensions=None, coord=None,
-               coord_system=None, dim_coords=None, name=None):
+               contains_dimension=None, dimensions=None, coord_system=None,
+               dim_coords=None):
         """
         Return a list of coordinates in this cube fitting the given criteria.
 
@@ -1251,8 +1251,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             :class:`iris.coords.DimCoord`, :class:`iris.coords.AuxCoord`,
             :class:`iris.aux_factory.AuxCoordFactory`
             or :class:`iris.coords.CoordDefn`.
-        * name
-            .. deprecated:: 1.6. Please use the name_or_coord kwarg.
         * standard_name
             The CF standard name of the desired coordinate. If None, does not
             check for standard name.
@@ -1276,8 +1274,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             The exact data dimensions of the desired coordinate. Coordinates
             with no data dimension can be found with an empty tuple or list
             (i.e. ``()`` or ``[]``). If None, does not check for dimensions.
-        * coord
-            .. deprecated:: 1.6. Please use the name_or_coord kwarg.
         * coord_system
             Whether the desired coordinates have coordinate systems equal to
             the given coordinate system. If None, no check is done.
@@ -1290,23 +1286,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         See also :meth:`Cube.coord()<iris.cube.Cube.coord>`.
 
         """
-        # Handle deprecated kwargs
-        if name is not None:
-            name_or_coord = name
-            warn_deprecated('the name kwarg is deprecated and will be removed '
-                            'in a future release. Consider converting '
-                            'existing code to use the name_or_coord '
-                            'kwarg as a replacement.',
-                            stacklevel=2)
-        if coord is not None:
-            name_or_coord = coord
-            warn_deprecated('the coord kwarg is deprecated and will be '
-                            'removed in a future release. Consider converting '
-                            'existing code to use the name_or_coord '
-                            'kwarg as a replacement.',
-                            stacklevel=2)
-        # Finish handling deprecated kwargs
-
         name = None
         coord = None
 
@@ -1402,8 +1381,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def coord(self, name_or_coord=None, standard_name=None,
               long_name=None, var_name=None, attributes=None, axis=None,
-              contains_dimension=None, dimensions=None, coord=None,
-              coord_system=None, dim_coords=None, name=None):
+              contains_dimension=None, dimensions=None, coord_system=None,
+              dim_coords=None):
         """
         Return a single coord given the same arguments as :meth:`Cube.coords`.
 
@@ -1419,23 +1398,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             documentation.
 
         """
-        # Handle deprecated kwargs
-        if name is not None:
-            name_or_coord = name
-            warn_deprecated('the name kwarg is deprecated and will be removed '
-                            'in a future release. Consider converting '
-                            'existing code to use the name_or_coord '
-                            'kwarg as a replacement.',
-                            stacklevel=2)
-        if coord is not None:
-            name_or_coord = coord
-            warn_deprecated('the coord kwarg is deprecated and will be '
-                            'removed in a future release. Consider converting '
-                            'existing code to use the name_or_coord '
-                            'kwarg as a replacement.',
-                            stacklevel=2)
-        # Finish handling deprecated kwargs
-
         coords = self.coords(name_or_coord=name_or_coord,
                              standard_name=standard_name,
                              long_name=long_name, var_name=var_name,
@@ -1451,8 +1413,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                                              coord in coords))
             raise iris.exceptions.CoordinateNotFoundError(msg)
         elif len(coords) == 0:
-            bad_name = name or standard_name or long_name or \
-                (coord and coord.name()) or ''
+            _name = name_or_coord
+            if name_or_coord is not None:
+                if not isinstance(name_or_coord, six.string_types):
+                    _name = name_or_coord.name()
+            bad_name = _name or standard_name or long_name or ''
             msg = 'Expected to find exactly 1 %s coordinate, but found ' \
                   'none.' % bad_name
             raise iris.exceptions.CoordinateNotFoundError(msg)

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -99,7 +99,6 @@ class TestUnmappable(tests.GraphicsTest):
             0)
         cube.standard_name = 'air_temperature'
         cube.units = 'K'
-        cube.assert_valid()
         self.cube = cube
 
     def test_simple(self):

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -668,11 +668,9 @@ class TestTimeTripleMerging(tests.IrisTest):
                                    ])
         cube = cubes.merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging2.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
         cube = iris.cube.CubeList(cubes[:-1]).merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging3.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
     def test_simple3(self):
         cubes = iris.cube.CubeList([
@@ -685,11 +683,9 @@ class TestTimeTripleMerging(tests.IrisTest):
                                    ])
         cube = cubes.merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging4.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
         cube = iris.cube.CubeList(cubes[:-1]).merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging5.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
 
 class TestCubeMergeTheoretical(tests.IrisTest):


### PR DESCRIPTION
Removal of deprecated methods/keywords from `iris.cube`. Handles all deprecations from #1592, except for the last one which needs further discussion.
