### PR TITLE
Remove coord checks when adding/subtracting cubes

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3078,11 +3078,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         return hash(id(self))
 
     def __add__(self, other):
-        return iris.analysis.maths.add(self, other, ignore=True)
+        return iris.analysis.maths.add(self, other)
     __radd__ = __add__
 
     def __sub__(self, other):
-        return iris.analysis.maths.subtract(self, other, ignore=True)
+        return iris.analysis.maths.subtract(self, other)
 
     __mul__ = iris.analysis.maths.multiply
     __rmul__ = iris.analysis.maths.multiply

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -70,15 +70,6 @@ class TestBasicMaths(tests.IrisTest):
 
         # Check that the subtraction has had no effect on the original
         self.assertCML(e, ('analysis', 'maths_original.cml'))
-
-    def test_minus_with_data_describing_coordinate(self):
-        a = self.cube
-        e = self.cube.copy()
-        lat = e.coord('latitude')
-        lat.points = lat.points+100
-
-        # Cannot ignore a axis describing coordinate
-        self.assertRaises(ValueError, iris.analysis.maths.subtract, a, e)
 
     def test_minus_scalar(self):
         a = self.cube
@@ -591,7 +582,7 @@ class TestIFunc(tests.IrisTest):
         c = a.copy() + 2
 
         vec_mag_ufunc = np.frompyfunc(vec_mag, 2, 1)
-        my_ifunc = iris.analysis.maths.IFunc(vec_mag_ufunc, 
+        my_ifunc = iris.analysis.maths.IFunc(vec_mag_ufunc,
                    lambda x,y: (x + y).units)
         b = my_ifunc(a, c)
 
@@ -613,7 +604,7 @@ class TestIFunc(tests.IrisTest):
 
         b = cs_ifunc(a, axis=1)
         ans = a.data.copy()
-        ans = np.cumsum(ans, axis=1) 
+        ans = np.cumsum(ans, axis=1)
 
         self.assertArrayAlmostEqual(b.data, ans)
 

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -80,7 +80,7 @@ class TestMonotonic(unittest.TestCase):
         b = np.array([3, 5.3, 5.3])
         self.assertNotMonotonic(b, strict=True)
         self.assertMonotonic(b, direction=1)
-        
+
         b = b[::-1]
         self.assertNotMonotonic(b, strict=True)
         self.assertMonotonic(b, direction=-1)
@@ -182,7 +182,7 @@ class TestClipString(unittest.TestCase):
             expected_length,
             'Mismatch in expected length of clipped string. Length was %s, '
             'expected value is %s' % (len(result), expected_length))
-        
+
 
 class TestDescribeDiff(iris.tests.IrisTest):
     def test_identical(self):
@@ -199,16 +199,16 @@ class TestDescribeDiff(iris.tests.IrisTest):
         # test incompatible attributes
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
-        
+
         test_cube_a.attributes['Conventions'] = 'CF-1.5'
         test_cube_b.attributes['Conventions'] = 'CF-1.6'
-        
+
         return_sio = six.StringIO()
         iris.util.describe_diff(test_cube_a, test_cube_b, output_file=return_sio)
         return_str = return_sio.getvalue()
-        
+
         self.assertString(return_str, 'incompatible_attr.str.txt')
-        
+
         # test incompatible names
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
@@ -224,15 +224,15 @@ class TestDescribeDiff(iris.tests.IrisTest):
         # test incompatible unit
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
-        
+
         test_cube_a.units = cf_units.Unit('m')
 
         return_sio = six.StringIO()
         iris.util.describe_diff(test_cube_a, test_cube_b, output_file=return_sio)
         return_str = return_sio.getvalue()
-        
+
         self.assertString(return_str, 'incompatible_unit.str.txt')
-        
+
         # test incompatible methods
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d().collapsed('model_level_number', iris.analysis.MEAN)
@@ -333,6 +333,21 @@ class TestAsCompatibleShape(tests.IrisTest):
         dim_to_aux(expected, 'grid_latitude')
         res = iris.util.as_compatible_shape(src, cube)
         self.assertEqual(res, expected)
