### PR TITLE
[DOC] What's new aggregation "contribution" description

### DIFF
--- a/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
@@ -2,20 +2,24 @@
 Contributing a "What's New" entry
 =================================
 
-Iris has an aggregator for building a draft "What's New" document for each
-release, from sections contributed by code authors. This means entries for the
-release documentation are written by the developer most familiar with the
-change made. 
+Iris has an aggregator for building a draft what's new document for each
+release. The draft what's new document is built from contributions by code authors.
+This means contributions to the what's new document are written by the
+developer most familiar with the change made.
+
+A contribution is an entry in the what's new document that describes a change to
+Iris that improved Iris in some way. This change may be a new feature in Iris or
+the fix for a bug introduced in a previous release. The contribution should be
+included as part of the Iris Pull Request that introduces the change to Iris.
 
 Creating a Contribution File
 ============================
 
 Each release must have a directory called ``contributions_<release number>``,
-which should be created following the release of the current version. Each
-release directory must be placed in ``docs/iris/src/whatsnew/``. Items for
-inclusion into the release documentation should be placed into this directory
-in RST format.
-The filename for each item should be structured as follows:
+which should be created following the release of the current version of Iris. Each
+release directory must be placed in ``docs/iris/src/whatsnew/``.
+Contributions to the what's new must be written in markdown and placed into this
+directory in text files. The filename for each item should be structured as follows:
 
 ``<category>_<date>_<summary>.txt``
 
@@ -44,6 +48,7 @@ The date must be a hyphen-separated ISO8601 date in the format of:
  * a two digit day.
 
 For example:
+
  * 2012-01-30
  * 2014-05-03
  * 2015-03-19
@@ -54,6 +59,7 @@ Summary
 The summary should be short and separated by hyphens.
 
 For example:
+
  * whats-new-aggregator
  * netcdf-streaming
  * correction-to-bilinear-regrid
@@ -62,8 +68,13 @@ For example:
 Writing a Contribution
 ======================
 
-Each contribution should be written in the form of bullet points highlighting the change.
-The content should describe the change that has been made, targeting an Iris user as the audience.
+As introduced above, a contribution is the description of a change to Iris that
+improved Iris in some way. As such, a single Iris Pull Request may contain multiple
+changes that are worth highlighting as contributions to the what's new document.
+
+Each contribution will ideally be written as a single concise bullet point.
+The content of the bullet point should highlight the change that has been made
+to Iris, targeting an Iris user as the audience.
 
 Compiling a Draft
 =================


### PR DESCRIPTION
Improves the wording of the contributions page in the developer guide, building on #1583 and #1608.

Specifically this change defines what a contribution is and adjusts the wording of the document based on this definition of a contribution. It also reasserts the necessity that a contribution, as per the definition now added to the file, be ideally limited to a single concise bullet point.