### PR TITLE
Quick demo method to handle unicode strings in units.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1029,6 +1029,9 @@ fc_extras
         try:
             iris.unit.as_unit(attr_units)
         except ValueError:
+        # formatting a unicode string causes an exception. Test for that.
+            if isinstance(attr_units, unicode):
+                attr_units = attr_units.encode('ascii', errors='backslashreplace')
             msg = 'Ignoring netCDF variable {!r} invalid units {!r}'
             msg_name = '{}'.format(cf_var.cf_name)
             msg_units = '{}'.format(attr_units)

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
@@ -1,0 +1,64 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.build_cube_metadata`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+import mock
+
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    get_attr_units
+
+
+class TestGetAttrUnits(tests.IrisTest):
+    @staticmethod
+    def _make_cf_var(global_attributes=None):
+        if global_attributes is None:
+            global_attributes = {}
+
+        cf_group = mock.Mock(global_attributes=global_attributes)
+
+        cf_var = mock.Mock(
+            cf_name='sound_frequency',
+            standard_name=None,
+            long_name=None,
+            units=u'\u266b',
+            dtype=np.float64,
+            cell_methods=None,
+            cf_group=cf_group)
+        return cf_var
+
+    def test_unicode_character(self):
+        attributes = {}
+        expected_attributes = {'invalid_units': '\\u266b'}
+        cf_var = self._make_cf_var()
+        attr_units = get_attr_units(cf_var, attributes)
+        self.assertEqual(attr_units, 'unknown')
+        self.assertEqual(attributes, expected_attributes)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
Hi all,

So, I'm looking at a situation where an api is returning a netCDF file which has unicode characters in the units. A little bit of research suggests to me that this is not discouraged, though it obviously isn't udunits-friendly.

This is presumably something that needs a slightly wider approach than just putting a fix in for this specific case - but thought it was worth raising this to discuss.

The below just tests for unicode characters in units and escapes them if it finds them.
E.G. ♫ would be \u266b

Not pretty, but relatively non-destructive as a conversation starter.

Thoughts?