### PR TITLE
Added check to ensure that no file is overwritten unless 'append' key…

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -345,6 +345,12 @@ def save(source, target, saver=None, **kwargs):
     if saver is None:
         raise ValueError("Cannot save; no saver")
 
+    # Don't overwrite!
+    if ((not('append' in kwargs) or kwargs['append'] is False)
+            and os.path.exists(target)):
+        msg = "File \'{!s}\' exists and \'append\' has not been set True."
+        raise ValueError(msg.format(target))
+
     # Single cube?
     if isinstance(source, iris.cube.Cube):
         saver(source, target, **kwargs)


### PR DESCRIPTION
…word exists and has been set True.

An issue has been reported, where attempting to overwrite a file causes corruption. I've verified this on both nc and pp files. The two ways of handling this I can think of are to have iris write to a temp file, then delete/rename - or to simply prevent overwriting a file unless the 'append' keyword is set true (and the appropriate saver can handle it, obviously). The latter was my preferred choice, since the first option is non-atomic, less obvious to a user who may wonder where all their disk space has gone - and has the potential for leaving unexpected junk if the script is killed or an exception is thrown.

I don't know if this is the best way/place to handle it - but thought it was worth pushing it for feedback.

Regards,
Gray.