### PR TITLE
Add GRIB2 load support for GDT-50 (spherical harmonics).

### DIFF
--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -889,6 +889,62 @@ def grid_definition_template_40_reduced(section, metadata, cs):
     metadata['aux_coords_and_dims'].append((x_coord, 0))
 
 
+def grid_definition_template_50(section, metadata):
+    """
+    Translate template representing spherical harmonic coefficients.
+
+    Updates the metadata in-place with the translations.
+
+    Args:
+
+    * section:
+        Dictionary of coded key/value pairs from section 3 of the message.
+
+    * metadata:
+        :class:`collections.OrderedDict` of metadata.
+
+    """
+    # Extract the wavenumber parameters.
+    J = section['J']
+    K = section['K']
+    M = section['M']
+
+    # Define the indexing function for each possible spectral representaion.
+    if J == K == M:
+        ttype = 'triangular'
+        Nm = lambda m: J
+    elif K == (J + M):
+        ttype = 'rhomboidal'
+        Nm = lambda m: J + m
+    elif K == J and K > M:
+        ttype = 'trapezoidal'
+        Nm = lambda m: J
+    else:
+        raise TranslationError('Unsupported spectral representation: '
+                               'J={}, K={}, M={}'.format(J, K, M))
+
+    # Calculate the wavenumber coordinates.
+    mn = [(_m, _n) for _m in range(M + 1) for _n in range(_m, Nm(_m) + 1)]
+
+    # Create AuxCoords for the wavenumber coordinates.
+    m_coord = AuxCoord([p[0] for p in mn], long_name='zonal_wavenumber',
+                       units=1, coord_system=None)
+    n_coord = AuxCoord([p[1] for p in mn], long_name='meridional_wavenumber',
+                       units=1, coord_system=None)
+
+    # Add the wavenumber coordinates to the metadata aux coords.
+    metadata['aux_coords_and_dims'].append((m_coord, 0))
+    metadata['aux_coords_and_dims'].append((n_coord, 0))
+
+    # Add extra attributes describing the spectral representation. Without
+    # these it would be very tricky to determine the type of truncation
+    # used, requiring careful inspection of the wavenumber coordinates.
+    metadata['attributes']['truncation_type'] = ttype
+    metadata['attributes']['J'] = J
+    metadata['attributes']['K'] = K
+    metadata['attributes']['M'] = M
+
+
 def grid_definition_template_90(section, metadata):
     """
     Translate template representing space view.
@@ -1035,7 +1091,11 @@ def grid_definition_section(section, metadata):
         # Process transverse Mercator.
         grid_definition_template_12(section, metadata)
     elif template == 40:
+        # Process Gaussian grid.
         grid_definition_template_40(section, metadata)
+    elif template == 50:
+        # Process spherical harmonics.
+        grid_definition_template_50(section, metadata)
     elif template == 90:
         # Process space view.
         grid_definition_template_90(section, metadata)

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -117,6 +117,28 @@ class _GribMessage(object):
             proxy = _DataProxy(shape, np.dtype('f8'), np.nan,
                                self._recreate_raw)
             data = biggus.NumpyArrayAdapter(proxy)
+        elif template in (50,):
+            # Spherical harmonics are slightly different to spatial data. We
+            # need to determine the truncation type in order to calculate the
+            # number of coefficients in the spectral representation.
+            J = grid_section['J']
+            K = grid_section['K']
+            M = grid_section['M']
+            if J == K == M:
+                # Triangular truncation.
+                ncoefs = (M + 1) * (J + 2) // 2
+            elif K == (J + M):
+                # Rhomboidal truncation.
+                ncoefs = (M + 1) * (J + 1)
+            elif K == J and K > M:
+                # Trapezoidal truncation.
+                ncoefs = (M + 1) * (2 * J + 2 - M) // 2
+            else:
+                msg = 'Unsupported spectral representation: J={}, K={}, M={}'
+                raise TranslationError(msg.format(J, K, M))
+            proxy = _DataProxy((ncoefs,), np.dtype('c16'), np.nan,
+                               self._recreate_raw)
+            data = biggus.NumpyArrayAdapter(proxy)
         else:
             fmt = 'Grid definition template {} is not supported'
             raise TranslationError(fmt.format(template))
@@ -189,7 +211,12 @@ class _DataProxy(object):
         sections = message.sections
         bitmap_section = sections[6]
         bitmap = self._bitmap(bitmap_section)
-        data = sections[7]['codedValues']
+        # Retrieving the key 'codedValues' always results in a dtype of 'f8'
+        # (uses grib_get_double_array() under the hood). Taking a view of this
+        # array using the proxy's native dtype has no effect for a proxy whose
+        # dtype is also 'f8', but allows proxies that uses other dtypes (such
+        # as 'c16') to properly interpret the 'codedValues' key.
+        data = sections[7]['codedValues'].view(self.dtype)
 
         if bitmap is not None:
             # Note that bitmap and data are both 1D arrays at this point.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_50.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_50.py
@@ -1,0 +1,111 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for
+:func:`iris.fileformats.grib._load_convert.grid_definition_template_50`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris.coords
+from iris.tests.unit.fileformats.grib.load_convert import empty_metadata
+from iris.fileformats.grib._load_convert import grid_definition_template_50
+
+
+MDI = 2 ** 32 - 1
+
+
+class Test(tests.IrisTest):
+
+    params = {'triangular': {'J': 5, 'K': 5, 'M': 5},
+              'rhomboidal': {'J': 5, 'K': 10, 'M': 5},
+              'trapezoidal': {'J': 5, 'K': 5, 'M': 3}}
+
+    def section_3(self, truncation_type):
+        section = {
+            'shapeOfTheEarth': 0,
+            'scaleFactorOfRadiusOfSphericalEarth': 0,
+            'scaledValueOfRadiusOfSphericalEarth': 6367470,
+            'scaleFactorOfEarthMajorAxis': 0,
+            'scaledValueOfEarthMajorAxis': MDI,
+            'scaleFactorOfEarthMinorAxis': 0,
+            'scaledValueOfEarthMinorAxis': MDI,
+            'J': self.params[truncation_type]['J'],
+            'K': self.params[truncation_type]['K'],
+            'M': self.params[truncation_type]['M'],
+        }
+        return section
+
+    def expected(self, truncation_type):
+        expected = empty_metadata()
+        if truncation_type == 'triangular':
+            m_points = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
+                        2, 2, 2, 2, 3, 3, 3, 4, 4, 5]
+            n_points = [0, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                        2, 3, 4, 5, 3, 4, 5, 4, 5, 5]
+        elif truncation_type == 'rhomboidal':
+            m_points = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
+                        3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5]
+            n_points = [0, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 2, 3, 4, 5, 6, 7,
+                        3, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 9, 5, 6, 7, 8, 9, 10]
+        elif truncation_type == 'trapezoidal':
+            m_points = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3]
+            n_points = [0, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 5]
+        m_coord = iris.coords.AuxCoord(m_points, long_name='zonal_wavenumber',
+                                       units=1, coord_system=None)
+        n_coord = iris.coords.AuxCoord(n_points,
+                                       long_name='meridional_wavenumber',
+                                       units=1, coord_system=None)
+        expected['aux_coords_and_dims'].append((m_coord, 0))
+        expected['aux_coords_and_dims'].append((n_coord, 0))
+        expected['attributes']['truncation_type'] = truncation_type
+        expected['attributes']['J'] = self.params[truncation_type]['J']
+        expected['attributes']['K'] = self.params[truncation_type]['K']
+        expected['attributes']['M'] = self.params[truncation_type]['M']
+        return expected
+
+    def test_triangular(self):
+        section = self.section_3('triangular')
+        metadata = empty_metadata()
+        grid_definition_template_50(section, metadata)
+        expected = self.expected('triangular')
+        self.assertEqual(metadata, expected)
+
+    def test_rhomboidal(self):
+        section = self.section_3('rhomboidal')
+        metadata = empty_metadata()
+        grid_definition_template_50(section, metadata)
+        expected = self.expected('rhomboidal')
+        self.assertEqual(metadata, expected)
+
+    def test_trapezoidal(self):
+        section = self.section_3('trapezoidal')
+        metadata = empty_metadata()
+        grid_definition_template_50(section, metadata)
+        expected = self.expected('trapezoidal')
+        self.assertEqual(metadata, expected)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -69,7 +69,7 @@ class Test_data__masked(tests.IrisTest):
                            'Ni': self.shape[1]}
 
     def test_no_bitmap(self):
-        values = np.arange(12)
+        values = np.arange(12, dtype=np.float64)
         message = _make_test_message({3: self._section_3,
                                       6: SECTION_6_NO_BITMAP,
                                       7: {'codedValues': values}})
@@ -81,7 +81,7 @@ class Test_data__masked(tests.IrisTest):
     def test_bitmap_present(self):
         # Test the behaviour where bitmap and codedValues shapes
         # are not equal.
-        input_values = np.arange(5)
+        input_values = np.arange(5, dtype=np.float64)
         output_values = np.array([-1, -1, 0, 1, -1, -1, -1, 2, -1, 3, -1, 4])
         message = _make_test_message({3: self._section_3,
                                       6: {'bitMapIndicator': 0,
@@ -96,7 +96,7 @@ class Test_data__masked(tests.IrisTest):
     def test_bitmap__shapes_mismatch(self):
         # Test the behaviour where bitmap and codedValues shapes do not match.
         # Too many or too few unmasked values in codedValues will cause this.
-        values = np.arange(6)
+        values = np.arange(6, dtype=np.float64)
         message = _make_test_message({3: self._section_3,
                                       6: {'bitMapIndicator': 0,
                                           'bitmap': self.bitmap},
@@ -105,7 +105,7 @@ class Test_data__masked(tests.IrisTest):
             message.data.masked_array()
 
     def test_bitmap__invalid_indicator(self):
-        values = np.arange(12)
+        values = np.arange(12, dtype=np.float64)
         message = _make_test_message({3: self._section_3,
                                       6: {'bitMapIndicator': 100,
                                           'bitmap': None},
@@ -170,7 +170,7 @@ class Mixin_data__grid_template(object):
         message = _make_test_message(
             {3: self.section_3(scanning_mode),
              6: SECTION_6_NO_BITMAP,
-             7: {'codedValues': np.arange(12)}})
+             7: {'codedValues': np.arange(12, dtype=np.float64)}})
         data = message.data
         self.assertIsInstance(data, biggus.Array)
         self.assertEqual(data.shape, (3, 4))
@@ -236,6 +236,49 @@ class Test_data__grid_template_90(tests.IrisTest, Mixin_data__grid_template):
         del section_3['Ni']
         del section_3['Nj']
         return section_3
+
+
+class Test_data_grid_template_50(tests.IrisTest):
+
+    def section_3(self, J, K, M):
+        return {'sourceOfGridDefinition': 0,
+                'numberOfOctectsForNumberOfPoints': 0,
+                'interpretationOfNumberOfPoints': 0,
+                'gridDefinitionTemplateNumber': 50,
+                'J': J,
+                'K': K,
+                'M': M}
+
+    def _test(self, J, K, M, ncoefs):
+        message = _make_test_message(
+            {3: self.section_3(J, K, M),
+             6: SECTION_6_NO_BITMAP,
+             7: {'codedValues': np.arange(ncoefs * 2, dtype=np.float64)}})
+        data = message.data
+        self.assertIsInstance(data, biggus.Array)
+        self.assertEqual(data.shape, (ncoefs,))
+        self.assertEqual(data.dtype, np.complex)
+        self.assertIs(data.fill_value, np.nan)
+        self.assertArrayEqual(
+            data.ndarray(),
+            np.arange(ncoefs * 2, dtype=np.float64).view(np.complex128))
+
+    def test_triangular(self):
+        J = K = M = 5
+        ncoefs = 21
+        self._test(J, K, M, ncoefs)
+
+    def test_rhomboidal(self):
+        J = M = 5
+        K = J + M
+        ncoefs = 36
+        self._test(J, K, M, ncoefs)
+
+    def test_trapezoidal(self):
+        J = K = 5
+        M = 3
+        ncoefs = 18
+        self._test(J, K, M, ncoefs)
 
 
 class Test_data__unknown_grid_template(tests.IrisTest):


### PR DESCRIPTION
This PR represents a preliminary attempt at loading spherical harmonics from GRIB2 files using Iris. I say preliminary because there is no CF specification for representing spherical harmonics. There will be specifics of this that require further discussion, in particular the question of what metadata beyond coordinates should the translation add to allow better understanding of the loaded coefficients (e.g. spectral resolution, coefficient normalisation).

The current implementation simply loads the coefficients as a 1D array, along with two auxiliary coordinates to describe the zonal and meridional wavenumber associated with each coefficient. I've also added attributes relating to the spectral resolution and truncation.

Most of the model output I generate is initially in the form of spherical harmonics. While Iris may not have built-in functionality to actually do anything with them (yet), in my opinion the handling of time and other metadata makes this feature worth having even at the current time (and perhaps there are independent use cases that have appeared at the MO too?).
