### PR TITLE
Saver callback mechanism.

### DIFF
--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -79,6 +79,14 @@ class NotYetImplementedError(IrisError):
 
 class TranslationError(IrisError):
     """Raised when Iris is unable to translate format-specific codes."""
+    pass
+
+
+class IgnoreFieldException(IrisError):
+    """
+    Raised from a callback function when a field should be ignored on save.
+
+    """
     pass
 
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -948,7 +948,7 @@ def save_grib2(cube, target, append=False, callback=None, **kwargs):
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
             raise ValueError("Target not binary")
-        filename = target.name
+        filename = target.name if hasattr(target, 'name') else None
         grib_file = target
     else:
         raise ValueError("Can only save grib to filename or writable")

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -572,7 +572,7 @@ def load_cubes(filenames, callback=None):
 class Saver(object):
     """A manager for saving netcdf files."""
 
-    def __init__(self, filename, netcdf_format):
+    def __init__(self, filename, netcdf_format, callback=None):
         """
         A manager for saving netcdf files.
 
@@ -585,8 +585,11 @@ class Saver(object):
             Underlying netCDF file format, one of 'NETCDF4', 'NETCDF4_CLASSIC',
             'NETCDF3_CLASSIC' or 'NETCDF3_64BIT'. Default is 'NETCDF4' format.
 
-        Returns:
-            None.
+        Kwargs:
+
+        * callback (callable):
+            Function which can be passed on to
+            :func:`iris.io.run_saver_callback`.
 
         For example::
 
@@ -601,7 +604,8 @@ class Saver(object):
                                  'NETCDF3_CLASSIC', 'NETCDF3_64BIT']:
             raise ValueError('Unknown netCDF file format, got %r' %
                              netcdf_format)
-
+        self.filename = filename
+        self.callback = callback
         # All persistent variables
         #: CF name mapping with iris coordinates
         self._name_coord_map = CFNameCoordMap()
@@ -779,6 +783,13 @@ class Saver(object):
                 msg = 'cf_profile is available but no {} defined.'.format(
                     'cf_patch')
                 warnings.warn(msg)
+
+        # Perform any user registered callback function.
+        # As the NetCDF saver commits to disk as it processes the cube and
+        # its metadata, it is not possible to skip or ignore the derived
+        # NetCDF representation of a cube as with other file format savers.
+        iris.io.run_saver_callback(self.callback, cube,
+                                   cf_var_cube, self.filename)
 
     def update_global_attributes(self, attributes=None, **kwargs):
         """
@@ -1537,7 +1548,7 @@ class Saver(object):
 def save(cube, filename, netcdf_format='NETCDF4', local_keys=None,
          unlimited_dimensions=None, zlib=False, complevel=4, shuffle=True,
          fletcher32=False, contiguous=False, chunksizes=None, endian='native',
-         least_significant_digit=None):
+         least_significant_digit=None, callback=None):
     """
     Save cube(s) to a netCDF file, given the cube and the filename.
 
@@ -1634,6 +1645,9 @@ def save(cube, filename, netcdf_format='NETCDF4', local_keys=None,
         in unpacked data that is a reliable value". Default is `None`, or no
         quantization, or 'lossless' compression.
 
+    * callback (callable):
+        Function which can be passed on to :func:`iris.io.run_saver_callback`.
+
     Returns:
         None.
 
@@ -1676,7 +1690,7 @@ def save(cube, filename, netcdf_format='NETCDF4', local_keys=None,
         local_keys.update(different_value_keys)
 
     # Initialise Manager for saving
-    with Saver(filename, netcdf_format) as sman:
+    with Saver(filename, netcdf_format, callback=callback) as sman:
         # Iterate through the cubelist.
         for cube in cubes:
             sman.write(cube, local_keys, unlimited_dimensions, zlib, complevel,

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2009,30 +2009,34 @@ def _load_cubes_variable_loader(filenames, callback, loading_function,
                                              pp_filter)
 
 
-def save(cube, target, append=False, field_coords=None):
+def save(cube, target, append=False, field_coords=None, callback=None):
     """
     Use the PP saving rules (and any user rules) to save a cube to a PP file.
 
     Args:
 
-        * cube         - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
-        * target       - A filename or open file handle.
+    * cube:
+        A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+    * target:
+        A filename or open file handle.
 
     Kwargs:
 
