### PR TITLE
Python3 builtin changes

### DIFF
--- a/docs/iris/example_code/General/custom_file_loading.py
+++ b/docs/iris/example_code/General/custom_file_loading.py
@@ -71,8 +71,8 @@ def load_NAME_III(filename):
     """
 
     # Loading a file gives a generator of lines which can be progressed using
-    # the next() method. This will come in handy as we wish to progress through
-    # the file line by line.
+    # the next() function. This will come in handy as we wish to progress
+    # through the file line by line.
     with open(filename) as file_handle:
         # Define a dictionary which can hold the header metadata for this file.
         headers = {}
@@ -84,7 +84,7 @@ def load_NAME_III(filename):
         # Read the next 16 lines of header information, putting the form
         # "header name:    header value" into a dictionary.
         for _ in range(16):
-            header_name, header_value = file_handle.next().split(':')
+            header_name, header_value = next(file_handle).split(':')
 
             # Strip off any spurious space characters in the header name and
             # value.
@@ -111,7 +111,7 @@ def load_NAME_III(filename):
         column_headings = {}
         for column_header_name in COLUMN_NAMES:
             column_headings[column_header_name] = [
-                col.strip() for col in file_handle.next().split(',')
+                col.strip() for col in next(file_handle).split(',')
             ][:-1]
 
         # Convert the time to python datetimes.

--- a/docs/iris/example_code/Meteorology/deriving_phenomena.py
+++ b/docs/iris/example_code/Meteorology/deriving_phenomena.py
@@ -30,7 +30,7 @@ def limit_colorbar_ticks(contour_object):
     # Matplotlib v1.3.x it is simply the colorbar.
     try:
         colorbar = contour_object.colorbar[0]
-    except AttributeError:
+    except (AttributeError, TypeError):
         colorbar = contour_object.colorbar
 
     colorbar.locator = matplotlib.ticker.MaxNLocator(4)

--- a/docs/iris/src/userguide/subsetting_a_cube.rst
+++ b/docs/iris/src/userguide/subsetting_a_cube.rst
@@ -140,9 +140,10 @@ slicing the 3 dimensional cube (15, 100, 100) by longitude (i starts at 0 and 15
 
 .. hint::
     It is often useful to get a single 2d slice from a multidimensional cube in order to develop a 2d plot function, for example.
-    This can be achieved by using the ``next()`` method on the result of slices::
+    This can be achieved by using the ``next()`` function on the result of
+    slices::
 
-         first_slice = cube.slices(['grid_latitude', 'grid_longitude']).next()
+         first_slice = next(cube.slices(['grid_latitude', 'grid_longitude']))
 
     Once the your code can handle a 2d slice, it is then an easy step to loop over **all** 2d slices within the bigger
     cube using the slices method.

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -332,7 +332,10 @@ def divide(cube, other, dim=None, in_place=False):
     _assert_is_cube(cube)
     other_unit = getattr(other, 'units', '1')
     new_unit = cube.units / other_unit
-    op = operator.idiv if in_place else operator.div
+    try:
+        op = operator.idiv if in_place else operator.div
+    except AttributeError:
+        op = operator.itruediv if in_place else operator.truediv
     return _binary_op_common(op, 'divison', cube, other, new_unit, dim,
                              in_place=in_place)
 

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -320,8 +320,15 @@ class RotatedGeogCS(CoordSystem):
 
     def __str__(self):
         attrs = self._pretty_attrs()
-        result = "RotatedGeogCS(%s)" % ", ".join(
-            ["%s=%s" % (k, v) for k, v in attrs])
+        text_attrs = []
+        for k, v in attrs:
+            if isinstance(v, float):
+                text_attrs.append('{}={:.16}'.format(k, v))
+            elif isinstance(v, np.float32):
+                text_attrs.append('{}={:.8}'.format(k, v))
+            else:
+                text_attrs.append('{}={}'.format(k, v))
+        result = 'RotatedGeogCS({})'.format(', '.join(text_attrs))
         # Extra prettiness
         result = result.replace("grid_north_pole_latitude=", "")
         result = result.replace("grid_north_pole_longitude=", "")

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -26,6 +26,7 @@ import six
 from abc import ABCMeta, abstractmethod
 import warnings
 
+import numpy as np
 import cartopy
 import cartopy.crs as ccrs
 
@@ -65,7 +66,13 @@ class CoordSystem(six.with_metaclass(ABCMeta, object)):
         attrs = sorted(attrs, key=lambda attr: attr[0])
 
         for name, value in attrs:
-            coord_system_xml_element.setAttribute(name, str(value))
+            if isinstance(value, float):
+                value_str = '{:.16}'.format(value)
+            elif isinstance(value, np.float32):
+                value_str = '{:.8}'.format(value)
+            else:
+                value_str = '{}'.format(value)
+            coord_system_xml_element.setAttribute(name, value_str)
 
         return coord_system_xml_element
 
@@ -211,10 +218,17 @@ class GeogCS(CoordSystem):
         attrs = self._pretty_attrs()
         # Special case for 1 pretty attr
         if len(attrs) == 1 and attrs[0][0] == "semi_major_axis":
-            return "GeogCS(%s)" % self.semi_major_axis
+            return 'GeogCS({:.16})'.format(self.semi_major_axis)
         else:
-            return "GeogCS(%s)" % ", ".join(
-                ["%s=%s" % (k, v) for k, v in attrs])
+            text_attrs = []
+            for k, v in attrs:
+                if isinstance(v, float):
+                    text_attrs.append('{}={:.16}'.format(k, v))
+                elif isinstance(v, np.float32):
+                    text_attrs.append('{}={:.8}'.format(k, v))
+                else:
+                    text_attrs.append('{}={}'.format(k, v))
+            return 'GeogCS({})'.format(', '.join(text_attrs))
 
     def xml_element(self, doc):
         # Special output for spheres

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1726,10 +1726,12 @@ class _CellIterator(collections.Iterator):
             raise iris.exceptions.CoordinateMultiDimError(coord)
         self._indices = iter(range(coord.shape[0]))
 
-    def next(self):
+    def __next__(self):
         # NB. When self._indices runs out it will raise StopIteration for us.
         i = next(self._indices)
         return self._coord.cell(i)
+
+    next = __next__
 
 
 # See ExplicitCoord._group() for the description/context.
@@ -1738,7 +1740,7 @@ class _GroupIterator(collections.Iterator):
         self._points = points
         self._start = 0
 
-    def next(self):
+    def __next__(self):
         num_points = len(self._points)
         if self._start >= num_points:
             raise StopIteration
@@ -1751,3 +1753,5 @@ class _GroupIterator(collections.Iterator):
         group = _GroupbyItem(m, slice(self._start, stop))
         self._start = stop
         return group
+
+    next = __next__

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3541,7 +3541,7 @@ class _SliceIterator(collections.Iterator):
         self._mod_requested_dims = np.argsort(requested_dims)
         self._ordered = ordered
 
-    def next(self):
+    def __next__(self):
         # NB. When self._ndindex runs out it will raise StopIteration for us.
         index_tuple = next(self._ndindex)
 
@@ -3561,3 +3561,5 @@ class _SliceIterator(collections.Iterator):
                 cube.transpose(self._mod_requested_dims)
 
         return cube
+
+    next = __next__

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2522,9 +2522,21 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             for name in sorted(six.iterkeys(self.attributes)):
                 attribute_element = doc.createElement('attribute')
                 attribute_element.setAttribute('name', name)
-                value = str(self.attributes[name])
+
+                value = self.attributes[name]
+                # Strict check because we don't want namedtuples.
+                if type(value) in (list, tuple):
+                    delimiter = '[]' if isinstance(value, list) else '()'
+                    value = ', '.join(("'%s'"
+                                       if isinstance(item, six.string_types)
+                                       else '%s') % (item, ) for item in value)
+                    value = delimiter[0] + value + delimiter[1]
+                else:
+                    value = str(value)
+
                 attribute_element.setAttribute('value', value)
                 attributes_element.appendChild(attribute_element)
+
             cube_xml_element.appendChild(attributes_element)
 
         coords_xml_element = doc.createElement("coords")

--- a/lib/iris/fileformats/_structured_array_identification.py
+++ b/lib/iris/fileformats/_structured_array_identification.py
@@ -102,11 +102,13 @@ class ArrayStructure(namedtuple('ArrayStructure',
     2
 
     """
