### PR TITLE
Added warning about data loss from overwriting a source file.

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -334,6 +334,23 @@ def save(source, target, saver=None, **kwargs):
         # Save a cube list to netCDF, using the NETCDF4_CLASSIC storage option
         iris.save(my_cube_list, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
 
+    .. warning::
+
+       Saving a cube whose data has been loaded lazily
+       (if `cube.has_lazy_data()` returns `True`) to the same file it expects
+       to load data from will cause both the data in-memory and the data on
+       disk to be lost.
+
+       .. code-block:: python
+
+          cube = iris.load_cube('somefile.nc')
+          # The next line causes data loss in 'somefile.nc' and the cube.
+          iris.save(cube, 'somefile.nc')
+
+       In general, overwriting a file which is the source for any lazily loaded
+       data can result in corruption. Users should proceed with caution when
+       attempting to overwrite an existing file.
+
     """
     # Determine format from filename
     if isinstance(target, basestring) and saver is None:


### PR DESCRIPTION
Hopefully someone can educate me on good documentation style! Following #1678, I've seen no clear way to resolve this issue, so I think a warning should be added to the docstring for iris.save in order to reduce the chance of someone losing data. @pelson would you mind criticizing?

Many thanks,
Gray.