### PR TITLE
Deep soil level/depth coordinate.

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -596,7 +596,7 @@ THEN
 # single depth level (Non-dimensional soil model level)
 IF
     scalar_coord(cm, 'soil_model_level_number') is not None
-    not scalar_coord(cm, 'soil_model_level_number').bounds
+    not scalar_coord(cm, 'soil_model_level_number').has_bounds()
     # The following `is None` checks ensure this rule does not get run
     # if any of the previous LBVC setting rules have run. It gives these
     # rules something of an IF-THEN-ELSE structure.
@@ -610,6 +610,28 @@ THEN
     pp.lbvc = 6
     pp.lblev = scalar_coord(cm, 'soil_model_level_number').points[0]
     pp.blev = pp.lblev
+    pp.brsvd[0] = 0
+    pp.brlev = 0
+
+# single depth level (deep soil depth)
+IF
+    scalar_coord(cm, 'depth') is not None
+    scalar_coord(cm, 'depth').has_bounds()
+    # The following `is None` checks ensure this rule does not get run
+    # if any of the previous LBVC setting rules have run. It gives these
+    # rules something of an IF-THEN-ELSE structure.
+    scalar_coord(cm, 'air_pressure') is None
+    scalar_coord(cm, 'soil_model_level_number') is None
+    scalar_coord(cm, 'model_level_number') is None
+    scalar_coord(cm, 'height') is None
+    scalar_coord(cm, 'pressure') is None
+    cm.standard_name is not None
+    'soil' in cm.standard_name
+THEN
+    pp.lbvc = 6
+    pp.blev = scalar_coord(cm, 'depth').points[0]
+    pp.brsvd[0] = scalar_coord(cm, 'depth').bounds[0, 0]
+    pp.brlev = scalar_coord(cm, 'depth').bounds[0, 1]
 
 # single potential-temperature level
 IF

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -613,7 +613,7 @@ THEN
     pp.brsvd[0] = 0
     pp.brlev = 0
 
-# single depth level (deep soil depth)
+# single depth level (soil depth)
 IF
     scalar_coord(cm, 'depth') is not None
     scalar_coord(cm, 'depth').has_bounds()

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -162,12 +162,22 @@ def _convert_vertical_coords(lbcode, lbvc, blev, lblev, stash,
                             attributes={'positive': 'down'})
         coords_and_dims.append((coord, dim))
 
-    # Soil level.
-    if len(lbcode) != 5 and \
-            lbvc == 6:
-        coord = _dim_or_aux(model_level_number, long_name='soil_model_level_number',
-                            attributes={'positive': 'down'})
-        coords_and_dims.append((coord, dim))
+    # Deep soil level/depth.
+    if len(lbcode) != 5 and lbvc == 6:
+        if np.all(brsvd1 == brlev) and np.sum(brlev) == 0:
+            # UM populates lblev, brsvd1 and brlev metadata INCORRECTLY,
+            # so continue to treat as a soil level.
+            coord = _dim_or_aux(model_level_number,
+                                long_name='soil_model_level_number',
+                                attributes={'positive': 'down'})
+            coords_and_dims.append((coord, dim))
+        elif np.all(brsvd1 != brlev):
+            # UM populates metadata CORRECTLY,
+            # so treat it as the expected (bounded) deep soil depth.
+            coord = _dim_or_aux(blev, standard_name='depth', units='m',
+                                bounds=np.vstack((brsvd1, brlev)).T,
+                                attributes={'positive': 'down'})
+            coords_and_dims.append((coord, dim))
 
     # Pressure.
     if (lbvc == 8) and \
@@ -666,9 +676,22 @@ def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
             (brsvd1 != brlev):
         coords_and_dims.append((DimCoord(blev, standard_name='depth', units='m', bounds=[brsvd1, brlev], attributes={'positive': 'down'}), None))
 
-    # soil level
+    # Deep soil level/depth.
     if len(lbcode) != 5 and lbvc == 6:
-        coords_and_dims.append((DimCoord(model_level_number, long_name='soil_model_level_number', attributes={'positive': 'down'}), None))
+        if brsvd1 == 0 and brlev == 0:
+            # UM populates lblev, brsvd1 and brlev metadata INCORRECTLY,
+            # so continue to treat lblev as a soil level.
+            coord = DimCoord(model_level_number,
+                             long_name='soil_model_level_number',
+                             attributes={'positive': 'down'})
+            coords_and_dims.append((coord, None))
+        else:
+            # UM populates metadata CORRECTLY,
+            # so treat it as the expected (bounded) deep soil depth.
+            coord = DimCoord(blev, standard_name='depth', units='m',
+                             bounds=[brsvd1, brlev],
+                             attributes={'positive': 'down'})
+            coords_and_dims.append((coord, None))
 
     if \
             (lbvc == 8) and \

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -162,9 +162,9 @@ def _convert_vertical_coords(lbcode, lbvc, blev, lblev, stash,
                             attributes={'positive': 'down'})
         coords_and_dims.append((coord, dim))
 
