### PR TITLE
Replace UserDict with collections.MutableMapping.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -27,7 +27,6 @@ import collections
 import copy
 import datetime
 import operator
-import UserDict
 import warnings
 import zlib
 
@@ -3432,7 +3431,7 @@ calendar='gregorian')
         return regridder(self)
 
 
-class ClassDict(object, UserDict.DictMixin):
+class ClassDict(collections.MutableMapping, object):
     """
     A mapping that stores objects keyed on their superclasses and their names.
 
@@ -3482,6 +3481,9 @@ class ClassDict(object, UserDict.DictMixin):
         except KeyError:
             raise KeyError('Coordinate system %r does not exist.' % class_)
 
+    def __setitem__(self, key, value):
+        raise NotImplementedError('You must call the add method instead.')
+
     def __delitem__(self, class_):
         cs = self[class_]
         keys = [k for k, v in self._retrieval_map.iteritems() if v == cs]
@@ -3489,6 +3491,13 @@ class ClassDict(object, UserDict.DictMixin):
             del self._retrieval_map[key]
         del self._basic_map[type(cs)]
         return cs
+
+    def __len__(self):
+        return len(self._basic_map)
+
+    def __iter__(self):
+        for item in self._basic_map:
+            yield item
 
     def keys(self):
         '''Return the keys of the dictionary mapping.'''

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -28,10 +28,9 @@ References:
 from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
-from collections import Iterable
+from collections import Iterable, MutableMapping
 import os
 import re
-import UserDict
 import warnings
 
 import netCDF4
@@ -784,7 +783,7 @@ class CFMeasureVariable(CFVariable):
 
 
 ################################################################################
-class CFGroup(object, UserDict.DictMixin):
+class CFGroup(MutableMapping, object):
     """
     Represents a collection of 'NetCDF Climate and Forecast (CF) Metadata
     Conventions' variables and netCDF global attributes.
@@ -855,6 +854,13 @@ class CFGroup(object, UserDict.DictMixin):
     def keys(self):
         """Return the names of all the CF-netCDF variables in the group."""
         return self._cf_variables.keys()
+
+    def __len__(self):
+        return len(self._cf_variables)
+
+    def __iter__(self):
+        for item in self._cf_variables:
+            yield item
 
     def __setitem__(self, name, variable):
         if not isinstance(variable, CFVariable):


### PR DESCRIPTION
The UserDict package is not available in Python 3, and added in 2.7.