### PR TITLE
Subset self exception

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2015-Dec-16_subset-scalar-coordinates.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2015-Dec-16_subset-scalar-coordinates.txt
@@ -1,0 +1,2 @@
+* fixed a bug in :mod:`iris.cube.subset` where an exception would be thrown
+  while trying to subset over a non-dimensional scalar coordinate.

--- a/lib/iris/tests/integration/test_subset.py
+++ b/lib/iris/tests/integration/test_subset.py
@@ -1,0 +1,56 @@
+# (C) British Crown Copyright 2015 - 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for subset."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.coords import DimCoord
+from iris.cube import Cube
+
+
+def _make_test_cube():
+    data = np.zeros((4, 4, 1))
+    lats, longs = [0, 10, 20, 30], [5, 15, 25, 35]
+    lat_coord = DimCoord(lats, standard_name='latitude', units='degrees')
+    lon_coord = DimCoord(longs, standard_name='longitude', units='degrees')
+    vrt_coord = DimCoord([850], long_name='pressure', units='hPa')
+    return Cube(data,
+                long_name='test_cube', units='1', attributes=None,
+                dim_coords_and_dims=[(lat_coord, 0), (lon_coord, 1)],
+                aux_coords_and_dims=[(vrt_coord, None)])
+
+
+class TestSubset(tests.IrisTest):
+    def setUp(self):
+        self.cube = _make_test_cube()
+
+    def test_coordinate_subset(self):
+        coord = self.cube.coord('pressure')
+        subsetted = self.cube.subset(coord)
+        self.assertEqual(self.cube, subsetted)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -1238,6 +1238,41 @@ class Test_dtype(tests.IrisTest):
         self.assertEqual(cube.dtype, np.float32)
         # Check that accessing the dtype does not trigger loading of the data.
         self.assertTrue(cube.has_lazy_data())
+
+
+class TestSubset(tests.IrisTest):
+    def test_scalar_coordinate(self):
+        cube = Cube(0, long_name='apricot', units='1')
+        cube.add_aux_coord(DimCoord([0], long_name='banana', units='1'))
+        result = cube.subset(cube.coord('banana'))
+        self.assertEqual(cube, result)
+
+    def test_dimensional_coordinate(self):
+        cube = Cube(np.zeros((4)), long_name='tinned_peach', units='1')
+        cube.add_dim_coord(DimCoord([0, 1, 2, 3],
+                                    long_name='sixteen_ton_weight',
+                                    units='1'),
+                           0)
+        result = cube.subset(cube.coord('sixteen_ton_weight'))
+        self.assertEqual(cube, result)
+
+    def test_missing_coordinate(self):
+        cube = Cube(0, long_name='raspberry', units='1')
+        cube.add_aux_coord(DimCoord([0], long_name='loganberry', units='1'))
+        bad_coord = DimCoord([0], long_name='tiger', units='1')
+        self.assertRaises(CoordinateNotFoundError, cube.subset, bad_coord)
+
+    def test_different_coordinate(self):
+        cube = Cube(0, long_name='raspberry', units='1')
+        cube.add_aux_coord(DimCoord([0], long_name='loganberry', units='1'))
+        different_coord = DimCoord([2], long_name='loganberry', units='1')
+        result = cube.subset(different_coord)
+        self.assertEqual(result, None)
+
+    def test_not_coordinate(self):
+        cube = Cube(0, long_name='peach', units='1')
+        cube.add_aux_coord(DimCoord([0], long_name='crocodile', units='1'))
+        self.assertRaises(ValueError, cube.subset, 'Pointed Stick')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Subset throws an exception if you pass it a scalar co-ordinate: `len(coord.points) == 1` and `coord in aux_coords == True`.

This is (I think) a fix to that problem. Comments? - The integration test I added should probably not go in..

Thanks,
Gray.