### PR TITLE
WIP: Candidate PPField->Cube interface.

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2028,6 +2028,23 @@ def load_cubes(filenames, callback=None, constraints=None):
                                        constraints=constraints)
 
 
+def as_cubes(pp_fields):
+    """
+    Convert an iterable of PP fields into an iterable of Cubes.
+
+    Args:
+
+    * pp_fields:
+        An iterable of :class:`iris.fileformats.pp.PPField`.
+
+    Returns:
+        An iterable of :class:`iris.cube.Cube`s.
+
+    """
+    return iris.fileformats.rules.as_cubes(pp_fields,
+                                           iris.fileformats.pp_rules.convert)
+
+
 def _load_cubes_variable_loader(filenames, callback, loading_function,
                                 loading_function_kwargs=None,
                                 constraints=None):


### PR DESCRIPTION
See #1917 - ping @cpelley.

Provides a way to work with PP fields that raise errors during the conversion to Cubes. For example, fields with a negative LBPROC value give:
```python
>>> cube = iris.load_cube(path)
...
ValueError: Negative numbers not supported with splittable integers object
```
Working at the lower, PP field level we can adjust the fields before conversion:
```python
fields = iris.fileformats.pp.load(path)
def mutate(field):
    field.lbproc = 0
    return field
tweaked_fields = (mutate(field) for field in fields)
cubes = iris.cube.CubeList(iris.fileformats.pp.as_cubes(tweaked_fields))
cube = cubes.merge_cube()
```