### PR TITLE
Python 3 __dict__ inheritance

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -78,6 +78,8 @@ class _CoordAndDims(namedtuple('CoordAndDims',
 
     """
 
+    __slots__ = ()
+
 
 class _CoordMetaData(namedtuple('CoordMetaData',
                                 ['defn', 'dims', 'points_dtype',
@@ -146,6 +148,8 @@ class _CoordMetaData(namedtuple('CoordMetaData',
                                                       kwargs)
         return metadata
 
+    __slots__ = ()
+
     def __hash__(self):
         return super(_CoordMetaData, self).__hash__()
 
@@ -197,6 +201,8 @@ class _SkeletonCube(namedtuple('SkeletonCube',
 
     """
 
+    __slots__ = ()
+
 
 class _Extent(namedtuple('Extent',
                          ['min', 'max'])):
@@ -212,6 +218,8 @@ class _Extent(namedtuple('Extent',
         The maximum value of the extent.
 
     """
+
+    __slots__ = ()
 
 
 class _CoordExtent(namedtuple('CoordExtent',
@@ -231,6 +239,8 @@ class _CoordExtent(namedtuple('CoordExtent',
         bounds exist for the coordinate.
 
     """
+
+    __slots__ = ()
 
 
 def concatenate(cubes, error_on_mismatch=False):

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -67,6 +67,8 @@ class _Template(namedtuple('Template',
 
     """
 
+    __slots__ = ()
+
 
 class _CoordMetaData(namedtuple('CoordMetaData',
                                 ['points_dtype', 'bounds_dtype', 'kwargs'])):
@@ -88,6 +90,8 @@ class _CoordMetaData(namedtuple('CoordMetaData',
 
     """
 
+    __slots__ = ()
+
 
 class _CoordAndDims(namedtuple('CoordAndDims',
                                ['coord', 'dims'])):
@@ -105,6 +109,8 @@ class _CoordAndDims(namedtuple('CoordAndDims',
         A tuple of the data dimension/s spanned by the coordinate.
 
     """
+
+    __slots__ = ()
 
 
 class _ScalarCoordPayload(namedtuple('ScalarCoordPayload',
@@ -133,6 +139,8 @@ class _ScalarCoordPayload(namedtuple('ScalarCoordPayload',
 
     """
 
+    __slots__ = ()
+
 
 class _VectorCoordPayload(namedtuple('VectorCoordPayload',
                                      ['dim_coords_and_dims',
@@ -157,6 +165,8 @@ class _VectorCoordPayload(namedtuple('VectorCoordPayload',
 
     """
 
+    __slots__ = ()
+
 
 class _CoordPayload(namedtuple('CoordPayload',
                                ['scalar', 'vector', 'factory_defns'])):
@@ -180,6 +190,9 @@ class _CoordPayload(namedtuple('CoordPayload',
         A list of :class:`_FactoryDefn` instances.
 
     """
+
+    __slots__ = ()
+
     def as_signature(self):
         """Construct and return a :class:`_CoordSignature` from the payload."""
 
@@ -297,6 +310,8 @@ class _CoordSignature(namedtuple('CoordSignature',
 
     """
 
+    __slots__ = ()
+
 
 class _CubeSignature(namedtuple('CubeSignature',
                                 ['defn', 'data_shape', 'data_type',
@@ -321,6 +336,9 @@ class _CubeSignature(namedtuple('CubeSignature',
         or None if no such value exists.
 
     """
+
+    __slots__ = ()
+
     def _defn_msgs(self, other_defn):
         msgs = []
         self_defn = self.defn
@@ -423,6 +441,8 @@ class _Skeleton(namedtuple('Skeleton',
 
     """
 
+    __slots__ = ()
+
 
 class _FactoryDefn(namedtuple('_FactoryDefn',
                               ['class_', 'dependency_defns'])):
@@ -439,6 +459,8 @@ class _FactoryDefn(namedtuple('_FactoryDefn',
         corresponding coordinate definition. Sorted on dependency key.
 
     """
+
+    __slots__ = ()
 
 
 class _Relation(namedtuple('Relation',
@@ -457,6 +479,8 @@ class _Relation(namedtuple('Relation',
         A set of dependent candidate dimension names.
 
     """
+
+    __slots__ = ()
 
 
 _COMBINATION_JOIN = '-'

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -55,6 +55,9 @@ class CoordDefn(collections.namedtuple('CoordDefn',
     :class:`AuxCoord` based on its metadata.
 
     """
+
+    __slots__ = ()
+
     def name(self, default='unknown'):
         """
         Returns a human-readable name.
@@ -120,6 +123,8 @@ class CoordExtent(collections.namedtuple('_CoordExtent', ['name_or_coord',
         return super(CoordExtent, cls).__new__(cls, name_or_coord, minimum,
                                                maximum, min_inclusive,
                                                max_inclusive)
+
+    __slots__ = ()
 
 
 # Coordinate cell styles. Used in plot and cartography.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -67,6 +67,9 @@ class CubeMetadata(collections.namedtuple('CubeMetadata',
     Represents the phenomenon metadata for a single :class:`Cube`.
 
     """
+
+    __slots__ = ()
+
     def name(self, default='unknown'):
         """
         Returns a human-readable name.

--- a/lib/iris/fileformats/_structured_array_identification.py
+++ b/lib/iris/fileformats/_structured_array_identification.py
@@ -105,10 +105,18 @@ class ArrayStructure(namedtuple('ArrayStructure',
     def __new__(cls, stride, unique_ordered_values):
         self = super(ArrayStructure, cls).__new__(cls, stride,
                                                   unique_ordered_values)
-        #: The ``size`` attribute is the number of the unique values in
-        #: the original array. It is **not** the length of the original array.
-        self.size = len(unique_ordered_values)
         return self
+
+    __slots__ = ()
+
+    @property
+    def size(self):
+        """
+        The ``size`` attribute is the number of the unique values in the
+        original array. It is **not** the length of the original array.
+
+        """
+        return len(self.unique_ordered_values)
 
     def __hash__(self):
         return super(ArrayStructure, self).__hash__()

--- a/lib/iris/fileformats/grib/_message.py
+++ b/lib/iris/fileformats/grib/_message.py
@@ -127,6 +127,9 @@ class _GribMessage(object):
 
 class _MessageLocation(namedtuple('_MessageLocation', 'filename offset')):
     """A reference to a specific GRIB message within a file."""
+
+    __slots__ = ()
+
     def __call__(self):
         return _RawGribMessage.from_file_offset(self.filename, self.offset)
 


### PR DESCRIPTION
For whatever reason, the `__dict__` property does not get inherited, so it needs to be re-implemented in a few classes.