### PR TITLE
Add remaining Python 3 builtins via six

### DIFF
--- a/docs/iris/example_tests/__init__.py
+++ b/docs/iris/example_tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,3 +16,4 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/docs/iris/example_tests/extest_util.py
+++ b/docs/iris/example_tests/extest_util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,6 +22,7 @@ to run the example tests.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import contextlib
 import os.path

--- a/docs/iris/example_tests/test_COP_1d_plot.py
+++ b/docs/iris/example_tests/test_COP_1d_plot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_COP_maps.py
+++ b/docs/iris/example_tests/test_COP_maps.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_SOI_filtering.py
+++ b/docs/iris/example_tests/test_SOI_filtering.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2014, Met Office
+# (C) British Crown Copyright 2012 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_TEC.py
+++ b/docs/iris/example_tests/test_TEC.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_anomaly_log_colouring.py
+++ b/docs/iris/example_tests/test_anomaly_log_colouring.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_atlantic_profiles.py
+++ b/docs/iris/example_tests/test_atlantic_profiles.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_cross_section.py
+++ b/docs/iris/example_tests/test_cross_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_custom_aggregation.py
+++ b/docs/iris/example_tests/test_custom_aggregation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_custom_file_loading.py
+++ b/docs/iris/example_tests/test_custom_file_loading.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_deriving_phenomena.py
+++ b/docs/iris/example_tests/test_deriving_phenomena.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_global_map.py
+++ b/docs/iris/example_tests/test_global_map.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_hovmoller.py
+++ b/docs/iris/example_tests/test_hovmoller.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_lagged_ensemble.py
+++ b/docs/iris/example_tests/test_lagged_ensemble.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_lineplot_with_legend.py
+++ b/docs/iris/example_tests/test_lineplot_with_legend.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/example_tests/test_orca_projection.py
+++ b/docs/iris/example_tests/test_orca_projection.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_polar_stereo.py
+++ b/docs/iris/example_tests/test_polar_stereo.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised
 # before importing anything else.

--- a/docs/iris/example_tests/test_polynomial_fit.py
+++ b/docs/iris/example_tests/test_polynomial_fit.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_projections_and_annotations.py
+++ b/docs/iris/example_tests/test_projections_and_annotations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before
 # importing anything else.

--- a/docs/iris/example_tests/test_rotated_pole_mapping.py
+++ b/docs/iris/example_tests/test_rotated_pole_mapping.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import Iris tests first so that some things can be initialised before importing anything else.
 import iris.tests as tests

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # -*- coding: utf-8 -*-
 #
@@ -97,7 +98,7 @@ master_doc = 'contents'
 project = u'Iris'
 # define the copyright information for latex builds. Note, for html builds,
 # the copyright exists directly inside "_templates/layout.html"
-copyright = u'British Crown Copyright 2010 - 2014, Met Office'
+copyright = u'British Crown Copyright 2010 - 2015, Met Office'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/iris/src/developers_guide/gitwash_dumper.py
+++ b/docs/iris/src/developers_guide/gitwash_dumper.py
@@ -2,6 +2,7 @@
 ''' Checkout gitwash repo into directory and do search replace on name '''
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 from os.path import join as pjoin

--- a/docs/iris/src/sphinxext/auto_label_figures.py
+++ b/docs/iris/src/sphinxext/auto_label_figures.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 from docutils import nodes

--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *

--- a/docs/iris/src/sphinxext/custom_data_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_data_autodoc.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from sphinx.ext.autodoc import DataDocumenter, ModuleLevelDocumenter
 try:

--- a/docs/iris/src/sphinxext/gen_example_directory.py
+++ b/docs/iris/src/sphinxext/gen_example_directory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Generate the rst files for the examples
 '''
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import re

--- a/docs/iris/src/sphinxext/gen_gallery.py
+++ b/docs/iris/src/sphinxext/gen_gallery.py
@@ -7,6 +7,7 @@ Generate a thumbnail gallery of examples.
 '''
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import glob

--- a/docs/iris/src/sphinxext/generate_package_rst.py
+++ b/docs/iris/src/sphinxext/generate_package_rst.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import sys

--- a/docs/iris/src/userguide/plotting_examples/1d_quickplot_simple.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_quickplot_simple.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/1d_simple.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_simple.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/1d_with_legend.py
+++ b/docs/iris/src/userguide/plotting_examples/1d_with_legend.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/brewer.py
+++ b/docs/iris/src/userguide/plotting_examples/brewer.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/docs/iris/src/userguide/plotting_examples/cube_blockplot.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_blockplot.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/cube_brewer_cite_contourf.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_brewer_cite_contourf.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/cube_brewer_contourf.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_brewer_contourf.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.cm as mpl_cm
 import matplotlib.pyplot as plt

--- a/docs/iris/src/userguide/plotting_examples/cube_contour.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_contour.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/plotting_examples/cube_contourf.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_contourf.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/docs/iris/src/userguide/regridding_plots/interpolate_column.py
+++ b/docs/iris/src/userguide/regridding_plots/interpolate_column.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 import iris.quickplot as qplt

--- a/docs/iris/src/userguide/regridding_plots/regridded_to_global.py
+++ b/docs/iris/src/userguide/regridding_plots/regridded_to_global.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 import iris.analysis

--- a/docs/iris/src/userguide/regridding_plots/regridded_to_global_area_weighted.py
+++ b/docs/iris/src/userguide/regridding_plots/regridded_to_global_area_weighted.py
@@ -1,6 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 import iris.analysis

--- a/docs/iris/src/userguide/regridding_plots/regridded_to_rotated.py
+++ b/docs/iris/src/userguide/regridding_plots/regridded_to_rotated.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 import iris.analysis

--- a/docs/iris/src/userguide/regridding_plots/regridding_plot.py
+++ b/docs/iris/src/userguide/regridding_plots/regridding_plot.py
@@ -1,5 +1,6 @@
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 import iris.plot as iplt

