### PR TITLE
Um fix lookup copy

### DIFF
--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -572,7 +572,8 @@ class FieldsFileVariant(object):
                     # Make a *copy* of field lookup data, as it was in the
                     # untouched original file, as a context for data loading.
                     # (N.B. most importantly, includes the original LBPACK)
-                    lookup_reference = field_class(ints[:], reals[:], None)
+                    lookup_reference = field_class(ints.copy(), reals.copy(),
+                                                   None)
                     # Make a "provider" that can fetch the data on request.
                     data_provider = data_class(source, filename,
                                                lookup_reference,

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -359,7 +359,6 @@ class _DataProvider(object):
     def _with_source(self):
         # Context manager to temporarily reopen the sourcefile if the original
         # provided at create time has been closed.
-        field = self.lookup_entry
         reopen_required = self.source.closed
         close_required = False
 

--- a/lib/iris/tests/integration/test_FieldsFileVariant.py
+++ b/lib/iris/tests/integration/test_FieldsFileVariant.py
@@ -320,6 +320,34 @@ class TestUpdate(tests.IrisTest):
             self.assertNotEqual(last_used_file, original_file)
             self.assertTrue(last_used_file.closed)
 
+    def test_save_packed_as_unpacked(self):
+        # Check that we can successfully re-save a packed datafile as unpacked.
+        src_path = tests.get_data_path(('FF', 'n48_multi_field'))
+        with self.temp_filename() as temp_path:
+            # Make a copy and open for UPDATE (maybe not strictly necessary?)
+            shutil.copyfile(src_path, temp_path)
+            ffv = FieldsFileVariant(temp_path, FieldsFileVariant.UPDATE_MODE)
+            self.assertEqual(ffv.fields[0].lbpack, 1)
+            old_sizes = [fld.lbnrec for fld in ffv.fields
+                         if hasattr(fld, 'lbpack')]
+            test_data_old = ffv.fields[0].get_data()
+            for fld in ffv.fields:
+                if hasattr(fld, 'lbpack'):
+                    fld.lbpack = 0
+            ffv.close()
+
+            ffv = FieldsFileVariant(temp_path)
+            new_sizes = [fld.lbnrec for fld in ffv.fields
+                         if hasattr(fld, 'lbpack')]
+            for i_field, (new_size, old_size) in enumerate(zip(new_sizes,
+                                                               old_sizes)):
+                msg = 'unpacked LBNREC({}) is <= packed({})'
+                self.assertGreater(new_size, old_size,
+                                   msg=msg.format(new_size, old_size))
+
+            test_data_new = ffv.fields[0].get_data()
+            self.assertArrayAllClose(test_data_old, test_data_new)
+
 
 class TestCreate(tests.IrisTest):
     @tests.skip_data


### PR DESCRIPTION
The code where a copy of the lookup is embedded in the data provider was wrong:
https://github.com/SciTools/iris/commit/fc98529d512e5b3f7a4372e054c962bf5cb0e889#diff-9afd04ec6db152872ae76b6a047cb46fL575

Because the 'ints' and 'reals' header values are *arrays* not lists, the '[:]' didn't make a copy.
So then when you set field.lbpack=0, you couldn't read the data anymore (!)
 - i.e. field.get_data() fails.
 - because changing field.lbpack also changes the lbpack  in the data provider

https://github.com/SciTools/iris/pull/1633 was supposed to have fixed this, but clearly it needed a bit more testing.
The enclosed test does that (fails under old code).