### PR TITLE
unordered pp cell methods

### DIFF
--- a/lib/iris/tests/test_pp_to_cube.py
+++ b/lib/iris/tests/test_pp_to_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -151,13 +151,14 @@ class TestPPLoadRules(tests.IrisTest):
         orig_file = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
 
         # Values that result in cell methods being created
-        cell_method_values = {128: "mean within years",
+        cell_method_values = {64: "mean",
+                              128: "mean within years",
                               4096: "minimum",
                               8192: "maximum"}
 
         # Make test values as list of single bit values and some multiple bit values
         single_bit_values = list(iris.fileformats.pp.LBPROC_PAIRS)
-        multiple_bit_values = [(128 + 64, ""), (4096 + 2096, ""), (8192 + 1024, "")]
+        multiple_bit_values = [(128 + 32, ""), (4096 + 2096, ""), (8192 + 1024, "")]
         test_values = list(single_bit_values) + multiple_bit_values
 
         for value, _ in test_values:
@@ -186,7 +187,7 @@ class TestPPLoadRules(tests.IrisTest):
         orig_file = tests.get_data_path(('PP', 'aPPglob1', 'global.pp'))
 
         # Values that result in process flags attribute NOT being created
-        omit_process_flags_values = (128, 4096, 8192)
+        omit_process_flags_values = (64, 128, 4096, 8192)
 
         # Test single flag values
         for value, _ in iris.fileformats.pp.LBPROC_PAIRS:
@@ -210,7 +211,7 @@ class TestPPLoadRules(tests.IrisTest):
             os.remove(temp_filename)
 
         # Test multiple flag values
-        multiple_bit_values = ((128, 64), (4096, 1024), (8192, 1024))
+        multiple_bit_values = ((128, 32), (4096, 1024), (8192, 1024))
 
         # Maps lbproc value to the process flags that should be created
         multiple_map = {sum(x) : [iris.fileformats.pp.lbproc_map[y] for y in x] for x in multiple_bit_values}

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ import mock
 
 import iris
 from iris.fileformats.pp_rules import _all_other_rules
+from iris.fileformats.pp import SplittableInt
 from iris.coords import CellMethod
 
 
@@ -113,6 +114,28 @@ class TestCellMethods(tests.IrisTest):
                                lbtim=mock.Mock(ia=24, ib=5, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
         expected = [CellMethod('minimum', 'time')]
+        self.assertEqual(res, expected)
+
+    def test_multiple_unordered_lbprocs(self):
+        field = mock.MagicMock(lbproc=192,
+                               lbtim=mock.Mock(ia=24, ib=5, ic=3),
+                               lbcode=SplittableInt(1),
+                               _x_coord_name=lambda: 'longitude',
+                               _y_coord_name=lambda: 'latitude')
+        res = _all_other_rules(field)[CELL_METHODS_INDEX]
+        expected = [CellMethod('mean', 'time'),
+                    CellMethod('mean', 'longitude')]
+        self.assertEqual(res, expected)
+
+    def test_multiple_unordered_rotated_lbprocs(self):
+        field = mock.MagicMock(lbproc=192,
+                               lbtim=mock.Mock(ia=24, ib=5, ic=3),
+                               lbcode=SplittableInt(101),
+                               _x_coord_name=lambda: 'grid_longitude',
+                               _y_coord_name=lambda: 'grid_latitude')
+        res = _all_other_rules(field)[CELL_METHODS_INDEX]
+        expected = [CellMethod('mean', 'time'),
+                    CellMethod('mean', 'grid_longitude')]
         self.assertEqual(res, expected)
 
 


### PR DESCRIPTION
This PR enables a PP compound LBPROC of time mean and zonal(x_coord) mean to be loaded.

The cell method order is not important, as the operations are independent, which is valid within CF
http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#statistics-more-than-one-axis
so an arbitrary order is applied