-        * append       - Whether to start a new file afresh or add the cube(s) to the end of the file.
-                         Only applicable when target is a filename, not a file handle.
-                         Default is False.
-
-        * field_coords - list of 2 coords or coord names which are to be used for
-                         reducing the given cube into 2d slices, which will ultimately
-                         determine the x and y coordinates of the resulting fields.
-                         If None, the final two  dimensions are chosen for slicing.
+    * append:
+        Whether to start a new file afresh or add the cube(s) to the end of the file.
+        Only applicable when target is a filename, not a file handle.
+        Default is False.
+    * field_coords:
+        List of 2 coords or coord names which are to be used for
+        reducing the given cube into 2d slices, which will ultimately
+        determine the x and y coordinates of the resulting fields.
+        If None, the final two  dimensions are chosen for slicing.
+    * callback:
+        A modifier/filter function.
 
     See also :func:`iris.io.save`.
 
     """
-
     # Open issues
     # Could use rules in "sections" ... e.g. to process the extensive dimensions; ...?
     # Could pre-process the cube to add extra convenient terms?
@@ -2075,9 +2079,11 @@ def save(cube, target, append=False, field_coords=None):
     # pp file
     if isinstance(target, basestring):
         pp_file = open(target, "ab" if append else "wb")
+        filename = target
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
             raise ValueError("Target not binary")
+        filename = target.name
         pp_file = target
     else:
         raise ValueError("Can only save pp to filename or writable")
@@ -2130,6 +2136,13 @@ def save(cube, target, append=False, field_coords=None):
 
         # Log the rules used
         iris.fileformats.rules.log('PP_SAVE', target if isinstance(target, basestring) else target.name, verify_rules_ran)
+
+        # Perform any user registered callback function.
+        pp_field = iris.io.run_saver_callback(callback, slice2D, pp_field, filename)
+
+        # Callback mechanism may return None, which must not be saved.
+        if pp_field is None:
+            continue
 
         # Write to file
         pp_field.save(pp_file)

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2083,7 +2083,7 @@ def save(cube, target, append=False, field_coords=None, callback=None):
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
             raise ValueError("Target not binary")
-        filename = target.name
+        filename = target.name if hasattr(target, 'name') else None
         pp_file = target
     else:
         raise ValueError("Can only save pp to filename or writable")

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -75,7 +75,7 @@ def run_saver_callback(callback, cube, field, filename):
     .. note::
 
         It is possible that this function returns None for certain callbacks,
-        the caller of this function should hangle this case.
+        the caller of this function should handle this case.
 
     """
     if callback is None:

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -50,9 +50,55 @@ class _SaversDict(dict):
 _savers = _SaversDict()
 
 
+def run_saver_callback(callback, cube, field, filename):
+    """
+    Runs the saver callback mechanism given the appropriate arguments.
+
+    Args:
+
+    * callback:
+        A function to manipulate the field generated from the associated
+        cube, obeying the following rules:
+
+            1. Function signature must be: ``(cube, field, filename)``.
+            2. Modifies the given field inplace, unless a new field is
+               returned by the function.
+            3. If the field is to be rejected the callback must raise
+               an :class:`iris.exceptions.IgnoreFieldException`.
+    * cube:
+        The cube that generated the field.
+    * field:
+        The field to be saved.
+    * filename:
+        The name of the file to save the field.
+
+    .. note::
+
+        It is possible that this function returns None for certain callbacks,
+        the caller of this function should hangle this case.
+
+    """
+    if callback is None:
+        return field
+
+    # Call the callback function on the field.
+    try:
+        result = callback(cube, field, filename)
+    except iris.exceptions.IgnoreFieldException:
+        result = None
+    else:
+        if result is None:
+            result = field
+        elif not isinstance(result, type(field)):
+            msg = 'Saver callback function returned an unhandled ' \
+                'data type, expected {}'.format(type(field))
+            raise TypeError(msg)
+    return result
+
+
 def run_callback(callback, cube, field, filename):
     """
-    Runs the callback mechanism given the appropriate arguments.
+    Runs the loader callback mechanism given the appropriate arguments.
 
     Args:
 
@@ -65,6 +111,12 @@ def run_callback(callback, cube, field, filename):
                returned by the function.
             3. If the cube is to be rejected the callback must raise
                an :class:`iris.exceptions.IgnoreCubeException`.
+    * cube:
+        The cube generated from the loaded field.
+    * field:
+        The loaded field that generated the cube.
+    * filename:
+        The name of the file from which the field was loaded.
 
     .. note::
 
@@ -86,8 +138,9 @@ def run_callback(callback, cube, field, filename):
         if result is None:
             result = cube
         elif not isinstance(result, iris.cube.Cube):
-                raise TypeError("Callback function returned an "
-                                "unhandled data type.")
+            msg = 'Loader callback function returned an unhandled ' \
+                'data type, expected {}'.format(type(cube))
+            raise TypeError(msg)
     return result
 
 
@@ -279,7 +332,7 @@ def find_saver(filespec):
     return _savers[matches[0]] if matches else None
 
 
-def save(source, target, saver=None, **kwargs):
+def save(source, target, saver=None, callback=None, **kwargs):
     """
     Save one or more Cubes to file (or other writable).
 
