### PR TITLE
Bake udunits version into package name.

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -8,7 +8,7 @@ matplotlib=1.3.1
 netcdf4
 numpy
 pyke
-udunits=2.*
+udunits2
 cf_units
 
 # Iris build dependencies

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -8,7 +8,7 @@ matplotlib=1.3.1
 netcdf4
 numpy
 pyke
-udunits=2.*
+udunits2
 cf_units
 
 # Iris build dependencies


### PR DESCRIPTION
Switch to the new name in conda-recipes-scitools. Avoids:
```
$ conda list
...
udunits                   2.2.17                        5    scitools
udunits2                  2.2.20                        0    scitools
...
```