### PR TITLE
BUG: Tolerant intersection

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/bugfix_2015-18-09_unnecessary_wrap_intersection.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/bugfix_2015-18-09_unnecessary_wrap_intersection.txt
@@ -1,0 +1,2 @@
+* fixed a bug in :meth:`iris.cube.Cube.intersection`.
+  When edge points were at (base + period), intersection would unnecessarily wrap the data.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2131,6 +2131,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # unordered collection of indices) we can simply index the cube
         # and we're done. If it's two subsets we need to stitch the two
         # pieces together.
+        # subsets provides a way of slicing the coordinates to ensure that
+        # they remain contiguous.  In doing so, this can mean
+        # transforming the data (this stitching together of two separate
+        # pieces).
         def make_chunk(key):
             chunk = self[key_tuple_prefix + (key,)]
             chunk_coord = chunk.coord(coord)
@@ -2278,8 +2282,68 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # because we've already restricted the coordinate's
                 # range to its modulus).
                 end_of_first_chunk = non_zero_step_indices[0]
-                subsets = [slice(inside_indices[end_of_first_chunk + 1], None),
-                           slice(None, inside_indices[end_of_first_chunk] + 1)]
+
+                # Ensure that we do not wrap if blocks are at the very edge.
+                # That is, if the very edge is wrapped and corresponds to
+                # base + period, stop this unnecessary wraparound.
+                # NOTE: The relationship between final index wrapping and
+                # being an increasing coordinate; and first index and being
+                # a decreasing coordinate, is based on the behaviour of
+                # wrap_lons.  wrap_lons wraps points at base + period.  How
+                # they are wrapped always identifies the direction of the
+                # coordinate.
+
+                # The following condition holds for increasing or decreasing
+                # coordinates with wraparound.
+                # Condition1: The two blocks don't themselves wrap
+                #             (inside_indices is contiguous).
+                # Condition2: Are we chunked at either extreme edge.
+                index_of_second_chunk = inside_indices[end_of_first_chunk + 1]
+                final_index = points.size - 1
+                if ((index_of_second_chunk ==
+                        inside_indices[end_of_first_chunk] + 1) and
+                        index_of_second_chunk in (final_index, 1)):
+
+                    # Check if final index is wrapped (increasing coordinate).
+                    # i.e. start of the second chunk is at the final index.
+                    if index_of_second_chunk == final_index:
+                        # Unwrap points and bounds
+                        if (bounds is not None and
+                                np.isclose(coord.bounds[-1, -1],
+                                           coord.bounds[0, 0] + modulus)):
+                            bounds[-1, :] = coord.bounds[-1, :]
+                            points[-1] = coord.points[-1]
+                            subsets = [slice(inside_indices[0],
+                                             inside_indices[-1] + 1)]
+                        # Unwrap points
+                        elif np.isclose(coord.points[-1],
+                                        coord.points[0] + modulus):
+                            points[-1] = coord.points[-1]
+                            subsets = [slice(inside_indices[0],
+                                       inside_indices[-1] + 1)]
+
+                    # Check if first index is wrapped (decreasing coordinate).
+                    # i.e. start of the second chunk is at the second index.
+                    elif index_of_second_chunk == 1:
+                        # Unwrap points and bounds
+                        if (bounds is not None and
+                                np.isclose(coord.bounds[0, 0],
+                                           coord.bounds[-1, -1] + modulus)):
+                            bounds[0, :] = coord.bounds[0, :]
+                            points[0] = coord.points[0]
+                            subsets = [slice(inside_indices[0],
+                                             inside_indices[-1] + 1)]
+                        # Unwrap points
+                        elif np.isclose(coord.points[0],
+                                        coord.points[-1] + modulus):
+                            points[0] = coord.points[0]
+                            subsets = [slice(inside_indices[0],
+                                             inside_indices[-1] + 1)]
+                else:
+                    subsets = [
+                        slice(index_of_second_chunk, None),
+                        slice(None, inside_indices[end_of_first_chunk] + 1)
+                        ]
             else:
                 # A single, contiguous block.
                 subsets = [slice(inside_indices[0], inside_indices[-1] + 1)]

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -768,6 +768,14 @@ class Test_intersection__RegionalSrcModulus(tests.IrisTest):
 # Check what happens with a global, points-only circular intersection
 # coordinate.
 class Test_intersection__GlobalSrcModulus(tests.IrisTest):
+    def test_global_wrapped_extreme(self):
+        # Ensure that we can correctly handle points defined at (base + period)
+        cube = create_cube(-180., 180.)
+        lons = cube.coord('longitude')
+        result = cube.intersection(longitude=(lons.points.min(),
+                                              lons.points.max()))
+        self.assertArrayEqual(result.data, cube.data)
+
     def test_global(self):
         cube = create_cube(0, 360)
         result = cube.intersection(longitude=(0, 360))
@@ -933,6 +941,22 @@ class Test_intersection__GlobalSrcModulus(tests.IrisTest):
 # Check what happens with a global, points-and-bounds circular
 # intersection coordinate.
 class Test_intersection__ModulusBounds(tests.IrisTest):
+    def test_global_wrapped_extreme_increasing(self):
+        # Ensure that we can correctly handle bounds defined at (base + period)
+        cube = create_cube(-180., 180., bounds=True)
+        lons = cube.coord('longitude')
+        result = cube.intersection(longitude=(lons.bounds.min(),
+                                              lons.bounds.max()))
+        self.assertArrayEqual(result.data, cube.data)
+
+    def test_global_wrapped_extreme_decreasing(self):
+        # Ensure that we can correctly handle bounds defined at (base + period)
+        cube = create_cube(180., -180., bounds=True)
+        lons = cube.coord('longitude')
+        result = cube.intersection(longitude=(lons.bounds.min(),
+                                              lons.bounds.max()))
+        self.assertArrayEqual(result.data, cube.data)
+
     def test_misaligned_points_inside(self):
         cube = create_cube(0, 360, bounds=True)
         result = cube.intersection(longitude=(169.75, 190.25))


### PR DESCRIPTION
This PR stops intersection from wrapping grids for the following situation:

The grid is being split in two at either edge due to the point being a value of (base + period).

This is not at all a neat solution but it yield the desired result.  Any alternate solutions are welcome.

Further context in #1662