### PR TITLE
Update WGDOS payload length.

### DIFF
--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -410,9 +410,7 @@ class _DataProvider(object):
         field = self.lookup_entry
         with self._with_source():
             self.source.seek(self.offset)
-            data_size = ((field.lbnrec * 2) - 1) * _WGDOS_SIZE
-            # This size calculation seems rather questionable, but derives from
-            # a very long code legacy, so appeal to a "sleeping dogs" policy.
+            data_size = (field.lbnrec * 2) * _WGDOS_SIZE
             data_bytes = self.source.read(data_size)
         return data_bytes
 

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -480,7 +480,7 @@ class FF2PP(object):
             # Data payload is packed.
             if lbpack_n1 == 1:
                 # Data packed using WGDOS archive method.
-                data_words = (field.lbnrec * 2) - 1
+                data_words = field.lbnrec * 2
             elif lbpack_n1 == 2:
                 # Data packed using CRAY 32-bit method.
                 data_words = field.lblrec - field.lbext

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -272,25 +272,25 @@ class TestFFPayload(tests.IrisTest):
         mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=100,
                                 raw_lbpack=_WGDOS,
                                 lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 796, pp.LBUSER_DTYPE_LOOKUP[_REAL])
+        self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_wgdos_real_ext(self):
         mock_field = _MockField(lbext=50, lblrec=-1, lbnrec=100,
                                 raw_lbpack=_WGDOS,
                                 lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 796, pp.LBUSER_DTYPE_LOOKUP[_REAL])
+        self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_REAL])
 
     def test_payload_wgdos_integer(self):
         mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=200,
                                 raw_lbpack=_WGDOS,
                                 lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 1596, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
