### PR TITLE
Added handling for a missing value of lbrel. Tests to follow.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="9de641446b3a44f80405608beb5bdb1d0f61ab30"
+  - export IRIS_TEST_DATA_REF="037fee7d26de00897d1694ec040b6ed895d24a38"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="1ed3e26606366717e2053bacc12bf5e8d8fa2704"

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -315,7 +315,7 @@ class Field3(Field):
 
 
 # Maps lbrel to a Field class.
-_FIELD_CLASSES = {2: Field2, 3: Field3, -99: Field}
+_FIELD_CLASSES = {2: Field2, 3: Field3}
 
 
 # Maps word size and then lbuser1 (i.e. the field's data type) to a dtype.
@@ -520,7 +520,8 @@ class FieldsFileVariant(object):
                     else:
                         offset = running_offset
                         data_provider = data_class(source, offset, word_size)
-                    klass = _FIELD_CLASSES[raw_headers[Field.LBREL_OFFSET]]
+                    klass = _FIELD_CLASSES.get(raw_headers[Field.LBREL_OFFSET],
+                                               Field)
                     ints = raw_headers[:_NUM_FIELD_INTS]
                     reals = raw_headers[_NUM_FIELD_INTS:].view(real_dtype)
                     fields.append(klass(ints, reals, data_provider))
@@ -533,7 +534,8 @@ class FieldsFileVariant(object):
                     else:
                         offset = raw_headers[Field.LBEGIN_OFFSET] * word_size
                         data_provider = data_class(source, offset, word_size)
-                    klass = _FIELD_CLASSES[raw_headers[Field.LBREL_OFFSET]]
+                    klass = _FIELD_CLASSES.get(raw_headers[Field.LBREL_OFFSET],
+                                               Field)
                     ints = raw_headers[:_NUM_FIELD_INTS]
                     reals = raw_headers[_NUM_FIELD_INTS:].view(real_dtype)
                     fields.append(klass(ints, reals, data_provider))

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -81,8 +81,8 @@ class Test_class_assignment(tests.IrisTest):
     def test_lbrel_class(self):
         path = tests.get_data_path(('FF', 'lbrel_test_data'))
         ffv = FieldsFileVariant(path)
-        self.assertEquals(type(ffv.fields[0]), str(Field))
-        self.assertEquals(type(ffv.fields[1]), str(Field3))
+        self.assertEquals(type(ffv.fields[0]), Field)
+        self.assertEquals(type(ffv.fields[1]), Field3)
         self.assertEqual(ffv.fields[0].int_headers[Field.LBREL_OFFSET], -32768)
         self.assertEqual(ffv.fields[1].int_headers[Field.LBREL_OFFSET], 3)
 

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -31,7 +31,7 @@ import tempfile
 
 import numpy as np
 
-from iris.experimental.um import FieldsFileVariant
+from iris.experimental.um import FieldsFileVariant, Field, Field3
 
 
 class Test___init__(tests.IrisTest):
@@ -74,6 +74,17 @@ class Test_filename(tests.IrisTest):
         path = tests.get_data_path(('FF', 'n48_multi_field'))
         ffv = FieldsFileVariant(path)
         self.assertEqual(ffv.filename, path)
+
+
+@tests.skip_data
+class Test_class_assignment(tests.IrisTest):
+    def test_lbrel_class(self):
+        path = tests.get_data_path(('FF', 'lbrel_test_data'))
+        ffv = FieldsFileVariant(path)
+        self.assertEquals(type(ffv.fields[0]), str(Field))
+        self.assertEquals(type(ffv.fields[1]), str(Field3))
+        self.assertEqual(ffv.fields[0].int_headers[Field.LBREL_OFFSET], -32768)
+        self.assertEqual(ffv.fields[1].int_headers[Field.LBREL_OFFSET], 3)
 
 
 class Test_mode(tests.IrisTest):


### PR DESCRIPTION
This is a simple implementation to override lbrel when IMBI value is given. Setting to current latest value. 'Interactively tested', putting in some unit tests now - but feedback on my implementation would be welcome!