### PR TITLE
Changed pp loading filter to accept callables as constraints

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/bugfix_2015-08-18_partial_pp_constraints.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/bugfix_2015-08-18_partial_pp_constraints.txt
@@ -1,0 +1,2 @@
+* Fixed a bug in :meth:`iris.fileformats.pp._convert_constraints`.
+  A previous release removed the ability to pass a partial constraint on STASH attribute.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1953,7 +1953,11 @@ def _convert_constraints(constraints):
     pp_constraints = {}
     unhandled_constraints = False
 
-    def make_func(stashobj):
+    def _make_func(stashobj):
+	"""
+	Provides unique name-space for each lambda function's stashobj
+	variable.
+	"""
         return lambda stash: stash==stashobj
 
     for con in constraints:
@@ -1965,10 +1969,11 @@ def _convert_constraints(constraints):
             stashobj = con._attributes['STASH']
             if callable(stashobj):
                 call_func = stashobj
-            else:
-                call_func = make_func(stashobj)
-
-            # Raise an exception if stashobj was not string or STASH object??   
+            elif isinstance(stashobj, (basestring, STASH)):
+                call_func = _make_func(stashobj)
+	    else:
+		raise TypeError("STASH constraints should be either a"
+				" callable, string or STASH object")
 
             if not 'stash' in pp_constraints:
                 pp_constraints['stash'] = [call_func]

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1992,11 +1992,9 @@ def _convert_constraints(constraints):
         """
         res = True
         if field.stash not in _STASH_ALLOW:
-
             if pp_constraints.get('stash'):
 
                     res = False
-
                     for call_func in pp_constraints['stash']:
 
                         if call_func(str(field.stash)):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1952,23 +1952,33 @@ def _convert_constraints(constraints):
     constraints = iris._constraints.list_of_constraints(constraints)
     pp_constraints = {}
     unhandled_constraints = False
+
+    def make_func(stashobj):
+        return lambda stash: stash==stashobj
+
     for con in constraints:
         if isinstance(con, iris.AttributeConstraint) and \
                 list(con._attributes.keys()) == ['STASH']:
             # Convert a STASH constraint.
+            # The attribute can be a STASH object, a stashcode string,or a 
+            # callable.
             stashobj = con._attributes['STASH']
-            if not isinstance(stashobj, STASH):
-                # The attribute can be a STASH object, or a stashcode string.
-                stashobj = STASH.from_msi(stashobj)
-            if not 'stash' in pp_constraints:
-                pp_constraints['stash'] = [stashobj]
+            if callable(stashobj):
+                call_func = stashobj
             else:
-                pp_constraints['stash'].append(stashobj)
+                call_func = make_func(stashobj)
+
+            # Raise an exception if stashobj was not string or STASH object??   
+
+            if not 'stash' in pp_constraints:
+                pp_constraints['stash'] = [call_func]
+            else:
+                pp_constraints['stash'].append(call_func)
         else:
             ## only keep the pp constraints set if they are all handled as
             ## pp constraints
             unhandled_constraints = True
- 
+
     def pp_filter(field):
         """
         return True if field is to be kept,
@@ -1976,10 +1986,17 @@ def _convert_constraints(constraints):
 
         """
         res = True
-        if pp_constraints.get('stash'):
-            if (field.stash not in _STASH_ALLOW and field.stash not in
-                    pp_constraints['stash']):
-                res = False
+        if field.stash not in _STASH_ALLOW:
+
+            if pp_constraints.get('stash'):
+
+                    res = False
+
+                    for call_func in pp_constraints['stash']:
+
+                        if call_func(str(field.stash)):
+                            res = True
+                            break
         return res
 
     if pp_constraints and not unhandled_constraints:

--- a/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
@@ -70,6 +70,18 @@ class Test_convert_constraints(tests.IrisTest):
         self.assertTrue(pp_filter(stcube4))
         self.assertFalse(pp_filter(stcube7))
 
+    def test_callable_stash(self):
+        stcube236 = mock.Mock(stash=STASH.from_msi('m01s03i236'))
+        stcube4 = mock.Mock(stash=STASH.from_msi('m01s00i004'))
+        stcube7 = mock.Mock(stash=STASH.from_msi('m01s00i007'))
+        con1 = iris.AttributeConstraint(STASH=lambda s: s.endswith("004"))
+        con2 = iris.AttributeConstraint(STASH=lambda s: s == "m01s00i007")
+        constraints = [con1, con2]
+        pp_filter = _convert_constraints(constraints)
+        self.assertFalse(pp_filter(stcube236))
+        self.assertTrue(pp_filter(stcube4))
+        self.assertTrue(pp_filter(stcube7))
+
     def test_multiple_with_stash(self):
         constraints = [iris.Constraint('air_potential_temperature'),
                        iris.AttributeConstraint(STASH='m01s00i004')]


### PR DESCRIPTION
This PR is in response to a support ticket that found a bug when using an example `iris.AttributeConstraint` found in its documentation. The example constraint is:

    iris.AttributeConstraint(STASH=lambda stash: stash.endswith('i005'))

When attempting to load a PP file with this constraint we get the following exception:

    TypeError: Expected STASH code MSI string, got <function <lambda> at 0x27061b8>

I believe the bug was introduced in v1.7.x when a PP loading optimisation was made to allow constraints to be applied to STASH codes at load time without actually creating the cube first. The code allows only for constraints to be strings or STASH objects, not callables as above.

After discussion with @marqh we decided it might be good to keep this older functionality and so this PR contains a tweak to the `_convert_constraints` function in the PP fileformat module to allow callables to be passed as constraints on the STASH attribute.
