### PR TITLE
Add 'month' coord instead of 'time' in pp_rules when lbyr=0 and lbtim.ib==2

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-10_add-month-coord.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-10_add-month-coord.txt
@@ -1,0 +1,4 @@
+Fixed a bug with a class of pp files with lbyr == 0, where the date would cause errors when converting to a datetime object (e.g. when printing a cube).
+
+When processing a pp field with lbtim = 2x, lbyr == lbyrd == 0 and lbmon == lbmond, 'month' and 'month_number' coordinates are created instead of 'time'.
+

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_time_coords.py
@@ -213,6 +213,19 @@ class TestLBTIMx3x_YearlyAggregation(TestField):
         self._check_yearly(_lbcode(ix=1, iy=20), expect_match=False)
 
 
+class TestLBTIMx2x_ZeroYear(TestField):
+    def test_(self):
+        lbtim = _lbtim(ib=2, ic=1)
+        t1 = nc_datetime(0, 1, 1)
+        t2 = nc_datetime(0, 1, 31, 23, 59, 00)
+        lbft = 0
+        lbcode = _lbcode(1)
+        coords_and_dims = _convert_scalar_time_coords(
+            lbcode=lbcode, lbtim=lbtim, epoch_hours_unit=_EPOCH_TIME_UNIT,
+            t1=t1, t2=t2, lbft=lbft)
+        self.assertEqual(coords_and_dims, [])
+
+
 class TestLBTIMxxx_Unhandled(TestField):
     def test_unrecognised(self):
         lbtim = _lbtim(ib=4, ic=1)


### PR DESCRIPTION
This change fixes a bug with a class of pp files with lbyr == 0, where the date would cause errors when converting to a datetime object (e.g. when printing a cube).

When processing a pp field with lbtim = 2x, lbyr == lbyrd == 0 and lbmon == lbmond, a numeric 'month' coordinate is created instead of 'time'.