### PR TITLE
Python 3 exceptions/warnings

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -275,7 +275,7 @@ def _load_collection(uris, constraints=None, callback=None):
         result = iris.cube._CubeFilterCollection.from_cubes(cubes, constraints)
     except EOFError as e:
         raise iris.exceptions.TranslationError(
-            "The file appears empty or incomplete: {!r}".format(e.message))
+            "The file appears empty or incomplete: {!r}".format(str(e)))
     return result
 
 

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -762,7 +762,7 @@ class HybridPressureFactory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)
@@ -1006,7 +1006,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)
@@ -1181,7 +1181,7 @@ class OceanSigmaFactory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)
@@ -1380,7 +1380,7 @@ class OceanSg1Factory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)
@@ -1579,7 +1579,7 @@ class OceanSFactory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)
@@ -1779,7 +1779,7 @@ class OceanSg2Factory(AuxCoordFactory):
                 try:
                     self._check_dependencies(**new_dependencies)
                 except ValueError as e:
-                    msg = 'Failed to update dependencies. ' + e.message
+                    msg = 'Failed to update dependencies. ' + str(e)
                     raise ValueError(msg)
                 else:
                     setattr(self, name, new_coord)

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -922,7 +922,7 @@ fc_extras
                     cube.attributes[str(attr_name)] = attr_value
             except ValueError as e:
                 msg = 'Skipping global attribute {!r}: {}'
-                warnings.warn(msg.format(attr_name, e.message))
+                warnings.warn(msg.format(attr_name, str(e)))
 
 
 

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1034,7 +1034,10 @@ fc_extras
         # Using converted unicode message. Can be reverted with Python 3.
             msg = u'Ignoring netCDF variable {!r} invalid units {!r}'.format(
                 cf_var.cf_name, attr_units)
-            warnings.warn(msg.encode('ascii', errors='backslashreplace'))
+            if six.PY3:
+                warnings.warn(msg)
+            else:
+                warnings.warn(msg.encode('ascii', errors='backslashreplace'))
             attributes['invalid_units'] = attr_units
             attr_units = iris.unit._UNKNOWN_UNIT_STRING
 

--- a/lib/iris/fileformats/grib/_save_rules.py
+++ b/lib/iris/fileformats/grib/_save_rules.py
@@ -506,7 +506,7 @@ def grid_definition_section(cube, grib):
 
     else:
         raise ValueError('Grib saving is not supported for coordinate system: '
-                         '{:s}'.format(cs))
+                         '{}'.format(cs))
 
 
 ###############################################################################

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1835,7 +1835,7 @@ def _field_gen(filename, read_data_bytes):
             except ValueError as e:
                 msg = 'Unable to interpret field {}. {}. Skipping ' \
                       'the remainder of the file.'.format(field_count,
-                                                          e.message)
+                                                          str(e))
                 warnings.warn(msg)
                 break
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -831,7 +831,7 @@ def load_cubes(filenames, user_callback, loader, filter_function=None):
                 args = _dereference_args(factory, concrete_reference_targets,
                                          regrid_cache, cube)
             except _ReferenceError as e:
-                msg = 'Unable to create instance of {factory}. ' + e.message
+                msg = 'Unable to create instance of {factory}. ' + str(e)
                 factory_name = factory.factory_class.__name__
                 warnings.warn(msg.format(filenames=filenames,
                                          factory=factory_name))

--- a/lib/iris/tests/test_load.py
+++ b/lib/iris/tests/test_load.py
@@ -45,8 +45,8 @@ class TestLoad(tests.IrisTest):
         )
         with self.assertRaises(IOError) as error_trap:
             cubes = iris.load(paths)
-        self.assertTrue(error_trap.exception.message.startswith(
-            'One or more of the files specified did not exist'))
+        self.assertIn('One or more of the files specified did not exist',
+                      str(error_trap.exception))
 
     def test_nonexist_wild(self):
         paths = (
@@ -55,8 +55,8 @@ class TestLoad(tests.IrisTest):
         )
         with self.assertRaises(IOError) as error_trap:
             cubes = iris.load(paths)
