### PR TITLE
Fix bug in um.FieldsFileVariant output (no test yet).

### DIFF
--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -590,12 +590,16 @@ class FieldsFileVariant(object):
         # Now deal with the LOOKUP and DATA components.
         if self.fields:
             header.lookup_start = word_number
-            lengths = set(field.num_values() for field in self.fields)
-            if len(lengths) != 1:
-                msg = 'Inconsistent header lengths - {}'.format(lengths)
+            header_lengths = [field.num_values() for field in self.fields]
+            if len(set(header_lengths)) != 1:
+                msg = 'Inconsistent header lengths - {}'.format(header_lengths)
                 raise ValueError(msg)
-            header.lookup_shape = (lengths.pop(), len(self.fields))
+            header_length = header_lengths.pop()
+            n_fields = len(self.fields)
+            header.lookup_shape = (header_length, n_fields)
 
+            # make space for the lookup
+            word_number += header_length * n_fields
             # Round up to the nearest whole number of "sectors".
             offset = word_number - 1
             offset -= offset % -self._WORDS_PER_SECTOR

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -590,16 +590,16 @@ class FieldsFileVariant(object):
         # Now deal with the LOOKUP and DATA components.
         if self.fields:
             header.lookup_start = word_number
-            header_lengths = [field.num_values() for field in self.fields]
-            if len(set(header_lengths)) != 1:
-                msg = 'Inconsistent header lengths - {}'.format(header_lengths)
-                raise ValueError(msg)
-            header_length = header_lengths.pop()
+            lookup_lengths = {field.num_values() for field in self.fields}
+            if len(lookup_lengths) != 1:
+                msg = 'Inconsistent lookup header lengths - {}'
+                raise ValueError(msg.format(lookup_lengths))
+            lookup_length = lookup_lengths.pop()
             n_fields = len(self.fields)
-            header.lookup_shape = (header_length, n_fields)
+            header.lookup_shape = (lookup_length, n_fields)
 
             # make space for the lookup
-            word_number += header_length * n_fields
+            word_number += lookup_length * n_fields
             # Round up to the nearest whole number of "sectors".
             offset = word_number - 1
             offset -= offset % -self._WORDS_PER_SECTOR


### PR DESCRIPTION
Fixes a bug in iris.experimental.um.FieldsFileVariant (investigating support issue).
The effect is that for files over a certain size, the lookup headers begin to overwrite the data payloads
It doesn't happen for smaller files, because the data-start is rounded up to the next block boundary.

To see the problem:
```
ff_file = um.FieldsFileVariant(test_filepath, mode=um.FieldsFileVariant.UPDATE_MODE)
ff_file.close()
```
This replaces the file with a re-written copy, which is corrupted if the file contains too many fields.

This PR is effectively just a heads-up and placeholder, because it should also contain a test, which I don't currently have time to do.