### PR TITLE
Python 3 hashing

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -146,6 +146,9 @@ class _CoordMetaData(namedtuple('CoordMetaData',
                                                       kwargs)
         return metadata
 
+    def __hash__(self):
+        return super(_CoordMetaData, self).__hash__()
+
     def __eq__(self, other):
         result = NotImplemented
         if isinstance(other, _CoordMetaData):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -210,6 +210,9 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
             bound = tuple([val + mod for val in bound])
         return Cell(point, bound)
 
+    def __hash__(self):
+        return super(Cell, self).__hash__()
+
     def __eq__(self, other):
         """
         Compares Cell equality depending on the type of the object to be

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1394,6 +1394,11 @@ class DimCoord(Coord):
 
     # The __ne__ operator from Coord implements the not __eq__ method.
 
+    # This is necessary for merging, but probably shouldn't be used otherwise.
+    # See #962 and #1772.
+    def __hash__(self):
+        return hash(id(self))
+
     def __getitem__(self, key):
         coord = super(DimCoord, self).__getitem__(key)
         coord.circular = self.circular and coord.shape == self.shape
@@ -1594,6 +1599,11 @@ class AuxCoord(Coord):
                 raise ValueError("Bounds shape must be compatible with points "
                                  "shape.")
         self._bounds = bounds
+
+    # This is necessary for merging, but probably shouldn't be used otherwise.
+    # See #962 and #1772.
+    def __hash__(self):
+        return hash(id(self))
 
 
 class CellMethod(iris.util._OrderedHashable):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2736,6 +2736,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             result = not result
         return result
 
+    # Must supply __hash__, Python 3 does not enable it if __eq__ is defined
+    # This is necessary for merging, but probably shouldn't be used otherwise.
+    # See #962 and #1772.
+    def __hash__(self):
+        return hash(id(self))
+
     def __add__(self, other):
         return iris.analysis.maths.add(self, other, ignore=True)
     __radd__ = __add__

--- a/lib/iris/fileformats/_structured_array_identification.py
+++ b/lib/iris/fileformats/_structured_array_identification.py
@@ -110,6 +110,9 @@ class ArrayStructure(namedtuple('ArrayStructure',
         self.size = len(unique_ordered_values)
         return self
 
+    def __hash__(self):
+        return super(ArrayStructure, self).__hash__()
+
     def __eq__(self, other):
         stride = getattr(other, 'stride', None)
         arr = getattr(other, 'unique_ordered_values', None)

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -167,6 +167,10 @@ class CFVariable(six.with_metaclass(ABCMeta, object)):
         # CF variable names are unique.
         return self.cf_name != other.cf_name
 
+    def __hash__(self):
+        # CF variable names are unique.
+        return hash(self.cf_name)
+
     def __getattr__(self, name):
         # Accessing netCDF attributes is surprisingly slow. Since
         # they're often read repeatedly, caching the values makes things

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -344,6 +344,9 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
     def is_valid(self):
         return '?' not in str(self)
 
+    def __hash__(self):
+        return super(STASH, self).__hash__()
+
     def __eq__(self, other):
         if isinstance(other, six.string_types):
             return super(STASH, self).__eq__(STASH.from_msi(other))

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1741,6 +1741,8 @@ class Unit(iris.util._OrderedHashable):
         # iris.util._OrderedHashable.
         return (self.name, self.calendar)
 
+    __hash__ = iris.util._OrderedHashable.__hash__
+
     def __eq__(self, other):
         """
         Compare the two units for equality and return the boolean result.


### PR DESCRIPTION
Several classes must be hashable because they are used as dictionary keys. This is generally implemented as a hash of the same information used for `__eq__`, or if that's not defined, the `id`.