### PR TITLE
Concatenate error on identical cubes

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -495,9 +495,9 @@ class CubeList(list):
                             'found {}.'.format(n_res_cubes))
                 raise iris.exceptions.ConcatenateError(msgs)
         else:
-            msgs = []
-            msgs.append('Cube names differ: {} != {}'.format(names[0],
-                                                             names[1]))
+            msgs = ['An unexpected problem prevented concatenation.',
+                    'Expected only a single cube, '
+                    'found {}.'.format(n_res_cubes)]
             raise iris.exceptions.ConcatenateError(msgs)
 
     def concatenate(self):

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -93,6 +93,13 @@ class TestMessages(tests.IrisTest):
                            data_dims=(1,))
         self.cube = cube
 
+    def test_cubes_identical(self):
+        cube_1 = self.cube
+        cube_2 = cube_1.copy()
+        exc_regexp = 'identical'
+        with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
+            result = concatenate([cube_1, cube_2], True)
+
     def test_anonymous_coord_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
@@ -173,7 +180,7 @@ class TestMessages(tests.IrisTest):
     def test_datatype_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
-        cube_2.data.dtype = np.float64
+        cube_2.data = cube_2.data.astype(np.float64)
         exc_regexp = 'Datatypes differ: .* != .*'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
             result = concatenate([cube_1, cube_2], True)


### PR DESCRIPTION
Here's a proposal to get concatenate to raise a `ConcatenateError` if you try to concatenate two identical cubes.

The good: one less reason why `ConcatenateError: an unexpected error prevented concatenation` will be raised.

The bad: `_CubeSignature` objects now have an explicit reference to the cube that the signature is being made for. This is necessary in this approach to run a sort of cube equality check to check for identical cubes.

Thoughts?