### PR TITLE
Safer _NP_VERSION

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -40,7 +40,7 @@ import iris.unit
 
 _Version = namedtuple('Version', ('major', 'minor', 'micro'))
 _NP_VERSION = _Version(*(int(val) for val in
-                         np.version.version.split('.')))
+                         np.version.version.split('.') if val.isdigit()))
 
 
 def _get_xy_coords(cube):


### PR DESCRIPTION
Tiny PR to make iris friends with numpy 1.10.0 (actually `'1.10.0.post2'` for some reason) .