### PR TITLE
remove regularise

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -872,7 +872,7 @@ def grib_generator(filename, auto_regularise=True):
             gribapi.grib_release(grib_message)
 
 
-def load_cubes(filenames, callback=None, regularise=True, auto_regularise=None):
+def load_cubes(filenames, callback=None, auto_regularise=True):
     """
     Returns a generator of cubes from the given list of filenames.
 
@@ -886,13 +886,6 @@ def load_cubes(filenames, callback=None, regularise=True, auto_regularise=None):
     * callback (callable function):
         Function which can be passed on to :func:`iris.io.run_callback`.
 
-    * regularise (*True* | *False*):
-        If *True*, any cube defined on a reduced grid will be interpolated
-        to an equivalent regular grid. If *False*, any cube defined on a
-        reduced grid will be loaded on the raw reduced grid with no shape
-        information. The default behaviour is to interpolate cubes on a
-        reduced grid to an equivalent regular grid.
-
     * auto_regularise (*True* | *False*):
         If *True*, any cube defined on a reduced grid will be interpolated
         to an equivalent regular grid. If *False*, any cube defined on a
@@ -902,30 +895,22 @@ def load_cubes(filenames, callback=None, regularise=True, auto_regularise=None):
 
         .. deprecated:: 1.8. Please use the `regularise` kwarg instead.
 
-    .. note::
-
-       To make use of the *regularise* keyword the normal Iris loading
-       pipeline cannot be used, the loading must be performed manually::
-
-           cube_generator = iris.fileformats.grib.load_cubes(
-               "reduced.grib", regularise=False)
-           cubes = iris.cube.CubeList(cube_generator).merge()
-
     """
     if auto_regularise is not None:
         warnings.warn('the`auto_regularise` kwarg is deprecated and '
-                      'will be removed in a future release. Please use '
-                      '`regularise` instead.')
-        regularise = auto_regularise
+                      'will be removed in a future release. Resampling '
+                      'quasi-regular grids on load will no longer be '
+                      'available.  Resampling should be done on the '
+                      'loaded cube instead using Cube.regrid.')
 
     if iris.FUTURE.strict_grib_load:
         grib_loader = iris.fileformats.rules.Loader(
             _GribMessage.messages_from_filename,
-            {'regularise': regularise},
+            {},
             iris.fileformats.grib._load_convert.convert, None)
     else:
         grib_loader = iris.fileformats.rules.Loader(
-            grib_generator, {'auto_regularise': regularise},
+            grib_generator, {'auto_regularise': auto_regularise},
             iris.fileformats.grib.load_rules.convert,
             _load_rules)
     return iris.fileformats.rules.load_cubes(filenames, callback, grib_loader)

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -893,7 +893,9 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
         information. The default behaviour is to interpolate cubes on a
         reduced grid to an equivalent regular grid.
 
-        .. deprecated:: 1.8. Please use the `regularise` kwarg instead.
+        .. deprecated:: 1.8. Please use strict_grib_load and regrid instead.
+        
+
 
     """
     if auto_regularise is not None:

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -39,7 +39,7 @@ class _GribMessage(object):
     """
 
     @staticmethod
-    def messages_from_filename(filename, regularise=True):
+    def messages_from_filename(filename):
         """
         Return a generator of :class:`_GribMessage` instances; one for
         each message in the supplied GRIB file.
@@ -58,9 +58,9 @@ class _GribMessage(object):
                     break
                 raw_message = _RawGribMessage(grib_id)
                 recreate_raw = _MessageLocation(filename, offset)
-                yield _GribMessage(raw_message, recreate_raw, regularise)
+                yield _GribMessage(raw_message, recreate_raw)
 
-    def __init__(self, raw_message, recreate_raw, regularise):
+    def __init__(self, raw_message, recreate_raw):
         """
 
         Args:
