### PR TITLE
Adding handling of Cell Measures attribute

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -332,7 +332,6 @@ def load_cube(uris, constraint=None, callback=None):
         raise ValueError('only a single constraint is allowed')
 
     cubes = _load_collection(uris, constraints, callback).merged().cubes()
-
     try:
         cube = cubes.merge_cube()
     except iris.exceptions.MergeError as e:

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1578,6 +1578,28 @@ class AuxCoord(Coord):
         self._bounds = bounds
 
 
+class CellMeasures(AuxCoord):
+    """
+    CF Cell Measures coordinate. Sublasses AuxCoord to provide string
+    representation for cube attributes list.
+
+    """
+
+    def __init__(self, points, cf_measures, standard_name=None, long_name=None,
+                 var_name=None, units='1', bounds=None, attributes=None,
+                 coord_system=None):
+
+        AuxCoord.__init__(self, points, standard_name=None,
+                          long_name=None, var_name=None, units='1',
+                          bounds=None, attributes=None, coord_system=None)
+
+        self.measures = cf_measures
+
+    def __repr__(self):
+
+        return(self.measures)
+
+
 class CellMethod(iris.util._OrderedHashable):
     """
     Represents a sub-cell pre-processing operation.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1589,9 +1589,12 @@ class CellMeasures(AuxCoord):
                  var_name=None, units='1', bounds=None, attributes=None,
                  coord_system=None):
 
-        AuxCoord.__init__(self, points, standard_name=None,
-                          long_name=None, var_name=None, units='1',
-                          bounds=None, attributes=None, coord_system=None)
+        super(CellMeasures, self).__init__(points, standard_name=standard_name,
+                                           long_name=long_name,
+                                           var_name=var_name, units=units,
+                                           bounds=bounds,
+                                           attributes=attributes,
+                                           coord_system=coord_system)
 
         self.measures = cf_measures
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1578,29 +1578,89 @@ class AuxCoord(Coord):
         self._bounds = bounds
 
 
-class CellMeasures(AuxCoord):
+class CellMeasures(object):
     """
-    CF Cell Measures coordinate. Sublasses AuxCoord to provide string
-    representation for cube attributes list.
+    CF Cell Measures attribute.
 
     """
 
-    def __init__(self, points, cf_measures, standard_name=None, long_name=None,
-                 var_name=None, units='1', bounds=None, attributes=None,
-                 coord_system=None):
+    def __init__(self, data, cf_measures, standard_name=None, long_name=None,
+                 var_name=None, units='1', attributes=None):
 
-        super(CellMeasures, self).__init__(points, standard_name=standard_name,
-                                           long_name=long_name,
-                                           var_name=var_name, units=units,
-                                           bounds=bounds,
-                                           attributes=attributes,
-                                           coord_system=coord_system)
+        #: CF standard name of the quantity that the coordinate represents.
+        self.standard_name = standard_name
+
+        #: Descriptive name of the coordinate.
+        self.long_name = long_name
+
+        #: The CF variable name for the coordinate.
+        self.var_name = var_name
+
+        #: Unit of the quantity that the coordinate represents.
+        self.units = units
+
+        #: Other attributes, including user specified attributes that
+        #: have no meaning to Iris.
+        self.attributes = attributes
 
         self.measures = cf_measures
+        
+        self.data = data
 
     def __repr__(self):
 
-        return(self.measures)
+        return("{}: {}".format(self.standard_name,self.measures))
+        
+    @property
+    def shape(self):
+        """The fundamental shape of the Coord, expressed as a tuple."""
+        # Access the underlying _points attribute to avoid triggering
+        # a deferred load unnecessarily.
+        return self.data.shape
+        
+    @property
+    def data(self):
+        if not isinstance(self._data, np.ndarray):
+            self._data = self._data.ndarray()
+            return self._data
+        
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        self._data = data
+
+    @property
+    def dtype(self):
+        """
+        Abstract property which returns the Numpy data type of the Coordinate.
+
+        """
+        return self.points.dtype
+        
+    def convert_units(self, unit):
+        """
+        Change the coordinate's units, converting the values in its points
+        and bounds arrays.
+
+        For example, if a coordinate's :attr:`~iris.coords.Coord.units`
+        attribute is set to radians then::
+
+            coord.convert_units('degrees')
+
+        will change the coordinate's
+        :attr:`~iris.coords.Coord.units` attribute to degrees and
+        multiply each value in :attr:`~iris.coords.Coord.points` and
+        :attr:`~iris.coords.Coord.bounds` by 180.0/:math:`\pi`.
+
+        """
+        # If the coord has units convert the values in points (and bounds if
+        # present).
+        if not self.units.is_unknown():
+            self.points = self.units.convert(self.points, unit)
+            if self.bounds is not None:
+                self.bounds = self.units.convert(self.bounds, unit)
+        self.units = unit
 
 
 class CellMethod(iris.util._OrderedHashable):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -61,6 +61,7 @@ class CubeMetadata(collections.namedtuple('CubeMetadata',
                                            'var_name',
                                            'units',
                                            'attributes',
+                                           'cell_measures',
                                            'cell_methods'])):
     """
     Represents the phenomenon metadata for a single :class:`Cube`.
