### PR TITLE
Fix dimensionless vertical coord standard_name

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -800,7 +800,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
         self.nsigma = nsigma
         self.zlev = zlev
 
-        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        self.standard_name = 'altitude'
         self.attributes = {'positive': 'up'}
 
     @property
@@ -1033,7 +1033,7 @@ class OceanSigmaFactory(AuxCoordFactory):
         self.eta = eta
         self.depth = depth
 
-        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        self.standard_name = 'altitude'
         self.attributes = {'positive': 'up'}
 
     @property
@@ -1212,7 +1212,7 @@ class OceanSg1Factory(AuxCoordFactory):
         self.depth = depth
         self.depth_c = depth_c
 
-        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        self.standard_name = 'altitude'
         self.attributes = {'positive': 'up'}
 
     @property
@@ -1415,7 +1415,7 @@ class OceanSFactory(AuxCoordFactory):
         self.b = b
         self.depth_c = depth_c
 
-        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        self.standard_name = 'altitude'
         self.attributes = {'positive': 'up'}
 
     @property
@@ -1611,7 +1611,7 @@ class OceanSg2Factory(AuxCoordFactory):
         self.depth = depth
         self.depth_c = depth_c
 
-        self.standard_name = 'sea_surface_height_above_reference_ellipsoid'
+        self.standard_name = 'altitude'
         self.attributes = {'positive': 'up'}
 
     @property

--- a/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
@@ -139,9 +139,8 @@ class Test_make_coord(tests.IrisTest):
              (np.tanh(a * (s + 0.5)) / (2 * np.tanh(0.5 * a)) - 0.5))
         result = eta * (1 + s) + depth_c * s + (depth - depth_c) * c
         if coord:
-            name = 'sea_surface_height_above_reference_ellipsoid'
             result = AuxCoord(result,
-                              standard_name=name,
+                              standard_name='altitude',
                               units='m',
                               attributes=dict(positive='up'))
         return result

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
@@ -133,9 +133,8 @@ class Test_make_coord(tests.IrisTest):
         S = depth_c * s + (depth - depth_c) * c
         result = S + eta * (1 + S / depth)
         if coord:
-            name = 'sea_surface_height_above_reference_ellipsoid'
             result = AuxCoord(result,
-                              standard_name=name,
+                              standard_name='altitude',
                               units='m',
                               attributes=dict(positive='up'))
         return result

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
@@ -133,9 +133,8 @@ class Test_make_coord(tests.IrisTest):
         S = (depth_c * s + depth * c) / (depth_c + depth)
         result = eta + (eta + depth) * S
         if coord:
-            name = 'sea_surface_height_above_reference_ellipsoid'
             result = AuxCoord(result,
-                              standard_name=name,
+                              standard_name='altitude',
                               units='m',
                               attributes=dict(positive='up'))
         return result

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
@@ -97,9 +97,8 @@ class Test_make_coord(tests.IrisTest):
     def derive(sigma, eta, depth, coord=True):
         result = eta + sigma * (depth + eta)
         if coord:
-            name = 'sea_surface_height_above_reference_ellipsoid'
             result = AuxCoord(result,
-                              standard_name=name,
+                              standard_name='altitude',
                               units='m',
                               attributes=dict(positive='up'))
         return result

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
@@ -155,9 +155,8 @@ class Test_make_coord(tests.IrisTest):
         result = np.ones(shape, dtype=temp.dtype) * zlev
         result[nsigma_slice] = temp[nsigma_slice]
         if coord:
-            name = 'sea_surface_height_above_reference_ellipsoid'
             result = AuxCoord(result,
-                              standard_name=name,
+                              standard_name='altitude',
                               units='m',
                               attributes=dict(positive='up'))
         return result


### PR DESCRIPTION
After a whole day banging my head against the wall to figure out why a `sea surface` filter I created was removing my z coord I realized we made a mistake in the `standard_name` for the derived z coord in ocean models.  (See  https://github.com/SciTools/iris/pull/509 and my reckless copying-and-pasting after that!)

This PR changes `sea_surface_height_above_reference_ellipsoid` to `altitude`.  From the CF-1.6 document:

> Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level.

PS: -z is altitude :wink: