### PR TITLE
Added exception handling for unsupported LBPACK values.

### DIFF
--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -688,7 +688,7 @@ class FieldsFileVariant(object):
             for field in self.fields:
                 data = field.get_data()
 
-                if hasattr(field, "lbpack"):
+                if data is not None:
                     lbpack = field.lbpack
                     packing = lbpack % 10
                     compression = (lbpack // 10) % 10
@@ -699,7 +699,6 @@ class FieldsFileVariant(object):
                         raise ValueError("Unsupported LBPACK: {!s}".format(
                                          lbpack))
 
-                if data is not None:
                     field.lbegin = output_file.tell() / self._word_size
                     # Round the data length up to the nearest whole
                     # number of "sectors".

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -693,9 +693,9 @@ class FieldsFileVariant(object):
                     packing = lbpack % 10
                     compression = (lbpack // 10) % 10
                     number_format = (lbpack // 1000) % 10
-                    if (packing not in (0, 1) or
-                            compression != 0 or
-                            number_format not in (0, 2, 3)):
+                    if not (packing in (0, 1) and
+                            compression == 0 and
+                            number_format in (0, 2, 3)):
                         raise ValueError("Unsupported LBPACK: {!s}".format(
                                          lbpack))
 

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -687,6 +687,18 @@ class FieldsFileVariant(object):
             sector_size = self._WORDS_PER_SECTOR * self._word_size
             for field in self.fields:
                 data = field.get_data()
+
+                if hasattr(field, "lbpack"):
+                    lbpack = field.lbpack
+                    packing = lbpack % 10
+                    compression = (lbpack // 10) % 10
+                    number_format = (lbpack // 1000) % 10
+                    if (packing not in (0, 1) or
+                            compression != 0 or
+                            number_format not in (0, 2, 3)):
+                        raise ValueError("Unsupported LBPACK: {!s}".format(
+                                         lbpack))
+
                 if data is not None:
                     field.lbegin = output_file.tell() / self._word_size
                     # Round the data length up to the nearest whole

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -75,23 +75,27 @@ class Test_filename(tests.IrisTest):
         ffv = FieldsFileVariant(path)
         self.assertEqual(ffv.filename, path)
 
+
 @tests.skip_data
-class Test_lbpack(tests.IrisTest):
-    def test_lbpack_packing(self):
+class Test_packing_exceptions(tests.IrisTest):
+    def test_fail_unknown_pack_method(self):
         path = tests.get_data_path(('FF', 'n48_multi_field'))
-        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv = FieldsFileVariant(path, mode=FieldsFileVariant.UPDATE_MODE)
         ffv.fields[0].lbpack = 2
         self.assertRaises(ValueError, ffv.close)
-    def test_lbpack_compression(self):
+
+    def test_fail_unknown_compression_method(self):
         path = tests.get_data_path(('FF', 'n48_multi_field'))
-        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv = FieldsFileVariant(path, mode=FieldsFileVariant.UPDATE_MODE)
         ffv.fields[0].lbpack = 30
         self.assertRaises(ValueError, ffv.close)
-    def test_lbpack_number_format(self):
+
+    def test_fail_unknown_number_format(self):
         path = tests.get_data_path(('FF', 'n48_multi_field'))
-        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv = FieldsFileVariant(path, mode=FieldsFileVariant.UPDATE_MODE)
         ffv.fields[0].lbpack = 4000
         self.assertRaises(ValueError, ffv.close)
+
 
 @tests.skip_data
 class Test_class_assignment(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -75,6 +75,23 @@ class Test_filename(tests.IrisTest):
         ffv = FieldsFileVariant(path)
         self.assertEqual(ffv.filename, path)
 
+@tests.skip_data
+class Test_lbpack(tests.IrisTest):
+    def test_lbpack_packing(self):
+        path = tests.get_data_path(('FF', 'n48_multi_field'))
+        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv.fields[0].lbpack = 2
+        self.assertRaises(ValueError, ffv.close)
+    def test_lbpack_compression(self):
+        path = tests.get_data_path(('FF', 'n48_multi_field'))
+        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv.fields[0].lbpack = 30
+        self.assertRaises(ValueError, ffv.close)
+    def test_lbpack_number_format(self):
+        path = tests.get_data_path(('FF', 'n48_multi_field'))
+        ffv = FieldsFileVariant(path, mode = FieldsFileVariant.UPDATE_MODE)
+        ffv.fields[0].lbpack = 4000
+        self.assertRaises(ValueError, ffv.close)
 
 @tests.skip_data
 class Test_class_assignment(tests.IrisTest):


### PR DESCRIPTION
Simple change that raises a ValueError if the LBPACK defines an unsupported data format.