### PR TITLE
Sparse interpolation optimizations

### DIFF
--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/_scipy_interpolate.py
+++ b/lib/iris/analysis/_scipy_interpolate.py
@@ -223,9 +223,9 @@ class _RegularGridInterpolator(object):
 
             for i, corner in enumerate(corners):
                 corner_indices = [ci for ci, cw in corner]
-                n_indices = np.ravel_multi_index(corner_indices, shape,
-                                                 mode='wrap')
-                col_indices[i::n_src_values_per_result_value] = n_indices
+                col_indices[i::n_src_values_per_result_value] = \
+                    np.ravel_multi_index(corner_indices, shape,
+                                         mode='wrap')
                 for ci, cw in corner:
                     weights[i::n_src_values_per_result_value] *= cw
 


### PR DESCRIPTION
Two changes here.

The first adds a single housekeep to the compute_interp_weights function, which reduces some in-process memory usage.

The second replaces a cartesian product using itertools, with one based solely on numpy. On my sample data, this took 3.27ms instead of 846ms, and used ~13.5MiB ram instead of ~126.5MiB.

Limitations of the new function are that all the points must be of the same datatype, which I _think_ is irrelevant in our usage? (Correct me if I'm wrong...)
