### PR TITLE
Lazy nc index

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -265,7 +265,10 @@ class NetCDFDataProxy(object):
     def ndim(self):
         return len(self.shape)
 
-    def __getitem__(self, keys):
+    def __getitem__(self, inkeys):
+        # Alter length one tuples to slice objects for safer indexing
+        keys = tuple([(slice(key[0], key[0] + 1) if isinstance(key, tuple) and
+                       len(key) == 1 else key) for key in inkeys])
         dataset = netCDF4.Dataset(self.path)
         try:
             variable = dataset.variables[self.variable_name]

--- a/lib/iris/tests/integration/test_intersection.py
+++ b/lib/iris/tests/integration/test_intersection.py
@@ -1,0 +1,50 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for regridding."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+import biggus
+import iris
+
+
+@tests.skip_data
+class TestLazyIntersection(tests.IrisTest):
+    def setUp(self):
+        path = tests.get_data_path(
+            ('NetCDF', 'global', 'xyt',
+             'SMALL_hires_wind_u_for_ipcc4.nc'))
+        self.cube = iris.load_cube(path)
+
+    def test_intersection(self):
+        self.icube = self.cube.intersection(latitude=(49.4, 50.4),
+                                            longitude=(199.5, 200.3),
+                                            ignore_bounds=True)
+        self.assertTrue(self.icube.has_lazy_data())
+        lazy_shape = self.icube.shape
+        tmp = self.icube.data
+        self.assertFalse(self.icube.has_lazy_data())
+        shape = self.icube.shape
+        self.assertEqual(lazy_shape, shape)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
I have added a trap to the netCDF indexer, to work around a problem encountered with lazy indexing and extraction:  a cube with multiple size one dimensions was mismatching it's data array shape when loaded from netCDF

see https://github.com/Unidata/netcdf4-python/issues/423

I have added a test and a fix, but I am unsure if this fix is anything more than an ungainly hack

please consider
