### PR TITLE
Implement fault tolerant GRIB2/PP loading.

### DIFF
--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -146,4 +146,13 @@ class DuplicateDataError(MergeError):
 
 
 class LazyAggregatorError(Exception):
+    pass
+
+
+class FieldLoadFault(Warning):
+    """
+    Warning raised when a fault-tolerant loader encounters a fault with
+    a field it is attempting to load.
+
+    """
     pass

--- a/lib/iris/experimental/fieldsfile.py
+++ b/lib/iris/experimental/fieldsfile.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -123,7 +123,8 @@ def load(filenames, callback=None):
         erroneous results.
 
     """
-    loader = Loader(_collations_from_filename, {}, _convert_collation, None)
+    loader = Loader(_collations_from_filename, {}, _convert_collation, None,
+                    False)
     return CubeList(load_cubes(filenames, callback, loader, None))
 
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -894,7 +894,7 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
         grib_loader = iris.fileformats.rules.Loader(
             _GribMessage.messages_from_filename,
             {},
-            iris.fileformats.grib._load_convert.convert)
+            iris.fileformats.grib._load_convert.convert, None, True)
     else:
         if auto_regularise is not None:
             # The old loader supports the auto_regularise keyword, but in
@@ -907,7 +907,7 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
 
         grib_loader = iris.fileformats.rules.Loader(
             grib_generator, {'auto_regularise': auto_regularise},
-            iris.fileformats.grib.load_rules.convert)
+            iris.fileformats.grib.load_rules.convert, None, False)
     return iris.fileformats.rules.load_cubes(filenames, callback, grib_loader)
 
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -2036,7 +2036,7 @@ def _load_cubes_variable_loader(filenames, callback, loading_function,
         pp_filter = _convert_constraints(constraints)
     pp_loader = iris.fileformats.rules.Loader(
         loading_function, loading_function_kwargs or {},
-        iris.fileformats.pp_rules.convert)
+        iris.fileformats.pp_rules.convert, None, False)
     return iris.fileformats.rules.load_cubes(filenames, callback, pp_loader,
                                              pp_filter)
 

--- a/lib/iris/tests/integration/test_pp_constrained_load_cubes.py
+++ b/lib/iris/tests/integration/test_pp_constrained_load_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -35,7 +35,8 @@ class Test(tests.IrisTest):
         filenames = [tests.get_data_path(('PP', 'globClim1', 'dec_subset.pp'))]
         stcon = iris.AttributeConstraint(STASH='m01s00i004')
         pp_constraints = pp._convert_constraints(stcon)
-        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert)
+        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert, None,
+                                                  False)
         cubes = list(load_cubes(filenames, None, pp_loader, pp_constraints))
         self.assertEqual(len(cubes), 38)
 
@@ -45,7 +46,8 @@ class Test(tests.IrisTest):
         stcon1 = iris.AttributeConstraint(STASH='m01s00i004')
         stcon2 = iris.AttributeConstraint(STASH='m01s00i010')
         pp_constraints = pp._convert_constraints([stcon1, stcon2])
-        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert)
+        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert, None,
+                                                  False)
         cubes = list(load_cubes(filenames, None, pp_loader, pp_constraints))
         self.assertEqual(len(cubes), 76)
 
@@ -53,7 +55,8 @@ class Test(tests.IrisTest):
     def test_pp_no_constraint(self):
         filenames = [tests.get_data_path(('PP', 'globClim1', 'dec_subset.pp'))]
         pp_constraints = pp._convert_constraints(None)
-        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert)
+        pp_loader = iris.fileformats.rules.Loader(pp.load, {}, convert, None,
+                                                  False)
         cubes = list(load_cubes(filenames, None, pp_loader, pp_constraints))
         self.assertEqual(len(cubes), 152)
 

--- a/lib/iris/tests/test_rules.py
+++ b/lib/iris/tests/test_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -113,7 +113,7 @@ class TestLoadCubes(tests.IrisTest):
             return ConversionMetadata([factory], [], '', '', '', {}, [], [],
                                       [])
         # Finish by making a fake Loader
-        fake_loader = Loader(field_generator, {}, converter, None)
+        fake_loader = Loader(field_generator, {}, converter, None, False)
         cubes = load_cubes(['fake_filename'], None, fake_loader)
 
         # Check the result is a generator with a single entry.
@@ -186,7 +186,7 @@ class TestLoadCubes(tests.IrisTest):
                                       src.cell_methods, dim_coords_and_dims,
                                       aux_coords_and_dims)
         # Finish by making a fake Loader
-        fake_loader = Loader(field_generator, {}, converter, None)
+        fake_loader = Loader(field_generator, {}, converter, None, False)
         cubes = load_cubes(['fake_filename'], None, fake_loader)
 
         # Check the result is a generator containing two Cubes.

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -47,7 +47,7 @@ class TestToggle(tests.IrisTest):
                     kw_args = {'auto_regularise': mock.sentinel.REGULARISE}
                 loader = iris.fileformats.rules.Loader(
                     generator, kw_args,
-                    converter, None)
+                    converter, None, mode)
                 rules_load.assert_called_once_with(mock.sentinel.FILES,
                                                    mock.sentinel.CALLBACK,
                                                    loader)


### PR DESCRIPTION
This PR allows loading of all convertible GRIB2 messages from a file even if some of the messages in the file cannot be converted to a cube. Since GRIB is inherently message based and there is not really a proper concept of a GRIB file, it seems unreasonable for Iris to fail completely when it meets a message it can't understand and fail to load the messages it does understand.

The implementation is relatively straightforward, an extra attribute `fault_tolerant` is added to the object `iris.fileformats.rules.Loader` which then allows `iris.fileformats.rules.load_cubes` to determine if it should try to carry on if it encounters a `TranslationError`. In principle this can be extended to any file format using `iris.fileformats.rules.load_cubes` as a handler, but only GRIB is implemented so far.

Remaining tasks:
- [ ] Push an integration test when the iris-test-data repository is updated with a suitable file.
