### PR TITLE
error types for different api versions

### DIFF
--- a/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_save_messages.py
@@ -46,7 +46,7 @@ class TestSaveMessages(tests.IrisTest):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises(AssertionError):
+            with self.assertRaises((AssertionError, TypeError)):
                 grib.save_messages([self.grib_message], 'foo.grib2')
         self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
@@ -60,7 +60,7 @@ class TestSaveMessages(tests.IrisTest):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises(AssertionError):
+            with self.assertRaises((AssertionError, TypeError)):
                 grib.save_messages([self.grib_message], 'foo.grib2',
                                    append=True)
         self.assertTrue(mock.call('foo.grib2', 'ab') in m.mock_calls)


### PR DESCRIPTION
I have updated known error codes for grib save unit test, so that it works with v12 and v14 of the grib API.

These tests do very little, I would be happy to just remove them, I think they add nothing to our test coverage.

However, if they are felt to be worth keeping, this at least gives us some more grib api version independence. 