-    # Deep soil level/depth.
+    # Soil level/depth.
     if len(lbcode) != 5 and lbvc == 6:
-        if np.all(brsvd1 == brlev) and np.sum(brlev) == 0:
+        if not (np.any(brsvd1) or np.any(brlev)):
             # UM populates lblev, brsvd1 and brlev metadata INCORRECTLY,
             # so continue to treat as a soil level.
             coord = _dim_or_aux(model_level_number,
@@ -173,7 +173,7 @@ def _convert_vertical_coords(lbcode, lbvc, blev, lblev, stash,
             coords_and_dims.append((coord, dim))
         elif np.all(brsvd1 != brlev):
             # UM populates metadata CORRECTLY,
-            # so treat it as the expected (bounded) deep soil depth.
+            # so treat it as the expected (bounded) soil depth.
             coord = _dim_or_aux(blev, standard_name='depth', units='m',
                                 bounds=np.vstack((brsvd1, brlev)).T,
                                 attributes={'positive': 'down'})
@@ -676,7 +676,7 @@ def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
             (brsvd1 != brlev):
         coords_and_dims.append((DimCoord(blev, standard_name='depth', units='m', bounds=[brsvd1, brlev], attributes={'positive': 'down'}), None))
 
-    # Deep soil level/depth.
+    # Soil level/depth.
     if len(lbcode) != 5 and lbvc == 6:
         if brsvd1 == 0 and brlev == 0:
             # UM populates lblev, brsvd1 and brlev metadata INCORRECTLY,
@@ -685,9 +685,9 @@ def _convert_scalar_vertical_coords(lbcode, lbvc, blev, lblev, stash,
                              long_name='soil_model_level_number',
                              attributes={'positive': 'down'})
             coords_and_dims.append((coord, None))
-        else:
+        elif brsvd1 != brlev:
             # UM populates metadata CORRECTLY,
-            # so treat it as the expected (bounded) deep soil depth.
+            # so treat it as the expected (bounded) soil depth.
             coord = DimCoord(blev, standard_name='depth', units='m',
                              bounds=[brsvd1, brlev],
                              attributes={'positive': 'down'})

--- a/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
+++ b/lib/iris/tests/unit/experimental/fieldsfile/test__convert_collation.py
@@ -24,6 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import netcdftime
+import numpy as np
 
 from iris.experimental.fieldsfile \
     import _convert_collation as convert_collation
@@ -219,6 +220,57 @@ class Test(tests.IrisTest):
                                                  long_name='pressure',
                                                  units='hPa'),
                             (0,))]
+        self.assertEqual(metadata.dim_coords_and_dims, coords_and_dims)
+        coords_and_dims = []
+        self.assertEqual(metadata.aux_coords_and_dims, coords_and_dims)
+
+    def test_soil_level(self):
+        field = self._field()
+        field.lbvc = 6
+        points = [10, 20, 30]
+        lower = [0] * 3
+        upper = [0] * 3
+        lblev = (points, (0,))
+        brsvd1 = (lower, (0,))
+        brlev = (upper, (0,))
+        collation = mock.Mock(fields=[field], vector_dims_shape=(3,),
+                              element_arrays_and_dims={'lblev': lblev,
+                                                       'brsvd1': brsvd1,
+                                                       'brlev': brlev})
+        metadata = convert_collation(collation)
+        self._check_phenomenon(metadata)
+        level = iris.coords.DimCoord(points,
+                                     long_name='soil_model_level_number',
+                                     attributes={'positive': 'down'})
+        coords_and_dims = [(LONGITUDE, 2),
+                           (LATITUDE, 1),
+                           (level, (0,))]
+        self.assertEqual(metadata.dim_coords_and_dims, coords_and_dims)
+        coords_and_dims = []
+        self.assertEqual(metadata.aux_coords_and_dims, coords_and_dims)
+
+    def test_soil_depth(self):
+        field = self._field()
+        field.lbvc = 6
+        points = [10, 20, 30]
+        lower = [0, 15, 25]
+        upper = [15, 25, 35]
+        blev = (points, (0,))
+        brsvd1 = (lower, (0,))
+        brlev = (upper, (0,))
+        collation = mock.Mock(fields=[field], vector_dims_shape=(3,),
+                              element_arrays_and_dims={'blev': blev,
+                                                       'brsvd1': brsvd1,
+                                                       'brlev': brlev})
+        metadata = convert_collation(collation)
+        self._check_phenomenon(metadata)
+        depth = iris.coords.DimCoord(points, standard_name='depth',
+                                     bounds=np.vstack((lower, upper)).T,
+                                     units='m',
+                                     attributes={'positive': 'down'})
+        coords_and_dims = [(LONGITUDE, 2),
+                           (LATITUDE, 1),
+                           (depth, (0,))]
         self.assertEqual(metadata.dim_coords_and_dims, coords_and_dims)
         coords_and_dims = []
         self.assertEqual(metadata.aux_coords_and_dims, coords_and_dims)

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -60,6 +60,30 @@ class TestVertical(tests.IrisTest):
         lbuser5_produced = _pp_save_ppfield_values(self.cube).lbuser[4]
         self.assertEqual(pseudo_level, lbuser5_produced)
 
