### PR TITLE
py3k: Replace assertEquals with assertEqual.

### DIFF
--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -123,12 +123,12 @@ class TestAnalysisWeights(tests.IrisTest):
         b = cube.collapsed(lon_coord, iris.analysis.MEAN, weights=weights)
         b.data = np.asarray(b.data)
         self.assertCMLApproxData(b, ('analysis', 'weighted_mean_lon.cml'))
-        self.assertEquals(b.coord("dummy").shape, (1,))
+        self.assertEqual(b.coord('dummy').shape, (1, ))
 
         # test collapsing multiple coordinates (and the fact that one of the coordinates isn't the same coordinate instance as on the cube)
         c = cube.collapsed([lat_coord[:], lon_coord], iris.analysis.MEAN, weights=weights)
         self.assertCMLApproxData(c, ('analysis', 'weighted_mean_latlon.cml'))
-        self.assertEquals(c.coord("dummy").shape, (1,))
+        self.assertEqual(c.coord('dummy').shape, (1, ))
 
         # Check new coord bounds - made from points
         self.assertArrayEqual(c.coord('lat').bounds, [[1, 3]])
@@ -162,7 +162,7 @@ class TestAnalysisWeights(tests.IrisTest):
         f, collapsed_area_weights = e.collapsed('latitude', iris.analysis.MEAN, weights=area_weights, returned=True)
         g = f.collapsed('longitude', iris.analysis.MEAN, weights=collapsed_area_weights)
         # check it's a 0d, scalar cube
-        self.assertEquals(g.shape, ())
+        self.assertEqual(g.shape, ())
         # check the value - pp_area_avg's result of 287.927 differs by factor of 1.00002959
         np.testing.assert_approx_equal(g.data, 287.935, significant=5)
 

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1152,22 +1152,24 @@ class TestConversionToCoordList(tests.IrisTest):
         cube = iris.tests.stock.realistic_4d()
         
         # Single string
-        self.assertEquals(len(cube._as_list_of_coords('grid_longitude')), 1)
+        self.assertEqual(len(cube._as_list_of_coords('grid_longitude')), 1)
         
         # List of string and unicode
-        self.assertEquals(len(cube._as_list_of_coords(['grid_longitude', u'grid_latitude'], )), 2)
+        self.assertEqual(len(cube._as_list_of_coords(['grid_longitude',
+                                                      u'grid_latitude'], )), 2)
         
         # Coord object(s)
         lat = cube.coords("grid_latitude")[0]
         lon = cube.coords("grid_longitude")[0]
-        self.assertEquals(len(cube._as_list_of_coords(lat)), 1)
-        self.assertEquals(len(cube._as_list_of_coords([lat, lon])), 2)
+        self.assertEqual(len(cube._as_list_of_coords(lat)), 1)
+        self.assertEqual(len(cube._as_list_of_coords([lat, lon])), 2)
         
         # Mix of string-like and coord
-        self.assertEquals(len(cube._as_list_of_coords(["grid_latitude", lon])), 2)
+        self.assertEqual(len(cube._as_list_of_coords(['grid_latitude', lon])),
+                         2)
 
         # Empty list
-        self.assertEquals(len(cube._as_list_of_coords([])), 0)
+        self.assertEqual(len(cube._as_list_of_coords([])), 0)
         
         # Invalid coords
         invalid_choices = [iris.analysis.MEAN, # Caused by mixing up argument order in call to cube.collasped for example

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -125,8 +125,8 @@ class TestCells(unittest.TestCase):
         
         # Ensure the Cell's operators return NotImplemented.
         class Terry(object): pass
-        self.assertEquals(self.d.__eq__(Terry()), NotImplemented)
-        self.assertEquals(self.d.__ne__(Terry()), NotImplemented)
+        self.assertEqual(self.d.__eq__(Terry()), NotImplemented)
+        self.assertEqual(self.d.__ne__(Terry()), NotImplemented)
 
     def test_numpy_int_equality(self):
         dtypes = (np.int, np.int16, np.int32, np.int64)

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -245,19 +245,19 @@ class TestLoad(tests.IrisTest):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt',
                                         'SMALL_hires_wind_u_for_ipcc4.nc'))
         cube = iris.load_cube(filename)
-        self.assertEquals(cube.coord('time').attributes, {})
+        self.assertEqual(cube.coord('time').attributes, {})
 
     def test_attributes_contain_positive(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt',
                                         'SMALL_hires_wind_u_for_ipcc4.nc'))
         cube = iris.load_cube(filename)
