### PR TITLE
Py3k consistent unicode handling

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -108,7 +108,7 @@ class CFVariableMixin(object):
             self.long_name = None
         except ValueError:
             self.standard_name = None
-            self.long_name = unicode(name)
+            self.long_name = six.text_type(name)
 
         # Always clear var_name when renaming.
         self.var_name = None

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1361,7 +1361,7 @@ class ProtoCube(object):
                         # string like).
                         dim_by_name[name] = dim = len(self._shape)
                         self._nd_names.append(name)
-                        if metadata[name].points_dtype.kind == 'S':
+                        if metadata[name].points_dtype.kind in 'SU':
                             self._aux_templates.append(
                                 _Template(dim, points, bounds, kwargs))
                         else:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1930,7 +1930,7 @@ class _Groupby(object):
 
         # Create new shared bounded coordinates.
         for coord in self._shared_coords:
-            if coord.points.dtype.kind == 'S':
+            if coord.points.dtype.kind in 'SU':
                 if coord.bounds is None:
                     new_points = []
                     new_bounds = None

--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -79,7 +79,7 @@ def add_categorised_coord(cube, name, from_coord, category_function,
     result = category_function(from_coord, from_coord.points.ravel()[0])
     if isinstance(result, six.string_types):
         str_vectorised_fn = np.vectorize(category_function, otypes=[object])
-        vectorised_fn = lambda *args: str_vectorised_fn(*args).astype('|S64')
+        vectorised_fn = lambda *args: str_vectorised_fn(*args).astype('|U64')
     else:
         vectorised_fn = np.vectorize(category_function)
     new_coord = iris.coords.AuxCoord(vectorised_fn(from_coord,

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -963,10 +963,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 for index in np.ndindex(shape):
                     index_slice = (slice(None),) + tuple(index)
                     bounds.append(serialize(self.bounds[index_slice]))
-                dtype = np.dtype('S{}'.format(max(map(len, bounds))))
+                dtype = np.dtype('U{}'.format(max(map(len, bounds))))
                 bounds = np.array(bounds, dtype=dtype).reshape((1,) + shape)
             points = serialize(self.points)
-            dtype = np.dtype('S{}'.format(len(points)))
+            dtype = np.dtype('U{}'.format(len(points)))
             # Create the new collapsed coordinate.
             coord = self.copy(points=np.array(points, dtype=dtype),
                               bounds=bounds)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1863,7 +1863,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if self.attributes:
                 attribute_lines = []
                 for name, value in sorted(six.iteritems(self.attributes)):
-                    value = iris.util.clip_string(unicode(value))
+                    value = iris.util.clip_string(six.text_type(value))
                     line = u'{pad:{width}}{name}: {value}'.format(pad=' ',
                                                                   width=indent,
                                                                   name=name,
@@ -1893,7 +1893,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         warnings.warn('Cube.assert_valid() has been deprecated.')
 
     def __str__(self):
-        return self.summary().encode(errors='replace')
+        # six has a decorator for this bit, but it doesn't do errors='replace'.
+        if six.PY3:
+            return self.summary()
+        else:
+            return self.summary().encode(errors='replace')
 
     def __unicode__(self):
         return self.summary()

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2306,7 +2306,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Convert a name, coord, or list of names/coords to a list of coords.
         """
         # If not iterable, convert to list of a single item
-        if not hasattr(names_or_coords, '__iter__'):
+        if (not hasattr(names_or_coords, '__iter__') or
+                isinstance(names_or_coords, str)):
             names_or_coords = [names_or_coords]
 
         coords = []
@@ -2352,7 +2353,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         # Required to handle a mix between types.
-        if not hasattr(ref_to_slice, '__iter__'):
+        if (not hasattr(ref_to_slice, '__iter__') or
+                isinstance(ref_to_slice, str)):
             ref_to_slice = [ref_to_slice]
 
         slice_dims = set()
@@ -2412,7 +2414,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             raise TypeError("'ordered' argument to slices must be boolean.")
 
         # Required to handle a mix between types
-        if not hasattr(ref_to_slice, '__iter__'):
+        if (not hasattr(ref_to_slice, '__iter__') or
+                isinstance(ref_to_slice, str)):
             ref_to_slice = [ref_to_slice]
 
         dim_to_slice = []

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -913,7 +913,7 @@ fc_extras
         # Set the cube global attributes. 
         for attr_name, attr_value in six.iteritems(cf_var.cf_group.global_attributes):
             try:
-                if isinstance(attr_value, unicode):
+                if six.PY2 and isinstance(attr_value, six.text_type):
                     try:
                         cube.attributes[str(attr_name)] = str(attr_value)
                     except UnicodeEncodeError:

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -70,6 +70,12 @@ reference_terms = dict(atmosphere_sigma_coordinate=['ps'],
                        ocean_s_coordinate_g2=['eta', 'depth'])
 
 
+# NetCDF returns a different type for strings depending on Python version.
+def _is_str_dtype(var):
+    return ((six.PY2 and np.issubdtype(var.dtype, np.str)) or
+            (six.PY3 and np.issubdtype(var.dtype, np.bytes_)))
+
+
 ################################################################################
 class CFVariable(six.with_metaclass(ABCMeta, object)):
     """Abstract base class wrapper for a CF-netCDF variable."""
@@ -313,7 +319,7 @@ class CFAuxiliaryCoordinateVariable(CFVariable):
                                 warnings.warn(message % (name, nc_var_name))
                         else:
                             # Restrict to non-string type i.e. not a CFLabelVariable.
-                            if not np.issubdtype(variables[name].dtype, np.str):
+                            if not _is_str_dtype(variables[name]):
                                 result[name] = CFAuxiliaryCoordinateVariable(name, variables[name])
 
         return result
@@ -478,7 +484,7 @@ class CFCoordinateVariable(CFVariable):
             if nc_var_name in ignore:
                 continue
             # String variables can't be coordinates
-            if np.issubdtype(nc_var.dtype, np.str):
+            if _is_str_dtype(nc_var):
                 continue
             # Restrict to one-dimensional with name as dimension OR zero-dimensional scalar
             if not ((nc_var.ndim == 1 and nc_var_name in nc_var.dimensions) or (nc_var.ndim == 0)):
@@ -638,8 +644,9 @@ class CFLabelVariable(CFVariable):
                                 warnings.warn(message % (name, nc_var_name))
                         else:
                             # Restrict to only string type.
-                            if np.issubdtype(variables[name].dtype, np.str):
-                                result[name] = CFLabelVariable(name, variables[name])
+                            if _is_str_dtype(variables[name]):
+                                var = variables[name]
+                                result[name] = CFLabelVariable(name, var)
 
         return result
 
@@ -683,7 +690,7 @@ class CFLabelVariable(CFVariable):
 
             # Calculate new label data shape (without string dimension) and create payload array.
             new_shape = tuple(dim_len for i, dim_len in enumerate(self.shape) if i != str_dim)
-            data = np.empty(new_shape, dtype='|S%d' % self.shape[str_dim])
+            data = np.empty(new_shape, dtype='|U%d' % self.shape[str_dim])
 
             for index in np.ndindex(new_shape):
                 # Create the slice for the label data.
@@ -692,7 +699,8 @@ class CFLabelVariable(CFVariable):
                 else:
                     label_index = index + (slice(None, None),)
 
-                data[index] = ''.join(label_data[label_index]).strip()
+                data[index] = b''.join(label_data[label_index]).strip().decode(
+                    'utf8')
 
         return data
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -64,11 +64,13 @@ hindcast_workaround = False
 _load_rules = None
 
 
-CENTRE_TITLES = {'egrr': 'U.K. Met Office - Exeter',
-                 'ecmf': 'European Centre for Medium Range Weather Forecasts',
-                 'rjtd': 'Tokyo, Japan Meteorological Agency',
-                 '55'  : 'San Francisco',
-                 'kwbc': 'US National Weather Service, National Centres for Environmental Prediction'}
+CENTRE_TITLES = {
+    'egrr': u'U.K. Met Office - Exeter',
+    'ecmf': u'European Centre for Medium Range Weather Forecasts',
+    'rjtd': u'Tokyo, Japan Meteorological Agency',
+    '55': u'San Francisco',
+    'kwbc': u'US National Weather Service, National Centres for Environmental '
+            u'Prediction'}
 
 TIME_RANGE_INDICATORS = {0:'none', 1:'none', 3:'time mean', 4:'time sum',
                          5:'time _difference', 10:'none',
@@ -449,7 +451,7 @@ class GribWrapper(object):
         #originating centre
         #TODO #574 Expand to include sub-centre
         self.extra_keys['_originatingCentre'] = CENTRE_TITLES.get(
-                                        centre, "unknown centre %s" % centre)
+            centre, u'unknown centre %s' % centre)
 
         #forecast time unit as a cm string
         #TODO #575 Do we want PP or GRIB style forecast delta?

--- a/lib/iris/fileformats/name.py
+++ b/lib/iris/fileformats/name.py
@@ -34,7 +34,7 @@ def _get_NAME_loader(filename):
     import iris.fileformats.name_loaders as name_loaders
 
     load = None
-    with open(filename, 'r') as file_handle:
+    with open(filename, 'rb') as file_handle:
         header = name_loaders.read_header(file_handle)
 
     # Infer file type based on contents of header.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -355,7 +355,7 @@ def _pyke_stats(engine, cf_name):
 def _set_attributes(attributes, key, value):
     """Set attributes dictionary, converting unicode strings appropriately."""
 
-    if isinstance(value, unicode):
+    if isinstance(value, six.text_type):
         try:
             attributes[str(key)] = str(value)
         except UnicodeEncodeError:

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1236,6 +1236,8 @@ class Saver(object):
 
         if np.issubdtype(coord.points.dtype, np.str):
             string_dimension_depth = coord.points.dtype.itemsize
+            if coord.points.dtype.kind == 'U':
+                string_dimension_depth //= 4
             string_dimension_name = 'string%d' % string_dimension_depth
 
             # Determine whether to create the string length dimension.

--- a/lib/iris/fileformats/nimrod.py
+++ b/lib/iris/fileformats/nimrod.py
@@ -81,7 +81,7 @@ data_header_int16s = ("radar_num", "radars_bitmask", "more_radars_bitmask",
 def _read_chars(infile, num):
     """Read characters from the (big-endian) file."""
     instr = infile.read(num)
-    return struct.unpack(">%ds" % num, instr)[0]
+    return struct.unpack(">%ds" % num, instr)[0].decode()
 
 
 class NimrodField(object):

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -260,7 +260,7 @@ def _draw_2d_from_bounds(draw_method_name, cube, *args, **kwargs):
                                               ['xaxis', 'yaxis'],
                                               [1, 0]):
             if coord:
-                if coord.points.dtype.char == 'S':
+                if coord.points.dtype.char in 'SU':
                     if coord.points.ndim != 1:
                         msg = 'Coord {!r} must be one-dimensional.'
                         raise ValueError(msg.format(coord))
@@ -336,7 +336,7 @@ def _draw_2d_from_points(draw_method_name, arg_func, cube, *args, **kwargs):
 
         for values, axis_name in zip([u, v], ['xaxis', 'yaxis']):
             # Replace any string coordinates with "index" coordinates.
-            if values.dtype.char == 'S':
+            if values.dtype.char in 'SU':
                 if values.ndim != 1:
                     raise ValueError('Multi-dimensional string coordinates '
                                      'not supported.')
@@ -446,7 +446,7 @@ def _draw_1d_from_points(draw_method_name, arg_func, *args, **kwargs):
 
     for values, axis_name in zip([u, v], ['xaxis', 'yaxis']):
         # Replace any string coordinates with "index" coordinates.
-        if values.dtype.char == 'S':
+        if values.dtype.char in 'SU':
             if values.ndim != 1:
                 msg = 'Multi-dimensional string coordinates are not supported.'
                 raise ValueError(msg)

--- a/lib/iris/tests/experimental/test_raster.py
+++ b/lib/iris/tests/experimental/test_raster.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import iris.tests as tests
 import iris
@@ -36,7 +37,7 @@ class TestGeoTiffExport(tests.IrisTest):
         """
         im = PIL.Image.open(geotiff_fh)
         tiff_header = '\n'.join(str((tag, val))
-                                if not isinstance(val, unicode)
+                                if not isinstance(val, six.text_type)
                                 else "(%s, '%s')" % (tag, val)
                                 for tag, val in sorted(im.tag.items()))
         reference_path = tests.get_result_path(reference_filename)

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -123,7 +123,7 @@ class TestPDT11(tests.IrisTest):
             # Get a grib_dump of the output file.
             dump_text = check_output(('grib_dump -O -wcount=1 ' +
                                       temp_file_path),
-                                     shell=True)
+                                     shell=True).decode()
 
             # Check that various aspects of the saved file are as expected.
             expect_strings = (
@@ -168,7 +168,7 @@ class TestGDT5(tests.IrisTest):
             # Get a grib_dump of the output file.
             dump_text = check_output(('grib_dump -O -wcount=1 ' +
                                       temp_file_path),
-                                     shell=True)
+                                     shell=True).decode()
 
             # Check that various aspects of the saved file are as expected.
             expect_strings = (

--- a/lib/iris/tests/results/categorisation/customcheck.cml
+++ b/lib/iris/tests/results/categorisation/customcheck.cml
@@ -14,7 +14,7 @@
       <coord datadims="[0]">
         <auxCoord id="13e3ba2a" long_name="seasons" points="[djfm, djfm, djfm, djfm, amjj, amjj, amjj, amjj,
 		ason, ason, ason, ason, ason, djfm, djfm, djfm,
-		djfm, amjj, amjj, amjj, amjj, amjj, ason]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		djfm, amjj, amjj, amjj, amjj, amjj, ason]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="c2d27f9e" points="[0, 27, 54, 81, 108, 135, 162, 189, 216, 243,

--- a/lib/iris/tests/results/categorisation/quickcheck.cml
+++ b/lib/iris/tests/results/categorisation/quickcheck.cml
@@ -14,13 +14,13 @@
       <coord datadims="[0]">
         <auxCoord id="c85f5f64" long_name="my_month" points="[Jan, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug,
 		Sep, Sep, Oct, Nov, Dec, Jan, Feb, Mar, Apr,
-		May, May, Jun, Jul, Aug]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		May, May, Jun, Jul, Aug]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="bd3bcb89" long_name="my_month_fullname" points="[January, January, February, March, April, May,
 		June, July, August, September, September,
 		October, November, December, January, February,
