### PR TITLE
Saver customisation

### DIFF
--- a/docs/iris/src/userguide/index.rst
+++ b/docs/iris/src/userguide/index.rst
@@ -27,6 +27,7 @@ User guide table of contents
 
    iris_cubes.rst
    loading_iris_cubes.rst
+   saving_iris_cubes.rst
    navigating_a_cube.rst
    subsetting_a_cube.rst
    plotting_a_cube.rst
@@ -34,6 +35,5 @@ User guide table of contents
    merge_and_concat.rst
    cube_statistics.rst
    cube_maths.rst
-   saving_iris_cubes.rst
    citation.rst
    end_of_userguide.rst

--- a/docs/iris/src/userguide/index.rst
+++ b/docs/iris/src/userguide/index.rst
@@ -34,5 +34,6 @@ User guide table of contents
    merge_and_concat.rst
    cube_statistics.rst
    cube_maths.rst
+   saving_iris_cubes.rst
    citation.rst
    end_of_userguide.rst

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -394,18 +394,3 @@ these two cubes into separate variables.
         >>> print number_two
         2
 
-
-Saving Iris Cubes
------------------
-
-The :py:func:`iris.save` function saves one or more cubes to a file.
-
-If the filename includes a supported suffix then Iris will use the correct saver
-and the keyword argument `saver` is not required.
-
-    >>> import iris
-    >>> filename = iris.sample_data_path('uk_hires.pp')
-    >>> cubes = iris.load(filename)
-    >>> iris.save(cubes, '/tmp/uk_hires.nc')
-
-Iris is able to save to CF NetCDF (1.5), GRIB (edition 2) and Met Office PP formats.

