### PR TITLE
Use latest iris-test-data in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="9de641446b3a44f80405608beb5bdb1d0f61ab30"
+  - export IRIS_TEST_DATA_REF=master
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="1ed3e26606366717e2053bacc12bf5e8d8fa2704"


### PR DESCRIPTION
This should prevent us having to maintain a commit-reference to the iris-test-data repo.
There's quite probably a reason we *don't* do this already
  \- **can anyone explain why ?**
