### PR TITLE
Py3k compatibility fixes for pp

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1987,7 +1987,7 @@ def _convert_constraints(constraints):
             stashobj = con._attributes['STASH']
             if callable(stashobj):
                 call_func = stashobj
-            elif isinstance(stashobj, (basestring, STASH)):
+            elif isinstance(stashobj, (six.string_types, STASH)):
                 call_func = _make_func(stashobj)
             else:
                 raise TypeError("STASH constraints should be either a"

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1972,10 +1972,10 @@ def _convert_constraints(constraints):
     unhandled_constraints = False
 
     def _make_func(stashobj):
-	"""
-	Provides unique name-space for each lambda function's stashobj
-	variable.
-	"""
+        """
+        Provides unique name-space for each lambda function's stashobj
+        variable.
+        """
         return lambda stash: stash==stashobj
 
     for con in constraints:
@@ -1989,9 +1989,9 @@ def _convert_constraints(constraints):
                 call_func = stashobj
             elif isinstance(stashobj, (basestring, STASH)):
                 call_func = _make_func(stashobj)
-	    else:
-		raise TypeError("STASH constraints should be either a"
-				" callable, string or STASH object")
+            else:
+                raise TypeError("STASH constraints should be either a"
+                                " callable, string or STASH object")
 
             if not 'stash' in pp_constraints:
                 pp_constraints['stash'] = [call_func]


### PR DESCRIPTION
I found some tabs when attempting to install on Python 3. There was also an instance of `basestring`.