### PR TITLE
Skip all grib tests for Python 3.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -813,7 +813,8 @@ def skip_plot(fn):
 if six.PY3:
     skip_grib = unittest.skipIf(
         True,
-        'Test(s) use "grib", which is not currently supported under Python 3.')
+        ('Test(s) require "gribapi", '
+         'which is not currently supported under Python 3.'))
 else:
     skip_grib = unittest.skipIf(
         not GRIB_AVAILABLE,

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -810,8 +810,14 @@ def skip_plot(fn):
     return skip(fn)
 
 
-skip_grib = unittest.skipIf(not GRIB_AVAILABLE, 'Test(s) require "gribapi", '
-                                                'which is not available.')
+if six.PY3:
+    skip_grib = unittest.skipIf(
+        True,
+        'Test(s) use "grib", which is not currently supported under Python 3.')
+else:
+    skip_grib = unittest.skipIf(
+        not GRIB_AVAILABLE,
+        'Test(s) require "gribapi", which is not available.')
 
 
 def no_warnings(func):

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -27,6 +27,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import glob
 import multiprocessing
 import os
+import six
 import sys
 
 
@@ -181,9 +182,13 @@ class TestRunner():
         args = ['', None, '--processes=%s' % n_processors,
                 '--verbosity=2', regexp_pat,
                 '--process-timeout=250']
-        try:
-            import gribapi
-        except ImportError:
+        gribapi = None
+        if six.PY2:
+            try:
+                import gribapi
+            except ImportError:
+                pass
+        if not gribapi:
             args.append('--exclude=^grib$')
         if self.stop:
             args.append('--stop')


### PR DESCRIPTION
**this is now a placeholder: DO NOT MERGE**
see : https://github.com/SciTools/iris/pull/1833#issuecomment-157074499

~~This excludes the grib tests from the standard test run in Python 3.
This is needed because we decided not to support Grib under Python 3 for the present,
because of outstanding problems (see https://github.com/SciTools/iris/pull/1806).~~

~~TO TEST:
running ```python3 setup.py test``` will generate various grib-related errors, which this removes.
Unfortunately, all tests won't run successfully under Python 3, until various other outstanding problems are resolved (see list in #1782)~~