### PR TITLE
[DOC]: Add floating point equality warning

### DIFF
--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -200,6 +200,25 @@ this can be achieved by passing the constraint a function::
 
         bottom_16_levels = lambda cell: cell <= 16
 
+
+.. warning::
+
+    Caution is required when using equality constraints with floating point coordinates.
+    Printing the points of a coordinate does not necessarily show the full precision of the underlying number.
+    It is very easy return no matches to a constraint when one was expected because of floating-point inaccuracies.
+    This can be avoided by using a function as the argument to the constraint::
+
+       def near_zero(cell):
+          """Returns true if the cell is between -0.1 and 0.1."""
+          return -0.1 < cell < 0.1
+
+       equator_constraint = iris.Constraint(grid_latitude=near_zero)
+
+    This could also be written as a lambda function on a single line::
+
+        equator_constraint = iris.Constraint(grid_latitude=lambda cell: -0.1 < cell < 0.1)
+
+
 Cube attributes can also be part of the constraint criteria. Supposing a 
 cube attribute of ``STASH`` existed, as is the case when loading ``PP`` files, 
 then specific STASH codes can be filtered::

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -201,22 +201,7 @@ this can be achieved by passing the constraint a function::
         bottom_16_levels = lambda cell: cell <= 16
 
 
-.. warning::
-
-    Caution is required when using equality constraints with floating point coordinates.
-    Printing the points of a coordinate does not necessarily show the full precision of the underlying number.
-    It is very easy return no matches to a constraint when one was expected because of floating-point inaccuracies.
-    This can be avoided by using a function as the argument to the constraint::
-
-       def near_zero(cell):
-          """Returns true if the cell is between -0.1 and 0.1."""
-          return -0.1 < cell < 0.1
-
-       equator_constraint = iris.Constraint(grid_latitude=near_zero)
-
-    This could also be written as a lambda function on a single line::
-
-        equator_constraint = iris.Constraint(grid_latitude=lambda cell: -0.1 < cell < 0.1)
+Note also the :ref:`warning on equality constraints with floating point coordinates <floating-point-warning>`.
 
 
 Cube attributes can also be part of the constraint criteria. Supposing a 

--- a/docs/iris/src/userguide/subsetting_a_cube.rst
+++ b/docs/iris/src/userguide/subsetting_a_cube.rst
@@ -37,6 +37,7 @@ In this example we start with a 3 dimensional cube, with dimensions of ``height`
 and extract every point where the latitude is 0, resulting in a 2d cube with axes of ``height`` and ``grid_longitude``.
 
 
+.. _floating-point-warning:
 .. warning::
 
     Caution is required when using equality constraints with floating point coordinates such as ``grid_latitude``.


### PR DESCRIPTION
Add a warning about constructing floating-point equalities to the Iris user guide, section 2.2. This is a near duplicate of the warning found in section 4.1.

The rationale for duplicating this warning to this section is that when I went to find the warning I expected to find it in this section and was surprised when I did not find it there. This means our docs are not as usable as they could be for a user.