### PR TITLE
iris load documentation - clarify constraint as string

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -57,9 +57,10 @@ All the load functions share very similar arguments:
 
     * constraints:
         Either a single constraint, or an iterable of constraints.
-        Each constraint can be either a CF standard name, an instance of
+        Each constraint can be either a string, an instance of
         :class:`iris.Constraint`, or an instance of
-        :class:`iris.AttributeConstraint`.
+        :class:`iris.AttributeConstraint`.  If the constraint is a string
+        it will be used to match against cube.name().
 
         .. _constraint_egs:
 


### PR DESCRIPTION
Hello, this is a small documentation modification.  I think if a constraint is simply a string it matches against cube.name() rather that the standard_name (is that right?)

I'm not completely sure the documentation is the best as I have it - feel free to reject if you think it could be clearer.

Sorry for these small pull requests - but I figure they are more likely to get done if I just do them as I come across them, rather than saving them up.