### PR TITLE
Deprecate the whole pp 'custom save rules' api.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2015-Dec-01_pp-custom-save-rules.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2015-Dec-01_pp-custom-save-rules.txt
@@ -1,0 +1,7 @@
+ * deprecated the custom pp save rules mechanism implemented by the functions
+   :func:`iris.fileformats.pp.add_save_rules' and
+   :func:`iris.fileformats.pp.reset_save_rules'.
+   The functions :func:`iris.fileformats.pp.as_fields',
+   :func:`iris.fileformats.pp.as_pairs'
+   and :func:`iris.fileformats.pp.save_fields' provide alternative means of
+   achieving the same ends.

--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Feb-25_logging.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Feb-25_logging.txt
@@ -1,0 +1,4 @@
+* deprecated logging functions (currently used only for rules logging):  
+ :data:`iris.config.iris.config.RULE_LOG_DIR`,
+ :data:`iris.config.iris.config.RULE_LOG_IGNORE` and
+ :data:`iris.fileformats.rules.log`.

--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Feb-25_text_rules.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Feb-25_text_rules.txt
@@ -1,0 +1,10 @@
+* deprecated all the remaining text rules mechanisms:  
+ :class:`iris.fileformats.rules.DebugString`,
+ :class:`iris.fileformats.rules.CmAttribute`,
+ :class:`iris.fileformats.rules.CmCustomAttribute`,
+ :class:`iris.fileformats.rules.CoordAndDims`,
+ :class:`iris.fileformats.rules.Rule`,
+ :class:`iris.fileformats.rules.FunctionRule`,
+ :class:`iris.fileformats.rules.ProcedureRule`,
+ :class:`iris.fileformats.rules.RulesContainer` and
+ :func:'iris.fileformats.rules.calculate_forecast_period`.

--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -41,19 +41,23 @@ defined by :mod:`ConfigParser`.
 
     The full path to the Iris palette configuration directory
 
+.. py:data:: iris.config.IMPORT_LOGGER
+
+    The [optional] name of the logger to notify when first imported.
+
 .. py:data:: iris.config.RULE_LOG_DIR
 
     The [optional] full path to the rule logging directory used by
     :func:`iris.fileformats.pp.load()` and
     :func:`iris.fileformats.pp.save()`.
 
+    .. deprecated:: 1.10
+
 .. py:data:: iris.config.RULE_LOG_IGNORE
 
     The [optional] list of users to ignore when logging rules.
 
-.. py:data:: iris.config.IMPORT_LOGGER
-
-    The [optional] name of the logger to notify when first imported.
+    .. deprecated:: 1.10
 
 ----------
 """

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -1910,7 +1910,9 @@ def _ensure_save_rules_loaded():
     if _save_rules is None:
         # Load the pp save rules
         rules_filename = os.path.join(iris.config.CONFIG_PATH, 'pp_save_rules.txt')
-        _save_rules = iris.fileformats.rules.RulesContainer(rules_filename, iris.fileformats.rules.ProcedureRule)
+        with iris.fileformats.rules._disable_deprecation_warnings():
+            _save_rules = iris.fileformats.rules.RulesContainer(
+                rules_filename, iris.fileformats.rules.ProcedureRule)
 
 
 def add_save_rules(filename):
@@ -1920,14 +1922,40 @@ def add_save_rules(filename):
     Registered files are processed after the standard conversion rules, and in
     the order they were registered.
 
+    .. deprecated:: 1.10
+
+        If you need to customise pp field saving, please refer to the functions
+        :func:`as_fields`, :func:`as_pairs` and :func:`save_fields` for an
+        alternative solution.
+
     """
+    warnings.warn(
+        'custom pp save rules are deprecated from v1.10.\n'
+        'If you need to customise pp field saving, please refer to the '
+        'functions iris.fileformats.pp.as_fields, '
+        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
+        'for an alternative solution.')
     _ensure_save_rules_loaded()
     _save_rules.import_rules(filename)
 
 
 def reset_save_rules():
-    """Resets the PP save process to use only the standard conversion rules."""
+    """
+    Resets the PP save process to use only the standard conversion rules.
 
+    .. deprecated:: 1.10
+
+        If you need to customise pp field saving, please refer to the functions
+        :func:`as_fields`, :func:`as_pairs` and :func:`save_fields` for an
+        alternative solution.
+
+    """
+    warnings.warn(
+        'custom pp save rules are deprecated from v1.10.\n'
+        'If you need to customise pp field saving, please refer to the '
+        'functions iris.fileformats.pp.as_fields, '
+        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
+        'for an alternative solution.')
     # Uses this module-level variable
     global _save_rules
 
@@ -2180,7 +2208,9 @@ def as_pairs(cube, field_coords=None, target=None):
             target = 'None'
         elif not isinstance(target, six.string_types):
             target = target.name
-        iris.fileformats.rules.log('PP_SAVE', str(target), verify_rules_ran)
+
+        with iris.fileformats.rules._disable_deprecation_warnings():
+            iris.fileformats.rules.log('PP_SAVE', str(target), verify_rules_ran)
 
         yield (slice2D, pp_field)
 

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -98,7 +98,8 @@ class TestPPSave(tests.IrisTest, pp.PPTest):
         try:
             with open(user_rules_filename, "wt") as user_rules_file:
                 user_rules_file.write("IF\ncm.standard_name == 'air_temperature'\nTHEN\npp.lbuser[3] = 9222")
-            iris.fileformats.pp.add_save_rules(user_rules_filename)
+            with iris.fileformats.rules._disable_deprecation_warnings():
+                iris.fileformats.pp.add_save_rules(user_rules_filename)
             try:
                 #read pp
                 in_filename = tests.get_data_path(('PP', 'simple_pp', 'global.pp'))


### PR DESCRIPTION
Replaces #1869
Note the proof-of-principle for replacing the pp-save-rules with a Python equivalent
 - https://github.com/pp-mo/iris/pull/18

Issues from there, remaining to address :
  * [x] @rhattersley "You've listed as_pairs twice." : https://github.com/SciTools/iris/pull/1869#discussion_r46388252
  * [x] @rhattersley "should also deprecate some of the contents of the iris.fileformats.rules module" : https://github.com/SciTools/iris/pull/1869#issuecomment-161602582

Note: to make this useful, we may want to cut an intermediate release including these deprecations, so we can then remove the functions (ideally, in Iris 2.0).
See : [@rhattersley on releases](https://github.com/SciTools/iris/pull/1869#issuecomment-163568785)
