### PR TITLE
Doctest Python 3 compatibility

### DIFF
--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -52,7 +52,7 @@ And finally we can subtract the two.
 The result is a cube of the same size as the original two time slices, 
 but with the data representing their difference:
 
-    >>> print t_last - t_first
+    >>> print(t_last - t_first)
     unknown / (K)                       (latitude: 37; longitude: 49)
          Dimension coordinates:
               latitude                           x              -
@@ -87,14 +87,14 @@ benefits of cube broadcasting.
 First, let's remind ourselves of the shape of our air temperature time-series
 cube::
 
-    >>> print air_temp.summary(True)
+    >>> print(air_temp.summary(True))
     air_temperature / (K)               (time: 240; latitude: 37; longitude: 49)
 
 Now, we'll calculate the time-series mean using the
 :meth:`Cube.collapsed <iris.cube.Cube.collapsed>` method::
 
     >>> air_temp_mean = air_temp.collapsed('time', iris.analysis.MEAN)
-    >>> print air_temp_mean.summary(True)
+    >>> print(air_temp_mean.summary(True))
     air_temperature / (K)               (latitude: 37; longitude: 49)
 
 As expected the *time* dimension has been collapsed, reducing the
@@ -103,7 +103,7 @@ now be used to calculate the time mean anomaly against the original
 time-series::
 
     >>> anomaly = air_temp - air_temp_mean
-    >>> print anomaly.summary(True)
+    >>> print(anomaly.summary(True))
     unknown / (K)                       (time: 240; latitude: 37; longitude: 49)
 
 Notice that the calculation of the *anomaly* involves subtracting a
@@ -129,13 +129,13 @@ Let's first create the transpose of the air temperature time-series::
 
     >>> air_temp_T = air_temp.copy()
     >>> air_temp_T.transpose()
-    >>> print air_temp_T.summary(True)
+    >>> print(air_temp_T.summary(True))
     air_temperature / (K)               (longitude: 49; latitude: 37; time: 240)
 
 Now add the transpose to the original time-series::
 
     >>> result = air_temp + air_temp_T
-    >>> print result.summary(True)
+    >>> print(result.summary(True))
     unknown / (K)                       (time: 240; latitude: 37; longitude: 49)
 
 Notice that the *result* is the same dimensionality and shape as *air_temp*.
@@ -149,7 +149,7 @@ Let's extend this example slightly, by taking a slice from the middle
 *latitude* dimension of the transpose cube::
 
     >>> air_temp_T_slice = air_temp_T[:, 0, :]
-    >>> print air_temp_T_slice.summary(True)
+    >>> print(air_temp_T_slice.summary(True))
     air_temperature / (K)               (longitude: 49; time: 240)
 
 Compared to our original time-series, the *air_temp_T_slice* cube has one
@@ -158,7 +158,7 @@ us from performing cube arithmetic with it, thanks to the extended cube
 broadcasting behaviour::
 
     >>> result = air_temp - air_temp_T_slice
-    >>> print result.summary(True)
+    >>> print(result.summary(True))
     unknown / (K)                       (time: 240; latitude: 37; longitude: 49)
 
 Combining multiple phenomena to form a new one

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -35,7 +35,7 @@ For instance, suppose we have a cube:
     >>> import iris
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cube = iris.load_cube(filename, 'air_potential_temperature')
-    >>> print cube
+    >>> print(cube)
     air_potential_temperature / (K)     (time: 3; model_level_number: 7; grid_latitude: 204; grid_longitude: 187)
          Dimension coordinates:
               time                           x                      -                 -                    -
@@ -64,7 +64,7 @@ we can pass the coordinate name and the aggregation definition to the
 
     >>> import iris.analysis
     >>> vertical_mean = cube.collapsed('model_level_number', iris.analysis.MEAN)
-    >>> print vertical_mean
+    >>> print(vertical_mean)
     air_potential_temperature / (K)     (time: 3; grid_latitude: 204; grid_longitude: 187)
          Dimension coordinates:
               time                           x                 -                    -
@@ -123,7 +123,7 @@ These areas can now be passed to the ``collapsed`` method as weights:
 .. doctest::
 
     >>> new_cube = cube.collapsed(['grid_longitude', 'grid_latitude'], iris.analysis.MEAN, weights=grid_areas)
-    >>> print new_cube
+    >>> print(new_cube)
     air_potential_temperature / (K)     (time: 3; model_level_number: 7)
          Dimension coordinates:
               time                           x                      -
@@ -213,7 +213,7 @@ Printing this cube now shows that two extra coordinates exist on the cube:
 
 .. doctest:: aggregation
 
-    >>> print cube
+    >>> print(cube)
     surface_temperature / (K)           (time: 54; latitude: 18; longitude: 432)
          Dimension coordinates:
               time                           x             -              -
@@ -239,7 +239,7 @@ These two coordinates can now be used to aggregate by season and climate-year:
     >>> annual_seasonal_mean = cube.aggregated_by(
     ...     ['clim_season', 'season_year'], 
     ...     iris.analysis.MEAN)
-    >>> print repr(annual_seasonal_mean)
+    >>> print(repr(annual_seasonal_mean))
     <iris 'Cube' of surface_temperature / (K) (time: 19; latitude: 18; longitude: 432)>
     
 The primary change in the cube is that the cube's data has been 
@@ -256,9 +256,9 @@ so adjacent ones are often in the same season:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print zip(
+    >>> print(zip(
     ...     cube.coord('clim_season')[:10].points, 
-    ...     cube.coord('season_year')[:10].points)
+    ...     cube.coord('season_year')[:10].points))
     [('mam', 2006), ('mam', 2006), ('jja', 2006), ('jja', 2006), ('jja', 2006), ('son', 2006),
      ('son', 2006), ('son', 2006), ('djf', 2007), ('djf', 2007)]
 
@@ -268,9 +268,9 @@ All the points now have distinct season+year values:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print zip(
+    >>> print(zip(
     ...     annual_seasonal_mean.coord('clim_season')[:10].points, 
-    ...     annual_seasonal_mean.coord('season_year')[:10].points)
+    ...     annual_seasonal_mean.coord('season_year')[:10].points))
     [('mam', 2006), ('jja', 2006), ('son', 2006), ('djf', 2007), ('mam', 2007), ('jja', 2007),
      ('son', 2007), ('djf', 2008), ('mam', 2008), ('jja', 2008)]
 
