### PR TITLE
Deprecate the whole pp 'custom save rules' api.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2015-Dec-01_pp-custom-save-rules.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2015-Dec-01_pp-custom-save-rules.txt
@@ -1,0 +1,5 @@
+ * deprecated the custom pp save rules mechanism implemented by the methods
+   :meth:`iris.fileformats.pp.add_save_rules' and :meth:`iris.fileformats.pp.reset_save_rules'.
+   The new methods :meth:`iris.fileformats.pp.as_pairs', :meth:`iris.fileformats.pp.as_pairs'
+   and :meth:`iris.fileformats.pp.save_fields' now  provide an alternative means
+   of achieving the same ends.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1920,14 +1920,40 @@ def add_save_rules(filename):
     Registered files are processed after the standard conversion rules, and in
     the order they were registered.
 
+    .. deprecated:: 1.9
+
+        If you need to customise pp field saving, please refer to the methods
+        :meth:`as_fields`, :meth:`as_pairs` and :meth:`save_fields` for an
+        alternative solution.
+
     """
+    warnings.warn(
+        'custom pp save rules are deprecated from v1.9.\n'
+        'If you need to customise pp field saving, please refer to '
+        'the methods iris.fileformats.pp.as_fields, '
+        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
+        'for an alternative solution.')
     _ensure_save_rules_loaded()
     _save_rules.import_rules(filename)
 
 
 def reset_save_rules():
-    """Resets the PP save process to use only the standard conversion rules."""
+    """
+    Resets the PP save process to use only the standard conversion rules.
 
+    .. deprecated:: 1.9
+
+        If you need to customise pp field saving, please refer to the methods
+        :meth:`as_fields`, :meth:`as_pairs` and :meth:`save_fields` for an
+        alternative solution.
+
+    """
+    warnings.warn(
+        'custom pp save rules are deprecated from v1.9.\n'
+        'If you need to customise pp field saving, please refer to '
+        'the methods iris.fileformats.pp.as_fields, '
+        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
+        'for an alternative solution.')
     # Uses this module-level variable
     global _save_rules
 


### PR DESCRIPTION
To be clear, I'm proposing that **this should go in the new 1.9 release**.

On reflection, I don't really see why we can't just do this.
The key point is that ***this will enable us to remove the last remnants of text rules processing***.

Possibly we shouldn't deprecate something without giving a clear upgrade route, but I think there is a very strong suspicion in this case that no-one ever uses these facilities.
Even if there **is** someone who is affected by this, I would expect them to be a MetOffice user who we can easily identify and help :  What non-MO users are likely to be saving to PP files ??