### PR TITLE
Um packed passthru

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/newfeature_2015-04-23_um_fieldsfiles_retain_packed_data.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/newfeature_2015-04-23_um_fieldsfiles_retain_packed_data.txt
@@ -1,0 +1,3 @@
+* When a Fieldsfile is opened for update as a :class:`iris.experimental.um.FieldsFileVariant`,
+  unmodified packed data in the file can now be retained in the original form
+  (whereas previously it could only be stored in an unpacked form).

--- a/lib/iris/tests/unit/experimental/um/test_Field.py
+++ b/lib/iris/tests/unit/experimental/um/test_Field.py
@@ -141,5 +141,31 @@ class Test_set_data(tests.IrisTest):
         self.assertIs(field.get_data(), mock.sentinel.DATA)
 
 
+class Test__can_copy_deferred_data(tests.IrisTest):
+    def _check_formats(self,
+                       old_lbpack, new_lbpack,
+                       old_bacc=-6, new_bacc=-6,
+                       absent_provider=False):
+        lookup_entry = mock.Mock(lbpack=old_lbpack, bacc=old_bacc)
+        provider = mock.Mock(lookup_entry=lookup_entry)
+        if absent_provider:
+            # Replace the provider with a simple array.
+            provider = np.zeros(2)
+        field = Field(range(45), range(19), provider)
+        return field._can_copy_deferred_data(new_lbpack, new_bacc)
+
+    def test_okay_simple(self):
+        self.assertTrue(self._check_formats(1234, 1234))
+
+    def test_fail_different_lbpack(self):
+        self.assertFalse(self._check_formats(1234, 1238))
+
+    def test_fail_nodata(self):
+        self.assertFalse(self._check_formats(1234, 1234, absent_provider=True))
+
+    def test_fail_different_bacc(self):
+        self.assertFalse(self._check_formats(1234, 1234, new_bacc=-8))
+
+
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
Cope with changing LBPACK values in an update-mode FieldsFileVariant, and then closing to write it out.
Now allows saving : 
 * "anything" (new data / unpacked source fields / WGDOS packed source fields) as unpacked 
 * packed data as same-method packed (the "pass-through" option)

The 'pass-through' should also speedup updates to 'ordinary' unpacked files, as these can also be copied without interpretation.

NOTE: includes bits of https://github.com/SciTools/iris/pull/1618, which it intends to replace.