-        self.assertEquals(cube.coord('height').attributes['positive'], 'up')
+        self.assertEqual(cube.coord('height').attributes['positive'], 'up')
 
     def test_attributes_populated(self):
         filename = tests.get_data_path(
             ('NetCDF', 'label_and_climate', 'small_FC_167_mon_19601101.nc'))
         cube = iris.load_cube(filename)
-        self.assertEquals(
+        self.assertEqual(
             sorted(cube.coord('longitude').attributes.items()), 
             [('data_type', 'float'), 
              ('modulo', 360), 
@@ -268,7 +268,11 @@ class TestLoad(tests.IrisTest):
     def test_cell_methods(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc'))
         cube = iris.load_cube(filename)
-        self.assertEquals(cube.cell_methods, (iris.coords.CellMethod(method=u'mean', coords=(u'time',), intervals=(u'6 minutes',), comments=()),))
+        self.assertEqual(cube.cell_methods,
+                         (iris.coords.CellMethod(method=u'mean',
+                                                 coords=(u'time', ),
+                                                 intervals=(u'6 minutes', ),
+                                                 comments=()), ))
 
 
 @tests.skip_data

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -603,7 +603,7 @@ class TestGetterSetter(tests.IrisTest):
         
         # get bounds
         bounds = coord.bounds
-        self.assertEquals(bounds.shape, (100, 2))
+        self.assertEqual(bounds.shape, (100, 2))
         
         self.assertEqual(bounds.shape[-1], coord.nbounds)
         

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -86,7 +86,7 @@ class TestCoordSystemSame(tests.IrisTest):
     def test_simple(self):
         a = self.cs1
         b = self.cs2
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_different_class(self):
         a = self.cs1
@@ -106,7 +106,7 @@ class TestCoordSystemSame(tests.IrisTest):
 
         # a and b should be the same
         b.foo = 'a'
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
         b.foo = 'b'
         # a and b should not be the same

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -272,7 +272,8 @@ class TestPPSaveRules(tests.IrisTest, pp.PPTest):
             iris.save(ll_cube, temp_filename)
      
             # Check the lbproc is what we expect
-            self.assertEquals(self.lbproc_from_pp(temp_filename), iris.fileformats.pp.lbproc_map[process_desc])
+            self.assertEqual(self.lbproc_from_pp(temp_filename),
+                             iris.fileformats.pp.lbproc_map[process_desc])
 
             os.remove(temp_filename)
 
@@ -291,7 +292,7 @@ class TestPPSaveRules(tests.IrisTest, pp.PPTest):
             iris.save(ll_cube, temp_filename)
             
             # Check the lbproc is what we expect
-            self.assertEquals(self.lbproc_from_pp(temp_filename), lbproc)
+            self.assertEqual(self.lbproc_from_pp(temp_filename), lbproc)
 
             os.remove(temp_filename)
             

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -89,14 +89,18 @@ class TestSavePP(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, pp.save)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
     def test_filehandle(self):
         # Save using iris.save and pp.save
         save_by_filehandle(self.temp_filename1, self.temp_filename2, self.cube1, pp.save, binary_mode = True)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
         # Check we can't save when file handle is not binary
         with self.assertRaises(ValueError):
@@ -112,14 +116,18 @@ class TestSaveDot(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, dot.save)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
     def test_filehandle(self):
         # Save using iris.save and dot.save
         save_by_filehandle(self.temp_filename1, self.temp_filename2, self.cube1, dot.save, binary_mode = False)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
         # Check we can't save when file handle is binary
         with self.assertRaises(ValueError):
@@ -138,7 +146,9 @@ class TestSaveDot(TestSaveMethods):
             data = infile.read()
 
         # Compare files
-        self.assertEquals(data, bio.getvalue(), "Mismatch in data when comparing iris bytesio save and dot.save.")
+        self.assertEqual(data, bio.getvalue(),
+                         'Mismatch in data when comparing iris bytesio save '
+                         'and dot.save.')
 
 
 @skip_dotpng
@@ -151,14 +161,18 @@ class TestSavePng(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, dot.save_png)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
     def test_filehandle(self):
         # Save using iris.save and dot.save_png
         save_by_filehandle(self.temp_filename1, self.temp_filename2, self.cube1, dot.save_png, binary_mode = True)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
         # Check we can't save when file handle is not binary
         with self.assertRaises(ValueError):
@@ -174,7 +188,9 @@ class TestSaver(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, pp.save, pp_saver)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
     def test_dot(self):
         # Make our own saver
@@ -182,7 +198,9 @@ class TestSaver(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, dot.save, dot_saver)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
     @skip_dotpng
     def test_png(self):
@@ -191,7 +209,9 @@ class TestSaver(TestSaveMethods):
         save_by_filename(self.temp_filename1, self.temp_filename2, self.cube1, dot.save_png, png_saver)
 
         # Compare files
-        self.assertEquals(self.file_checksum(self.temp_filename2), self.file_checksum(self.temp_filename1), CHKSUM_ERR.format(self.ext))
+        self.assertEqual(self.file_checksum(self.temp_filename2),
+                         self.file_checksum(self.temp_filename1),
+                         CHKSUM_ERR.format(self.ext))
 
 class TestSaveInvalid(TestSaveMethods):
     """Test iris cannot automatically save to file extensions it does not know about"""

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -864,7 +864,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
                     len(cube.attributes["ukmo__process_flags"]) == 1,
                     "Mismatch in number of process flags.")
                 process_flag = cube.attributes["ukmo__process_flags"][0]
-                self.assertEquals(process_flag, process_desc)
+                self.assertEqual(process_flag, process_desc)
 
         # Test mutiple process flags
         multiple_bit_values = ((128, 64), (4096, 1024), (8192, 1024))
@@ -889,7 +889,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
                 process_flags = cube.attributes["ukmo__process_flags"]
                 self.assertTrue(len(process_flags) == len(bits), 'Mismatch in '
                                 'number of process flags.')
-                self.assertEquals(set(process_flags), set(descriptions))
+                self.assertEqual(set(process_flags), set(descriptions))
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_pp_to_cube.py
+++ b/lib/iris/tests/test_pp_to_cube.py
@@ -229,7 +229,10 @@ class TestPPLoadRules(tests.IrisTest):
             cube = iris.load_cube(temp_filename)
 
             # Check the process flags created
-            self.assertEquals(set(cube.attributes["ukmo__process_flags"]), set(multiple_map[sum(bit_values)]), "Mismatch between expected and actual process flags.")
+            self.assertEqual(set(cube.attributes['ukmo__process_flags']),
+                             set(multiple_map[sum(bit_values)]),
+                             'Mismatch between expected and actual process '
+                             'flags.')
 
             os.remove(temp_filename)
 

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -161,7 +161,8 @@ class TestClipString(unittest.TestCase):
         self.assertLess(len(result), len(self.test_string), "String was not clipped.")
 
         rider_returned = result[-len(arg_dict["rider"]):]
-        self.assertEquals(rider_returned, arg_dict["rider"], "Default rider was not applied.")
+        self.assertEqual(rider_returned, arg_dict['rider'],
+                         'Default rider was not applied.')
 
     def test_trim_string_with_no_spaces(self):
 
@@ -175,7 +176,11 @@ class TestClipString(unittest.TestCase):
         expected_length = clip_length + len(self.rider)
 
         # Check the length of the returned string is equal to clip length + length of rider
-        self.assertEquals(len(result), expected_length, "Mismatch in expected length of clipped string. Length was %s, expected value is %s" % (len(result), expected_length))
+        self.assertEqual(
+            len(result),
+            expected_length,
+            'Mismatch in expected length of clipped string. Length was %s, '
+            'expected value is %s' % (len(result), expected_length))
         
 
 class TestDescribeDiff(iris.tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -171,8 +171,8 @@ class Test_cell(tests.IrisTest):
         coord = self._mock_coord()
         cell = Coord.cell(coord, 0)
         self.assertIs(cell.point, mock.sentinel.time)
-        self.assertEquals(cell.bound,
-                          (mock.sentinel.lower, mock.sentinel.upper))
+        self.assertEqual(cell.bound,
+                         (mock.sentinel.lower, mock.sentinel.upper))
 
     def test_time_as_object(self):
         # When iris.FUTURE.cell_datetime_objects is True, ensure
@@ -186,9 +186,9 @@ class Test_cell(tests.IrisTest):
         with mock.patch('iris.FUTURE', cell_datetime_objects=True):
             cell = Coord.cell(coord, 0)
         self.assertIs(cell.point, mock.sentinel.datetime)
-        self.assertEquals(cell.bound,
-                          (mock.sentinel.datetime_lower,
-                           mock.sentinel.datetime_upper))
+        self.assertEqual(cell.bound,
+                         (mock.sentinel.datetime_lower,
+                          mock.sentinel.datetime_upper))
         self.assertEqual(coord.units.num2date.call_args_list,
                          [mock.call((mock.sentinel.time,)),
                           mock.call((mock.sentinel.lower,

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -87,32 +87,32 @@ class Test_extract_overlapping(tests.IrisTest):
     def test_extract_one_str_dim(self):
         cubes = iris.cube.CubeList([self.cube[2:], self.cube[:4]])
         a, b = cubes.extract_overlapping('time')
-        self.assertEquals(a.coord('time'), self.cube.coord('time')[2:4])
-        self.assertEquals(b.coord('time'), self.cube.coord('time')[2:4])
+        self.assertEqual(a.coord('time'), self.cube.coord('time')[2:4])
+        self.assertEqual(b.coord('time'), self.cube.coord('time')[2:4])
 
     def test_extract_one_list_dim(self):
         cubes = iris.cube.CubeList([self.cube[2:], self.cube[:4]])
         a, b = cubes.extract_overlapping(['time'])
-        self.assertEquals(a.coord('time'), self.cube.coord('time')[2:4])
-        self.assertEquals(b.coord('time'), self.cube.coord('time')[2:4])
+        self.assertEqual(a.coord('time'), self.cube.coord('time')[2:4])
+        self.assertEqual(b.coord('time'), self.cube.coord('time')[2:4])
 
     def test_extract_two_dims(self):
         cubes = iris.cube.CubeList([self.cube[2:, 5:], self.cube[:4, :10]])
         a, b = cubes.extract_overlapping(['time', 'latitude'])
-        self.assertEquals(a.coord('time'),
-                          self.cube.coord('time')[2:4])
-        self.assertEquals(a.coord('latitude'),
-                          self.cube.coord('latitude')[5:10])
-        self.assertEquals(b.coord('time'),
-                          self.cube.coord('time')[2:4])
-        self.assertEquals(b.coord('latitude'),
-                          self.cube.coord('latitude')[5:10])
+        self.assertEqual(a.coord('time'),
+                         self.cube.coord('time')[2:4])
+        self.assertEqual(a.coord('latitude'),
+                         self.cube.coord('latitude')[5:10])
+        self.assertEqual(b.coord('time'),
+                         self.cube.coord('time')[2:4])
+        self.assertEqual(b.coord('latitude'),
+                         self.cube.coord('latitude')[5:10])
 
     def test_different_orders(self):
         cubes = iris.cube.CubeList([self.cube[::-1][:4], self.cube[:4]])
         a, b = cubes.extract_overlapping('time')
-        self.assertEquals(a.coord('time'), self.cube[::-1].coord('time')[2:4])
-        self.assertEquals(b.coord('time'), self.cube.coord('time')[2:4])
+        self.assertEqual(a.coord('time'), self.cube[::-1].coord('time')[2:4])
+        self.assertEqual(b.coord('time'), self.cube.coord('time')[2:4])
 
 
 class Test_merge_cube(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -93,8 +93,8 @@ class Test_class_assignment(tests.IrisTest):
     def test_lbrel_class(self):
         path = tests.get_data_path(('FF', 'lbrel_test_data'))
         ffv = FieldsFileVariant(path)
-        self.assertEquals(type(ffv.fields[0]), Field)
-        self.assertEquals(type(ffv.fields[1]), Field3)
+        self.assertEqual(type(ffv.fields[0]), Field)
+        self.assertEqual(type(ffv.fields[1]), Field3)
         self.assertEqual(ffv.fields[0].int_headers[Field.LBREL_OFFSET], -32768)
         self.assertEqual(ffv.fields[1].int_headers[Field.LBREL_OFFSET], 3)
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -114,7 +114,7 @@ class Test_write(tests.IrisTest):
             with Saver(nc_path, 'NETCDF4') as saver:
                 saver.write(cube, least_significant_digit=1)
             cube_saved = iris.load_cube(nc_path)
-            self.assertEquals(
+            self.assertEqual(
                 cube_saved.attributes['least_significant_digit'], 1)
             self.assertFalse(np.all(cube.data == cube_saved.data))
             self.assertArrayAllClose(cube.data, cube_saved.data, 0.1)

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -95,7 +95,7 @@ class Test_save(tests.IrisTest):
         with mock.patch('warnings.warn') as warn:
             checksum_64 = field_checksum(data_64.astype('>f8'))
 
-        self.assertEquals(checksum_32, checksum_64)
+        self.assertEqual(checksum_32, checksum_64)
         warn.assert_called()
 
 


### PR DESCRIPTION
assertEquals is deprecated and raises a warning on Python 3.