### PR TITLE
Fix value check in _LBProc constructor.

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -681,10 +681,11 @@ class _LBProc(BitwiseInt):
             The initial value which will determine the flags.
 
         """
+        value = int(value)
         if value < 0:
             raise ValueError('Negative numbers not supported with '
                              'splittable integers object')
-        self._value = int(value)
+        self._value = value
 
     def __len__(self):
         """

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -36,11 +36,14 @@ class Test___init__(tests.IrisTest):
         _LBProc('245')
 
     def test_negative(self):
-        with self.assertRaises(ValueError):
+        msg = 'Negative numbers not supported with splittable integers object'
+        with self.assertRaisesRegexp(ValueError, msg):
             _LBProc(-1)
+        with self.assertRaisesRegexp(ValueError, msg):
+            _LBProc('-1')
 
     def test_invalid_str(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'invalid literal for int'):
             _LBProc('asdf')
 
 


### PR DESCRIPTION
The value should be converted to an int first, since, e.g., `'-123' < 0` is `False` even though it's invalid. Additionally, `str < int` does not work in Python 3.