### PR TITLE
Warning for PP fields with lbcode 31323

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -18,6 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+import warnings
 
 # Historically this was auto-generated from
 # SciTools/iris-code-generators:tools/gen_rules.py
@@ -763,6 +764,14 @@ def convert(f):
     """
     factories = []
     aux_coords_and_dims = []
+
+    # Raise a warning for `f.lbcode` == 31323, which is currently not being
+    # translated properly by the rules.
+    if f.lbcode._value == 31323:
+        msg = ('Loaded PP field has LBCODE=31323, whose meaning is not clearly'
+               ' defined by the PP spec. Interpretation is subject to change '
+               'based upon clarification to the PP spec.')
+        warnings.warn(msg)
 
     # "Normal" (non-cross-sectional) Time values (--> scalar coordinates)
     time_coords_and_dims = _convert_scalar_time_coords(

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -101,8 +101,9 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
+            lbcode = iris.fileformats.pp.SplittableInt(1)
             field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
+                                   lbcode=lbcode, lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'
@@ -180,8 +181,9 @@ class TestVertical(tests.IrisTest):
     def test_hybrid_pressure_with_duplicate_references(self):
         def field_with_data(scale=1):
             x, y = 40, 30
+            lbcode = iris.fileformats.pp.SplittableInt(1)
             field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
+                                   lbcode=lbcode, lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'
@@ -293,8 +295,9 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
+            lbcode = iris.fileformats.pp.SplittableInt(1)
             field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
+                                   lbcode=lbcode, lbnpt=x, lbrow=y,
                                    bzx=350, bdx=1.5, bzy=40, bdy=1.5,
                                    lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -25,6 +25,7 @@ import six
 import iris.tests as tests
 
 import types
+import warnings
 
 import numpy as np
 
@@ -66,6 +67,15 @@ class TestLBCODE(iris.tests.unit.fileformats.TestField):
                              TestLBCODE._is_cross_section_height_coord,
                              expected_points=points,
                              expected_bounds=bounds)
+
+    def test_cross_section_warning(self):
+        lbcode = SplittableInt(31323)
+        field = mock.MagicMock(lbcode=lbcode)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            msg = 'PP field has LBCODE=31323'
+            with self.assertRaisesRegexp(UserWarning, msg):
+                convert(field)
 
 
 class TestLBVC(iris.tests.unit.fileformats.TestField):

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -74,7 +74,7 @@ class TestLBCODE(iris.tests.unit.fileformats.TestField):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             msg = 'PP field has LBCODE=31323'
-            with self.assertRaisesRegexp(UserWarning, msg):
+            with six.assertRaisesRegex(UserWarning, msg):
                 convert(field)
 
 


### PR DESCRIPTION
Add warning when loading PP files containing any fields with `LBCODE=31323`.

Fixes #1851. 