### PR TITLE
Point-in-cell regrid scheme

### DIFF
--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -125,7 +125,7 @@ def extend_circular_data(data, coord_dim):
     return data
 
 
-def get_xy_dim_coords(cube):
+def get_xy_dim_coords(cube, dim_coords=True):
     """
     Return the x and y dimension coordinates from a cube.
 
@@ -143,13 +143,13 @@ def get_xy_dim_coords(cube):
         A tuple containing the cube's x and y dimension coordinates.
 
     """
-    x_coords = cube.coords(axis='x', dim_coords=True)
+    x_coords = cube.coords(axis='x', dim_coords=dim_coords)
     if len(x_coords) != 1:
         raise ValueError('Cube {!r} must contain a single 1D x '
                          'coordinate.'.format(cube.name()))
     x_coord = x_coords[0]
 
-    y_coords = cube.coords(axis='y', dim_coords=True)
+    y_coords = cube.coords(axis='y', dim_coords=dim_coords)
     if len(y_coords) != 1:
         raise ValueError('Cube {!r} must contain a single 1D y '
                          'coordinate.'.format(cube.name()))
@@ -163,13 +163,13 @@ def get_xy_dim_coords(cube):
     return x_coord, y_coord
 
 
-def snapshot_grid(cube):
+def snapshot_grid(cube, dim_coords=True):
     """
-    Helper function that returns deep copies of lateral dimension coordinates
+    Helper function that returns deep copies of lateral (dimension) coordinates
     from a cube.
 
     """
-    x, y = get_xy_dim_coords(cube)
+    x, y = get_xy_dim_coords(cube, dim_coords=dim_coords)
     return x.copy(), y.copy()
 
 

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -125,7 +125,7 @@ def extend_circular_data(data, coord_dim):
     return data
 
 
-def get_xy_dim_coords(cube, dim_coords=True):
+def get_xy_dim_coords(cube):
     """
     Return the x and y dimension coordinates from a cube.
 
@@ -143,13 +143,13 @@ def get_xy_dim_coords(cube, dim_coords=True):
         A tuple containing the cube's x and y dimension coordinates.
 
     """
-    x_coords = cube.coords(axis='x', dim_coords=dim_coords)
+    x_coords = cube.coords(axis='x', dim_coords=True)
     if len(x_coords) != 1:
         raise ValueError('Cube {!r} must contain a single 1D x '
                          'coordinate.'.format(cube.name()))
     x_coord = x_coords[0]
 
-    y_coords = cube.coords(axis='y', dim_coords=dim_coords)
+    y_coords = cube.coords(axis='y', dim_coords=True)
     if len(y_coords) != 1:
         raise ValueError('Cube {!r} must contain a single 1D y '
                          'coordinate.'.format(cube.name()))
@@ -163,13 +163,13 @@ def get_xy_dim_coords(cube, dim_coords=True):
     return x_coord, y_coord
 
 
-def snapshot_grid(cube, dim_coords=True):
+def snapshot_grid(cube):
     """
     Helper function that returns deep copies of lateral (dimension) coordinates
     from a cube.
 
     """
-    x, y = get_xy_dim_coords(cube, dim_coords=dim_coords)
+    x, y = get_xy_dim_coords(cube)
     return x.copy(), y.copy()
 
 

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -31,7 +31,7 @@ import numpy.ma as ma
 from scipy.sparse import csc_matrix
 
 import iris.analysis.cartography
-from iris.analysis._interpolation import get_xy_dim_coords
+from iris.analysis._interpolation import get_xy_dim_coords, snapshot_grid
 from iris.analysis._regrid import RectilinearRegridder
 import iris.coord_systems
 import iris.cube
@@ -818,10 +818,6 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
         msg = 'The source cube and weights require the same data shape.'
         raise ValueError(msg)
 
-    if src_cube.ndim != 2 or grid_cube.ndim != 2:
-        msg = 'The source cube and target grid cube must reference 2D data.'
-        raise ValueError(msg)
-
     if src_cube.aux_factories:
         msg = 'All source cube derived coordinates will be ignored.'
         warnings.warn(msg)
@@ -1015,3 +1011,123 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
         cube.add_aux_coord(coord.copy())
 
     return cube
