### PR TITLE
ENH: LBPROC IMDI

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -32,7 +32,8 @@ from iris.fileformats._ff_cross_references import STASH_TRANS
 from . import pp
 
 
-IMDI = -32768
+IMDI = pp.IMDI
+
 
 FF_HEADER_DEPTH = 256      # In words (64-bit).
 DEFAULT_FF_WORD_DEPTH = 8  # In bytes.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -43,6 +43,10 @@ import iris.config
 import iris.fileformats.rules
 import iris.fileformats.pp_rules
 import iris.coord_systems
+
+
+IMDI = -32768
+
 
 try:
     import mo_pack
@@ -684,6 +688,8 @@ class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
 
         """
         value = int(value)
+        if value == IMDI:
+            value = 0
         if value < 0:
             raise ValueError('Negative numbers not supported with '
                              'splittable integers object')

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -40,6 +40,11 @@ class Test___init__(tests.IrisTest):
             _LBProc(-1)
         with self.assertRaisesRegexp(ValueError, msg):
             _LBProc('-1')
+
+    def test_imdi(self):
+        # Ensure that we don't discriminate between an lbproc of IMDI and as 0.
+        proc = _LBProc(-32768)
+        self.assertEqual(proc._value, 0)
 
     def test_invalid_str(self):
         with self.assertRaisesRegexp(ValueError, 'invalid literal for int'):


### PR DESCRIPTION
Currently iris does not accept LBPROC values of IMDI.  The UM F03 spec specifies:
"It should be 0 if no processing has been done, otherwise the relevant numbers from the list below are added together"

```Python
...
  File "/home/h05/cpelley/git/iris/lib/iris/fileformats/pp.py", line 694, in __init__
    raise ValueError('Negative numbers not supported with '
ValueError: Negative numbers not supported with splittable integers object
```

In reality, real datasets can be found with its value set to IMDI.  I see no problem in interpreting LPBROC of IMDI as a 0.  This PR does exactly this.