### PR TITLE
Lazy cube maths

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -75,7 +75,7 @@ numpy 1.6 or later (http://numpy.scipy.org/)
     Python package for scientific computing including a powerful N-dimensional
     array object.
 
-biggus 0.8 or later (https://github.com/SciTools/biggus)
+biggus 0.12 or later (https://github.com/SciTools/biggus)
     Virtual large arrays and lazy evaluation.
 
 scipy 0.10 or later (http://www.scipy.org/)

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,7 +2,7 @@
 # conda create -n <name> --file conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.8
+biggus>=0.12.0
 cartopy
 matplotlib=1.3.1
 netcdf4

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -129,11 +129,11 @@ def _assert_compatible(cube, other):
 
     try:
         if not isinstance(other, biggus.Array):
-            data_view, other_view = BA.broadcast_arrays(cube.lazy_data(),
+            data_view, other_view = BA.broadcast_arrays(cube._my_data,
                                                         np.asarray(other))
 
         else:
-            data_view, other_view = BA.broadcast_arrays(cube.lazy_data(), other)
+            data_view, other_view = BA.broadcast_arrays(cube._my_data, other)
     except ValueError as err:
         # re-raise
         raise ValueError("The array was not broadcastable to the cube's data "
@@ -577,11 +577,11 @@ def _binary_op_common(operation_function, operation_noun, cube, other,
         other = _broadcast_cube_coord_data(cube, other, operation_noun, dim)
     elif isinstance(other, iris.cube.Cube):
         try:
-            BA.broadcast_arrays(cube.lazy_data(), other.lazy_data())
+            BA.broadcast_arrays(cube._my_data, other._my_data)
         except ValueError:
-            other = iris.util.as_compatible_shape(other, cube).lazy_data()
+            other = iris.util.as_compatible_shape(other, cube)._my_data
         else:
-            other = other.lazy_data()
+            other = other._my_data
 
     # don't worry about checking for other data types (such as scalars or
     # np.ndarrays) because _assert_compatible validates that they are broadcast
@@ -644,12 +644,12 @@ def _math_op_common(cube, operation_function, new_unit, in_place=False):
     if in_place:
         new_cube = cube
         try:
-            operation_function(new_cube.lazy_data(), out=new_cube.lazy_data())
+            operation_function(new_cube._my_data, out=new_cube._my_data)
         except TypeError:
             # Non ufunc function
             operation_function(new_cube.data)
     else:
-        new_cube = cube.copy(data=operation_function(cube.lazy_data()))
+        new_cube = cube.copy(data=operation_function(cube._my_data))
     iris.analysis.clear_phenomenon_identity(new_cube)
     new_cube.units = new_unit
     return new_cube

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -1,0 +1,106 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.cube.Cube` class operators."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+import iris
+import iris.tests as tests
+import numpy as np
+import biggus
+
+
+class Test_Lazy_Maths(tests.IrisTest):
+    def build_lazy_cube(self, points, bounds=None, nx=10):
+        data = np.arange(len(points) * nx).reshape(len(points), nx)
+        data = biggus.NumpyArrayAdapter(data)
+        cube = iris.cube.Cube(data, standard_name='air_temperature', units='K')
+        lat = iris.coords.DimCoord(points, 'latitude', bounds=bounds)
+        lon = iris.coords.DimCoord(np.arange(nx), 'longitude')
+        cube.add_dim_coord(lat, 0)
+        cube.add_dim_coord(lon, 1)
+        return cube
+
+    def assert_elementwise(self, cube, other, result, np_op):
+        self.assertIsInstance(result, biggus._Elementwise)
+        self.assertEqual(result._numpy_op, np_op)
+        self.assertArrayAlmostEqual(result._array1, cube.lazy_data())
+        if other is not None:
+            self.assertArrayAlmostEqual(result._array2, other)
+
+    def test_lazy_biggus_add_cubes(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 + c1
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, c1.lazy_data(), result, np.add)
+
+    def test_lazy_biggus_add_scalar(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 + 5
+        self.assertEqual(c1 + 5, 5 + c1)
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, None, result, np.add)
+
+    def test_lazy_biggus_mul_cubes(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 * c1
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, c1.lazy_data(), result, np.multiply)
+
+    def test_lazy_biggus_mul_scalar(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 * 5
+        self.assertEqual(c1 * 5, 5 * c1)
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, None, result, np.multiply)
+
+    def test_lazy_biggus_sub_cubes(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 - c1
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, c1.lazy_data(), result, np.subtract)
+
+    def test_lazy_biggus_sub_scalar(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 - 5
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, None, result, np.subtract)
+
+    def test_lazy_biggus_div_cubes(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 / c1
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, c1.lazy_data(), result, np.divide)
+
+    def test_lazy_biggus_div_scalar(self):
+        c1 = self.build_lazy_cube([1, 2])
+        cube = c1 / 5
+        result = cube.lazy_data()
+        self.assertTrue(cube.has_lazy_data())
+        self.assert_elementwise(c1, None, result, np.divide)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
As noted by @dkillick in #1744, doing basic maths with cubes (adding, subtracting etc) does not currently preserve lazy data. 

I have modified the `iris/analysis/maths.py` file to support lazy data evaluation of cubes using some of the more recent features in biggus (broadcasting etc).

Let me know what you think!