### PR TITLE
Remove warnings about data payload from concatenate.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -563,10 +563,6 @@ class CubeList(list):
             :func:`iris.util.unify_time_units` to normalise the epochs of the
             time coordinates so that the cubes can be concatenated.
 
-        .. warning::
-
-            This routine will load your data payload!
-
         """
         return iris._concatenate.concatenate(self)
 


### PR DESCRIPTION
Cherry picked a commit from v1.8.x onto master to ensure all the concatenate documentation is up-to-date (much less hassle than merging all v1.8.x and dealing with several conflicts).