+
+
+class CurvilinearRegridder(object):
+    """
+    This class provides support for performing point-in-cell regridding
+    between a curvilinear source grid and a rectilinear target grid.
+
+    """
+    def __init__(self, src_grid_cube, target_grid_cube, weights):
+        """
+        Create a regridder for conversions between the source
+        and target grids.
+
+        Args:
+
+        * src_grid_cube:
+            The :class:`~iris.cube.Cube` providing the source grid.
+        * tgt_grid_cube:
+            The :class:`~iris.cube.Cube` providing the target grid.
+        * weights:
+            A :class:`numpy.ndarray` instance that defines the weights
+            for the grid cells of the source grid. Must have the same shape
+            as the data of the source grid.
+
+        """
+        # Validity checks.
+        if not isinstance(src_grid_cube, iris.cube.Cube):
+            raise TypeError("'src_grid_cube' must be a Cube")
+        if not isinstance(target_grid_cube, iris.cube.Cube):
+            raise TypeError("'target_grid_cube' must be a Cube")
+        # Snapshot the state of the cubes to ensure that the regridder
+        # is impervious to external changes to the original source cubes.
+        self._src_cube = src_grid_cube.copy()
+        self._target_cube = target_grid_cube.copy()
+        self.weights = weights
+
+    def __call__(self, src):
+        """
+        Regrid the supplied :class:`~iris.cube.Cube` on to the target grid of
+        this :class:`CurvilinearRegridder`.
+
+        The given cube must be defined with the same grid as the source
+        grid used to create this :class:`CurvilinearRegridder`.
+
+        Args:
+
+        * src:
+            A :class:`~iris.cube.Cube` to be regridded.
+
+        Returns:
+            A cube defined with the horizontal dimensions of the target
+            and the other dimensions from this cube. The data values of
+            this cube will be converted to values on the new grid using
+            point-in-cell regridding.
+
+        """
+        # Validity checks.
+        if not isinstance(src, iris.cube.Cube):
+            raise TypeError("'src' must be a Cube")
+
+        src_grid = snapshot_grid(self._src_cube, dim_coords=False)
+        if get_xy_dim_coords(src, dim_coords=False) != src_grid:
+            raise ValueError('The given cube is not defined on the same '
+                             'source grid as this regridder.')
+
+        # Call the regridder function.
+        res = regrid_weighted_curvilinear_to_rectilinear(src, self.weights,
+                                                         self._target_cube)
+        return res
+
+
+class PointInCell(object):
+    """
+    This class describes the point-in-cell regridding scheme for regridding
+    over one or more orthogonal coordinates, typically for use with
+    :meth:`iris.cube.Cube.regrid()`.
+
+    """
+    def __init__(self, weights):
+        """
+        Point-in-cell regridding scheme suitable for regridding over one
+        or more orthogonal coordinates.
+
+        Args:
+
+        * weights:
+            A :class:`numpy.ndarray` instance that defines the weights
+            for the grid cells of the source grid. Must have the same shape
+            as the data of the source grid.
+
+        """
+        self.weights = weights
+
+    def regridder(self, src_grid, target_grid):
+        """
+        Creates a point-in-cell regridder to perform regridding from the
+        source grid to the target grid.
+
+        Typically you should use :meth:`iris.cube.Cube.regrid` for
+        regridding a cube. There are, however, some situations when
+        constructing your own regridder is preferable. These are detailed in
+        the :ref:`user guide <caching_a_regridder>`.
+
+        Args:
+
+        * src_grid:
+            The :class:`~iris.cube.Cube` defining the source grid.
+        * target_grid:
+            The :class:`~iris.cube.Cube` defining the target grid.
+
+        Returns:
+            A callable with the interface:
+
+                `callable(cube)`
+
+            where `cube` is a cube with the same grid as `src_grid`
+            that is to be regridded to the `target_grid`.
+
+        """
+        return CurvilinearRegridder(src_grid, target_grid, self.weights)

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1047,6 +1047,30 @@ class CurvilinearRegridder(object):
         self._target_cube = target_grid_cube.copy()
         self.weights = weights
 
