### PR TITLE
py3k: Fix range usage in new tests.

### DIFF
--- a/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
@@ -17,6 +17,7 @@
 """Unit tests for the :data:`iris.analysis.PERCENTILE` aggregator."""
 
 from __future__ import (absolute_import, division, print_function)
+from six.moves import range
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -140,7 +141,7 @@ class Test_aggregate(tests.IrisTest):
         actual = WPERCENTILE.aggregate(data, axis=0, percent=percent,
                                        weights=weights)
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
-        expected = np.array(range(shape[-1]) * percent.size)
+        expected = np.tile(np.arange(shape[-1]), percent.size)
         expected = expected.reshape(percent.size, shape[-1]).T
         expected[:, 1:-1] += (percent[1:-1]-25)*0.2
         expected[:, -1] += 10.
@@ -155,7 +156,7 @@ class Test_aggregate(tests.IrisTest):
         actual = WPERCENTILE.aggregate(data, axis=0, percent=percent,
                                        weights=weights)
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
-        expected = np.array(range(shape[-1]) * percent.size)
+        expected = np.tile(np.arange(shape[-1]), percent.size)
         expected = expected.reshape(percent.size, shape[-1]).T
         expected[:, 1:-1] += (percent[1:-1]-25)*0.4
         expected[:, -1] += 20.
@@ -171,7 +172,7 @@ class Test_aggregate(tests.IrisTest):
         actual, weight_total = WPERCENTILE.aggregate(
             data, axis=0, percent=percent, weights=weights, returned=True)
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
-        expected = np.array(range(shape[-1]) * percent.size)
+        expected = np.tile(np.arange(shape[-1]), percent.size)
         expected = expected.reshape(percent.size, shape[-1]).T
         expected[:, 1:] = 2.0 * (
             (0.875 - percent[1:]/100.0) * data[0, np.newaxis].T +

--- a/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
@@ -58,8 +58,8 @@ class Test_post_process(tests.IrisTest):
         self.cube_simple.add_dim_coord(self.coord_simple, 0)
         self.weights_simple = np.ones_like(data, dtype=float)
 
-        self.coord_multi_0 = DimCoord(range(shape[0]), 'time')
-        self.coord_multi_1 = DimCoord(range(shape[1]), 'height')
+        self.coord_multi_0 = DimCoord(np.arange(shape[0]), 'time')
+        self.coord_multi_1 = DimCoord(np.arange(shape[1]), 'height')
         self.cube_multi = Cube(data.reshape(shape))
         self.cube_multi.add_dim_coord(self.coord_multi_0, 0)
         self.cube_multi.add_dim_coord(self.coord_multi_1, 1)


### PR DESCRIPTION
I pulled this out of #1700 because GitHub was being confusing about the necessary commits. Plus, it slightly muddies what's changed in that PR.