### PR TITLE
Add __deepcopy__ to DimCoord

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jan-20_add-__deepcopy__-to-DimCoord.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jan-20_add-__deepcopy__-to-DimCoord.txt
@@ -1,0 +1,1 @@
+* fixed a bug where a deepcopy of a :class:`~iris.coords.DimCoord` would have writable `points` and `bounds` arrays. These arrays can now no longer be modified in-place.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1397,6 +1397,20 @@ class DimCoord(Coord):
         #: Whether the coordinate wraps by ``coord.units.modulus``.
         self.circular = bool(circular)
 
+    def __deepcopy__(self, memo):
+        """
+        coord.__deepcopy__() -> Deep copy of coordinate.
+
+        Used if copy.deepcopy is called on a coordinate.
+
+        """
+        new_coord = copy.deepcopy(super(Coord, self), memo)
+        # Ensure points and bounds arrays are read-only
+        new_coord._points.flags.writeable = False
+        if new_coord._bounds is not None:
+            new_coord._bounds.flags.writeable = False
+        return new_coord
+
     def copy(self, points=None, bounds=None):
         new_coord = super(DimCoord, self).copy(points=points, bounds=bounds)
         # Make the array read-only.

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -566,7 +566,7 @@ class TestCurlInterface(tests.IrisTest):
 
         v = u.copy()
         y = v.coord('latitude')
-        y.points += 5
+        y.points = y.points + 5
         self.assertRaises(ValueError, iris.analysis.calculus.curl, u, v)
 
     def test_standard_name(self):

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1148,7 +1148,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
             cube1 = iris.load_cube(temp_pp_path)
             cube2 = cube1.copy()
             # make cube1 and cube2 differ on a scalar coord, to make them mergeable into a 3d cube
-            cube2.coord("pressure").points[0] = 1001.0
+            cube2.coord("pressure").points = [1001.0]
             merged_cubes = iris.cube.CubeList([cube1, cube2]).merge()
             self.assertEqual(len(merged_cubes), 1, "expected a single merged cube")
             merged_cube = merged_cubes[0]


### PR DESCRIPTION
The points and bounds properties of the `DimCoord` class are intended to be read-only. However, when a `DimCoord` object is deepcopied, the underlying numpy arrays have their 'writeable' flag set to True by `np.ndarray.__deepcopy__(...)`.

This fix adds an implementation of `__deepcopy__(...)` to `DimCoord`s which resets these flags to False. It also modifies some unit tests which were failing due to the fix.