### PR TITLE
Fixed unicode issue for generate_std_names.

### DIFF
--- a/tools/generate_std_names.py
+++ b/tools/generate_std_names.py
@@ -118,11 +118,11 @@ def to_dict(infile, outfile):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Create Python code from CF standard name XML.')
-    parser.add_argument('input', type=argparse.FileType(),
-                        metavar='INPUT',
+    parser.add_argument('input', metavar='INPUT',
                         help='Path to CF standard name XML')
-    parser.add_argument('output', type=argparse.FileType('w'),
-                        metavar='OUTPUT',
+    parser.add_argument('output', metavar='OUTPUT',
                         help='Path to resulting Python code')
     args = parser.parse_args()
-    to_dict(args.input, args.output)
+    with open(args.input, 'r') as in_fh:
+        with open(args.output, 'w') as out_fh:
+            to_dict(in_fh, out_fh)


### PR DESCRIPTION
Closes #1876.
Based on the comment in http://stackoverflow.com/questions/18862836/how-to-open-file-using-argparse#comment34787630_18863046 I've removed the use of FileType in favour of just opening the handle ourselves.