+    @staticmethod
+    def _get_horizontal_coord(cube, axis):
+        """
+        Gets the horizontal coordinate on the supplied cube along the
+        specified axis.
+
+        Args:
+
+        * cube:
+            An instance of :class:`iris.cube.Cube`.
+        * axis:
+            Locate coordinates on `cube` along this axis.
+
+        Returns:
+            The horizontal coordinate on the specified axis of the supplied
+            cube.
+
+        """
+        coords = cube.coords(axis=axis, dim_coords=False)
+        if len(coords) != 1:
+            raise ValueError('Cube {!r} must contain a single 1D {} '
+                             'coordinate.'.format(cube.name()), axis)
+        return coords[0]
+
     def __call__(self, src):
         """
         Regrid the supplied :class:`~iris.cube.Cube` on to the target grid of
@@ -1071,8 +1095,12 @@ class CurvilinearRegridder(object):
         if not isinstance(src, iris.cube.Cube):
             raise TypeError("'src' must be a Cube")
 
-        src_grid = snapshot_grid(self._src_cube, dim_coords=False)
-        if get_xy_dim_coords(src, dim_coords=False) != src_grid:
+        gx = self._get_horizontal_coord(self._src_cube, 'x')
+        gy = self._get_horizontal_coord(self._src_cube, 'y')
+        src_grid = (gx.copy(), gy.copy())
+        sx = self._get_horizontal_coord(src, 'x')
+        sy = self._get_horizontal_coord(src, 'y')
+        if (sx, sy) != src_grid:
             raise ValueError('The given cube is not defined on the same '
                              'source grid as this regridder.')
 

--- a/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
@@ -17,7 +17,6 @@
 """Unit tests for :class:`iris.experimental.regrid.CurvilinearRegridder`."""
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import zip
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -27,10 +26,6 @@ import mock
 import numpy as np
 
 from iris.experimental.regrid import CurvilinearRegridder as Regridder
-from iris.aux_factory import HybridHeightFactory
-from iris.coord_systems import GeogCS, OSGB
-from iris.coords import AuxCoord, DimCoord
-from iris.cube import Cube
 from iris.tests.stock import global_pp, lat_lon_cube
 
 

--- a/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_CurviliearRegridder.py
@@ -1,0 +1,106 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for :class:`iris.experimental.regrid.CurvilinearRegridder`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import zip
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+import numpy as np
+
+from iris.experimental.regrid import CurvilinearRegridder as Regridder
+from iris.aux_factory import HybridHeightFactory
+from iris.coord_systems import GeogCS, OSGB
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+from iris.tests.stock import global_pp, lat_lon_cube
+
+
+RESULT_DIR = ('analysis', 'regrid')
+
+
+class Test__initialisation(tests.IrisTest):
+    def setUp(self):
+        self.ok = lat_lon_cube()
+        self.bad = np.ones((3, 4))
+        self.weights = np.ones(self.ok.shape, self.ok.dtype)
+
+    def test_bad_src_type(self):
+        with self.assertRaisesRegexp(TypeError, "'src_grid_cube'"):
+            Regridder(self.bad, self.ok, self.weights)
+
+    def test_bad_grid_type(self):
+        with self.assertRaisesRegexp(TypeError, "'target_grid_cube'"):
+            Regridder(self.ok, self.bad, self.weights)
+
+
+class Test__operation(tests.IrisTest):
+    def setUp(self):
+        self.func = ('iris.experimental.regrid.'
+                     'regrid_weighted_curvilinear_to_rectilinear')
+        self.ok = global_pp()
+        y = self.ok.coord('latitude')
+        x = self.ok.coord('longitude')
+        self.ok.remove_coord('latitude')
+        self.ok.remove_coord('longitude')
+        self.ok.add_aux_coord(y, 0)
+        self.ok.add_aux_coord(x, 1)
+        self.weights = np.ones(self.ok.shape, self.ok.dtype)
+
+    def test__use_once(self):
+        with mock.patch(self.func,
+                        return_value=mock.sentinel.regridded) as clr:
+            Regridder(self.ok, self.ok, self.weights)
+
+        clr.assertCalledOnceWith(self.ok, self.weights, self.ok)
+
+    def test__cache_regridder(self):
+        regridder = Regridder(self.ok, self.ok, self.weights)
+        src = self.ok
+        src.data = np.ones(src.shape, src.dtype)
+        with mock.patch(self.func,
+                        return_value=mock.sentinel.regridded) as clr:
+            res = regridder(src)
+
+        clr.assertCalledOnceWith(src, self.weights, self.ok)
+        self.assertIs(res, mock.sentinel.regridded)
+
+
+class Test___call____bad_src(tests.IrisTest):
+    def setUp(self):
+        self.ok = global_pp()
+        y = self.ok.coord('latitude')
+        x = self.ok.coord('longitude')
+        self.ok.remove_coord('latitude')
+        self.ok.remove_coord('longitude')
+        self.ok.add_aux_coord(y, 0)
+        self.ok.add_aux_coord(x, 1)
+        weights = np.ones(self.ok.shape, self.ok.dtype)
+        self.regridder = Regridder(self.ok, self.ok, weights)
+
+    def test_bad_src_type(self):
+        with self.assertRaisesRegexp(TypeError, 'must be a Cube'):
+            self.regridder(np.ones((3, 4)))
+
+    def test_bad_src_shape(self):
+        with self.assertRaisesRegexp(ValueError,
+                                     'not defined on the same source grid'):
+            self.regridder(self.ok[::2, ::2])

--- a/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
@@ -1,0 +1,46 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for :class:`iris.experimental.regrid.PointInCell`."""
+
+from __future__ import (absolute_import, division, print_function)
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+
+from iris.experimental.regrid import PointInCell
+
+
+class Test_regridder(tests.IrisTest):
+    def test(self):
+        point_in_cell = PointInCell(mock.sentinel.weights)
+
+        with mock.patch('iris.experimental.regrid.CurvilinearRegridder',
+                        return_value=mock.sentinel.regridder) as ecr:
+            regridder = point_in_cell.regridder(mock.sentinel.src,
+                                                mock.sentinel.target)
+
+        ecr.assert_called_once_with(mock.sentinel.src,
+                                    mock.sentinel.target,
+                                    mock.sentinel.weights)
+        self.assertIs(regridder, mock.sentinel.regridder)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Added point-in-cell as a regrid scheme. Note that the underlying regridder (`regrid_weighted_curvilinear_to_rectilinear`) still lives in `iris.experimental`, as do the code changes to provide point-in-cell as a regridder.