### PR TITLE
Add option to print failed images as HTML.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,10 +108,10 @@ install:
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests;
+      python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
-      python -m iris.tests.runner --example-tests;
+      python -m iris.tests.runner --example-tests --print-failed-images;
     fi
   # "make html" produces an error when run on Travis that does not
   # affect any downstream functionality but causes the build to fail


### PR DESCRIPTION
This is similar to options included in Cartopy.

Not totally sure about the name of the option, but it seems to work, at least.