### PR TITLE
numerical tolerance

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2113,7 +2113,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if modulus is None:
             raise ValueError('coordinate units with no modulus are not yet'
                              ' supported')
-
         subsets, points, bounds = self._intersect_modulus(coord,
                                                           minimum, maximum,
                                                           min_inclusive,
@@ -2234,7 +2233,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # and call the new bounds = the new points + the difference.
             pre_wrap_delta = np.diff(coord.bounds[inside_indices])
             post_wrap_delta = np.diff(bounds[inside_indices])
-            split_cell_indices, _ = np.where(pre_wrap_delta != post_wrap_delta)
+            close_enough = np.allclose(pre_wrap_delta, post_wrap_delta)
+            if close_enough:
+                split_cell_indices = np.array(())
+            else:
+                split_cell_indices, _ = np.where(pre_wrap_delta !=
+                                                 post_wrap_delta)
             if split_cell_indices.size:
                 # Recalculate the extended minimum.
                 indices = inside_indices[split_cell_indices]

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2234,12 +2234,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             pre_wrap_delta = np.diff(coord.bounds[inside_indices])
             post_wrap_delta = np.diff(bounds[inside_indices])
             close_enough = np.allclose(pre_wrap_delta, post_wrap_delta)
-            if close_enough:
-                split_cell_indices = np.array(())
-            else:
+            if not close_enough:
                 split_cell_indices, _ = np.where(pre_wrap_delta !=
                                                  post_wrap_delta)
-            if split_cell_indices.size:
+
                 # Recalculate the extended minimum.
                 indices = inside_indices[split_cell_indices]
                 cells = bounds[indices]

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1051,6 +1051,14 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
         self.assertEqual(result.data[0, 0, 0], 350)
         self.assertEqual(result.data[0, 0, -1], 10)
 
+    def test_numerical_tolerance(self):
+        # test the tolerance on the coordinate value is not causing a
+        # modulus wrapping
+        cube = create_cube(28.5, 68.5, bounds=True)
+        result = cube.intersection(longitude=(27.74, 68.61))
+        self.assertAlmostEqual(result.coord('longitude').points[0], 28.5)
+        self.assertAlmostEqual(result.coord('longitude').points[-1], 67.5)
+
 
 def unrolled_cube():
     data = np.arange(5, dtype='f4')


### PR DESCRIPTION
There is a bug in the cube intersection code where 
```
np.where(pre_wrap_delta != post_wrap_delta)
```
can return a result due to numerical tolerances in the floating point coordinate value

I have trapped this and added a test.  This is a reported bug against 1.8.0, so please may it be targeted at the 1.8.1 milestone?

thank you