### PR TITLE
Experimental raster import

### DIFF
--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -108,7 +108,7 @@ def _gdal_write_array(x_min, x_step, y_max, y_step, coord_system, data, fname,
     band.WriteArray(data)
 
 
-def import_raster(fname):
+def import_raster(fname, header=None):
     """
     Imports raster images using gdal and constructs a cube.
 
@@ -159,8 +159,8 @@ def import_raster(fname):
         raise ValueError(msg)
 
     if num_raster > 1:
-        warnings.warn('Multiple raster band support ({}) has yet to be '
-                      'validated, use at your own risk'.format(num_raster))
+        warnings.warn('Multiple raster band support ({}) is highly '
+                      'experimental, use at your own risk'.format(num_raster))
     elif num_raster == 0:
         return None
 
@@ -181,8 +181,8 @@ def import_raster(fname):
 
     # Load data for each raster band.
     cubes = iris.cube.CubeList()
-    for iraster in range(1, num_raster + 1):
-        iband = dataset.GetRasterBand(iraster)
+    for iraster in range(num_raster):
+        iband = dataset.GetRasterBand(iraster+1)
         # ReadAsArray(xoffset, yoffset, xsize, ysize)
         data = iband.ReadAsArray(0, 0, num_xy[0], num_xy[1])[::-1, :]
         mdi = iband.GetNoDataValue() or np.nan

--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -24,10 +24,12 @@ TODO: If this module graduates from experimental the (optional) GDAL
       dependency should be added to INSTALL
 
 """
-
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
+import warnings
+
+from gdalconst import GA_ReadOnly
 import numpy as np
 from osgeo import gdal, osr
 
@@ -104,6 +106,96 @@ def _gdal_write_array(x_min, x_step, y_max, y_step, coord_system, data, fname,
     if byte_order == '>':
         data = data.astype(data.dtype.newbyteorder('<'))
     band.WriteArray(data)
+
+
+def import_raster(fname):
+    """
+    Imports raster images using gdal and constructs a cube.
+
+    Parameters
+    ----------
+    fname : str
+        Input file name.
+
+    Returns
+    -------
+    cube : iris.cube.Cube
+        A 2D regularly gridded cube.  The resulting cube has regular,
+        contiguous bounds.
+
+    .. note::
+
+        Coordinate system information it not yet interpreted.
+        Constrained raster import not yet supported.
+
+    .. warning::
+
+        Deferred loading not yet supported.
+
+    """
+    dataset = gdal.Open(fname, GA_ReadOnly)
+    if dataset is None:
+        raise IOError('gdal failed to open raster image')
+
+    projection = dataset.GetProjection()
+    if projection:
+        warnings.warn('Currently the following projection information is '
+                      'not interpreted: {}'.format(projection))
+
+    # Get metadata applies to all raster bands
+    transform = dataset.GetGeoTransform()
+    origin_xy = (transform[0], transform[3])
+    num_xy = (dataset.RasterXSize, dataset.RasterYSize)
+
+    # This effectively indicates the bounds of the cells.
+    pixel_width = (transform[1], transform[5])
+    num_raster = dataset.RasterCount
+
+    # Position of North 0, 0 is north-up
+    rotation = (transform[2], transform[4])
+    if rotation[0] != 0 or rotation[1] != 0:
+        msg = ('Rotation not supported: ({}, {})'.format(rotation[0],
+                                                         rotation[1]))
+        raise ValueError(msg)
+
+    if num_raster > 1:
+        warnings.warn('Multiple raster band support ({}) has yet to be '
+                      'validated, use at your own risk'.format(num_raster))
+    elif num_raster == 0:
+        return None
+
+    # Calculate coordinate points
+    if transform is not None:
+        points_origin = (origin_xy[0] + pixel_width[0]/2,
+                         origin_xy[1] + pixel_width[1]/2)
+        points_x = np.arange(points_origin[0], points_origin[0] +
+                             pixel_width[0] * num_xy[0], pixel_width[0])
+        points_y = np.arange(points_origin[1], points_origin[1] +
+                             pixel_width[1] * num_xy[1], pixel_width[1])[::-1]
+        x = iris.coords.DimCoord(points_x,
+                                 standard_name='projection_x_coordinate')
+        x.guess_bounds()
+        y = iris.coords.DimCoord(points_y,
+                                 standard_name='projection_y_coordinate')
+        y.guess_bounds()
+
+    # Load data for each raster band.
+    cubes = iris.cube.CubeList()
+    for iraster in range(1, num_raster + 1):
+        iband = dataset.GetRasterBand(iraster)
+        # ReadAsArray(xoffset, yoffset, xsize, ysize)
+        data = iband.ReadAsArray(0, 0, num_xy[0], num_xy[1])[::-1, :]
+        mdi = iband.GetNoDataValue() or np.nan
+        mask = data == mdi
+        if mask.any():
+            data = np.ma.masked_equal(data, mdi)
+        cube = iris.cube.Cube(data)
+        if transform is not None:
+            cube.add_dim_coord(x, 1)
+            cube.add_dim_coord(y, 0)
+        cubes.append(cube)
+
+    return cubes
 
 
 def export_geotiff(cube, fname):

--- a/lib/iris/tests/integration/experimental/__init__.py
+++ b/lib/iris/tests/integration/experimental/__init__.py
@@ -1,0 +1,17 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for the :mod:`iris.experimental.raster` module."""

--- a/lib/iris/tests/integration/experimental/__init__.py
+++ b/lib/iris/tests/integration/experimental/__init__.py
@@ -16,3 +16,4 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the :mod:`iris.experimental.raster` module."""
 from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/integration/experimental/__init__.py
+++ b/lib/iris/tests/integration/experimental/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -15,3 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the :mod:`iris.experimental.raster` module."""
+from __future__ import (absolute_import, division, print_function)

--- a/lib/iris/tests/integration/experimental/test_raster.py
+++ b/lib/iris/tests/integration/experimental/test_raster.py
@@ -1,0 +1,69 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+import iris.tests.stock
+try:
+    from osgeo import gdal
+    from iris.experimental.raster import import_raster, export_geotiff
+except ImportError:
+    gdal = None
+
+
+@tests.skip_gdal
+class TestTiff(tests.IrisTest):
+    def setUp(self):
+        self.cube = tests.stock.lat_lon_cube()
+        self.cube.coord(axis='x').guess_bounds()
+        self.cube.coord(axis='y').guess_bounds()
+
+    def test_unmasked_data(self):
+        tmp_filename = iris.util.create_temp_filename(suffix='.tiff')
+        export_geotiff(self.cube, tmp_filename)
+
+        result = import_raster(tmp_filename)[0]
+        self.assertArrayEqual(self.cube.coord(axis='x').points,
+                              result.coord(axis='x').points)
+        self.assertArrayEqual(self.cube.coord(axis='y').points,
+                              result.coord(axis='y').points)
+        self.assertArrayEqual(self.cube.data, result.data)
+
+    def test_masked_data(self):
+        tmp_filename = iris.util.create_temp_filename(suffix='.tiff')
+        self.cube.data = np.ma.masked_greater(self.cube.data, 5)
+        export_geotiff(self.cube, tmp_filename)
+        result = import_raster(tmp_filename)[0]
+        self.assertMaskedArrayEqual(self.cube.data,
+                                    result.data)
+
+    def test_expected_metadata(self):
+        # CML check.
+        tmp_filename = iris.util.create_temp_filename(suffix='.tiff')
+        export_geotiff(self.cube, tmp_filename)
+
+        result = import_raster(tmp_filename)[0]
+        self.assertCML(result, ('experimental', 'raster_import.cml'))
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/integration/experimental/test_raster.py
+++ b/lib/iris/tests/integration/experimental/test_raster.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -18,6 +18,7 @@
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 

--- a/lib/iris/tests/integration/experimental/test_raster.py
+++ b/lib/iris/tests/integration/experimental/test_raster.py
@@ -15,10 +15,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 

--- a/lib/iris/tests/results/experimental/raster_import.cml
+++ b/lib/iris/tests/results/experimental/raster_import.cml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-1.5, -0.5],
+		[-0.5, 0.5],
+		[0.5, 1.5],
+		[1.5, 2.5]]" id="b928afc9" points="[-1.0, 0.0, 1.0, 2.0]" shape="(4,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-1.5, -0.5],
+		[-0.5, 0.5],
+		[0.5, 1.5]]" id="513f3f68" points="[-1.0, 0.0, 1.0]" shape="(3,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="-0x49adf4af" dtype="int32" shape="(3, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/experimental/raster_import.cml
+++ b/lib/iris/tests/results/experimental/raster_import.cml
@@ -6,15 +6,15 @@
         <dimCoord bounds="[[-1.5, -0.5],
 		[-0.5, 0.5],
 		[0.5, 1.5],
-		[1.5, 2.5]]" id="b928afc9" points="[-1.0, 0.0, 1.0, 2.0]" shape="(4,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
+		[1.5, 2.5]]" id="4e26f693" points="[-1.0, 0.0, 1.0, 2.0]" shape="(4,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[-1.5, -0.5],
 		[-0.5, 0.5],
-		[0.5, 1.5]]" id="513f3f68" points="[-1.0, 0.0, 1.0]" shape="(3,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
+		[0.5, 1.5]]" id="d1fc750d" points="[-1.0, 0.0, 1.0]" shape="(3,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="-0x49adf4af" dtype="int32" shape="(3, 4)"/>
+    <data checksum="0xb6520b51" dtype="int32" shape="(3, 4)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/experimental/raster_multiple_band_import.cml
+++ b/lib/iris/tests/results/experimental/raster_multiple_band_import.cml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-200000.0, -150000.0],
+		[-150000.0, -100000.0],
+		[-100000.0, -50000.0],
+		[-50000.0, 0.0],
+		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[50000.0, 0.0],
+		[0.0, -50000.0],
+		[-50000.0, -100000.0],
+		[-100000.0, -150000.0],
+		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x5a7fd8b3" dtype="int64" shape="(5, 5)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-200000.0, -150000.0],
+		[-150000.0, -100000.0],
+		[-100000.0, -50000.0],
+		[-50000.0, 0.0],
+		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[50000.0, 0.0],
+		[0.0, -50000.0],
+		[-50000.0, -100000.0],
+		[-100000.0, -150000.0],
+		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x5a7fd8b3" dtype="int64" shape="(5, 5)"/>
+  </cube>
+  <cube units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord bounds="[[-200000.0, -150000.0],
+		[-150000.0, -100000.0],
+		[-100000.0, -50000.0],
+		[-50000.0, 0.0],
+		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[50000.0, 0.0],
+		[0.0, -50000.0],
+		[-50000.0, -100000.0],
+		[-100000.0, -150000.0],
+		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x5a7fd8b3" dtype="int64" shape="(5, 5)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/experimental/raster_multiple_band_import.cml
+++ b/lib/iris/tests/results/experimental/raster_multiple_band_import.cml
@@ -7,14 +7,16 @@
 		[-150000.0, -100000.0],
 		[-100000.0, -50000.0],
 		[-50000.0, 0.0],
-		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+		[0.0, 50000.0]]" id="4e26f693" points="[-175000.0, -125000.0, -75000.0, -25000.0,
+		25000.0]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[50000.0, 0.0],
 		[0.0, -50000.0],
 		[-50000.0, -100000.0],
 		[-100000.0, -150000.0],
-		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+		[-150000.0, -200000.0]]" id="d1fc750d" points="[25000.0, -25000.0, -75000.0, -125000.0,
+		-175000.0]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -27,14 +29,16 @@
 		[-150000.0, -100000.0],
 		[-100000.0, -50000.0],
 		[-50000.0, 0.0],
-		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+		[0.0, 50000.0]]" id="4e26f693" points="[-175000.0, -125000.0, -75000.0, -25000.0,
+		25000.0]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[50000.0, 0.0],
 		[0.0, -50000.0],
 		[-50000.0, -100000.0],
 		[-100000.0, -150000.0],
-		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+		[-150000.0, -200000.0]]" id="d1fc750d" points="[25000.0, -25000.0, -75000.0, -125000.0,
+		-175000.0]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -47,14 +51,16 @@
 		[-150000.0, -100000.0],
 		[-100000.0, -50000.0],
 		[-50000.0, 0.0],
-		[0.0, 50000.0]]" id="b928afc9" points="[-175000, -125000, -75000, -25000, 25000]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="int64"/>
+		[0.0, 50000.0]]" id="4e26f693" points="[-175000.0, -125000.0, -75000.0, -25000.0,
+		25000.0]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord bounds="[[50000.0, 0.0],
 		[0.0, -50000.0],
 		[-50000.0, -100000.0],
 		[-100000.0, -150000.0],
-		[-150000.0, -200000.0]]" id="513f3f68" points="[25000, -25000, -75000, -125000, -175000]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="int64"/>
+		[-150000.0, -200000.0]]" id="d1fc750d" points="[25000.0, -25000.0, -75000.0, -125000.0,
+		-175000.0]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/unit/experimental/raster/test_import_raster.py
+++ b/lib/iris/tests/unit/experimental/raster/test_import_raster.py
@@ -16,10 +16,11 @@
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for the `iris.experimental.raster.import_raster` function."""
 
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from __future__ import (absolute_import, division, print_function)
 
 import mock
 import numpy as np

--- a/lib/iris/tests/unit/experimental/raster/test_import_raster.py
+++ b/lib/iris/tests/unit/experimental/raster/test_import_raster.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Iris.
 #
@@ -19,6 +19,7 @@
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+from __future__ import (absolute_import, division, print_function)
 
 import mock
 import numpy as np
@@ -72,8 +73,8 @@ class TestTiff(tests.IrisTest):
             self.assertEqual(len(cubes), self.dataset.RasterCount)
             self.assertCML(cubes, ('experimental',
                                    'raster_multiple_band_import.cml'))
-        warn.assert_called_once_with('Multiple raster band support ({}) has '
-                                     'yet to be validated, use at your own '
+        warn.assert_called_once_with('Multiple raster band support ({}) is '
+                                     'highly experimental, use at your own '
                                      'risk'.format(self.dataset.RasterCount))
 
     def test_no_raster_bands(self):

--- a/lib/iris/tests/unit/experimental/raster/test_import_raster.py
+++ b/lib/iris/tests/unit/experimental/raster/test_import_raster.py
@@ -1,0 +1,99 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.experimental.raster.import_raster` function."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import mock
+import numpy as np
+try:
+    from osgeo import gdal
+    from iris.experimental.raster import import_raster
+except ImportError:
+    gdal = None
+
+
+@tests.skip_gdal
+class TestTiff(tests.IrisTest):
+    def setUp(self):
+        self.dataset = mock.Mock(name='dataset')
+        self.dataset.RasterCount = 1
+        self.dataset.GetGeoTransform.return_value = (-200000, 50000, 0,
+                                                     -200000, 0, 50000)
+        self.dataset.RasterXSize = 5
+        self.dataset.RasterYSize = 5
+        self.dataset.GetProjection.return_value = ''
+        getdata = mock.Mock()
+        getdata.ReadAsArray.return_value = np.arange(5*5).reshape(5, 5)
+        getdata.GetNoDataValue.return_value = -999
+        self.dataset.GetRasterBand.return_value = getdata
+        self.gdal_patch = mock.patch('osgeo.gdal.Open',
+                                     return_value=self.dataset)
+        self.gdal_patch.start()
+        self.addCleanup(self.gdal_patch.stop)
+
+    def test_dataset_is_none(self):
+        with mock.patch('osgeo.gdal.Open', return_value=None):
+            with self.assertRaisesRegexp(IOError, 'gdal failed to open raster '
+                                         'image'):
+                import_raster('some_filename')
+
+    def test_unsupported_projection(self):
+        self.dataset.GetProjection.return_value = 'some projection'
+        msg = ('Currently the following projection information is not '
+               'interpreted: some projection')
+        with mock.patch('warnings.warn') as warn:
+            import_raster('some_filename')
+        warn.assert_called_once_with(msg)
+
+    def test_multiple_raster_bands(self):
+        # Ensure that CubeList of length corresponding to the number of bands
+        # is returned and that each has associated coordinates.
+        self.dataset.RasterCount = 3
+        with mock.patch('osgeo.gdal.Open', return_value=self.dataset), \
+                mock.patch('warnings.warn') as warn:
+            cubes = import_raster('some_filename')
+            self.assertEqual(len(cubes), self.dataset.RasterCount)
+            self.assertCML(cubes, ('experimental',
+                                   'raster_multiple_band_import.cml'))
+        warn.assert_called_once_with('Multiple raster band support ({}) has '
+                                     'yet to be validated, use at your own '
+                                     'risk'.format(self.dataset.RasterCount))
+
+    def test_no_raster_bands(self):
+        self.dataset.RasterCount = 0
+        with mock.patch('osgeo.gdal.Open', return_value=self.dataset):
+            self.assertIs(import_raster('some_filename'), None)
+
+    def test_rotated_raster(self):
+        # Rotated is where a non north-up image is defined.
+        # No test data to develop interpretation of rotation so an exception
+        # is raised.
+        rotation = [1, 1]
+        self.dataset.GetGeoTransform.return_value = (
+            -200000, 50000, rotation[0], -200000, rotation[1], 50000)
+        msg = ('Rotation not supported: \({}, {}\)'.format(rotation[0],
+                                                           rotation[1]))
+        with mock.patch('osgeo.gdal.Open', return_value=self.dataset), \
+                self.assertRaisesRegexp(ValueError, msg):
+            import_raster('some_filename')
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This PR adds experimental raster import capability to iris.

1. Coordinate systems not yet interpreted.
2. Multiple raster band supported.
3. Rotation not supported (north-up only supported) - lack of real test data and documentation - raises an exception if rotated.

New PR which replaces my old PR https://github.com/SciTools/iris/pull/1298

This is being put up as we have data which comes in the form of a band Interleaved by line image file.

If there is still no interest in having raster import capabilities then we can incorporate it into our library.  Ideally though I think this would live in iris next to the export capability.