### PR TITLE
Remove warnings about data payload from concatenate.

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -42,8 +42,6 @@ from iris.util import guess_coord_axis, array_equal, unify_time_units
 #
 #   * Cope with auxiliary coordinate factories.
 #
-#   * Don't load the cube data payload.
-#
 #   * Deal with anonymous dimensions.
 #
 #   * Allow concatentation over a user specified dimension.
@@ -247,10 +245,6 @@ def concatenate(cubes, error_on_mismatch=False):
     Returns:
         A :class:`iris.cube.CubeList` of concatenated :class:`iris.cube.Cube`
         instances.
-
-    .. warning::
-
-        This routine will load your data payload!
 
     """
     proto_cubes_by_name = defaultdict(list)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -555,10 +555,6 @@ class CubeList(list):
             :func:`iris.util.unify_time_units` to normalise the epochs of the
             time coordinates so that the cubes can be concatenated.
 
-        .. warning::
-
-            This routine will load your data payload!
-
         """
         return iris._concatenate.concatenate(self)
 


### PR DESCRIPTION
I may be wrong about this, but I thought concatenate now plays nicely with deferred data, and hence these warnings are no longer necessary. This should go into the 1.8.1 release ideally.