### PR TITLE
Fix rules global usage.

### DIFF
--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -95,7 +95,7 @@ _rules_globals = None
 _import_pending = True
 def _rules_execution_environment():
     """
-    Return a environment with the globals needed for rules code execution.
+    Return an environment with the globals needed for rules code execution.
 
     This is needed as the rules file does not use fully qualified class names.
     If something is needed for rules execution, it can be added here.


### PR DESCRIPTION
An attempt to fix the problems discussed in [this problem comment](https://github.com/SciTools/iris/pull/1826#issuecomment-156031183)
**This should fix the current intermittent test failures.**

I tried to tidy the nastiness in the rules code a wee bit, rather than just work around it (e.g. by simply renaming the 'rules.config' variable).
I haven't removed the use of 'exec', or avoided the "```from xx import *```" equivalents, but at least it is no longer polluting the namespace of ```iris.fileformats.rules``` itself (which caused the bug).

I also switched it to using a blank 'locals' in the exec calls, as the current use of locals() (as see e.g. [here](https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/rules.py#L323)) is not needed and not really a very good idea.  I suspect the *original* idea here was for the function to 'appear' as a local variable in the caller, but modifying "locals()" can't actually do that -- unlike with "globals()" where it can.