### PR TITLE
Ignore CDL history attribute leading timestamp.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -45,6 +45,7 @@ import io
 import logging
 import os
 import os.path
+import re
 import shutil
 import subprocess
 import sys
@@ -90,6 +91,13 @@ except ImportError:
 else:
     GRIB_AVAILABLE = True
 
+
+#: CDL history attribute regular expression pattern for ISO8601 timestamp.
+iso8601 = '(?P<lhs>\s*:history = ")' \
+    '(?P<timestamp>\d{4}\-?\d{2}\-?\d{2}' \
+    '(T\d{2}\:?\d{2}\:?\d{2}(\.\d{3})?(([\+\-]\d{2}\:?\d{2})|Z)?)?: )' \
+    '(?P<rhs>.*)'
+iso8601 = re.compile(iso8601)
 
 #: Basepath for test results.
 _RESULT_PATH = os.path.join(os.path.dirname(__file__), 'results')
@@ -441,10 +449,21 @@ class IrisTest(unittest.TestCase):
         self.assertString(repr(obj), reference_filename)
 
     def _check_same(self, item, reference_path, type_comparison_name='CML'):
+        def _patch_history_attr(cdl):
+            result = iso8601.search(cdl)
+            if result:
+                start = result.start('timestamp')
+                end = result.end('timestamp')
+                cdl = cdl[:start] + cdl[end:]
+            return cdl
+
         if self._check_reference_file(reference_path):
             with open(reference_path, 'rb') as reference_fh:
                 reference = ''.join(part.decode('utf-8')
                                     for part in reference_fh.readlines())
+            if type_comparison_name == 'CDL':
+                item = _patch_history_attr(item)
+                reference = _patch_history_attr(reference)
             self._assert_str_same(reference, item, reference_path,
                                   type_comparison_name)
         else:


### PR DESCRIPTION
The PR changes the behaviour of `iris.tests.assertCDL` to ignore the leading timestamp of the CF-netCDF `history` attribute.

This is desirable, as when testing the CDL representation of a cube generated by functionality that appends/creates the `history` attribute with a CF-metadata recommended time stamped history entry, it is not possible to compare archived expected results with actual results as the time stamp will always differ.

**Seeking advice**: We don't seem to have test coverage of changes to testing-framwork code i.e. `iris.tests.__init__` (that, or I simply can't find them). Hence no additional test cases have been bundled with this PR. What's the best working practice here? Apart from all existing tests passing ...