### PR TITLE
Allow calculation of curl for cubes with 'grid_latitude' and 'grid_longitude' coords

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -600,7 +600,8 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         #    (d/dtheta (i_cube * sin(lat)) - d_j_cube_dphi)
         # phi_cmpt = 1/r * ( d/dr (r * j_cube) - d_k_cube_dtheta)
         # theta_cmpt = 1/r * ( 1/cos(lat) * d_k_cube_dphi - d/dr (r * i_cube)
-        if y_coord.name() != 'latitude' or x_coord.name() != 'longitude':
+        if y_coord.name() not in ['latitude', 'grid_latitude'] \
+                or x_coord.name() not in ['longitude', 'grid_longitude']:
             raise ValueError('Expecting latitude as the y coord and '
                              'longitude as the x coord for spherical curl.')
 
@@ -638,7 +639,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         # recalculate dicos_dtheta.
         d_j_cube_dphi = _curl_differentiate(j_cube, lon_coord)
         d_j_cube_dphi = _curl_regrid(d_j_cube_dphi, prototype_diff)
-        new_lat_coord = d_j_cube_dphi.coord('latitude')
+        new_lat_coord = d_j_cube_dphi.coord(axis='Y')
         new_lat_cos_coord = _coord_cos(new_lat_coord)
         lat_dim = d_j_cube_dphi.coord_dims(new_lat_coord)[0]
         r_cmpt = iris.analysis.maths.divide(_curl_subtract(dicos_dtheta,


### PR DESCRIPTION
Rotated pole cubes tend to have the coord names 'grid_latitude' and 'grid_longitude'. These names aren't currently being allowed in the curl calculation despite it saying it handles rotated pole cubes.