### PR TITLE
Add missing deprecation directives

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -455,6 +455,10 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
     * k_cube
         The k cube of the vector to operate on
+    * ignore
+        This argument is not used.
+        .. deprecated:: 0.8
+            The coordinates to ignore are determined automatically.
 
     Return (i_cmpt_curl_cube, j_cmpt_curl_cube, k_cmpt_curl_cube)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1042,18 +1042,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             matches = [factory.derived_dims(self.coord_dims) for factory in
                        factories]
 
-        # Deprecate name based searching
-        # -- Search by coord name, if have no match
-        # XXX Where did this come from? And why isn't it reflected in the
-        # docstring?
-        if not matches:
-            warnings.warn('name based coord matching is deprecated and will '
-                          'be removed in a future release.',
-                          stacklevel=2)
-            matches = [(dim,) for coord_, dim in self._dim_coords_and_dims if
-                       coord_.name() == coord.name()]
-        # Finish deprecate name based searching
-
         if not matches:
             raise iris.exceptions.CoordinateNotFoundError(coord.name())
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1891,8 +1891,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         return summary
 
     def assert_valid(self):
-        """Raise an exception if the cube is invalid; otherwise return None."""
+        """
+        Does nothing and returns None.
 
+        .. deprecated:: 0.8
+
+        """
         warnings.warn('Cube.assert_valid() has been deprecated.')
 
     def __str__(self):


### PR DESCRIPTION
It turns out that the "deprecated" code in `Cube.coord_dims()` is never run so I've just removed it.

Fixes #1790 