### PR TITLE
PP-to-Cube time rounding.

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -423,15 +423,16 @@ def _convert_time_coords(lbcode, lbtim, epoch_hours_unit,
     t1, t2, lbft = _reshape_vector_args([(t1, t1_dims), (t2, t2_dims),
                                          (lbft, lbft_dims)])
 
-    def date2hours(times_array):
-        """Convert datetime values to hours-since-epoch values."""
-        # Use a minimum-1D form, as netcdftime.date2num doesn't like scalars.
-        times_array = np.asarray(times_array)
-        return epoch_hours_unit.date2num(
-            np.atleast_1d(times_array)).reshape(times_array.shape)
+    def date2hours(t):
+        epoch_hours = epoch_hours_unit.date2num(t)
+        if t.minute == 0 and t.second == 0:
+            epoch_hours = round(epoch_hours)
+        return epoch_hours
 
-    t1_epoch_hours = date2hours(t1)
-    t2_epoch_hours = date2hours(t2)
+    dates2hours = np.vectorize(date2hours)
+
+    t1_epoch_hours = dates2hours(t1)
+    t2_epoch_hours = dates2hours(t2)
     hours_from_t1_to_t2 = t2_epoch_hours - t1_epoch_hours
     hours_from_t2_to_t1 = t1_epoch_hours - t2_epoch_hours
     coords_and_dims = []
@@ -557,8 +558,14 @@ def _convert_scalar_time_coords(lbcode, lbtim, epoch_hours_unit, t1, t2, lbft):
     Returns a list of coords_and_dims.
 
     """
-    t1_epoch_hours = epoch_hours_unit.date2num(t1)
-    t2_epoch_hours = epoch_hours_unit.date2num(t2)
+    def date2hours(t):
+        epoch_hours = epoch_hours_unit.date2num(t)
+        if t.minute == 0 and t.second == 0:
+            epoch_hours = round(epoch_hours)
+        return epoch_hours
+
+    t1_epoch_hours = date2hours(t1)
+    t2_epoch_hours = date2hours(t2)
     hours_from_t1_to_t2 = t2_epoch_hours - t1_epoch_hours
     hours_from_t2_to_t1 = t1_epoch_hours - t2_epoch_hours
     coords_and_dims = []

--- a/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
+++ b/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
@@ -396,8 +396,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.166666667908, 0.333333335817, 0.500000003725,
-		0.666666671634, 0.833333339542, 1.00000000745]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.166666664183, 0.333333332092, 0.5,
+		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -919,8 +919,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.166666667908, 0.333333335817, 0.500000003725,
-		0.666666671634, 0.833333339542, 1.00000000745]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.166666664183, 0.333333332092, 0.5,
+		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -1054,7 +1054,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[1.00000000745]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[1.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347920.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/original.cml
+++ b/lib/iris/tests/results/analysis/original.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -8,9 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="73141289" points="[0.0, 0.999999996275, 2.00000000373, 3.0,
-		3.99999999627, 5.00000000373, 6.0,
-		6.99999999627, 8.00000000373, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]" shape="(10,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/cdm/masked_cube.cml
+++ b/lib/iris/tests/results/cdm/masked_cube.cml
@@ -10,7 +10,7 @@
         <auxCoord id="73141289" points="[0.0, 3.0, 6.0, 0.0, 3.0, 6.0, 0.0, 6.0]" shape="(8,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
-        <dimCoord id="f8c7ad26" points="[999.999999996]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+        <dimCoord id="f8c7ad26" points="[1000.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="44153592" points="[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
@@ -31,8 +31,8 @@
 		900.0, 900.0]" shape="(8,)" units="Unit('hPa')" value_type="float32"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="6a1b3c16" points="[999.999999996, 1003.0, 1006.0, 999.999999996,
-		1003.0, 1006.0, 999.999999996, 1006.0]" shape="(8,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+        <auxCoord id="6a1b3c16" points="[1000.0, 1003.0, 1006.0, 1000.0, 1003.0, 1006.0,
+		1000.0, 1006.0]" shape="(8,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="73141289" points="[0.0, 3.99999999627, 5.00000000373, 2.00000000373]" shape="(4,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <auxCoord id="73141289" points="[0.0, 4.0, 5.0, 2.0]" shape="(4,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="73141289" points="[0.0, 3.99999999627, 5.00000000373, 2.00000000373]" shape="(4,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <auxCoord id="73141289" points="[0.0, 4.0, 5.0, 2.0]" shape="(4,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[319536.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
@@ -414,8 +414,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="1d7d6eff" points="[0.166666667908, 0.333333335817, 0.500000003725,
-		0.666666671634, 0.833333339542, 1.00000000745]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64" var_name="forecast_period"/>
+        <auxCoord id="1d7d6eff" points="[0.166666664183, 0.333333332092, 0.5,
+		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64" var_name="forecast_period"/>
       </coord>
       <coord>
         <dimCoord id="b880473b" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="forecast_reference_time"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
@@ -8,7 +8,7 @@
     </attributes>
     <coords>
       <coord>
-        <dimCoord id="73141289" points="[0.500000003725]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="73141289" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="f8c7ad26" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -113,6 +113,29 @@ class TestLBTIMx1x_Forecast(TestField):
 
     def test_time_cross_section(self):
         self._check_forecast(_lbcode(ix=1, iy=20), expect_match=False)
+
+    def test_exact_hours(self):
+        lbtim = _lbtim(ib=1, ic=1)
+        t1 = nc_datetime(2015, 1, 20, hour=7, minute=0, second=0)
+        t2 = nc_datetime(2015, 1, 20, hour=0, minute=0, second=0)
+        coords_and_dims = _convert_scalar_time_coords(
+            lbcode=_lbcode(1), lbtim=lbtim, epoch_hours_unit=_EPOCH_TIME_UNIT,
+            t1=t1, t2=t2, lbft=None)
+        (fp, _), (t, _), (frt, _) = coords_and_dims
+        # These should both be exact whole numbers.
+        self.assertEqual(fp.points[0], 7)
+        self.assertEqual(t.points[0], 394927)
+
+    def test_not_exact_hours(self):
+        lbtim = _lbtim(ib=1, ic=1)
+        t1 = nc_datetime(2015, 1, 20, hour=7, minute=10, second=0)
+        t2 = nc_datetime(2015, 1, 20, hour=0, minute=0, second=0)
+        coords_and_dims = _convert_scalar_time_coords(
+            lbcode=_lbcode(1), lbtim=lbtim, epoch_hours_unit=_EPOCH_TIME_UNIT,
+            t1=t1, t2=t2, lbft=None)
+        (fp, _), (t, _), (frt, _) = coords_and_dims
+        self.assertEqual(fp.points[0], 7.1666666641831398)
+        self.assertEqual(t.points[0], 394927.16666666418)
 
 
 class TestLBTIMx2x_TimePeriod(TestField):

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -118,6 +118,29 @@ class TestLBTIMx1x_Forecast(TestField):
 
     def test_time_cross_section(self):
         self._check_forecast(_lbcode(ix=1, iy=20), expect_match=False)
+
+    def test_exact_hours(self):
+        lbtim = _lbtim(ib=1, ic=1)
+        t1 = nc_datetime(2015, 1, 20, hour=7, minute=0, second=0)
+        t2 = nc_datetime(2015, 1, 20, hour=0, minute=0, second=0)
+        coords_and_dims = _convert_time_coords(
+            lbcode=_lbcode(1), lbtim=lbtim, epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            t1=t1, t2=t2, lbft=None)
+        (fp, _), (t, _), (frt, _) = coords_and_dims
+        # These should both be exact whole numbers.
+        self.assertEqual(fp.points[0], 7)
+        self.assertEqual(t.points[0], 394927)
+
+    def test_not_exact_hours(self):
+        lbtim = _lbtim(ib=1, ic=1)
+        t1 = nc_datetime(2015, 1, 20, hour=7, minute=10, second=0)
+        t2 = nc_datetime(2015, 1, 20, hour=0, minute=0, second=0)
+        coords_and_dims = _convert_time_coords(
+            lbcode=_lbcode(1), lbtim=lbtim, epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            t1=t1, t2=t2, lbft=None)
+        (fp, _), (t, _), (frt, _) = coords_and_dims
+        self.assertEqual(fp.points[0], 7.1666666641831398)
+        self.assertEqual(t.points[0], 394927.16666666418)
 
 
 class TestLBTIMx2x_TimePeriod(TestField):


### PR DESCRIPTION
Floating point errors can creep in when converting PP header datetimes to hours-since-1970:
```python
>>> iris.unit.Unit('hours since epoch').date2num(netcdftime.datetime(2015, 1, 20, 7, 0))
394926.9999999963
```
This can have a corresponding knock-on effect on calculated forecast periods, and downstream processing.

But PP header datetimes have a maximum precision of one second, so when expressed as hours we can safely round off to a few decimal places (sufficient to capture 1 / 3600).