### PR TITLE
Saving multiple individual aux-factories.

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -925,6 +925,10 @@ class Saver(object):
 
         * cube (:class:`iris.cube.Cube`):
             A :class:`iris.cube.Cube` to be saved to a netCDF file.
+        * cf_var_cube (:class:`netcdf.netcdf_variable`)
+            CF variable cube representation.
+        * dimension_names (list):
+            Names associated with the dimensions of the cube.
 
         """
         primaries = []
@@ -959,6 +963,16 @@ class Saver(object):
                 if hasattr(cf_var, 'formula_terms'):
                     if cf_var.formula_terms != formula_terms or \
                             cf_var.standard_name != std_name:
+                        # TODO: We need to resolve this corner-case where
+                        # the dimensionless vertical coordinate containing the
+                        # formula_terms is a dimension coordinate of the
+                        # associated cube and a new alternatively named
+                        # dimensionless vertical coordinate is required with
+                        # new formula_terms and a renamed dimension.
+                        if cf_name in dimension_names:
+                            msg = 'Unable to create dimensonless vertical ' \
+                                'coordinate.'
+                            raise ValueError(msg)
                         key = (cf_name, std_name, formula_terms)
                         name = self._formula_terms_cache.get(key)
                         if name is None:

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -609,6 +609,8 @@ class Saver(object):
         self._coord_systems = []
         #: A dictionary, listing dimension names and corresponding length
         self._existing_dim = {}
+        #: A dictionary, mapping formula terms to owner cf variable name
+        self._formula_terms_cache = {}
         #: NetCDF dataset
         try:
             self._dataset = netCDF4.Dataset(filename, mode='w',
@@ -767,7 +769,7 @@ class Saver(object):
 
         # Add the formula terms to the appropriate cf variables for each
         # aux factory in the cube.
-        self._add_aux_factories(cube)
+        self._add_aux_factories(cube, cf_var_cube, dimension_names)
 
         # Add data variable-only attribute names to local_keys.
         if local_keys is None:
@@ -913,7 +915,7 @@ class Saver(object):
                                                    coord)
                 self._name_coord_map.append(cf_name, coord)
 
-    def _add_aux_factories(self, cube):
+    def _add_aux_factories(self, cube, cf_var_cube, dimension_names):
         """
         Modifies the variables of the NetCDF dataset to represent
         the presence of dimensionless vertical coordinates based on
@@ -944,15 +946,43 @@ class Saver(object):
                           'single coordinate is not supported.'
                     raise ValueError(msg.format(cube, primary_coord.name()))
                 primaries.append(primary_coord)
+
                 cf_name = self._name_coord_map.name(primary_coord)
                 cf_var = self._dataset.variables[cf_name]
-                cf_var.standard_name = factory_defn.std_name
-                cf_var.axis = 'Z'
+
                 names = {key: self._name_coord_map.name(coord) for
                          key, coord in factory.dependencies.iteritems()}
                 formula_terms = factory_defn.formula_terms_format.format(
                     **names)
