### PR TITLE
Py3k unicode slicers

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -574,11 +574,8 @@ def _is_single_item(testee):
     We count string types as 'single', also.
 
     """
-    if isinstance(testee, six.string_types):
-        result = True
-    else:
-        result = not isinstance(testee, collections.Iterable)
-    return result
+    return (isinstance(testee, six.string_types)
+            or not isinstance(testee, collections.Iterable))
 
 
 class Cube(CFVariableMixin):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -567,6 +567,20 @@ class CubeList(list):
         return iris._concatenate.concatenate(self)
 
 
+def _is_single_item(testee):
+    """
+    Return whether this is a single item, rather than an iterable.
+
+    We count string types as 'single', also.
+
+    """
+    if isinstance(testee, six.string_types):
+        result = True
+    else:
+        result = not isinstance(testee, collections.Iterable)
+    return result
+
+
 class Cube(CFVariableMixin):
     """
     A single Iris cube of data and metadata.
@@ -2367,7 +2381,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Convert a name, coord, or list of names/coords to a list of coords.
         """
         # If not iterable, convert to list of a single item
-        if not hasattr(names_or_coords, '__iter__'):
+        if _is_single_item(names_or_coords):
             names_or_coords = [names_or_coords]
 
         coords = []
@@ -2413,7 +2427,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         # Required to handle a mix between types.
-        if not hasattr(ref_to_slice, '__iter__'):
+        if _is_single_item(ref_to_slice):
             ref_to_slice = [ref_to_slice]
 
         slice_dims = set()
@@ -2473,7 +2487,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             raise TypeError("'ordered' argument to slices must be boolean.")
 
         # Required to handle a mix between types
-        if not hasattr(ref_to_slice, '__iter__'):
+        if _is_single_item(ref_to_slice):
             ref_to_slice = [ref_to_slice]
 
         dim_to_slice = []


### PR DESCRIPTION
A step towards an alternative version of #1782 which conserves existing Python 2 behaviour : see [comment there](https://github.com/SciTools/iris/pull/1782#issuecomment-154050680)

An adjusted version of @QuLogic ["b759876 py3k: Correctly handle string input to slicers. "](https://github.com/QuLogic/iris/commit/b7598762531c727bb6939a2017c15fa6cac86183)
The implementation is somewhat rewritten, as I previously suggested : [comment on #1782](https://github.com/SciTools/iris/pull/1782#discussion_r43653959)
This should make *no* functional difference.

TO TEST :
```python3 -m unittest iris.tests.unit.cube.test_Cube``` fails before this, succeeds after

NOTE :
As the second commit efffectively reverts some changes from the first one,  it probably makes good sense to squish before merging.