@@ -72,7 +72,6 @@ class _GribMessage(object):
         """
         self._raw_message = raw_message
         self._recreate_raw = recreate_raw
-        self._regularise = regularise
 
     @property
     def sections(self):
@@ -113,7 +112,7 @@ class _GribMessage(object):
             else:
                 shape = (grid_section['Nj'], grid_section['Ni'])
             proxy = _DataProxy(shape, np.dtype('f8'), np.nan,
-                               self._recreate_raw, self._regularise)
+                               self._recreate_raw)
             data = biggus.NumpyArrayAdapter(proxy)
         else:
             fmt = 'Grid definition template {} is not supported'
@@ -130,14 +129,13 @@ class _MessageLocation(namedtuple('_MessageLocation', 'filename offset')):
 class _DataProxy(object):
     """A reference to the data payload of a single GRIB message."""
 
-    __slots__ = ('shape', 'dtype', 'fill_value', 'recreate_raw', 'regularise')
+    __slots__ = ('shape', 'dtype', 'fill_value', 'recreate_raw')
 
-    def __init__(self, shape, dtype, fill_value, recreate_raw, regularise):
+    def __init__(self, shape, dtype, fill_value, recreate_raw):
         self.shape = shape
         self.dtype = dtype
         self.fill_value = fill_value
         self.recreate_raw = recreate_raw
-        self.regularise = regularise
 
     @property
     def ndim(self):
@@ -209,8 +207,7 @@ class _DataProxy(object):
     def __repr__(self):
         msg = '<{self.__class__.__name__} shape={self.shape} ' \
             'dtype={self.dtype!r} fill_value={self.fill_value!r} ' \
-            'recreate_raw={self.recreate_raw!r} ' \
-            'regularise={self.regularise}>'
+            'recreate_raw={self.recreate_raw!r} '
         return msg.format(self=self)
 
     def __getstate__(self):

--- a/lib/iris/tests/unit/fileformats/grib/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,4 +26,4 @@ from iris.fileformats.grib._message import _GribMessage
 def _make_test_message(sections):
     raw_message = mock.Mock(sections=sections)
     recreate_raw = mock.Mock(return_value=raw_message)
-    return _GribMessage(raw_message, recreate_raw, None)
+    return _GribMessage(raw_message, recreate_raw)

--- a/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -35,20 +35,20 @@ from iris.fileformats.grib._message import _DataProxy
 class Test__bitmap(tests.IrisTest):
     def test_no_bitmap(self):
         section_6 = {'bitMapIndicator': 255, 'bitmap': None}
-        data_proxy = _DataProxy(0, 0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0, 0)
         result = data_proxy._bitmap(section_6)
         self.assertIsNone(result)
 
     def test_bitmap_present(self):
         bitmap = randint(2, size=(12))
         section_6 = {'bitMapIndicator': 0, 'bitmap': bitmap}
-        data_proxy = _DataProxy(0, 0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0, 0)
         result = data_proxy._bitmap(section_6)
         self.assertArrayEqual(bitmap, result)
 
     def test_bitmap__invalid_indicator(self):
         section_6 = {'bitMapIndicator': 100, 'bitmap': None}
-        data_proxy = _DataProxy(0, 0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0, 0)
         with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
             data_proxy._bitmap(section_6)
 

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -41,9 +41,12 @@ class TestToggle(tests.IrisTest):
                 result = load_cubes(mock.sentinel.FILES,
                                     mock.sentinel.CALLBACK,
                                     mock.sentinel.REGULARISE)
-                reg_kw = 'regularise' if mode else 'auto_regularise'
+                if mode:
+                    kw_args = {}
+                else:
+                    kw_args = {'auto_regularise': mock.sentinel.REGULARISE}
                 loader = iris.fileformats.rules.Loader(
-                    generator, {reg_kw: mock.sentinel.REGULARISE},
+                    generator, kw_args,
                     converter, None)
                 rules_load.assert_called_once_with(mock.sentinel.FILES,
                                                    mock.sentinel.CALLBACK,


### PR DESCRIPTION
remove regularise key word from grib load when using strict_grib_load

this is non-functional at present and the behaviour is not wanted so it should be removed before it is released