### PR TITLE
ENH: Safeguarded against installed python imports which are broken

### DIFF
--- a/lib/iris/experimental/um.py
+++ b/lib/iris/experimental/um.py
@@ -36,8 +36,11 @@ from iris.fileformats.pp import _header_defn
 
 try:
     import mo_pack
-except ImportError:
-    mo_pack = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        mo_pack = None
+    else:
+        raise
 
 DEFAULT_WORD_SIZE = 8  # In bytes.
 

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -29,8 +29,8 @@ from . import abf
 from . import ff
 try:
     from . import grib
-except ValueError as err:
-    if err.message.startswith('Attempted relative import in non-package'):
+except ImportError as err:
+    if err.message.startswith('No module named'):
         grib = None
     else:
         raise

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -29,8 +29,11 @@ from . import abf
 from . import ff
 try:
     from . import grib
-except ImportError:
-    grib = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        grib = None
+    else:
+        raise
 from . import name
 from . import netcdf
 from . import nimrod

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -29,8 +29,8 @@ from . import abf
 from . import ff
 try:
     from . import grib
-except ImportError as err:
-    if err.message.startswith('No module named'):
+except ValueError as err:
+    if err.message.startswith('Attempted relative import in non-package'):
         grib = None
     else:
         raise

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -46,13 +46,19 @@ import iris.coord_systems
 
 try:
     import mo_pack
-except ImportError:
-    mo_pack = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        mo_pack = None
+    else:
+        raise
 
 try:
     from iris.fileformats import pp_packing
-except ImportError:
-    pp_packing = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        pp_packing = None
+    else:
+        raise
 
 
 __all__ = ['load', 'save', 'load_cubes', 'PPField',

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -54,8 +54,8 @@ except ImportError as err:
 
 try:
     from iris.fileformats import pp_packing
-except ImportError as err:
-    if err.message.startswith('No module named'):
+except ValueError as err:
+    if err.message.startswith('Attempted relative import in non-package'):
         pp_packing = None
     else:
         raise

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -249,9 +249,12 @@ def _grib_save(cube, target, append=False, **kwargs):
     # installed.
     try:
         import gribapi
-    except ImportError:
-        raise RuntimeError('Unable to save GRIB file - the ECMWF '
-                           '`gribapi` package is not installed.')
+    except ImportError as err:
+        if err.message.startswith('No module named'):
+            raise RuntimeError('Unable to save GRIB file - the ECMWF '
+                               '`gribapi` package is not installed.')
+        else:
+            raise
     return iris.fileformats.grib.save_grib2(cube, target, append, **kwargs)
 
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -71,22 +71,31 @@ try:
     import matplotlib
     import matplotlib.testing.compare as mcompare
     import matplotlib.pyplot as plt
-except ImportError:
-    MPL_AVAILABLE = False
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        MPL_AVAILABLE = False
+    else:
+        raise
 else:
     MPL_AVAILABLE = True
 
 try:
     from osgeo import gdal
-except ImportError:
-    GDAL_AVAILABLE = False
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        GDAL_AVAILABLE = False
+    else:
+        raise
 else:
     GDAL_AVAILABLE = True
 
 try:
     import gribapi
-except ImportError:
-    GRIB_AVAILABLE = False
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        GRIB_AVAILABLE = False
+    else:
+        raise
 else:
     GRIB_AVAILABLE = True
 

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -38,8 +38,11 @@ try:
     import ESMF
     # Check it *is* the real module, and not an iris.proxy FakeModule.
     ESMF.Manager
-except ImportError as AttributeError:
-    ESMF = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        ESMF = None
+    else:
+        raise
 skip_esmf = unittest.skipIf(
     condition=ESMF is None,
     reason='Requires ESMF, which is not available.')

--- a/lib/iris/tests/integration/test_FieldsFileVariant.py
+++ b/lib/iris/tests/integration/test_FieldsFileVariant.py
@@ -34,9 +34,12 @@ from iris.experimental.um import (Field, Field2, Field3, FieldsFileVariant,
 
 try:
     import mo_pack
-except ImportError:
-    # Disable all these tests if mo_pack is not installed.
-    mo_pack = None
+except ImportError as err: 
+    if err.message.startswith('No module named'):
+        # Disable all these tests if mo_pack is not installed.
+        mo_pack = None
+    else:
+        raise
 
 skip_mo_pack = unittest.skipIf(mo_pack is None,
                                'Test(s) require "mo_pack", '

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -183,8 +183,11 @@ class TestRunner():
                 '--process-timeout=250']
         try:
             import gribapi
-        except ImportError:
-            args.append('--exclude=^grib$')
+        except ImportError as err:
+            if err.message.startswith('No module named'):
+                args.append('--exclude=^grib$')
+            else:
+                raise
         if self.stop:
             args.append('--stop')
 

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -35,11 +35,17 @@ import numpy as np
 # Importing pandas has the side-effect of messing with the formatters
 # used by matplotlib for handling dates.
 default_units_registry = copy.copy(matplotlib.units.registry)
+
+
 try:
     import pandas
-except ImportError:
-    # Disable all these tests if pandas is not installed.
-    pandas = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        pandas = None
+    else:
+        raise
+
+
 matplotlib.units.registry = default_units_registry
 
 skip_pandas = unittest.skipIf(pandas is None,

--- a/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
+++ b/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
@@ -27,8 +27,11 @@ import numpy as np
 try:
     from osgeo import gdal
     from iris.experimental.raster import export_geotiff
-except ImportError:
-    gdal = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        gdal = None
+    else:
+        raise
 
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord

--- a/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
+++ b/lib/iris/tests/unit/experimental/um/test_FieldsFileVariant.py
@@ -37,9 +37,12 @@ from iris.experimental.um import FieldsFileVariant, Field, Field3
 
 try:
     import mo_pack
-except ImportError:
-    # Disable all these tests if mo_pack is not installed.
-    mo_pack = None
+except ImportError as err:
+    if err.message.startswith('No module named'):
+        # Disable all these tests if mo_pack is not installed.
+        mo_pack = None
+    else:
+        raise
 
 skip_mo_pack = unittest.skipIf(mo_pack is None,
                                'Test(s) require "mo_pack", '


### PR DESCRIPTION
This commit ensures that optional dependencies fall over whilst running
continuous integration tests if the libraries are installed but broken.

Relates to #1884 but does not close it.

I have targeted v1.9.x as we currently support a 1.9.1 tag release, yet our continuous integration tests are not ensured to run optional dependencies where those packages are present but broken (see #1884 for further details).

**Example:** - the following before this PR would cause the test to skip.

``` Python
>>> from osgeo import gdal
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/carwyn/miniconda/envs/ants_env/lib/python2.7/site-packages/osgeo/__init__.py", line 21, in <module>
    _gdal = swig_import_helper()
  File "/home/carwyn/miniconda/envs/ants_env/lib/python2.7/site-packages/osgeo/__init__.py", line 17, in swig_import_helper
    _mod = imp.load_module('_gdal', fp, pathname, description)
ImportError: libhdf5_hl.so.10: cannot open shared object file: No such file or directory
```

gdal is installed as part of the iris travis build, yet the gdal import is captured as not being able to be imported (thus the test gets skipped and unnoticed).  This PR simply differentiates between a missing package and a broken one to ensure a more robust continuous integration.

**NOTE:**

This PR will correctly cause a travis failure as gdal tests will cause a error at import (see #1884).