-        self.assertTrue(error_trap.exception.message.startswith(
-            'One or more of the files specified did not exist'))
+        self.assertIn('One or more of the files specified did not exist',
+                      str(error_trap.exception))
 
     def test_bogus(self):
         paths = (

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_set_time_range.py
@@ -22,10 +22,13 @@ Unit tests for
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+
+import warnings
 
 import gribapi
 import mock
@@ -88,11 +91,13 @@ class Test(tests.IrisTest):
         lower = 10.0
         upper = 20.9
         self.coord.bounds = [lower, upper]
-        with mock.patch('warnings.warn') as warn:
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always")
             set_time_range(self.coord, mock.sentinel.grib)
-        msg = 'Truncating floating point lengthOfTimeRange 10.9 ' \
+        self.assertEqual(len(warn), 1)
+        msg = 'Truncating floating point lengthOfTimeRange 10\.8?9+ ' \
               'to integer value 10'
-        warn.assert_called_once_with(msg)
+        six.assertRegex(self, str(warn[0].message), msg)
         mock_set_long.assert_any_call(mock.sentinel.grib,
                                       'indicatorOfUnitForTimeRange', 1)
         mock_set_long.assert_any_call(mock.sentinel.grib,

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -107,7 +107,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
             self.assertEqual(len(warn), 1)
             msg = 'Ignoring atmosphere hybrid sigma pressure scalar ' \
                 'coordinate {!r} bounds.'.format(coord_p0.name())
-            self.assertEqual(msg, warn[0].message.message)
+            self.assertEqual(msg, str(warn[0].message))
 
     def test_formula_terms_ap_missing_coords(self):
         coordinates = [(mock.sentinel.b, 'b'), (mock.sentinel.ps, 'ps')]

--- a/lib/iris/tests/unit/io/test_run_callback.py
+++ b/lib/iris/tests/unit/io/test_run_callback.py
@@ -71,7 +71,9 @@ class Test_run_callback(tests.IrisTest):
         def callback(cube):
             pass
         with self.assertRaisesRegexp(TypeError,
-                                     'takes exactly 1 argument '):
+                                     # exactly == Py2, positional == Py3
+                                     'takes (exactly )?1 (positional )?'
+                                     'argument '):
             iris.io.run_callback(callback, None, None, None)
 
     def test_callback_args(self):

--- a/lib/iris/tests/unit/unit/test_suppress_unit_warnings.py
+++ b/lib/iris/tests/unit/unit/test_suppress_unit_warnings.py
@@ -40,7 +40,7 @@ class Test(tests.IrisTest):
                 warnings.warn(unit_warning)
                 warnings.warn(example_warning)
         # Get to the actual warning strings for testing purposes.
-        filtered_warnings_list = [w.message.message for w in filtered_warnings]
+        filtered_warnings_list = [str(w.message) for w in filtered_warnings]
         self.assertNotIn(unit_warning, filtered_warnings_list)
         self.assertIn(example_warning, filtered_warnings_list)
 
@@ -50,7 +50,7 @@ class Test(tests.IrisTest):
         with warnings.catch_warnings(record=True) as filtered_warnings:
             with suppress_unit_warnings():
                 iris.load(test_filename)
-        filtered_warnings_list = [w.message.message for w in filtered_warnings]
+        filtered_warnings_list = [str(w.message) for w in filtered_warnings]
         self.assertEqual(len(filtered_warnings_list), 0)
 
 

--- a/lib/iris/tests/unit/util/test_file_is_newer_than.py
+++ b/lib/iris/tests/unit/util/test_file_is_newer_than.py
@@ -121,14 +121,14 @@ class TestFileIsNewer(tests.IrisTest):
     def test_error_missing_source(self):
         with self.assertRaises(IOError) as error_trap:
             self._test(False, 'example_result', ['older_sour*', 'non_exist'])
-        self.assertTrue(error_trap.exception.message.startswith(
-            'One or more of the files specified did not exist'))
+        self.assertIn('One or more of the files specified did not exist',
+                      str(error_trap.exception))
 
     def test_error_missing_wild(self):
         with self.assertRaises(IOError) as error_trap:
             self._test(False, 'example_result', ['older_sour*', 'unknown_*'])
-        self.assertTrue(error_trap.exception.message.startswith(
-            'One or more of the files specified did not exist'))
+        self.assertIn('One or more of the files specified did not exist',
+                      str(error_trap.exception))
 
 
 if __name__ == '__main__':

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1505,7 +1505,7 @@ def promote_aux_coord_to_dim_coord(cube, name_or_coord):
         msg = ("Attempt to promote an AuxCoord ({}) fails "
                "when attempting to create a DimCoord from the "
                "AuxCoord because: {}")
-        msg = msg.format(aux_coord.name(), valerr.message)
+        msg = msg.format(aux_coord.name(), str(valerr))
         raise ValueError(msg)
 
     old_dim_coord = cube.coords(dim_coords=True,


### PR DESCRIPTION
Some exception text has changed and both exceptions and warnings no longer have a `message` attribute.