-    def __init__(self, *args, **kwargs):
+    def __new__(cls, stride, unique_ordered_values):
+        self = super(ArrayStructure, cls).__new__(cls, stride,
+                                                  unique_ordered_values)
         #: The ``size`` attribute is the number of the unique values in
         #: the original array. It is **not** the length of the original array.
-        self.size = len(self.unique_ordered_values)
-        super(ArrayStructure, self).__init__(self, *args, **kwargs)
+        self.size = len(unique_ordered_values)
+        return self
 
     def __eq__(self, other):
         stride = getattr(other, 'stride', None)

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -76,7 +76,7 @@ def read_header(file_handle):
 
     """
     header = {}
-    header['NAME Version'] = file_handle.next().strip()
+    header['NAME Version'] = next(file_handle).strip()
     for line in file_handle:
         words = line.split(':', 1)
         if len(words) != 2:
@@ -516,7 +516,7 @@ def load_NAMEIII_field(filename):
 
     """
     # Loading a file gives a generator of lines which can be progressed using
-    # the next() method. This will come in handy as we wish to progress
+    # the next() function. This will come in handy as we wish to progress
     # through the file line by line.
     with open(filename, 'r') as file_handle:
         # Create a dictionary which can hold the header metadata about this
@@ -536,7 +536,7 @@ def load_NAMEIII_field(filename):
                                    'Vertical Av or Int', 'Prob Perc',
                                    'Prob Perc Ens', 'Prob Perc Time',
                                    'Time', 'Z', 'D']:
-            cols = [col.strip() for col in file_handle.next().split(',')]
+            cols = [col.strip() for col in next(file_handle).split(',')]
             column_headings[column_header_name] = cols[4:-1]
 
         # Convert the time to python datetimes.
@@ -607,7 +607,7 @@ def load_NAMEII_field(filename):
         for column_header_name in ['Species Category', 'Species',
                                    'Time Av or Int', 'Quantity',
                                    'Unit', 'Z', 'Time']:
-            cols = [col.strip() for col in file_handle.next().split(',')]
+            cols = [col.strip() for col in next(file_handle).split(',')]
             column_headings[column_header_name] = cols[4:-1]
 
         # Convert the time to python datetimes
@@ -683,7 +683,7 @@ def load_NAMEIII_timeseries(filename):
                                    'Vertical Av or Int', 'Prob Perc',
                                    'Prob Perc Ens', 'Prob Perc Time',
                                    'Location', 'X', 'Y', 'Z', 'D']:
-            cols = [col.strip() for col in file_handle.next().split(',')]
+            cols = [col.strip() for col in next(file_handle).split(',')]
             column_headings[column_header_name] = cols[1:-1]
 
         # Determine the coordinates of the data and store in namedtuples.
@@ -751,7 +751,7 @@ def load_NAMEII_timeseries(filename):
         for column_header_name in ['Y', 'X', 'Location',
                                    'Species Category', 'Species',
                                    'Quantity', 'Z', 'Unit']:
-            cols = [col.strip() for col in file_handle.next().split(',')]
+            cols = [col.strip() for col in next(file_handle).split(',')]
             column_headings[column_header_name] = cols[1:-1]
 
         # Determine the coordinates of the data and store in namedtuples.

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -242,7 +242,7 @@ class _ZipSlicesIterator(collections.Iterator):
         # (1, 0, 1), (1, 0, 2)]
         self._ndindex = np.ndindex(*master_dims_index)
 
-    def next(self):
+    def __next__(self):
         # When self._ndindex runs out it will raise StopIteration for us.
         master_index_tuple = next(self._ndindex)
 
@@ -270,6 +270,8 @@ class _ZipSlicesIterator(collections.Iterator):
             subcubes.append(subcube)
 
         return tuple(subcubes)
+
+    next = __next__
 
 
 class _CoordWrapper(object):

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -43,7 +43,6 @@ import gzip
 import inspect
 import io
 import logging
-import mock
 import os
 import os.path
 import shutil
@@ -53,6 +52,11 @@ import unittest
 import warnings
 import xml.dom.minidom
 import zlib
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import numpy as np
 import numpy.ma as ma

--- a/lib/iris/tests/integration/test_ff.py
+++ b/lib/iris/tests/integration/test_ff.py
@@ -25,11 +25,11 @@ import iris.tests as tests
 
 import shutil
 
-import mock
 import numpy as np
 
 import iris
 import iris.experimental.um as um
+from iris.tests import mock
 
 
 @tests.skip_data

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -24,13 +24,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from contextlib import contextmanager
-import mock
 import numpy as np
 
 import iris
 from iris.cube import Cube, CubeList
 from iris.fileformats.netcdf import CF_CONVENTIONS_VERSION
 from iris.fileformats.netcdf import Saver
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from contextlib import nested
-
 import mock
 import numpy as np
 
@@ -211,8 +209,8 @@ class TestVertical(tests.IrisTest):
                                             pressure_field,
                                             pressure_field]))
         msg = 'Multiple reference cubes for surface_air_pressure'
-        with nested(mock.patch('iris.fileformats.pp.load', new=load),
-                    mock.patch('warnings.warn')) as (load, warn):
+        with mock.patch('iris.fileformats.pp.load',
+                        new=load) as load, mock.patch('warnings.warn') as warn:
             _, _, _ = iris.fileformats.pp.load_cubes('DUMMY')
             warn.assert_called_with(msg)
 

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -23,7 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
@@ -31,6 +30,7 @@ from iris.coords import AuxCoord, CellMethod
 from iris.cube import Cube
 import iris.fileformats.pp
 import iris.fileformats.pp_rules
+from iris.tests import mock
 
 
 class TestVertical(tests.IrisTest):

--- a/lib/iris/tests/results/analysis/project/default_source_cs.cml
+++ b/lib/iris/tests/results/analysis/project/default_source_cs.cml
@@ -13,7 +13,7 @@
         <dimCoord id="9c8bdf81" points="[243363.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='360_day')" value_type="float64"/>
       </coord>
       <coord datadims="[0, 1]">
-        <auxCoord id="99e1c155" points="[[-86.7919126364, -86.7919126364, -86.7919126364,
+        <auxCoord id="cf6eec38" points="[[-86.7919126364, -86.7919126364, -86.7919126364,
  		..., -86.7919126364, -86.7919126364,
  		-86.7919126364],
 		[-82.4663018441, -82.4663018441, -82.4663018441,
@@ -32,11 +32,11 @@
 		[86.7919126364, 86.7919126364, 86.7919126364,
  		..., 86.7919126364, 86.7919126364,
  		86.7919126364]]" shape="(73, 96)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31425"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314245179"/>
         </auxCoord>
       </coord>
       <coord datadims="[0, 1]">
-        <auxCoord id="de65d9e7" points="[[39.9621553628, 46.6997941973, 53.4374330318,
+        <auxCoord id="dd77119d" points="[[39.9621553628, 46.6997941973, 53.4374330318,
  		..., -53.4374330318, -46.6997941973,
  		-39.9621553628],
 		[61.2515118973, 67.5409537521, 73.8303956069,
@@ -55,7 +55,7 @@
 		[39.9621553628, 46.6997941973, 53.4374330318,
  		..., -53.4374330318, -46.6997941973,
  		-39.9621553628]]" shape="(73, 96)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31425"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314245179"/>
         </auxCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/grib_load/earth_shape_2.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_2.cml
@@ -6,7 +6,7 @@
         <dimCoord bounds="[[-28587.0, 6477.0]]" id="1d45e087" points="[-11055.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="3e65c13a" points="[89.999983, 87.499984, 84.999985, 82.499986,
+        <dimCoord id="b8cb6f39" points="[89.999983, 87.499984, 84.999985, 82.499986,
 		79.999987, 77.499988, 74.999989, 72.49999,
 		69.999991, 67.499992, 64.999993, 62.499994,
 		59.999995, 57.499996, 54.999997, 52.499998,
@@ -25,13 +25,13 @@
 		-67.499954, -69.999953, -72.499952, -74.999951,
 		-77.49995, -79.999949, -82.499948, -84.999947,
 		-87.499946, -89.999945]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378160.0" semi_minor_axis="6356684.7138"/>
