### PR TITLE
NumPy 1.9 fixes

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -526,8 +526,8 @@ class FF2PP(object):
             return lower, upper
 
         # Ensure that the resolution is the same on both edges.
-        res_low = np.array([field_dim[1] - field_dim[0]])
-        res_high = np.array([field_dim[-1] - field_dim[-2]])
+        res_low = field_dim[1] - field_dim[0]
+        res_high = field_dim[-1] - field_dim[-2]
         if not np.allclose(res_low, res_high):
             msg = ('The x or y coordinates of your boundary condition field '
                    'may be incorrect, not having taken into account the '


### PR DESCRIPTION
Two tests break with NumPy 1.9, since `np.linspace` newly produces a result of the same shape as the input. This now-2D array cannot be concatenated later on.
```python
======================================================================
ERROR: test_decreasing_field_values (iris.tests.unit.fileformats.ff.test_FF2PP.Test__det_border)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/elliott/code/conda/envs/iris27/lib/python2.7/site-packages/Iris-1.9.0.dev0-py2.7.egg/iris/tests/unit/fileformats/ff/test_FF2PP.py", line 293, in test_decreasing_field_values
    result = ff2pp._det_border(field_x, 1)
  File "/home/elliott/code/conda/envs/iris27/lib/python2.7/site-packages/Iris-1.9.0.dev0-py2.7.egg/iris/fileformats/ff.py", line 549, in _det_border
    field_dim = np.concatenate([extra_before, field_dim, extra_after])
ValueError: all the input arrays must have same number of dimensions

======================================================================
ERROR: test_increasing_field_values (iris.tests.unit.fileformats.ff.test_FF2PP.Test__det_border)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/elliott/code/conda/envs/iris27/lib/python2.7/site-packages/Iris-1.9.0.dev0-py2.7.egg/iris/tests/unit/fileformats/ff/test_FF2PP.py", line 285, in test_increasing_field_values
    result = ff2pp._det_border(field_x, 1)
  File "/home/elliott/code/conda/envs/iris27/lib/python2.7/site-packages/Iris-1.9.0.dev0-py2.7.egg/iris/fileformats/ff.py", line 549, in _det_border
    field_dim = np.concatenate([extra_before, field_dim, extra_after])
ValueError: all the input arrays must have same number of dimensions
```