@@ -293,9 +293,9 @@ from jja-2006 to jja-2010:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print zip(
+    >>> print(zip(
     ...     full_season_means.coord('clim_season').points, 
-    ...     full_season_means.coord('season_year').points)
+    ...     full_season_means.coord('season_year').points))
     [('jja', 2006), ('son', 2006), ('djf', 2007), ('mam', 2007), ('jja', 2007), ('son', 2007), ('djf', 2008),
      ('mam', 2008), ('jja', 2008), ('son', 2008), ('djf', 2009), ('mam', 2009), ('jja', 2009), ('son', 2009),
      ('djf', 2010), ('mam', 2010), ('jja', 2010)]

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -256,11 +256,19 @@ so adjacent ones are often in the same season:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print(zip(
-    ...     cube.coord('clim_season')[:10].points, 
-    ...     cube.coord('season_year')[:10].points))
-    [('mam', 2006), ('mam', 2006), ('jja', 2006), ('jja', 2006), ('jja', 2006), ('son', 2006),
-     ('son', 2006), ('son', 2006), ('djf', 2007), ('djf', 2007)]
+    >>> for season, year in zip(cube.coord('clim_season')[:10].points,
+    ...                         cube.coord('season_year')[:10].points):
+    ...     print(season + ' ' + str(year))
+    mam 2006
+    mam 2006
+    jja 2006
+    jja 2006
+    jja 2006
+    son 2006
+    son 2006
+    son 2006
+    djf 2007
+    djf 2007
 
 Compare this with the first 10 values of the new cube's coordinates:  
 All the points now have distinct season+year values:
@@ -268,11 +276,20 @@ All the points now have distinct season+year values:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print(zip(
-    ...     annual_seasonal_mean.coord('clim_season')[:10].points, 
-    ...     annual_seasonal_mean.coord('season_year')[:10].points))
-    [('mam', 2006), ('jja', 2006), ('son', 2006), ('djf', 2007), ('mam', 2007), ('jja', 2007),
-     ('son', 2007), ('djf', 2008), ('mam', 2008), ('jja', 2008)]
+    >>> for season, year in zip(
+    ...         annual_seasonal_mean.coord('clim_season')[:10].points,
+    ...         annual_seasonal_mean.coord('season_year')[:10].points):
+    ...     print(season + ' ' + str(year))
+    mam 2006
+    jja 2006
+    son 2006
+    djf 2007
+    mam 2007
+    jja 2007
+    son 2007
+    djf 2008
+    mam 2008
+    jja 2008
 
 Because the original data started in April 2006 we have some incomplete seasons
 (e.g. there were only two months worth of data for 'mam-2006').
@@ -293,10 +310,24 @@ from jja-2006 to jja-2010:
 .. doctest:: aggregation
     :options: +NORMALIZE_WHITESPACE
 
-    >>> print(zip(
-    ...     full_season_means.coord('clim_season').points, 
-    ...     full_season_means.coord('season_year').points))
-    [('jja', 2006), ('son', 2006), ('djf', 2007), ('mam', 2007), ('jja', 2007), ('son', 2007), ('djf', 2008),
-     ('mam', 2008), ('jja', 2008), ('son', 2008), ('djf', 2009), ('mam', 2009), ('jja', 2009), ('son', 2009),
-     ('djf', 2010), ('mam', 2010), ('jja', 2010)]
+    >>> for season, year in zip(full_season_means.coord('clim_season').points,
+    ...                         full_season_means.coord('season_year').points):
+    ...     print(season + ' ' + str(year))
+    jja 2006
+    son 2006
+    djf 2007
+    mam 2007
+    jja 2007
+    son 2007
+    djf 2008
+    mam 2008
+    jja 2008
+    son 2008
+    djf 2009
+    mam 2009
+    jja 2009
+    son 2009
+    djf 2010
+    mam 2010
+    jja 2010
 

--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -130,9 +130,10 @@ the one defined below:
 This cube has a "hybrid-height" vertical coordinate system, meaning that the vertical
 coordinate is unevenly spaced in altitude:
 
-    >>> print(column.coord('altitude').points)
-    [  418.7    434.57   456.79   485.37   520.29   561.58   609.21   663.21
-       723.58   790.31   863.41   942.88  1028.74  1120.98  1219.61]
+   >>> print(column.coord('altitude').points)
+   [  418.69836426   434.57049561   456.79278564   485.3664856    520.29327393
+      561.57519531   609.21447754   663.21411133   723.57696533   790.30664062
+      863.40722656   942.88232422  1028.73706055  1120.97644043  1219.60510254]
 
 We could regularise the vertical coordinate by defining 10 equally spaced altitude
 sample points between 400 and 1250 and interpolating our vertical coordinate onto
@@ -172,11 +173,11 @@ with the extrapolation mode keyword set as required. The constructed scheme
 is then passed to the :meth:`~iris.cube.Cube.interpolate` method.
 For example, to mask values that lie beyond the range of the original data:
 
-    >>> scheme = iris.analysis.Linear(extrapolation_mode='mask')
-    >>> new_column = column.interpolate(sample_points, scheme)
-    >>> print(new_column.coord('altitude').points)
-    [     nan   494.44   588.89   683.33   777.78   872.22   966.67  1061.11
-      1155.56      nan]
+   >>> scheme = iris.analysis.Linear(extrapolation_mode='mask')
+   >>> new_column = column.interpolate(sample_points, scheme)
+   >>> print(new_column.coord('altitude').points)
+   [           nan   494.44451904   588.88891602   683.33325195   777.77783203
+      872.222229     966.66674805  1061.11108398  1155.55541992            nan]
 
 
 .. _caching_an_interpolator:

--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -53,7 +53,7 @@ e.g. ``[('time', datetime.datetime(2009, 11, 19, 10, 30))]``).
 Let's take the air temperature cube we've seen previously:
 
     >>> air_temp = iris.load_cube(iris.sample_data_path('air_temp.pp'))
-    >>> print air_temp
+    >>> print(air_temp)
     air_temperature / (K)               (latitude: 73; longitude: 96)
          Dimension coordinates:
               latitude                           x              -
@@ -73,7 +73,7 @@ Let's take the air temperature cube we've seen previously:
 We can interpolate specific values from the coordinates of the cube:
 
     >>> sample_points = [('latitude', 51.48), ('longitude', 0)]
-    >>> print air_temp.interpolate(sample_points, iris.analysis.Linear())
+    >>> print(air_temp.interpolate(sample_points, iris.analysis.Linear()))
     air_temperature / (K)               (scalar cube)
          Scalar coordinates:
               forecast_period: 6477 hours, bound=(-28083.0, 6477.0) hours
@@ -96,9 +96,9 @@ It isn't necessary to specify sample points for every dimension, only those that
 wish to interpolate over:
 
     >>> result = air_temp.interpolate([('longitude', 0)], iris.analysis.Linear())
-    >>> print 'Original:', air_temp.summary(shorten=True)
+    >>> print('Original: ' + air_temp.summary(shorten=True))
     Original: air_temperature / (K)               (latitude: 73; longitude: 96)
