### PR TITLE
bug in coord slice with step -1 and bounds 

### DIFF
--- a/lib/iris/etc/site.cfg.template
+++ b/lib/iris/etc/site.cfg.template
@@ -1,5 +1,5 @@
 [System]
-udunits2_path = /path/to/libudunits2.so
+udunits2_path = /home/vagrant/miniconda/envs/iris/lib/libudunits2.so
 dot_path = /path/to/dot # see iris.fileformats.dot
 
 [Resources]

--- a/lib/iris/etc/site.cfg.template
+++ b/lib/iris/etc/site.cfg.template
@@ -1,5 +1,5 @@
 [System]
-udunits2_path = /home/vagrant/miniconda/envs/iris/lib/libudunits2.so
+udunits2_path = /path/to/libudunits2.so
 dot_path = /path/to/dot # see iris.fileformats.dot
 
 [Resources]

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -140,7 +140,7 @@ class TestCoordSlicing(unittest.TestCase):
 
     # These next two tests demonstrate some funny behaviour with -1
     # indexing when you have bounds.  I think the order of the bounds
-    # should be reversed too - but it isn't.
+    # for each cell should be reversed too - but it isn't.
     def test_rev_slice_commutes_with_guess_bounds(self):
 
         points = np.arange(2)
@@ -157,9 +157,12 @@ class TestCoordSlicing(unittest.TestCase):
         points = np.arange(2)
         coord = iris.coords.DimCoord(points)
         coord.guess_bounds()
-        slice_after_bounds = coord[::-1]
-        self.assertTrue(coord.is_contiguous())
-        self.assertTrue(slice_after_bounds.is_contiguous())
+
+        self.assertTrue(coord.is_contiguous())   # just a sanity check
+        
+        # Test: slicing with step -1 should not change is_contiguous
+        self.assertEquals(coord.is_contiguous(),
+                          coord[::-1].is_contiguous())
 
     def test_multidim(self):
         a = self.surface_altitude

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -137,7 +137,30 @@ class TestCoordSlicing(unittest.TestCase):
         
         c = b[::-1]
         self.assertEqual(self.lat, c)
-        
+
+    # These next two tests demonstrate some funny behaviour with -1
+    # indexing when you have bounds.  I think the order of the bounds
+    # should be reversed too - but it isn't.
+    def test_rev_slice_commutes_with_guess_bounds(self):
+
+        points = np.arange(2)
+        coord = iris.coords.DimCoord(points)
+        coord.guess_bounds()
+        slice_after_bounds = coord[::-1]
+
+        coord = iris.coords.DimCoord(points)
+        slice_before_bounds = coord[::-1]
+        slice_before_bounds.guess_bounds()
+        self.assertEquals(slice_after_bounds, slice_before_bounds)
+    
+    def test_rev_slice_preserves_is_contiguous(self):
+        points = np.arange(2)
+        coord = iris.coords.DimCoord(points)
+        coord.guess_bounds()
+        slice_after_bounds = coord[::-1]
+        self.assertTrue(coord.is_contiguous())
+        self.assertTrue(slice_after_bounds.is_contiguous())
+
     def test_multidim(self):
         a = self.surface_altitude
         # make some arbitrary bounds


### PR DESCRIPTION
Hello,

this is more of a bug report than a pull request.  I've added a couple of failing tests that I think should pass.  Could you review and see if you agree?

This is likely propagate into other analysis - cube slice with -1 step (I think) would suffer from the same issue... which could give problems for area weighted regrid.

I don't feel confident of putting in a fix - particularly in quick time - I think there could be some issues I'd need to research, and I'm not sure when I'll have time.
1. can the 'cell/nbounds' dimension of a bounds array be anything other than the inner most (furthest left) dimension
2. I think the correct behaviour for 1d coords is clear - reverse the values along the 'cell/nbounds' dimension.  I'd have to think how this works for 2 (or more) dimensioned aux coords.

Jamie
