### PR TITLE
Initial attempt at tidying the demote_dim_coord... docstring

### DIFF
--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1520,8 +1520,12 @@ def promote_aux_coord_to_dim_coord(cube, name_or_coord):
 
 def demote_dim_coord_to_aux_coord(cube, name_or_coord):
     """
-    Demotes a DimCoord on the cube to an AuxCoord, leaving that
-    dimension anonymous.
+    Demotes a dimension coordinate  on the cube to an auxiliary coordinate.
+
+    The DimCoord is demoted to an auxiliary coordinate on the cube.
+    The dimension of the cube that was associated with the DimCoord becomes
+    anonymous.  The class of the coordinate is left as DimCoord, it is not
+    recast as an AuxCoord instance.
 
     Args:
 


### PR DESCRIPTION
Hello, I was doing a bit of work yesterday and was caught out by a docstring that I *thought* was  a bit deceptive - but it could be my reading.  This is an attempt to tidy the doc string.  Feel free to reject if you think it is just the way I was reading the doc.

Here's the context: I needed to change the labelling on the pseudo_levels of a cube.  The initial values of the labels were monotonic, the new values were not monotonic.  I thought I could do what I the relabel by first demoting pseudo_level to an AuxCoord and then updating the values.  I thought I could use iris.util.demote_dim_coord_to_aux_coord to do this... however it turns out it doesn't do the step of turning the DimCoord into an AuxCoord.  There may be cases where this is the right thing to do - so I haven't changed this.  I have, however, updated the doc string to make it a little clearer.

An alternative would be to change the behaviour to use a DimCoord or AuxCoord through a keyword argument that defaults to DimCoord.  But I wasn't sure...

Could you review what you think the behaviour should be.  If you agree to changing the behaviour I'm happy to have a go.  But if you want to leave the behaviour as is could you review the doc string - is it any clearer?

Thanks,

Jamie