### PR TITLE
Skip tests if they require mo_pack and it isn't found.

### DIFF
--- a/lib/iris/tests/integration/test_FieldsFileVariant.py
+++ b/lib/iris/tests/integration/test_FieldsFileVariant.py
@@ -32,14 +32,14 @@ from iris.experimental.um import (Field, Field2, Field3, FieldsFileVariant,
                                   FixedLengthHeader)
 
 try:
-    import mo_unpack
+    import mo_pack
 except ImportError:
-    # Disable all these tests if mo_unpack is not installed.
-    mo_unpack = None
+    # Disable all these tests if mo_pack is not installed.
+    mo_pack = None
 
-skip_mo_unpack = unittest.skipIf(mo_unpack is None,
-                                 'Test(s) require "mo_unpack", '
-                                 'which is not available.')
+skip_mo_pack = unittest.skipIf(mo_pack is None,
+                               'Test(s) require "mo_pack", '
+                               'which is not available.')
 
 IMDI = -32768
 RMDI = -1073741824.0
@@ -111,7 +111,7 @@ class TestRead(tests.IrisTest):
         ffv = self.load()
         self.assertEqual(ffv.fields[0].lbfc, 16)
 
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_fields__data_wgdos(self):
         ffv = self.load()
         data = ffv.fields[0].get_data()
@@ -331,7 +331,7 @@ class TestUpdate(tests.IrisTest):
             self.assertNotEqual(last_used_file, original_file)
             self.assertTrue(last_used_file.closed)
 
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_save_packed_as_unpacked(self):
         # Check that we can successfully re-save a packed datafile as unpacked.
         src_path = tests.get_data_path(('FF', 'n48_multi_field'))
@@ -360,7 +360,7 @@ class TestUpdate(tests.IrisTest):
             test_data_new = ffv.fields[0].get_data()
             self.assertArrayAllClose(test_data_old, test_data_new)
 
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_save_packed_unchanged(self):
         # Check that we can copy packed fields without ever unpacking them.
         original_getdata_call = Field.get_data
@@ -386,7 +386,7 @@ class TestUpdate(tests.IrisTest):
         # Finally, check we never fetched any field data.
         self.assertEqual(patch_getdata_call.call_count, 0)
 
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_save_packed_mixed(self):
         # Check all save options, and show we can "partially" unpack a file.
         src_path = tests.get_data_path(('FF', 'n48_multi_field'))
@@ -426,7 +426,7 @@ class TestUpdate(tests.IrisTest):
             self.assertEqual(ffv.fields[2].lbpack, 3000)
             self.assertArrayAllClose(ffv.fields[2].get_data(), data_2)
 
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_fail_save_with_packing(self):
         # Check that trying to save data as packed causes an error.
         src_path = tests.get_data_path(('FF', 'n48_multi_field'))

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -35,14 +35,14 @@ import numpy as np
 from iris.experimental.um import FieldsFileVariant, Field, Field3
 
 try:
-    import mo_unpack
+    import mo_pack
 except ImportError:
-    # Disable all these tests if mo_unpack is not installed.
-    mo_unpack = None
+    # Disable all these tests if mo_pack is not installed.
+    mo_pack = None
 
-skip_mo_unpack = unittest.skipIf(mo_unpack is None,
-                                 'Test(s) require "mo_unpack", '
-                                 'which is not available.')
+skip_mo_pack = unittest.skipIf(mo_pack is None,
+                               'Test(s) require "mo_pack", '
+                               'which is not available.')
 
 
 class Test___init__(tests.IrisTest):
@@ -89,7 +89,7 @@ class Test_filename(tests.IrisTest):
 
 @tests.skip_data
 class Test_class_assignment(tests.IrisTest):
-    @skip_mo_unpack
+    @skip_mo_pack
     def test_lbrel_class(self):
         path = tests.get_data_path(('FF', 'lbrel_test_data'))
         ffv = FieldsFileVariant(path)


### PR DESCRIPTION
Fixes a 'little oops' from #1652. The package name is `mo_pack`, not `mo_unpack`. The wrong name meant certain tests were doomed never to run. :fire: :fire_engine: