### PR TITLE
Make GRIB API optional.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,10 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda config --add channels scitools
-  # Explicitly add missing libgfortran dependency for numpy.
-  # See SciTools/iris#1777 and ContinuumIO/anaconda-issues#445.
   - if [[ "$TEST_MINIMAL" == true ]]; then
-      conda install --quiet --file minimal-conda-requirements.txt libgfortran;
+      conda install --quiet --file minimal-conda-requirements.txt;
     else
-      conda install --quiet --file conda-requirements.txt libgfortran;
+      conda install --quiet --file conda-requirements.txt;
     fi
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 
 env:
   - TEST_TARGET=default
+  - TEST_TARGET=default TEST_MINIMAL=true
   - TEST_TARGET=coding
   - TEST_TARGET=example
   - TEST_TARGET=doctest
@@ -52,7 +53,11 @@ install:
   - conda config --add channels scitools
   # Explicitly add missing libgfortran dependency for numpy.
   # See SciTools/iris#1777 and ContinuumIO/anaconda-issues#445.
-  - conda install --quiet --file conda-requirements.txt libgfortran
+  - if [[ "$TEST_MINIMAL" == true ]]; then
+      conda install --quiet --file minimal-conda-requirements.txt libgfortran;
+    else
+      conda install --quiet --file conda-requirements.txt libgfortran;
+    fi
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -75,13 +75,19 @@ FORMAT_AGENT.add_spec(
 #
 # GRIB files.
 #
+def _load_grib(*args, **kwargs):
+    if grib is None:
+        raise RuntimeError('Unable to load GRIB file - the ECMWF '
+                           '`gribapi` package is not installed.')
+    return grib.load_cubes(*args, **kwargs)
+
+
 # NB. Because this is such a "fuzzy" check, we give this a very low
 # priority to avoid collateral damage from false positives.
-if grib is not None:
-    FORMAT_AGENT.add_spec(
-        FormatSpecification('GRIB', MagicNumber(100),
-                            lambda header_bytes: b'GRIB' in header_bytes,
-                            grib.load_cubes, priority=1))
+FORMAT_AGENT.add_spec(
+    FormatSpecification('GRIB', MagicNumber(100),
+                        lambda header_bytes: b'GRIB' in header_bytes,
+                        _load_grib, priority=1))
 
 
 #

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -27,7 +27,10 @@ from iris.io.format_picker import (FileExtension, FormatAgent,
                                    UriProtocol, LeadingLine)
 from . import abf
 from . import ff
-from . import grib
+try:
+    from . import grib
+except ImportError:
+    grib = None
 from . import name
 from . import netcdf
 from . import nimrod
@@ -74,10 +77,11 @@ FORMAT_AGENT.add_spec(
 #
 # NB. Because this is such a "fuzzy" check, we give this a very low
 # priority to avoid collateral damage from false positives.
-FORMAT_AGENT.add_spec(
-    FormatSpecification('GRIB', MagicNumber(100),
-                        lambda header_bytes: b'GRIB' in header_bytes,
-                        grib.load_cubes, priority=1))
+if grib is not None:
+    FORMAT_AGENT.add_spec(
+        FormatSpecification('GRIB', MagicNumber(100),
+                            lambda header_bytes: b'GRIB' in header_bytes,
+                            grib.load_cubes, priority=1))
 
 
 #

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -31,12 +31,10 @@ import warnings
 
 import biggus
 import cartopy.crs as ccrs
+import gribapi
 import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
-
-import iris.proxy
-iris.proxy.apply_proxy('gribapi', globals())
 
 from iris.analysis.interpolate import Linear1dExtrapolator
 import iris.coord_systems as coord_systems

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -227,6 +227,18 @@ def load_http(urls, callback):
             yield cube
 
 
+def _grib_save(cube, target, append=False, **kwargs):
+    # A simple wrapper for `iris.fileformats.grib.save_grib2` which
+    # allows the saver to be registered without having `gribapi`
+    # installed.
+    try:
+        import gribapi
+    except ImportError:
+        raise RuntimeError('Unable to save GRIB file - the ECMWF '
+                           '`gribapi` package is not installed.')
+    return iris.fileformats.grib.save_grib2(cube, target, append, **kwargs)
+
+
 def _check_init_savers():
     # TODO: Raise a ticket to resolve the cyclic import error that requires
     # us to initialise this on first use. Probably merge io and fileformats.
@@ -234,13 +246,8 @@ def _check_init_savers():
         _savers.update({"pp": iris.fileformats.pp.save,
                         "nc": iris.fileformats.netcdf.save,
                         "dot": iris.fileformats.dot.save,
-                        "dotpng": iris.fileformats.dot.save_png})
-        try:
-            import gribapi
-        except ImportError:
-            pass
-        else:
-            _savers['grib2'] = iris.fileformats.grib.save_grib2
+                        "dotpng": iris.fileformats.dot.save_png,
+                        "grib2": _grib_save})
 
 
 def add_saver(file_extension, new_saver):

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -234,8 +234,13 @@ def _check_init_savers():
         _savers.update({"pp": iris.fileformats.pp.save,
                         "nc": iris.fileformats.netcdf.save,
                         "dot": iris.fileformats.dot.save,
-                        "dotpng": iris.fileformats.dot.save_png,
-                        "grib2": iris.fileformats.grib.save_grib2})
+                        "dotpng": iris.fileformats.dot.save_png})
+        try:
+            import gribapi
+        except ImportError:
+            pass
+        else:
+            _savers['grib2'] = iris.fileformats.grib.save_grib2
 
 
 def add_saver(file_extension, new_saver):

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -83,6 +83,13 @@ except ImportError:
 else:
     GDAL_AVAILABLE = True
 
+try:
+    import gribapi
+except ImportError:
+    GRIB_AVAILABLE = False
+else:
+    GRIB_AVAILABLE = True
+
 
 #: Basepath for test results.
 _RESULT_PATH = os.path.join(os.path.dirname(__file__), 'results')
@@ -801,6 +808,10 @@ def skip_plot(fn):
         reason='Graphics tests require the matplotlib library.')
 
     return skip(fn)
+
+
+skip_grib = unittest.skipIf(not GRIB_AVAILABLE, 'Test(s) require "gribapi", '
+                                                'which is not available.')
 
 
 def no_warnings(func):

--- a/lib/iris/tests/integration/format_interop/test_name_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_name_grib.py
@@ -28,6 +28,9 @@ import numpy as np
 import iris
 import iris.unit
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
+
 
 def name_cb(cube, field, filename):
     # NAME files give the time point at the end of the range but Iris'
@@ -47,6 +50,7 @@ def name_cb(cube, field, filename):
         z_coord[0].long_name = 'altitude above sea level'
 
 
+@tests.skip_grib
 class TestNameToGRIB(tests.IrisTest):
 
     def check_common(self, name_cube, grib_cube):

--- a/lib/iris/tests/integration/format_interop/test_pp_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_pp_grib.py
@@ -25,7 +25,11 @@ import iris.tests as tests
 
 import iris
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
 
+
+@tests.skip_grib
 class TestBoundedTime(tests.IrisTest):
     @tests.skip_data
     def test_time_and_forecast_period_round_trip(self):

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -23,11 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import numpy.ma as ma
-
-from iris import FUTURE, load_cube
-
 from subprocess import check_output
+
+import numpy.ma as ma
 
 import iris
 from iris import FUTURE, load_cube, save
@@ -36,8 +34,12 @@ from iris.coord_systems import RotatedGeogCS
 from iris.fileformats.pp import EARTH_RADIUS as UM_DEFAULT_EARTH_RADIUS
 from iris.util import is_regular
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
+
 
 @tests.skip_data
+@tests.skip_grib
 class TestImport(tests.IrisTest):
     def test_gdt1(self):
         with FUTURE.context(strict_grib_load=True):
@@ -64,6 +66,7 @@ class TestImport(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestPDT8(tests.IrisTest):
     def setUp(self):
         # Load from the test file.
@@ -104,6 +107,7 @@ class TestPDT8(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestPDT11(tests.IrisTest):
     def test_perturbation(self):
         path = tests.get_data_path(('NetCDF', 'global', 'xyt',
@@ -138,6 +142,7 @@ class TestPDT11(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestGDT5(tests.IrisTest):
     def test_save_load(self):
         # Load sample UKV data (variable-resolution rotated grid).
@@ -250,6 +255,7 @@ class TestGDT5(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestGDT30(tests.IrisTest):
 
     def test_lambert(self):
@@ -260,6 +266,7 @@ class TestGDT30(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestGDT40(tests.IrisTest):
 
     def test_regular(self):
@@ -276,6 +283,7 @@ class TestGDT40(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestDRT3(tests.IrisTest):
 
     def test_grid_complex_spatial_differencing(self):

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -25,10 +25,13 @@ import iris.tests as tests
 
 import six.moves.cPickle as pickle
 
-from iris.fileformats.grib import _GribMessage
+if tests.GRIB_AVAILABLE:
+    import gribapi
+    from iris.fileformats.grib import _GribMessage
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestGribMessage(tests.IrisTest):
     def test(self):
         # Check that a _GribMessage pickles without errors.

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -181,6 +181,10 @@ class TestRunner():
         args = ['', None, '--processes=%s' % n_processors,
                 '--verbosity=2', regexp_pat,
                 '--process-timeout=250']
+        try:
+            import gribapi
+        except ImportError:
+            args.append('--exclude=^grib$')
         if self.stop:
             args.append('--stop')
 

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -31,11 +31,15 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import numpy as np
 
 import iris
-import iris.fileformats.grib as grib
 import iris.fileformats.netcdf as netcdf
 import iris.fileformats.pp as pp
 import iris.tests as tests
 import iris.unit
+
+if tests.GRIB_AVAILABLE:
+    import gribapi
+    import iris.fileformats.grib as grib
+
 
 class SystemInitialTest(tests.IrisTest):
 
@@ -68,7 +72,10 @@ class SystemInitialTest(tests.IrisTest):
 
         cm.assert_valid()
 
-        for filetype in ('.nc', '.pp', '.grib2'):
+        filetypes = ('.nc', '.pp')
+        if tests.GRIB_AVAILABLE:
+            filetypes += ('.grib2',)
+        for filetype in filetypes:
             saved_tmpfile = iris.util.create_temp_filename(suffix=filetype)
             iris.save(cm, saved_tmpfile)
 
@@ -76,6 +83,7 @@ class SystemInitialTest(tests.IrisTest):
 
             self.assertCML(new_cube, ('system', 'supported_filetype_%s.cml' % filetype))
 
+    @tests.skip_grib
     def system_test_grib_patch(self):
         import gribapi
         gm = gribapi.grib_new_from_samples("GRIB2")

--- a/lib/iris/tests/test_grib_load.py
+++ b/lib/iris/tests/test_grib_load.py
@@ -25,12 +25,10 @@ import iris.tests as tests
 import datetime
 from distutils.version import StrictVersion
 
-import gribapi
 import numpy as np
 
 import iris
 import iris.exceptions
-import iris.fileformats.grib
 from iris.tests import mock
 import iris.tests.stock
 import iris.util
@@ -42,10 +40,9 @@ if tests.MPL_AVAILABLE:
     import iris.plot as iplt
     import iris.quickplot as qplt
 
-
-# Construct a mock object to mimic the gribapi for GribWrapper testing.
-_mock_gribapi = mock.Mock(spec=gribapi)
-_mock_gribapi.GribInternalError = Exception
+if tests.GRIB_AVAILABLE:
+    import gribapi
+    import iris.fileformats.grib
 
 
 def _mock_gribapi_fetch(message, key):
@@ -84,15 +81,21 @@ def _mock_gribapi__grib_get_native_type(grib_message, keyname):
         return type(grib_message[keyname])
     raise _mock_gribapi.GribInternalError(keyname)
 
-_mock_gribapi.grib_get_long = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_string = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_double = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_double_array = mock.Mock(
-    side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_is_missing = mock.Mock(
-    side_effect=_mock_gribapi__grib_is_missing)
-_mock_gribapi.grib_get_native_type = mock.Mock(
-    side_effect=_mock_gribapi__grib_get_native_type)
+
+if tests.GRIB_AVAILABLE:
+    # Construct a mock object to mimic the gribapi for GribWrapper testing.
+    _mock_gribapi = mock.Mock(spec=gribapi)
+    _mock_gribapi.GribInternalError = Exception
+
+    _mock_gribapi.grib_get_long = mock.Mock(side_effect=_mock_gribapi_fetch)
+    _mock_gribapi.grib_get_string = mock.Mock(side_effect=_mock_gribapi_fetch)
+    _mock_gribapi.grib_get_double = mock.Mock(side_effect=_mock_gribapi_fetch)
+    _mock_gribapi.grib_get_double_array = mock.Mock(
+        side_effect=_mock_gribapi_fetch)
+    _mock_gribapi.grib_is_missing = mock.Mock(
+        side_effect=_mock_gribapi__grib_is_missing)
+    _mock_gribapi.grib_get_native_type = mock.Mock(
+        side_effect=_mock_gribapi__grib_get_native_type)
 
 # define seconds in an hour, for general test usage
 _hour_secs = 3600.0
@@ -189,6 +192,7 @@ class FakeGribMessage(dict):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestGribLoad(tests.GraphicsTest):
 
     def setUp(self):
@@ -386,6 +390,7 @@ class TestGribLoad(tests.GraphicsTest):
         self.assertCML(cube, ("grib_load", "reduced_ll_missing_grib1.cml"))
 
 
+@tests.skip_grib
 class TestGribTimecodes(tests.IrisTest):
     def _run_timetests(self, test_set):
         # Check the unit-handling for given units-codes and editions.
@@ -584,6 +589,7 @@ class TestGribTimecodes(tests.IrisTest):
             )
 
 
+@tests.skip_grib
 class TestGribSimple(tests.IrisTest):
     # A testing class that does not need the test data.
     def mock_grib(self):
@@ -610,6 +616,7 @@ class TestGribSimple(tests.IrisTest):
         return cube
 
 
+@tests.skip_grib
 class TestGrib1LoadPhenomenon(TestGribSimple):
     # Test recognition of grib phenomenon types.
     def mock_grib(self):
@@ -660,6 +667,7 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.known_grib1(34, 'y_wind', 'm s-1')
 
 
+@tests.skip_grib
 class TestGrib2LoadPhenomenon(TestGribSimple):
     # Test recognition of grib phenomenon types.
     def mock_grib(self):

--- a/lib/iris/tests/test_grib_phenomenon_translations.py
+++ b/lib/iris/tests/test_grib_phenomenon_translations.py
@@ -25,13 +25,17 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris tests first so that some things can be initialised before
 # importing anything else
-import iris.tests as itests
+import iris.tests as tests
 
-import iris.fileformats.grib.grib_phenom_translation as gptx
 import iris.unit
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
+    import iris.fileformats.grib.grib_phenom_translation as gptx
 
-class TestGribLookupTableType(itests.IrisTest):
+
+@tests.skip_grib
+class TestGribLookupTableType(tests.IrisTest):
     def test_lookuptable_type(self):
         ll = gptx.LookupTable([('a', 1), ('b', 2)])
         assert ll['a'] == 1
@@ -47,7 +51,8 @@ class TestGribLookupTableType(itests.IrisTest):
         assert ll['q'] == 7
 
 
-class TestGribPhenomenonLookup(itests.IrisTest):
+@tests.skip_grib
+class TestGribPhenomenonLookup(tests.IrisTest):
     def test_grib1_cf_lookup(self):
         def check_grib1_cf(param,
                            standard_name, long_name, units,
@@ -163,4 +168,4 @@ class TestGribPhenomenonLookup(itests.IrisTest):
 
 
 if __name__ == '__main__':
-    itests.main()
+    tests.main()

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -26,7 +26,6 @@ import warnings
 import datetime
 from distutils.version import StrictVersion
 
-import gribapi
 import numpy as np
 
 import iris
@@ -34,8 +33,12 @@ import iris.cube
 import iris.coord_systems
 import iris.coords
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
+
 
 @tests.skip_data
+@tests.skip_grib
 class TestLoadSave(tests.IrisTest):
     # load and save grib
 
@@ -117,6 +120,7 @@ class TestLoadSave(tests.IrisTest):
 
 
 @tests.skip_data
+@tests.skip_grib
 class TestCubeSave(tests.IrisTest):
     # save fabricated cubes
 
@@ -203,6 +207,7 @@ class TestCubeSave(tests.IrisTest):
                     1949.0)
 
 
+@tests.skip_grib
 class TestHandmade(tests.IrisTest):
 
     def _lat_lon_cube_no_time(self):

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -22,16 +22,22 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
-import gribapi
-import numpy as np
 import warnings
+
+import numpy as np
 
 import iris.cube
 import iris.coords
-import iris.fileformats.grib._save_rules as grib_save_rules
 from iris.tests import mock
 
+if tests.GRIB_AVAILABLE:
+    import gribapi
+    import iris.fileformats.grib._save_rules as grib_save_rules
+else:
+    gribapi = None
 
+
+@tests.skip_grib
 class Test_set_fixed_surfaces(tests.IrisTest):
     @mock.patch.object(gribapi, "grib_set")
     def test_altitude_point(self, mock_set):
@@ -76,6 +82,7 @@ class Test_set_fixed_surfaces(tests.IrisTest):
         mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface", -1)
 
 
+@tests.skip_grib
 class Test_phenomenon(tests.IrisTest):
     @mock.patch.object(gribapi, "grib_set")
     def test_phenom_unknown(self, mock_set):
@@ -119,6 +126,7 @@ class Test_phenomenon(tests.IrisTest):
         mock_set.assert_any_call(grib, "parameterNumber", 22)
 
 
+@tests.skip_grib
 class Test_type_of_statistical_processing(tests.IrisTest):
     @mock.patch.object(gribapi, "grib_set")
     def test_stats_type_min(self, mock_set):

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -56,6 +56,7 @@ class TestDecodeUri(unittest.TestCase):
 
 
 class TestFileFormatPicker(tests.IrisTest):
+    @tests.skip_grib
     def test_known_formats(self):
         self.assertString(str(iff.FORMAT_AGENT),
                           tests.get_result_path(('file_load',
@@ -75,10 +76,6 @@ class TestFileFormatPicker(tests.IrisTest):
                 ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k4']),
             ('UM Fieldsfile (FF) post v5.2',
                 ['FF', 'n48_multi_field']),
-            ('GRIB',
-                ['GRIB', 'grib1_second_order_packing', 'GRIB_00008_FRANX01']),
-            ('GRIB',
-                ['GRIB', 'jpeg2000', 'file.grib2']),
             ('UM Post Processing file (PP)',
                 ['PP', 'simple_pp', 'global.pp']),
             ('UM Fieldsfile (FF) ancillary',
@@ -93,7 +90,13 @@ class TestFileFormatPicker(tests.IrisTest):
 #                ['NAME', '20100509_18Z_variablesource_12Z_VAAC',
 #                 'Fields_grid1_201005110000.txt']),
         ]
-
+        if tests.GRIB_AVAILABLE:
+            test_specs.extend([
+                ('GRIB',
+                    ['GRIB', 'grib1_second_order_packing',
+                     'GRIB_00008_FRANX01']),
+                ('GRIB',
+                    ['GRIB', 'jpeg2000', 'file.grib2'])])
         # test that each filespec is identified as the expected format
         for (expected_format_name, file_spec) in test_specs:
             test_path = tests.get_data_path(file_spec)
@@ -101,6 +104,7 @@ class TestFileFormatPicker(tests.IrisTest):
                 a = iff.FORMAT_AGENT.get_spec(test_path, test_file)
                 self.assertEqual(a.name, expected_format_name)
 
+    @tests.skip_grib
     def test_format_picker_nodata(self):
         # The following is to replace the above at some point as no real files
         # are required.

--- a/lib/iris/tests/test_io_init.py
+++ b/lib/iris/tests/test_io_init.py
@@ -76,6 +76,10 @@ class TestFileFormatPicker(tests.IrisTest):
                 ['NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc4.k4']),
             ('UM Fieldsfile (FF) post v5.2',
                 ['FF', 'n48_multi_field']),
+            ('GRIB',
+                ['GRIB', 'grib1_second_order_packing', 'GRIB_00008_FRANX01']),
+            ('GRIB',
+                ['GRIB', 'jpeg2000', 'file.grib2']),
             ('UM Post Processing file (PP)',
                 ['PP', 'simple_pp', 'global.pp']),
             ('UM Fieldsfile (FF) ancillary',
@@ -90,13 +94,7 @@ class TestFileFormatPicker(tests.IrisTest):
 #                ['NAME', '20100509_18Z_variablesource_12Z_VAAC',
 #                 'Fields_grid1_201005110000.txt']),
         ]
-        if tests.GRIB_AVAILABLE:
-            test_specs.extend([
-                ('GRIB',
-                    ['GRIB', 'grib1_second_order_packing',
-                     'GRIB_00008_FRANX01']),
-                ('GRIB',
-                    ['GRIB', 'jpeg2000', 'file.grib2'])])
+
         # test that each filespec is identified as the expected format
         for (expected_format_name, file_spec) in test_specs:
             test_path = tests.get_data_path(file_spec)
@@ -104,7 +102,6 @@ class TestFileFormatPicker(tests.IrisTest):
                 a = iff.FORMAT_AGENT.get_spec(test_path, test_file)
                 self.assertEqual(a.name, expected_format_name)
 
-    @tests.skip_grib
     def test_format_picker_nodata(self):
         # The following is to replace the above at some point as no real files
         # are required.

--- a/lib/iris/tests/test_uri_callback.py
+++ b/lib/iris/tests/test_uri_callback.py
@@ -28,6 +28,7 @@ import iris.coords
 
 @tests.skip_data
 class TestCallbacks(tests.IrisTest):
+    @tests.skip_grib
     def test_grib_callback(self):
         def grib_thing_getter(cube, field, filename):
             cube.add_aux_coord(iris.coords.AuxCoord(field.extra_keys['_periodStartDateTime'], long_name='random element', units='no_unit'))

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -1,5 +1,5 @@
 # Use this file to create a conda environment using:
-# conda create -n <name> --file conda-requirements.txt
+# conda create -n <name> --file minimal-conda-requirements.txt
 
 # Mandatory dependencies
 biggus>=0.12.0

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -1,0 +1,27 @@
+# Use this file to create a conda environment using:
+# conda create -n <name> --file conda-requirements.txt
+
+# Mandatory dependencies
+biggus>=0.12.0
+cartopy
+matplotlib=1.3.1
+netcdf4
+numpy
+pyke
+udunits=2.*
+
+# Iris build dependencies
+setuptools
+
+# Iris testing/documentation dependencies
+mock
+nose
+pep8=1.5.7
+sphinx
+
+# Optional iris dependencies
+gdal
+libmo_unpack
+pandas
+pyugrid
+mo_pack=0.2.0


### PR DESCRIPTION
NB. This adds a new entry to the test matrix which runs the standard test suite against an installation with a reduced set of dependencies. Currently this is only missing ecmwf_grib but I would expect other dependencies could be removed once the concept is proven.