+    def test_soil_level(self):
+        soil_level = 314
+        coord = DimCoord(soil_level, long_name='soil_model_level_number')
+        self.cube.add_aux_coord(coord)
+        self.cube.standard_name = 'moisture_content_of_soil_layer'
+        field = _pp_save_ppfield_values(self.cube)
+        self.assertEqual(field.lbvc, 6)
+        self.assertEqual(field.lblev, soil_level)
+        self.assertEqual(field.blev, soil_level)
+        self.assertEqual(field.brsvd[0], 0)
+        self.assertEqual(field.brlev, 0)
+
+    def test_soil_depth(self):
+        lower, point, upper = 1, 2, 3
+        coord = DimCoord(point, standard_name='depth', bounds=[[lower, upper]])
+        self.cube.add_aux_coord(coord)
+        self.cube.standard_name = 'moisture_content_of_soil_layer'
+        field = _pp_save_ppfield_values(self.cube)
+        self.assertEqual(field.lbvc, 6)
+        self.assertEqual(field.lblev, 0)
+        self.assertEqual(field.blev, point)
+        self.assertEqual(field.brsvd[0], lower)
+        self.assertEqual(field.brlev, upper)
+
 
 class TestLbfcProduction(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
@@ -138,9 +138,9 @@ class TestLBVC006_SoilLevel(TestField):
     def _check_soil_level(self, lbcode, expect_match=True):
         lbvc = 6
         lblev = 12.3
+        brsvd1, brlev = 0, 0
         stash = STASH(1, 1, 1)
-        blev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
-            None, None, None, None, None, None
+        blev, bhlev, bhrlev, brsvd2 = None, None, None, None
         coords_and_dims, factories = _convert_scalar_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
@@ -148,6 +148,34 @@ class TestLBVC006_SoilLevel(TestField):
         if expect_match:
             expect_result = [
                 (DimCoord([lblev], long_name='soil_model_level_number',
+                          attributes={'positive': 'down'}), None)]
+        else:
+            expect_result = []
+        self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
+        self.assertEqual(factories, [])
+
+    def test_normal(self):
+        self._check_soil_level(_lbcode(0))
+
+    def test_cross_section(self):
+        self._check_soil_level(_lbcode(ix=1, iy=2), expect_match=False)
+
+
+class TestLBVC006_SoilDepth(TestField):
+    def _check_soil_level(self, lbcode, expect_match=True):
+        lbvc = 6
+        blev = 0.05
+        brsvd1, brlev = 0, 0.1
+        stash = STASH(1, 1, 1)
+        lblev, bhlev, bhrlev, brsvd2 = None, None, None, None
+        coords_and_dims, factories = _convert_scalar_vertical_coords(
+            lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
+            bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
+            brlev=brlev)
+        if expect_match:
+            expect_result = [
+                (DimCoord([blev], standard_name='depth', units='m',
+                          bounds=[[brsvd1, brlev]],
                           attributes={'positive': 'down'}), None)]
         else:
             expect_result = []

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
@@ -162,7 +162,7 @@ class TestLBVC006_SoilLevel(TestField):
 
 
 class TestLBVC006_SoilDepth(TestField):
-    def _check_soil_level(self, lbcode, expect_match=True):
+    def _check_soil_depth(self, lbcode, expect_match=True):
         lbvc = 6
         blev = 0.05
         brsvd1, brlev = 0, 0.1
@@ -183,10 +183,10 @@ class TestLBVC006_SoilDepth(TestField):
         self.assertEqual(factories, [])
 
     def test_normal(self):
-        self._check_soil_level(_lbcode(0))
+        self._check_soil_depth(_lbcode(0))
 
     def test_cross_section(self):
-        self._check_soil_level(_lbcode(ix=1, iy=2), expect_match=False)
+        self._check_soil_depth(_lbcode(ix=1, iy=2), expect_match=False)
 
 
 class TestLBVC008_Pressure(TestField):

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
@@ -218,18 +218,20 @@ class TestLBVC006_SoilLevel(TestField):
                           dim=None):
         lbvc = 6
         stash = STASH(1, 1, 1)
