### PR TITLE
Deprecate user pp save rules.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-17_pp-save-rules.txt
+++ b/docs/iris/src/whatsnew/contributions_1.9/deprecate_2015-11-17_pp-save-rules.txt
@@ -1,0 +1,1 @@
+* deprecated :meth:`iris.fileformats.pp.add_save_rules` and :meth:`iris.fileformats.pp.reset_save_rules`.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1943,17 +1943,23 @@ def add_save_rules(filename):
     Registered files are processed after the standard conversion rules, and in
     the order they were registered.
 
+    .. deprecated:: 1.9
+
     """
     _ensure_save_rules_loaded()
     _save_rules.import_rules(filename)
 
 
 def reset_save_rules():
-    """Resets the PP save process to use only the standard conversion rules."""
+    """
+    Resets the PP save process to use only the standard conversion rules.
+
+    .. deprecated:: 1.9
+
+    """
 
     # Uses this module-level variable
     global _save_rules
-
     _save_rules = None
 
 


### PR DESCRIPTION
Add deprecations for the user API functions supporting PP custom save rules.
We suspect this is basically not used by anyone.

The PP save rules are the only remaining 'built-in' text rules.
So, if we have this **and** #1836, then we can remove the whole text rules mechanism in version 2.0.

I've added a whatsnew item, but no tests.
It seems simple enough not to need any ?