+
+    def test_mismatched_dim(self):
+        cube = tests.stock.realistic_4d()
+        cube_wrong_coord = cube.copy()
+        cube_wrong_coord.coord('time').rename('spam')
+        self.assertRaises(ValueError, iris.util.as_compatible_shape,
+                          cube_wrong_coord, cube)
+
+    def test_match_auxcoord(self):
+        cube = tests.stock.realistic_4d()
+        cube_missing_dim_coord = cube.copy()
+        cube_missing_dim_coord.remove_coord('model_level_number')
+        # This dimension still has auxcoords so mapping should still work.
+        res = iris.util.as_compatible_shape(cube_missing_dim_coord, cube)
+        self.assertEqual(res, cube_missing_dim_coord)
 
 
 if __name__ == '__main__':

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1116,9 +1116,8 @@ def as_compatible_shape(src_cube, target_cube):
     This function can be used to add the dimensions that have been collapsed,
     aggregated or sliced out, promoting scalar coordinates to length one
     dimension coordinates where necessary. It operates by matching coordinate
-    metadata to infer the dimensions that need modifying, so the provided
-    cubes must have coordinates with the same metadata
-    (see :class:`iris.coords.CoordDefn`).
+    names to infer the dimensions that need modifying, so the provided
+    cubes must have coordinates with the same names along existing dimensions.
 
     .. note:: This function will load and copy the data payload of `src_cube`.
 
@@ -1140,9 +1139,9 @@ def as_compatible_shape(src_cube, target_cube):
     for coord in target_cube.aux_coords + target_cube.dim_coords:
         dims = target_cube.coord_dims(coord)
         try:
-            collapsed_dims = src_cube.coord_dims(coord)
+            collapsed_dims = src_cube.coord_dims(coord.name())
         except iris.exceptions.CoordinateNotFoundError:
-            continue
+            collapsed_dims = None
         if collapsed_dims:
             if len(collapsed_dims) == len(dims):
                 for dim_from, dim_to in zip(dims, collapsed_dims):
@@ -1179,7 +1178,7 @@ def as_compatible_shape(src_cube, target_cube):
 
     def add_coord(coord):
         """Closure used to add a suitably reshaped coord to new_cube."""
-        dims = target_cube.coord_dims(coord)
+        dims = target_cube.coord_dims(coord.name())
         shape = [new_cube.shape[dim] for dim in dims]
         if not shape:
             shape = [1]

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1148,9 +1148,16 @@ def as_compatible_shape(src_cube, target_cube):
                     dim_mapping[dim_from] = dim_to
         elif dims:
             for dim_from in dims:
-                dim_mapping[dim_from] = None
+                if dim_from not in dim_mapping:
+                    dim_mapping[dim_from] = None
 
-    if len(dim_mapping) != target_cube.ndim:
+    target_unmapped = len(dim_mapping) != target_cube.ndim
+    src_unmapped = False
+    for dim, length in enumerate(src_cube.shape):
+        if dim not in dim_mapping.values() and length > 1:
+            src_unmapped = True
+
+    if target_unmapped or src_unmapped:
         raise ValueError('Insufficient or conflicting coordinate '
                          'metadata. Cannot infer dimension mapping '
                          'to restore cube dimensions.')

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
As discussed at #1887, this PR removes checks which are applied to coordinates before adding and subtracting cubes.  It makes these operations consistent with multiplication and division in terms of whether two cubes are compatible.

Having bypassed `_add_subtract_common`, scalar coords which exist on `cube` but not on `other` ("ignorable" coords) are no longer removed as part of the operation.  I think this is consistent with allowing the vector coords to differ (if I've understood correctly, `_binary_op_common` ignores all of the coords on `other`).  There are no unit tests to check whether the "ignorable" coords are removed, but I am getting a failure in the doctests for `userguide/cube_maths.rst` because a print out of a cube shows more metadata than previously.

I have also removed the depreciated (since 0.8.0) keyword `ignore`.  It's not 100% clear what it did, but I guess it triggered the above mentioned removal of "ignorable" coords.