-        blev, bhlev, bhrlev, brsvd1, brsvd2, brlev = \
-            None, None, None, None, None, None
+        brsvd1, brlev = 0, 0
+        if hasattr(lblev, '__iter__'):
+            brsvd1 = [0] * len(lblev)
+            brlev = [0] * len(lblev)
+        blev, bhlev, bhrlev, brsvd2 = None, None, None, None
         coords_and_dims, factories = _convert_vertical_coords(
             lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
             bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
             brlev=brlev, dim=dim)
+        expect_result = []
         if expect_match:
-            expect_result = [
-                (DimCoord(lblev, long_name='soil_model_level_number',
-                          attributes={'positive': 'down'}), dim)]
-        else:
-            expect_result = []
+            coord = DimCoord(lblev, long_name='soil_model_level_number',
+                             attributes={'positive': 'down'})
+            expect_result = [(coord, dim)]
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
         self.assertEqual(factories, [])
 
@@ -246,6 +248,43 @@ class TestLBVC006_SoilLevel(TestField):
     def test_cross_section__vector(self):
         lblev = np.arange(10)
         self._check_soil_level(_lbcode(ix=1, iy=2), lblev=lblev,
+                               expect_match=False, dim=0)
+
+
+class TestLBVC006_SoilDepth(TestField):
+    def _check_soil_level(self, lbcode, blev=0.05, brsvd1=0, brlev=0.1,
+                          expect_match=True, dim=None):
+        lbvc = 6
+        stash = STASH(1, 1, 1)
+        lblev, bhlev, bhrlev, brsvd2 = None, None, None, None
+        coords_and_dims, factories = _convert_vertical_coords(
+            lbcode=lbcode, lbvc=lbvc, blev=blev, lblev=lblev, stash=stash,
+            bhlev=bhlev, bhrlev=bhrlev, brsvd1=brsvd1, brsvd2=brsvd2,
+            brlev=brlev, dim=dim)
+        expect_result = []
+        if expect_match:
+            coord = DimCoord(blev, standard_name='depth',
+                             bounds=np.vstack((brsvd1, brlev)).T,
+                             units='m', attributes={'positive': 'down'})
+            expect_result = [(coord, dim)]
+        self.assertCoordsAndDimsListsMatch(coords_and_dims, expect_result)
+        self.assertEqual(factories, [])
+
+    def test_normal(self):
+        self._check_soil_level(_lbcode(0))
+
+    def test_normal__vector(self):
+        points = np.arange(10)
+        self._check_soil_level(_lbcode(0), blev=points,
+                               brsvd1=points - 1, brlev=points + 1, dim=0)
+
+    def test_cross_section(self):
+        self._check_soil_level(_lbcode(ix=1, iy=2), expect_match=False)
+
+    def test_cross_section__vector(self):
+        points = np.arange(10)
+        self._check_soil_level(_lbcode(ix=1, iy=2), blev=points,
+                               brsvd1=points - 1, brlev=points + 1,
                                expect_match=False, dim=0)
 
 

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
@@ -252,7 +252,7 @@ class TestLBVC006_SoilLevel(TestField):
 
 
 class TestLBVC006_SoilDepth(TestField):
