### PR TITLE
Py3k installable

### DIFF
--- a/docs/iris/example_code/General/custom_file_loading.py
+++ b/docs/iris/example_code/General/custom_file_loading.py
@@ -144,7 +144,8 @@ def NAME_to_cube(filenames, callback):
         for i, data_array in enumerate(data_arrays):
             # turn the dictionary of column headers with a list of header information for each field into a dictionary of
             # headers for just this field. Ignore the first 4 columns of grid position (data was located with the data array).
-            field_headings = dict([(k, v[i + 4]) for k, v in column_headings.iteritems()])
+            field_headings = dict((k, v[i + 4])
+                                  for k, v in column_headings.items())
 
             # make an cube
             cube = iris.cube.Cube(data_array)

--- a/docs/iris/src/sphinxext/gen_gallery.py
+++ b/docs/iris/src/sphinxext/gen_gallery.py
@@ -193,7 +193,7 @@ images = new Array();
         with open(gallery_path, 'w') as fh:
             fh.write(content)
 
-    for key in app.builder.status_iterator(thumbnails.iterkeys(),
+    for key in app.builder.status_iterator(thumbnails,
                                            'generating thumbnails... ',
                                            length=len(thumbnails)):
         image.thumbnail(key, thumbnails[key], 0.3)

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -97,6 +97,7 @@ All the load functions share very similar arguments:
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import contextlib
 import itertools
@@ -247,7 +248,7 @@ else:
 
 def _generate_cubes(uris, callback, constraints):
     """Returns a generator of cubes given the URIs and a callback."""
-    if isinstance(uris, basestring):
+    if isinstance(uris, six.string_types):
         uris = [uris]
 
     # Group collections of uris by their iris handler

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -220,7 +220,7 @@ class Future(threading.local):
         # Save the current context
         current_state = self.__dict__.copy()
         # Update the state
-        for name, value in kwargs.iteritems():
+        for name, value in six.iteritems(kwargs):
             setattr(self, name, value)
         try:
             yield

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -21,6 +21,7 @@ Automatic concatenation of multiple cubes over one or more existing dimensions.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from collections import defaultdict, namedtuple
 
@@ -385,7 +386,7 @@ class _CubeSignature(object):
             result = ('', ', '.join(self_names), ', '.join(other_names))
         else:
             diff_names = []
-            for self_key, self_value in self_dict.iteritems():
+            for self_key, self_value in six.iteritems(self_dict):
                 other_value = other_dict[self_key]
                 if self_value != other_value:
                     diff_names.append(self_key)

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -21,6 +21,7 @@ Provides objects for building up expressions useful for pattern matching.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import operator
@@ -91,7 +92,7 @@ class Constraint(object):
         :class:`iris.coords.Cell`.
 
         """
-        if not (name is None or isinstance(name, basestring)):
+        if not (name is None or isinstance(name, six.string_types)):
             raise TypeError('name must be None or string, got %r' % name)
         if not (cube_func is None or callable(cube_func)):
             raise TypeError('cube_func must be None or callable, got %r'
@@ -259,7 +260,7 @@ class _CoordConstraint(object):
             call_func = self._coord_thing
         elif (isinstance(self._coord_thing, collections.Iterable) and
                 not isinstance(self._coord_thing,
-                               (basestring, iris.coords.Cell))):
+                               (six.string_types, iris.coords.Cell))):
             call_func = lambda cell: cell in list(self._coord_thing)
         else:
             call_func = lambda c: c == self._coord_thing
@@ -420,7 +421,7 @@ def as_constraint(thing):
         return thing
     elif thing is None:
         return Constraint()
-    elif isinstance(thing, basestring):
+    elif isinstance(thing, six.string_types):
         return Constraint(thing)
     else:
         raise TypeError('%r cannot be cast to a constraint.' % thing)

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -103,7 +103,7 @@ class Constraint(object):
                             'collections.Mapping, got %r' % coord_values)
 
         coord_values = coord_values or {}
-        duplicate_keys = coord_values.viewkeys() & kwargs.viewkeys()
+        duplicate_keys = set(coord_values.keys()) & set(kwargs.keys())
         if duplicate_keys:
             raise ValueError('Duplicate coordinate conditions specified for: '
                              '%s' % list(duplicate_keys))
@@ -446,7 +446,7 @@ class AttributeConstraint(Constraint):
 
     def _cube_func(self, cube):
         match = True
-        for name, value in self._attributes.iteritems():
+        for name, value in six.iteritems(self._attributes):
             if name in cube.attributes:
                 cube_attr = cube.attributes.get(name)
                 # if we have a callable, then call it with the value,

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # TODO: Is this a mixin or a base class?
 
@@ -37,15 +38,15 @@ class LimitedAttributeDict(dict):
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         # Check validity of keys
-        for key in self.iterkeys():
+        for key in six.iterkeys(self):
             if key in self._forbidden_keys:
                 raise ValueError('%r is not a permitted attribute' % key)
 
     def __eq__(self, other):
         # Extend equality to allow for NumPy arrays.
-        match = self.viewkeys() == other.viewkeys()
+        match = set(self.keys()) == set(other.keys())
         if match:
-            for key, value in self.iteritems():
+            for key, value in six.iteritems(self):
                 match = value == other[key]
                 try:
                     match = bool(match)

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -24,6 +24,7 @@ Typically the cube merge process is handled by
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from collections import namedtuple, OrderedDict
 from copy import deepcopy
@@ -336,8 +337,8 @@ class _CubeSignature(namedtuple('CubeSignature',
             msgs.append('cube.units differs: {!r} != {!r}'.format(
                 self_defn.units, other_defn.units))
         if self_defn.attributes != other_defn.attributes:
-            diff_keys = (self_defn.attributes.viewkeys() ^
-                         other_defn.attributes.viewkeys())
+            diff_keys = (set(self_defn.attributes.keys()) ^
+                         set(other_defn.attributes.keys()))
             if diff_keys:
                 msgs.append('cube.attributes keys differ: ' +
                             ', '.join(repr(key) for key in diff_keys))
@@ -526,7 +527,7 @@ def build_indexes(positions):
     scalar_index_by_name = {name: {} for name in names}
 
     for position in positions:
-        for name, value in position.iteritems():
+        for name, value in six.iteritems(position):
             name_index_by_scalar = scalar_index_by_name[name]
 
             if value in name_index_by_scalar:
@@ -566,7 +567,7 @@ def _separable_pair(name, index):
         Boolean.
 
     """
-    items = index.itervalues()
+    items = six.itervalues(index)
     reference = next(items)[name]
 
     return all([item[name] == reference for item in items])
@@ -1347,7 +1348,7 @@ class ProtoCube(object):
 
                     def name_in_independents():
                         return any(name in independents
-                                   for independents in space.itervalues()
+                                   for independents in six.itervalues(space)
                                    if independents is not None)
                     if len(cells) == 1 and not name_in_independents():
                         # A scalar coordinate not participating in a
@@ -1391,7 +1392,7 @@ class ProtoCube(object):
 
                 # Populate the points and bounds based on the appropriate
                 # function mapping.
-                temp = function_matrix[name].iteritems()
+                temp = six.iteritems(function_matrix[name])
                 for function_independents, name_value in temp:
                     # Build the index (and cache it) for the auxiliary
                     # coordinate based on the associated independent

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -48,6 +48,7 @@ The gallery contains several interesting worked examples of how an
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 
@@ -343,7 +344,7 @@ def coord_comparison(*cubes):
 
     # for convenience, turn all of the sets in the dictionary into lists,
     # sorted by the name of the group
-    for key, groups in result.iteritems():
+    for key, groups in six.iteritems(result):
         result[key] = sorted(groups, key=lambda group: group.name())
 
     return result
@@ -1868,7 +1869,7 @@ class _Groupby(object):
                 # Calculate the new shared coordinates.
                 self._compute_shared_coords()
             # Generate the group-by slices/groups.
-            for groupby_slice in self._slices_by_key.itervalues():
+            for groupby_slice in six.itervalues(self._slices_by_key):
                 yield groupby_slice
 
         return
@@ -1882,7 +1883,7 @@ class _Groupby(object):
         # Iterate over the ordered dictionary in order to reduce
         # multiple slices into a single tuple and collapse
         # all items from containing list.
-        for key, groupby_slices in self._slices_by_key.iteritems():
+        for key, groupby_slices in six.iteritems(self._slices_by_key):
             if len(groupby_slices) > 1:
                 # Compress multiple slices into tuple representation.
                 groupby_indicies = []
@@ -1903,7 +1904,7 @@ class _Groupby(object):
 
         # Iterate over the ordered dictionary in order to construct
         # a group-by slice that samples the first element from each group.
-        for key_slice in self._slices_by_key.itervalues():
+        for key_slice in six.itervalues(self._slices_by_key):
             if isinstance(key_slice, tuple):
                 groupby_slice.append(key_slice[0])
             else:
@@ -1921,7 +1922,7 @@ class _Groupby(object):
 
         # Iterate over the ordered dictionary in order to construct
         # a list of tuple group boundary indexes.
-        for key_slice in self._slices_by_key.itervalues():
+        for key_slice in six.itervalues(self._slices_by_key):
             if isinstance(key_slice, tuple):
                 groupby_bounds.append((key_slice[0], key_slice[-1]))
             else:
@@ -1933,7 +1934,7 @@ class _Groupby(object):
                 if coord.bounds is None:
                     new_points = []
                     new_bounds = None
-                    for key_slice in self._slices_by_key.itervalues():
+                    for key_slice in six.itervalues(self._slices_by_key):
                         if isinstance(key_slice, slice):
                             indices = key_slice.indices(coord.points.shape[0])
                             key_slice = range(*indices)

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import copy
 import functools
@@ -428,7 +429,7 @@ class RectilinearRegridder(object):
         # Copy across any AuxFactory instances, and regrid their reference
         # surfaces where required.
         for factory in src.aux_factories:
-            for coord in factory.dependencies.itervalues():
+            for coord in six.itervalues(factory.dependencies):
                 if coord is None:
                     continue
                 dims = src.coord_dims(coord)

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -23,6 +23,7 @@ See also: :mod:`NumPy <numpy>`.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import re
 import warnings
@@ -151,7 +152,7 @@ cube_delta(temperature_cube, 'pressure')
 
     """
     # handle the case where a user passes a coordinate name
-    if isinstance(coord, basestring):
+    if isinstance(coord, six.string_types):
         coord = cube.coord(coord)
 
     if coord.ndim != 1:
@@ -250,7 +251,7 @@ def differentiate(cube, coord_to_differentiate):
     # This operation results in a copy of the original cube.
     delta_cube = cube_delta(cube, coord_to_differentiate)
 
-    if isinstance(coord_to_differentiate, basestring):
+    if isinstance(coord_to_differentiate, six.string_types):
         coord = cube.coord(coord_to_differentiate)
     else:
         coord = coord_to_differentiate

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -23,6 +23,7 @@ See also: :mod:`NumPy <numpy>`, and :ref:`SciPy <scipy:modindex>`.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import warnings
@@ -132,7 +133,7 @@ def nearest_neighbour_indices(cube, sample_points):
 
     points = []
     for coord, values in sample_points:
-        if isinstance(coord, basestring):
+        if isinstance(coord, six.string_types):
             coord = cube.coord(coord)
         else:
             coord = cube.coord(coord)
@@ -209,7 +210,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
     point = []
     ok_coord_ids = set(map(id, cube.dim_coords + cube.aux_coords))
     for coord, value in sample_point:
-        if isinstance(coord, basestring):
+        if isinstance(coord, six.string_types):
             coord = cube.coord(coord)
         else:
             coord = cube.coord(coord)
@@ -636,7 +637,7 @@ def linear(cube, sample_points, extrapolation_mode='linear'):
         sample_points = list(sample_points.items())
 
     # catch the case where a user passes a single (coord/name, value) pair rather than a list of pairs
-    if sample_points and not (isinstance(sample_points[0], collections.Container) and not isinstance(sample_points[0], basestring)):
+    if sample_points and not (isinstance(sample_points[0], collections.Container) and not isinstance(sample_points[0], six.string_types)):
         raise TypeError('Expecting the sample points to be a list of tuple pairs representing (coord, points), got a list of %s.' % type(sample_points[0]))
 
     scheme = Linear(extrapolation_mode)

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -21,6 +21,7 @@ Defines a Trajectory class, and a routine to extract a sub-cube along a trajecto
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import math
 
@@ -150,7 +151,7 @@ def interpolate(cube, sample_points, method=None):
     # Convert any coordinate names to coords
     points = []
     for coord, values in sample_points:
-        if isinstance(coord, basestring):
+        if isinstance(coord, six.string_types):
             coord = cube.coord(coord)
         points.append((coord, values))
     sample_points = points

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -21,6 +21,7 @@ Definitions of derived coordinates.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 import warnings
@@ -105,7 +106,7 @@ class LazyArray(object):
         return self._cached_array().view(*args, **kwargs)
 
 
-class AuxCoordFactory(CFVariableMixin):
+class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
     """
     Represents a "factory" which can manufacture an additional auxiliary
     coordinate on demand, by combining the values of other coordinates.
@@ -118,7 +119,6 @@ class AuxCoordFactory(CFVariableMixin):
     properties of the resulting auxiliary coordinates.
 
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self):
         #: Descriptive name of the coordinate made by the factory

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -197,7 +197,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         # Which dimensions are relevant?
         # e.g. If sigma -> [1] and orog -> [2, 3] then result = [1, 2, 3]
         derived_dims = set()