--- a/docs/iris/src/whatsnew/aggregate_directory.py
+++ b/docs/iris/src/whatsnew/aggregate_directory.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 import datetime
 import os
 import re

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -96,6 +96,7 @@ All the load functions share very similar arguments:
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import contextlib
 import itertools

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -20,7 +20,7 @@ Automatic concatenation of multiple cubes over one or more existing dimensions.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import defaultdict, namedtuple
 

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -20,7 +20,7 @@ Provides objects for building up expressions useful for pattern matching.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import operator

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # TODO: Is this a mixin or a base class?
 

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -23,7 +23,7 @@ Typically the cube merge process is handled by
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple, OrderedDict
 from copy import deepcopy

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -47,7 +47,7 @@ The gallery contains several interesting worked examples of how an
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -17,7 +17,7 @@
 """A collection of helpers for interpolation."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 from itertools import product

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import copy
 import functools

--- a/lib/iris/analysis/_scipy_interpolate.py
+++ b/lib/iris/analysis/_scipy_interpolate.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import itertools
 

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -22,7 +22,7 @@ See also: :mod:`NumPy <numpy>`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import re
 import warnings

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -20,7 +20,7 @@ Various utilities and numeric transformations relevant to cartography.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import copy
 import warnings

--- a/lib/iris/analysis/geometry.py
+++ b/lib/iris/analysis/geometry.py
@@ -23,7 +23,7 @@ Various utilities related to geometric operations.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import warnings
 

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -22,7 +22,7 @@ See also: :mod:`NumPy <numpy>`, and :ref:`SciPy <scipy:modindex>`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import warnings

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -20,7 +20,7 @@ Basic mathematical and statistical operations.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import warnings
 import math

--- a/lib/iris/analysis/stats.py
+++ b/lib/iris/analysis/stats.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Statistical operations between cubes.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -20,7 +20,7 @@ Defines a Trajectory class, and a routine to extract a sub-cube along a trajecto
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import math
 

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -20,7 +20,7 @@ Definitions of derived coordinates.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 import warnings

--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -59,6 +59,7 @@ defined by :mod:`ConfigParser`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import ConfigParser
 import os.path

--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -28,7 +28,7 @@ All the functions provided here add a new coordinate to a cube.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import calendar
 import collections

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -20,6 +20,7 @@ Definitions of coordinate systems.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractmethod
 import warnings

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -20,7 +20,7 @@ Definitions of coordinates.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, map, range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractproperty
 import collections

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -21,7 +21,7 @@ Classes for representing multi-dimensional data with metadata.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, map, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from xml.dom.minidom import Document
 import collections

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Exceptions specific to the Iris package.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.coords
 

--- a/lib/iris/experimental/__init__.py
+++ b/lib/iris/experimental/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,3 +23,4 @@ codebase. The code is expected to graduate, eventually, to "full status".
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/experimental/animate.py
+++ b/lib/iris/experimental/animate.py
@@ -20,7 +20,7 @@ Wrapper for animating iris cubes using iris or matplotlib plotting functions
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import warnings
 

--- a/lib/iris/experimental/concatenate.py
+++ b/lib/iris/experimental/concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,6 +25,7 @@ Automatic concatenation of multiple cubes over one or more existing dimensions.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 
 def concatenate(cubes):

--- a/lib/iris/experimental/equalise_cubes.py
+++ b/lib/iris/experimental/equalise_cubes.py
@@ -20,6 +20,7 @@ Experimental cube-adjusting functions to assist merge operations.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 

--- a/lib/iris/experimental/fieldsfile.py
+++ b/lib/iris/experimental/fieldsfile.py
@@ -20,7 +20,7 @@ High-speed loading of structured FieldsFiles.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from iris.coords import DimCoord
 from iris.cube import CubeList

--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ TODO: If this module graduates from experimental the (optional) GDAL
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 from osgeo import gdal, osr

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -20,7 +20,7 @@ Regridding functions.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 import copy

--- a/lib/iris/experimental/regrid_conservative.py
+++ b/lib/iris/experimental/regrid_conservative.py
@@ -20,7 +20,7 @@ Support for conservative regridding via ESMPy.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import ESMF via iris.proxy, just so we can build the docs with no ESMF.
 import iris.proxy

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Ugrid functions.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris
 

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -20,7 +20,7 @@ Low level support for UM FieldsFile variants.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from contextlib import contextmanager
 import os

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ A package for converting cubes to and from specific file formats.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from iris.io.format_picker import (FileExtension, FormatAgent,
                                    FormatSpecification, MagicNumber,

--- a/lib/iris/fileformats/_ff_cross_references.py
+++ b/lib/iris/fileformats/_ff_cross_references.py
@@ -23,6 +23,7 @@ Relates grid code and field code to the stash code.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 

--- a/lib/iris/fileformats/_structured_array_identification.py
+++ b/lib/iris/fileformats/_structured_array_identification.py
@@ -55,7 +55,7 @@ An example using numpy arrays:
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 

--- a/lib/iris/fileformats/abf.py
+++ b/lib/iris/fileformats/abf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2014, Met Office
+# (C) British Crown Copyright 2012 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ The documentation for this file format can be found
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import calendar
 import datetime

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -26,6 +26,7 @@ References:
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractmethod
 from collections import Iterable, MutableMapping

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Provides Creation and saving of DOT graphs for a :class:`iris.cube.Cube`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import subprocess

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -20,7 +20,7 @@ Provides UK Met Office Fields File (FF) format specific capabilities.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import warnings

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -22,6 +22,7 @@ See also: `ECMWF GRIB API <http://www.ecmwf.int/publications/manuals/grib_api/in
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import datetime
 import math  #for fmod

--- a/lib/iris/fileformats/grib/_grib_cf_map.py
+++ b/lib/iris/fileformats/grib/_grib_cf_map.py
@@ -22,6 +22,7 @@ Provides GRIB/CF phenomenon translations.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 

--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -21,6 +21,7 @@ cube metadata.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple, Iterable, OrderedDict
 from datetime import datetime, timedelta

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -20,6 +20,7 @@ Defines a lightweight wrapper class to wrap a single GRIB message.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 import re

--- a/lib/iris/fileformats/grib/_save_rules.py
+++ b/lib/iris/fileformats/grib/_save_rules.py
@@ -25,6 +25,7 @@ with no public API. It is invoked from
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import warnings
 

--- a/lib/iris/fileformats/grib/grib_phenom_translation.py
+++ b/lib/iris/fileformats/grib/grib_phenom_translation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ Currently supports only these ones:
 '''
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import warnings

--- a/lib/iris/fileformats/grib/grib_save_rules.py
+++ b/lib/iris/fileformats/grib/grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ no public API.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import warnings
 

--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Historically this was auto-generated from
 # SciTools/iris-code-generators:tools/gen_rules.py

--- a/lib/iris/fileformats/name.py
+++ b/lib/iris/fileformats/name.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Provides NAME file format loading capabilities."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.io
 

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -17,7 +17,7 @@
 """NAME file format loading functions."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import datetime

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -25,7 +25,7 @@ Version 1.4, 27 February 2009.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import os

