### PR TITLE
py3k: Fix newly added map call.

### DIFF
--- a/lib/iris/analysis/_scipy_interpolate.py
+++ b/lib/iris/analysis/_scipy_interpolate.py
@@ -229,7 +229,7 @@ class _RegularGridInterpolator(object):
                 for ci, cw in corner:
                     weights[i::n_src_values_per_result_value] *= cw
 
-            n_src_values = np.prod(map(len, self.grid))
+            n_src_values = np.prod(list(map(len, self.grid)))
             sparse_matrix = csr_matrix((weights, col_indices, row_ptrs),
                                        shape=(n_result_values, n_src_values))
 


### PR DESCRIPTION
This `map` call added in #1706 does not work on Python 3.

aka, yet another reason to merge #1700.