-        for coord in self.dependencies.itervalues():
+        for coord in six.itervalues(self.dependencies):
             if coord:
                 derived_dims.update(coord_dims_func(coord))
 
@@ -220,7 +220,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         """
         new_dependencies = {}
-        for key, coord in self.dependencies.iteritems():
+        for key, coord in six.iteritems(self.dependencies):
             if coord:
                 coord = new_coord_mapping[id(coord)]
             new_dependencies[key] = coord
@@ -232,14 +232,14 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         """
         element = doc.createElement('coordFactory')
-        for key, coord in self.dependencies.iteritems():
+        for key, coord in six.iteritems(self.dependencies):
             element.setAttribute(key, coord._xml_id())
         element.appendChild(self.make_coord().xml_element(doc))
         return element
 
     def _dependency_dims(self, coord_dims_func):
         dependency_dims = {}
-        for key, coord in self.dependencies.iteritems():
+        for key, coord in six.iteritems(self.dependencies):
             if coord:
                 dependency_dims[key] = coord_dims_func(coord)
         return dependency_dims
@@ -314,7 +314,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
             ndim = 1
 
         nd_points_by_key = {}
-        for key, coord in self.dependencies.iteritems():
+        for key, coord in six.iteritems(self.dependencies):
             if coord:
                 # Get the points as consistent with the Cube.
                 nd_points = self._nd_points(coord, dependency_dims[key], ndim)
@@ -342,7 +342,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
             ndim = 1
 
         nd_values_by_key = {}
-        for key, coord in self.dependencies.iteritems():
+        for key, coord in six.iteritems(self.dependencies):
             if coord:
                 # Get the bounds or points as consistent with the Cube.
                 if coord.nbounds:
@@ -400,7 +400,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
     def _dtype(self, arrays_by_key, **other_args):
         dummy_args = {}
-        for key, array in arrays_by_key.iteritems():
+        for key, array in six.iteritems(arrays_by_key):
             dummy_args[key] = np.zeros(1, dtype=array.dtype)
         dummy_args.update(other_args)
         dummy_data = self._derive(**dummy_args)

--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -61,7 +61,7 @@ defined by :mod:`ConfigParser`.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import ConfigParser
+from six.moves import configparser
 import os.path
 import warnings
 
@@ -106,7 +106,7 @@ ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 CONFIG_PATH = os.path.join(ROOT_PATH, 'etc')
 
 # Load the optional "site.cfg" file if it exists.
-config = ConfigParser.SafeConfigParser()
+config = configparser.SafeConfigParser()
 config.read([os.path.join(CONFIG_PATH, 'site.cfg')])
 
 

--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -29,6 +29,7 @@ All the functions provided here add a new coordinate to a cube.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import calendar
 import collections