--- a/lib/iris/fileformats/nimrod.py
+++ b/lib/iris/fileformats/nimrod.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Provides NIMROD file format capabilities."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import glob
 import numpy as np

--- a/lib/iris/fileformats/nimrod_load_rules.py
+++ b/lib/iris/fileformats/nimrod_load_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Rules for converting NIMROD fields into cubes."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 
 import warnings

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -20,7 +20,7 @@ Provides UK Met Office Post Process (PP) format specific capabilities.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import abc
 import collections

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Historically this was auto-generated from
 # SciTools/iris-code-generators:tools/gen_rules.py

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -20,7 +20,7 @@ Processing of simple IF-THEN rules.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import abc
 import collections

--- a/lib/iris/fileformats/um/__init__.py
+++ b/lib/iris/fileformats/um/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Conversion of cubes to/from PP/FF formats.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Experimental code for fast loading of structured UM data."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import itertools
 

--- a/lib/iris/fileformats/um/_optimal_array_structuring.py
+++ b/lib/iris/fileformats/um/_optimal_array_structuring.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """A module to provide an optimal array structure calculation."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import itertools
 

--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -22,6 +22,7 @@ Provides UM/CF phenomenon translations.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -20,7 +20,7 @@ Provides an interface to manage URI scheme support in iris.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import glob
 import os.path

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -51,6 +51,7 @@ The calling sequence of handler is dependent on the function given in the origin
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import functools

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -20,7 +20,7 @@ Cube functions for iteration in step.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import itertools

--- a/lib/iris/palette.py
+++ b/lib/iris/palette.py
@@ -21,7 +21,7 @@ color map meta-data mappings.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from functools import wraps
 import os

--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,6 +22,7 @@ See also: http://pandas.pydata.org/
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import datetime
 

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -23,7 +23,7 @@ See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import datetime

--- a/lib/iris/proxy.py
+++ b/lib/iris/proxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,6 +22,7 @@ handling as much as needed
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import sys
 

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,6 +25,7 @@ See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import matplotlib.pyplot as plt
 

--- a/lib/iris/symbols.py
+++ b/lib/iris/symbols.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Contains symbol definitions for use with :func:`iris.plot.symbols`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import itertools
 import math

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -31,7 +31,7 @@ graphical test results.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import map
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import contextlib

--- a/lib/iris/tests/analysis/__init__.py
+++ b/lib/iris/tests/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Package for testing the iris.analysis package.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/analysis/test_interpolate.py
+++ b/lib/iris/tests/analysis/test_interpolate.py
@@ -20,6 +20,7 @@ Test the iris.analysis.interpolate module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/analysis/test_stats.py
+++ b/lib/iris/tests/analysis/test_stats.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the iris.analysis.stats module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/experimental/__init__.py
+++ b/lib/iris/tests/experimental/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Experimental code is tested in this package.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/experimental/regrid/__init__.py
+++ b/lib/iris/tests/experimental/regrid/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Regridding code is tested in this package.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -20,7 +20,7 @@ Test area weighted regridding.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Tests for :func:`iris.experimental.regrid.regrid_conservative_via_esmpy`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/experimental/test_animate.py
+++ b/lib/iris/tests/experimental/test_animate.py
@@ -20,7 +20,7 @@ Test the animation of cubes within iris.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/experimental/test_fieldsfile.py
+++ b/lib/iris/tests/experimental/test_fieldsfile.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the fast loading of structured Fieldsfiles.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/experimental/test_raster.py
+++ b/lib/iris/tests/experimental/test_raster.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 import iris

--- a/lib/iris/tests/experimental/ugrid/__init__.py
+++ b/lib/iris/tests/experimental/ugrid/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Ugrid code is tested in this package.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/experimental/ugrid/test_ugrid.py
+++ b/lib/iris/tests/experimental/ugrid/test_ugrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the :func:`iris.experimental.ugrid.ugrid` function.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,7 @@ Currently relies on matplotlib for image processing so limited to PNG format.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os.path
 import shutil

--- a/lib/iris/tests/integration/__init__.py
+++ b/lib/iris/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Integration tests for the :mod:`iris` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/integration/concatenate/__init__.py
+++ b/lib/iris/tests/integration/concatenate/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Integration tests for the :mod:`iris._concatenate` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/integration/concatenate/test_concatenate.py
+++ b/lib/iris/tests/integration/concatenate/test_concatenate.py
@@ -21,7 +21,7 @@ using :func:`iris.util.unify_time_units`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/integration/format_interop/__init__.py
+++ b/lib/iris/tests/integration/format_interop/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Integration tests for format interoperability."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/integration/format_interop/test_name_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_name_grib.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Integration tests for NAME to GRIB2 interoperability."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/format_interop/test_pp_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_pp_grib.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Integration tests for PP/GRIB interoperability."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/plot/__init__.py
+++ b/lib/iris/tests/integration/plot/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Integration tests for the :mod:`iris.plot` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/integration/plot/test_colorbar.py
+++ b/lib/iris/tests/integration/plot/test_colorbar.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test interaction between :mod:`iris.plot` and
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/integration/test_FieldsFileVariant.py
+++ b/lib/iris/tests/integration/test_FieldsFileVariant.py
@@ -17,7 +17,7 @@
 """Integration tests for loading UM FieldsFile variants."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -17,6 +17,7 @@
 """Integration tests for :class:`iris.cube.Cube`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_ff.py
+++ b/lib/iris/tests/integration/test_ff.py
@@ -17,6 +17,7 @@
 """Integration tests for loading LBC fieldsfiles."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -17,6 +17,7 @@
 """Integration tests for loading and saving GRIB2 files."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -17,6 +17,7 @@
 """Integration tests for loading and saving netcdf files."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -17,6 +17,7 @@
 """Integration tests for pickling things."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Integration tests for loading and saving PP files."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_pp_constrained_load_cubes.py
+++ b/lib/iris/tests/integration/test_pp_constrained_load_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Integration tests for :func:`iris.fileformats.rules.load_cubes`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/integration/test_regridding.py
+++ b/lib/iris/tests/integration/test_regridding.py
@@ -17,6 +17,7 @@
 """Integration tests for regridding."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/pp.py
