### PR TITLE
BUG: Lazy cube with mask not saved correctly to NetCDF

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -1444,9 +1444,12 @@ class Saver(object):
 
         else:
             # Create the cube CF-netCDF data variable.
+            # Explicitly assign the fill_value, which will be the type default
+            # in the case of an unmasked array.
             cf_var = self._dataset.createVariable(
                 cf_name, cube.lazy_data().dtype.newbyteorder('='),
-                dimension_names, **kwargs)
+                dimension_names, fill_value=cube.lazy_data().fill_value,
+                **kwargs)
             # stream the data
             biggus.save([cube.lazy_data()], [cf_var], masked=True)
 

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -24,6 +24,7 @@ import iris.tests as tests
 
 from contextlib import contextmanager
 import mock
+import numpy as np
 
 import iris
 from iris.cube import Cube, CubeList
@@ -170,6 +171,17 @@ class TestLazySave(tests.IrisTest):
             with Saver(nc_path, 'NETCDF4') as saver:
                 saver.write(acube)
         self.assertTrue(acube.has_lazy_data())
+
+    def test_lazy_mask_preserve_fill_value(self):
+        cube = iris.cube.Cube(np.ma.array([0, 1], mask=[False, True],
+                                          fill_value=-1))
+        with self.temp_filename(suffix='.nc') as filename, \
+                self.temp_filename(suffix='.nc') as other_filename:
+            iris.save(cube, filename, unlimited_dimensions=[])
+            ncube = iris.load_cube(filename)
+            # Lazy save of the masked cube
+            iris.save(ncube, other_filename, unlimited_dimensions=[])
+            self.assertCDL(other_filename)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/results/integration/netcdf/TestLazySave/lazy_mask_preserve_fill_value.cdl
+++ b/lib/iris/tests/results/integration/netcdf/TestLazySave/lazy_mask_preserve_fill_value.cdl
@@ -1,0 +1,10 @@
+dimensions:
+	dim0 = 2 ;
+variables:
+	int64 unknown(dim0) ;
+		unknown:_FillValue = -1L ;
+		unknown:units = "1" ;
+
+// global attributes:
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_hybrid_height.cdl
@@ -6,6 +6,7 @@ dimensions:
 	model_level_number = 10 ;
 variables:
 	float air_potential_temperature(time, model_level_number, grid_latitude, grid_longitude) ;
+		air_potential_temperature:_FillValue = -1.073742e+09f ;
 		air_potential_temperature:standard_name = "air_potential_temperature" ;
 		air_potential_temperature:units = "K" ;
 		air_potential_temperature:um_stash_source = "m01s00i004" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_0.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_0.cdl
@@ -5,6 +5,7 @@ dimensions:
 	longitude = 96 ;
 variables:
 	float air_temperature(time, latitude, longitude) ;
+		air_temperature:_FillValue = -1.e+30f ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_1.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_1.cdl
@@ -5,6 +5,7 @@ dimensions:
 	longitude = 96 ;
 variables:
 	float air_temperature(time, latitude, longitude) ;
+		air_temperature:_FillValue = -1.e+30f ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multi_2.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multi_2.cdl
@@ -5,6 +5,7 @@ dimensions:
 	longitude = 96 ;
 variables:
 	float precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:_FillValue = -1.e+30f ;
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:um_stash_source = "m01s05i216" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_multiple.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_multiple.cdl
@@ -5,6 +5,7 @@ dimensions:
 	longitude = 96 ;
 variables:
 	float air_temperature(time, latitude, longitude) ;
+		air_temperature:_FillValue = -1.e+30f ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
@@ -44,6 +45,7 @@ variables:
 		height:standard_name = "height" ;
 		height:positive = "up" ;
 	float air_temperature_0(time, latitude, longitude) ;
+		air_temperature_0:_FillValue = -1.e+30f ;
 		air_temperature_0:standard_name = "air_temperature" ;
 		air_temperature_0:units = "K" ;
 		air_temperature_0:um_stash_source = "m01s03i236" ;
@@ -51,6 +53,7 @@ variables:
 		air_temperature_0:grid_mapping = "latitude_longitude" ;
 		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
 	float precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:_FillValue = -1.e+30f ;
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:um_stash_source = "m01s05i216" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
@@ -5,6 +5,7 @@ dimensions:
 	rlon = 174 ;
 variables:
 	float pr(time, rlat, rlon) ;
+		pr:_FillValue = 1.e+30f ;
 		pr:standard_name = "precipitation_flux" ;
 		pr:long_name = "Precipitation" ;
 		pr:units = "kg m-2 s-1" ;

--- a/lib/iris/tests/results/netcdf/netcdf_save_single.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_single.cdl
@@ -4,6 +4,7 @@ dimensions:
 	longitude = 96 ;
 variables:
 	float air_temperature(latitude, longitude) ;
+		air_temperature:_FillValue = -1.e+30f ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;


### PR DESCRIPTION
Currently the `fill_value` keyword argument to [createVariable](https://github.com/SciTools/iris/blob/7890a7292d988e3ce2fbf31559fcb5ba39dbb041/lib/iris/fileformats/netcdf.py#L1447) is not utilised
when writing a NetCDF file when the data is lazy.

Determining the `fill_value` is not straight forward as biggus returns a default value (not None) so how do we differentiate between an ordinary array (pass a `fill_value=None`) and a masked array (pass a  `fill_value = cube.lazy_data().fill_value`) without touching the data??

Here is a simple illustration of the problem if my added integration test is not good enough:
http://nbviewer.ipython.org/gist/cpelley/2da0b8dd347f7a4772e0