### PR TITLE
Promote netCDF var 'depth'

### DIFF
--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -62,11 +62,11 @@ reference_terms = dict(atmosphere_sigma_coordinate=['ps'],
                        atmosphere_hybrid_sigma_pressure_coordinate=['ps'],
                        atmosphere_hybrid_height_coordinate=['orog'],
                        atmosphere_sleve_coordinate=['zsurf1', 'zsurf2'],
-                       ocean_sigma_coordinate=['eta'],
-                       ocean_s_coordinate=['eta'],
-                       ocean_sigma_z_coordinate=['eta'],
-                       ocean_s_coordinate_g1=['eta'],
-                       ocean_s_coordinate_g2=['eta'])
+                       ocean_sigma_coordinate=['eta', 'depth'],
+                       ocean_s_coordinate=['eta', 'depth'],
+                       ocean_sigma_z_coordinate=['eta', 'depth'],
+                       ocean_s_coordinate_g1=['eta', 'depth'],
+                       ocean_s_coordinate_g2=['eta', 'depth'])
 
 
 ################################################################################


### PR DESCRIPTION
It makes sense to have both elevation (`eta`) and bathymetry (`depth`) promoted to cubes on ocean models.

@rsignell-usgs I am not keen to add `s`, `c`, and `depth_c`.  What do you think?

@rhattersley We still need to type `iris.FUTURE.netcdf_promote = True` to get these cubes.  What are the plans to make that the default behavior?