### PR TITLE
Support all grid-point data representation templates.

### DIFF
--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -1875,7 +1875,12 @@ def data_representation_section(section):
     # Reference GRIB2 Code Table 5.0.
     template = section['dataRepresentationTemplateNumber']
 
-    if template != 0:
+    # Supported templates for both grid point and spectral data:
+    grid_point_templates = (0, 1, 2, 3, 4, 40, 41, 61)
+    spectral_templates = tuple()
+    supported_templates = grid_point_templates + spectral_templates
+
+    if template not in supported_templates:
         msg = 'Data Representation Section Template [{}] is not ' \
             'supported'.format(template)
         raise TranslationError(msg)


### PR DESCRIPTION
The new GRIB loader currently only supports data representation section template number 0, which represents grid-point simple packing ('grid_simple' in GRIB API terminology). However, iris doesn't really do anything with this information, there is no translation process associated with it as we don't handle the unpacking, GRIB API does that for us. My point of view is that iris should be able to load GRIB2 messages with any packing that is supported by GRIB API.

This PR allows iris to load any GRIB2 messages with grid-point packing supported by GRIB API:
* 0 (grid_simple)
* 1 (grid_simple_matrix, grib_simple_matrix_bitmap)
* 2 (grid_complex)
* 3 (grid_complex_spatial_differencing)
* 4 (grid_ieee)
* 40 (grid_jpeg)
* 41 (grid_png)
* 61 (grid_simple_log_preprocessing)

I've left out 50 and 51 (spectral_simple and spectral_complex) since we don't support any spectral data. However, there is an argument for including these: we never do any translation on packing (Section 5), so why do we discriminate? Spectral messages will be rejected by Section 3 (grid description section). This would actually leave us supporting all defined Section 5 templates (0, 1, 2, 3, 4, 40, 41, 50, 51, 61, 200) and only rejecting those that are reserved or for local use. I think this route is worth considering.