@@ -64,7 +65,7 @@ def add_categorised_coord(cube, name, from_coord, category_function,
         units of the category value, typically 'no_unit' or '1'.
     """
     # Interpret coord, if given as a name
-    if isinstance(from_coord, basestring):
+    if isinstance(from_coord, six.string_types):
         from_coord = cube.coord(from_coord)
 
     if len(cube.coords(name)) > 0:
@@ -76,7 +77,7 @@ def add_categorised_coord(cube, name, from_coord, category_function,
     # Test whether the result contains strings. If it does we must manually
     # force the dtype because of a numpy bug (see numpy #3270 on GitHub).
     result = category_function(from_coord, from_coord.points.ravel()[0])
-    if isinstance(result, basestring):
+    if isinstance(result, six.string_types):
         str_vectorised_fn = np.vectorize(category_function, otypes=[object])
         vectorised_fn = lambda *args: str_vectorised_fn(*args).astype('|S64')
     else:

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -21,6 +21,7 @@ Definitions of coordinate systems.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractmethod
 import warnings
@@ -29,12 +30,11 @@ import cartopy
 import cartopy.crs as ccrs
 
 
-class CoordSystem(object):
+class CoordSystem(six.with_metaclass(ABCMeta, object)):
     """
     Abstract base class for coordinate systems.
 
     """
-    __metaclass__ = ABCMeta
 
     grid_mapping_name = None
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -349,12 +349,11 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
         return np.min(self.bound) <= point <= np.max(self.bound)
 
 
-class Coord(CFVariableMixin):
+class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
     """
     Abstract superclass for coordinates.
 
     """
-    __metaclass__ = ABCMeta
 
     _MODE_ADD = 1
     _MODE_SUB = 2

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1210,7 +1210,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         if self.attributes:
             attributes_element = doc.createElement('attributes')
-            for name in sorted(self.attributes.iterkeys()):
+            for name in sorted(six.iterkeys(self.attributes)):
                 attribute_element = doc.createElement('attribute')
                 attribute_element.setAttribute('name', name)
                 attribute_element.setAttribute('value',

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -26,7 +26,8 @@ import six
 from abc import ABCMeta, abstractproperty
 import collections
 import copy
-from itertools import chain, izip_longest
+from itertools import chain
+from six.moves import zip_longest
 import operator
 import warnings
 import zlib
@@ -1660,8 +1661,8 @@ class CellMethod(iris.util._OrderedHashable):
     def __str__(self):
         """Return a custom string representation of CellMethod"""
         # Group related coord names intervals and comments together
-        cell_components = izip_longest(self.coord_names, self.intervals,
-                                       self.comments, fillvalue="")
+        cell_components = zip_longest(self.coord_names, self.intervals,
+                                      self.comments, fillvalue="")
 
         collection_summaries = []
         cm_summary = "%s: " % self.method
@@ -1689,9 +1690,9 @@ class CellMethod(iris.util._OrderedHashable):
         cellMethod_xml_element = doc.createElement('cellMethod')
         cellMethod_xml_element.setAttribute('method', self.method)
 
-        for coord_name, interval, comment in izip_longest(self.coord_names,
-                                                          self.intervals,
-                                                          self.comments):
+        for coord_name, interval, comment in zip_longest(self.coord_names,
+                                                         self.intervals,
+                                                         self.comments):
             coord_xml_element = doc.createElement('coord')
             if coord_name is not None:
                 coord_xml_element.setAttribute('name', coord_name)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -21,6 +21,7 @@ Definitions of coordinates.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractproperty
 import collections
@@ -208,8 +209,8 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
                 return self.point == other
         elif isinstance(other, Cell):
             return (self.point == other.point) and (self.bound == other.bound)
-        elif (isinstance(other, basestring) and self.bound is None and
-              isinstance(self.point, basestring)):
+        elif (isinstance(other, six.string_types) and self.bound is None and
+              isinstance(self.point, six.string_types)):
             return self.point == other
         else:
             return NotImplemented
@@ -838,7 +839,7 @@ class Coord(CFVariableMixin):
         if compatible:
             common_keys = set(self.attributes).intersection(other.attributes)
             if ignore is not None:
-                if isinstance(ignore, basestring):
+                if isinstance(ignore, six.string_types):
                     ignore = (ignore,)
                 common_keys = common_keys.difference(ignore)
             for key in common_keys:
@@ -1622,7 +1623,7 @@ class CellMethod(iris.util._OrderedHashable):
             comments.
 
         """
-        if not isinstance(method, basestring):
+        if not isinstance(method, six.string_types):
             raise TypeError("'method' must be a string - got a '%s'" %
                             type(method))
 
@@ -1631,7 +1632,7 @@ class CellMethod(iris.util._OrderedHashable):
             pass
         elif isinstance(coords, Coord):
             _coords.append(coords.name())
-        elif isinstance(coords, basestring):
+        elif isinstance(coords, six.string_types):
             _coords.append(coords)
         else:
             normalise = (lambda coord: coord.name() if
@@ -1641,7 +1642,7 @@ class CellMethod(iris.util._OrderedHashable):
         _intervals = []
         if intervals is None:
             pass
-        elif isinstance(intervals, basestring):
+        elif isinstance(intervals, six.string_types):
             _intervals = [intervals]
         else:
             _intervals.extend(intervals)
@@ -1649,7 +1650,7 @@ class CellMethod(iris.util._OrderedHashable):
         _comments = []
         if comments is None:
             pass
-        elif isinstance(comments, basestring):
+        elif isinstance(comments, six.string_types):
             _comments = [comments]
         else:
             _comments.extend(comments)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -283,13 +283,13 @@ class CubeList(list):
         constraint_groups = dict([(constraint, CubeList()) for constraint in
                                  constraints])
         for cube in cubes:
-            for constraint, cube_list in constraint_groups.iteritems():
+            for constraint, cube_list in six.iteritems(constraint_groups):
                 sub_cube = constraint.extract(cube)
                 if sub_cube is not None:
                     cube_list.append(sub_cube)
 
         if merge_unique is not None:
-            for constraint, cubelist in constraint_groups.iteritems():
+            for constraint, cubelist in six.iteritems(constraint_groups):
                 constraint_groups[constraint] = cubelist.merge(merge_unique)
 
         result = CubeList()
@@ -1234,7 +1234,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 raise ValueError(msg)
             attr_filter = lambda coord_: all(k in coord_.attributes and
                                              coord_.attributes[k] == v for
-                                             k, v in attributes.iteritems())
+                                             k, v in six.iteritems(attributes))
             coords_and_factories = [coord_ for coord_ in coords_and_factories
                                     if attr_filter(coord_)]
 
@@ -1583,7 +1583,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # Find all the attribute keys
             keys = set()
             for similar_coord in similar_coords:
-                keys.update(similar_coord.attributes.iterkeys())
+                keys.update(six.iterkeys(similar_coord.attributes))
             # Look for any attributes that vary
             vary = set()
             attributes = {}
@@ -1596,7 +1596,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     if attributes.setdefault(key, value) != value:
                         vary.add(key)
                         break
-            keys = sorted(vary & coord.attributes.viewkeys())
+            keys = sorted(vary & set(coord.attributes.keys()))
             bits = ['{}={!r}'.format(key, coord.attributes[key]) for key in
                     keys]
             if bits:
@@ -1858,7 +1858,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             #
             if self.attributes:
                 attribute_lines = []
-                for name, value in sorted(self.attributes.iteritems()):
+                for name, value in sorted(six.iteritems(self.attributes)):
                     value = iris.util.clip_string(unicode(value))
                     line = u'{pad:{width}}{name}: {value}'.format(pad=' ',
                                                                   width=indent,
@@ -2102,7 +2102,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         ignore_bounds = kwargs.pop('ignore_bounds', False)
         for arg in args:
             result = result._intersect(*arg, ignore_bounds=ignore_bounds)
-        for name, value in kwargs.iteritems():
+        for name, value in six.iteritems(kwargs):
             result = result._intersect(name, *value,
                                        ignore_bounds=ignore_bounds)
         return result
@@ -2515,7 +2515,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         if self.attributes:
             attributes_element = doc.createElement('attributes')
-            for name in sorted(self.attributes.iterkeys()):
+            for name in sorted(six.iterkeys(self.attributes)):
                 attribute_element = doc.createElement('attribute')
                 attribute_element.setAttribute('name', name)
                 value = str(self.attributes[name])
@@ -3491,7 +3491,7 @@ class ClassDict(collections.MutableMapping, object):
 
     def __delitem__(self, class_):
         cs = self[class_]
-        keys = [k for k, v in self._retrieval_map.iteritems() if v == cs]
+        keys = [k for k, v in six.iteritems(self._retrieval_map) if v == cs]
         for key in keys:
             del self._retrieval_map[key]
         del self._basic_map[type(cs)]

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -22,6 +22,7 @@ Classes for representing multi-dimensional data with metadata.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from xml.dom.minidom import Document
 import collections
@@ -325,7 +326,7 @@ class CubeList(list):
            over which to perform the extraction.
 
         """
-        if isinstance(coord_names, basestring):
+        if isinstance(coord_names, six.string_types):
             coord_names = [coord_names]
 
         def make_overlap_fn(coord_name):
@@ -666,7 +667,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         # Temporary error while we transition the API.
-        if isinstance(data, basestring):
+        if isinstance(data, six.string_types):
             raise TypeError('Invalid data type: {!r}.'.format(data))
 
         if not isinstance(data, (biggus.Array, ma.MaskedArray)):
@@ -791,7 +792,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if compatible:
             common_keys = set(self.attributes).intersection(other.attributes)
             if ignore is not None:
-                if isinstance(ignore, basestring):
+                if isinstance(ignore, six.string_types):
                     ignore = (ignore,)
                 common_keys = common_keys.difference(ignore)
             for key in common_keys:
@@ -1190,7 +1191,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         name = None
         coord = None
 
-        if isinstance(name_or_coord, basestring):
+        if isinstance(name_or_coord, six.string_types):
             name = name_or_coord
         else:
             coord = name_or_coord
@@ -1363,7 +1364,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             The :class:`iris.coord_systems.CoordSystem` or None.
 
         """
-        if isinstance(spec, basestring) or spec is None:
+        if isinstance(spec, six.string_types) or spec is None:
             spec_name = spec
         else:
             msg = "type %s is not a subclass of CoordSystem" % spec
@@ -1793,7 +1794,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     # has a bound
                     with iris.FUTURE.context(cell_datetime_objects=False):
                         coord_cell = coord.cell(0)
-                    if isinstance(coord_cell.point, basestring):
+                    if isinstance(coord_cell.point, six.string_types):
                         # Indent string type coordinates
                         coord_cell_split = [iris.util.clip_string(str(item))
                                             for item in
@@ -2302,13 +2303,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         coords = []
         for name_or_coord in names_or_coords:
-            if (isinstance(name_or_coord, basestring) or
+            if (isinstance(name_or_coord, six.string_types) or
                     isinstance(name_or_coord, iris.coords.Coord)):
                 coords.append(self.coord(name_or_coord))
             else:
                 # Don't know how to handle this type
                 msg = "Don't know how to handle coordinate of type %s. " \
-                      "Ensure all coordinates are of type basestring or " \
+                      "Ensure all coordinates are of type six.string_types or " \
                       "iris.coords.Coord." % type(name_or_coord)
                 raise TypeError(msg)
         return coords

--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -21,6 +21,7 @@ Low level support for UM FieldsFile variants.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from contextlib import contextmanager
 import os
@@ -104,7 +105,7 @@ class _HeaderMetaclass(type):
                                                         bases, class_dict)
 
 
-class FixedLengthHeader(object):
+class FixedLengthHeader(six.with_metaclass(_HeaderMetaclass, object)):
     """
     Represents the FIXED_LENGTH_HEADER component of a UM FieldsFile
     variant.
@@ -115,8 +116,6 @@ class FixedLengthHeader(object):
     view of the header.
 
     """
-
-    __metaclass__ = _HeaderMetaclass
 
     NUM_WORDS = 256
     IMDI = -32768
@@ -211,13 +210,12 @@ class _FieldMetaclass(type):
                                                        bases, class_dict)
 
 
-class Field(object):
+class Field(six.with_metaclass(_FieldMetaclass, object)):
     """
     Represents a single entry in the LOOKUP component and its
     corresponding section of the DATA component.
 
     """
-    __metaclass__ = _FieldMetaclass
 
     #: Zero-based index for lblrec.
     LBLREC_OFFSET = 14

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -747,6 +747,8 @@ fc_formula_terms
 
 
 fc_extras
+    import six
+
     import re
     import warnings
 
@@ -909,7 +911,7 @@ fc_extras
         cube.cell_methods = _parse_cell_methods(cf_var.cf_name, nc_att_cell_methods)
 
         # Set the cube global attributes. 
-        for attr_name, attr_value in cf_var.cf_group.global_attributes.iteritems():
+        for attr_name, attr_value in six.iteritems(cf_var.cf_group.global_attributes):
             try:
                 if isinstance(attr_value, unicode):
                     try:

--- a/lib/iris/fileformats/abf.py
+++ b/lib/iris/fileformats/abf.py
@@ -27,6 +27,7 @@ The documentation for this file format can be found
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import calendar
 import datetime
@@ -193,7 +194,7 @@ def load_cubes(filespecs, callback=None):
         The resultant cubes may not be in the same order as in the file.
 
     """
-    if isinstance(filespecs, basestring):
+    if isinstance(filespecs, six.string_types):
         filespecs = [filespecs]
 
     for filespec in filespecs:

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -27,6 +27,7 @@ References:
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractmethod
 from collections import Iterable, MutableMapping
@@ -106,7 +107,7 @@ class CFVariable(object):
 
         if target is None:
             target = variables
-        elif isinstance(target, basestring):
+        elif isinstance(target, six.string_types):
             if target not in variables:
                 raise ValueError('Cannot identify unknown target CF-netCDF variable %r' % target)
             target = {target: variables[target]}
@@ -1059,7 +1060,7 @@ class CFReader(object):
                     cf_root_var = self.cf_group[cf_root]
                     name = cf_root_var.standard_name or cf_root_var.long_name
                     terms = reference_terms.get(name, [])
-                    if isinstance(terms, basestring) or \
+                    if isinstance(terms, six.string_types) or \
                             not isinstance(terms, Iterable):
                         terms = [terms]
                     cf_var_name = cf_var.cf_name

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -71,10 +71,8 @@ reference_terms = dict(atmosphere_sigma_coordinate=['ps'],
 
 
 ################################################################################
-class CFVariable(object):
+class CFVariable(six.with_metaclass(ABCMeta, object)):
     """Abstract base class wrapper for a CF-netCDF variable."""
-
-    __metaclass__ = ABCMeta
 
     #: Name of the netCDF variable attribute that identifies this
     #: CF-netCDF variable.

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -256,7 +256,7 @@ class CFAncillaryDataVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF ancillary data variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for ancillary data variable references.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -296,7 +296,7 @@ class CFAuxiliaryCoordinateVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF auxiliary coordinate variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for auxiliary coordinate variable references.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -338,7 +338,7 @@ class CFBoundaryVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF boundary variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for a boundary variable reference.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -406,7 +406,7 @@ class CFClimatologyVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF climatology variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for a climatology variable reference.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -470,7 +470,7 @@ class CFCoordinateVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF coordinate variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             if nc_var_name in ignore:
                 continue
             # String variables can't be coordinates
@@ -528,7 +528,7 @@ class _CFFormulaTermsVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF formula terms variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for formula terms variable references.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -584,7 +584,7 @@ class CFGridMappingVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all grid mapping variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for a grid mapping variable reference.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -621,7 +621,7 @@ class CFLabelVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF label variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for label variable references.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -761,7 +761,7 @@ class CFMeasureVariable(CFVariable):
         ignore, target = cls._identify_common(variables, ignore, target)
 
         # Identify all CF measure variables.
-        for nc_var_name, nc_var in target.iteritems():
+        for nc_var_name, nc_var in six.iteritems(target):
             # Check for measure variable references.
             nc_var_att = getattr(nc_var, cls.cf_identity, None)
 
@@ -799,7 +799,9 @@ class CFGroup(MutableMapping, object):
 
     def _cf_getter(self, cls):
         # Generate dictionary with dictionary comprehension.
-        return {cf_name:cf_var for cf_name, cf_var in self._cf_variables.iteritems() if isinstance(cf_var, cls)}
+        return {cf_name: cf_var
+                for cf_name, cf_var in six.iteritems(self._cf_variables)
+                if isinstance(cf_var, cls)}
 
     @property
     def ancillary_variables(self):
@@ -834,7 +836,9 @@ class CFGroup(MutableMapping, object):
     @property
     def formula_terms(self):
         """Collection of CF-netCDF variables that participate in a CF-netCDF formula term."""
-        return {cf_name:cf_var for cf_name, cf_var in self._cf_variables.iteritems() if cf_var.has_formula_terms()}
+        return {cf_name: cf_var
+                for cf_name, cf_var in six.iteritems(self._cf_variables)
+                if cf_var.has_formula_terms()}
 
     @property
     def grid_mappings(self):
@@ -954,8 +958,8 @@ class CFReader(object):
         # Identify and register all CF formula terms.
         formula_terms = _CFFormulaTermsVariable.identify(self._dataset.variables)
 
-        for cf_var in formula_terms.itervalues():
-            for cf_root, cf_term in cf_var.cf_terms_by_root.iteritems():
+        for cf_var in six.itervalues(formula_terms):
+            for cf_root, cf_term in six.iteritems(cf_var.cf_terms_by_root):
                 # Ignore formula terms owned by a bounds variable.
                 if cf_root not in self.cf_group.bounds:
                     cf_name = cf_var.cf_name
@@ -988,7 +992,7 @@ class CFReader(object):
                 match = variable_type.identify(self._dataset.variables, ignore=ignore,
                                                target=cf_variable.cf_name, warn=False)
                 # Sanity check dimensionality coverage.
-                for cf_name, cf_var in match.iteritems():
+                for cf_name, cf_var in six.iteritems(match):
                     if cf_var.spans(cf_variable):
                         cf_group[cf_name] = self.cf_group[cf_name]
                     else:
@@ -1017,7 +1021,7 @@ class CFReader(object):
                                     in coordinates_attr.split() if cf_name in
                                     self.cf_group.coordinates})
                 # Add appropriate formula terms.
-                for cf_var in self.cf_group.formula_terms.itervalues():
+                for cf_var in six.itervalues(self.cf_group.formula_terms):
                     for cf_root in cf_var.cf_terms_by_root:
                         if cf_root in cf_group and cf_var.cf_name not in cf_group:
                             # Sanity check dimensionality.
@@ -1045,7 +1049,7 @@ class CFReader(object):
         # a subset of the dimensionality of the data variable.
         ignored = set()
 
-        for cf_variable in self.cf_group.itervalues():
+        for cf_variable in six.itervalues(self.cf_group):
             _build(cf_variable)
 
         # Determine whether there are any formula terms that
@@ -1053,8 +1057,8 @@ class CFReader(object):
         if iris.FUTURE.netcdf_promote:
             # Restrict promotion to only those formula terms
             # that are reference surface/phenomenon.
-            for cf_var in self.cf_group.formula_terms.itervalues():
-                for cf_root, cf_term in cf_var.cf_terms_by_root.iteritems():
+            for cf_var in six.itervalues(self.cf_group.formula_terms):
+                for cf_root, cf_term in six.iteritems(cf_var.cf_terms_by_root):
                     cf_root_var = self.cf_group[cf_root]
                     name = cf_root_var.standard_name or cf_root_var.long_name
                     terms = reference_terms.get(name, [])
@@ -1086,7 +1090,7 @@ class CFReader(object):
 
     def _reset(self):
         """Reset the attribute touch history of each variable."""
-        for nc_var_name in self._dataset.variables.iterkeys():
+        for nc_var_name in six.iterkeys(self._dataset.variables):
             self.cf_group[nc_var_name].cf_attrs_reset()
 
     def __del__(self):

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -21,6 +21,7 @@ Provides Creation and saving of DOT graphs for a :class:`iris.cube.Cube`.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import os
 import subprocess
@@ -59,7 +60,7 @@ def save(cube, target):
     See also :func:`iris.io.save`.
 
     """
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         dot_file = open(target, "wt")
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" in target.mode:
@@ -70,7 +71,7 @@ def save(cube, target):
 
     dot_file.write(cube_text(cube))
 
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         dot_file.close()
 
 
@@ -96,7 +97,7 @@ def save_png(source, target, launch=False):
         # Create dot file
         dot_file_path = iris.util.create_temp_filename(".dot")
         save(source, dot_file_path)
-    elif isinstance(source, basestring):
+    elif isinstance(source, six.string_types):
         dot_file_path = source
     else:
         raise ValueError("Can only write dot png for a Cube or DOT file")
@@ -106,7 +107,7 @@ def save_png(source, target, launch=False):
         raise ValueError('Executable "dot" not found: '
                          'Review dot_path setting in site.cfg.')
     # To filename or open file handle?
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         subprocess.call([_DOT_EXECUTABLE_PATH, '-T', 'png', '-o', target,
                          dot_file_path])
     elif hasattr(target, "write"):

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -239,7 +239,8 @@ digraph CubeGraph{
     %(associations)s
 }
     '''
-    cube_attributes = [(name, value) for name, value in sorted(cube.attributes.iteritems(), key=lambda item: item[0])]
+    cube_attributes = list(sorted(six.iteritems(cube.attributes),
+                                  key=lambda item: item[0]))
     cube_node = _dot_node(_GRAPH_INDENT, ':Cube', 'Cube', cube_attributes)
     res_string = template % {
                         'cube_node': cube_node,
@@ -275,7 +276,7 @@ def _coord_text(label, coord):
     attrs = [(name, getattr(coord, name)) for name in _dot_attrs]
 
     if coord.attributes:
-        custom_attrs = sorted(coord.attributes.iteritems(), key=lambda item: item[0])
+        custom_attrs = sorted(six.iteritems(coord.attributes), key=lambda item: item[0])
         attrs.extend(custom_attrs)
 
     node = _dot_node(_SUBGRAPH_INDENT, label, coord.__class__.__name__, attrs)
@@ -295,7 +296,7 @@ def _coord_system_text(cs, uid):
 
     """
     attrs = []
-    for k, v in cs.__dict__.iteritems():
+    for k, v in six.iteritems(cs.__dict__):
         if isinstance(v, iris.cube.Cube):
             attrs.append((k, 'defined'))
         else:

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -178,7 +178,7 @@ class GribDataProxy(object):
         return {attr:getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in state.iteritems():
+        for key, value in six.iteritems(state):
             setattr(self, key, value)
 
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -23,6 +23,7 @@ See also: `ECMWF GRIB API <http://www.ecmwf.int/publications/manuals/grib_api/in
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import datetime
 import math  #for fmod
@@ -1002,7 +1003,7 @@ def save_messages(messages, target, append=False):
 
     """
     # grib file (this bit is common to the pp and grib savers...)
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         grib_file = open(target, "ab" if append else "wb")
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
@@ -1016,5 +1017,5 @@ def save_messages(messages, target, append=False):
         gribapi.grib_release(message)
 
     # (this bit is common to the pp and grib savers...)
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         grib_file.close()

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -21,6 +21,7 @@ Defines a lightweight wrapper class to wrap a single GRIB message.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from collections import namedtuple
 import re
@@ -218,7 +219,7 @@ class _DataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in state.iteritems():
+        for key, value in six.iteritems(state):
             setattr(self, key, value)
 
 

--- a/lib/iris/fileformats/grib/grib_phenom_translation.py
+++ b/lib/iris/fileformats/grib/grib_phenom_translation.py
@@ -30,6 +30,7 @@ Currently supports only these ones:
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import warnings
@@ -110,7 +111,7 @@ def _make_grib1_cf_table():
         return (grib1_key, cf_data)
 
     # Interpret the imported Grib1-to-CF table.
-    for (grib1data, cfdata) in grcf.GRIB1_LOCAL_TO_CF.iteritems():
+    for (grib1data, cfdata) in six.iteritems(grcf.GRIB1_LOCAL_TO_CF):
         assert grib1data.edition == 1
         association_entry = _make_grib1_cf_entry(
             table2_version=grib1data.t2version,
@@ -125,7 +126,7 @@ def _make_grib1_cf_table():
 
     # Do the same for special Grib1 codes that include an implied height level.
     for (grib1data, (cfdata, extra_dimcoord)) \
-            in grcf.GRIB1_LOCAL_TO_CF_CONSTRAINED.iteritems():
+            in six.iteritems(grcf.GRIB1_LOCAL_TO_CF_CONSTRAINED):
         assert grib1data.edition == 1
         if extra_dimcoord.standard_name != 'height':
             raise ValueError('Got implied dimension coord of "{}", '
@@ -197,7 +198,7 @@ def _make_grib2_to_cf_table():
         return (grib2_key, cf_data)
 
     # Interpret the grib2 info from grib_cf_map
-    for grib2data, cfdata in grcf.GRIB2_TO_CF.iteritems():
+    for grib2data, cfdata in six.iteritems(grcf.GRIB2_TO_CF):
         assert grib2data.edition == 2
         association_entry = _make_grib2_cf_entry(
             param_discipline=grib2data.discipline,
@@ -257,7 +258,7 @@ def _make_cf_to_grib2_table():
         return (cf_key, grib2_data)
 
     # Interpret the imported CF-to-Grib2 table into a lookup table
-    for cfdata, grib2data in grcf.CF_TO_GRIB2.iteritems():
+    for cfdata, grib2data in six.iteritems(grcf.CF_TO_GRIB2):
         assert grib2data.edition == 2
         iris_units = iris.unit.Unit(cfdata.units)
         association_entry = _make_cf_grib2_entry(

--- a/lib/iris/fileformats/name.py
+++ b/lib/iris/fileformats/name.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import iris.io
 
@@ -76,7 +77,7 @@ def load_cubes(filenames, callback):
          A generator of :class:`iris.cubes.Cube` instances.
 
     """
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, six.string_types):
         filenames = [filenames]
 
     for filename in filenames:

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import datetime
@@ -367,8 +368,7 @@ def _generate_cubes(header, column_headings, coords, data_arrays,
         # Turn the dictionary of column headings with a list of header
         # information for each field into a dictionary of headings for
         # just this field.
-        field_headings = {k: v[i] for k, v in
-                          column_headings.iteritems()}
+        field_headings = {k: v[i] for k, v in six.iteritems(column_headings)}
 
         # Make a cube.
         cube = iris.cube.Cube(data_array)
@@ -446,13 +446,13 @@ def _generate_cubes(header, column_headings, coords, data_arrays,
                     'X grid resolution', 'Y grid resolution', ]
 
         # Add the Main Headings as attributes.
-        for key, value in header.iteritems():
+        for key, value in six.iteritems(header):
             if value is not None and value != '' and \
                     key not in headings:
                 cube.attributes[key] = value
 
         # Add the Column Headings as attributes
-        for key, value in field_headings.iteritems():
+        for key, value in six.iteritems(field_headings):
             if value is not None and value != '' and \
                     key not in headings:
                 cube.attributes[key] = value

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -286,7 +286,7 @@ class NetCDFDataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in state.iteritems():
+        for key, value in six.iteritems(state):
             setattr(self, key, value)
 
 
@@ -295,30 +295,30 @@ def _assert_case_specific_facts(engine, cf, cf_group):
     engine.provides['coordinates'] = []
 
     # Assert facts for CF coordinates.
-    for cf_name in cf_group.coordinates.iterkeys():
+    for cf_name in six.iterkeys(cf_group.coordinates):
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'coordinate',
                                       (cf_name,))
 
     # Assert facts for CF auxiliary coordinates.
-    for cf_name in cf_group.auxiliary_coordinates.iterkeys():
+    for cf_name in six.iterkeys(cf_group.auxiliary_coordinates):
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'auxiliary_coordinate',
                                       (cf_name,))
 
     # Assert facts for CF grid_mappings.
-    for cf_name in cf_group.grid_mappings.iterkeys():
+    for cf_name in six.iterkeys(cf_group.grid_mappings):
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'grid_mapping',
                                       (cf_name,))
 
     # Assert facts for CF labels.
-    for cf_name in cf_group.labels.iterkeys():
+    for cf_name in six.iterkeys(cf_group.labels):
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'label',
                                       (cf_name,))
 
     # Assert facts for CF formula terms associated with the cf_group
     # of the CF data variable.
     formula_root = set()
-    for cf_var in cf.cf_group.formula_terms.itervalues():
-        for cf_root, cf_term in cf_var.cf_terms_by_root.iteritems():
+    for cf_var in six.itervalues(cf.cf_group.formula_terms):
+        for cf_root, cf_term in six.iteritems(cf_var.cf_terms_by_root):
             # Only assert this fact if the formula root variable is
             # defined in the CF group of the CF data variable.
             if cf_root in cf_group:
@@ -347,7 +347,7 @@ def _pyke_stats(engine, cf_name):
         print('Case Specific Facts:')
         kb_facts = engine.get_kb(_PYKE_FACT_BASE)
 
-        for key in kb_facts.entity_lists.iterkeys():
+        for key in six.iterkeys(kb_facts.entity_lists):
             for arg in kb_facts.entity_lists[key].case_specific_facts:
                 print('\t%s%s' % (key, arg))
 
@@ -548,8 +548,8 @@ def load_cubes(filenames, callback=None):
         cf = iris.fileformats.cf.CFReader(filename)
 
         # Process each CF data variable.
-        data_variables = cf.cf_group.data_variables.values() + \
-            cf.cf_group.promoted.values()
+        data_variables = (list(cf.cf_group.data_variables.values()) +
+                          list(cf.cf_group.promoted.values()))
         for cf_var in data_variables:
             cube = _load_cube(engine, cf, cf_var, filename)
 
@@ -782,8 +782,9 @@ class Saver(object):
         local_keys.update(_CF_DATA_ATTRS, _UKMO_DATA_ATTRS)
 
         # Add global attributes taking into account local_keys.
-        global_attributes = {k: v for k, v in cube.attributes.iteritems() if k
-                             not in local_keys and k.lower() != 'conventions'}
+        global_attributes = {k: v for k, v in six.iteritems(cube.attributes)
+                             if (k not in local_keys and
+                                 k.lower() != 'conventions')}
         self.update_global_attributes(global_attributes)
 
         if cf_profile_available:
@@ -958,7 +959,7 @@ class Saver(object):
                 cf_var = self._dataset.variables[cf_name]
 
                 names = {key: self._name_coord_map.name(coord) for
-                         key, coord in factory.dependencies.iteritems()}
+                         key, coord in six.iteritems(factory.dependencies)}
                 formula_terms = factory_defn.formula_terms_format.format(
                     **names)
                 std_name = factory_defn.std_name

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -26,6 +26,7 @@ Version 1.4, 27 February 2009.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import os
@@ -539,7 +540,7 @@ def load_cubes(filenames, callback=None):
     # Initialise the pyke inference engine.
     engine = _pyke_kb_engine()
 
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, six.string_types):
         filenames = [filenames]
 
     for filename in filenames:

--- a/lib/iris/fileformats/nimrod.py
+++ b/lib/iris/fileformats/nimrod.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import glob
 import numpy as np
@@ -223,7 +224,7 @@ def load_cubes(filenames, callback=None):
         The resultant cubes may not be in the same order as in the files.
 
     """
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, six.string_types):
         filenames = [filenames]
 
     for filename in filenames:

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1356,7 +1356,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         # set up a list to hold the extra data which will need to be encoded at the end of the data
         extra_items = []
         # iterate through all of the possible extra data fields
-        for ib, extra_data_attr_name in EXTRA_DATA.iteritems():
+        for ib, extra_data_attr_name in six.iteritems(EXTRA_DATA):
             # try to get the extra data field, returning None if it doesn't exist
             extra_elem = getattr(self, extra_data_attr_name, None)
             if extra_elem is not None:

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -21,6 +21,7 @@ Provides UK Met Office Post Process (PP) format specific capabilities.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import abc
 import collections
@@ -295,7 +296,7 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
     @staticmethod
     def from_msi(msi):
         """Convert a STASH code MSI string to a STASH instance."""
-        if not isinstance(msi, basestring):
+        if not isinstance(msi, six.string_types):
             raise TypeError('Expected STASH code MSI string, got %r' % (msi,))
 
         msi_match = re.match('^\s*m(.*)s(.*)i(.*)\s*$', msi, re.IGNORECASE)
@@ -344,7 +345,7 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         return '?' not in str(self)
 
     def __eq__(self, other):
-        if isinstance(other, basestring):
+        if isinstance(other, six.string_types):
             return super(STASH, self).__eq__(STASH.from_msi(other))
         else:
             return super(STASH, self).__eq__(other)
@@ -1178,7 +1179,7 @@ class PPField(object):
     
     @stash.setter
     def stash(self, stash):
-        if isinstance(stash, basestring):
+        if isinstance(stash, six.string_types):
             self._stash = STASH.from_msi(stash)
         elif isinstance(stash, STASH):
             self._stash = stash
@@ -1364,7 +1365,7 @@ class PPField(object):
             extra_elem = getattr(self, extra_data_attr_name, None)
             if extra_elem is not None:
                 # The special case of character extra data must be caught
-                if isinstance(extra_elem, basestring):
+                if isinstance(extra_elem, six.string_types):
                     ia = len(extra_elem)
                     # pad any strings up to a multiple of PP_WORD_DEPTH (this length is # of bytes)
                     ia = (PP_WORD_DEPTH - (ia-1) % PP_WORD_DEPTH) + (ia-1)
@@ -1467,7 +1468,7 @@ class PPField(object):
         # extra data elements
         for int_code, extra_data in extra_items:
             pp_file.write(struct.pack(">L", int(int_code)))
-            if isinstance(extra_data, basestring):
+            if isinstance(extra_data, six.string_types):
                 pp_file.write(struct.pack(">%sc" % len(extra_data), *extra_data))
             else:
                 extra_data = extra_data.astype(np.dtype('>f4'))
@@ -2166,7 +2167,7 @@ def as_pairs(cube, field_coords=None, target=None):
         # Log the rules used
         if target is None:
             target = 'None'
-        elif not isinstance(target, basestring):
+        elif not isinstance(target, six.string_types):
             target = target.name
         iris.fileformats.rules.log('PP_SAVE', str(target), verify_rules_ran)
 
@@ -2244,7 +2245,7 @@ def save_fields(fields, target, append=False):
     #   LBTYP - Fields file field type code
     #   LBLEV - Fields file level code / hybrid height model level
 
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         pp_file = open(target, "ab" if append else "wb")
         filename = target
     elif hasattr(target, "write"):
@@ -2260,5 +2261,5 @@ def save_fields(fields, target, append=False):
         # Write to file
         pp_field.save(pp_file)
 
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
         pp_file.close()

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -669,11 +669,9 @@ class _FlagMetaclass(type):
         return type.__new__(cls, classname, bases, class_dict)
 
 
-class _LBProc(BitwiseInt):
+class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
     # Use a metaclass to define the `flag1`, `flag2`, `flag4, etc.
     # properties.
-    __metaclass__ = _FlagMetaclass
-
     def __init__(self, value):
         """
         Args:
@@ -1047,7 +1045,7 @@ def _pp_attribute_names(header_defn):
     return normal_headers + special_headers + extra_data + special_attributes
 
 
-class PPField(object):
+class PPField(six.with_metaclass(abc.ABCMeta, object)):
     """
     A generic class for PP fields - not specific to a particular header release number.
 
@@ -1065,8 +1063,6 @@ class PPField(object):
 
     # NB. Subclasses must define the attribute HEADER_DEFN to be their
     # zero-based header definition. See PPField2 and PPField3 for examples.
-
-    __metaclass__ = abc.ABCMeta
 
     __slots__ = ()
 

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Historically this was auto-generated from
 # SciTools/iris-code-generators:tools/gen_rules.py
@@ -1084,7 +1085,8 @@ def _all_other_rules(f):
 
     if unhandled_lbproc:
         attributes["ukmo__process_flags"] = tuple(sorted(
-            [name for value, name in iris.fileformats.pp.lbproc_map.iteritems()
+            [name
+             for value, name in six.iteritems(iris.fileformats.pp.lbproc_map)
              if isinstance(value, int) and f.lbproc & value]))
 
     if (f.lbsrce % 10000) == 1111:

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -82,7 +82,7 @@ class ConcreteReferenceTarget(object):
             else:
                 final_cube = src_cube.copy()
                 attributes = self.transform(final_cube)
-                for name, value in attributes.iteritems():
+                for name, value in six.iteritems(attributes):
                     setattr(final_cube, name, value)
                 self._final_cube = final_cube
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -21,6 +21,7 @@ Processing of simple IF-THEN rules.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import abc
 import collections
@@ -787,7 +788,7 @@ def load_cubes(filenames, user_callback, loader, filter_function=None):
     concrete_reference_targets = {}
     results_needing_reference = []
 
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, six.string_types):
         filenames = [filenames]
 
     for filename in filenames:

--- a/lib/iris/fileformats/um/_optimal_array_structuring.py
+++ b/lib/iris/fileformats/um/_optimal_array_structuring.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import itertools
 
@@ -164,7 +165,7 @@ def optimal_array_structure(ordering_elements, actual_values_elements=None):
     # Filter out the trivial (scalar) ones.
     elements_and_dimensions = {
         name: (array, dims)
-        for name, (array, dims) in elements_and_dimensions.iteritems()
+        for name, (array, dims) in six.iteritems(elements_and_dimensions)
         if len(dims)}
 
     # Make a list of 'primary' elements; i.e. those in the target structure.

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -21,6 +21,7 @@ Provides an interface to manage URI scheme support in iris.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import glob
 import os.path
@@ -38,7 +39,7 @@ import iris.exceptions
 class _SaversDict(dict):
     """A dictionary that can only have string keys with no overlap."""
     def __setitem__(self, key, value):
-        if not isinstance(key, basestring):
+        if not isinstance(key, six.string_types):
             raise ValueError("key is not a string")
         if key in self:
             raise ValueError("A saver already exists for", key)
@@ -337,11 +338,11 @@ def save(source, target, saver=None, **kwargs):
 
     """
     # Determine format from filename
-    if isinstance(target, basestring) and saver is None:
+    if isinstance(target, six.string_types) and saver is None:
         saver = find_saver(target)
     elif isinstance(target, types.FileType) and saver is None:
         saver = find_saver(target.name)
-    elif isinstance(saver, basestring):
+    elif isinstance(saver, six.string_types):
         saver = find_saver(saver)
     if saver is None:
         raise ValueError("Cannot save; no saver")

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -161,11 +161,11 @@ def expand_filespecs(file_specs):
     glob_expanded = {fn : sorted(glob.glob(fn)) for fn in filenames}
 
     # If any of the specs expanded to an empty list then raise an error
-    value_lists = glob_expanded.viewvalues()
+    value_lists = glob_expanded.values()
     if not all(value_lists):
         raise IOError("One or more of the files specified did not exist %s." %
         ["%s expanded to %s" % (pattern, expanded if expanded else "empty")
-         for pattern, expanded in glob_expanded.iteritems()])
+         for pattern, expanded in six.iteritems(glob_expanded)])
 
     return sum(value_lists, [])
 
@@ -192,7 +192,7 @@ def load_files(filenames, callback, constraints=None):
             handler_map[handling_format_spec].append(fn)
 
     # Call each iris format handler with the approriate filenames
-    for handling_format_spec, fnames in handler_map.iteritems():
+    for handling_format_spec, fnames in six.iteritems(handler_map):
         if handling_format_spec.constraint_aware_handler:
             for cube in handling_format_spec.handler(fnames, callback,
                                                      constraints):
@@ -220,7 +220,7 @@ def load_http(urls, callback):
         handler_map[handling_format_spec].append(url)
 
     # Call each iris format handler with the appropriate filenames
-    for handling_format_spec, fnames in handler_map.iteritems():
+    for handling_format_spec, fnames in six.iteritems(handler_map):
         for cube in handling_format_spec.handler(fnames, callback):
             yield cube
 

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -52,6 +52,7 @@ The calling sequence of handler is dependent on the function given in the origin
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import functools
@@ -140,7 +141,7 @@ class FormatAgent(object):
                 return format_spec
 
         printable_values = {}
-        for key, value in element_cache.iteritems():
+        for key, value in six.iteritems(element_cache):
             value = str(value)
             if len(value) > 50:
                 value = value[:50] + '...'

--- a/lib/iris/palette.py
+++ b/lib/iris/palette.py
@@ -22,6 +22,7 @@ color map meta-data mappings.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from functools import wraps
 import os
@@ -100,7 +101,7 @@ def _default_cmap_norm(args, kwargs):
 
             if len(cmaps) == 0:
                 # Check for a fuzzy match against a keyword.
-                for keyword in _CMAP_BY_KEYWORD.iterkeys():
+                for keyword in six.iterkeys(_CMAP_BY_KEYWORD):
                     if keyword in std_name:
                         cmaps.update(_CMAP_BY_KEYWORD[keyword])
 

--- a/lib/iris/symbols.py
+++ b/lib/iris/symbols.py
@@ -21,6 +21,7 @@ Contains symbol definitions for use with :func:`iris.plot.symbols`.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import itertools
 import math
@@ -222,7 +223,7 @@ See http://www.wmo.int/pages/prog/www/DPFS/documents/485_Vol_I_en_colour.pdf
 
 def _convert_paths_to_patches():
     # Convert the symbols defined as lists-of-paths into patches.
-    for code, symbol in CLOUD_COVER.iteritems():
+    for code, symbol in six.iteritems(CLOUD_COVER):
         CLOUD_COVER[code] = _make_merged_patch(symbol)
 
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -32,6 +32,7 @@ graphical test results.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import collections
 import contextlib
@@ -144,14 +145,14 @@ def get_data_path(relative_path):
     as a string, or sequence of strings.
 
     """
-    if not isinstance(relative_path, basestring):
+    if not isinstance(relative_path, six.string_types):
         relative_path = os.path.join(*relative_path)
     data_path = os.path.join(iris.config.TEST_DATA_DIR, relative_path)
 
     if _EXPORT_DATAPATHS_FILE is not None:
         _EXPORT_DATAPATHS_FILE.write(data_path + '\n')
 
-    if isinstance(data_path, basestring) and not os.path.exists(data_path):
+    if isinstance(data_path, six.string_types) and not os.path.exists(data_path):
         # if the file is gzipped, ungzip it and return the path of the ungzipped
         # file.
         gzipped_fname = data_path + '.gz'
@@ -176,7 +177,7 @@ def get_data_path(relative_path):
 def get_result_path(relative_path):
     """Returns the absolute path to a result file when given the relative path
     as a string, or sequence of strings."""
-    if not isinstance(relative_path, basestring):
+    if not isinstance(relative_path, six.string_types):
         relative_path = os.path.join(*relative_path)
     return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
@@ -286,7 +287,7 @@ class IrisTest(unittest.TestCase):
 
         if flags is None:
             flags = []
-        elif isinstance(flags, basestring):
+        elif isinstance(flags, six.string_types):
             flags = flags.split()
         else:
             flags = list(map(str, flags))

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -23,7 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import cPickle as pickle
+import six.moves.cPickle as pickle
 
 from iris.fileformats.grib import _GribMessage
 

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -21,6 +21,7 @@ A collection of routines which create standard Cubes for test purposes.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import os.path
 
@@ -474,7 +475,7 @@ def realistic_4d():
     data_path = os.path.join(os.path.dirname(__file__), 'stock_arrays.npz')
     r = np.load(data_path)
     # sort the arrays based on the order they were originally given. The names given are of the form 'arr_1' or 'arr_10'
-    _, arrays =  zip(*sorted(r.iteritems(), key=lambda item: int(item[0][4:])))
+    _, arrays =  zip(*sorted(six.iteritems(r), key=lambda item: int(item[0][4:])))
 
     lat_pts, lat_bnds, lon_pts, lon_bnds, level_height_pts, \
     level_height_bnds, model_level_pts, sigma_pts, sigma_bnds, time_pts, \

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -43,7 +44,7 @@ if tests.MPL_AVAILABLE:
 class TestAnalysisCubeCoordComparison(tests.IrisTest):
     def assertComparisonDict(self, comarison_dict, reference_filename):
         string = ''
-        for key, coord_groups in comarison_dict.iteritems():
+        for key, coord_groups in six.iteritems(comarison_dict):
             string += ('%40s  ' % key)
             names = [[coord.name() if coord is not None else 'None' for coord in coords] for coords in coord_groups]
             string += str(sorted(names))
@@ -1043,7 +1044,7 @@ class TestProject(tests.GraphicsTest):
         # Set up figure
         fig = plt.figure(figsize=(10, 10))
         gs = matplotlib.gridspec.GridSpec(nrows=3, ncols=3, hspace=1.5, wspace=0.5)
-        for subplot_spec, (name, target_proj) in zip(gs, projections.iteritems()):
+        for subplot_spec, (name, target_proj) in zip(gs, six.iteritems(projections)):
             # Set up axes and title
             ax = plt.subplot(subplot_spec, frameon=False, projection=target_proj)
             ax.set_title(name)

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -283,7 +284,7 @@ class TestPPSaveRules(tests.IrisTest, pp.PPTest):
         # Maps lbproc value to the process flags that should be created
         multiple_map = {sum(bits) : [iris.fileformats.pp.lbproc_map[bit] for bit in bits] for bits in multiple_bit_values}
 
-        for lbproc, descriptions in multiple_map.iteritems():
+        for lbproc, descriptions in six.iteritems(multiple_map):
             ll_cube = stock.lat_lon_cube()
             ll_cube.attributes["ukmo__process_flags"] = descriptions
             

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -539,22 +539,22 @@ class TestGribTimecodes(tests.IrisTest):
             gribapi_ver = gribapi.grib_get_api_version()
 
         if StrictVersion(gribapi_ver) < StrictVersion('1.9.18'):
-            exp_end_date = datetime.datetime(year=2007, month=03, day=25,
+            exp_end_date = datetime.datetime(year=2007, month=3, day=25,
                                              hour=12, minute=0, second=0)
         else:
-            exp_end_date = datetime.datetime(year=2007, month=03, day=25,
+            exp_end_date = datetime.datetime(year=2007, month=3, day=25,
                                              hour=19, minute=0, second=0)
 
         # Check that it captures the statistics time period info.
         # (And for now, nothing else)
         self.assertEqual(
             grib_wrapper._referenceDateTime,
-            datetime.datetime(year=2007, month=03, day=23,
+            datetime.datetime(year=2007, month=3, day=23,
                               hour=12, minute=0, second=0)
         )
         self.assertEqual(
             grib_wrapper._periodStartDateTime,
-            datetime.datetime(year=2007, month=03, day=23,
+            datetime.datetime(year=2007, month=3, day=23,
                               hour=22, minute=0, second=0)
         )
         self.assertEqual(grib_wrapper._periodEndDateTime, exp_end_date)

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -21,6 +21,7 @@ Test the hybrid vertical coordinate representations.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before
 # importing anything else
@@ -70,7 +71,9 @@ class TestRealistic4d(tests.GraphicsTest):
 
         # Check the factory now only has surface_altitude and delta dependencies.
         factory = cube.aux_factory(name='altitude')
-        t = [key for key, coord in factory.dependencies.iteritems() if coord is not None]
+        t = [key
+             for key, coord in six.iteritems(factory.dependencies)
+             if coord is not None]
         self.assertItemsEqual(t, ['orography', 'delta'])
 
     def test_removing_orography(self):
@@ -82,7 +85,9 @@ class TestRealistic4d(tests.GraphicsTest):
 
         # Check the factory now only has sigma and delta dependencies.
         factory = cube.aux_factory(name='altitude')
-        t = [key for key, coord in factory.dependencies.iteritems() if coord is not None]
+        t = [key
+             for key, coord in six.iteritems(factory.dependencies)
+             if coord is not None]
         self.assertItemsEqual(t, ['sigma', 'delta'])
 
     def test_derived_coords(self):

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -21,6 +21,7 @@ Test the cube merging mechanism.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -193,7 +194,7 @@ class TestCombination(tests.IrisTest):
                                     long_name='y', units='1'), 0)
 
         for name, value in zip(['a', 'b', 'c', 'd'], [a, b, c, d]):
-            dtype = np.str if isinstance(value, basestring) else np.float32
+            dtype = np.str if isinstance(value, six.string_types) else np.float32
             cube.add_aux_coord(AuxCoord(np.array([value], dtype=dtype),
                                         long_name=name, units='1'))
 
@@ -259,7 +260,7 @@ class TestDimSelection(tests.IrisTest):
                                     long_name='y', units='1'), 0)
 
         for name, value, dim in zip(['a', 'b'], [a, b], [a_dim, b_dim]):
-            dtype = np.str if isinstance(value, basestring) else np.float32
+            dtype = np.str if isinstance(value, six.string_types) else np.float32
             ctype = DimCoord if dim else AuxCoord
             coord = ctype(np.array([value], dtype=dtype),
                           long_name=name, units='1')

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -21,6 +21,7 @@ Test CF-NetCDF file loading and saving.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else.
@@ -874,7 +875,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
         multiple_map = {bits: [iris.fileformats.pp.lbproc_map[bit] for
                                bit in bits] for bits in multiple_bit_values}
 
-        for bits, descriptions in multiple_map.iteritems():
+        for bits, descriptions in six.iteritems(multiple_map):
 
             ll_cube = stock.lat_lon_cube()
             ll_cube.attributes["ukmo__process_flags"] = descriptions

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -319,11 +319,11 @@ class TestSeriesAsCube(tests.IrisTest):
     def test_series_datetime_gregorian(self):
         series = pandas.Series(
             [0, 1, 2, 3, 4],
-            index=[datetime.datetime(2001, 01, 01, 01, 01, 01),
-                   datetime.datetime(2002, 02, 02, 02, 02, 02),
-                   datetime.datetime(2003, 03, 03, 03, 03, 03),
-                   datetime.datetime(2004, 04, 04, 04, 04, 04),
-                   datetime.datetime(2005, 05, 05, 05, 05, 05)])
+            index=[datetime.datetime(2001, 1, 1, 1, 1, 1),
+                   datetime.datetime(2002, 2, 2, 2, 2, 2),
+                   datetime.datetime(2003, 3, 3, 3, 3, 3),
+                   datetime.datetime(2004, 4, 4, 4, 4, 4),
+                   datetime.datetime(2005, 5, 5, 5, 5, 5)])
         self.assertCML(
             iris.pandas.as_cube(series),
             tests.get_result_path(('pandas', 'as_cube',
@@ -332,11 +332,11 @@ class TestSeriesAsCube(tests.IrisTest):
     def test_series_netcdftime_360(self):
         series = pandas.Series(
             [0, 1, 2, 3, 4],
-            index=[netcdftime.datetime(2001, 01, 01, 01, 01, 01),
-                   netcdftime.datetime(2002, 02, 02, 02, 02, 02),
-                   netcdftime.datetime(2003, 03, 03, 03, 03, 03),
-                   netcdftime.datetime(2004, 04, 04, 04, 04, 04),
-                   netcdftime.datetime(2005, 05, 05, 05, 05, 05)])
+            index=[netcdftime.datetime(2001, 1, 1, 1, 1, 1),
+                   netcdftime.datetime(2002, 2, 2, 2, 2, 2),
+                   netcdftime.datetime(2003, 3, 3, 3, 3, 3),
+                   netcdftime.datetime(2004, 4, 4, 4, 4, 4),
+                   netcdftime.datetime(2005, 5, 5, 5, 5, 5)])
         self.assertCML(
             iris.pandas.as_cube(series,
                                 calendars={0: iris.unit.CALENDAR_360_DAY}),
@@ -393,8 +393,8 @@ class TestDataFrameAsCube(tests.IrisTest):
         data_frame = pandas.DataFrame(
             [[0, 1, 2, 3, 4],
              [5, 6, 7, 8, 9]],
-            index=[netcdftime.datetime(2001, 01, 01, 01, 01, 01),
-                   netcdftime.datetime(2002, 02, 02, 02, 02, 02)],
+            index=[netcdftime.datetime(2001, 1, 1, 1, 1, 1),
+                   netcdftime.datetime(2002, 2, 2, 2, 2, 2)],
             columns=[10, 11, 12, 13, 14])
         self.assertCML(
             iris.pandas.as_cube(
@@ -407,8 +407,8 @@ class TestDataFrameAsCube(tests.IrisTest):
         data_frame = pandas.DataFrame(
             [[0, 1, 2, 3, 4],
              [5, 6, 7, 8, 9]],
-            index=[datetime.datetime(2001, 01, 01, 01, 01, 01),
-                   datetime.datetime(2002, 02, 02, 02, 02, 02)],
+            index=[datetime.datetime(2001, 1, 1, 1, 1, 1),
+                   datetime.datetime(2002, 2, 2, 2, 2, 2)],
             columns=[10, 11, 12, 13, 14])
         self.assertCML(
             iris.pandas.as_cube(data_frame),

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -25,7 +25,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
-import cPickle
+import six.moves.cPickle as pickle
 import io
 
 import numpy as np
@@ -36,13 +36,13 @@ import iris
 class TestPickle(tests.IrisTest):
     def pickle_then_unpickle(self, obj):
         """Returns a generator of ("cpickle protocol number", object) tuples."""
-        for protocol in range(1 + cPickle.HIGHEST_PROTOCOL):
+        for protocol in range(1 + pickle.HIGHEST_PROTOCOL):
             bio = io.BytesIO()
-            cPickle.dump(obj, bio, protocol)
+            pickle.dump(obj, bio, protocol)
 
             # move the bio back to the start and reconstruct
             bio.seek(0)
-            reconstructed_obj = cPickle.load(bio)
+            reconstructed_obj = pickle.load(bio)
 
             yield protocol, reconstructed_obj
 

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before
 # importing anything else
@@ -568,13 +569,13 @@ class CheckForWarningsMetaclass(type):
 
 
 @tests.skip_data
-class TestPcolorNoBounds(tests.GraphicsTest, SliceMixin):
+class TestPcolorNoBounds(six.with_metaclass(CheckForWarningsMetaclass,
+                                            tests.GraphicsTest, SliceMixin)):
     """
     Test the iris.plot.pcolor routine on a cube with coordinates
     that have no bounds.
 
     """
-    __metaclass__ = CheckForWarningsMetaclass
 
     def setUp(self):
         self.wind = _load_wind_no_bounds()
@@ -582,13 +583,14 @@ class TestPcolorNoBounds(tests.GraphicsTest, SliceMixin):
 
 
 @tests.skip_data
-class TestPcolormeshNoBounds(tests.GraphicsTest, SliceMixin):
+class TestPcolormeshNoBounds(six.with_metaclass(CheckForWarningsMetaclass,
+                                                tests.GraphicsTest,
+                                                SliceMixin)):
     """
     Test the iris.plot.pcolormesh routine on a cube with coordinates
     that have no bounds.
 
     """
-    __metaclass__ = CheckForWarningsMetaclass
 
     def setUp(self):
         self.wind = _load_wind_no_bounds()

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -116,10 +116,10 @@ class TestPPStash(tests.IrisTest):
 
     def test_illegal_stash_type(self):
         with self.assertRaises(TypeError):
-            self.assertEqual(iris.fileformats.pp.STASH.from_msi(0102003), 'm01s02i003')
+            self.assertEqual(iris.fileformats.pp.STASH.from_msi(102003), 'm01s02i003')
 
         with self.assertRaises(TypeError):
-            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi(0102003))
+            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi(102003))
 
         with self.assertRaises(TypeError):
             self.assertEqual(iris.fileformats.pp.STASH.from_msi(['m01s02i003']), 'm01s02i003')

--- a/lib/iris/tests/test_trajectory.py
+++ b/lib/iris/tests/test_trajectory.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -102,7 +103,7 @@ class TestTrajectory(tests.IrisTest):
         def traj_to_sample_points(trajectory):
             sample_points = []
             src_points = trajectory.sampled_points
-            for name in src_points[0].iterkeys():
+            for name in six.iterkeys(src_points[0]):
                 values = [point[name] for point in src_points]
                 sample_points.append((name, values))
             return sample_points

--- a/lib/iris/tests/test_unit.py
+++ b/lib/iris/tests/test_unit.py
@@ -28,6 +28,10 @@ import iris.tests as tests
 import copy
 import datetime as datetime
 import operator
+try:
+    from operator import truediv
+except ImportError:
+    from operator import div as truediv
 
 import numpy as np
 
@@ -255,7 +259,7 @@ class TestOffset(TestUnit):
 
     def test_offset_pass_2(self):
         u = Unit("meter")
-        self.assertEqual(u + 1000L, "m @ 1000")
+        self.assertEqual(u + 1000, "m @ 1000")
 
 
 class TestOffsetByTime(TestUnit):
@@ -385,7 +389,7 @@ class TestMultiply(TestUnit):
 
     def test_multiply_pass_2(self):
         u = Unit("amp")
-        self.assertEqual((u * 1000L).format(), "1000 A")
+        self.assertEqual((u * 1000).format(), "1000 A")
 
     def test_multiply_pass_3(self):
         u = Unit("amp")
@@ -396,7 +400,7 @@ class TestMultiply(TestUnit):
 class TestDivide(TestUnit):
     def test_divide_fail_0(self):
         u = Unit("watts")
-        self.assertRaises(ValueError, operator.div, u, "naughty")
+        self.assertRaises(ValueError, truediv, u, "naughty")
 
     def test_divide_fail_1(self):
         u = Unit('unknown')
@@ -407,14 +411,14 @@ class TestDivide(TestUnit):
     def test_divide_fail_3(self):
         u = Unit('unknown')
         v = Unit('no unit')
-        self.assertRaises(ValueError, operator.div, u, v)
-        self.assertRaises(ValueError, operator.div, v, u)
+        self.assertRaises(ValueError, truediv, u, v)
+        self.assertRaises(ValueError, truediv, v, u)
 
     def test_divide_fail_5(self):
         u = Unit('meters')
         v = Unit('no unit')
-        self.assertRaises(ValueError, operator.div, u, v)
-        self.assertRaises(ValueError, operator.div, v, u)
+        self.assertRaises(ValueError, truediv, u, v)
+        self.assertRaises(ValueError, truediv, v, u)
 
     def test_divide_pass_0(self):
         u = Unit("watts")
@@ -426,7 +430,7 @@ class TestDivide(TestUnit):
 
     def test_divide_pass_2(self):
         u = Unit("watts")
-        self.assertEqual((u / 1000L).format(), "0.001 W")
+        self.assertEqual((u / 1000).format(), "0.001 W")
 
     def test_divide_pass_3(self):
         u = Unit("watts")
@@ -443,7 +447,7 @@ class TestPower(TestUnit):
         self.assertRaises(TypeError, operator.pow, u, Unit('no unit'))
         self.assertEqual(u ** 2, Unit('A^2'))
         self.assertEqual(u ** 3.0, Unit('A^3'))
-        self.assertEqual(u ** 4L, Unit('A^4'))
+        self.assertEqual(u ** 4, Unit('A^4'))
         self.assertRaises(ValueError, operator.pow, u, 2.4)
 
         u = Unit("m^2")
@@ -456,7 +460,7 @@ class TestPower(TestUnit):
         self.assertRaises(TypeError, operator.pow, u, Unit('m'))
         self.assertEqual(u ** 2, Unit('unknown'))
         self.assertEqual(u ** 3.0, Unit('unknown'))
-        self.assertEqual(u ** 4L, Unit('unknown'))
+        self.assertEqual(u ** 4, Unit('unknown'))
 
     def test_power_nounit(self):
         u = Unit('no unit')

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractproperty
 
@@ -28,11 +29,9 @@ from iris.cube import Cube
 import iris.tests.stock as stock
 
 
-class CubeArithmeticBroadcastingTestMixin(object):
+class CubeArithmeticBroadcastingTestMixin(six.with_metaclass(ABCMeta, object)):
     # A framework for testing the broadcasting behaviour of the various cube
     # arithmetic operations.  (A test for each operation inherits this).
-    __metaclass__ = ABCMeta
-
     @abstractproperty
     def data_op(self):
         # Define an operator to be called, I.E. 'operator.xx'.
@@ -119,11 +118,9 @@ class CubeArithmeticBroadcastingTestMixin(object):
                                   err_msg=msg.format(dim))
 
 
-class CubeArithmeticMaskingTestMixin(object):
+class CubeArithmeticMaskingTestMixin(six.with_metaclass(ABCMeta, object)):
     # A framework for testing the mask handling behaviour of the various cube
     # arithmetic operations.  (A test for each operation inherits this).
-    __metaclass__ = ABCMeta
-
     @abstractproperty
     def data_op(self):
         # Define an operator to be called, I.E. 'operator.xx'.

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
@@ -52,7 +52,7 @@ class Test(tests.IrisTest):
                                   attributes=attributes)
 
         # Source cube x-coordinates.
-        points = np.array([[010, 020, 200, 220],
+        points = np.array([[10, 20, 200, 220],
                            [110, 120, 180, 185],
                            [190, 203, 211, 220]])
         self.src_x_positive = iris.coords.AuxCoord(points,
@@ -69,8 +69,8 @@ class Test(tests.IrisTest):
                                                    units='degrees')
 
         # Source cube y-coordinates.
-        points = np.array([[00, 04, 03, 01],
-                           [05, 07, 10, 06],
+        points = np.array([[0, 4, 3, 1],
+                           [5, 7, 10, 6],
                            [12, 20, 15, 30]])
         self.src_y = iris.coords.AuxCoord(points,
                                           standard_name='latitude',

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -136,24 +136,24 @@ class Test_translate__formula_terms(tests.IrisTest):
             group = cf_group.coordinates
             self.assertEqual(len(group), 3)
             coordinates = ['height', 'lat', 'lon']
-            self.assertEqual(group.viewkeys(), set(coordinates))
+            self.assertEqual(set(group.keys()), set(coordinates))
             for name in coordinates:
                 self.assertIs(group[name].cf_data, getattr(self, name))
             # Check there are three auxiliary coordinates.
             group = cf_group.auxiliary_coordinates
             self.assertEqual(len(group), 3)
             aux_coordinates = ['delta', 'sigma', 'orography']
-            self.assertEqual(group.viewkeys(), set(aux_coordinates))
+            self.assertEqual(set(group.keys()), set(aux_coordinates))
             for name in aux_coordinates:
                 self.assertIs(group[name].cf_data, getattr(self, name))
             # Check all the auxiliary coordinates are formula terms.
             formula_terms = cf_group.formula_terms
-            self.assertEqual(group.viewitems(), formula_terms.viewitems())
+            self.assertEqual(set(group.items()), set(formula_terms.items()))
             # Check there are three bounds.
             group = cf_group.bounds
             self.assertEqual(len(group), 3)
             bounds = ['height_bnds', 'delta_bnds', 'sigma_bnds']
-            self.assertEqual(group.viewkeys(), set(bounds))
+            self.assertEqual(set(group.keys()), set(bounds))
             for name in bounds:
                 self.assertEqual(group[name].cf_data, getattr(self, name))
 
@@ -218,7 +218,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
             group = temp_cf_group.coordinates
             self.assertEqual(len(group), 3)
             coordinates = ['height', 'lat', 'lon']
-            self.assertEqual(group.viewkeys(), set(coordinates))
+            self.assertEqual(set(group.keys()), set(coordinates))
             for name in coordinates:
                 self.assertIs(group[name].cf_data, getattr(self, name))
             # Check the height coordinate is bounded.
@@ -230,7 +230,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
             group = temp_cf_group.auxiliary_coordinates
             self.assertEqual(len(group), 5)
             aux_coordinates = ['delta', 'sigma', 'orography', 'x', 'y']
-            self.assertEqual(group.viewkeys(), set(aux_coordinates))
+            self.assertEqual(set(group.keys()), set(aux_coordinates))
             for name in aux_coordinates:
                 self.assertIs(group[name].cf_data, getattr(self, name))
             # Check all the auxiliary coordinates are formula terms.
@@ -265,7 +265,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
             group = cf_group.promoted['orography'].cf_group.coordinates
             self.assertEqual(len(group), 2)
             coordinates = ('lat', 'lon')
-            self.assertEqual(group.viewkeys(), set(coordinates))
+            self.assertEqual(set(group.keys()), set(coordinates))
             for name in coordinates:
                 self.assertIs(group[name].cf_data, getattr(self, name))
 
@@ -294,7 +294,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
                 if state:
                     promoted = ['x', 'orography']
                     group = cf_group.promoted
-                    self.assertEqual(group.viewkeys(), set(promoted))
+                    self.assertEqual(set(group.keys()), set(promoted))
                     for name in promoted:
                         self.assertIs(group[name].cf_data, getattr(self, name))
                 else:
@@ -310,7 +310,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
                 mock.patch('warnings.warn') as warn:
             cf_group = CFReader('dummy').cf_group.promoted
             promoted = ['wibble', 'orography']
-            self.assertEqual(cf_group.viewkeys(), set(promoted))
+            self.assertEqual(set(cf_group.keys()), set(promoted))
             for name in promoted:
                 self.assertIs(cf_group[name].cf_data, getattr(self, name))
             self.assertEqual(warn.call_count, 2)

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_90.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_90.py
@@ -22,6 +22,7 @@ Unit tests for
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised
 # before importing anything else.
@@ -127,7 +128,7 @@ class Test(tests.IrisTest):
             self.assertEqual(result_coord, expected_coord)
 
         # Ensure no other metadata was created.
-        for name in expected.iterkeys():
+        for name in six.iterkeys(expected):
             if name == 'dim_coords_and_dims':
                 continue
             self.assertEqual(metadata[name], expected[name])

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -21,6 +21,7 @@ Unit tests for the `iris.fileformats.grib.message._GribMessage` class.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -153,9 +154,7 @@ class Test_data__unsupported(tests.IrisTest):
 
 # Abstract, mix-in class for testing the `data` attribute for various
 # grid definition templates.
-class Mixin_data__grid_template(object):
-    __metaclass__ = ABCMeta
-
+class Mixin_data__grid_template(six.with_metaclass(ABCMeta, object)):
     @abstractmethod
     def section_3(self, scanning_mode):
         raise NotImplementedError()

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -135,7 +136,7 @@ class Test_write(tests.IrisTest):
             with Saver(nc_path, 'NETCDF4') as saver:
                 saver.write(cube, unlimited_dimensions=[])
             ds = nc.Dataset(nc_path)
-            for dim in ds.dimensions.itervalues():
+            for dim in six.itervalues(ds.dimensions):
                 self.assertFalse(dim.isunlimited())
             ds.close()
 

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
@@ -159,7 +159,7 @@ class Test_element_arrays_and_dims(tests.IrisTest):
         result = collation.element_arrays_and_dims
         keys = set(['blev', 'brsvd1', 'brsvd2', 'brlev',
                     'bhrlev', 'lblev', 'bhlev'])
-        self.assertEqual(result.viewkeys(), keys)
+        self.assertEqual(set(result.keys()), keys)
         values, dims = result['blev']
         self.assertArrayEqual(values, [1, 2])
         self.assertEqual(dims, (0,))
@@ -170,7 +170,7 @@ class Test_element_arrays_and_dims(tests.IrisTest):
         result = collation.element_arrays_and_dims
         keys = set(['blev', 'brsvd1', 'brsvd2', 'brlev',
                     'bhrlev', 'lblev', 'bhlev'])
-        self.assertEqual(result.viewkeys(), keys)
+        self.assertEqual(set(result.keys()), keys)
         values, dims = result['bhlev']
         self.assertArrayEqual(values, [1, 2])
         self.assertEqual(dims, (0,))

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -277,7 +278,7 @@ class _MergeTest(object):
         return str(arc.exception)
 
     def check_fail(self, *substrs):
-        if isinstance(substrs, basestring):
+        if isinstance(substrs, six.string_types):
             substrs = [substrs]
         msg = self.check_merge_fails_with_message()
         for substr in substrs:

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -44,9 +44,7 @@ def example_cube():
                           units='K', attributes={'mint': 'thin'})
 
 
-class Mixin_register(object):
-    __metaclass__ = abc.ABCMeta
-
+class Mixin_register(six.with_metaclass(abc.ABCMeta, object)):
     @property
     def cube1(self):
         return example_cube()

--- a/lib/iris/tests/unit/tests/test_IrisTest.py
+++ b/lib/iris/tests/unit/tests/test_IrisTest.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before
 # importing anything else
@@ -28,9 +29,7 @@ from abc import ABCMeta, abstractproperty
 import numpy as np
 
 
-class _MaskedArrayEquality(object):
-    __metaclass__ = ABCMeta
-
+class _MaskedArrayEquality(six.with_metaclass(ABCMeta, object)):
     def setUp(self):
         self.arr1 = np.ma.array([1, 2, 3, 4], mask=[False, True, True, False])
         self.arr2 = np.ma.array([1, 3, 2, 4], mask=[False, True, True, False])

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -158,7 +159,7 @@ def negate_expectations(expectations):
             expected = not expected
         return expected
 
-    return {name: negate(value) for name, value in expectations.iteritems()}
+    return {name: negate(value) for name, value in six.iteritems(expectations)}
 
 
 EQ_EXPECTATIONS = {'no_difference': True, 'item1_lo': False, 'item1_hi': False,

--- a/lib/iris/tests/unit/util/test_file_is_newer_than.py
+++ b/lib/iris/tests/unit/util/test_file_is_newer_than.py
@@ -21,6 +21,7 @@ Test function :func:`iris.util.test_file_is_newer`.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before
 # importing anything else
@@ -66,7 +67,7 @@ class TestFileIsNewer(tests.IrisTest):
         """Test expected result of executing with given args."""
         # Make args into full paths
         result_path = self._name2path(result_name)
-        if isinstance(source_names, basestring):
+        if isinstance(source_names, six.string_types):
             source_paths = self._name2path(source_names)
         else:
             source_paths = [self._name2path(name)

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -27,6 +27,7 @@ See also: `UDUNITS-2
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from contextlib import contextmanager
 import copy
@@ -312,7 +313,7 @@ if _lib_ud is None:
     _cv_convert_array = {FLOAT32: _cv_convert_floats,
                          FLOAT64: _cv_convert_doubles}
     _numpy2ctypes = {np.float32: FLOAT32, np.float64: FLOAT64}
-    _ctypes2numpy = {v: k for k, v in _numpy2ctypes.iteritems()}
+    _ctypes2numpy = {v: k for k, v in _numpy2ctypes.items()}
 #
 # load the UDUNITS-2 xml-formatted unit-database
 #
@@ -760,7 +761,7 @@ def as_unit(unit):
         result = unit
     else:
         result = None
-        use_cache = isinstance(unit, basestring) or unit is None
+        use_cache = isinstance(unit, six.string_types) or unit is None
         if use_cache:
             result = _CACHE.get(unit)
         if result is None:
@@ -932,7 +933,7 @@ class Unit(iris.util._OrderedHashable):
             if _OP_SINCE in unit.lower():
                 if calendar is None:
                     calendar_ = CALENDAR_GREGORIAN
-                elif isinstance(calendar, basestring):
+                elif isinstance(calendar, six.string_types):
                     if calendar.lower() in CALENDARS:
                         calendar_ = calendar.lower()
                     else:
@@ -1377,7 +1378,7 @@ class Unit(iris.util._OrderedHashable):
 
         """
 
-        if not isinstance(origin, (int, float, long)):
+        if not isinstance(origin, (float, six.integer_types)):
             raise TypeError('a numeric type for the origin argument is'
                             ' required')
         ut_unit = _ut_offset_by_time(self.ut_unit, ctypes.c_double(origin))
@@ -1420,7 +1421,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * root (int/long): Value by which the unit root is taken.
+        * root (int): Value by which the unit root is taken.
 
         Returns:
             None.
@@ -1440,7 +1441,7 @@ class Unit(iris.util._OrderedHashable):
         try:
             root = ctypes.c_int(root)
         except TypeError:
-            raise TypeError('An int or long type for the root argument'
+            raise TypeError('An int type for the root argument'
                             ' is required')
 
         if self.is_unknown():
@@ -1466,7 +1467,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * base (int/float/long): Value of the logorithmic base.
+        * base (int/float): Value of the logorithmic base.
 
         Returns:
             None.
@@ -1605,7 +1606,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * other (int/float/long/string/Unit): Multiplication scale
+        * other (int/float/string/Unit): Multiplication scale
           factor or unit.
 
         Returns:
@@ -1632,7 +1633,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * other (int/float/long/string/Unit): Division scale factor or unit.
+        * other (int/float/string/Unit): Division scale factor or unit.
 
         Returns:
             Unit.
@@ -1658,7 +1659,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * other (int/float/long/string/Unit): Division scale factor or unit.
+        * other (int/float/string/Unit): Division scale factor or unit.
 
         Returns:
             Unit.
@@ -1685,7 +1686,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * power (int/float/long): Value by which the unit power is raised.
+        * power (int/float): Value by which the unit power is raised.
 
         Returns:
             Unit.
@@ -1805,7 +1806,7 @@ class Unit(iris.util._OrderedHashable):
 
         Args:
 
-        * value (int/float/long/numpy.ndarray):
+        * value (int/float/numpy.ndarray):
             Value/s to be converted.
         * other (string/Unit):
             Target unit to convert to.
@@ -1873,7 +1874,7 @@ class Unit(iris.util._OrderedHashable):
                             value_copy = value_copy.astype(
                                 _ctypes2numpy[ctype])
                         # strict type check of numpy array
-                        if value_copy.dtype.type not in _numpy2ctypes.keys():
+                        if value_copy.dtype.type not in _numpy2ctypes:
                             raise TypeError(
                                 "Expect a numpy array of '%s' or '%s'" %
                                 tuple(sorted(_numpy2ctypes.keys())))
@@ -1886,7 +1887,7 @@ class Unit(iris.util._OrderedHashable):
                                                  value_copy.size, pointer)
                         result = value_copy
                     else:
-                        if ctype not in _cv_convert_scalar.keys():
+                        if ctype not in _cv_convert_scalar:
                             raise ValueError('Invalid target type. Can only '
                                              'convert to float or double.')
                         # Utilise global convenience dictionary

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -331,7 +331,7 @@ if not _ud_system:
     if _ud_system is None:
         _alt_xml_path = os.path.join(sys.prefix, 'share',
                                      'udunits', 'udunits2.xml')
-        _ud_system = _ut_read_xml(_alt_xml_path)
+        _ud_system = _ut_read_xml(_alt_xml_path.encode())
     # reinstate old error handler
     _ut_set_error_message_handler(_default_handler)
     del _func_type
@@ -925,7 +925,7 @@ class Unit(iris.util._OrderedHashable):
             unit = _NO_UNIT_STRING
         else:
             category = _CATEGORY_UDUNIT
-            ut_unit = _ut_parse(_ud_system, unit, UT_ASCII)
+            ut_unit = _ut_parse(_ud_system, unit.encode('ascii'), UT_ASCII)
             # _ut_parse returns 0 on failure
             if ut_unit is None:
                 self._raise_error('Failed to parse unit "%s"' % unit)
@@ -1019,7 +1019,7 @@ class Unit(iris.util._OrderedHashable):
         if self.is_unknown() or self.is_no_unit():
             result = False
         else:
-            day = _ut_get_unit_by_name(_ud_system, 'day')
+            day = _ut_get_unit_by_name(_ud_system, b'day')
             result = _ut_are_convertible(self.ut_unit, day) != 0
         return result
 
@@ -1045,10 +1045,10 @@ class Unit(iris.util._OrderedHashable):
         if self.is_unknown() or self.is_no_unit():
             result = False
         else:
-            bar = _ut_get_unit_by_name(_ud_system, 'bar')
+            bar = _ut_get_unit_by_name(_ud_system, b'bar')
             result = _ut_are_convertible(self.ut_unit, bar) != 0
             if not result:
-                meter = _ut_get_unit_by_name(_ud_system, 'meter')
+                meter = _ut_get_unit_by_name(_ud_system, b'meter')
                 result = _ut_are_convertible(self.ut_unit, meter) != 0
         return result
 
@@ -1277,7 +1277,7 @@ class Unit(iris.util._OrderedHashable):
                                ctypes.sizeof(string_buffer), bitmask)
             if depth < 0:
                 self._raise_error('Failed to format %r' % self)
-        return string_buffer.value
+        return str(string_buffer.value.decode('ascii'))
 
     @property
     def name(self):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1160,7 +1160,7 @@ def as_compatible_shape(src_cube, target_cube):
                          'to restore cube dimensions.')
 
     new_shape = [1] * target_cube.ndim
-    for dim_from, dim_to in dim_mapping.iteritems():
+    for dim_from, dim_to in six.iteritems(dim_mapping):
         if dim_to is not None:
             new_shape[dim_from] = src_cube.shape[dim_to]
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -786,7 +786,8 @@ class _MetaOrderedHashable(abc.ABCMeta):
 
 
 @functools.total_ordering
-class _OrderedHashable(collections.Hashable):
+class _OrderedHashable(six.with_metaclass(_MetaOrderedHashable,
+                                          collections.Hashable)):
     """
     Convenience class for creating "immutable", hashable, and ordered classes.
 
@@ -804,9 +805,6 @@ class _OrderedHashable(collections.Hashable):
         its attributes are themselves hashable.
 
     """
-
-    # The metaclass adds default __init__ methods when appropriate.
-    __metaclass__ = _MetaOrderedHashable
 
     @abc.abstractproperty
     def _names(self):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -21,6 +21,7 @@ Miscellaneous utility functions.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import abc
 import collections
@@ -1286,7 +1287,7 @@ def file_is_newer_than(result_path, source_paths):
 
     """
     # Accept a string as a single source path
-    if isinstance(source_paths, basestring):
+    if isinstance(source_paths, six.string_types):
         source_paths = [source_paths]
     # Fix our chosen timestamp function
     file_date = os.path.getmtime
@@ -1470,14 +1471,14 @@ def promote_aux_coord_to_dim_coord(cube, name_or_coord):
 
     """
 
-    if isinstance(name_or_coord, basestring):
+    if isinstance(name_or_coord, six.string_types):
         aux_coord = cube.coord(name_or_coord)
     elif isinstance(name_or_coord, iris.coords.Coord):
         aux_coord = name_or_coord
     else:
         # Don't know how to handle this type
         msg = ("Don't know how to handle coordinate of type {}. "
-               "Ensure all coordinates are of type basestring or "
+               "Ensure all coordinates are of type six.string_types or "
                "iris.coords.Coord.")
         msg = msg.format(type(name_or_coord))
         raise TypeError(msg)
@@ -1566,14 +1567,14 @@ def demote_dim_coord_to_aux_coord(cube, name_or_coord):
 
     """
 
-    if isinstance(name_or_coord, basestring):
+    if isinstance(name_or_coord, six.string_types):
         dim_coord = cube.coord(name_or_coord)
     elif isinstance(name_or_coord, iris.coords.Coord):
         dim_coord = name_or_coord
     else:
         # Don't know how to handle this type
         msg = ("Don't know how to handle coordinate of type {}. "
-               "Ensure all coordinates are of type basestring or "
+               "Ensure all coordinates are of type six.string_types or "
                "iris.coords.Coord.")
         msg = msg.format(type(name_or_coord))
         raise TypeError(msg)

--- a/tools/generate_std_names.py
+++ b/tools/generate_std_names.py
@@ -30,6 +30,7 @@ as obtained from:
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import argparse
 import pprint
@@ -106,7 +107,7 @@ def to_dict(infile, outfile):
     for section in process_name_table(tree, 'alias', 'entry_id'):
         aliases.update(section)
 
-    for key, valued in aliases.iteritems():
+    for key, valued in six.iteritems(aliases):
         values.update({
                 key : {'canonical_units' : values.get(valued['entry_id']).get('canonical_units')}
             })

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -26,7 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import deque, namedtuple
 import copy
-from Queue import Queue
+from six.moves.queue import Queue
 import re
 from threading import Thread
 import warnings

--- a/tools/translator/__init__.py
+++ b/tools/translator/__init__.py
@@ -22,6 +22,7 @@ translations.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import deque, namedtuple
@@ -99,13 +100,12 @@ class EncodableMap(object):
                                         self.targetmsg.format(**self.targetid))
 
 
-class Mappings(object):
+class Mappings(six.with_metaclass(ABCMeta, object)):
     """
     Abstract base class to support the encoding of specific metarelate
     mapping translations.
 
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, mappings):
         """


### PR DESCRIPTION
Following up on #1699 and #1700, this one allows you to install on Python 3, i.e., you can run `python3 setup.py install` and there won't be errors or warnings. Now, it doesn't actually _run_, but that's a bigger problem.

Again, this looks huge since it's based on a couple previous ones. It's a little bit smaller than it looks right now.