-		March, April, May, May, June, July, August]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		March, April, May, May, June, July, August]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="58dfe2e3" long_name="my_month_in_quarter" points="[0, 0, 1, 2, 0, 1, 2, 0, 1, 2, 2, 0, 1, 2, 0, 1,
@@ -33,7 +33,7 @@
       <coord datadims="[0]">
         <auxCoord id="538bccc4" long_name="my_season" points="[djf, djf, djf, mam, mam, mam, jja, jja, jja,
 		son, son, son, son, djf, djf, djf, mam, mam,
-		mam, mam, jja, jja, jja]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		mam, mam, jja, jja, jja]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="f0259071" long_name="my_season_number" points="[0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0,
@@ -47,14 +47,14 @@
       <coord datadims="[0]">
         <auxCoord id="0c9978e7" long_name="my_weekday" points="[Thu, Wed, Tue, Mon, Sun, Sat, Fri, Thu, Wed,
 		Tue, Mon, Sun, Sat, Fri, Thu, Wed, Tue, Mon,
-		Sun, Sat, Fri, Thu, Wed]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		Sun, Sat, Fri, Thu, Wed]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="34e46a5f" long_name="my_weekday_fullname" points="[Thursday, Wednesday, Tuesday, Monday, Sunday,
 		Saturday, Friday, Thursday, Wednesday, Tuesday,
 		Monday, Sunday, Saturday, Friday, Thursday,
 		Wednesday, Tuesday, Monday, Sunday, Saturday,