@@ -604,8 +605,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def __init__(self, data, standard_name=None, long_name=None,
                  var_name=None, units=None, attributes=None,
-                 cell_methods=None, dim_coords_and_dims=None,
-                 aux_coords_and_dims=None, aux_factories=None):
+                 cell_measures=None, cell_methods=None,
+                 dim_coords_and_dims=None, aux_coords_and_dims=None,
+                 aux_factories=None):
         """
         Creates a cube with data and optional metadata.
 
@@ -720,6 +722,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if aux_factories:
             for factory in aux_factories:
                 self.add_aux_factory(factory)
+                
+        self.cell_measures = cell_measures
 
     @property
     def metadata(self):
@@ -734,7 +738,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         return CubeMetadata(self.standard_name, self.long_name, self.var_name,
-                            self.units, self.attributes, self.cell_methods)
+                            self.units, self.attributes, self.cell_measures,
+                            self.cell_methods)
 
     @metadata.setter
     def metadata(self, value):
@@ -1400,6 +1405,31 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         self._cell_methods = tuple(cell_methods) if cell_methods else tuple()
 
     @property
+    def cell_measures(self):
+
+        return self._cell_measures
+
+    @cell_measures.setter
+    def cell_measures(self, cell_measures):
+        
+        if cell_measures:
+            if not isinstance(cell_measures, iris.coords.CellMeasures):
+
+                raise TypeError("cell_measures must be an instance of iris."
+                                "coords.CellMeasures or None")
+            
+
+            # this is not quite right, I've not been able to find an easy way
+            # to get the spatial shape of the cube (i.e. the cell structures
+            # shape)
+            if not set(cell_measures.shape).issubset(set(self.shape)):
+                
+               raise TypeError("Cell Measures shape %r must match Cube shape %r"
+                               % (cell_measures.shape, self.shape))
+
+        self._cell_measures = cell_measures
+
+    @property
     def shape(self):
         """The shape of the data of this cube."""
         shape = self.lazy_data().shape
@@ -1775,6 +1805,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     vector_derived_coords, cube_header, max_line_offset)
                 summary += '\n     Derived coordinates:\n' + \
                     '\n'.join(derived_coord_summary)
+                            
+            #
+            # Generate summary of cube cell measures attribute
+            #
+
+            if self.cell_measures:
+                summary += '\n     Cell Measures:\n'
+                
+                summary += '%*s%s' % (indent, ' ', str(self.cell_measures))
 
             #
             # Generate textual summary of cube scalar coordinates.
@@ -1852,6 +1891,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 summary += '\n     Invalid coordinates:\n' + \
                     '\n'.join(invalid_summary)
 
+
             #
             # Generate summary of cube attributes.
             #
@@ -1866,6 +1906,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     attribute_lines.append(line)
                 summary += '\n     Attributes:\n' + '\n'.join(attribute_lines)
 
+
             #
             # Generate summary of cube cell methods
             #
@@ -1876,6 +1917,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 for cm in self.cell_methods:
                     cm_lines.append('%*s%s' % (indent, ' ', str(cm)))
                 summary += '\n'.join(cm_lines)
+
 
         # Construct the final cube summary.
         summary = cube_header + summary

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -352,6 +352,21 @@ fc_build_auxiliary_coordinate
         python build_auxiliary_coordinate(engine, cf_coord_var)
         python engine.rule_triggered.add(rule.name)
 
+#
+# Context:
+#   This rule will trigger for each cell_measure_coordinate() case specific fact.
+#
+# Purpose:
+#   Add the cell measures coordinate to the cube.  
+#
+fc_build_cell_measure_coordinate
+    foreach
+        facts_cf.cell_measure_coordinate($coordinate)
+    assert
+        python cf_coord_var = engine.cf_var.cf_group.cell_measures[$coordinate]
+        python build_cell_measures_coordinate(engine, cf_coord_var)
+        python engine.rule_triggered.add(rule.name)
+
 
 #
 # Context:
@@ -1307,6 +1322,81 @@ fc_extras
 
         # Update the coordinate to CF-netCDF variable mapping.
         engine.provides['coordinates'].append((coord, cf_coord_var.cf_name))
+        
+    ################################################################################
+    def build_cell_measures_coordinate(engine, cf_coord_var, coord_name=None, coord_system=None):
+        """Create a cell measures coordinate (CellMeasures) and add it to the cube."""
+
+        cf_var = engine.cf_var
+        cube = engine.cube
+        attributes = {}
+
+        # Get units
+        attr_units = get_attr_units(cf_coord_var, attributes)
+
+        def cf_var_as_biggus(cf_var):
+            dtype = cf_var.dtype
+            fill_value = getattr(cf_var.cf_data, '_FillValue',
+                                 netCDF4.default_fillvals[dtype.str[1:]])
+            proxy = iris.fileformats.netcdf.NetCDFDataProxy(
+                cf_var.shape, dtype, engine.filename,
+                cf_var.cf_name, fill_value)
+            return biggus.OrthoArrayAdapter(proxy)
+
+        # Get any coordinate point data.
+        if isinstance(cf_coord_var, cf.CFLabelVariable):
+            points_data = cf_coord_var.cf_label_data(cf_var)
+        else:
+            points_data = cf_var_as_biggus(cf_coord_var)
+
+        # Get any coordinate bounds.
+        cf_bounds_var = get_cf_bounds_var(cf_coord_var)
+        if cf_bounds_var is not None:
+            bounds_data = cf_var_as_biggus(cf_bounds_var)
+
+            # Handle transposed bounds where the vertex dimension is not
+            # the last one. Test based on shape to support different
+            # dimension names.
+            if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
+                # Biggus 0.7 doesn't support rollaxis, so we have to
+                # resolve the data to a numpy array.
+                # NB. This is what used to happen with LazyArray as well.
+                bounds_data = bounds_data.ndarray()
+                bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
+                                                  cf_coord_var)
+        else:
+            bounds_data = None
+
+        # Determine the name of the dimension/s shared between the CF-netCDF data variable
+        # and the coordinate being built.
+        common_dims = [dim for dim in cf_coord_var.dimensions
+                       if dim in cf_var.dimensions]
+        data_dims = None    
+        if common_dims:
+            # Calculate the offset of each common dimension.
+            data_dims = [cf_var.dimensions.index(dim) for dim in common_dims]
+
+        # Determine the standard_name, long_name and var_name
+        standard_name, long_name, var_name = get_names(cf_coord_var, coord_name, attributes)
+        
+        # Obtain the cf_measure standard name.
+        measures = cf_coord_var.cf_measure
+        
+        # Create the coordinate
+        cell_measures_coord = iris.coords.CellMeasures(points_data, measures,
+                                     standard_name=standard_name,
+                                     long_name=long_name,
+                                     var_name=var_name,
+                                     units=attr_units,
+                                     bounds=bounds_data,
+                                     attributes=attributes,
+                                     coord_system=coord_system)
+
+        # Add it to the cube
+        cube.attributes["cell_measures"] = cell_measures_coord
+
+        # Update the coordinate to CF-netCDF variable mapping.
+        engine.provides['coordinates'].append((cell_measures_coord, cf_coord_var.cf_name))
 
 
     ################################################################################

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -354,17 +354,17 @@ fc_build_auxiliary_coordinate
 
 #
 # Context:
-#   This rule will trigger for each cell_measure_coordinate() case specific fact.
+#   This rule will trigger for each cell_measure_attribute() case specific fact.
 #
 # Purpose:
-#   Add the cell measures coordinate to the cube.  
+#   Add the cell measures attribute to the cube.  
 #
-fc_build_cell_measure_coordinate
+fc_build_cell_measure_attribute
     foreach
-        facts_cf.cell_measure_coordinate($coordinate)
+        facts_cf.cell_measure_attribute($coordinate)
     assert
         python cf_coord_var = engine.cf_var.cf_group.cell_measures[$coordinate]
-        python build_cell_measures_coordinate(engine, cf_coord_var)
+        python build_cell_measures_attribute(engine, cf_coord_var)
         python engine.rule_triggered.add(rule.name)
 
 
@@ -1325,15 +1325,15 @@ fc_extras
 
  
     ################################################################################
-    def build_cell_measures_coordinate(engine, cf_coord_var, coord_name=None, coord_system=None):
-        """Create a cell measures coordinate (CellMeasures) and add it to the cube."""
+    def build_cell_measures_attribute(engine, cf_cm_attr, coord_name=None):
+        """Create a cell measures attribute (CellMeasures) and add it to the cube."""
 
         cf_var = engine.cf_var
         cube = engine.cube
         attributes = {}
 
         # Get units
-        attr_units = get_attr_units(cf_coord_var, attributes)
+        attr_units = get_attr_units(cf_cm_attr, attributes)
 
         def cf_var_as_biggus(cf_var):
             dtype = cf_var.dtype
@@ -1344,60 +1344,25 @@ fc_extras
                 cf_var.cf_name, fill_value)
             return biggus.OrthoArrayAdapter(proxy)
 
-        # Get any coordinate point data.
-        if isinstance(cf_coord_var, cf.CFLabelVariable):
-            points_data = cf_coord_var.cf_label_data(cf_var)
-        else:
-            points_data = cf_var_as_biggus(cf_coord_var)
 
-        # Get any coordinate bounds.
-        cf_bounds_var = get_cf_bounds_var(cf_coord_var)
-        if cf_bounds_var is not None:
-            bounds_data = cf_var_as_biggus(cf_bounds_var)
-
-            # Handle transposed bounds where the vertex dimension is not
-            # the last one. Test based on shape to support different
-            # dimension names.
-            if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
-                # Biggus 0.7 doesn't support rollaxis, so we have to
-                # resolve the data to a numpy array.
-                # NB. This is what used to happen with LazyArray as well.
-                bounds_data = bounds_data.ndarray()
-                bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
-                                                  cf_coord_var)
-        else:
-            bounds_data = None
-
-        # Determine the name of the dimension/s shared between the CF-netCDF data variable
-        # and the coordinate being built.
-        common_dims = [dim for dim in cf_coord_var.dimensions
-                       if dim in cf_var.dimensions]
-        data_dims = None    
-        if common_dims:
-            # Calculate the offset of each common dimension.
-            data_dims = [cf_var.dimensions.index(dim) for dim in common_dims]
+        data = cf_var_as_biggus(cf_cm_attr)
 
         # Determine the standard_name, long_name and var_name
-        standard_name, long_name, var_name = get_names(cf_coord_var, coord_name, attributes)
+        standard_name, long_name, var_name = get_names(cf_cm_attr, coord_name, attributes)
         
         # Obtain the cf_measure standard name.
-        measures = cf_coord_var.cf_measure
+        measures = cf_cm_attr.cf_measure
         
         # Create the coordinate
-        cell_measures_coord = iris.coords.CellMeasures(points_data, measures,
-                                     standard_name=standard_name,
-                                     long_name=long_name,
-                                     var_name=var_name,
-                                     units=attr_units,
-                                     bounds=bounds_data,
-                                     attributes=attributes,
-                                     coord_system=coord_system)
+        cell_measures_attr = iris.coords.CellMeasures(data, measures,
+                                                      standard_name=standard_name,
+                                                      long_name=long_name,
+                                                      var_name=var_name,
+                                                      units=attr_units,
+                                                      attributes=attributes)
 
         # Add it to the cube
-        cube.attributes["cell_measures"] = cell_measures_coord
-
-        # Update the coordinate to CF-netCDF variable mapping.
-        engine.provides['coordinates'].append((cell_measures_coord, cf_coord_var.cf_name))
+        cube.cell_measures = cell_measures_attr
 
 
     ################################################################################

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1322,7 +1322,8 @@ fc_extras
 
         # Update the coordinate to CF-netCDF variable mapping.
         engine.provides['coordinates'].append((coord, cf_coord_var.cf_name))
-        
+
+ 
     ################################################################################
     def build_cell_measures_coordinate(engine, cf_coord_var, coord_name=None, coord_system=None):
         """Create a cell measures coordinate (CellMeasures) and add it to the cube."""

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -298,6 +298,11 @@ def _assert_case_specific_facts(engine, cf, cf_group):
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'coordinate',
                                       (cf_name,))
 
+    # Assert facts for CF cell measures.
+    for cf_name in cf_group.cell_measures.iterkeys():
+        engine.add_case_specific_fact(_PYKE_FACT_BASE,
+                                      'cell_measure_coordinate', (cf_name,))
+
     # Assert facts for CF auxiliary coordinates.
     for cf_name in cf_group.auxiliary_coordinates.iterkeys():
         engine.add_case_specific_fact(_PYKE_FACT_BASE, 'auxiliary_coordinate',

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -301,7 +301,7 @@ def _assert_case_specific_facts(engine, cf, cf_group):
     # Assert facts for CF cell measures.
     for cf_name in cf_group.cell_measures.iterkeys():
         engine.add_case_specific_fact(_PYKE_FACT_BASE,
-                                      'cell_measure_coordinate', (cf_name,))
+                                      'cell_measure_attribute', (cf_name,))
 
     # Assert facts for CF auxiliary coordinates.
     for cf_name in cf_group.auxiliary_coordinates.iterkeys():
@@ -566,6 +566,7 @@ def load_cubes(filenames, callback=None):
 
             # Perform any user registered callback function.
             cube = iris.io.run_callback(callback, cube, cf_var, filename)
+
 
             # Callback mechanism may return None, which must not be yielded
             if cube is None:

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -21,6 +21,7 @@
       <attribute name="DOMAIN_type" value="box"/>
       <attribute name="NCO" value="4.0.8"/>
       <attribute name="TimeStamp" value="2008-SEP-09 11:18:37 GMT+0000"/>
+      <attribute name="cell_measures" value="area"/>
       <attribute name="file_name" value="ORCA2_1d_00010101_00010101_grid_T_0000.nc"/>
       <attribute name="history" value="Mon Apr  2 10:25:46 2012: /project/ukmo/rhel6/nco/bin/ncks -v votemper,deptht_bounds,nav_lat,nav_lon,areat,latt_bounds,lont_bounds ORCA2_1d_00010101_00010101_grid_T_0000.nc votemper.nc"/>
       <attribute name="interval_operation" value="5760.0"/>


### PR DESCRIPTION
So, following a support ticket and discussion with @marqh about this, I and @scmc72 have had a look at adding the ability to include the cell measures attribute from netCDF files in cubes. We've intentionally made this pull request early on to get some feedback on the direction our approach is taking.

We decided to treat the cell measures data in a very similar way to an auxiliary coordinate, except to list the cell measures standard name in the cube attributes and allow the user some way to access the underlying data as a coordinate object. We made the subclass `CellMeasures` of `AuxCoord` essentially so that we could change the string representation to be appropriate for printing the cubes attribute dictionary. We'd further intend to add a `cell_measures` property to the cube rather than having the user get the data from the attributes dictionary and I'm sure there are many other improvements still to be made from where we are now.

We'd be interested to hear opinions on this kind of approach or even suggestions of a totally different way of handling cell measures (e.g. making a cell_area cube) before we go any further.