--- a/docs/iris/src/userguide/saving_iris_cubes.rst
+++ b/docs/iris/src/userguide/saving_iris_cubes.rst
@@ -1,0 +1,68 @@
+.. _saving_iris_cubes:
+
+==================
+Saving Iris cubes
+==================
+
+Iris supports the saving of cubes and cube lists to:
+
+* CF netCDF (1.5)
+* GRIB (edition 2)
+* Met Office PP
+
+
+The :py:func:`iris.save` function saves one or more cubes to a file.
+
+If the filename includes a supported suffix then Iris will use the correct saver
+and the keyword argument `saver` is not required.
+
+    >>> import iris
+    >>> filename = iris.sample_data_path('uk_hires.pp')
+    >>> cubes = iris.load(filename)
+    >>> iris.save(cubes, '/tmp/uk_hires.nc')
+
+
+Controlling the save process
+-----------------------------
+
+The :py:func:`iris.save` function passes all other keywords through to the saver function defined, or automatically set from the file extension.  This enables saver specific functionality to be called.
+
+    >>> # Save a cube to PP
+    >>> iris.save(my_cube, "myfile.pp")
+    >>> # Save a cube list to a PP file, appending to the contents of the file
+    >>> # if it already exists
+    >>> iris.save(my_cube_list, "myfile.pp", append=True)
+    >>> # Save a cube to netCDF, defaults to NETCDF4 file format
+    >>> iris.save(my_cube, "myfile.nc")
+    >>> # Save a cube list to netCDF, using the NETCDF4_CLASSIC storage option
+    >>> iris.save(my_cube_list, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
+
+Customising the save process
+-----------------------------
+
+When saving to GRIB or PP, the save process may be intercepted between the translation step and the file writing.  This enables customisation of the output messages, based on Cube metadata if required, over and above the translations supplied by Iris.
+
+For example, a GRIB2 message with a particular known long_name may need to be saved to a specific parameter code and type of statistical process.  This can be achieved by::
+
+        def tweaked_messages(cube):
+            for message in iris.fileformats.grib.as_messages(cube):
+                # post process the GRIB2 message, prior to saving
+                if cube.name() == 'carefully_customised_precipitation_amount':
+		    gribapi.grib_set_long(grib, "typeOfStatisticalProcess", 1)
+                    gribapi.grib_set_long(grib, "parameterCategory", 1)
+                    gribapi.grib_set_long(grib, "parameterNumber", 1)
+                yield message
+        iris.fileformats.grib.save(tweaked_messages(cube))
+
+
+
+netCDF
+^^^^^^^
+
+As the cube is closely related to the CF for netCDF semantics, there is no similar functionality for netCDF saving, cube metadata is closely related to netCDF metadata, so custom cube changes are generally written our cleanly to netCDF files.
+
+Custom Saver
+-------------
+
+A custom saver can be provided to the function to write to a different file format; the custom saver has to be written to meet the needs of the file format, but this is out of scope for the user guide.
+

--- a/docs/iris/src/userguide/saving_iris_cubes.rst
+++ b/docs/iris/src/userguide/saving_iris_cubes.rst
@@ -19,6 +19,7 @@ and the keyword argument `saver` is not required.
     >>> import iris
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cubes = iris.load(filename)
+    >>> cube = cubes[0]
     >>> iris.save(cubes, '/tmp/uk_hires.nc')
 
 
@@ -28,14 +29,22 @@ Controlling the save process
 The :py:func:`iris.save` function passes all other keywords through to the saver function defined, or automatically set from the file extension.  This enables saver specific functionality to be called.
 
     >>> # Save a cube to PP
-    >>> iris.save(my_cube, "myfile.pp")
+    >>> iris.save(cube, "myfile.pp")
     >>> # Save a cube list to a PP file, appending to the contents of the file
     >>> # if it already exists
-    >>> iris.save(my_cube_list, "myfile.pp", append=True)
+    >>> iris.save(cubes, "myfile.pp", append=True)
     >>> # Save a cube to netCDF, defaults to NETCDF4 file format
-    >>> iris.save(my_cube, "myfile.nc")
+    >>> iris.save(cube, "myfile.nc")
     >>> # Save a cube list to netCDF, using the NETCDF4_CLASSIC storage option
-    >>> iris.save(my_cube_list, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
+    >>> iris.save(cubes, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
+
+See 
+
+* :py:func:`iris.fileformats.netcdf.save`
+* :py:func:`iris.fileformats.grib.save_grib2`
+* :py:func:`iris.fileformats.pp.save`
+
+for more details on supported arguments for the individual savers.
 
 Customising the save process
 -----------------------------
@@ -45,24 +54,39 @@ When saving to GRIB or PP, the save process may be intercepted between the trans
 For example, a GRIB2 message with a particular known long_name may need to be saved to a specific parameter code and type of statistical process.  This can be achieved by::
 
         def tweaked_messages(cube):
-            for message in iris.fileformats.grib.as_messages(cube):
+            for cube, grib_message in iris.fileformats.grib.as_pairs(cube):
                 # post process the GRIB2 message, prior to saving
                 if cube.name() == 'carefully_customised_precipitation_amount':
-		    gribapi.grib_set_long(grib, "typeOfStatisticalProcess", 1)
-                    gribapi.grib_set_long(grib, "parameterCategory", 1)
-                    gribapi.grib_set_long(grib, "parameterNumber", 1)
+		    gribapi.grib_set_long(grib_message, "typeOfStatisticalProcess", 1)
+                    gribapi.grib_set_long(grib_message, "parameterCategory", 1)
+                    gribapi.grib_set_long(grib_message, "parameterNumber", 1)
                 yield message
-        iris.fileformats.grib.save(tweaked_messages(cube))
+        iris.fileformats.grib.save_messages(tweaked_messages(cube), '/tmp/agrib2.grib2')
 
+Similarly a PP field may need to be written out with a specific value for LBEXP.  This can be achieved by::
+
+        def tweaked_fields(cube):
+            for cube, field in iris.fileformats.pp.as_pairs(cube):
+                # post process the PP field, prior to saving
+                if cube.name() == 'air_pressure':
+		    field.lbexp = 'meaxp'
+		elif cube.name() == 'air_density':
+		    field.lbexp = 'meaxr'
+                yield field
+        iris.fileformats.pp.save_fields(tweaked_fields(cube), '/tmp/app.pp')
 
 
 netCDF
 ^^^^^^^
 
-As the cube is closely related to the CF for netCDF semantics, there is no similar functionality for netCDF saving, cube metadata is closely related to netCDF metadata, so custom cube changes are generally written our cleanly to netCDF files.
+NetCDF is a flexible container for metadata and cube metadata is closely related to the CF for netCDF semantics.  This means that cube metadata is well represented in netCDF files, closely resembling the in memory metadata representation.
+Thus there is no provision for similar save customisation functionality for netCDF saving, all customisations should be applied to the cube prior to saving to netCDF.
 
-Custom Saver
--------------
+Bespoke Saver
+--------------
 
-A custom saver can be provided to the function to write to a different file format; the custom saver has to be written to meet the needs of the file format, but this is out of scope for the user guide.
+A bespoke saver may be written to support an alternative file format.  This can be provided to the :py:func:`iris.save`  function, enabling Iris to write to a different file format.
+Such a custom saver will need be written to meet the needs of the file format and to handle the metadata translation from cube metadata effectively. 
+
+Implementing a bespoke saver is out of scope for the user guide.
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -940,7 +940,57 @@ def save_grib2(cube, target, append=False, **kwargs):
     See also :func:`iris.io.save`.
 
     """
+    messages = as_messages(cube)
+    save(messages, target, append=append)
 
+
+def as_pairs(cube):
+    """
+    Convert one or more cubes to (2D cube, GRIB message) pairs.
+
+    Args:
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+
+    """
+    x_coords = cube.coords(axis='x', dim_coords=True)
+    y_coords = cube.coords(axis='y', dim_coords=True)
+    if len(x_coords) != 1 or len(y_coords) != 1:
+        raise TranslationError("Did not find one (and only one) x or y coord")
+
+    # Save each latlon slice2D in the cube
+    for slice2D in cube.slices([y_coords[0], x_coords[0]]):
+        grib_message = gribapi.grib_new_from_samples("GRIB2")
+        _save_rules.run(slice2D, grib_message)
+        yield (slice2D, grib_message)
+
+
+def as_messages(cube):
+    """
+    Convert one or more cubes to GRIB messages.
+
+    Args:
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+
+    """
+    return (message for cube, message in as_pairs(cube))
+
+
+def save(messages, target, append=False):
+    """
+    Save a messages to a GRIB2 file.
+
+    Args:
+
+        * messages
+        * target    - A filename or open file handle.
+
+    Kwargs:
+
+        * append    - Whether to start a new file afresh or add the cube(s) to the end of the file.
+                      Only applicable when target is a filename, not a file handle.
+                      Default is False.
+
+    """
     # grib file (this bit is common to the pp and grib savers...)
     if isinstance(target, basestring):
         grib_file = open(target, "ab" if append else "wb")
@@ -951,19 +1001,9 @@ def save_grib2(cube, target, append=False, **kwargs):
     else:
         raise ValueError("Can only save grib to filename or writable")
 
-    x_coords = cube.coords(axis='x', dim_coords=True)
-    y_coords = cube.coords(axis='y', dim_coords=True)
-    if len(x_coords) != 1 or len(y_coords) != 1:
-        raise TranslationError("Did not find one (and only one) x or y coord")
-
-    # Save each latlon slice2D in the cube
-    for slice2D in cube.slices([y_coords[0], x_coords[0]]):
-
-        # Save this slice to the grib file
-        grib_message = gribapi.grib_new_from_samples("GRIB2")
-        _save_rules.run(slice2D, grib_message)
-        gribapi.grib_write(grib_message, grib_file)
-        gribapi.grib_release(grib_message)
+    for message in messages:
+        gribapi.grib_write(message, grib_file)
+        gribapi.grib_release(message)
 
     # (this bit is common to the pp and grib savers...)
     if isinstance(target, basestring):

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -948,8 +948,8 @@ def save_grib2(cube, target, append=False, **kwargs):
 def as_pairs(cube):
     """
     Convert one or more cubes to (2D cube, GRIB message) pairs.
-    Returns an iterable of tuples each consisting of one 2D cubes and
-    one GRIB message, the result of the 2D cube being processed by the GRIB
+    Returns an iterable of tuples each consisting of one 2D cube and
+    one GRIB message ID, the result of the 2D cube being processed by the GRIB
     save rules.
 
     Args:
@@ -984,11 +984,12 @@ def as_messages(cube):
 
 def save_messages(messages, target, append=False):
     """
-    Save a messages to a GRIB2 file.
+    Save messages to a GRIB2 file.
+    The messages will be released as part of the save.
 
     Args:
 
-        * messages
+        * messages  - An iterable of grib_api message IDs.
         * target    - A filename or open file handle.
 
     Kwargs:

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -896,7 +896,6 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
         on a reduced grid to an equivalent regular grid.
 
         .. deprecated:: 1.8. Please use strict_grib_load and regrid instead.
-        
 
 
     """
@@ -928,28 +927,34 @@ def save_grib2(cube, target, append=False, **kwargs):
 
     Args:
 
-        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+                      list of cubes.
         * target    - A filename or open file handle.
 
     Kwargs:
 
-        * append    - Whether to start a new file afresh or add the cube(s) to the end of the file.
-                      Only applicable when target is a filename, not a file handle.
-                      Default is False.
+        * append    - Whether to start a new file afresh or add the cube(s) to
+                      the end of the file.
+                      Only applicable when target is a filename, not a file
+                      handle. Default is False.
 
     See also :func:`iris.io.save`.
 
     """
     messages = as_messages(cube)
-    save(messages, target, append=append)
+    save_messages(messages, target, append=append)
 
 
 def as_pairs(cube):
     """
     Convert one or more cubes to (2D cube, GRIB message) pairs.
+    Returns an iterable of tuples each consisting of one 2D cubes and
+    one GRIB message, the result of the 2D cube being processed by the GRIB
+    save rules.
 
     Args:
-        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+        list of cubes.
 
     """
     x_coords = cube.coords(axis='x', dim_coords=True)
@@ -967,15 +972,17 @@ def as_pairs(cube):
 def as_messages(cube):
     """
     Convert one or more cubes to GRIB messages.
+    Returns an iterable of grib_api GRIB messages.
 
     Args:
-        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+                      list of cubes.
 
     """
     return (message for cube, message in as_pairs(cube))
 
 
-def save(messages, target, append=False):
+def save_messages(messages, target, append=False):
     """
     Save a messages to a GRIB2 file.
 
@@ -986,64 +993,10 @@ def save(messages, target, append=False):
 
     Kwargs:
 
-        * append    - Whether to start a new file afresh or add the cube(s) to the end of the file.
-                      Only applicable when target is a filename, not a file handle.
-                      Default is False.
-
-    """
-    # grib file (this bit is common to the pp and grib savers...)
-    if isinstance(target, basestring):
-        grib_file = open(target, "ab" if append else "wb")
-    elif hasattr(target, "write"):
-        if hasattr(target, "mode") and "b" not in target.mode:
-            raise ValueError("Target not binary")
-        grib_file = target
-    else:
-        raise ValueError("Can only save grib to filename or writable")
-
-    for message in messages:
-        gribapi.grib_write(message, grib_file)
-        gribapi.grib_release(message)
-
-    # (this bit is common to the pp and grib savers...)
-    if isinstance(target, basestring):
-        grib_file.close()
-
-
-def as_messages(cube):
-    """
-    Convert one or more cubes to GRIB messages.
-
-    Args:
-        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
-
-    """
-    x_coords = cube.coords(axis='x', dim_coords=True)
-    y_coords = cube.coords(axis='y', dim_coords=True)
-    if len(x_coords) != 1 or len(y_coords) != 1:
-        raise TranslationError("Did not find one (and only one) x or y coord")
-
-    # Save each latlon slice2D in the cube
-    for slice2D in cube.slices([y_coords[0], x_coords[0]]):
-        grib_message = gribapi.grib_new_from_samples("GRIB2")
-        _save_rules.run(slice2D, grib_message)
-        yield grib_message
-
-
-def save(messages, target, append=False):
-    """
-    Save a messages to a GRIB2 file.
-
-    Args:
-
-        * messages
-        * target    - A filename or open file handle.
-
-    Kwargs:
-
-        * append    - Whether to start a new file afresh or add the cube(s) to the end of the file.
-                      Only applicable when target is a filename, not a file handle.
-                      Default is False.
+        * append    - Whether to start a new file afresh or add the cube(s) to
+                      the end of the file.
+                      Only applicable when target is a filename, not a file
+                      handle. Default is False.
 
     """
     # grib file (this bit is common to the pp and grib savers...)

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -1008,3 +1008,58 @@ def save(messages, target, append=False):
     # (this bit is common to the pp and grib savers...)
     if isinstance(target, basestring):
         grib_file.close()
+
+
+def as_messages(cube):
+    """
+    Convert one or more cubes to GRIB messages.
+
+    Args:
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+
+    """
+    x_coords = cube.coords(axis='x', dim_coords=True)
+    y_coords = cube.coords(axis='y', dim_coords=True)
+    if len(x_coords) != 1 or len(y_coords) != 1:
+        raise TranslationError("Did not find one (and only one) x or y coord")
+
+    # Save each latlon slice2D in the cube
+    for slice2D in cube.slices([y_coords[0], x_coords[0]]):
+        grib_message = gribapi.grib_new_from_samples("GRIB2")
+        _save_rules.run(slice2D, grib_message)
+        yield grib_message
+
+
+def save(messages, target, append=False):
+    """
+    Save a messages to a GRIB2 file.
+
+    Args:
+
+        * messages
+        * target    - A filename or open file handle.
+
+    Kwargs:
+
+        * append    - Whether to start a new file afresh or add the cube(s) to the end of the file.
+                      Only applicable when target is a filename, not a file handle.
+                      Default is False.
+
+    """
+    # grib file (this bit is common to the pp and grib savers...)
+    if isinstance(target, basestring):
+        grib_file = open(target, "ab" if append else "wb")
+    elif hasattr(target, "write"):
+        if hasattr(target, "mode") and "b" not in target.mode:
+            raise ValueError("Target not binary")
+        grib_file = target
+    else:
+        raise ValueError("Can only save grib to filename or writable")
+
+    for message in messages:
+        gribapi.grib_write(message, grib_file)
+        gribapi.grib_release(message)
+
+    # (this bit is common to the pp and grib savers...)
+    if isinstance(target, basestring):
+        grib_file.close()

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2032,7 +2032,29 @@ def save(cube, target, append=False, field_coords=None):
     See also :func:`iris.io.save`.
 
     """
+    fields = as_fields(cube)
+    save_fields(fields, target, append=append)
 
+
+def as_pairs(cube, field_coords=None):
+    """
+    Use the PP saving rules (and any user rules) to convert a cube to
+    an iterable of (2D cube, PP field) pairs.
+
+    Args:
+
+    * cube:
+        A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+
+    Kwargs:
+
+    * field_coords:
+        List of 2 coords or coord names which are to be used for
+        reducing the given cube into 2d slices, which will ultimately
+        determine the x and y coordinates of the resulting fields.
+        If None, the final two  dimensions are chosen for slicing.
+
+    """
     # Open issues
     # Could use rules in "sections" ... e.g. to process the extensive dimensions; ...?
     # Could pre-process the cube to add extra convenient terms?
@@ -2071,16 +2093,6 @@ def save(cube, target, append=False, field_coords=None):
     # unused?
 
     _ensure_save_rules_loaded()
-
-    # pp file
-    if isinstance(target, basestring):
-        pp_file = open(target, "ab" if append else "wb")
-    elif hasattr(target, "write"):
-        if hasattr(target, "mode") and "b" not in target.mode:
-            raise ValueError("Target not binary")
-        pp_file = target
-    else:
-        raise ValueError("Can only save pp to filename or writable")
 
     n_dims = len(cube.shape)
     if n_dims < 2:
@@ -2129,8 +2141,92 @@ def save(cube, target, append=False, field_coords=None):
         verify_rules_ran = rules_result.matching_rules
 
         # Log the rules used
-        iris.fileformats.rules.log('PP_SAVE', target if isinstance(target, basestring) else target.name, verify_rules_ran)
+        # XXX Get rid of this? Or have an optional `target` parameter?
+        #iris.fileformats.rules.log('PP_SAVE', target if isinstance(target, basestring) else target.name, verify_rules_ran)
 
+        yield (slice2D, pp_field)
+
+
+def as_fields(cube, field_coords=None):
+    """
+    Use the PP saving rules (and any user rules) to convert a cube to
+    an iterable of PP fields.
+
+    Args:
+
+    * cube:
+        A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or list of cubes.
+
+    Kwargs:
+
+    * field_coords:
+        List of 2 coords or coord names which are to be used for
+        reducing the given cube into 2d slices, which will ultimately
+        determine the x and y coordinates of the resulting fields.
+        If None, the final two  dimensions are chosen for slicing.
+
+    """
+    return (field for cube, field in as_pairs(cube, field_coords=field_coords))
+
+
+def save_fields(fields, target, append=False):
+    """
+    Save an iterable of PP fields to a PP file.
+
+    Args:
+
+    * fields:
+        TODO
+    * target:
+        A filename or open file handle.
+
+    Kwargs:
+
+    * append:
+        Whether to start a new file afresh or add the cube(s) to the end of the file.
+        Only applicable when target is a filename, not a file handle.
+        Default is False.
+    * callback:
+        A modifier/filter function.
+
+    See also :func:`iris.io.save`.
+
+    """
+    # Open issues
+
+    # Deal with:
+    #   LBLREC - Length of data record in words (incl. extra data)
+    #       Done on save(*)
+    #   LBUSER[0] - Data type
+    #       Done on save(*)
+    #   LBUSER[1] - Start address in DATA (?! or just set to "null"?)
+    #   BLEV - Level - the value of the coordinate for LBVC
+
+    # *) With the current on-save way of handling LBLREC and LBUSER[0] we can't
+    # check if they've been set correctly without *actually* saving as a binary
+    # PP file. That also means you can't use the same reference.txt file for
+    # loaded vs saved fields (unless you re-load the saved field!).
+
+    # Set to (or leave as) "null":
+    #   LBEGIN - Address of start of field in direct access dataset
+    #   LBEXP - Experiment identification
+    #   LBPROJ - Fields file projection number
+    #   LBTYP - Fields file field type code
+    #   LBLEV - Fields file level code / hybrid height model level
+
+    if isinstance(target, basestring):
+        pp_file = open(target, "ab" if append else "wb")
+        filename = target
+    elif hasattr(target, "write"):
+        if hasattr(target, "mode") and "b" not in target.mode:
+            raise ValueError("Target not binary")
+        filename = target.name if hasattr(target, 'name') else None
+        pp_file = target
+    else:
+        raise ValueError("Can only save pp to filename or writable")
+
+    # Save each field
+    for pp_field in fields:
         # Write to file
         pp_field.save(pp_file)
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2032,11 +2032,11 @@ def save(cube, target, append=False, field_coords=None):
     See also :func:`iris.io.save`.
 
     """
-    fields = as_fields(cube)
+    fields = as_fields(cube, field_coords)
     save_fields(fields, target, append=append)
 
 
-def as_pairs(cube, field_coords=None):
+def as_pairs(cube, field_coords=None, target=None):
     """
     Use the PP saving rules (and any user rules) to convert a cube to
     an iterable of (2D cube, PP field) pairs.
@@ -2142,12 +2142,16 @@ def as_pairs(cube, field_coords=None):
 
         # Log the rules used
         # XXX Get rid of this? Or have an optional `target` parameter?
-        #iris.fileformats.rules.log('PP_SAVE', target if isinstance(target, basestring) else target.name, verify_rules_ran)
+        if target is None:
+            target = 'None'
+        elif not isinstance(target, basestring):
+            target = target.name
+        iris.fileformats.rules.log('PP_SAVE', str(target), verify_rules_ran)
 
         yield (slice2D, pp_field)
 
 
-def as_fields(cube, field_coords=None):
+def as_fields(cube, field_coords=None, target=None):
     """
     Use the PP saving rules (and any user rules) to convert a cube to
     an iterable of PP fields.
@@ -2166,7 +2170,8 @@ def as_fields(cube, field_coords=None):
         If None, the final two  dimensions are chosen for slicing.
 
     """
-    return (field for cube, field in as_pairs(cube, field_coords=field_coords))
+    return (field for cube, field in as_pairs(cube, field_coords=field_coords,
+                                              target=target))
 
 
 def save_fields(fields, target, append=False):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2032,7 +2032,7 @@ def save(cube, target, append=False, field_coords=None):
     See also :func:`iris.io.save`.
 
     """
-    fields = as_fields(cube, field_coords)
+    fields = as_fields(cube, field_coords, target)
     save_fields(fields, target, append=append)
 
 
@@ -2053,6 +2053,9 @@ def as_pairs(cube, field_coords=None, target=None):
         reducing the given cube into 2d slices, which will ultimately
         determine the x and y coordinates of the resulting fields.
         If None, the final two  dimensions are chosen for slicing.
+
+    * target:
+        A filename or open file handle.
 
     """
     # Open issues
@@ -2141,7 +2144,6 @@ def as_pairs(cube, field_coords=None, target=None):
         verify_rules_ran = rules_result.matching_rules
 
         # Log the rules used
-        # XXX Get rid of this? Or have an optional `target` parameter?
         if target is None:
             target = 'None'
         elif not isinstance(target, basestring):
@@ -2169,6 +2171,9 @@ def as_fields(cube, field_coords=None, target=None):
         determine the x and y coordinates of the resulting fields.
         If None, the final two  dimensions are chosen for slicing.
 
+    * target:
+        A filename or open file handle.
+
     """
     return (field for cube, field in as_pairs(cube, field_coords=field_coords,
                                               target=target))
@@ -2181,7 +2186,7 @@ def save_fields(fields, target, append=False):
     Args:
 
     * fields:
-        TODO
+        An iterable of PP fields.
     * target:
         A filename or open file handle.
 

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -401,6 +401,42 @@ def simple_4d_with_hybrid_height():
                                     delta=cube.coord("level_height"),
                                     sigma=cube.coord("sigma"),
                                     orography=cube.coord("surface_altitude")))
+    return cube
+
+
+def realistic_3d():
+    """
+    Returns a realistic 3d cube.
+
+    >>> print(repr(realistic_3d()))
+    <iris 'Cube' of air_potential_temperature (time: 7; grid_latitude: 9;
+    grid_longitude: 11)>
+
+    """
+    data = np.arange(7*9*11).reshape((7,9,11))
+    lat_pts = np.linspace(-4, 4, 9)
+    lon_pts = np.linspace(-5, 5, 11)
+    time_pts = np.linspace(394200, 394236, 7)
+    forecast_period_pts = np.linspace(0, 36, 7)
+    ll_cs = RotatedGeogCS(37.5, 177.5, ellipsoid=GeogCS(6371229.0))
+
+    lat = icoords.DimCoord(lat_pts, standard_name='grid_latitude',
+                           units='degrees', coord_system=ll_cs)
+    lon = icoords.DimCoord(lon_pts, standard_name='grid_longitude',
+                           units='degrees', coord_system=ll_cs)
+    time = icoords.DimCoord(time_pts, standard_name='time',
+                            units='hours since 1970-01-01 00:00:00')
+    forecast_period = icoords.DimCoord(forecast_period_pts,
+                                       standard_name='forecast_period',
+                                       units='hours')
+    height = icoords.DimCoord(1000.0, standard_name='air_pressure',
+                              units='Pa')
+    cube = iris.cube.Cube(data, standard_name='air_potential_temperature',
+                          units='K',
+                          dim_coords_and_dims=[(time, 0), (lat, 1), (lon, 2)],
+                          aux_coords_and_dims=[(forecast_period, 0),
+                                               (height, None)],
+                          attributes={'source': 'Iris test case'})
     return cube
 
 

--- a/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
@@ -1,0 +1,50 @@
+# (C) British Crown Copyright 2014 - 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.grib.as_messages` function."""
+
+from __future__ import (absolute_import, division, print_function)
+
+import iris.tests as tests
+
+import mock
+
+import gribapi
+
+import iris
+from iris.coords import DimCoord
+import iris.fileformats.grib as grib
+import iris.tests.stock as stock
+
+
+class TestAsMessages(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.realistic_3d()
+
+    def test_TypeOfGeneratingProcess(self):
+        realization = 2
+        type_of_process = 4
+        coord = DimCoord(realization, standard_name='realization', units='1')
+        self.cube.add_aux_coord(coord)
+        messages = grib.as_messages(self.cube)
+        for message in messages:
+            self.assertEqual(gribapi.grib_get_long(message,
+                                                   'typeOfProcessedData'),
+                             type_of_process)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the `iris.fileformats.grib.as_messages` function."""
+"""Unit tests for the `iris.fileformats.grib.as_pairs` function."""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -39,8 +39,9 @@ class TestAsMessages(tests.IrisTest):
         type_of_process = 4
         coord = DimCoord(realization, standard_name='realization', units='1')
         self.cube.add_aux_coord(coord)
-        messages = grib.as_messages(self.cube)
-        for message in messages:
+        slices_and_messages = grib.as_pairs(self.cube)
+        for aslice, message in slices_and_messages:
+            self.assertEqual(aslice.shape, (9, 11))
             self.assertEqual(gribapi.grib_get_long(message,
                                                    'typeOfProcessedData'),
                              type_of_process)

--- a/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
@@ -1,0 +1,61 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.grib.save_messages` function."""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import gribapi
+import mock
+from mock import call
+import numpy as np
+
+import iris.fileformats.grib as grib
+
+
+class TestSaveMessages(tests.IrisTest):
+    def setUp(self):
+        # Create a test object to stand in for a real PPField.
+        self.grib_message = gribapi.grib_new_from_samples("GRIB2")
+
+    def test_save(self):
+        m = mock.mock_open()
+        with mock.patch('__builtin__.open', m, create=True):
+            # sending a MagicMock object to gribapi raises an AssertionError
+            # as the gribapi code does a type check
+            # this is deemed acceptable within the scope of this unit test
+            with self.assertRaises(AssertionError):
+                grib.save_messages([self.grib_message], 'foo.grib2')
+        self.assertTrue(call('foo.grib2', 'wb') in m.mock_calls)
+
+    def test_save_append(self):
+        m = mock.mock_open()
+        with mock.patch('__builtin__.open', m, create=True):
+            # sending a MagicMock object to gribapi raises an AssertionError
+            # as the gribapi code does a type check
+            # this is deemed acceptable within the scope of this unit test
+            with self.assertRaises(AssertionError):
+                grib.save_messages([self.grib_message], 'foo.grib2',
+                                   append=True)
+        self.assertTrue(call('foo.grib2', 'ab') in m.mock_calls)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -32,94 +32,19 @@ import iris.tests.stock as stock
 
 class TestAsFields(tests.IrisTest):
     def setUp(self):
-        self.cube = stock.lat_lon_cube()
+        self.cube = stock.realistic_3d()
 
-    def test_pseudo_level(self):
-        pseudo_level = 123
-        coord = DimCoord(pseudo_level, long_name='pseudo_level', units='1')
-        self.cube.add_aux_coord(coord)
+    def test_cube_only(self):
         fields = pp.as_fields(self.cube)
         for field in fields:
-            self.assertEqual(pseudo_level, field.lbuser[4])
+            self.assertEqual(field.lbcode, 101)
 
-
-class TestLbfcProduction(tests.IrisTest):
-    def setUp(self):
-        self.cube = stock.lat_lon_cube()
-
-    def check_cube_stash_yields_lbfc(self, stash, lbfc_expected):
-        if stash:
-            self.cube.attributes['STASH'] = stash
-        fields = pp.as_fields(self.cube)
+    def test_field_coords(self):
+        fields = pp.as_fields(self.cube,
+                              field_coords=['grid_longitude',
+                                            'grid_latitude'])
         for field in fields:
-            self.assertEqual(field.lbfc, lbfc_expected)
-
-    def test_known_stash(self):
-        stashcode_str = 'm04s07i002'
-        self.assertIn(stashcode_str, STASH_TRANS)
-        self.check_cube_stash_yields_lbfc(stashcode_str, 359)
-
-    def test_unknown_stash(self):
-        stashcode_str = 'm99s99i999'
-        self.assertNotIn(stashcode_str, STASH_TRANS)
-        self.check_cube_stash_yields_lbfc(stashcode_str, 0)
-
-    def test_no_stash(self):
-        self.assertNotIn('STASH', self.cube.attributes)
-        self.check_cube_stash_yields_lbfc(None, 0)
-
-    def check_cube_name_units_yields_lbfc(self, name, units, lbfc_expected):
-        self.cube.rename(name)
-        self.cube.units = units
-        fields = pp.as_fields(self.cube)
-        for field in fields:
-            self.assertEqual(field.lbfc, lbfc_expected,
-                             'Lbfc for ({!r} / {!r}) should be {:d}, '
-                             'got {:d}'.format(
-                                 name, units, lbfc_expected, field.lbfc))
-
-    def test_name_units_to_lbfc(self):
-        # Check LBFC value produced from name and units.
-        self.check_cube_name_units_yields_lbfc(
-            'sea_ice_temperature', 'K', 209)
-
-    def test_bad_name_units_to_lbfc_0(self):
-        # Check that badly-formed / unrecognised cases yield LBFC == 0.
-        self.check_cube_name_units_yields_lbfc('sea_ice_temperature', 'degC',
-                                               0)
-        self.check_cube_name_units_yields_lbfc('Junk_Name', 'K',
-                                               0)
-
-
-class TestLbsrceProduction(tests.IrisTest):
-    def setUp(self):
-        self.cube = stock.lat_lon_cube()
-
-    def check_cube_um_source_yields_lbsrce(
-            self, source_str=None, um_version_str=None, lbsrce_expected=None):
-        if source_str is not None:
-            self.cube.attributes['source'] = source_str
-        if um_version_str is not None:
-            self.cube.attributes['um_version'] = um_version_str
-        fields = pp.as_fields(self.cube)
-        for field in fields:
-            self.assertEqual(field.lbsrce, lbsrce_expected)
-
-    def test_none(self):
-        self.check_cube_um_source_yields_lbsrce(
-            None, None, 0)
-
-    def test_source_only_no_version(self):
-        self.check_cube_um_source_yields_lbsrce(
-            'Data from Met Office Unified Model', None, 1111)
-
-    def test_source_only_with_version(self):
-        self.check_cube_um_source_yields_lbsrce(
-            'Data from Met Office Unified Model 12.17', None, 12171111)
-
-    def test_um_version(self):
-        self.check_cube_um_source_yields_lbsrce(
-            'Data from Met Office Unified Model 12.17', '25.36', 25361111)
+            self.assertEqual(field.lbcode, 101)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -1,0 +1,126 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.as_fields` function."""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+
+from iris.coords import DimCoord
+from iris.fileformats._ff_cross_references import STASH_TRANS
+import iris.fileformats.pp as pp
+import iris.tests.stock as stock
+
+
+class TestAsFields(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.lat_lon_cube()
+
+    def test_pseudo_level(self):
+        pseudo_level = 123
+        coord = DimCoord(pseudo_level, long_name='pseudo_level', units='1')
+        self.cube.add_aux_coord(coord)
+        fields = pp.as_fields(self.cube)
+        for field in fields:
+            self.assertEqual(pseudo_level, field.lbuser[4])
+
+
+class TestLbfcProduction(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.lat_lon_cube()
+
+    def check_cube_stash_yields_lbfc(self, stash, lbfc_expected):
+        if stash:
+            self.cube.attributes['STASH'] = stash
+        fields = pp.as_fields(self.cube)
+        for field in fields:
+            self.assertEqual(field.lbfc, lbfc_expected)
+
+    def test_known_stash(self):
+        stashcode_str = 'm04s07i002'
+        self.assertIn(stashcode_str, STASH_TRANS)
+        self.check_cube_stash_yields_lbfc(stashcode_str, 359)
+
+    def test_unknown_stash(self):
+        stashcode_str = 'm99s99i999'
+        self.assertNotIn(stashcode_str, STASH_TRANS)
+        self.check_cube_stash_yields_lbfc(stashcode_str, 0)
+
+    def test_no_stash(self):
+        self.assertNotIn('STASH', self.cube.attributes)
+        self.check_cube_stash_yields_lbfc(None, 0)
+
+    def check_cube_name_units_yields_lbfc(self, name, units, lbfc_expected):
+        self.cube.rename(name)
+        self.cube.units = units
+        fields = pp.as_fields(self.cube)
+        for field in fields:
+            self.assertEqual(field.lbfc, lbfc_expected,
+                             'Lbfc for ({!r} / {!r}) should be {:d}, '
+                             'got {:d}'.format(
+                                 name, units, lbfc_expected, field.lbfc))
+
+    def test_name_units_to_lbfc(self):
+        # Check LBFC value produced from name and units.
+        self.check_cube_name_units_yields_lbfc(
+            'sea_ice_temperature', 'K', 209)
+
+    def test_bad_name_units_to_lbfc_0(self):
+        # Check that badly-formed / unrecognised cases yield LBFC == 0.
+        self.check_cube_name_units_yields_lbfc('sea_ice_temperature', 'degC',
+                                               0)
+        self.check_cube_name_units_yields_lbfc('Junk_Name', 'K',
+                                               0)
+
+
+class TestLbsrceProduction(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.lat_lon_cube()
+
+    def check_cube_um_source_yields_lbsrce(
+            self, source_str=None, um_version_str=None, lbsrce_expected=None):
+        if source_str is not None:
+            self.cube.attributes['source'] = source_str
+        if um_version_str is not None:
+            self.cube.attributes['um_version'] = um_version_str
+        fields = pp.as_fields(self.cube)
+        for field in fields:
+            self.assertEqual(field.lbsrce, lbsrce_expected)
+
+    def test_none(self):
+        self.check_cube_um_source_yields_lbsrce(
+            None, None, 0)
+
+    def test_source_only_no_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model', None, 1111)
+
+    def test_source_only_with_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model 12.17', None, 12171111)
+
+    def test_um_version(self):
+        self.check_cube_um_source_yields_lbsrce(
+            'Data from Met Office Unified Model 12.17', '25.36', 25361111)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -14,36 +14,39 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the `iris.fileformats.grib.as_messages` function."""
+"""Unit tests for the `iris.fileformats.pp.as_pairs` function."""
 
 from __future__ import (absolute_import, division, print_function)
 
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
 import iris.tests as tests
 
 import mock
 
-import gribapi
-
-import iris
 from iris.coords import DimCoord
-import iris.fileformats.grib as grib
+from iris.fileformats._ff_cross_references import STASH_TRANS
+import iris.fileformats.pp as pp
 import iris.tests.stock as stock
 
 
-class TestAsMessages(tests.IrisTest):
+class TestAsFields(tests.IrisTest):
     def setUp(self):
         self.cube = stock.realistic_3d()
 
-    def test_as_messages(self):
-        realization = 2
-        type_of_process = 4
-        coord = DimCoord(realization, standard_name='realization', units='1')
-        self.cube.add_aux_coord(coord)
-        messages = grib.as_messages(self.cube)
-        for message in messages:
-            self.assertEqual(gribapi.grib_get_long(message,
-                                                   'typeOfProcessedData'),
-                             type_of_process)
+    def test_cube_only(self):
+        slices_and_fields = pp.as_pairs(self.cube)
+        for aslice, field in slices_and_fields:
+            self.assertEqual(aslice.shape, (9, 11))
+            self.assertEqual(field.lbcode, 101)
+
+    def test_field_coords(self):
+        slices_and_fields = pp.as_pairs(self.cube,
+                                        field_coords=['grid_longitude',
+                                                      'grid_latitude'])
+        for aslice, field in slices_and_fields:
+            self.assertEqual(aslice.shape, (11, 9))
+            self.assertEqual(field.lbcode, 101)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -1,0 +1,61 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.fileformats.pp.save_fields` function."""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+from mock import call
+import numpy as np
+
+import iris.fileformats.pp as pp
+
+
+def asave(afilehandle):
+    afilehandle.write('saved')
+
+
+class TestSaveFields(tests.IrisTest):
+    def setUp(self):
+        # Create a test object to stand in for a real PPField.
+        self.pp_field = mock.MagicMock(spec=pp.PPField3)
+        # Add minimal content required by the pp.save operation.
+        self.pp_field.HEADER_DEFN = pp.PPField3.HEADER_DEFN
+        self.pp_field.data = np.zeros((1, 1))
+        self.pp_field.save = asave
+
+    def test_save(self):
+        m = mock.mock_open()
+        with mock.patch('__builtin__.open', m, create=True):
+            pp.save_fields([self.pp_field], 'foo.pp')
+        self.assertTrue(call('foo.pp', 'wb') in m.mock_calls)
+        self.assertTrue(call().write('saved') in m.mock_calls)
+
+    def test_save_append(self):
+        m = mock.mock_open()
+        with mock.patch('__builtin__.open', m, create=True):
+            pp.save_fields([self.pp_field], 'foo.pp', append=True)
+        self.assertTrue(call('foo.pp', 'ab') in m.mock_calls)
+        self.assertTrue(call().write('saved') in m.mock_calls)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
Deconstructed Save for GRIB and PP

as_messages | as_fields provides an interim step which may be used by users to adapt the field/message prior to saving

The save API is unchanged and all iris.save functionality is intended to be unchanged

Testing strategy: 
  unit tests are added for as_fields|as_messages following the pattern from pp.save|grib.save
  save unit tests and integration tests are left as is, which then test the save_message|save_field functions

Attempts to replace #1642 