-		Friday, Thursday, Wednesday]" shape="(23,)" units="Unit('no_unit')" value_type="string"/>
+		Friday, Thursday, Wednesday]" shape="(23,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="521df3b7" long_name="my_weekday_number" points="[3, 2, 1, 0, 6, 5, 4, 3, 2, 1, 0, 6, 5, 4, 3, 2,

--- a/lib/iris/tests/results/grib_load/3_layer.cml
+++ b/lib/iris/tests/results/grib_load/3_layer.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>
@@ -65,7 +65,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>
@@ -99,7 +99,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[999900.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_0.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_0.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_1.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_1.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_2.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_2.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_3.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_3.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_4.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_4.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_5.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_5.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_6.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_6.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_7.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_7.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/earth_shape_grib1.cml
+++ b/lib/iris/tests/results/grib_load/earth_shape_grib1.cml
@@ -17,7 +17,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="6eef7051" long_name="pressure" points="[1000]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>

--- a/lib/iris/tests/results/grib_load/ineg_jneg.cml
+++ b/lib/iris/tests/results/grib_load/ineg_jneg.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/ineg_jpos.cml
+++ b/lib/iris/tests/results/grib_load/ineg_jpos.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/ipos_jneg.cml
+++ b/lib/iris/tests/results/grib_load/ipos_jneg.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/ipos_jpos.cml
+++ b/lib/iris/tests/results/grib_load/ipos_jpos.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/lambert_grib1.cml
+++ b/lib/iris/tests/results/grib_load/lambert_grib1.cml
@@ -13,7 +13,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="07a25078" points="[-2396487.0124, -2392487.0124, -2388487.0124,

--- a/lib/iris/tests/results/grib_load/lambert_grib2.cml
+++ b/lib/iris/tests/results/grib_load/lambert_grib2.cml
@@ -9,7 +9,7 @@
         <dimCoord id="a62739f9" points="[2.0]" shape="(1,)" standard_name="height" units="Unit('m')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="0f43c07d" points="[-2396487.0124, -2392487.0124, -2388487.0124,

--- a/lib/iris/tests/results/grib_load/missing_values_grib2.cml
+++ b/lib/iris/tests/results/grib_load/missing_values_grib2.cml
@@ -25,7 +25,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="cb784457" points="[380304.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/polar_stereo_grib1.cml
+++ b/lib/iris/tests/results/grib_load/polar_stereo_grib1.cml
@@ -6,7 +6,7 @@
         <dimCoord bounds="[[0.0, 0.999999996275]]" id="1d45e087" points="[0.499999998137]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="bbb95e38" points="[-1902539.27055, -1897776.27055, -1893013.27055,

--- a/lib/iris/tests/results/grib_load/polar_stereo_grib2.cml
+++ b/lib/iris/tests/results/grib_load/polar_stereo_grib2.cml
@@ -6,7 +6,7 @@
         <dimCoord id="1d45e087" points="[6]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[unknown centre cwao]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[unknown centre cwao]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[101500.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/reduced_gg_grib2.cml
+++ b/lib/iris/tests/results/grib_load/reduced_gg_grib2.cml
@@ -27,7 +27,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	European Centre for Medium Range Weather Forecasts]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	European Centre for Medium Range Weather Forecasts]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="a5c170db" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/reduced_ll_grib1.cml
+++ b/lib/iris/tests/results/grib_load/reduced_ll_grib1.cml
@@ -37,7 +37,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="6eef7051" long_name="pressure" points="[850]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>

--- a/lib/iris/tests/results/grib_load/reduced_ll_missing_grib1.cml
+++ b/lib/iris/tests/results/grib_load/reduced_ll_missing_grib1.cml
@@ -37,7 +37,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="6eef7051" long_name="pressure" points="[850]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>

--- a/lib/iris/tests/results/grib_load/regular_gg_grib1.cml
+++ b/lib/iris/tests/results/grib_load/regular_gg_grib1.cml
@@ -17,7 +17,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="6eef7051" long_name="pressure" points="[850]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>

--- a/lib/iris/tests/results/grib_load/regular_gg_grib2.cml
+++ b/lib/iris/tests/results/grib_load/regular_gg_grib2.cml
@@ -17,7 +17,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[52500.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/rotated.cml
+++ b/lib/iris/tests/results/grib_load/rotated.cml
@@ -16,7 +16,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="6eef7051" long_name="pressure" points="[600]" shape="(1,)" units="Unit('hPa')" value_type="int32"/>

--- a/lib/iris/tests/results/grib_load/time_bound_grib1.cml
+++ b/lib/iris/tests/results/grib_load/time_bound_grib1.cml
@@ -17,7 +17,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[361152.0, 361155.0]]" id="cb784457" points="[361153.5]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/time_bound_grib2.cml
+++ b/lib/iris/tests/results/grib_load/time_bound_grib2.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/y_fastest.cml
+++ b/lib/iris/tests/results/grib_load/y_fastest.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEII/0_TRACER_AIR_CONCENTRATION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEII/0_TRACER_AIR_CONCENTRATION.cml
@@ -21,7 +21,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEII/1_TRACER_DOSAGE.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEII/1_TRACER_DOSAGE.cml
@@ -21,7 +21,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEII/2_TRACER_WET_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEII/2_TRACER_WET_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEII/3_TRACER_DRY_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEII/3_TRACER_DRY_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEII/4_TRACER_TOTAL_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEII/4_TRACER_TOTAL_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEIII/0_TRACER_AIR_CONCENTRATION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEIII/0_TRACER_AIR_CONCENTRATION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEIII/1_TRACER_AIR_CONCENTRATION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEIII/1_TRACER_AIR_CONCENTRATION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[349218.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEIII/2_TRACER_DRY_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEIII/2_TRACER_DRY_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEIII/3_TRACER_WET_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEIII/3_TRACER_WET_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/integration/name_grib/NAMEIII/4_TRACER_DEPOSITION.cml
+++ b/lib/iris/tests/results/integration/name_grib/NAMEIII/4_TRACER_DEPOSITION.cml
@@ -18,7 +18,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/merge/separable_combination.cml
+++ b/lib/iris/tests/results/merge/separable_combination.cml
@@ -5,7 +5,7 @@
       <coord datadims="[0]">
         <auxCoord id="78c32bc2" long_name="a" points="[2005, 2005, 2005, 2026, 2026, 2026, 2002, 2002,
 		2002, 2002, 2002, 2002, 2502, 2502, 2502, 2502,
-		2502, 2502, 2502, 2502, 2502]" shape="(21,)" units="Unit('1')" value_type="string"/>
+		2502, 2502, 2502, 2502, 2502]" shape="(21,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="414e1707" long_name="b" points="[ECMWF, ECMWF, ECMWF, UK Met Office,
@@ -13,7 +13,7 @@
 		CERFACS, IFM-GEOMAR, IFM-GEOMAR, IFM-GEOMAR,
 		UK Met Office, UK Met Office, UK Met Office,
 		UK Met Office, UK Met Office, UK Met Office,
-		UK Met Office, UK Met Office, UK Met Office]" shape="(21,)" units="Unit('1')" value_type="string"/>
+		UK Met Office, UK Met Office, UK Met Office]" shape="(21,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="56350344" long_name="c" points="[HOPE-E, Sys 1, Met 1, ENSEMBLES,
@@ -36,7 +36,7 @@
 		HadCM3, Sys 51, Met 15, ENSEMBLES,
 		HadCM3, Sys 51, Met 16, ENSEMBLES,
 		HadCM3, Sys 51, Met 17, ENSEMBLES,
-		HadCM3, Sys 51, Met 18, ENSEMBLES]" shape="(21,)" units="Unit('1')" value_type="string"/>
+		HadCM3, Sys 51, Met 18, ENSEMBLES]" shape="(21,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <auxCoord id="32546e8d" long_name="d" points="[0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0,

--- a/lib/iris/tests/results/merge/string_a_b.cml
+++ b/lib/iris/tests/results/merge/string_a_b.cml
@@ -3,10 +3,10 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="414e1707" long_name="b" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="414e1707" long_name="b" points="[0, 1, 2, 3]" shape="(4,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[2]">
         <dimCoord id="78a0dfe8" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/string_a_with_aux.cml
+++ b/lib/iris/tests/results/merge/string_a_with_aux.cml
@@ -3,7 +3,7 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="414e1707" long_name="b" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/string_a_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_a_with_dim.cml
@@ -3,7 +3,7 @@
   <cube units="unknown">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="414e1707" long_name="b" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/string_b_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_b_with_dim.cml
@@ -6,7 +6,7 @@
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="414e1707" long_name="b" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>
+        <auxCoord id="414e1707" long_name="b" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="unicode"/>
       </coord>
       <coord datadims="[2]">
         <dimCoord id="78a0dfe8" long_name="x" points="[0, 1, 2, 3, 4]" shape="(5,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/name/NAMEIII_field.cml
+++ b/lib/iris/tests/results/name/NAMEIII_field.cml
@@ -53,7 +53,7 @@
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -116,7 +116,7 @@
         <dimCoord bounds="[[349218.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -178,7 +178,7 @@
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -240,7 +240,7 @@
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -302,7 +302,7 @@
         <dimCoord bounds="[[349215.0, 349219.0]]" id="cb784457" points="[349219.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/name/NAMEIII_timeseries.cml
+++ b/lib/iris/tests/results/name/NAMEIII_timeseries.cml
@@ -63,7 +63,7 @@
 		358354.0, 358355.0, 358356.0, 358357.0]" shape="(72,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -132,7 +132,7 @@
 		358354.0, 358355.0, 358356.0, 358357.0]" shape="(72,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer average]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -200,7 +200,7 @@
 		358354.0, 358355.0, 358356.0, 358357.0]" shape="(72,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -268,7 +268,7 @@
 		358354.0, 358355.0, 358356.0, 358357.0]" shape="(72,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -336,7 +336,7 @@
 		358354.0, 358355.0, 358356.0, 358357.0]" shape="(72,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory.cml
@@ -6,13 +6,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -44,13 +44,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -82,13 +82,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -120,13 +120,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -158,13 +158,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -196,13 +196,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -234,13 +234,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -272,13 +272,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -310,13 +310,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -348,13 +348,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -386,13 +386,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -424,13 +424,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -462,13 +462,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -500,13 +500,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -538,13 +538,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -576,13 +576,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,
@@ -614,13 +614,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,

--- a/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
@@ -6,13 +6,13 @@
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="a0c313e6" long_name="Puff?" points="[N]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="051ecdd8" long_name="Release Time" points="[366678.0]" shape="(1,)" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="154a2a49" long_name="Source" points="[Trajectory1]" shape="(1,)" units="Unit('unknown')" value_type="unicode"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="ce812520" long_name="Travel Time" points="[899.9999, 1800.0, 2700.0, ..., 750600.0,

--- a/lib/iris/tests/results/name/NAMEII_field.cml
+++ b/lib/iris/tests/results/name/NAMEII_field.cml
@@ -164,7 +164,7 @@
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -222,7 +222,7 @@
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>
@@ -280,7 +280,7 @@
         <dimCoord bounds="[[351249.0, 351252.0]]" id="cb784457" points="[351252.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods>

--- a/lib/iris/tests/results/name/NAMEII_timeseries.cml
+++ b/lib/iris/tests/results/name/NAMEII_timeseries.cml
@@ -40,7 +40,7 @@
 		370475.0, 370476.0]" shape="(132,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>
@@ -86,7 +86,7 @@
 		370475.0, 370476.0]" shape="(132,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord>
-        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="457ac36d" long_name="z" points="[Boundary layer]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/system/supported_filetype_.grib2.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.grib2.cml
@@ -30,7 +30,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[99.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/fileformats/grib/load_cubes/load_cubes/reduced_raw.cml
+++ b/lib/iris/tests/results/unit/fileformats/grib/load_cubes/load_cubes/reduced_raw.cml
@@ -27,7 +27,7 @@
         </auxCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[	European Centre for Medium Range Weather Forecasts]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[	European Centre for Medium Range Weather Forecasts]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <auxCoord id="a5c170db" long_name="sigma" points="[0.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/uri_callback/grib_global.cml
+++ b/lib/iris/tests/results/uri_callback/grib_global.cml
@@ -35,7 +35,7 @@
         </dimCoord>
       </coord>
       <coord>
-        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="[U.K. Met Office - Exeter]" shape="(1,)" units="Unit('no_unit')" value_type="unicode"/>
       </coord>
       <coord>
         <dimCoord id="302bf438" long_name="pressure" points="[100000.0]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -21,6 +21,7 @@ Test cube indexing, slicing, and extracting, and also the dot graphs.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
@@ -253,7 +254,7 @@ class TestCubeStringRepresentations(IrisDotTest):
         path = tests.get_data_path(('PP', 'simple_pp', 'global.pp'))
         self.cube_2d = iris.load_cube(path)
         # Generate the unicode cube up here now it's used in two tests.
-        unicode_str = unichr(40960) + u'abcd' + unichr(1972)
+        unicode_str = six.unichr(40960) + u'abcd' + six.unichr(1972)
         self.unicode_cube = iris.tests.stock.simple_1d()
         self.unicode_cube.attributes['source'] = unicode_str
 
@@ -296,7 +297,7 @@ class TestCubeStringRepresentations(IrisDotTest):
     def test_basic_0d_cube(self):
         self.assertString(repr(self.cube_2d[0, 0]),
                           ('cdm', 'str_repr', '0d_cube.__repr__.txt'))
-        self.assertString(unicode(self.cube_2d[0, 0]),
+        self.assertString(six.text_type(self.cube_2d[0, 0]),
                           ('cdm', 'str_repr', '0d_cube.__unicode__.txt'))
         self.assertString(str(self.cube_2d[0, 0]),
                           ('cdm', 'str_repr', '0d_cube.__str__.txt'))
@@ -378,8 +379,8 @@ class TestCubeStringRepresentations(IrisDotTest):
 
     def test_unicode_attribute(self):
         self.assertString(
-            unicode(self.unicode_cube), ('cdm', 'str_repr',
-                                         'unicode_attribute.__unicode__.txt'))
+            six.text_type(self.unicode_cube),
+            ('cdm', 'str_repr', 'unicode_attribute.__unicode__.txt'))
 
 
 @tests.skip_data

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 import os
 import re
 import sys
+import unittest
 
 import numpy as np
 import numpy.ma as ma
@@ -360,6 +361,7 @@ class TestCubeStringRepresentations(IrisDotTest):
         sys.setdefaultencoding(default_encoding)
         del sys.setdefaultencoding
 
+    @unittest.skipIf(six.PY3, 'Encodings are sane in Python 3.')
     def test_adjusted_default_encoding(self):
         # Test cube str representation on non-system-default encodings.
         # Doing this requires access to a sys method that is removed by default

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -310,7 +310,7 @@ class TestLicenseHeaders(unittest.TestCase):
         output = subprocess.check_output(['git', 'whatchanged',
                                           "--pretty=TIME:%ct"],
                                          cwd=REPO_DIR)
-        output = output.split('\n')
+        output = output.decode().split('\n')
         res = {}
         for fname, dt in TestLicenseHeaders.whatchanged_parse(output):
             if fname not in res or dt > res[fname]:

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -194,7 +194,8 @@ class TestCombination(tests.IrisTest):
                                     long_name='y', units='1'), 0)
 
         for name, value in zip(['a', 'b', 'c', 'd'], [a, b, c, d]):
-            dtype = np.str if isinstance(value, six.string_types) else np.float32
+            dtype = (np.dtype(six.text_type)
+                     if isinstance(value, six.string_types) else np.float32)
             cube.add_aux_coord(AuxCoord(np.array([value], dtype=dtype),
                                         long_name=name, units='1'))
 

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -260,7 +260,7 @@ class TestDimSelection(tests.IrisTest):
                                     long_name='y', units='1'), 0)
 
         for name, value, dim in zip(['a', 'b'], [a, b], [a_dim, b_dim]):
-            dtype = np.str if isinstance(value, six.string_types) else np.float32
+            dtype = 'U' if isinstance(value, six.string_types) else np.float32
             ctype = DimCoord if dim else AuxCoord
             coord = ctype(np.array([value], dtype=dtype),
                           long_name=name, units='1')


### PR DESCRIPTION
Convert all strings to Unicode as soon as possible. I had to add in some `decode`/`encode` without a specified encoding because I am not familiar with all the formats. This is probably consistent with Python 2, but it's not good practice. If you are more familiar with the correct encoding for a specific format, please let me know so I can make it explicit.