### PR TITLE
Add GRIB2 support for Lambert conformal grids (GDT-30)

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/newfeature_2015-05-26_grib2_gdt30.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/newfeature_2015-05-26_grib2_gdt30.txt
@@ -1,0 +1,2 @@
+* Support for loading GRIB2 messages defined on a Lambert conformal grid has been added to
+  the new GRIB2 loader.

--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -28,6 +28,7 @@ import math
 import threading
 import warnings
 
+import cartopy.crs as ccrs
 import numpy as np
 import numpy.ma as ma
 
@@ -52,6 +53,10 @@ ScanningMode = namedtuple('ScanningMode', ['i_negative',
                                            'j_positive',
                                            'j_consecutive',
                                            'i_alternative'])
+
+ProjectionCentre = namedtuple('ProjectionCentre',
+                              ['south_pole_on_projection_plane',
+                               'bipolar_and_symmetric'])
 
 ResolutionFlags = namedtuple('ResolutionFlags',
                              ['i_increments_given',
@@ -299,6 +304,27 @@ def reference_time_coord(section):
 # Grid Definition Section 3
 #
 ###############################################################################
+
+def projection_centre(projectionCentreFlag):
+    """
+    Translate the projection centre flag bitmask.
+
+    Reference GRIB2 Flag Table 3.5.
+
+    Args:
+
+    * projectionCentreFlag
+        Message section 3, coded key value.
+
+    Returns:
+        A :class:`collections.namedtuple` representation.
+
+    """
+    south_pole_on_projection_plane = bool(projectionCentreFlag & 0x80)
+    bipolar_and_symmetric = bool(projectionCentreFlag & 0x40)
+    return ProjectionCentre(south_pole_on_projection_plane,
+                            bipolar_and_symmetric)
+
 
 def scanning_mode(scanningMode):
     """
@@ -766,6 +792,87 @@ def grid_definition_template_12(section, metadata):
     metadata['dim_coords_and_dims'].append((x_coord, x_dim))
 
 
+def grid_definition_template_30(section, metadata):
+    """
+    Translate template representing a Lambert Conformal grid.
+
+    Updates the metadata in-place with the translations.
+
+    Args:
+
+    * section:
+        Dictionary of coded key/value pairs from section 3 of the message.
+
+    * metadata:
+        :class:`collections.OrderedDict` of metadata.
+
+    """
+    major, minor, radius = ellipsoid_geometry(section)
+    geog_cs = ellipsoid(section['shapeOfTheEarth'], major, minor, radius)
+
+    central_latitude = section['LaD'] * _GRID_ACCURACY_IN_DEGREES
+    central_longitude = section['LoV'] * _GRID_ACCURACY_IN_DEGREES
+    false_easting = 0
+    false_northing = 0
+    secant_latitudes = (section['Latin1'] * _GRID_ACCURACY_IN_DEGREES,
+                        section['Latin2'] * _GRID_ACCURACY_IN_DEGREES)
+
+    cs = icoord_systems.LambertConformal(central_latitude,
+                                         central_longitude,
+                                         false_easting,
+                                         false_northing,
+                                         secant_latitudes=secant_latitudes,
+                                         ellipsoid=geog_cs)
+
+    # A projection centre flag is defined for GDT30. However, we don't need to
+    # know which pole is in the projection plane as Cartopy handles that. The
+    # Other component of the projection centre flag determines if there are
+    # multiple projection centres. There is no support for this in Proj4 or
+    # Cartopy so a translation error is raised if this flag is set.
+    proj_centre = projection_centre(section['projectionCentreFlag'])
+    if proj_centre.bipolar_and_symmetric:
+        msg = 'Unsupported projection centre: Bipolar and symmetric.'
+        raise TranslationError(msg)
+
+    res_flags = resolution_flags(section['resolutionAndComponentFlags'])
+    if not res_flags.uv_resolved and options.warn_on_unsupported:
+        # Vector components are given as relative to east an north, rather than
+        # relative to the projection coordinates, issue a warning in this case.
+        # (ideally we need a way to add this information to a cube)
+        msg = 'Unable to translate resolution and component flags.'
+        warnings.warn(msg)
+
+    # Construct the coordinate points, the start point is given in millidegrees
+    # but the distance measurement is in 10-3 m, so a conversion is necessary
+    # to find the origin in m.
+    scan = scanning_mode(section['scanningMode'])
+    lon_0 = section['longitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
+    lat_0 = section['latitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
+    x0_m, y0_m = cs.as_cartopy_crs().transform_point(
+        lon_0, lat_0, ccrs.Geodetic())
+    dx_m = section['Dx'] * 1e-3
+    dy_m = section['Dy'] * 1e-3
+    x_dir = -1 if scan.i_negative else 1
+    y_dir = 1 if scan.j_positive else -1
+    x_points = x0_m + dx_m * x_dir * np.arange(section['Nx'], dtype=np.float64)
+    y_points = y0_m + dy_m * y_dir * np.arange(section['Ny'], dtype=np.float64)
+
+    # Create the dimension coordinates.
+    x_coord = DimCoord(x_points, standard_name='projection_x_coordinate',
+                       units='m', coord_system=cs)
+    y_coord = DimCoord(y_points, standard_name='projection_y_coordinate',
+                       units='m', coord_system=cs)
+
+    # Determine the order of the dimensions.
+    y_dim, x_dim = 0, 1
+    if scan.j_consecutive:
+        y_dim, x_dim = 1, 0
+
+    # Add the projection coordinates to the metadata dim coords.
+    metadata['dim_coords_and_dims'].append((y_coord, y_dim))
+    metadata['dim_coords_and_dims'].append((x_coord, x_dim))
+
+
 def grid_definition_template_40(section, metadata):
     """
     Translate template representing a Gaussian grid.
@@ -1034,6 +1141,9 @@ def grid_definition_section(section, metadata):
     elif template == 12:
         # Process transverse Mercator.
         grid_definition_template_12(section, metadata)
+    elif template == 30:
+        # Process Lambert conformal:
+        grid_definition_template_30(section, metadata)
     elif template == 40:
         grid_definition_template_40(section, metadata)
     elif template == 90:

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -101,14 +101,14 @@ class _GribMessage(object):
             raise TranslationError('Grid definition Section 3 contains '
                                    'unsupported quasi-regular grid.')
 
-        if template in (0, 1, 5, 12, 40, 90):
+        if template in (0, 1, 5, 12, 30, 40, 90):
             # We can ignore the first two bits (i-neg, j-pos) because
             # that is already captured in the coordinate values.
             if grid_section['scanningMode'] & 0x3f:
                 msg = 'Unsupported scanning mode: {}'.format(
                     grid_section['scanningMode'])
                 raise TranslationError(msg)
-            if template == 90:
+            if template in (30, 90):
                 shape = (grid_section['Ny'], grid_section['Nx'])
             elif template == 40 and reduced:
                 shape = (grid_section['numberOfDataPoints'],)

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -214,6 +214,16 @@ class TestGDT5(tests.IrisTest):
 
 
 @tests.skip_data
+class TestGDT30(tests.IrisTest):
+
+    def test_lambert(self):
+        path = tests.get_data_path(('GRIB', 'lambert', 'lambert.grib2'))
+        with FUTURE.context(strict_grib_load=True):
+            cube = load_cube(path)
+        self.assertCMLApproxData(cube)
+
+
+@tests.skip_data
 class TestGDT40(tests.IrisTest):
 
     def test_regular(self):

--- a/lib/iris/tests/results/integration/grib2/TestGDT30/lambert.cml
+++ b/lib/iris/tests/results/integration/grib2/TestGDT30/lambert.cml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube standard_name="air_temperature" units="K">
+    <coords>
+      <coord>
+        <dimCoord id="73141289" points="[2]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int64"/>
+      </coord>
+      <coord>
+        <dimCoord id="f8c7ad26" points="[379980.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+      <coord>
+        <dimCoord id="c7be93c8" long_name="height" points="[2.0]" shape="(1,)" units="Unit('m')" value_type="float64"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="c8464af7" points="[-2396487.0124, -2392487.0124, -2388487.0124,
+		..., 2387512.9876, 2391512.9876, 2395512.9876]" shape="(1199,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="5561d9d4" points="[-3870311.24926, -3866311.24926, -3862311.24926,
+		..., -686311.249256, -682311.249256,
+		-678311.249256]" shape="(799,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="6a1b3c16" points="[379982.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data dtype="float64" shape="(799, 1199)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_30.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_30.py
@@ -1,0 +1,107 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for
+:func:`iris.fileformats.grib._load_convert.grid_definition_template_30`.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import cartopy.crs as ccrs
+import numpy as np
+
+import iris.coord_systems
+import iris.coords
+from iris.tests.unit.fileformats.grib.load_convert import empty_metadata
+from iris.fileformats.grib._load_convert import grid_definition_template_30
+
+
+MDI = 2 ** 32 - 1
+
+
+class Test(tests.IrisTest):
+
+    def section_3(self):
+        section = {
+            'shapeOfTheEarth': 0,
+            'scaleFactorOfRadiusOfSphericalEarth': 0,
+            'scaledValueOfRadiusOfSphericalEarth': 6367470,
+            'scaleFactorOfEarthMajorAxis': 0,
+            'scaledValueOfEarthMajorAxis': MDI,
+            'scaleFactorOfEarthMinorAxis': 0,
+            'scaledValueOfEarthMinorAxis': MDI,
+            'Nx': 15,
+            'Ny': 10,
+            'longitudeOfFirstGridPoint': 239550000,
+            'latitudeOfFirstGridPoint': 21641000,
+            'resolutionAndComponentFlags': 0b00001000,
+            'LaD': 60000000,
+            'LoV': 262000000,
+            'Dx': 320000000,
+            'Dy': 320000000,
+            'projectionCentreFlag': 0b00000000,
+            'scanningMode': 0b01000000,
+            'Latin1': 60000000,
+            'Latin2': 30000000,
+        }
+        return section
+
+    def expected(self, y_dim, x_dim):
+        # Prepare the expectation.
+        expected = empty_metadata()
+        cs = iris.coord_systems.GeogCS(6367470)
+        cs = iris.coord_systems.LambertConformal(
+            central_lat=60.,
+            central_lon=262.,
+            false_easting=0,
+            false_northing=0,
+            secant_latitudes=(60., 30.),
+            ellipsoid=iris.coord_systems.GeogCS(6367470))
+        lon0 = 239.55
+        lat0 = 21.641
+        x0m, y0m = cs.as_cartopy_crs().transform_point(
+            lon0, lat0, ccrs.Geodetic())
+        dxm = dym = 320000.
+        x_points = x0m + dxm * np.arange(15)
+        y_points = y0m + dym * np.arange(10)
+        x = iris.coords.DimCoord(x_points,
+                                 standard_name='projection_x_coordinate',
+                                 units='m',
+                                 coord_system=cs,
+                                 circular=False)
+        y = iris.coords.DimCoord(y_points,
+                                 standard_name='projection_y_coordinate',
+                                 units='m',
+                                 coord_system=cs)
+        expected['dim_coords_and_dims'].append((y, y_dim))
+        expected['dim_coords_and_dims'].append((x, x_dim))
+        return expected
+
+    def test(self):
+        section = self.section_3()
+        metadata = empty_metadata()
+        grid_definition_template_30(section, metadata)
+        expected = self.expected(0, 1)
+        self.assertEqual(metadata, expected)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_projection_centre.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_projection_centre.py
@@ -1,0 +1,51 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats.grib._load_convert.projection centre.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+from iris.fileformats.grib._load_convert import (projection_centre,
+                                                 ProjectionCentre)
+
+
+class Test(tests.IrisTest):
+    def test_unset(self):
+        expected = ProjectionCentre(False, False)
+        self.assertEqual(projection_centre(0x0), expected)
+
+    def test_bipolar_and_symmetric(self):
+        expected = ProjectionCentre(False, True)
+        self.assertEqual(projection_centre(0x40), expected)
+
+    def test_south_pole_on_projection_plane(self):
+        expected = ProjectionCentre(True, False)
+        self.assertEqual(projection_centre(0x80), expected)
+
+    def test_both(self):
+        expected = ProjectionCentre(True, True)
+        self.assertEqual(projection_centre(0xc0), expected)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -221,6 +221,17 @@ class Test_data__grid_template_12(tests.IrisTest, Mixin_data__grid_template):
         return _example_section_3(12, scanning_mode)
 
 
+class Test_data__grid_template_30(tests.IrisTest, Mixin_data__grid_template):
+    def section_3(self, scanning_mode):
+        section_3 = _example_section_3(30, scanning_mode)
+        # Dimensions are 'Nx' + 'Ny' instead of 'Ni' + 'Nj'.
+        section_3['Nx'] = section_3['Ni']
+        section_3['Ny'] = section_3['Nj']
+        del section_3['Ni']
+        del section_3['Nj']
+        return section_3
+
+
 class Test_data__grid_template_40_regular(tests.IrisTest,
                                           Mixin_data__grid_template):
     def section_3(self, scanning_mode):


### PR DESCRIPTION
This PR adds load support for GDT-30 (Lambert conformal) to the new GRIB2 loader.

Replaces #1681 because I messed that branch up. @pelson - sorry for the inconvenience!