### PR TITLE
Optional whitespace before the colon in the 'cell_methods' regular expression

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -870,7 +870,7 @@ fc_extras
     CM_NAME = 'name'
 
     CM_PARSE = re.compile(  r'''
-                                (?P<name>([\w_]+:\s+)+)
+                                (?P<name>([\w_]+\s*:\s+)+)
                                 (?P<method>[\w_\s]+(?![\w_]*:))\s*
                                 (?:
                                     \(\s*


### PR DESCRIPTION
I have a netCDF file containing data variables that have a `cell_methods` attribute with the value `time : mean` (note there is a space before and after the colon). When I run CF Checker on the netCDF file there are no errors. In addition, even though the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#cell-methods) state "[the `cell_methods` attribute of the variable] is a string attribute comprising a list of blank-separated words of the form `name: method`", I would argue that the amount of whitespace in this form is unimportant as there is no direct mention of it.

Please let me know if this change will be approved and I will write some appropriate tests :)