@@ -298,23 +351,35 @@ def save(source, target, saver=None, **kwargs):
 
     Args:
 
-        * source    - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
-                      sequence of cubes.
-        * target    - A filename (or writable, depending on file format).
-                      When given a filename or file, Iris can determine the
-                      file format.
+    * source:
+        A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+        sequence of cubes.
+    * target:
+        A filename (or writable, depending on file format).
+        When given a filename or file, Iris can determine the
+        file format.
 
     Kwargs:
 
-        * saver     - Optional. Specifies the save function to use.
-                      If omitted, Iris will attempt to determine the format.
+    * saver:
+        Optional. Specifies the save function to use.
+        If omitted, Iris will attempt to determine the format.
 
-                      This keyword can be used to implement a custom save
-                      format. Function form must be:
-                      ``my_saver(cube, target)`` plus any custom keywords. It
-                      is assumed that a saver will accept an ``append`` keyword
-                      if it's file format can handle multiple cubes. See also
-                      :func:`iris.io.add_saver`.
+        This keyword can be used to implement a custom save
+        format. Function form must be:
+        ``my_saver(cube, target)`` plus any custom keywords. It
+        is assumed that a saver will accept an ``append`` keyword
+        if it's file format can handle multiple cubes. See also
+        :func:`iris.io.add_saver`.
+    * callback:
+        A function to manipulate the field generated from the associated
+        cube, obeying the following rules:
+
+            1. Function signature must be: ``(cube, field, filename)``.
+            2. Modifies the given field inplace, unless a new field is
+               returned by the function.
+            3. If the field is to be rejected the callback must raise
+               an :class:`iris.exception.IgnoreFieldException`.
 
     All other keywords are passed through to the saver function; see the
     relevant saver documentation for more information on keyword arguments.
@@ -347,7 +412,7 @@ def save(source, target, saver=None, **kwargs):
 
     # Single cube?
     if isinstance(source, iris.cube.Cube):