-    def _check_soil_level(self, lbcode, blev=0.05, brsvd1=0, brlev=0.1,
+    def _check_soil_depth(self, lbcode, blev=0.05, brsvd1=0, brlev=0.1,
                           expect_match=True, dim=None):
         lbvc = 6
         stash = STASH(1, 1, 1)
@@ -271,19 +271,27 @@ class TestLBVC006_SoilDepth(TestField):
         self.assertEqual(factories, [])
 
     def test_normal(self):
-        self._check_soil_level(_lbcode(0))
+        self._check_soil_depth(_lbcode(0))
 
     def test_normal__vector(self):
         points = np.arange(10)
-        self._check_soil_level(_lbcode(0), blev=points,
+        self._check_soil_depth(_lbcode(0), blev=points,
                                brsvd1=points - 1, brlev=points + 1, dim=0)
 
+    def test_bad_bounds(self):
+        points = [-0.5, 0.5]
+        lower = [-1, 1]
+        upper = [-1, 1]
+        self._check_soil_depth(_lbcode(0), blev=points,
+                               brsvd1=lower, brlev=upper, dim=0,
+                               expect_match=False)
+
     def test_cross_section(self):
-        self._check_soil_level(_lbcode(ix=1, iy=2), expect_match=False)
+        self._check_soil_depth(_lbcode(ix=1, iy=2), expect_match=False)
 
     def test_cross_section__vector(self):
         points = np.arange(10)
-        self._check_soil_level(_lbcode(ix=1, iy=2), blev=points,
+        self._check_soil_depth(_lbcode(ix=1, iy=2), blev=points,
                                brsvd1=points - 1, brlev=points + 1,
                                expect_match=False, dim=0)
 

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -91,18 +91,33 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
                 coord.units.is_dimensionless())
 
     @staticmethod
-    def _is_soil_model_level_number_coord(coord):
+    def _is_deep_soil_model_level_number_coord(coord):
         return (coord.long_name == 'soil_model_level_number' and
                 coord.units.is_dimensionless() and
                 coord.attributes['positive'] == 'down')
 
-    def test_soil_levels(self):
+    @staticmethod
+    def _is_deep_soil_depth_coord(coord):
+        return (coord.standard_name == 'depth' and
+                coord.units == 'm' and
+                coord.attributes['positive'] == 'down')
+
+    def test_deep_soil_levels(self):
         level = 1234
-        field = mock.MagicMock(lbvc=6, lblev=level)
+        field = mock.MagicMock(lbvc=6, lblev=level, brsvd=[0, 0], brlev=0)
         self._test_for_coord(field, convert,
-                             TestLBVC._is_soil_model_level_number_coord,
+                             self._is_deep_soil_model_level_number_coord,
                              expected_points=[level],
                              expected_bounds=None)
+
+    def test_deep_soil_depth(self):
+        lower, point, upper = 1.2, 3.4, 5.6
+        field = mock.MagicMock(lbvc=6, blev=point, brsvd=[lower, 0],
+                               brlev=upper)
+        self._test_for_coord(field, convert,
+                             self._is_deep_soil_depth_coord,
+                             expected_points=[point],
+                             expected_bounds=[[lower, upper]])
 
     def test_hybrid_pressure_model_level_number(self):
         level = 5678

--- a/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test_convert.py
@@ -91,31 +91,31 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
                 coord.units.is_dimensionless())
 
     @staticmethod
-    def _is_deep_soil_model_level_number_coord(coord):
+    def _is_soil_model_level_number_coord(coord):
         return (coord.long_name == 'soil_model_level_number' and
                 coord.units.is_dimensionless() and
                 coord.attributes['positive'] == 'down')
 
     @staticmethod
-    def _is_deep_soil_depth_coord(coord):
+    def _is_soil_depth_coord(coord):
         return (coord.standard_name == 'depth' and
                 coord.units == 'm' and
                 coord.attributes['positive'] == 'down')
 
-    def test_deep_soil_levels(self):
+    def test_soil_levels(self):
         level = 1234
         field = mock.MagicMock(lbvc=6, lblev=level, brsvd=[0, 0], brlev=0)
         self._test_for_coord(field, convert,
-                             self._is_deep_soil_model_level_number_coord,
+                             self._is_soil_model_level_number_coord,
                              expected_points=[level],
                              expected_bounds=None)
 
-    def test_deep_soil_depth(self):
+    def test_soil_depth(self):
         lower, point, upper = 1.2, 3.4, 5.6
         field = mock.MagicMock(lbvc=6, blev=point, brsvd=[lower, 0],
                                brlev=upper)
         self._test_for_coord(field, convert,
-                             self._is_deep_soil_depth_coord,
+                             self._is_soil_depth_coord,
                              expected_points=[point],
                              expected_bounds=[[lower, upper]])
 


### PR DESCRIPTION
This PR fixes a known current issue with UM model output incorrectly populating PP field attributes for deep soil level (vertical coordinate LBVC=6).

Rather than being an unbounded, dimensionless vertical soil model level (lblev), it should be a bounded ([brsvd[0], brlev]) vertical model depth (blev) in units of metres.