+        self._test_payload(mock_field, 1600, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
     def test_payload_wgdos_integer_ext(self):
         mock_field = _MockField(lbext=100, lblrec=-1, lbnrec=200,
                                 raw_lbpack=_WGDOS,
                                 lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 1596, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
+        self._test_payload(mock_field, 1600, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
     def test_payload_cray_real(self):
         mock_field = _MockField(lbext=0, lblrec=100, lbnrec=-1,

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -36,23 +36,6 @@ import iris.fileformats.pp as pp
 from iris.tests import mock
 
 
-_MockField = collections.namedtuple('_MockField',
-                                    'lbext lblrec lbnrec raw_lbpack '
-                                    'lbuser boundary_packing')
-
-# PP-field: LBPACK N1 values.
-_UNPACKED = 0
-_WGDOS = 1
-_CRAY = 2
-_GRIB = 3  # Not implemented.
-_RLE = 4   # Not supported, deprecated FF format.
-
-# PP-field: LBUSER(1) values.
-_REAL = 1
-_INTEGER = 2
-_LOGICAL = 3  # Not implemented.
-
-
 class TestFF_HEADER(tests.IrisTest):
     def test_initialisation(self):
         self.assertEqual(ff.FF_HEADER[0], ('data_set_format_version', (0,)))
@@ -225,96 +208,6 @@ class TestFFVariableResolutionGrid(tests.IrisTest):
 
     def test_v(self):
         self._check_stash('m01s00i003', self.P_grid_x, self.V_grid_y)
-
-
-class TestFFPayload(tests.IrisTest):
-    def _test_payload(self, mock_field, expected_depth, expected_type):
-        with mock.patch('iris.fileformats.ff.FFHeader') as mock_header:
-            mock_header.return_value = None
-            ff2pp = ff.FF2PP('Not real')
-            data_depth, data_type = ff2pp._payload(mock_field)
-            self.assertEqual(data_depth, expected_depth)
-            self.assertEqual(data_type, expected_type)
-
-    def test_payload_unpacked_real(self):
-        mock_field = _MockField(lbext=0, lblrec=100, lbnrec=-1,
-                                raw_lbpack=_UNPACKED,
-                                lbuser=[_REAL], boundary_packing=None)
-        expected_type = ff._LBUSER_DTYPE_LOOKUP[_REAL].format(word_depth=8)
-        expected_type = np.dtype(expected_type)
-        self._test_payload(mock_field, 800, expected_type)
-
-    def test_payload_unpacked_real_ext(self):
-        mock_field = _MockField(lbext=50, lblrec=100, lbnrec=-1,
-                                raw_lbpack=_UNPACKED,
-                                lbuser=[_REAL], boundary_packing=None)
-        expected_type = ff._LBUSER_DTYPE_LOOKUP[_REAL].format(word_depth=8)
-        expected_type = np.dtype(expected_type)
-        self._test_payload(mock_field, 400, expected_type)
-
-    def test_payload_unpacked_integer(self):
-        mock_field = _MockField(lbext=0, lblrec=200, lbnrec=-1,
-                                raw_lbpack=_UNPACKED,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        expected_type = ff._LBUSER_DTYPE_LOOKUP[_INTEGER].format(word_depth=8)
-        expected_type = np.dtype(expected_type)
-        self._test_payload(mock_field, 1600, expected_type)
-
-    def test_payload_unpacked_integer_ext(self):
-        mock_field = _MockField(lbext=100, lblrec=200, lbnrec=-1,
-                                raw_lbpack=_UNPACKED,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        expected_type = ff._LBUSER_DTYPE_LOOKUP[_INTEGER].format(word_depth=8)
-        expected_type = np.dtype(expected_type)
-        self._test_payload(mock_field, 800, expected_type)
-
-    def test_payload_wgdos_real(self):
-        mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=100,
-                                raw_lbpack=_WGDOS,
-                                lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_REAL])
-
-    def test_payload_wgdos_real_ext(self):
-        mock_field = _MockField(lbext=50, lblrec=-1, lbnrec=100,
-                                raw_lbpack=_WGDOS,
-                                lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_REAL])
-
-    def test_payload_wgdos_integer(self):
-        mock_field = _MockField(lbext=0, lblrec=-1, lbnrec=200,
-                                raw_lbpack=_WGDOS,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 1600, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
-
-    def test_payload_wgdos_integer_ext(self):
-        mock_field = _MockField(lbext=100, lblrec=-1, lbnrec=200,
-                                raw_lbpack=_WGDOS,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 1600, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
-
-    def test_payload_cray_real(self):
-        mock_field = _MockField(lbext=0, lblrec=100, lbnrec=-1,
-                                raw_lbpack=_CRAY,
-                                lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 400, pp.LBUSER_DTYPE_LOOKUP[_REAL])
-
-    def test_payload_cray_real_ext(self):
-        mock_field = _MockField(lbext=50, lblrec=100, lbnrec=-1,
-                                raw_lbpack=_CRAY,
-                                lbuser=[_REAL], boundary_packing=None)
-        self._test_payload(mock_field, 200, pp.LBUSER_DTYPE_LOOKUP[_REAL])
-
-    def test_payload_cray_integer(self):
-        mock_field = _MockField(lbext=0, lblrec=200, lbnrec=-1,
-                                raw_lbpack=_CRAY,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 800, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
-
-    def test_payload_cray_integer_ext(self):
-        mock_field = _MockField(lbext=100, lblrec=200, lbnrec=-1,
-                                raw_lbpack=_CRAY,
-                                lbuser=[_INTEGER], boundary_packing=None)
-        self._test_payload(mock_field, 400, pp.LBUSER_DTYPE_LOOKUP[_INTEGER])
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -225,7 +225,7 @@ class Test__payload(tests.IrisTest):
         field = self.mock_field
         field.raw_lbpack = 1
         data_depth, data_type = ff2pp._payload(field)
-        self.assertEqual(data_depth, 396)
+        self.assertEqual(data_depth, 400)
         self.assertEqual(data_type, np.dtype('>f4'))
 
     def test__lbpack_2(self):


### PR DESCRIPTION
**<del>CAUTION!</del>**

We've seen some WGDOS unpacking failures recently where they look like they are running out of data ... so this is a quick hack to get rid of a mysterious (*1) `-1` in the FieldsFile data length calculation and see if it helps. @bjlittle & @mo-g - this might be of use to you!

*1) No one can remember how it got into the code.

**NB.** Even though the tests pass, please don't merge this PR unless it fixes the unpack failures we've seen and can be shown that it doesn't muck up the reading of other real FieldsFiles! (The FieldsFiles in the test data are probably too artificial to be trusted on their own.)