+          <geogCS semi_major_axis="6378160.0" semi_minor_axis="6356684.713804713"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord circular="True" id="08b20cd4" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
+        <dimCoord circular="True" id="aad2929c" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
 		352.499812, 356.24981]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378160.0" semi_minor_axis="6356684.7138"/>
+          <geogCS semi_major_axis="6378160.0" semi_minor_axis="6356684.713804713"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/grib_load/earth_shape_4.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_4.cml
@@ -6,7 +6,7 @@
         <dimCoord bounds="[[-28587.0, 6477.0]]" id="1d45e087" points="[-11055.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="8a96048c" points="[89.999983, 87.499984, 84.999985, 82.499986,
+        <dimCoord id="cab9a6be" points="[89.999983, 87.499984, 84.999985, 82.499986,
 		79.999987, 77.499988, 74.999989, 72.49999,
 		69.999991, 67.499992, 64.999993, 62.499994,
 		59.999995, 57.499996, 54.999997, 52.499998,
@@ -25,13 +25,13 @@
 		-67.499954, -69.999953, -72.499952, -74.999951,
 		-77.49995, -79.999949, -82.499948, -84.999947,
 		-87.499946, -89.999945]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31414"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314140356"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord circular="True" id="cd121c3e" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
+        <dimCoord circular="True" id="d8a05b1b" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
 		352.499812, 356.24981]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31414"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314140356"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/grib_load/earth_shape_5.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_5.cml
@@ -6,7 +6,7 @@
         <dimCoord bounds="[[-28587.0, 6477.0]]" id="1d45e087" points="[-11055.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="99e1c155" points="[89.999983, 87.499984, 84.999985, 82.499986,
+        <dimCoord id="cf6eec38" points="[89.999983, 87.499984, 84.999985, 82.499986,
 		79.999987, 77.499988, 74.999989, 72.49999,
 		69.999991, 67.499992, 64.999993, 62.499994,
 		59.999995, 57.499996, 54.999997, 52.499998,
@@ -25,13 +25,13 @@
 		-67.499954, -69.999953, -72.499952, -74.999951,
 		-77.49995, -79.999949, -82.499948, -84.999947,
 		-87.499946, -89.999945]" shape="(73,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31425"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314245179"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord circular="True" id="de65d9e7" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
+        <dimCoord circular="True" id="dd77119d" points="[0.0, 3.749998, 7.499996, ..., 348.749814,
 		352.499812, 356.24981]" shape="(96,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
-          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.31425"/>
+          <geogCS semi_major_axis="6378137.0" semi_minor_axis="6356752.314245179"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/integration/grib2/TestImport/gdt1.cml
+++ b/lib/iris/tests/results/integration/grib2/TestImport/gdt1.cml
@@ -11,13 +11,13 @@
       <coord datadims="[0]">
         <dimCoord id="71a1116e" points="[-20.069997, -19.959999, -19.850001, ...,
 		19.199289, 19.309287, 19.419285]" shape="(360,)" standard_name="grid_latitude" units="Unit('degrees')" value_type="float64">