+++ b/lib/iris/tests/pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import contextlib
 import os.path

--- a/lib/iris/tests/runner/__init__.py
+++ b/lib/iris/tests/runner/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Empty file to allow import.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/runner/__main__.py
+++ b/lib/iris/tests/runner/__main__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Provides testing capabilities for installed copies of Iris.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import argparse
 

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -20,6 +20,7 @@ Provides testing capabilities for installed copies of Iris.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Because this file is imported by setup.py, there may be additional runtime
 # imports later in the file.

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -20,7 +20,7 @@ A collection of routines which create standard Cubes for test purposes.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os.path
 

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ The system tests can be run with ``python setup.py test --system-tests``.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 

--- a/lib/iris/tests/test_abf.py
+++ b/lib/iris/tests/test_abf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2014, Met Office
+# (C) British Crown Copyright 2012 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -17,7 +17,7 @@
 
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_cartography.py
+++ b/lib/iris/tests/test_cartography.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Tests elements of the cartography module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -20,6 +20,7 @@ Test cube indexing, slicing, and extracting, and also the dot graphs.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -17,6 +17,7 @@
 
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -20,6 +20,7 @@ Test the cf module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from datetime import datetime
 from fnmatch import fnmatch

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -379,6 +379,10 @@ class TestFutureImports(unittest.TestCase):
         r"print_function(,\s*unicode_literals)?\)$",
         flags=re.MULTILINE)
 
+    six_import_pattern = re.compile(
+        r"^from six.moves import \(filter, input, map, range, zip\)  # noqa$",
+        flags=re.MULTILINE)
+
     def test_future_imports(self):
         # Tests that every single Python file includes the appropriate
         # __future__ import to enforce consistent behaviour.
@@ -407,9 +411,15 @@ class TestFutureImports(unittest.TestCase):
                               'test.'.format(full_fname))
                         failed = True
 
+                    if re.search(self.six_import_pattern, content) is None:
+                        print('The file {} has no valid six import '
+                              'and has not been excluded from the imports '
+                              'test.'.format(full_fname))
+                        failed = True
+
         if failed:
-            raise ValueError('There were __future__ import check failures. '
-                             'See stdout.')
+            raise AssertionError('There were Python 3 compatibility import '
+                                 'check failures. See stdout.')
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the cube concatenate mechanism.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -20,7 +20,7 @@ Test the constrained cube loading mechanism.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -17,7 +17,7 @@
 
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_coord_categorisation.py
+++ b/lib/iris/tests/test_coord_categorisation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -19,6 +19,7 @@ Test the coordinate categorisation functions.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -17,6 +17,7 @@
 
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_cube.py
+++ b/lib/iris/tests/test_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -20,7 +20,7 @@ Test the Fieldsfile file loading plugin and FFHeader.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_file_load.py
+++ b/lib/iris/tests/test_file_load.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the file loading mechanism.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -20,6 +20,7 @@ Test the file saving mechanism.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_grib_phenomenon_translations.py
+++ b/lib/iris/tests/test_grib_phenomenon_translations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Created on Apr 26, 2013
 '''
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :mod:`iris.fileformats.grib._save_rules`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the hybrid vertical coordinate representations.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -20,6 +20,7 @@ Test the interpolation of Iris cubes.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_intersect.py
+++ b/lib/iris/tests/test_intersect.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the intersection of Coords
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the io/__init__.py module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_iterate.py
+++ b/lib/iris/tests/test_iterate.py
@@ -20,7 +20,7 @@ Test the iteration of cubes in step.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_load.py
+++ b/lib/iris/tests/test_load.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test the main loading API.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -19,7 +19,7 @@ Tests map creation.
 
 """
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -20,7 +20,7 @@ Test the cube merging mechanism.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_name.py
+++ b/lib/iris/tests/test_name.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Tests for NAME loading."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -20,6 +20,7 @@ Test CF-NetCDF file loading and saving.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/test_nimrod.py
+++ b/lib/iris/tests/test_nimrod.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_peak.py
+++ b/lib/iris/tests/test_peak.py
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 import iris.tests.stock

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -20,7 +20,7 @@ Test pickling of Iris objects.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_pp_to_cube.py
+++ b/lib/iris/tests/test_pp_to_cube.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Tests the high-level plotting interface.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_regrid.py
+++ b/lib/iris/tests/test_regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_rules.py
+++ b/lib/iris/tests/test_rules.py
@@ -20,7 +20,7 @@ Test metadata translation rules.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_std_names.py
+++ b/lib/iris/tests/test_std_names.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/lib/iris/tests/test_trajectory.py
+++ b/lib/iris/tests/test_trajectory.py
@@ -16,7 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test Unit the wrapper class for Unidata udunits2.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_uri_callback.py
+++ b/lib/iris/tests/test_uri_callback.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -20,7 +20,7 @@ Test iris.util
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/test_verbose_logging.py
+++ b/lib/iris/tests/test_verbose_logging.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests

--- a/lib/iris/tests/unit/__init__.py
+++ b/lib/iris/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/__init__.py
+++ b/lib/iris/tests/unit/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.analysis` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/area_weighted/__init__.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis._area_weighted` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -20,6 +20,7 @@ Unit tests for :class:`iris.analysis._area_weighted.AreaWeightedRegridder`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/cartography/__init__.py
+++ b/lib/iris/tests/unit/analysis/cartography/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis.cartography` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
+++ b/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -18,6 +18,7 @@
 """Unit tests for the `iris.analysis.cartography._quadrant_area` function"""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/cartography/test_area_weights.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_area_weights.py
@@ -21,6 +21,7 @@
 # importing anything else.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 import iris.tests.stock as stock
 import iris.analysis.cartography

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.cartography.project` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
@@ -20,6 +20,7 @@ Unit tests for the function
 
 """
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/geometry/__init__.py
+++ b/lib/iris/tests/unit/analysis/geometry/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis.geometry` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/geometry/test__extract_relevant_cube_slice.py
+++ b/lib/iris/tests/unit/analysis/geometry/test__extract_relevant_cube_slice.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for :func:`iris.analysis.geometry._extract_relevant_cube_slice`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
+++ b/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ function.
  """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/interpolate/__init__.py
+++ b/lib/iris/tests/unit/analysis/interpolate/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis.interpolate` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/interpolate/test_linear.py
+++ b/lib/iris/tests/unit/analysis/interpolate/test_linear.py
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.interpolate.linear` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/interpolation/__init__.py
+++ b/lib/iris/tests/unit/analysis/interpolation/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis._interpolation` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
@@ -20,6 +20,7 @@ Unit tests for :class:`iris.analysis._interpolation.RectilinearInterpolator`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/interpolation/test_get_xy_dim_coords.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_get_xy_dim_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for :func:`iris.analysis._interpolation.get_xy_dim_coords`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -17,7 +17,7 @@
 """Unit tests for the :mod:`iris.analysis.maths` module."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractproperty
 

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.maths.add` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.maths.divide` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.maths.multiply` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :func:`iris.analysis.maths.subtract` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/regrid/__init__.py
+++ b/lib/iris/tests/unit/analysis/regrid/__init__.py
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.analysis._regrid` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -17,7 +17,7 @@
 """Unit tests for :class:`iris.analysis._regrid.RectilinearRegridder`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
+++ b/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
@@ -18,6 +18,7 @@
 :func:`iris.analysis._scipy_interpolate._RegularGridInterpolator` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.analysis.Aggregator` class instance."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_AreaWeighted.py
+++ b/lib/iris/tests/unit/analysis/test_AreaWeighted.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.analysis.AreaWeighted`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_COUNT.py
+++ b/lib/iris/tests/unit/analysis/test_COUNT.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.COUNT` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.analysis.Linear`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_MEAN.py
+++ b/lib/iris/tests/unit/analysis/test_MEAN.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.MEAN` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_Nearest.py
+++ b/lib/iris/tests/unit/analysis/test_Nearest.py
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.analysis.Nearest`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -17,7 +17,7 @@
 """Unit tests for the :data:`iris.analysis.PERCENTILE` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_PROPORTION.py
+++ b/lib/iris/tests/unit/analysis/test_PROPORTION.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.PROPORTION` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -20,7 +20,7 @@ Unit tests for the :class:`iris.analysis.PercentileAggregator` class instance.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.RMS` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_STD_DEV.py
+++ b/lib/iris/tests/unit/analysis/test_STD_DEV.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.STD_DEV` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.VARIANCE` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
@@ -17,7 +17,7 @@
 """Unit tests for the :data:`iris.analysis.PERCENTILE` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
@@ -20,6 +20,7 @@ Unit tests for the :class:`iris.analysis.PercentileAggregator` class instance.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/__init__.py
+++ b/lib/iris/tests/unit/aux_factory/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.aux_factory` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -20,6 +20,7 @@ Unit tests for `iris.aux_factory.AuxCoordFactory`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/concatenate/__init__.py
+++ b/lib/iris/tests/unit/concatenate/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris._concatenate` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/concatenate/test__CubeSignature.py
+++ b/lib/iris/tests/unit/concatenate/test__CubeSignature.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test class :class:`iris._concatenate._CubeSignature`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -17,7 +17,7 @@
 """Test function :func:`iris._concatenate.concatenate.py`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/coord_categorisation/__init__.py
+++ b/lib/iris/tests/unit/coord_categorisation/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.coord_categorisation` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
+++ b/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
@@ -17,7 +17,7 @@
 """Test function :func:`iris.coord_categorisation.add_categorised_coord`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/coord_systems/__init__.py
+++ b/lib/iris/tests/unit/coord_systems/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.coord_systems` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/coord_systems/test_Orthographic.py
+++ b/lib/iris/tests/unit/coord_systems/test_Orthographic.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.coord_systems.Orthographic` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
+++ b/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.coord_systems.RotatedPole` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 import mock
 
 # Import iris.tests first so that some things can be initialised before

--- a/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
+++ b/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.coord_systems.VerticalPerspective` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/coords/__init__.py
+++ b/lib/iris/tests/unit/coords/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.coords` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.coords.Cell` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -17,6 +17,7 @@
 """Unit tests for the :class:`iris.coords.Coord` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/cube/__init__.py
+++ b/lib/iris/tests/unit/cube/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.cube` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -17,7 +17,7 @@
 """Unit tests for the `iris.cube.Cube` class."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -17,7 +17,7 @@
 """Unit tests for the `iris.cube.CubeList` class."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/experimental/__init__.py
+++ b/lib/iris/tests/unit/experimental/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.experimental` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/equalise_cubes/__init__.py
+++ b/lib/iris/tests/unit/experimental/equalise_cubes/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the `iris.experimental.equalise_cubes` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
+++ b/lib/iris/tests/unit/experimental/equalise_cubes/test_equalise_attributes.py
@@ -21,7 +21,7 @@ function.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/experimental/fieldsfile/__init__.py
+++ b/lib/iris/tests/unit/experimental/fieldsfile/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for :mod:`iris.experimental.fieldsfile`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
+++ b/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :func:`iris.experimental.fieldsfile._convert_collation`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/experimental/raster/__init__.py
+++ b/lib/iris/tests/unit/experimental/raster/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.experimental.raster` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
+++ b/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.experimental.raster.export_geotiff` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/experimental/regrid/__init__.py
+++ b/lib/iris/tests/unit/experimental/regrid/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.experimental.regrid` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.experimental.regrid.CurvilinearRegridder`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.experimental.regrid.PointInCell`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
@@ -21,7 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/um/__init__.py
+++ b/lib/iris/tests/unit/experimental/um/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.experimental.um` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/experimental/um/test_Field.py
+++ b/lib/iris/tests/unit/experimental/um/test_Field.py
@@ -20,7 +20,7 @@ Unit tests for :class:`iris.experimental.um.Field`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/um/test_Field2.py
+++ b/lib/iris/tests/unit/experimental/um/test_Field2.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for :class:`iris.experimental.um.Field2`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/um/test_Field3.py
+++ b/lib/iris/tests/unit/experimental/um/test_Field3.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for :class:`iris.experimental.um.Field3`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -20,6 +20,7 @@ Unit tests for :class:`iris.experimental.um.FieldsFileVariant`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/experimental/um/test_FixedLengthHeader.py
+++ b/lib/iris/tests/unit/experimental/um/test_FixedLengthHeader.py
@@ -20,7 +20,7 @@ Unit tests for :class:`iris.experimental.um.FixedLengthHeader`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/__init__.py
+++ b/lib/iris/tests/unit/fileformats/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.fileformats` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/unit/fileformats/abf/__init__.py
+++ b/lib/iris/tests/unit/fileformats/abf/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.abf` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
+++ b/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.abf.ABFField` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/cf/__init__.py
+++ b/lib/iris/tests/unit/fileformats/cf/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.cf` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -20,7 +20,7 @@ Unit tests for the `iris.fileformats.cf.CFReader` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/__init__.py
+++ b/lib/iris/tests/unit/fileformats/ff/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.ff` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/ff/test_ArakawaC.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_ArakawaC.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.fileformat.ff.ArakawaC`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/test_ENDGame.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_ENDGame.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.fileformat.ff.ENDGame`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -17,7 +17,7 @@
 """Unit tests for the :class:`iris.fileformat.ff.FF2PP` class."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.fileformat.ff.FFHeader`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/test_Grid.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_Grid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.fileformat.ff.Grid`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/ff/test_NewDynamics.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_NewDynamics.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :class:`iris.fileformat.ff.NewDynamics`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/__init__.py
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.fileformats.grib` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import mock
 

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.fileformats.grib._load_convert` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test__hindcast_fix.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test__hindcast_fix.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Tests for function :func:`iris.fileformats.grib._load_convert._hindcast_fix`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_bitmap_section.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_bitmap_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.bitmap_section.`
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.fileformats.grib._load_convert.convert`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Tests for function :func:`iris.fileformats.grib._load_convert.data_cutoff`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_ellipsoid.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_ellipsoid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.ellipsoid.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_ellipsoid_geometry.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_ellipsoid_geometry.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.ellipsoid_geometry.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_fixup_float32_from_int32.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_fixup_float32_from_int32.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for `iris.fileformats.grib._load_convert.fixup_float32_from_int32`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_fixup_int32_from_uint32.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_fixup_int32_from_uint32.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for `iris.fileformats.grib._load_convert.fixup_int32_from_uint32`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_forecast_period_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_forecast_period_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.forecast_period_coord.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_generating_process.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_generating_process.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grib2_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grib2_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.fileformats.grib._load_convert.grib2_convert`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_0_and_1.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_0_and_1.py
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_12.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_12.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_30.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_30.py
@@ -20,6 +20,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_40.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_40.py
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_4_and_5.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_4_and_5.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_5.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_5.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_90.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_90.py
@@ -21,7 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_other_time_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_other_time_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.other_time_coord.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_0.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_0.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_1.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_1.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Test function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_31.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_31.py
@@ -20,7 +20,7 @@ Tests for `iris.fileformats.grib._load_convert.product_definition_template_31`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_8.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_8.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_9.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_9.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_projection_centre.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_projection_centre.py
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.projection centre.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_reference_time_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_reference_time_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,6 +22,7 @@ Reference Code Table 1.2.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_resolution_flags.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_resolution_flags.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.resolution_flags.`
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_scanning_mode.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_scanning_mode.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.scanning_mode.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_cell_method.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_cell_method.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_forecast_period_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_forecast_period_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_time_range_unit.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_time_range_unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.time_range_unit.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_translate_phenomenon.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_translate_phenomenon.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Tests for function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_unscale.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_unscale.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.unscale.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_validity_time_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_validity_time_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.validity_time_coord.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.fileformats.grib._load_convert.vertical_coords`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/load_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.grib.load_rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
@@ -17,6 +17,7 @@
 """Unit tests for :func:`iris.fileformats.grib.load_rules.convert`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/grib/message/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.grib._message` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
@@ -20,6 +20,7 @@ Unit tests for the `iris.fileformats.grib.message._DataProxy` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -20,6 +20,7 @@ Unit tests for the `iris.fileformats.grib.message._GribMessage` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for the `iris.fileformats.grib.message._MessageLocation` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/message/test__RawGribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__RawGribMessage.py
@@ -20,7 +20,7 @@ Unit tests for the `iris.fileformats.grib.message._RawGribMessage` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/message/test__Section.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__Section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for `iris.fileformats.grib._message._Section`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.fileformats.grib.grib_save_rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test__missing_forecast_period.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test__missing_forecast_period.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test__non_missing_forecast_period.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test__non_missing_forecast_period.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for module-level functions."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_fixup_float32_as_int32.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_fixup_float32_as_int32.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for `iris.fileformats.grib._save_rules.fixup_float32_as_int32`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_fixup_int32_as_uint32.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_fixup_int32_as_uint32.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for `iris.fileformats.grib._save_rules.fixup_int32_as_uint32`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_section.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_0.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_0.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_1.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_1.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_12.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_12.py
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_5.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_grid_definition_template_5.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_identification.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_identification.py
@@ -17,6 +17,7 @@
 """Unit tests for `iris.fileformats.grib.grib_save_rules.identification`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_8.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_8.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for `iris.fileformats.grib.grib_save_rules.reference_time`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_fixed_surfaces.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_fixed_surfaces.py
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_increment.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_increment.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for the `iris.fileformats.grib.GribWrapper` class.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.grib.as_messages` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.grib.as_pairs` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.grib.load_cubes` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 

--- a/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.grib.save_messages` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/name_loaders/__init__.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.name_loaders` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for :func:`iris.fileformats.name_loaders._build_cell_methods`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__cf_height_from_name.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__cf_height_from_name.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ function.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/name_loaders/test_generate_cubes.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test_generate_cubes.py
@@ -20,7 +20,7 @@ Unit tests for :func:`iris.analysis.name_loaders._generate_cubes`.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/netcdf/__init__.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.netcdf` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -17,7 +17,7 @@
 """Unit tests for the `iris.fileformats.netcdf.Saver` class."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.netcdf._load_aux_factory` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -17,7 +17,7 @@
 """Unit tests for the `iris.fileformats.netcdf._load_cube` function."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/netcdf/test_save.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_save.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.netcdf.save` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.nimrod_load_rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ function.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ function.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pp/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.pp` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.PPDataProxy` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.PPField` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -17,7 +17,7 @@
 """Unit tests for :class:`iris.fileformats.pp._LBProc`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.load` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp._create_field_data` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Unit tests for the `iris.fileformats.pp._data_bytes_to_shaped_array` function.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp._field_gen` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp._interpret_field` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.as_fields` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.as_pairs` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_load.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_load.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.load` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.save` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp.save_fields` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.pp_rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.fileformats.pp._all_other_rules` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__collapse_degenerate_points_and_bounds.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__collapse_degenerate_points_and_bounds.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_pseudo_level_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_pseudo_level_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_realization_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_realization_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
@@ -21,7 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__dim_or_aux.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__dim_or_aux.py
@@ -17,7 +17,7 @@
 """Unit tests for :func:`iris.fileformats.pp_rules._dim_or_aux`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__model_level_number.py
@@ -17,7 +17,7 @@
 """Unit tests for :func:`iris.fileformats.pp_rules._model_level_number`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__reduced_points_and_bounds.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__reduced_points_and_bounds.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__reshape_vector_args.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__reshape_vector_args.py
@@ -21,7 +21,7 @@ Unit tests for
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -17,7 +17,7 @@
 """Unit tests for :func:`iris.fileformats.pp_rules.convert`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/pyke_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats._pyke_rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,3 +20,4 @@ Unit tests for the :mod:`iris.fileformats._pyke_rules.compiled_krb` module.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/__init__.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.fc_rules_cf_fc` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
@@ -21,6 +21,7 @@ fc_rules_cf_fc._parse_cell_methods`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -21,6 +21,7 @@ fc_rules_cf_fc.build_auxilliary_coordinate`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,6 +21,7 @@ fc_rules_cf_fc.build_cube_metadata`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -21,6 +21,7 @@ fc_rules_cf_fc.build_dimension_coordinate`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
@@ -21,6 +21,7 @@ fc_rules_cf_fc.build_cube_metadata`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -21,6 +21,7 @@ fc_rules_cf_fc.reorder_bounds_data`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/fileformats/rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.fileformats.rules` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for :func:`iris.fileformats.rules._make_cube`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/structured_array_identification/__init__.py
+++ b/lib/iris/tests/unit/fileformats/structured_array_identification/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,3 +21,4 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/structured_array_identification/test_ArrayStructure.py
+++ b/lib/iris/tests/unit/fileformats/structured_array_identification/test_ArrayStructure.py
@@ -21,7 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/structured_array_identification/test_GroupStructure.py
+++ b/lib/iris/tests/unit/fileformats/structured_array_identification/test_GroupStructure.py
@@ -21,7 +21,7 @@ Unit tests for the
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/fileformats/um/__init__.py
+++ b/lib/iris/tests/unit/fileformats/um/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the `iris.fileformats.um` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/__init__.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,3 +21,4 @@ Unit tests for the module
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
@@ -21,6 +21,7 @@ Unit tests for the class
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
@@ -21,7 +21,7 @@ Unit tests for the function :func:\
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/__init__.py
+++ b/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -21,3 +21,4 @@ Unit tests for the module
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/test_optimal_array_structure.py
+++ b/lib/iris/tests/unit/fileformats/um/optimal_array_structuring/test_optimal_array_structure.py
@@ -21,6 +21,7 @@ Unit tests for the function
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.

--- a/lib/iris/tests/unit/io/__init__.py
+++ b/lib/iris/tests/unit/io/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.io` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/io/test_run_callback.py
+++ b/lib/iris/tests/unit/io/test_run_callback.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.io.run_callback` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/merge/__init__.py
+++ b/lib/iris/tests/unit/merge/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris._merge` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris._merge.ProtoCube` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/merge/test__CubeSignature.py
+++ b/lib/iris/tests/unit/merge/test__CubeSignature.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris._merge._CubeSignature` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -17,7 +17,7 @@
 """Unit tests for the :mod:`iris.plot` module."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_contour.py
+++ b/lib/iris/tests/unit/plot/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.contour` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.contourf` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_outline.py
+++ b/lib/iris/tests/unit/plot/test_outline.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.outline` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.pcolor` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.pcolormesh` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_plot.py
+++ b/lib/iris/tests/unit/plot/test_plot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.plot` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_points.py
+++ b/lib/iris/tests/unit/plot/test_points.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.points` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/plot/test_scatter.py
+++ b/lib/iris/tests/unit/plot/test_scatter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.plot.scatter` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/__init__.py
+++ b/lib/iris/tests/unit/quickplot/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.quickplot` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/quickplot/test_contour.py
+++ b/lib/iris/tests/unit/quickplot/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.contour` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.contourf` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_outline.py
+++ b/lib/iris/tests/unit/quickplot/test_outline.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.outline` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_pcolor.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolor.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.pcolor` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolormesh.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.pcolormesh` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_plot.py
+++ b/lib/iris/tests/unit/quickplot/test_plot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.plot` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_points.py
+++ b/lib/iris/tests/unit/quickplot/test_points.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.points` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/quickplot/test_scatter.py
+++ b/lib/iris/tests/unit/quickplot/test_scatter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.quickplot.scatter` function."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.Future` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/tests/__init__.py
+++ b/lib/iris/tests/unit/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.tests` package."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/tests/test_IrisTest.py
+++ b/lib/iris/tests/unit/tests/test_IrisTest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the :mod:`iris.tests.IrisTest` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -17,7 +17,7 @@
 """Unit tests for the `iris.time.PartialDateTime` class."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/unit/__init__.py
+++ b/lib/iris/tests/unit/unit/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.unit` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/unit/test_Unit.py
+++ b/lib/iris/tests/unit/unit/test_Unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Unit tests for the `iris.unit.Unit` class."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/unit/test_suppress_unit_warnings.py
+++ b/lib/iris/tests/unit/unit/test_suppress_unit_warnings.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.unit.suppress_unit_warnings`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/__init__.py
+++ b/lib/iris/tests/unit/util/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,3 +17,4 @@
 """Unit tests for the :mod:`iris.util` module."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/util/test_array_equal.py
+++ b/lib/iris/tests/unit/util/test_array_equal.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.array_equal`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_broadcast_to_shape.py
+++ b/lib/iris/tests/unit/util/test_broadcast_to_shape.py
@@ -17,7 +17,7 @@
 """Test function :func:`iris.util.broadcast_to_shape`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_column_slices_generator.py
+++ b/lib/iris/tests/unit/util/test_column_slices_generator.py
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.column_slices_generator`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
+++ b/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.demote_dim_coord_to_aux_coord`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/util/test_describe_diff.py
+++ b/lib/iris/tests/unit/util/test_describe_diff.py
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.describe_diff`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_file_is_newer_than.py
+++ b/lib/iris/tests/unit/util/test_file_is_newer_than.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Test function :func:`iris.util.test_file_is_newer`.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -17,7 +17,7 @@
 """Test function :func:`iris.util.new_axis`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
+++ b/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.promote_aux_coord_to_dim_coord`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/util/test_rolling_window.py
+++ b/lib/iris/tests/unit/util/test_rolling_window.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.rolling_window`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/tests/unit/util/test_squeeze.py
+++ b/lib/iris/tests/unit/util/test_squeeze.py
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.squeeze`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.

--- a/lib/iris/tests/unit/util/test_unify_time_units.py
+++ b/lib/iris/tests/unit/util/test_unify_time_units.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -17,6 +17,7 @@
 """Test function :func:`iris.util.array_equal`."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before
 # importing anything else

--- a/lib/iris/time.py
+++ b/lib/iris/time.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -20,6 +20,7 @@ Time handling.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import functools
 

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -26,7 +26,7 @@ See also: `UDUNITS-2
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from contextlib import contextmanager
 import copy

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -20,7 +20,7 @@ Miscellaneous utility functions.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import filter, range, zip
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import abc
 import collections

--- a/tools/gen_helpers.py
+++ b/tools/gen_helpers.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from datetime import datetime
 import os

--- a/tools/gen_stash_refs.py
+++ b/tools/gen_stash_refs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -16,6 +16,7 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import json
 import urllib

--- a/tools/gen_translations.py
+++ b/tools/gen_translations.py
@@ -21,6 +21,7 @@ metOcean mapping translations.
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from datetime import datetime
 import os.path
@@ -56,6 +57,7 @@ HEADER = """# (C) British Crown Copyright 2013 - {year}, Met Office
 {doc_string}
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 

--- a/tools/generate_std_names.py
+++ b/tools/generate_std_names.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ as obtained from:
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import argparse
 import pprint
@@ -36,7 +37,7 @@ import xml.etree.ElementTree as ET
 
 
 STD_VALUES_FILE_TEMPLATE = '''
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -72,6 +73,7 @@ Or for more control (e.g. to use an alternative XML file) via:
 """
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 
 STD_NAMES = '''.lstrip()

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -21,7 +21,7 @@ translations.
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import range
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import deque, namedtuple


### PR DESCRIPTION
To follow up on #1699, this adds the compatibility builtins on all files. This will look bigger because it's based on #1699, but I want to be sure tests can pass here too.

Much like the `__future__` imports, this PR adds `six` imports that change behaviour of builtin functions. This is a blanket change, so hopefully it's not too hard to go through again. At least this time there's a functional change involved.