-        saver(source, target, **kwargs)
+        saver(source, target, callback=callback, **kwargs)
 
     # CubeList or sequence of cubes?
     elif (isinstance(source, iris.cube.CubeList) or
@@ -367,10 +432,10 @@ def save(source, target, saver=None, **kwargs):
             for i, cube in enumerate(source):
                 if i != 0:
                     kwargs['append'] = True
-                saver(cube, target, **kwargs)
+                saver(cube, target, callback=callback, **kwargs)
         # Netcdf saver.
         else:
-            saver(source, target, **kwargs)
+            saver(source, target, callback=callback, **kwargs)
 
     else:
         raise ValueError("Cannot save; non Cube found in source")

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -170,6 +170,27 @@ class TestLazySave(tests.IrisTest):
             with Saver(nc_path, 'NETCDF4') as saver:
                 saver.write(acube)
         self.assertTrue(acube.has_lazy_data())
+
+
+@tests.skip_data
+class TestSaverCallback(tests.IrisTest):
+    def test_netcdf(self):
+        expected = 'K'
+
+        def callback_save(cube, field, filename):
+            self.assertEqual(field.units, 'kg m**-2')
+            # Clobber the original units attribute.
+            field.units = expected
+
+        def callback_check(cube, field, filename):
+            self.assertEqual(field.units, expected)
+
+        fname = 'SMALL_total_column_co2.nc'
+        path = tests.get_data_path(('NetCDF', 'global', 'xyt', fname))
+        cube = iris.load_cube(path)
+        with self.temp_filename(fname) as fo:
+            iris.save(cube, fo, callback=callback_save)
+            iris.load_cube(fo, callback=callback_check)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ from contextlib import nested
 import mock
 import numpy as np
 
+import iris
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod
 from iris.cube import Cube
@@ -489,6 +490,27 @@ class TestCoordinateForms(tests.IrisTest):
         self.assertEqual(pp_field.bdx, 0.0)
         self.assertArrayAllClose(pp_field.x, x_values)
         self.assertEqual(pp_field.lbnpt, nx)
+
+
+@tests.skip_data
+class TestSaverCallback(tests.IrisTest):
+    def test_pp(self):
+        expected = 2000.0
+
+        def callback_save(cube, field, fname):
+            self.assertEqual(field.blev, 1000.0)
+            # Clobber the original pressure level.
+            field.blev = expected
+
+        def callback_check(cube, field, fname):
+            self.assertEqual(field.blev, expected)
+
+        fname = 'global.pp'
+        path = tests.get_data_path(('PP', 'simple_pp', fname))
+        cube = iris.load_cube(path)
+        with self.temp_filename(fname) as fo:
+            iris.save(cube, fo, callback=callback_save)
+            iris.load_cube(fo, callback=callback_check)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/io/test_run_saver_callback.py
+++ b/lib/iris/tests/unit/io/test_run_saver_callback.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the `iris.io.run_callback` function."""
+"""Unit tests for the `iris.io.run_saver_callback` function."""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -23,67 +23,62 @@ from __future__ import (absolute_import, division, print_function)
 import iris.tests as tests
 
 import mock
-import iris.exceptions
-import iris.io
+
+import iris
+from iris.exceptions import IgnoreFieldException
+from iris.io import run_saver_callback
 
 
-class Test_run_callback(tests.IrisTest):
+class Test(tests.IrisTest):
     def setUp(self):
-        tests.IrisTest.setUp(self)
         self.cube = mock.sentinel.cube
+        self.field = mock.sentinel.field
+        self.fname = mock.sentinel.fname
 
     def test_no_callback(self):
-        # No callback results in the cube being returned.
-        self.assertEqual(iris.io.run_callback(None, self.cube, None, None),
-                         self.cube)
+        # No callback results in the field being returned.
+        result = run_saver_callback(None, None, self.field, None)
+        self.assertEqual(result, self.field)
 
-    def test_ignore_cube(self):
-        # Ignore cube should result in None being returned.
+    def test_ignore_field(self):
+        # Ignore field should result in None being returned.
         def callback(cube, field, fname):
-            raise iris.exceptions.IgnoreCubeException()
-        cube = self.cube
-        self.assertEqual(iris.io.run_callback(callback, cube, None, None),
-                         None)
+            raise IgnoreFieldException()
+        result = run_saver_callback(callback, None, self.field, None)
+        self.assertIsNone(result)
 
     def test_callback_no_return(self):
         # Check that a callback not returning anything still results in the
-        # cube being passed back from "run_callback".
+        # cube being passed back from "run_saver_callback".
         def callback(cube, field, fname):
             pass
-
-        cube = self.cube
-        self.assertEqual(iris.io.run_callback(callback, cube, None, None),
-                         cube)
+        result = run_saver_callback(callback, None, self.field, None)
+        self.assertEqual(result, self.field)
 
     def test_bad_callback_return_type(self):
         # Check that a TypeError is raised with a bad callback return value.
         def callback(cube, field, fname):
             return iris.cube.CubeList()
-        with self.assertRaisesRegexp(TypeError,
-                                     'Loader callback function returned an '
-                                     'unhandled data type'):
-            iris.io.run_callback(callback, None, None, None)
+        emsg = 'Saver callback function returned an unhandled data type'
+        with self.assertRaisesRegexp(TypeError, emsg):
+            run_saver_callback(callback, None, None, None)
 
     def test_bad_signature(self):
         # Check that a TypeError is raised with a bad callback function
         # signature.
         def callback(cube):
             pass
-        with self.assertRaisesRegexp(TypeError,
-                                     'takes exactly 1 argument '):
-            iris.io.run_callback(callback, None, None, None)
+        emsg = 'takes exactly 1 argument'
+        with self.assertRaisesRegexp(TypeError, emsg):
+            run_saver_callback(callback, None, None, None)
 
     def test_callback_args(self):
         # Check that the appropriate args are passed through to the callback.
-        self.field = mock.sentinel.field
-        self.fname = mock.sentinel.fname
-
         def callback(cube, field, fname):
             self.assertEqual(cube, self.cube)
             self.assertEqual(field, self.field)
             self.assertEqual(fname, self.fname)
-
-        iris.io.run_callback(callback, self.cube, self.field, self.fname)
+        run_saver_callback(callback, self.cube, self.field, self.fname)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements a saver callback mechanism for `PP`, `GRIB2` and `NetCDF`, akin to the existing loader callback mechanism.

Note that, for NetCDF it's not possible to ignore or skip a `field` as with the other core file formats, simply because the NetCDF saver saves as it processes the associated cube and its metadata. So the callback in this regard gives the user the option to manipulate what's already been written rather than ignore it.