-    >>> print 'Interpolated:', result.summary(shorten=True)
+    >>> print('Interpolated: ' + result.summary(shorten=True))
     Interpolated: air_temperature / (K)               (latitude: 73)
 
 The sample points for a coordinate can be an array of values. When multiple coordinates are
@@ -108,7 +108,7 @@ will be orthogonal:
     >>> sample_points = [('longitude', np.linspace(-11, 2, 14)),
     ...                  ('latitude',  np.linspace(48, 60, 13))]
     >>> result = air_temp.interpolate(sample_points, iris.analysis.Linear())
-    >>> print result.summary(shorten=True)
+    >>> print(result.summary(shorten=True))
     air_temperature / (K)               (latitude: 13; longitude: 14)
 
 
@@ -124,13 +124,13 @@ monotonic, coordinates. Supposing we have a single column cube such as
 the one defined below:
 
     >>> column = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))[:, 0, 0]
-    >>> print column.summary(shorten=True)
+    >>> print(column.summary(shorten=True))
     air_potential_temperature / (K)     (model_level_number: 15)
 
 This cube has a "hybrid-height" vertical coordinate system, meaning that the vertical
 coordinate is unevenly spaced in altitude:
 
-    >>> print column.coord('altitude').points
+    >>> print(column.coord('altitude').points)
     [  418.7    434.57   456.79   485.37   520.29   561.58   609.21   663.21
        723.58   790.31   863.41   942.88  1028.74  1120.98  1219.61]
 
@@ -140,7 +140,7 @@ these sample points:
 
     >>> sample_points = [('altitude', np.linspace(400, 1250, 10))]
     >>> new_column = column.interpolate(sample_points, iris.analysis.Linear())
-    >>> print new_column.summary(shorten=True)
+    >>> print(new_column.summary(shorten=True))
     air_potential_temperature / (K)     (model_level_number: 10)
 
 Let's look at the original data, the interpolation line and
@@ -174,7 +174,7 @@ For example, to mask values that lie beyond the range of the original data:
 
     >>> scheme = iris.analysis.Linear(extrapolation_mode='mask')
     >>> new_column = column.interpolate(sample_points, scheme)
-    >>> print new_column.coord('altitude').points
+    >>> print(new_column.coord('altitude').points)
     [     nan   494.44   588.89   683.33   777.78   872.22   966.67  1061.11
       1155.56      nan]
 
@@ -308,12 +308,12 @@ Let's demonstrate this with the global air temperature cube we saw previously,
 along with a limited area cube containing total concentration of volcanic ash:
 
     >>> global_air_temp = iris.load_cube(iris.sample_data_path('air_temp.pp'))
-    >>> print global_air_temp.summary(shorten=True)
+    >>> print(global_air_temp.summary(shorten=True))
     air_temperature / (K)               (latitude: 73; longitude: 96)
     >>>
     >>> regional_ash = iris.load_cube(iris.sample_data_path('NAME_output.txt'))
     >>> regional_ash = regional_ash.collapsed('flight_level', iris.analysis.SUM)
-    >>> print regional_ash.summary(shorten=True)
+    >>> print(regional_ash.summary(shorten=True))
     VOLCANIC_ASH_AIR_CONCENTRATION / (g/m3) (latitude: 214; longitude: 584)
 
 One of the key limitations of the :class:`~iris.analysis.AreaWeighted`
@@ -341,7 +341,7 @@ regridding scheme:
 
     >>> scheme = iris.analysis.AreaWeighted(mdtol=0.5)
     >>> global_ash = regional_ash.regrid(global_air_temp, scheme)
-    >>> print global_ash.summary(shorten=True)
+    >>> print(global_ash.summary(shorten=True))
     VOLCANIC_ASH_AIR_CONCENTRATION / (g/m3) (latitude: 73; longitude: 96)
 
 Note that the :class:`~iris.analysis.AreaWeighted` regridding scheme allows us

--- a/docs/iris/src/userguide/iris_cubes.rst
+++ b/docs/iris/src/userguide/iris_cubes.rst
@@ -154,7 +154,7 @@ output as this is the quickest way of inspecting the contents of a cube. Here is
      import iris
      filename = iris.sample_data_path('uk_hires.pp')
      # NOTE: Every time the output of this cube changes, the full list of deductions below should be re-assessed. 
-     print iris.load_cube(filename, 'air_potential_temperature')
+     print(iris.load_cube(filename, 'air_potential_temperature'))
 
 .. testoutput::
 

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -29,7 +29,7 @@ In order to find out what has been loaded, the result can be printed:
     >>> import iris
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cubes = iris.load(filename)
-    >>> print cubes
+    >>> print(cubes)
     0: air_potential_temperature / (K)     (time: 3; model_level_number: 7; grid_latitude: 204; grid_longitude: 187)
     1: surface_altitude / (m)              (grid_latitude: 204; grid_longitude: 187)
 
@@ -76,7 +76,7 @@ list indexing can be used:
     >>> cubes = iris.load(filename)
     >>> # get the first cube (list indexing is 0 based)
     >>> air_potential_temperature = cubes[0]
-    >>> print air_potential_temperature
+    >>> print(air_potential_temperature)
     air_potential_temperature / (K)     (time: 3; model_level_number: 7; grid_latitude: 204; grid_longitude: 187)
          Dimension coordinates:
               time                           x                      -                 -                    -
@@ -236,7 +236,7 @@ explicitly enabled by setting the "cell_datetime_objects" option in :class:`iris
 
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cube_all = iris.load_cube(filename, 'air_potential_temperature')
-    >>> print 'All times :\n', cube_all.coord('time')
+    >>> print('All times :\n' + str(cube_all.coord('time')))
     All times :
     DimCoord([2009-11-19 10:00:00, 2009-11-19 11:00:00, 2009-11-19 12:00:00], standard_name='time', calendar='gregorian')
     >>> # Define a function which accepts a datetime as its argument (this is simplified in later examples).
@@ -244,7 +244,7 @@ explicitly enabled by setting the "cell_datetime_objects" option in :class:`iris
     >>> with iris.FUTURE.context(cell_datetime_objects=True):
     ...     cube_11 = cube_all.extract(hour_11)
     ... 
-    >>> print 'Selected times :\n', cube_11.coord('time')
+    >>> print('Selected times :\n' + str(cube_11.coord('time')))
     Selected times :
     DimCoord([2009-11-19 11:00:00], standard_name='time', calendar='gregorian')
 
@@ -256,9 +256,9 @@ then test only those 'aspects' which the PartialDateTime instance defines:
     >>> import datetime
     >>> from iris.time import PartialDateTime
     >>> dt = datetime.datetime(2011, 3, 7)
-    >>> print dt > PartialDateTime(year=2010, month=6)
+    >>> print(dt > PartialDateTime(year=2010, month=6))
     True
-    >>> print dt > PartialDateTime(month=6)
+    >>> print(dt > PartialDateTime(month=6))
     False
     >>> 
 
