### PR TITLE
Check aux coords match before concatenating

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jan-20_check-aux-coords-before-concatenating.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jan-20_check-aux-coords-before-concatenating.txt
@@ -1,0 +1,5 @@
+* Concatenation no longer occurs when the auxilliary coordinates of the cubes
+ do not match. This check is not applied to AuxCoords that span the dimension
+ the concatenation is occuring along. This behaviour can be switched off by
+ setting the check_aux_coords kwarg in the
+ :method:`iris.cube.CubeList.concatenate` to False.

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -235,7 +235,7 @@ class _CoordExtent(namedtuple('CoordExtent',
     __slots__ = ()
 
 
-def concatenate(cubes, error_on_mismatch=False):
+def concatenate(cubes, error_on_mismatch=False, check_aux_coords=True):
     """
     Concatenate the provided cubes over common existing dimensions.
 
@@ -269,7 +269,8 @@ def concatenate(cubes, error_on_mismatch=False):
 
         # Register cube with an existing proto-cube.
         for proto_cube in proto_cubes:
-            registered = proto_cube.register(cube, axis, error_on_mismatch)
+            registered = proto_cube.register(cube, axis, error_on_mismatch,
+                                             check_aux_coords)
             if registered:
                 axis = proto_cube.axis
                 break
@@ -671,7 +672,8 @@ class _ProtoCube(object):
 
         return cube
 
-    def register(self, cube, axis=None, error_on_mismatch=False):
+    def register(self, cube, axis=None, error_on_mismatch=False,
+                 check_aux_coords=False):
         """
         Determine whether the given source-cube is suitable for concatenation
         with this :class:`_ProtoCube`.
@@ -717,6 +719,18 @@ class _ProtoCube(object):
         if match:
             match = self._sequence(coord_signature.dim_extents[candidate_axis],
                                    candidate_axis)
+
+        # Check for compatible AuxCoords.
+        if match:
+            if check_aux_coords:
+                for coord_a, coord_b in zip(
+                        self._cube_signature.aux_coords_and_dims,
+                        cube_signature.aux_coords_and_dims):
+                    # AuxCoords that span the candidate axis can difffer
+                    if (candidate_axis not in coord_a.dims or
+                            candidate_axis not in coord_b.dims):
+                        if not coord_a == coord_b:
+                            match = False
 
         if match:
             # Register the cube as a source-cube for this proto-cube.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -468,7 +468,7 @@ class CubeList(list):
 
         return merged_cubes
 
-    def concatenate_cube(self):
+    def concatenate_cube(self, check_aux_coords=True):
         """
         Return the concatenated contents of the :class:`CubeList` as a single
         :class:`Cube`.
@@ -477,6 +477,13 @@ class CubeList(list):
         `Cube`, a :class:`~iris.exceptions.ConcatenateError` will be raised
         describing the reason for the failure.
 
+        Kwargs:
+
+        * check_aux_coords
+            Checks the auxilliary coordinates of the cubes match. This check
+            is not applied to auxilliary coordinates that span the dimension
+            the concatenation is occuring along. Defaults to True.
+
         """
         if not self:
             raise ValueError("can't concatenate an empty CubeList")
@@ -484,7 +491,9 @@ class CubeList(list):
         names = [cube.metadata.name() for cube in self]
         unique_names = list(collections.OrderedDict.fromkeys(names))
         if len(unique_names) == 1:
-            res = iris._concatenate.concatenate(self, error_on_mismatch=True)
+            res = iris._concatenate.concatenate(
+                self, error_on_mismatch=True,
+                check_aux_coords=check_aux_coords)
             n_res_cubes = len(res)
             if n_res_cubes == 1:
                 return res[0]
@@ -500,9 +509,16 @@ class CubeList(list):
                                                              names[1]))
             raise iris.exceptions.ConcatenateError(msgs)
 
-    def concatenate(self):
+    def concatenate(self, check_aux_coords=True):
         """
         Concatenate the cubes over their common dimensions.
+
+        Kwargs:
+
+        * check_aux_coords
+            Checks the auxilliary coordinates of the cubes match. This check
+            is not applied to auxilliary coordinates that span the dimension
+            the concatenation is occuring along. Defaults to True.
 
         Returns:
             A new :class:`iris.cube.CubeList` of concatenated
@@ -564,7 +580,8 @@ class CubeList(list):
             time coordinates so that the cubes can be concatenated.
 
         """
-        return iris._concatenate.concatenate(self)
+        return iris._concatenate.concatenate(self,
+                                             check_aux_coords=check_aux_coords)
 
 
 def _is_single_item(testee):


### PR DESCRIPTION
Currently, for concatenation, only AuxCoord metadata is being checked. This allows two cubes with different AuxCoord points to be concatenated. For an example case, see the integration test I added.

This PR ensures the AuxCoords match before the concatenation can happen.