-          <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.46698"/>
+          <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.4669799999999"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="b2f338a6" points="[326.219965, 326.329959, 326.439953, ...,
 		391.886383, 391.996377, 392.106371]" shape="(600,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float64">
-          <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.46698"/>
+          <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.4669799999999"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/integration/grib2/TestImport/gdt1.cml
+++ b/lib/iris/tests/results/integration/grib2/TestImport/gdt1.cml
@@ -9,13 +9,13 @@
         <dimCoord id="9c8bdf81" points="[344904.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="71a1116e" points="[-20.069997, -19.959999, -19.850001, ...,
+        <dimCoord id="f971e3af" points="[-20.069997, -19.959999, -19.850001, ...,
 		19.199289, 19.309287, 19.419285]" shape="(360,)" standard_name="grid_latitude" units="Unit('degrees')" value_type="float64">
           <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.4669799999999"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="b2f338a6" points="[326.219965, 326.329959, 326.439953, ...,
+        <dimCoord id="e5e4f895" points="[326.219965, 326.329959, 326.439953, ...,
 		391.886383, 391.996377, 392.106371]" shape="(600,)" standard_name="grid_longitude" units="Unit('degrees')" value_type="float64">
           <rotatedGeogCS ellipsoid="GeogCS(6367470.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="152.4669799999999"/>
         </dimCoord>

--- a/lib/iris/tests/results/integration/grib2/TestImport/gdt90_with_bitmap.cml
+++ b/lib/iris/tests/results/integration/grib2/TestImport/gdt90_with_bitmap.cml
@@ -9,13 +9,13 @@
         <dimCoord id="e9d77814" points="[369081.561454, 366080.898353, 363080.235252,
 		..., -792175.058731, -795175.721833,
 		-798176.384934]" shape="(390,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
-          <verticalPerspective ellipsoid="GeogCS(semi_major_axis=6378168.8, semi_minor_axis=6356584.0)" false_easting="0" false_northing="0" latitude_of_projection_origin="0.0" longitude_of_projection_origin="0.0" perspective_point_height="35785825.8538"/>
+          <verticalPerspective ellipsoid="GeogCS(semi_major_axis=6378168.800000001, semi_minor_axis=6356584.0)" false_easting="0" false_northing="0" latitude_of_projection_origin="0.0" longitude_of_projection_origin="0.0" perspective_point_height="35785825.85377121"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="7be8ad9f" points="[4392884.59202, 4395885.19625, 4398885.80048,
 		..., 5065019.93943, 5068020.54366, 5071021.14789]" shape="(227,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
-          <verticalPerspective ellipsoid="GeogCS(semi_major_axis=6378168.8, semi_minor_axis=6356584.0)" false_easting="0" false_northing="0" latitude_of_projection_origin="0.0" longitude_of_projection_origin="0.0" perspective_point_height="35785825.8538"/>
+          <verticalPerspective ellipsoid="GeogCS(semi_major_axis=6378168.800000001, semi_minor_axis=6356584.0)" false_easting="0" false_northing="0" latitude_of_projection_origin="0.0" longitude_of_projection_origin="0.0" perspective_point_height="35785825.85377121"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
@@ -5,7 +5,7 @@
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
-      <attribute name="ukmo__process_flags" value="(u'Maximum value of field during time period', u'Time mean field')"/>
+      <attribute name="ukmo__process_flags" value="('Maximum value of field during time period', 'Time mean field')"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -5,7 +5,7 @@
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
-      <attribute name="ukmo__process_flags" value="(u'Mean over an ensemble of parallel runs', u'Time mean field')"/>
+      <attribute name="ukmo__process_flags" value="('Mean over an ensemble of parallel runs', 'Time mean field')"/>
     </attributes>
     <coords>
       <coord datadims="[0]">

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -635,8 +635,14 @@ class TestLog(tests.IrisTest):
 
 
 class TestMaskedArrays(tests.IrisTest):
-    ops = (operator.add, operator.sub, operator.mul, operator.div)
-    iops = (operator.iadd, operator.isub, operator.imul, operator.idiv)
+    ops = (operator.add, operator.sub, operator.mul)
+    iops = (operator.iadd, operator.isub, operator.imul)
+    try:
+        ops = ops + (operator.div, )
+        iops = iops + (operator.idiv, )
+    except AttributeError:
+        ops = ops + (operator.truediv, )
+        iops = iops + (operator.itruediv, )
 
     def setUp(self):
         self.data1 = ma.MaskedArray([[9, 9, 9], [8, 8, 8,]], mask=[[0, 1, 0], [0, 0, 1]])

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -27,10 +27,9 @@ import iris.tests as tests
 
 import unittest
 
-import mock
-
 import iris
 import iris.fileformats.cf as cf
+from iris.tests import mock
 
 
 class TestCaching(unittest.TestCase):

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -21,6 +21,7 @@ Test the constrained cube loading mechanism.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -334,7 +335,9 @@ class TestConstraints(TestMixin, tests.IrisTest):
         rl10 = repr(self.level_10)
 
         rt_l10 = repr(self.theta & self.level_10)
-        self.assertEqual(rt_l10, "ConstraintCombination(%s, %s, <built-in function __and__>)" % (rt, rl10))
+        expr = 'ConstraintCombination(%s, %s, <built-in function %s>)' % (
+            rt, rl10, '__and__' if six.PY2 else 'and_')
+        self.assertEqual(expr, rt_l10)
 
     def test_string_repr(self):
         rt = repr(iris.Constraint(SN_AIR_POTENTIAL_TEMPERATURE))

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -325,7 +325,10 @@ def fields_from_cube(cubes):
     to a temporary file, and then subsequently loading them again 
     """
     with tempfile.NamedTemporaryFile('w+b', suffix='.pp') as tmp_file:
-        fh = tmp_file.file
+        if six.PY2:
+            fh = tmp_file.file
+        else:
+            fh = tmp_file
         iris.save(cubes, fh, saver='pp')
         
         # make sure the fh is written to disk, and move it back to the

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -25,7 +25,6 @@ import iris.tests as tests
 import os
 import tempfile
 
-import mock
 import numpy as np
 
 import iris
@@ -35,6 +34,7 @@ import iris.fileformats.pp as ff_pp
 from iris.fileformats.pp import PPField3
 import iris.io
 import iris.unit
+from iris.tests import mock
 import iris.tests.pp as pp
 import iris.util
 import iris.tests.stock as stock

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -28,12 +28,12 @@ import iris.tests as tests
 
 import collections
 
-import mock
 import numpy as np
 
 import iris
 import iris.fileformats.ff as ff
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 _MockField = collections.namedtuple('_MockField',

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -26,12 +26,12 @@ import datetime
 from distutils.version import StrictVersion
 
 import gribapi
-import mock
 import numpy as np
 
 import iris
 import iris.exceptions
 import iris.fileformats.grib
+from iris.tests import mock
 import iris.tests.stock
 import iris.util
 

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -24,12 +24,12 @@ import iris.tests as tests
 
 import gribapi
 import numpy as np
-import mock
 import warnings
 
 import iris.cube
 import iris.coords
 import iris.fileformats.grib._save_rules as grib_save_rules
+from iris.tests import mock
 
 
 class Test_set_fixed_surfaces(tests.IrisTest):

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -74,7 +74,7 @@ class TestRealistic4d(tests.GraphicsTest):
         t = [key
              for key, coord in six.iteritems(factory.dependencies)
              if coord is not None]
-        self.assertItemsEqual(t, ['orography', 'delta'])
+        six.assertCountEqual(self, t, ['orography', 'delta'])
 
     def test_removing_orography(self):
         # Check the cube remains OK when the orography is removed.
@@ -88,7 +88,7 @@ class TestRealistic4d(tests.GraphicsTest):
         t = [key
              for key, coord in six.iteritems(factory.dependencies)
              if coord is not None]
-        self.assertItemsEqual(t, ['sigma', 'delta'])
+        six.assertCountEqual(self, t, ['sigma', 'delta'])
 
     def test_derived_coords(self):
         derived_coords = self.cube.derived_coords

--- a/lib/iris/tests/test_iterate.py
+++ b/lib/iris/tests/test_iterate.py
@@ -124,7 +124,7 @@ class TestIterateFunctions(tests.IrisTest):
         zip_iterator = iris.iterate.izip(self.cube_b, coords=[])
         for cube_slice in slice_iterator:
             # First element of tuple: (extractedcube, )
-            zip_slice = zip_iterator.next()[0]
+            zip_slice = next(zip_iterator)[0]
             self.assertEqual(cube_slice, zip_slice)
         with self.assertRaises(StopIteration):
             next(zip_iterator)  # Should raise exception if we continue try to
@@ -136,7 +136,7 @@ class TestIterateFunctions(tests.IrisTest):
         zip_iterator = iris.iterate.izip(self.cube_b, coords=self.coord_names)
         for cube_slice in slice_iterator:
             # First element of tuple: (extractedcube, )
-            zip_slice = zip_iterator.next()[0]
+            zip_slice = next(zip_iterator)[0]
             self.assertEqual(cube_slice, zip_slice)
         with self.assertRaises(StopIteration):
             next(zip_iterator)  # Should raise exception if we continue to try
@@ -148,7 +148,7 @@ class TestIterateFunctions(tests.IrisTest):
         zip_iterator = iris.iterate.izip(self.cube_b, coords='grid_latitude')
         for cube_slice in slice_iterator:
             # First element of tuple: (extractedcube, )
-            zip_slice = zip_iterator.next()[0]
+            zip_slice = next(zip_iterator)[0]
             self.assertEqual(cube_slice, zip_slice)
         with self.assertRaises(StopIteration):
             next(zip_iterator)  # Should raise exception if we continue to try
@@ -163,7 +163,7 @@ class TestIterateFunctions(tests.IrisTest):
                                                               'grid_longitude'])
         for cube_slice in slice_iterator:
             # First element of tuple: (extractedcube, )
-            zip_slice = zip_iterator.next()[0]
+            zip_slice = next(zip_iterator)[0]
             self.assertEqual(cube_slice, zip_slice)
         with self.assertRaises(StopIteration):
             next(zip_iterator)  # Should raise exception if we continue to try

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -34,7 +34,6 @@ import stat
 import tempfile
 
 import biggus
-import mock
 import netCDF4 as nc
 import numpy as np
 import numpy.ma as ma
@@ -46,6 +45,7 @@ import iris.fileformats.netcdf
 import iris.std_names
 import iris.util
 import iris.coord_systems as icoord_systems
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -177,8 +177,7 @@ def attach_tests():
     for file_name in TestAll.files_to_check:
         func_name = 'test_{}'.format(file_name.replace('.', '_'))
         test_func = make_test_function(func_name, file_name)
-        test_method = types.MethodType(test_func, None, TestAll)
-        setattr(TestAll, func_name, test_method)
+        setattr(TestAll, func_name, test_func)
 
 
 attach_tests()

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -27,12 +27,12 @@ from types import GeneratorType
 import unittest
 
 import biggus
-import mock
 import netcdftime
 from numpy.testing import assert_array_equal
 
 import iris.fileformats
 import iris.fileformats.pp as pp
+from iris.tests import mock
 import iris.util
 
 

--- a/lib/iris/tests/unit/analysis/__init__.py
+++ b/lib/iris/tests/unit/analysis/__init__.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.analysis import Linear
+from iris.tests import mock
 
 
 class Test_Linear(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -26,13 +26,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.analysis._area_weighted import AreaWeightedRegridder
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord
 from iris.cube import Cube
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/interpolate/test_linear.py
+++ b/lib/iris/tests/unit/analysis/interpolate/test_linear.py
@@ -23,12 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
-import iris
 
+import iris
 from iris.analysis.interpolate import linear
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -35,7 +35,10 @@ from iris.tests.unit.analysis.maths import \
 class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):
-        return operator.div
+        try:
+            return operator.div
+        except AttributeError:
+            return operator.truediv
 
     @property
     def cube_func(self):
@@ -45,7 +48,10 @@ class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
 class TestMasking(tests.IrisTest, CubeArithmeticMaskingTestMixin):
     @property
     def data_op(self):
-        return operator.div
+        try:
+            return operator.div
+        except AttributeError:
+            return operator.truediv
 
     @property
     def cube_func(self):

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -23,7 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.analysis._regrid import RectilinearRegridder as Regridder
@@ -31,6 +30,7 @@ from iris.aux_factory import HybridHeightFactory
 from iris.coord_systems import GeogCS, OSGB
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
+from iris.tests import mock
 from iris.tests.stock import global_pp, lat_lon_cube, realistic_4d
 
 

--- a/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
+++ b/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
@@ -24,13 +24,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 import iris
 
 from iris.analysis._scipy_interpolate import _RegularGridInterpolator
 from scipy.sparse.csr import csr_matrix
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -23,12 +23,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from mock import patch, sentinel, Mock
 import numpy as np
 import numpy.ma as ma
 
 from iris.analysis import Aggregator
 from iris.exceptions import LazyAggregatorError
+from iris.tests import mock
 
 
 class Test_aggregate(tests.IrisTest):
@@ -50,16 +50,16 @@ class Test_aggregate(tests.IrisTest):
         # Providing masked array with no tolerance keyword (mdtol) provided.
         axis = 0
         mock_return = self.expected_result_axis0.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis)
             self.assertMaskedArrayEqual(result, self.expected_result_axis0)
         mock_method.assert_called_once_with(self.array, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis)
             self.assertMaskedArrayEqual(result, self.expected_result_axis1)
         mock_method.assert_called_once_with(self.array, axis=axis)
@@ -68,16 +68,16 @@ class Test_aggregate(tests.IrisTest):
         # Providing masked array with a high tolerance (mdtol) provided.
         axis = 0
         mock_return = self.expected_result_axis0.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.55)
             self.assertMaskedArrayEqual(result, self.expected_result_axis0)
         mock_method.assert_called_once_with(self.array, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.55)
             self.assertMaskedArrayEqual(result, self.expected_result_axis1)
         mock_method.assert_called_once_with(self.array, axis=axis)
@@ -89,16 +89,16 @@ class Test_aggregate(tests.IrisTest):
         result_axis_0 = self.expected_result_axis0.copy()
         result_axis_0.mask = np.array([True, True, False])
         mock_return = ma.array([1, 2, 3], mask=None)
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.45)
             self.assertMaskedArrayAlmostEqual(result, result_axis_0)
         mock_method.assert_called_once_with(self.array, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.45)
             self.assertMaskedArrayEqual(result, self.expected_result_axis1)
         mock_method.assert_called_once_with(self.array, axis=axis)
@@ -110,8 +110,8 @@ class Test_aggregate(tests.IrisTest):
         result_axis_1 = self.expected_result_axis1.copy()
         result_axis_1.mask = np.array([True, True])
         mock_return = self.expected_result_axis1.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.1)
             self.assertMaskedArrayAlmostEqual(result, result_axis_1)
         mock_method.assert_called_once_with(self.array, axis=axis)
@@ -123,16 +123,16 @@ class Test_aggregate(tests.IrisTest):
 
         axis = 0
         mock_return = self.expected_result_axis0.data.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis, mdtol=0.5)
             self.assertArrayAlmostEqual(result, mock_return.copy())
         mock_method.assert_called_once_with(data, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.data.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis, mdtol=0.5)
             self.assertArrayAlmostEqual(result, mock_return.copy())
         mock_method.assert_called_once_with(data, axis=axis)
@@ -144,16 +144,16 @@ class Test_aggregate(tests.IrisTest):
 
         axis = 0
         mock_return = self.expected_result_axis0.data.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis)
             self.assertArrayAlmostEqual(result, mock_return.copy())
         mock_method.assert_called_once_with(data, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.data.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis)
             self.assertArrayAlmostEqual(result, mock_return.copy())
         mock_method.assert_called_once_with(data, axis=axis)
@@ -164,8 +164,8 @@ class Test_aggregate(tests.IrisTest):
         axis = -1
         data = self.array.flatten()
         mock_return = 2
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis, mdtol=1)
             self.assertMaskedArrayEqual(result, ma.array(2, mask=False))
         mock_method.assert_called_once_with(data, axis=axis)
@@ -177,8 +177,8 @@ class Test_aggregate(tests.IrisTest):
         axis = -1
         data = self.array.flatten()
         mock_return = 2
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(data, axis, mdtol=0)
             self.assertMaskedArrayEqual(result, ma.array(2, mask=True))
         mock_method.assert_called_once_with(data, axis=axis)
@@ -189,50 +189,50 @@ class Test_aggregate(tests.IrisTest):
         axis = 0
         mock_return = self.expected_result_axis0.data.copy()
         result_axis_0 = ma.array(mock_return, mask=[True, True, False])
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.45)
             self.assertMaskedArrayAlmostEqual(result, result_axis_0)
         mock_method.assert_called_once_with(self.array, axis=axis)
 
         axis = 1
         mock_return = self.expected_result_axis1.data.copy()
-        with patch.object(self.TEST, 'call_func',
-                          return_value=mock_return) as mock_method:
+        with mock.patch.object(self.TEST, 'call_func',
+                               return_value=mock_return) as mock_method:
             result = self.TEST.aggregate(self.array, axis, mdtol=.45)
             self.assertMaskedArrayEqual(result, self.expected_result_axis1)
         mock_method.assert_called_once_with(self.array, axis=axis)
 
     def test_kwarg_pass_through_no_kwargs(self):
-        call_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        call_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         aggregator = Aggregator('', call_func)
         aggregator.aggregate(data, axis)
         call_func.assert_called_once_with(data, axis=axis)
 
     def test_kwarg_pass_through_call_kwargs(self):
-        call_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        call_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         kwargs = dict(wibble='wobble', foo='bar')
         aggregator = Aggregator('', call_func)
         aggregator.aggregate(data, axis, **kwargs)
         call_func.assert_called_once_with(data, axis=axis, **kwargs)
 
     def test_kwarg_pass_through_init_kwargs(self):
-        call_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        call_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         kwargs = dict(wibble='wobble', foo='bar')
         aggregator = Aggregator('', call_func, **kwargs)
         aggregator.aggregate(data, axis)
         call_func.assert_called_once_with(data, axis=axis, **kwargs)
 
     def test_kwarg_pass_through_combined_kwargs(self):
-        call_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        call_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         init_kwargs = dict(wibble='wobble', var=1.0)
         call_kwargs = dict(foo='foo', var=0.5)
         aggregator = Aggregator('', call_func, **init_kwargs)
@@ -242,9 +242,9 @@ class Test_aggregate(tests.IrisTest):
         call_func.assert_called_once_with(data, axis=axis, **expected_kwargs)
 
     def test_mdtol_intercept(self):
-        call_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        call_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         aggregator = Aggregator('', call_func)
         aggregator.aggregate(data, axis, wibble='wobble', mdtol=0.8)
         call_func.assert_called_once_with(data, axis=axis, wibble='wobble')
@@ -261,52 +261,52 @@ class Test_update_metadata(tests.IrisTest):
         # If the Aggregator has no units_func then the units should be
         # left unchanged.
         aggregator = Aggregator('', None)
-        cube = Mock(units=sentinel.units)
+        cube = mock.Mock(units=mock.sentinel.units)
         aggregator.update_metadata(cube, [])
-        self.assertIs(cube.units, sentinel.units)
+        self.assertIs(cube.units, mock.sentinel.units)
 
     def test_units_change(self):
         # If the Aggregator has a units_func then the new units should
         # be defined by its return value.
-        units_func = Mock(return_value=sentinel.new_units)
+        units_func = mock.Mock(return_value=mock.sentinel.new_units)
         aggregator = Aggregator('', None, units_func)
-        cube = Mock(units=sentinel.units)
+        cube = mock.Mock(units=mock.sentinel.units)
         aggregator.update_metadata(cube, [])
-        units_func.assert_called_once_with(sentinel.units)
-        self.assertEqual(cube.units, sentinel.new_units)
+        units_func.assert_called_once_with(mock.sentinel.units)
+        self.assertEqual(cube.units, mock.sentinel.new_units)
 
 
 class Test_lazy_aggregate(tests.IrisTest):
     def test_kwarg_pass_through_no_kwargs(self):
-        lazy_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        lazy_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         aggregator = Aggregator('', None, lazy_func=lazy_func)
         aggregator.lazy_aggregate(data, axis)
         lazy_func.assert_called_once_with(data, axis)
 
     def test_kwarg_pass_through_call_kwargs(self):
-        lazy_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        lazy_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         kwargs = dict(wibble='wobble', foo='bar')
         aggregator = Aggregator('', None, lazy_func=lazy_func)
         aggregator.lazy_aggregate(data, axis, **kwargs)
         lazy_func.assert_called_once_with(data, axis, **kwargs)
 
     def test_kwarg_pass_through_init_kwargs(self):
-        lazy_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        lazy_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         kwargs = dict(wibble='wobble', foo='bar')
         aggregator = Aggregator('', None, lazy_func=lazy_func, **kwargs)
         aggregator.lazy_aggregate(data, axis)
         lazy_func.assert_called_once_with(data, axis, **kwargs)
 
     def test_kwarg_pass_through_combined_kwargs(self):
-        lazy_func = Mock()
-        data = sentinel.data
-        axis = sentinel.axis
+        lazy_func = mock.Mock()
+        data = mock.sentinel.data
+        axis = mock.sentinel.axis
         init_kwargs = dict(wibble='wobble', var=1.0)
         call_kwargs = dict(foo='foo', var=0.5)
         aggregator = Aggregator('', None, lazy_func=lazy_func, **init_kwargs)

--- a/lib/iris/tests/unit/analysis/test_AreaWeighted.py
+++ b/lib/iris/tests/unit/analysis/test_AreaWeighted.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.analysis import AreaWeighted
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.analysis import Linear
+from iris.tests import mock
 
 
 def create_scheme(mode=None):

--- a/lib/iris/tests/unit/analysis/test_Nearest.py
+++ b/lib/iris/tests/unit/analysis/test_Nearest.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.analysis import Nearest
+from iris.tests import mock
 
 
 def create_scheme(mode=None):

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -26,20 +26,20 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from mock import sentinel
 import numpy as np
 
 from iris.analysis import PercentileAggregator, _percentile
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):
     def test_init(self):
         name = 'percentile'
         call_func = _percentile
-        units_func = sentinel.units_func
-        lazy_func = sentinel.lazy_func
+        units_func = mock.sentinel.units_func
+        lazy_func = mock.sentinel.lazy_func
         aggregator = PercentileAggregator(units_func=units_func,
                                           lazy_func=lazy_func)
         self.assertEqual(aggregator.name(), name)

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import biggus
 import numpy as np
 import numpy.ma as ma
@@ -32,6 +30,7 @@ import numpy.ma as ma
 from iris.analysis import VARIANCE
 import iris.cube
 from iris.coords import DimCoord
+from iris.tests import mock
 
 
 class Test_units_func(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
@@ -26,20 +26,20 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from mock import sentinel
 import numpy as np
 
 from iris.analysis import WeightedPercentileAggregator, _weighted_percentile
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):
     def test_init(self):
         name = 'weighted_percentile'
         call_func = _weighted_percentile
-        units_func = sentinel.units_func
-        lazy_func = sentinel.lazy_func
+        units_func = mock.sentinel.units_func
+        lazy_func = mock.sentinel.lazy_func
         aggregator = WeightedPercentileAggregator(units_func=units_func,
                                                   lazy_func=lazy_func)
         self.assertEqual(aggregator.name(), name)

--- a/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 import iris
 from iris.aux_factory import HybridPressureFactory
+from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 from iris.aux_factory import OceanSFactory
 from iris.coords import AuxCoord, DimCoord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 from iris.aux_factory import OceanSg1Factory
 from iris.coords import AuxCoord, DimCoord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 from iris.aux_factory import OceanSg2Factory
 from iris.coords import AuxCoord, DimCoord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 from iris.aux_factory import OceanSigmaFactory
 from iris.coords import AuxCoord, DimCoord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 from iris.aux_factory import OceanSigmaZFactory
 from iris.coords import AuxCoord, DimCoord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
+++ b/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
@@ -23,13 +23,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.coord_categorisation import add_categorised_coord
 from iris.coord_categorisation import add_day_of_year
 from iris.cube import Cube
 from iris.coords import DimCoord
+from iris.tests import mock
 from iris.unit import CALENDARS as calendars
 from iris.unit import Unit
 

--- a/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
+++ b/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
@@ -18,7 +18,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import mock
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -27,6 +26,7 @@ import iris.tests as tests
 import cartopy
 import cartopy.crs as ccrs
 from iris.coord_systems import GeogCS, RotatedGeogCS
+from iris.tests import mock
 
 
 class Test_init(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -25,10 +25,10 @@ import iris.tests as tests
 
 import datetime
 
-import mock
 import netcdftime
 
 from iris.coords import Cell
+from iris.tests import mock
 from iris.time import PartialDateTime
 
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -25,10 +25,10 @@ import iris.tests as tests
 
 import collections
 
-import mock
 import numpy as np
 
 from iris.coords import DimCoord, AuxCoord, Coord
+from iris.tests import mock
 
 
 Pair = collections.namedtuple('Pair', 'points bounds')

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -24,7 +24,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import biggus
-import mock
 import numpy as np
 import numpy.ma as ma
 
@@ -37,6 +36,7 @@ from iris.analysis import MEAN
 from iris.cube import Cube
 from iris.coords import AuxCoord, DimCoord
 from iris.exceptions import CoordinateNotFoundError
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
+++ b/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
@@ -23,7 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import netcdftime
 
 from iris.experimental.fieldsfile \
@@ -33,6 +32,7 @@ import iris.coord_systems
 import iris.coords
 import iris.fileformats.pp
 import iris.fileformats.rules
+from iris.tests import mock
 import iris.unit
 
 

--- a/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_PointInCell.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.experimental.regrid import PointInCell
+from iris.tests import mock
 
 
 class Test_regridder(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
@@ -23,10 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.experimental.regrid import _CurvilinearRegridder as Regridder
+from iris.tests import mock
 from iris.tests.stock import global_pp, lat_lon_cube
 
 

--- a/lib/iris/tests/unit/experimental/um/test_Field.py
+++ b/lib/iris/tests/unit/experimental/um/test_Field.py
@@ -26,10 +26,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.experimental.um import Field
+from iris.tests import mock
 
 
 class Test_int_headers(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
+++ b/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.abf import ABFField
+from iris.tests import mock
 
 
 class MethodCounter(object):

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -26,12 +26,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import numpy as np
 
 import iris
 from iris.fileformats.cf import CFReader
+from iris.tests import mock
 
 
 def netcdf_variable(name, dimensions, dtype, ancillary_variables=None,

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -26,15 +26,14 @@ import iris.tests as tests
 
 import contextlib
 import copy
-import mock
 import numpy as np
 import warnings
 
 from iris.exceptions import NotYetImplementedError
 import iris.fileformats.ff as ff
 import iris.fileformats.pp as pp
-
 from iris.fileformats.ff import FF2PP
+from iris.tests import mock
 
 
 class Test____iter__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -73,8 +74,12 @@ class Test__extract_field__LBC_format(tests.IrisTest):
         grid.vectors = mock.Mock(return_value=(x, y))
         ff2pp._ff_header.grid = mock.Mock(return_value=grid)
 
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         with mock.patch('numpy.fromfile', return_value=[0]), \
-                mock.patch('__builtin__.open'), \
+                mock.patch(open_func), \
                 mock.patch('struct.unpack_from', return_value=[4]), \
                 mock.patch('iris.fileformats.pp.make_pp_field',
                            side_effect=fields), \

--- a/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
@@ -25,9 +25,9 @@ import iris.tests as tests
 
 import collections
 import numpy as np
-import mock
 
 from iris.fileformats.ff import FFHeader
+from iris.tests import mock
 
 
 MyGrid = collections.namedtuple('MyGrid', 'column row real horiz_grid_type')

--- a/lib/iris/tests/unit/fileformats/ff/test_Grid.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_Grid.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.ff import Grid
+from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/__init__.py
@@ -19,9 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import mock
-
 from iris.fileformats.grib._message import _GribMessage
+from iris.tests import mock
 
 
 def _make_test_message(sections):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_convert.py
@@ -23,10 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.exceptions import TranslationError
 from iris.fileformats.grib._load_convert import convert
+from iris.tests import mock
 from iris.tests.unit.fileformats.grib import _make_test_message
 
 

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_data_cutoff.py
@@ -26,11 +26,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.grib._load_convert import _MDI as MDI
-
 from iris.fileformats.grib._load_convert import data_cutoff
+from iris.tests import mock
 
 
 class TestDataCutoff(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grib2_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grib2_convert.py
@@ -24,10 +24,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import copy
-import mock
 
 import iris
 from iris.fileformats.grib._load_convert import grib2_convert
+from iris.tests import mock
 from iris.tests.unit.fileformats.grib import _make_test_message
 
 

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_4_and_5.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_4_and_5.py
@@ -30,13 +30,13 @@ import iris.tests as tests
 from copy import deepcopy
 import warnings
 
-import mock
 import numpy as np
 
 from iris.coords import DimCoord
 from iris.fileformats.grib._load_convert import \
     grid_definition_template_4_and_5, \
     _MDI as MDI
+from iris.tests import mock
 
 
 RESOLUTION = 1e6

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_5.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_grid_definition_template_5.py
@@ -29,9 +29,8 @@ import iris.tests as tests
 
 from copy import deepcopy
 
-import mock
-
 from iris.fileformats.grib._load_convert import grid_definition_template_5
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_0.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_0.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 import iris.coords
 from iris.tests.unit.fileformats.grib.load_convert import (LoadConvertTest,
                                                            empty_metadata)
 from iris.fileformats.grib._load_convert import product_definition_template_0
+from iris.tests import mock
 
 
 MDI = 0xffffffff

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_1.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_1.py
@@ -30,10 +30,9 @@ import iris.tests as tests
 from copy import deepcopy
 import warnings
 
-import mock
-
 from iris.coords import DimCoord
 from iris.fileformats.grib._load_convert import product_definition_template_1
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_31.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_31.py
@@ -29,11 +29,11 @@ import iris.tests as tests
 from copy import deepcopy
 import warnings
 
-import mock
 import numpy as np
 
 from iris.coords import AuxCoord
 from iris.fileformats.grib._load_convert import product_definition_template_31
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_8.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_8.py
@@ -27,9 +27,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.grib._load_convert import product_definition_template_8
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_9.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_9.py
@@ -27,12 +27,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.exceptions import TranslationError
-
 from iris.fileformats.grib._load_convert import product_definition_template_9
 from iris.fileformats.grib._load_convert import Probability, _MDI
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_forecast_period_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_statistical_forecast_period_coord.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import datetime
-import mock
 
 from iris.fileformats.grib._load_convert import \
     statistical_forecast_period_coord
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_validity_time_coord.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_validity_time_coord.py
@@ -26,11 +26,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.coords import DimCoord
 from iris.fileformats.grib._load_convert import validity_time_coord
+from iris.tests import mock
 from iris.unit import Unit
 
 

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_vertical_coords.py
@@ -27,15 +27,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from copy import deepcopy
-import mock
 
 from iris.coords import DimCoord
 from iris.exceptions import TranslationError
 from iris.fileformats.grib._load_convert import vertical_coords
-
 from iris.fileformats.grib._load_convert import \
     _TYPE_OF_FIXED_SURFACE_MISSING as MISSING_SURFACE, \
     _MDI as MISSING_LEVEL
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_rules/test_convert.py
@@ -24,10 +24,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 import iris
 from iris.fileformats.rules import Reference
+from iris.tests import mock
 from iris.tests.test_grib_load import TestGribSimple
 from iris.tests.unit.fileformats import TestField
 import iris.unit

--- a/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__GribMessage.py
@@ -30,11 +30,11 @@ import iris.tests as tests
 from abc import ABCMeta, abstractmethod
 
 import biggus
-import mock
 import numpy as np
 
 from iris.exceptions import TranslationError
 from iris.fileformats.grib._message import _GribMessage
+from iris.tests import mock
 from iris.tests.unit.fileformats.grib import _make_test_message
 
 

--- a/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
@@ -26,9 +26,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.grib._message import _MessageLocation
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/__init__.py
@@ -23,7 +23,7 @@ import iris.tests as tests
 
 import iris
 from iris.fileformats.pp import EARTH_RADIUS as PP_DEFAULT_EARTH_RADIUS
-import mock
+from iris.tests import mock
 import numpy as np
 
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test__product_definition_template_8_and_11.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test__product_definition_template_8_and_11.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 from iris.unit import Unit
+from iris.tests import mock
 import iris.tests.stock as stock
 from iris.fileformats.grib._save_rules import \
     _product_definition_template_8_and_11

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
@@ -27,12 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 import iris.cube
 
 from iris.fileformats.grib._save_rules import data_section
+from iris.tests import mock
 
 
 GRIB_API = 'iris.fileformats.grib._save_rules.gribapi'

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_identification.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_identification.py
@@ -24,10 +24,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 import iris.fileformats.grib
 from iris.fileformats.grib._save_rules import identification
+from iris.tests import mock
 import iris.tests.stock as stock
 from iris.tests.test_grib_load import TestGribSimple
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_11.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_11.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 from iris.unit import Unit
+from iris.tests import mock
 import iris.tests.stock as stock
 from iris.fileformats.grib._save_rules import product_definition_template_11
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_8.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_8.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 from iris.unit import Unit
+from iris.tests import mock
 import iris.tests.stock as stock
 from iris.fileformats.grib._save_rules import product_definition_template_8
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_reference_time.py
@@ -24,10 +24,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 import iris.fileformats.grib
 from iris.fileformats.grib._save_rules import reference_time
+from iris.tests import mock
 import iris.tests.stock as stock
 from iris.tests.test_grib_load import TestGribSimple
 

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_increment.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_increment.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 from iris.coords import CellMethod
 from iris.fileformats.grib._save_rules import set_time_increment
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
@@ -28,11 +28,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import gribapi
-import mock
 
 from iris.coords import DimCoord
 from iris.unit import Unit
 from iris.fileformats.grib._save_rules import set_time_range
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_GribWrapper.py
@@ -27,10 +27,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from biggus import NumpyArrayAdapter
-import mock
 import numpy as np
 
 from iris.fileformats.grib import GribWrapper, GribDataProxy
+from iris.tests import mock
 
 _message_length = 1000
 

--- a/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
@@ -21,13 +21,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 
-import mock
-
 import gribapi
 
 import iris
 from iris.coords import DimCoord
 import iris.fileformats.grib as grib
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_pairs.py
@@ -21,13 +21,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 
-import mock
-
 import gribapi
 
 import iris
 from iris.coords import DimCoord
 import iris.fileformats.grib as grib
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -21,14 +21,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 
-import mock
-
 import iris
 import iris.fileformats.grib
 import iris.fileformats.grib.load_rules
 import iris.fileformats.rules
 
 from iris.fileformats.grib import load_cubes
+from iris.tests import mock
 
 
 class TestToggle(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
@@ -25,11 +25,10 @@ import six
 import iris.tests as tests
 
 import gribapi
-import mock
-from mock import call
 import numpy as np
 
 import iris.fileformats.grib as grib
+from iris.tests import mock
 
 
 class TestSaveMessages(tests.IrisTest):
@@ -49,7 +48,7 @@ class TestSaveMessages(tests.IrisTest):
             # this is deemed acceptable within the scope of this unit test
             with self.assertRaises(AssertionError):
                 grib.save_messages([self.grib_message], 'foo.grib2')
-        self.assertTrue(call('foo.grib2', 'wb') in m.mock_calls)
+        self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
         if six.PY3:
@@ -64,7 +63,7 @@ class TestSaveMessages(tests.IrisTest):
             with self.assertRaises(AssertionError):
                 grib.save_messages([self.grib_message], 'foo.grib2',
                                    append=True)
-        self.assertTrue(call('foo.grib2', 'ab') in m.mock_calls)
+        self.assertTrue(mock.call('foo.grib2', 'ab') in m.mock_calls)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -37,8 +38,12 @@ class TestSaveMessages(tests.IrisTest):
         self.grib_message = gribapi.grib_new_from_samples("GRIB2")
 
     def test_save(self):
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch('__builtin__.open', m, create=True):
+        with mock.patch(open_func, m, create=True):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test
@@ -47,8 +52,12 @@ class TestSaveMessages(tests.IrisTest):
         self.assertTrue(call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch('__builtin__.open', m, create=True):
+        with mock.patch(open_func, m, create=True):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
@@ -26,11 +26,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 
 import iris.coords
-
 from iris.fileformats.name_loaders import _build_cell_methods
+from iris.tests import mock
 
 
 class Tests(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__generate_cubes.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__generate_cubes.py
@@ -26,10 +26,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import iris.cube
 from iris.fileformats.name_loaders import _generate_cubes, NAMECoord
+from iris.tests import mock
 
 
 class TestCellMethods(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -24,7 +24,6 @@ import six
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import netCDF4 as nc
 import numpy as np
 
@@ -33,6 +32,7 @@ from iris.coord_systems import GeogCS, TransverseMercator, RotatedGeogCS
 from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import Saver
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -23,13 +23,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 import warnings
 
 from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import _load_aux_factory
+from iris.tests import mock
 
 
 class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -23,13 +23,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import netCDF4
 import numpy as np
 
 from iris.coords import DimCoord
 import iris.fileformats.cf
 from iris.fileformats.netcdf import _load_cube
+from iris.tests import mock
 
 
 class TestFillValue(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.nimrod_load_rules import (tm_meridian_scaling,
                                                 NIMROD_DEFAULT,
                                                 MERIDIAN_SCALING_BNG)
 from iris.fileformats.nimrod import NimrodField
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
@@ -27,12 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.nimrod_load_rules import (vertical_coord,
                                                 NIMROD_DEFAULT,
                                                 TranslationWarning)
 from iris.fileformats.nimrod import NimrodField
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.pp import PPDataProxy, SplittableInt
+from iris.tests import mock
 
 
 class Test_lbpack(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -23,12 +23,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 import iris.fileformats.pp as pp
 from iris.fileformats.pp import PPField
 from iris.fileformats.pp import SplittableInt
+from iris.tests import mock
 
 # The PPField class is abstract, so to test we define a minimal,
 # concrete subclass with the `t1` and `t2` properties.

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.pp import _LBProc
+from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
@@ -23,11 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import iris
 from iris.fileformats.pp import _convert_constraints
 from iris.fileformats.pp import STASH
+from iris.tests import mock
 
 
 class Test_convert_constraints(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -24,9 +24,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import biggus
-import mock
 
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 class Test__create_field_data(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -28,10 +28,10 @@ import iris.tests as tests
 
 import io
 
-import mock
 import numpy as np
 
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 class Test__data_bytes_to_shaped_array__lateral_boundary_compression(

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -47,8 +48,12 @@ class Test(tests.IrisTest):
                 np.fromfile.return_value = []
             return result
 
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         with mock.patch('numpy.fromfile', return_value=[0]), \
-                mock.patch('__builtin__.open'), \
+                mock.patch(open_func), \
                 mock.patch('struct.unpack_from', return_value=[4]), \
                 mock.patch('iris.fileformats.pp.make_pp_field',
                            side_effect=make_pp_field_override):

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -27,10 +27,10 @@ import iris.tests as tests
 import contextlib
 import io
 
-import mock
 import numpy as np
 
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -25,9 +25,8 @@ import iris.tests as tests
 
 from copy import deepcopy
 
-import mock
-
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 class Test__interpret_fields__land_packed_fields(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -23,11 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.coords import DimCoord
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_pairs.py
@@ -23,11 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.coords import DimCoord
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test_load.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_load.py
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 class Test_load(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -23,11 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.coords import DimCoord
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
+from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -44,15 +45,23 @@ class TestSaveFields(tests.IrisTest):
         self.pp_field.save = asave
 
     def test_save(self):
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch('__builtin__.open', m, create=True):
+        with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], 'foo.pp')
         self.assertTrue(call('foo.pp', 'wb') in m.mock_calls)
         self.assertTrue(call().write('saved') in m.mock_calls)
 
     def test_save_append(self):
+        if six.PY3:
+            open_func = 'builtins.open'
+        else:
+            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch('__builtin__.open', m, create=True):
+        with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], 'foo.pp', append=True)
         self.assertTrue(call('foo.pp', 'ab') in m.mock_calls)
         self.assertTrue(call().write('saved') in m.mock_calls)

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -24,11 +24,10 @@ import six
 # importing anything else.
 import iris.tests as tests
 
-import mock
-from mock import call
 import numpy as np
 
 import iris.fileformats.pp as pp
+from iris.tests import mock
 
 
 def asave(afilehandle):
@@ -52,8 +51,8 @@ class TestSaveFields(tests.IrisTest):
         m = mock.mock_open()
         with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], 'foo.pp')
-        self.assertTrue(call('foo.pp', 'wb') in m.mock_calls)
-        self.assertTrue(call().write('saved') in m.mock_calls)
+        self.assertTrue(mock.call('foo.pp', 'wb') in m.mock_calls)
+        self.assertTrue(mock.call().write('saved') in m.mock_calls)
 
     def test_save_append(self):
         if six.PY3:
@@ -63,8 +62,8 @@ class TestSaveFields(tests.IrisTest):
         m = mock.mock_open()
         with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], 'foo.pp', append=True)
-        self.assertTrue(call('foo.pp', 'ab') in m.mock_calls)
-        self.assertTrue(call().write('saved') in m.mock_calls)
+        self.assertTrue(mock.call('foo.pp', 'ab') in m.mock_calls)
+        self.assertTrue(mock.call().write('saved') in m.mock_calls)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__all_other_rules.py
@@ -23,12 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import iris
 from iris.fileformats.pp_rules import _all_other_rules
 from iris.fileformats.pp import SplittableInt
 from iris.coords import CellMethod
+from iris.tests import mock
 
 
 # iris.fileformats.pp._all_other_rules() returns a tuple of

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_time_coords.py
@@ -27,13 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 from netcdftime import datetime as nc_datetime
 import numpy as np
 
 from iris.coords import DimCoord, AuxCoord
 from iris.fileformats.pp import SplittableInt
 from iris.fileformats.pp_rules import _convert_time_coords
+from iris.tests import mock
 from iris.tests.unit.fileformats import TestField
 from iris.unit import Unit, CALENDAR_GREGORIAN
 

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -26,7 +26,6 @@ import iris.tests as tests
 
 import types
 
-import mock
 import numpy as np
 
 from iris.fileformats.pp_rules import convert
@@ -34,6 +33,7 @@ from iris.util import guess_coord_axis
 from iris.fileformats.pp import SplittableInt
 from iris.fileformats.pp import STASH
 from iris.fileformats.pp import PPField3
+from iris.tests import mock
 import iris.tests.unit.fileformats
 import iris.unit
 

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -154,7 +155,7 @@ class TestLBTIM(iris.tests.unit.fileformats.TestField):
                            lbyr=2013, lbmon=1, lbdat=1, lbhr=12, lbmin=0,
                            lbsec=0,
                            spec=PPField3)
-        f.time_unit = types.MethodType(PPField3.time_unit, f)
+        f.time_unit = six.create_bound_method(PPField3.time_unit, f)
         f.calendar = iris.unit.CALENDAR_365_DAY
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test__parse_cell_methods.py
@@ -27,11 +27,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
-import mock
-
 from iris.coords import CellMethod
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     _parse_cell_methods
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -28,11 +28,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import mock
 
 from iris.coords import AuxCoord
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_auxiliary_coordinate
+from iris.tests import mock
 
 
 class TestBoundsVertexDim(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
@@ -28,11 +28,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import mock
 
 from iris.cube import Cube
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_cube_metadata
+from iris.tests import mock
 
 
 class TestInvalidGlobalAttributes(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -30,11 +30,11 @@ import iris.tests as tests
 import warnings
 
 import numpy as np
-import mock
 
 from iris.coords import AuxCoord, DimCoord
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_dimension_coordinate
+from iris.tests import mock
 
 
 class RulesTestMixin(object):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
@@ -28,10 +28,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import mock
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     get_attr_units
+from iris.tests import mock
 
 
 class TestGetAttrUnits(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -28,11 +28,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import mock
 
 from iris.aux_factory import LazyArray
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     reorder_bounds_data
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -23,10 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.rules import _make_cube
 import iris.fileformats.rules
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
@@ -27,13 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 import iris
-
 from iris.fileformats.um._fast_load_structured_fields import \
     group_structured_fields
+from iris.tests import mock
 
 
 def _convert_to_vector(value, length, default):

--- a/lib/iris/tests/unit/io/test_run_callback.py
+++ b/lib/iris/tests/unit/io/test_run_callback.py
@@ -23,9 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import iris.exceptions
 import iris.io
+from iris.tests import mock
 
 
 class Test_run_callback(tests.IrisTest):

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -26,7 +26,6 @@ import iris.tests as tests
 
 import abc
 
-import mock
 import numpy as np
 import numpy.ma as ma
 
@@ -35,6 +34,7 @@ from iris._merge import ProtoCube
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import DimCoord, AuxCoord
 from iris.exceptions import MergeError
+from iris.tests import mock
 
 
 def example_cube():

--- a/lib/iris/tests/unit/merge/test__CubeSignature.py
+++ b/lib/iris/tests/unit/merge/test__CubeSignature.py
@@ -23,11 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 import iris.exceptions
 from iris._merge import _CubeSignature as CubeSig
+from iris.tests import mock
 
 
 class Test_match__fill_value(tests.IrisTest):

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -27,9 +27,9 @@ import iris.tests as tests
 import datetime
 import operator
 
-import mock
 import netcdftime
 
+from iris.tests import mock
 from iris.time import PartialDateTime
 
 


### PR DESCRIPTION
Several builtins have changed names or semantics and require a bit of special handling.
 * `x.next()` -> `next(x)`
 * `div` -> `truediv`, `__and__` -> `and_`
 * nested contexts
 * `namedtuple.__init__` -> `namedtuple.__new__`
 * Rename of builtin package
 * Formatting of floats (see SciTools/cartopy#426)
 * `mock` -> `unittest.mock`