@@ -269,8 +269,9 @@ The previous constraint example can now be written as:
 
    >>> the_11th_hour = iris.Constraint(time=iris.time.PartialDateTime(hour=11))
    >>> with iris.FUTURE.context(cell_datetime_objects=True):
-   ...     print iris.load_cube(iris.sample_data_path('uk_hires.pp'),
-   ...                          'air_potential_temperature' & the_11th_hour).coord('time')
+   ...     print(iris.load_cube(
+   ...         iris.sample_data_path('uk_hires.pp'),
+   ...         'air_potential_temperature' & the_11th_hour).coord('time'))
    DimCoord([2009-11-19 11:00:00], standard_name='time', calendar='gregorian')
 
 A more complex example might be when there exists a time sequence representing the first day of every week
@@ -289,7 +290,7 @@ for many years:
 .. doctest:: timeseries_range
     :options: +NORMALIZE_WHITESPACE, +ELLIPSIS
     
-    >>> print long_ts.coord('time')
+    >>> print(long_ts.coord('time'))
     DimCoord([2007-04-09 00:00:00, 2007-04-16 00:00:00, 2007-04-23 00:00:00,
               ...
               2010-02-01 00:00:00, 2010-02-08 00:00:00, 2010-02-15 00:00:00],
@@ -306,7 +307,7 @@ functionality with PartialDateTime:
     >>> with iris.FUTURE.context(cell_datetime_objects=True):
     ...   within_st_swithuns = long_ts.extract(st_swithuns_daterange)
     ... 
-    >>> print within_st_swithuns.coord('time')
+    >>> print(within_st_swithuns.coord('time'))
     DimCoord([2007-07-16 00:00:00, 2007-07-23 00:00:00, 2007-07-30 00:00:00,
            2007-08-06 00:00:00, 2007-08-13 00:00:00, 2007-08-20 00:00:00,
            2008-07-21 00:00:00, 2008-07-28 00:00:00, 2008-08-04 00:00:00,
@@ -334,7 +335,7 @@ A single cube is loaded in the following example::
 
     >>> filename = iris.sample_data_path('air_temp.pp')
     >>> cube = iris.load_cube(filename)
-    >>> print cube
+    >>> print(cube)
     air_temperature / (K)                 (latitude: 73; longitude: 96)
          Dimension coordinates:
               latitude                           x              -
@@ -371,7 +372,7 @@ in order to run::
     import iris
     filename = iris.sample_data_path('uk_hires.pp')
     air_pot_temp = iris.load_cube(filename, 'air_potential_temperature')
-    print air_pot_temp
+    print(air_pot_temp)
 
 Should the file not produce exactly one cube with a standard name of 
 'air_potential_temperature', an exception will be raised.
@@ -393,8 +394,8 @@ these two cubes into separate variables.
     using *multiple assignment*:
 
         >>> number_one, number_two = [1, 2]
-        >>> print number_one
+        >>> print(number_one)
         1
-        >>> print number_two
+        >>> print(number_two)
         2
 

--- a/docs/iris/src/userguide/merge_and_concat.rst
+++ b/docs/iris/src/userguide/merge_and_concat.rst
@@ -100,28 +100,28 @@ make a new ``z`` dimension coordinate:
 .. doctest:: merge
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (y: 4; x: 5)
     1: air_temperature / (kelvin)          (y: 4; x: 5)
     2: air_temperature / (kelvin)          (y: 4; x: 5)
 
-    >>> print cubes[0]
+    >>> print(cubes[0])
     air_temperature / (kelvin)          (y: 4; x: 5)
      ...
          Scalar coordinates:
               z: 1 meters
-    >>> print cubes[1]
+    >>> print(cubes[1])
     air_temperature / (kelvin)          (y: 4; x: 5)
      ...
          Scalar coordinates:
               z: 2 meters
-    >>> print cubes[2]
+    >>> print(cubes[2])
     air_temperature / (kelvin)          (y: 4; x: 5)
      ...
          Scalar coordinates:
               z: 3 meters
 
-    >>> print cubes.merge()
+    >>> print(cubes.merge())
     0: air_temperature / (kelvin)          (z: 3; y: 4; x: 5)
 
 The following diagram illustrates what has taken place in this example:
@@ -170,23 +170,23 @@ into a single cube:
 .. doctest:: merge_vs_merge_cube
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (y: 4; x: 5)
     1: air_temperature / (kelvin)          (y: 4; x: 5)
     2: air_temperature / (kelvin)          (y: 4; x: 5)
 
-    >>> print cubes[0].attributes
+    >>> print(cubes[0].attributes)
     {'Conventions': 'CF-1.5'}
-    >>> print cubes[1].attributes
+    >>> print(cubes[1].attributes)
     {}
-    >>> print cubes[2].attributes
+    >>> print(cubes[2].attributes)
     {}
 
-    >>> print cubes.merge()
+    >>> print(cubes.merge())
     0: air_temperature / (kelvin)          (y: 4; x: 5)
     1: air_temperature / (kelvin)          (z: 2; y: 4; x: 5)
 
-    >>> print cubes.merge_cube()
+    >>> print(cubes.merge_cube())
     Traceback (most recent call last):
         ...
         raise iris.exceptions.MergeError(msgs)
@@ -276,12 +276,12 @@ cubes to form a new cube with an extended ``t`` coordinate:
 .. doctest:: concatenate
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
     1: air_temperature / (kelvin)          (t: 28; y: 3; x: 4)
     2: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
 
-    >>> print cubes.concatenate()
+    >>> print(cubes.concatenate())
     0: air_temperature / (kelvin)          (t: 90; y: 3; x: 4)
 
 
@@ -332,20 +332,20 @@ concatenate into a single cube:
 .. doctest:: concatenate_vs_concatenate_cube
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
     1: air_temperature / (kelvin)          (t: 28; y: 3; x: 4)
     2: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
 
-    >>> print cubes[0].attributes
+    >>> print(cubes[0].attributes)
     {'History': 'Created 2010-06-30'}
-    >>> print cubes[1].attributes
+    >>> print(cubes[1].attributes)
     {}
 
-    >>> print cubes.concatenate()
+    >>> print(cubes.concatenate())
     0: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
     1: air_temperature / (kelvin)          (t: 59; y: 3; x: 4)
-    >>> print cubes.concatenate_cube()
+    >>> print(cubes.concatenate_cube())
     Traceback (most recent call last):
         ...
         raise iris.exceptions.ConcatenateError(msgs)
@@ -417,19 +417,19 @@ input cubes before merging the input cubes using :meth:`~iris.cube.CubeList.merg
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     >>> from iris.experimental.equalise_cubes import equalise_attributes
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (y: 4; x: 5)
     1: air_temperature / (kelvin)          (y: 4; x: 5)
     2: air_temperature / (kelvin)          (y: 4; x: 5)
 
-    >>> print cubes[0].attributes
+    >>> print(cubes[0].attributes)
     {'Conventions': 'CF-1.5'}
-    >>> print cubes[1].attributes
+    >>> print(cubes[1].attributes)
     {}
-    >>> print cubes[2].attributes
+    >>> print(cubes[2].attributes)
     {}
 
-    >>> print cubes.merge_cube()
+    >>> print(cubes.merge_cube())
     Traceback (most recent call last):
         ...
         raise iris.exceptions.MergeError(msgs)
@@ -438,10 +438,10 @@ input cubes before merging the input cubes using :meth:`~iris.cube.CubeList.merg
 
     >>> equalise_attributes(cubes)
 
-    >>> print cubes[0].attributes
+    >>> print(cubes[0].attributes)
     {}
 
-    >>> print cubes.merge_cube()
+    >>> print(cubes.merge_cube())
     air_temperature / (kelvin)          (z: 3; y: 4; x: 5)
          Dimension coordinates:
               z                           x     -     -
@@ -458,7 +458,7 @@ The misleading results cause the merged cube to gain an anonymous leading dimens
 All the merged coordinates appear as auxiliary coordinates on the anonymous leading dimension.
 This is shown in the example below::
 
-    >>> print cube
+    >>> print(cube)
     surface_temperature / (K)           (-- : 5494; latitude: 325; longitude: 432)
          Dimension coordinates:
               latitude                      -               x               -
@@ -504,16 +504,16 @@ is the default behaviour):
 .. doctest:: merge_duplicate
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (y: 4; x: 5)
     1: air_temperature / (kelvin)          (y: 4; x: 5)
     2: air_temperature / (kelvin)          (y: 4; x: 5)
 
-    >>> print cubes.merge(unique=False)
+    >>> print(cubes.merge(unique=False))
     0: air_temperature / (kelvin)          (z: 2; y: 4; x: 5)
     1: air_temperature / (kelvin)          (z: 2; y: 4; x: 5)
 
-    >>> print cubes.merge()  # unique=True is the default.
+    >>> print(cubes.merge())  # unique=True is the default.
     Traceback (most recent call last):
       ...
     iris.exceptions.DuplicateDataError: failed to merge into a single cube.
@@ -551,14 +551,14 @@ If your cubes are similar to those below (the single value ``z`` coordinate
 is not on a dimension) then use :meth:`~iris.cube.CubeList.merge` to
 combine your cubes::
 
-    >>> print cubes[0]
+    >>> print(cubes[0])
     air_temperature / (kelvin)          (y: 4; x: 5)
          Dimension coordinates:
               x                           x      -
               y                           -      x
          Scalar coordinates:
               z: 1
-    >>> print cubes[1]
+    >>> print(cubes[1])
     air_temperature / (kelvin)          (y: 4; x: 5)
          Dimension coordinates:
               x                           x      -
@@ -571,7 +571,7 @@ If your cubes are similar to those below (the single value ``z`` coordinate is
 associated with a dimension) then use :meth:`~iris.cube.CubeList.concatenate` to
 combine your cubes::
 
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (z: 1; y: 4; x: 5)
     1: air_temperature / (kelvin)          (z: 1; y: 4; x: 5)
 
@@ -613,17 +613,17 @@ the input cubes using :meth:`~iris.cube.CubeList.concatenate_cube`:
     :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     >>> from iris.util import unify_time_units
-    >>> print cubes
+    >>> print(cubes)
     0: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
     1: air_temperature / (kelvin)          (t: 28; y: 3; x: 4)
     2: air_temperature / (kelvin)          (t: 31; y: 3; x: 4)
 
-    >>> print cubes[0].coord('t').units
+    >>> print(cubes[0].coord('t').units)
     days since 1990-02-15
-    >>> print cubes[1].coord('t').units
+    >>> print(cubes[1].coord('t').units)
     days since 1970-01-01
 
-    >>> print cubes.concatenate_cube()
+    >>> print(cubes.concatenate_cube())
     Traceback (most recent call last):
      ...
     ConcatenateError: failed to concatenate into a single cube.
@@ -631,10 +631,10 @@ the input cubes using :meth:`~iris.cube.CubeList.concatenate_cube`:
 
     >>> unify_time_units(cubes)
 
-    >>> print cubes[1].coord('t').units
+    >>> print(cubes[1].coord('t').units)
     days since 1990-02-15
 
-    >>> print cubes.concatenate_cube()
+    >>> print(cubes.concatenate_cube())
     air_temperature / (kelvin)          (t: 90; y: 3; x: 4)
          Dimension coordinates:
               t                           x      -     -

--- a/docs/iris/src/userguide/navigating_a_cube.rst
+++ b/docs/iris/src/userguide/navigating_a_cube.rst
@@ -23,7 +23,7 @@ We have already seen a basic string representation of a cube when printing:
     >>> import iris
     >>> filename = iris.sample_data_path('rotated_pole.nc')
     >>> cube = iris.load_cube(filename)
-    >>> print cube
+    >>> print(cube)
     air_pressure_at_sea_level / (Pa)    (grid_latitude: 22; grid_longitude: 36)
          Dimension coordinates:
               grid_latitude                           x                   -
@@ -42,9 +42,9 @@ This representation is equivalent to passing the cube to the :func:`str` functio
 any Python variable to get a string representation of that variable. 
 Similarly there exist other standard functions for interrogating your variable: :func:`repr`, :func:`type` for example::
 
-    print str(cube)
-    print repr(cube)
-    print type(cube)
+    print(str(cube))
+    print(repr(cube))
+    print(type(cube))
 
 Other, more verbose, functions also exist which give information on **what** you can do with *any* given 
 variable. In most cases it is reasonable to ignore anything starting with a "``_``" (underscore) or a "``__``" (double underscore)::
@@ -60,23 +60,23 @@ Every cube has a standard name, long name and units which are accessed with
 :attr:`Cube.long_name <iris.cube.Cube.long_name>` 
 and :attr:`Cube.units <iris.cube.Cube.units>` respectively::
 
-    print cube.standard_name
-    print cube.long_name
-    print cube.units
+    print(cube.standard_name)
+    print(cube.long_name)
+    print(cube.units)
     
 Interrogating these with the standard :func:`type` function will tell you that ``standard_name`` and ``long_name`` 
 are either a string or ``None``, and ``units`` is an instance of :class:`iris.unit.Unit`.
 
 You can access a string representing the "name" of a cube with the :meth:`Cube.name() <iris.cube.Cube.name>` method::
 
-    print cube.name()
+    print(cube.name())
     
 The result of which is **always** a string.
 
 Each cube also has a :mod:`numpy` array which represents the phenomenon of the cube which can be accessed with the 
 :attr:`Cube.data <iris.cube.Cube.data>` attribute. As you can see the type is a :class:`numpy n-dimensional array <numpy.ndarray>`::
 
-    print type(cube.data)
+    print(type(cube.data))
 
 .. note::
 
@@ -89,8 +89,8 @@ Each cube also has a :mod:`numpy` array which represents the phenomenon of the c
     For convenience :attr:`~iris.cube.Cube.shape` and :attr:`~iris.cube.Cube.ndim` attributes exists on a cube, which 
     can tell you the shape of the cube's data without loading it::
 
-       print cube.shape
-       print cube.ndim
+       print(cube.shape)
+       print(cube.ndim)
 
 You can change the units of a cube using the :meth:`~iris.cube.Cube.convert_units` method. For example::
 
@@ -103,7 +103,7 @@ As well as changing the value of the :attr:`~iris.cube.Cube.units` attribute thi
 Some cubes represent a processed phenomenon which are represented with cell methods, these can be accessed on a 
 cube with the :attr:`Cube.cell_methods <iris.cube.Cube.cell_methods>` attribute::
 
-    print cube.cell_methods
+    print(cube.cell_methods)
 
 
 Accessing coordinates on the cube
@@ -113,7 +113,7 @@ A cube's coordinates can be retrieved via :meth:`Cube.coords <iris.cube.Cube.coo
 A simple for loop over the coords can print a coordinate's :meth:`~iris.coords.Coord.name`::
 
      for coord in cube.coords():
-         print coord.name()
+         print(coord.name())
 
 Alternatively, we can use *list comprehension* to store the names in a list::
 
@@ -121,26 +121,26 @@ Alternatively, we can use *list comprehension* to store the names in a list::
 
 The result is a basic Python list which could be sorted alphabetically and joined together:
 
-     >>> print ', '.join(sorted(coord_names))
+     >>> print(', '.join(sorted(coord_names)))
      forecast_period, forecast_reference_time, grid_latitude, grid_longitude, time
 
 To get an individual coordinate given its name, the :meth:`Cube.coord <iris.cube.Cube.coord>` method can be used::
 
      coord = cube.coord('grid_latitude')
-     print type(coord)
+     print(type(coord))
 
 Every coordinate has a :attr:`Coord.standard_name <iris.coords.Coord.standard_name>`, 
 :attr:`Coord.long_name <iris.coords.Coord.long_name>`, and :attr:`Coord.units <iris.coords.Coord.units>` attribute::
 
-     print coord.standard_name
-     print coord.long_name
-     print coord.units
+     print(coord.standard_name)
+     print(coord.long_name)
+     print(coord.units)
 
 Additionally every coordinate can provide its :attr:`~iris.coords.Coord.points` and :attr:`~iris.coords.Coord.bounds` 
 numpy array. If the coordinate has no bounds ``None`` will be returned::
 
-     print type(coord.points)
-     print type(coord.bounds)
+     print(type(coord.points))
+     print(type(coord.bounds))
 
 
 Adding metadata to a cube
@@ -153,7 +153,7 @@ We can add and remove coordinates via :func:`Cube.add_dim_coord<iris.cube.Cube.a
     >>> import iris.coords
     >>> new_coord = iris.coords.AuxCoord(1, long_name='my_custom_coordinate', units='no_unit')
     >>> cube.add_aux_coord(new_coord)
-    >>> print cube
+    >>> print(cube)
     air_pressure_at_sea_level / (Pa)    (grid_latitude: 22; grid_longitude: 36)
          Dimension coordinates:
               grid_latitude                           x                   -
@@ -195,7 +195,7 @@ model mean that the run is spread over several days.
 If we try to load the data directly for ``surface_temperature``:
 
     >>> filename = iris.sample_data_path('GloSea4', '*.pp')
-    >>> print iris.load(filename, 'surface_temperature')
+    >>> print(iris.load(filename, 'surface_temperature'))
     0: surface_temperature / (K)           (time: 6; forecast_reference_time: 2; latitude: 145; longitude: 192)
     1: surface_temperature / (K)           (time: 6; forecast_reference_time: 2; latitude: 145; longitude: 192)
     2: surface_temperature / (K)           (realization: 9; time: 6; latitude: 145; longitude: 192)
@@ -210,7 +210,7 @@ which, given the filename, we could extract::
 
     filename = iris.sample_data_path('GloSea4', 'ensemble_001.pp')
     realization = int(filename[-6:-3])
-    print realization
+    print(realization)
 
 We can solve this problem by adding the appropriate metadata, on load, by using a callback function, which runs on a field
 by field basis *before* they are automatically merged together:
@@ -230,7 +230,7 @@ by field basis *before* they are automatically merged together:
 
     filename = iris.sample_data_path('GloSea4', '*.pp')
 
-    print iris.load(filename, 'surface_temperature', callback=lagged_ensemble_callback)
+    print(iris.load(filename, 'surface_temperature', callback=lagged_ensemble_callback))
 
 
 The result is a single cube which represents the data in a form that was expected:

--- a/docs/iris/src/userguide/plotting_a_cube.rst
+++ b/docs/iris/src/userguide/plotting_a_cube.rst
@@ -53,7 +53,7 @@ Subsequent changes to your figure will be automatically rendered in the window.
 The current rendering mode can be determined as follows::
 
 	import matplotlib.pyplot as plt
-	print plt.isinteractive()
+	print(plt.isinteractive())
 
 .. note::
 
@@ -64,7 +64,7 @@ The current rendering mode can be determined as follows::
         	import matplotlib.pyplot as plt
 	        plt.interactive(True)
 	        plt.plot([1, 2, 2.5])
-	        print plt.isinteractive()
+	        print(plt.isinteractive())
 
 Interactive mode does not clear out the figure buffer, so figures have to be 
 explicitly closed when they are finished with::

--- a/docs/iris/src/userguide/subsetting_a_cube.rst
+++ b/docs/iris/src/userguide/subsetting_a_cube.rst
@@ -19,7 +19,7 @@ A subset of a cube can be "extracted" from a multi-dimensional cube in order to 
     >>> filename = iris.sample_data_path('space_weather.nc')
     >>> cube = iris.load_cube(filename, 'electron density')
     >>> equator_slice = cube.extract(iris.Constraint(grid_latitude=0))
-    >>> print equator_slice
+    >>> print(equator_slice)
     electron density / (1E11 e/m^3)     (height: 29; grid_longitude: 31)
          Dimension coordinates:
               height                           x                   -
@@ -61,12 +61,12 @@ The extract method could be applied again to the *equator_slice* cube to get a f
 For example to get a ``height`` of 9000 metres at the equator the following line extends the previous example::
 
 	equator_height_9km_slice = equator_slice.extract(iris.Constraint(height=9000))
-	print equator_height_9km_slice
+	print(equator_height_9km_slice)
 
 The two steps required to get ``height`` of 9000 m at the equator can be simplified into a single constraint::
 
 	equator_height_9km_slice = cube.extract(iris.Constraint(grid_latitude=0, height=9000))
-	print equator_height_9km_slice
+	print(equator_height_9km_slice)
 
 As we saw in :doc:`loading_iris_cubes` the result of :func:`iris.load` is a :class:`CubeList <iris.cube.CubeList>`.
 The ``extract`` method also exists on a :class:`CubeList <iris.cube.CubeList>` and behaves in exactly the
@@ -77,9 +77,9 @@ same way as loading with constraints:
     >>> level_10 = iris.Constraint(model_level_number=10)
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cubes = iris.load(filename).extract(air_temp_and_fp_6 & level_10)
-    >>> print cubes
+    >>> print(cubes)
     0: air_potential_temperature / (K)     (grid_latitude: 204; grid_longitude: 187)
-    >>> print cubes[0]
+    >>> print(cubes[0])
     air_potential_temperature / (K)     (grid_latitude: 204; grid_longitude: 187)
          Dimension coordinates:
               grid_latitude                           x                    -
@@ -110,12 +110,12 @@ which make up the full 3d cube.::
 	import iris
 	filename = iris.sample_data_path('hybrid_height.nc')
 	cube = iris.load_cube(filename)
-	print cube
+	print(cube)
 	for yx_slice in cube.slices(['grid_latitude', 'grid_longitude']):
-	   print repr(yx_slice)
+	   print(repr(yx_slice))
 
 As the original cube had the shape (15, 100, 100) there were 15 latitude longitude slices and hence the
-line ``print repr(yx_slice)`` was run 15 times.
+line ``print(repr(yx_slice))`` was run 15 times.
 
 .. note::
 
@@ -130,9 +130,9 @@ This method can handle n-dimensional slices by providing more or fewer coordinat
 	import iris
 	filename = iris.sample_data_path('hybrid_height.nc')
 	cube = iris.load_cube(filename)
-	print cube
+	print(cube)
 	for i, x_slice in enumerate(cube.slices(['grid_longitude'])):
-	   print i, repr(x_slice)
+	   print(i, repr(x_slice))
 
 The Python function :py:func:`enumerate` is used in this example to provide an incrementing variable **i** which is
 printed with the summary of each cube slice. Note that there were 1500 1d longitude cubes as a result of
@@ -159,29 +159,29 @@ Here are some examples of array indexing in :py:mod:`numpy`::
 	import numpy as np
 	# create an array of 12 consecutive integers starting from 0
 	a = np.arange(12)
-	print a
+	print(a)
 
-	print a[0]       # first element of the array
+	print(a[0])     # first element of the array
 
-	print a[-1]       # last element of the array
+	print(a[-1])    # last element of the array
 
-	print a[0:4]       # first four elements of the array (this is the same as a[:4])
+	print(a[0:4])   # first four elements of the array (the same as a[:4])
 
-	print a[-4:]       # last four elements of the array
+	print(a[-4:])   # last four elements of the array
 
-	print a[::-1]       # gives all of the array, but backwards
+	print(a[::-1])  # gives all of the array, but backwards
 
 	# Make a 2d array by reshaping a
 	b = a.reshape(3, 4)
-	print b
+	print(b)
 
-	print b[0, 0]       # first element of the first and second dimensions
+	print(b[0, 0])  # first element of the first and second dimensions
 
-	print b[0]       # first element of the first dimension (+ every other dimension)
+	print(b[0])     # first element of the first dimension (+ every other dimension)
 
 	# get the second element of the first dimension and all of the second dimension
 	# in reverse, by steps of two.
-	print b[1, ::-2]
+	print(b[1, ::-2])
 
 
 Similarly, Iris cubes have indexing capability::
@@ -190,20 +190,20 @@ Similarly, Iris cubes have indexing capability::
         filename = iris.sample_data_path('hybrid_height.nc')
 	cube = iris.load_cube(filename)
 
-	print cube
+	print(cube)
 
 	# get the first element of the first dimension (+ every other dimension)
-	print cube[0]
+	print(cube[0])
 
 	# get the last element of the first dimension (+ every other dimension)
-	print cube[-1]
+	print(cube[-1])
 
 	# get the first 4 elements of the first dimension (+ every other dimension)
-	print cube[0:4]
+	print(cube[0:4])
 
 	# Get the first element of the first and third dimension (+ every other dimension)
-	print cube[0, :, 0]
+	print(cube[0, :, 0])
 
 	# Get the second element of the first dimension and all of the second dimension
 	# in reverse, by steps of two.
-	print cube[1, ::-2]
+	print(cube[1, ::-2])

--- a/docs/iris/src/whatsnew/1.0.rst
+++ b/docs/iris/src/whatsnew/1.0.rst
@@ -221,7 +221,7 @@ Metadata attributes
 Iris now stores "source" and "history" metadata in Cube attributes.
 For example::
 
-    >>> print iris.tests.stock.global_pp()
+    >>> print(iris.tests.stock.global_pp())
     air_temperature                     (latitude: 73; longitude: 96)
          ...
          Attributes:

--- a/docs/iris/src/whatsnew/1.1.rst
+++ b/docs/iris/src/whatsnew/1.1.rst
@@ -87,7 +87,7 @@ one might do::
 
     >>> seasons = ['mamjja', 'sondjf']
     >>> iris.coord_categorisation.add_custom_season(cube, 'time', seasons)
-    >>> print cube.coord('season').points
+    >>> print(cube.coord('season').points)
     ['ondjfm' 'ondjfm' 'mamjja' 'mamjja' 'mamjja' 'mamjja' 'mamjja' 'mamjja'
      'ondjfm' 'ondjfm' 'ondjfm' 'ondjfm']
 

--- a/docs/iris/src/whatsnew/1.3.rst
+++ b/docs/iris/src/whatsnew/1.3.rst
@@ -110,7 +110,7 @@ restriction.
 For example, if one began with a collection of Cubes, each containing
 data for a different range of times::
 
-        >>> print cubes
+        >>> print(cubes)
         0: air_temperature                     (time: 30; latitude: 145; longitude: 192)
         1: air_temperature                     (time: 30; latitude: 145; longitude: 192)
         2: air_temperature                     (time: 30; latitude: 145; longitude: 192)
@@ -119,7 +119,7 @@ One could use :func:`iris.experimental.concatenate.concatenate()` to
 combine these into a single Cube as follows::
 
         >>> new_cubes = iris.experimental.concatenate.concatenate(cubes)
-        >>> print new_cubes
+        >>> print(new_cubes)
         0: air_temperature                     (time: 90; latitude: 145; longitude: 192)
 
 .. note::

--- a/docs/iris/src/whatsnew/1.5.rst
+++ b/docs/iris/src/whatsnew/1.5.rst
@@ -36,7 +36,7 @@ Iris 1.5 features
       # Get cube slices corresponding to the dimension associated with longitude
       # and the first dimension from a multi-dimensional cube.
       for sub_cube in cube.slices(['longitude', 0]):
-          print sub_cube
+          print(sub_cube)
 
 * :mod:`iris.experimental.animate` now provides experimental animation support.
 

--- a/docs/iris/src/whatsnew/1.6.rst
+++ b/docs/iris/src/whatsnew/1.6.rst
@@ -26,7 +26,7 @@ Iris 1.6 features
         >>> from iris.coords import DimCoord
         >>> iris.FUTURE.cell_datetime_objects = True
         >>> coord = DimCoord([1, 2, 3], 'time', units='hours since epoch')
-        >>> print [str(cell) for cell in coord.cells()]
+        >>> print([str(cell) for cell in coord.cells()])
         ['1970-01-01 01:00:00', '1970-01-01 02:00:00', '1970-01-01 03:00:00']
 
     Note that, either a :class:`datetime.datetime` or :class:`netcdftime.datetime`
@@ -46,14 +46,14 @@ Iris 1.6 features
 
     .. code-block:: python
 
-        >>> print iris.FUTURE
+        >>> print(iris.FUTURE)
         Future(cell_datetime_objects=False)
         >>> with iris.FUTURE.context(cell_datetime_objects=True):
         ...     # Code that expects to deal with datetime-like objects.
-        ...     print iris.FUTURE
+        ...     print(iris.FUTURE)
         ...
         Future(cell_datetime_objects=True)
-        >>> print iris.FUTURE
+        >>> print(iris.FUTURE)
         Future(cell_datetime_objects=False)
 
 .. admonition:: Showcase Feature - Partial date/time ...

--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -30,7 +30,7 @@ Iris 1.7 features
     larger than available system memory::
 
         >>> result = extremely_large_cube.collapsed('time', iris.analyis.MEAN)
-        >>> print type(result)
+        >>> print(type(result))
         <class 'iris.cube.Cube'>
 
     Memory is still a limiting factor if ever the data is desired as a NumPy array

--- a/docs/iris/src/whatsnew/1.8.rst
+++ b/docs/iris/src/whatsnew/1.8.rst
@@ -50,13 +50,13 @@ Iris 1.8 features
     To demonstrate this::
 
         >>> cube = iris.load(iris.sample_data_path('colpex.pp'))[0]
-        >>> print cube.summary(shorten=True)
+        >>> print(cube.summary(shorten=True))
         air_potential_temperature / (K)     (time: 6; model_level_number: 10; grid_latitude: 83; grid_longitude: 83)
         >>> my_slice = next(cube.slices('time'))
         >>> my_slice_over = next(cube.slices_over('time'))
-        >>> print my_slice.summary(shorten=True)
+        >>> print(my_slice.summary(shorten=True))
         air_potential_temperature / (K)     (time: 6)
-        >>> print my_slice_over.summary(shorten=True)
+        >>> print(my_slice_over.summary(shorten=True))
         air_potential_temperature / (K)     (model_level_number: 10; grid_latitude: 83; grid_longitude: 83)
     
 

--- a/docs/iris/src/whitepapers/um_files_loading.rst
+++ b/docs/iris/src/whitepapers/um_files_loading.rst
@@ -143,14 +143,15 @@ For example:
     >>> field = next(fields_iter)
     >>> 
     >>> # Show grid details and first 5 longitude values.
-    ... print field.lbcode, field.lbnpt, field.bzx, field.bdx
+    >>> print(' '.join(str(_) for _ in (field.lbcode, field.lbnpt, field.bzx,
+    ...                                 field.bdx)))
     1 96 -3.75 3.75
-    >>> print field.bzx + field.bdx * np.arange(1, 6)
+    >>> print(field.bzx + field.bdx * np.arange(1, 6))
     [  0.     3.75   7.5   11.25  15.  ]
     >>> 
     >>> # Show Iris equivalent information.
     ... cube = iris.load_cube(fname)
-    >>> print cube.coord('longitude').points[:5]
+    >>> print(cube.coord('longitude').points[:5])
     [  0.     3.75   7.5   11.25  15.  ]
 
 .. note::
@@ -192,13 +193,19 @@ identified (for example, to load only certain stashcodes with a constraint
 
 For example:
     >>> # Show PPfield phenomenon details.
-    ... print field.lbuser[3], field.lbuser[6]
-    16203 1
+    >>> print(field.lbuser[3])
+    16203
+    >>> print(field.lbuser[6])
+    1
     >>> 
     >>> 
     >>> # Show Iris equivalents.
-    ... print cube.standard_name, cube.units, cube.attributes['STASH']
-    air_temperature K m01s16i203
+    >>> print(cube.standard_name)
+    air_temperature
+    >>> print(cube.units)
+    K
+    >>> print(cube.attributes['STASH'])
+    m01s16i203
 
 .. note::
     On saving data, no attempt is made to translate a cube standard_name into a
@@ -414,11 +421,13 @@ For example:
     >>> # Show stats metadata in a test PP field.
     ... fname = iris.sample_data_path('pre-industrial.pp')
     >>> eg_field = next(iris.fileformats.pp.load(fname))
-    >>> print eg_field.lbtim, eg_field.lbproc
-    622 128
+    >>> print(eg_field.lbtim)
+    622
+    >>> print(eg_field.lbproc)
+    128
     >>> 
     >>> # Print out the Iris equivalent information.
-    ... print iris.load_cube(fname).cell_methods
+    >>> print(iris.load_cube(fname).cell_methods)
     (CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),)
 
 

--- a/docs/iris/src/whitepapers/um_files_loading.rst
+++ b/docs/iris/src/whitepapers/um_files_loading.rst
@@ -8,6 +8,11 @@
     np.set_printoptions(precision=2)
 
 
+.. testcleanup::
+
+    np.set_printoptions(precision=8)
+
+
 ===================================
 Iris handling of PP and Fieldsfiles
 ===================================

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1823,8 +1823,8 @@ class Unit(iris.util._OrderedHashable):
             >>> import numpy as np
             >>> c = unit.Unit('deg_c')
             >>> f = unit.Unit('deg_f')
-            >>> print(c.convert(0, f))
-            32.0
+            >>> c.convert(0, f)
+            31.999999999999886
             >>> c.convert(0, f, unit.FLOAT32)
             32.0
             >>> a64 = np.arange(10, dtype=np.float64)


### PR DESCRIPTION
Just a few minor things to help with printing compatibility. In order to minimize the changes and avoid using `__future__`, I changed all the `print`s to only output a single item at a time.