### PR TITLE
G2 int test strat

### DIFF
--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -31,11 +31,25 @@ import iris
 from iris import FUTURE, load_cube, save
 from iris.coords import CellMethod
 from iris.coord_systems import RotatedGeogCS
+from iris.fileformats.grib._message import _GribMessage
 from iris.fileformats.pp import EARTH_RADIUS as UM_DEFAULT_EARTH_RADIUS
 from iris.util import is_regular
 
 if tests.GRIB_AVAILABLE:
     import gribapi
+
+
+def _evaluate_grib_message(test, filename, contents):
+    """
+    Evaluate whether all messages in a GRIB2 file contains contents:
+    an iterable of keys and values.
+
+    """
+    messages = _GribMessage.messages_from_filename(filename)
+    for message in messages:
+        for element in contents:
+            section, key, val = element
+            test.assertEqual(message.sections[section][key], val)
 
 
 @tests.skip_data
@@ -124,21 +138,16 @@ class TestPDT11(tests.IrisTest):
                                                 units='1'))
         with self.temp_filename('testPDT11.GRIB2') as temp_file_path:
             iris.save(cube, temp_file_path)
-            # Get a grib_dump of the output file.
-            dump_text = check_output(('grib_dump -O -wcount=1 ' +
-                                      temp_file_path),
-                                     shell=True).decode()
 
             # Check that various aspects of the saved file are as expected.
-            expect_strings = (
-                'editionNumber = 2',
-                'gridDefinitionTemplateNumber = 0',
-                'productDefinitionTemplateNumber = 11',
-                'perturbationNumber = 1',
-                'typeOfStatisticalProcessing = 0',
-                'numberOfForecastsInEnsemble = 255')
-            for expect in expect_strings:
-                self.assertIn(expect, dump_text)
+            expect_values = (
+                (0, 'editionNumber',  2),
+                (3, 'gridDefinitionTemplateNumber', 0),
+                (4, 'productDefinitionTemplateNumber', 11),
+                (4, 'perturbationNumber', 1),
+                (4, 'typeOfStatisticalProcessing', 0),
+                (4, 'numberOfForecastsInEnsemble', 255))
+            _evaluate_grib_message(self, temp_file_path, expect_values)
 
 
 @tests.skip_data
@@ -170,26 +179,20 @@ class TestGDT5(tests.IrisTest):
         with self.temp_filename('ukv_sample.grib2') as temp_file_path:
             save(cube, temp_file_path)
 
-            # Get a grib_dump of the output file.
-            dump_text = check_output(('grib_dump -O -wcount=1 ' +
-                                      temp_file_path),
-                                     shell=True).decode()
-
             # Check that various aspects of the saved file are as expected.
-            expect_strings = (
-                'editionNumber = 2',
-                'gridDefinitionTemplateNumber = 5',
-                'Ni = {:d}'.format(cube.shape[-1]),
-                'Nj = {:d}'.format(cube.shape[-2]),
-                'shapeOfTheEarth = 1',
-                'scaledValueOfRadiusOfSphericalEarth = {:d}'.format(
-                    int(UM_DEFAULT_EARTH_RADIUS)),
-                'resolutionAndComponentFlags = 0',
-                'latitudeOfSouthernPole = -37500000',
-                'longitudeOfSouthernPole = 357500000',
-                'angleOfRotation = 0')
-            for expect in expect_strings:
-                self.assertIn(expect, dump_text)
+            expect_values = (
+                (0, 'editionNumber', 2),
+                (3, 'gridDefinitionTemplateNumber', 5),
+                (3, 'Ni', cube.shape[-1]),
+                (3, 'Nj', cube.shape[-2]),
+                (3, 'shapeOfTheEarth', 1),
+                (3, 'scaledValueOfRadiusOfSphericalEarth',
+                 int(UM_DEFAULT_EARTH_RADIUS)),
+                (3, 'resolutionAndComponentFlags', 0),
+                (3, 'latitudeOfSouthernPole', -37500000),
+                (3, 'longitudeOfSouthernPole', 357500000),
+                (3, 'angleOfRotation', 0))
+            _evaluate_grib_message(self, temp_file_path, expect_values)
 
             # Load the Grib file back into a new cube.
             with FUTURE.context(strict_grib_load=True):

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -31,14 +31,14 @@ import iris
 from iris import FUTURE, load_cube, save
 from iris.coords import CellMethod
 from iris.coord_systems import RotatedGeogCS
-from iris.fileformats.grib._message import _GribMessage
 from iris.fileformats.pp import EARTH_RADIUS as UM_DEFAULT_EARTH_RADIUS
 from iris.util import is_regular
 
 if tests.GRIB_AVAILABLE:
     import gribapi
+    from iris.fileformats.grib._message import _GribMessage
 
-@tests.skip_grib
+
 def _evaluate_grib_message(test, filename, contents):
     """
     Evaluate whether all messages in a GRIB2 file contains contents:

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -38,7 +38,7 @@ from iris.util import is_regular
 if tests.GRIB_AVAILABLE:
     import gribapi
 
-
+@tests.skip_grib
 def _evaluate_grib_message(test, filename, contents):
     """
     Evaluate whether all messages in a GRIB2 file contains contents:


### PR DESCRIPTION
Updated testing strategy for GRIB2 integration tests

The dependency on the exact text of grib_dump is removed, with individual testing in code preferred

I would like to get this pattern adopted so I can use it to address issues with the 
lib/iris/tests/test_grib_save.py
module, which has a fragile grib_api version dependency