### PR TITLE
DOC: Note about collapsing multi-dimensional coordinates

### DIFF
--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -97,22 +97,9 @@ For an example of using this functionality, the
 in the gallery takes a zonal mean of an ``XYT`` cube by using the
 ``collapsed`` method with ``latitude`` and ``iris.analysis.MEAN`` as arguments.
 
-
-.. note::
-    You cannot partially collapse a multi-dimensional coordinate. Thus in the
-    above example you would not be able to collapse the cube along either of
-    the axes described by the ``grid_latitude`` or ``grid_longitude``
-    coordinates individually. Doing so would result in a partial collapse of
-    the 2D ``surface_altitude`` coordinate.
-
-    Instead you must either fully collapse the coordinate (in this case
-    requiring that both ``grid_latitude`` or ``grid_longitude`` coordinates be
-    collapsed together in a single collapse operation) or not collapse the
-    coordinate at all.
-
-    Multi-dimensional derived coordinates (such as ``altitude`` in the above
-    example) will not prevent a successful collapse operation across a
-    cube dimension that the multi-dimensional derived coordinate spans.
+You cannot partially collapse a multi-dimensional coordinate. See
+:ref:`cube.collapsed <partially_collapse_multi-dim_coord>` for more
+information.
 
 .. _cube-statistics-collapsing-average:
 

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -98,6 +98,22 @@ in the gallery takes a zonal mean of an ``XYT`` cube by using the
 ``collapsed`` method with ``latitude`` and ``iris.analysis.MEAN`` as arguments.
 
 
+.. note::
+    You cannot partially collapse a multi-dimensional coordinate. Thus in the
+    above example you would not be able to collapse the cube along either of
+    the axes described by the ``grid_latitude`` or ``grid_longitude``
+    coordinates individually. Doing so would result in a partial collapse of
+    the 2D ``surface_altitude`` coordinate.
+
+    Instead you must either fully collapse the coordinate (in this case
+    requiring that both ``grid_latitude`` or ``grid_longitude`` coordinates be
+    collapsed together in a single collapse operation) or not collapse the
+    coordinate at all.
+
+    Multi-dimensional derived coordinates (such as ``altitude`` in the above
+    example) will not prevent a successful collapse operation across a
+    cube dimension that the multi-dimensional derived coordinate spans.
+
 .. _cube-statistics-collapsing-average:
 
 Area averaging

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -943,10 +943,20 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
     def collapsed(self, dims_to_collapse=None):
         """
-        Returns a copy of this coordinate which has been collapsed along
+        Returns a copy of this coordinate, which has been collapsed along
         the specified dimensions.
 
         Replaces the points & bounds with a simple bounded region.
+
+        .. note::
+            You cannot partially collapse a multi-dimensional coordinate. To
+            successfully collapse a multi-dimensional coordinate (i.e. a
+            coordinate that describes more than one of a cube's axes) you
+            must collapse all cube axes that the multi-dimensional coordinate
+            spans in a single collapse operation.
+
+            Multi-dimensional derived coordinates will not prevent a successful
+            collapse operation.
 
         """
         if isinstance(dims_to_collapse, (int, np.integer)):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -949,14 +949,9 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         Replaces the points & bounds with a simple bounded region.
 
         .. note::
-            You cannot partially collapse a multi-dimensional coordinate. To
-            successfully collapse a multi-dimensional coordinate (i.e. a
-            coordinate that describes more than one of a cube's axes) you
-            must collapse all cube axes that the multi-dimensional coordinate
-            spans in a single collapse operation.
-
-            Multi-dimensional derived coordinates will not prevent a successful
-            collapse operation.
+            You cannot partially collapse a multi-dimensional coordinate. See
+            :ref:`cube.collapsed <partially_collapse_multi-dim_coord>` for more
+            information.
 
         """
         if isinstance(dims_to_collapse, (int, np.integer)):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2945,12 +2945,17 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 cube.collapsed(['latitude', 'longitude'],
                                iris.analysis.VARIANCE)
 
+        .. _partially_collapse_multi-dim_coord:
+
         .. note::
-            You cannot partially collapse a multi-dimensional coordinate. To
-            successfully collapse a multi-dimensional coordinate (i.e. a
-            coordinate that describes more than one of a cube's axes) you
-            must collapse all cube axes that the multi-dimensional coordinate
-            spans in a single collapse operation.
+            You cannot partially collapse a multi-dimensional coordinate. Doing
+            so would result in a partial collapse of the multi-dimensional
+            coordinate. Instead you must either:
+                 * collapse in a single operation all cube axes that the
+                   multi-dimensional coordinate spans,
+                 * remove the multi-dimensional coordinate from the cube before
+                   performing the collapse operation, or
+                 * not collapse the coordinate at all.
 
             Multi-dimensional derived coordinates will not prevent a successful
             collapse operation.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2945,6 +2945,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 cube.collapsed(['latitude', 'longitude'],
                                iris.analysis.VARIANCE)
 
+        .. note::
+            You cannot partially collapse a multi-dimensional coordinate. To
+            successfully collapse a multi-dimensional coordinate (i.e. a
+            coordinate that describes more than one of a cube's axes) you
+            must collapse all cube axes that the multi-dimensional coordinate
+            spans in a single collapse operation.
+
+            Multi-dimensional derived coordinates will not prevent a successful
+            collapse operation.
+
         """
         # Convert any coordinate names to coordinates
         coords = self._as_list_of_coords(coords)


### PR DESCRIPTION
Adds a note on partially collapsing multi-dimensional coordinates to the userguide &sect;9.1, `iris.cube.Cube.collapsed` and `iris.coords.Coord.collapsed`.