-                cf_var.formula_terms = formula_terms
+                std_name = factory_defn.std_name
+
+                if hasattr(cf_var, 'formula_terms'):
+                    if cf_var.formula_terms != formula_terms or \
+                            cf_var.standard_name != std_name:
+                        key = (cf_name, std_name, formula_terms)
+                        name = self._formula_terms_cache.get(key)
+                        if name is None:
+                            # Create a new variable
+                            name = self._create_cf_variable(cube,
+                                                            dimension_names,
+                                                            primary_coord)
+                            cf_var = self._dataset.variables[name]
+                            cf_var.standard_name = std_name
+                            cf_var.axis = 'Z'
+                            # Update the formula terms.
+                            ft = formula_terms.split()
+                            ft = [name if t == cf_name else t for t in ft]
+                            cf_var.formula_terms = ' '.join(ft)
+                            # Update the cache.
+                            self._formula_terms_cache[key] = name
+                        # Update the associated cube variable.
+                        coords = cf_var_cube.coordinates.split()
+                        coords = [name if c == cf_name else c for c in coords]
+                        cf_var_cube.coordinates = ' '.join(coords)
+                else:
+                    cf_var.standard_name = std_name
+                    cf_var.axis = 'Z'
+                    cf_var.formula_terms = formula_terms
 
     def _get_dim_names(self, cube):
         """

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -111,6 +111,16 @@ class TestSaveMultipleAuxFactories(tests.IrisTest):
             cubes = sorted(cubes, key=lambda cube: cube.attributes['cube'])
             self.assertCML(cubes)
 
+    def test_hybrid_height_cubes_on_dimension_coordinate(self):
+        hh1 = stock.hybrid_height()
+        hh2 = stock.hybrid_height()
+        sa = hh2.coord('surface_altitude')
+        sa.points = sa.points * 10
+        emsg = 'Unable to create dimensonless vertical coordinate.'
+        with self.temp_filename('.nc') as fname, \
+                self.assertRaisesRegexp(ValueError, emsg):
+            iris.save([hh1, hh2], fname)
+
 
 class TestUmVersionAttribute(tests.IrisTest):
     def test_single_saves_as_global(self):

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -98,6 +98,19 @@ class TestSaveMultipleAuxFactories(tests.IrisTest):
                 self.assertRaisesRegexp(ValueError, 'multiple aux factories'):
             iris.save(cube, filename)
 
+    def test_hybrid_height_cubes(self):
+        hh1 = stock.simple_4d_with_hybrid_height()
+        hh1.attributes['cube'] = 'hh1'
+        hh2 = stock.simple_4d_with_hybrid_height()
+        hh2.attributes['cube'] = 'hh2'
+        sa = hh2.coord('surface_altitude')
+        sa.points = sa.points * 10
+        with self.temp_filename('.nc') as fname:
+            iris.save([hh1, hh2], fname)
+            cubes = iris.load(fname)
+            cubes = sorted(cubes, key=lambda cube: cube.attributes['cube'])
+            self.assertCML(cubes)
+
 
 class TestUmVersionAttribute(tests.IrisTest):
     def test_single_saves_as_global(self):

--- a/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
+++ b/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
@@ -1,0 +1,131 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="cube" value="hh1"/>
+    </attributes>
+    <coords>
+      <coord datadims="[1, 2, 3]">
+        <auxCoord id="c56f646c" points="[[[5040, 5090, 5140, 5190, 5240, 5290],
+ 		[5340, 5390, 5440, 5490, 5540, 5590],
+ 		[5640, 5690, 5740, 5790, 5840, 5890],
+ 		[5940, 5990, 6040, 6090, 6140, 6190],
+ 		[6240, 6290, 6340, 6390, 6440, 6490]],
+
+		[[5141, 5192, 5243, 5294, 5345, 5396],
+ 		[5447, 5498, 5549, 5600, 5651, 5702],
+ 		[5753, 5804, 5855, 5906, 5957, 6008],
+ 		[6059, 6110, 6161, 6212, 6263, 6314],
+ 		[6365, 6416, 6467, 6518, 6569, 6620]],
+
+		[[5242, 5294, 5346, 5398, 5450, 5502],
+ 		[5554, 5606, 5658, 5710, 5762, 5814],
+ 		[5866, 5918, 5970, 6022, 6074, 6126],
+ 		[6178, 6230, 6282, 6334, 6386, 6438],
+ 		[6490, 6542, 6594, 6646, 6698, 6750]],
+
+		[[5343, 5396, 5449, 5502, 5555, 5608],
+ 		[5661, 5714, 5767, 5820, 5873, 5926],
+ 		[5979, 6032, 6085, 6138, 6191, 6244],
+ 		[6297, 6350, 6403, 6456, 6509, 6562],
+ 		[6615, 6668, 6721, 6774, 6827, 6880]]]" shape="(4, 5, 6)" standard_name="altitude" units="Unit('m')" value_type="int64">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="3092228b" long_name="level_height" points="[40, 41, 42, 43]" shape="(4,)" standard_name="atmosphere_hybrid_height_coordinate" units="Unit('m')" value_type="int64" var_name="level_height"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="60f15cad" points="[20, 21, 22, 23, 24]" shape="(5,)" standard_name="grid_latitude" units="Unit('degrees')" value_type="int64" var_name="grid_latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="743fa935" points="[30, 31, 32, 33, 34, 35]" shape="(6,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="int64" var_name="grid_longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f0c5855b" points="[10, 11, 12, 13]" shape="(4,)" standard_name="model_level_number" units="Unit('1')" value_type="int64" var_name="model_level_number"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="273ab6c5" long_name="sigma" points="[50, 51, 52, 53]" shape="(4,)" units="Unit('1')" value_type="int64" var_name="sigma"/>
+      </coord>
+      <coord datadims="[2, 3]">
+        <auxCoord id="9320b923" long_name="surface_altitude" points="[[100, 101, 102, 103, 104, 105],
+		[106, 107, 108, 109, 110, 111],
+		[112, 113, 114, 115, 116, 117],
+		[118, 119, 120, 121, 122, 123],
+		[124, 125, 126, 127, 128, 129]]" shape="(5, 6)" standard_name="surface_altitude" units="Unit('m')" value_type="int64" var_name="surface_altitude"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="2fd50af3" points="[0, 1, 2]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int64" var_name="time"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x2acdccca" dtype="int64" shape="(3, 4, 5, 6)"/>
+  </cube>
+  <cube standard_name="air_temperature" units="K" var_name="air_temperature_0">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="cube" value="hh2"/>
+    </attributes>
+    <coords>
+      <coord datadims="[1, 2, 3]">
+        <auxCoord id="c56f646c" points="[[[50040, 50540, 51040, 51540, 52040, 52540],
+ 		[53040, 53540, 54040, 54540, 55040, 55540],
+ 		[56040, 56540, 57040, 57540, 58040, 58540],
+ 		[59040, 59540, 60040, 60540, 61040, 61540],
+ 		[62040, 62540, 63040, 63540, 64040, 64540]],
+
+		[[51041, 51551, 52061, 52571, 53081, 53591],
+ 		[54101, 54611, 55121, 55631, 56141, 56651],
+ 		[57161, 57671, 58181, 58691, 59201, 59711],
+ 		[60221, 60731, 61241, 61751, 62261, 62771],
+ 		[63281, 63791, 64301, 64811, 65321, 65831]],
+
+		[[52042, 52562, 53082, 53602, 54122, 54642],
+ 		[55162, 55682, 56202, 56722, 57242, 57762],
+ 		[58282, 58802, 59322, 59842, 60362, 60882],
+ 		[61402, 61922, 62442, 62962, 63482, 64002],
+ 		[64522, 65042, 65562, 66082, 66602, 67122]],
+
+		[[53043, 53573, 54103, 54633, 55163, 55693],
+ 		[56223, 56753, 57283, 57813, 58343, 58873],
+ 		[59403, 59933, 60463, 60993, 61523, 62053],
+ 		[62583, 63113, 63643, 64173, 64703, 65233],
+ 		[65763, 66293, 66823, 67353, 67883, 68413]]]" shape="(4, 5, 6)" standard_name="altitude" units="Unit('m')" value_type="int64">
+          <attributes>
+            <attribute name="positive" value="up"/>
+          </attributes>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="3092228b" long_name="level_height" points="[40, 41, 42, 43]" shape="(4,)" standard_name="atmosphere_hybrid_height_coordinate" units="Unit('m')" value_type="int64" var_name="level_height_0"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="60f15cad" points="[20, 21, 22, 23, 24]" shape="(5,)" standard_name="grid_latitude" units="Unit('degrees')" value_type="int64" var_name="grid_latitude"/>
+      </coord>
+      <coord datadims="[3]">
+        <dimCoord id="743fa935" points="[30, 31, 32, 33, 34, 35]" shape="(6,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="int64" var_name="grid_longitude"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f0c5855b" points="[10, 11, 12, 13]" shape="(4,)" standard_name="model_level_number" units="Unit('1')" value_type="int64" var_name="model_level_number"/>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="273ab6c5" long_name="sigma" points="[50, 51, 52, 53]" shape="(4,)" units="Unit('1')" value_type="int64" var_name="sigma"/>
+      </coord>
+      <coord datadims="[2, 3]">
+        <auxCoord id="43d91839" long_name="surface_altitude" points="[[1000, 1010, 1020, 1030, 1040, 1050],
+		[1060, 1070, 1080, 1090, 1100, 1110],
+		[1120, 1130, 1140, 1150, 1160, 1170],
+		[1180, 1190, 1200, 1210, 1220, 1230],
+		[1240, 1250, 1260, 1270, 1280, 1290]]" shape="(5, 6)" units="Unit('m')" value_type="int64" var_name="surface_altitude_0"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="2fd50af3" points="[0, 1, 2]" shape="(3,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="int64" var_name="time"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x2acdccca" dtype="int64" shape="(3, 4, 5, 6)"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
This PR allows multiple individual auxiliary factories to be saved to the same NetCDF file.

This targets the use case where two hybrid height cubes with differing `orography` (aka `surface_altitude`) coordinates, but similar `sigma` and `delta` are saved to the same NetCDF file. The `formula_terms` attribute is attached to an auxiliary vertical coordinate, rather than a dimension coordinate. The NetCDF representation of these cubes should result in two auxiliary vertical coordinates with appropriately different `formula_terms` (due to the `orography` difference).

This PR does not cover the completely nasty case where the `formula_terms` is attached to a dimensional vertical coordinate. The current saver implementation will require to be revisited to support this case.