### PR TITLE
Add deprecation warnings for `iris.unit`

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
@@ -1,0 +1,1 @@
+* deprecated :mod:`iris.unit`

--- a/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
@@ -1,1 +1,1 @@
-* deprecated :mod:`iris.unit`
+* deprecated :mod:`iris.unit`, with unit functionality provided instead by `cf_units <https://github.com/SciTools/cf_units>`_ instead.

--- a/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-01_unit-module.txt
@@ -1,1 +1,1 @@
-* deprecated :mod:`iris.unit`, with unit functionality provided instead by `cf_units <https://github.com/SciTools/cf_units>`_ instead.
+* deprecated :mod:`iris.unit`, with unit functionality provided by `cf_units <https://github.com/SciTools/cf_units>`_ instead.

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -15,6 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
+.. deprecated:: 1.9
+    This module has been deprecated. Please use `cf_units
+    <https://github.com/SciTools/cf_units>`_ instead.
+
 Units of measure.
 
 Provision of a wrapper class to support Unidata/UCAR UDUNITS-2, and the
@@ -42,6 +46,10 @@ import numpy as np
 
 import iris.config
 import iris.util
+
+
+warnings.warn('iris.unit is deprecated in Iris v1.9. Please use cf_units '
+              '(https://github.com/SciTools/cf_units) instead.')
 
 
 __all__ = ['Unit', 'date2num', 'decode_time', 'encode_clock', 'encode_date',


### PR DESCRIPTION
Deprecation warning added to code so that a `UserWarning` is raised when `iris.unit` is imported. Deprecation directive added to module-level docs. Whatsnew entry added.

Addresses #1821.  