### PR TITLE
Correction to curl function

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-10_correct-curl-sign.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-10_correct-curl-sign.txt
@@ -1,0 +1,1 @@
+Fixed a bug in :meth:`~iris.analysis.calculus.curl` where the sign of the r-component for spherical coordinates was opposite to what was expected.  

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -635,7 +635,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         dicos_dtheta = _curl_differentiate(temp, lat_coord)
         prototype_diff = dicos_dtheta
 
-        # r curl component: 1 / (r * cos(lat)) * (dicos_dtheta - d_j_cube_dphi)
+        # r curl component: 1 / (r * cos(lat)) * (d_j_cube_dphi - dicos_dtheta)
         # Since prototype_diff == dicos_dtheta we don't need to
         # recalculate dicos_dtheta.
         d_j_cube_dphi = _curl_differentiate(j_cube, lon_coord)
@@ -643,8 +643,8 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         new_lat_coord = d_j_cube_dphi.coord(axis='Y')
         new_lat_cos_coord = _coord_cos(new_lat_coord)
         lat_dim = d_j_cube_dphi.coord_dims(new_lat_coord)[0]
-        r_cmpt = iris.analysis.maths.divide(_curl_subtract(dicos_dtheta,
-                                                           d_j_cube_dphi),
+        r_cmpt = iris.analysis.maths.divide(_curl_subtract(d_j_cube_dphi,
+                                                           dicos_dtheta),
                                             r * new_lat_cos_coord, dim=lat_dim)
         r_cmpt.units = r_cmpt.units / r_unit
         d_j_cube_dphi = dicos_dtheta = None

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -553,7 +553,8 @@ class TestCalculusWKnownSolutions(tests.IrisTest):
         cos_x_pts = np.cos(np.radians(x.points)).reshape(1, x.shape[0])
         cos_y_pts = np.cos(np.radians(y.points)).reshape(y.shape[0], 1)
 
-        result = r.copy(data=2*cos_x_pts*cos_y_pts)
+        # Expected r-component value: -2 cos(lon) cos(lat)
+        result = r.copy(data=-2*cos_x_pts*cos_y_pts)
 
         # Note: This numerical comparison was created when the radius was 1000 times smaller
         np.testing.assert_array_almost_equal(result.data[30:-30, :], r.data[30:-30, :]/1000.0, decimal=1)


### PR DESCRIPTION
The sign of the r component of the curl function is wrong when using spherical coordinates. This change reverses the sign.

This needs to be checked by someone who understands the maths better than I do.