### PR TITLE
Py3k unicode collapse

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -968,10 +968,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 for index in np.ndindex(shape):
                     index_slice = (slice(None),) + tuple(index)
                     bounds.append(serialize(self.bounds[index_slice]))
-                dtype = np.dtype('U{}'.format(max(map(len, bounds))))
+                string_type_fmt = 'S{}' if six.PY2 else 'U{}'
+                dtype = np.dtype(string_type_fmt.format(max(map(len, bounds))))
                 bounds = np.array(bounds, dtype=dtype).reshape((1,) + shape)
             points = serialize(self.points)
-            dtype = np.dtype('U{}'.format(len(points)))
+            dtype = np.dtype(string_type_fmt.format(len(points)))
             # Create the new collapsed coordinate.
             coord = self.copy(points=np.array(points, dtype=dtype),
                               bounds=bounds)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -968,10 +968,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 for index in np.ndindex(shape):
                     index_slice = (slice(None),) + tuple(index)
                     bounds.append(serialize(self.bounds[index_slice]))
-                dtype = np.dtype('S{}'.format(max(map(len, bounds))))
+                dtype = np.dtype('U{}'.format(max(map(len, bounds))))
                 bounds = np.array(bounds, dtype=dtype).reshape((1,) + shape)
             points = serialize(self.points)
-            dtype = np.dtype('S{}'.format(len(points)))
+            dtype = np.dtype('U{}'.format(len(points)))
             # Create the new collapsed coordinate.
             coord = self.copy(points=np.array(points, dtype=dtype),
                               bounds=bounds)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -962,13 +962,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             # bounds as strings.
             serialize = lambda x: '|'.join([str(i) for i in x.flatten()])
             bounds = None
+            string_type_fmt = 'S{}' if six.PY2 else 'U{}'
             if self.bounds is not None:
                 shape = self.bounds.shape[1:]
                 bounds = []
                 for index in np.ndindex(shape):
                     index_slice = (slice(None),) + tuple(index)
                     bounds.append(serialize(self.bounds[index_slice]))
-                string_type_fmt = 'S{}' if six.PY2 else 'U{}'
                 dtype = np.dtype(string_type_fmt.format(max(map(len, bounds))))
                 bounds = np.array(bounds, dtype=dtype).reshape((1,) + shape)
             points = serialize(self.points)

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -205,6 +205,8 @@ class Test_collapsed(tests.IrisTest):
                                 ['three', 'five'],
                                 ['five', 'seven'],
                                 ['seven', 'nine']]))
+        string_nobounds = Pair(np.array(['ecks', 'why', 'zed']),
+                               None)
         string_multi = Pair(np.array(['three', 'six', 'nine']),
                             np.array([['one', 'two', 'four', 'five'],
                                       ['four', 'five', 'seven', 'eight'],
@@ -214,15 +216,17 @@ class Test_collapsed(tests.IrisTest):
             return '|'.join(str(item) for item in data.flatten())
 
         for units in ['unknown', 'no_unit']:
-            for points, bounds in [string, string_multi]:
+            for points, bounds in [string, string_nobounds, string_multi]:
                 coord = AuxCoord(points=points, bounds=bounds, units=units)
                 collapsed_coord = coord.collapsed()
                 self.assertArrayEqual(collapsed_coord.points,
                                       _serialize(points))
-                for index in np.ndindex(bounds.shape[1:]):
-                    index_slice = (slice(None),) + tuple(index)
-                    self.assertArrayEqual(collapsed_coord.bounds[index_slice],
-                                          _serialize(bounds[index_slice]))
+                if bounds is not None:
+                    for index in np.ndindex(bounds.shape[1:]):
+                        index_slice = (slice(None),) + tuple(index)
+                        self.assertArrayEqual(
+                            collapsed_coord.bounds[index_slice],
+                            _serialize(bounds[index_slice]))
 
     def test_dim_1d(self):
         # Numeric coords should not be serialised.


### PR DESCRIPTION
A step towards an alternative version of #1782 which conserves existing Python 2 behaviour : see [comment there](https://github.com/SciTools/iris/pull/1782#issuecomment-154050680)

An adjusted version of @QuLogic
["f9cc0f9 py3k: Use Unicode in coord collapse."](https://github.com/QuLogic/iris/commit/f9cc0f93330624179094eaeb7f673f2cfdcd7354)
Make it unicode only in Python 3.

TO TEST :
```python3 -m unittest iris.tests.unit.coords.test_Coord.Test_collapsed``` fails before this, succeeds after

NOTE :
As the second commit effectively reverts some changes from the first one,  it probably makes good sense to squish before merging.