### PR TITLE
Add missing skip_test decorators.

### DIFF
--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -185,6 +185,8 @@ class TestConventionsAttributes(tests.IrisTest):
 
 
 class TestLazySave(tests.IrisTest):
+
+    @tests.skip_data
     def test_lazy_preserved_save(self):
         fpath = tests.get_data_path(('NetCDF', 'label_and_climate',
                                      'small_FC_167_mon_19601101.nc'))

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ import cPickle as pickle
 from iris.fileformats.grib import _GribMessage
 
 
+@tests.skip_data
 class TestGribMessage(tests.IrisTest):
     def test(self):
         # Check that a _GribMessage pickles without errors.


### PR DESCRIPTION
Adds two missing `tests.skip_data` decorators. Running the tests with the `--no-data` option now gives me no errors.