### PR TITLE
Added handling of axes to regular plotting functions

### DIFF
--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,7 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from iris.tests.stock import simple_2d
+from iris.tests.stock import simple_2d, lat_lon_cube
 from iris.coords import AuxCoord
 
 
@@ -34,26 +34,32 @@ class TestGraphicStringCoord(tests.GraphicsTest):
         self.cube = simple_2d(with_bounds=True)
         self.cube.add_aux_coord(AuxCoord(list('abcd'),
                                          long_name='str_coord'), 1)
+        self.lat_lon_cube = lat_lon_cube()
 
-    def tick_loc_and_label(self, axis_name):
+    def tick_loc_and_label(self, axis_name, axes=None):
         # Intentional lazy import so that subclasses can have an opportunity
         # to change the backend.
         import matplotlib.pyplot as plt
 
         # Draw the plot to 'fix' the ticks.
-        plt.draw()
-        axis = getattr(plt.gca(), axis_name)
+        if axes:
+            axes.figure.canvas.draw()
+        else:
+            axes = plt.gca()
+            plt.draw()
+        axis = getattr(axes, axis_name)
+
         locations = axis.get_majorticklocs()
         labels = [tick.get_text() for tick in axis.get_ticklabels()]
         return list(zip(locations, labels))
 
-    def assertBoundsTickLabels(self, axis):
-        actual = self.tick_loc_and_label(axis)
+    def assertBoundsTickLabels(self, axis, axes=None):
+        actual = self.tick_loc_and_label(axis, axes)
         expected = [(-1.0, ''), (0.0, 'a'), (1.0, 'b'),
                     (2.0, 'c'), (3.0, 'd'), (4.0, '')]
         self.assertEqual(expected, actual)
 
-    def assertPointsTickLabels(self, axis):
-        actual = self.tick_loc_and_label(axis)
+    def assertPointsTickLabels(self, axis, axes=None):
+        actual = self.tick_loc_and_label(axis, axes)
         expected = [(0.0, 'a'), (1.0, 'b'), (2.0, 'c'), (3.0, 'd')]
         self.assertEqual(expected, actual)

--- a/lib/iris/tests/unit/plot/test_contour.py
+++ b/lib/iris/tests/unit/plot/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,29 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.contour(self.cube, coords=('str_coord', 'bar'))
         self.assertPointsTickLabels('xaxis')
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.contour(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.contour(self.cube, axes=ax, coords=('str_coord', 'bar'))
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.contour, self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,30 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.contourf(self.cube, coords=('str_coord', 'bar'))
         self.assertPointsTickLabels('xaxis')
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.contourf(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.contourf(self.cube, axes=ax, coords=('str_coord', 'bar'))
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.contourf,
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_outline.py
+++ b/lib/iris/tests/unit/plot/test_outline.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,32 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.outline(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        iplt.outline(self.cube, coords=('str_coord', 'bar'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        iplt.outline(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.outline,
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -38,6 +38,31 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         iplt.pcolor(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
 
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        iplt.pcolor(self.cube, coords=('str_coord', 'bar'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        iplt.pcolor(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.pcolor,
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,32 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.pcolormesh(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        iplt.pcolormesh(self.cube, axes=ax, coords=('str_coord', 'bar'),)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        iplt.pcolormesh(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.pcolormesh,
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_plot.py
+++ b/lib/iris/tests/unit/plot/test_plot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -33,6 +33,7 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def setUp(self):
         super(TestStringCoordPlot, self).setUp()
         self.cube = self.cube[0, :]
+        self.lat_lon_cube = self.lat_lon_cube[0, :]
 
     def test_yaxis_labels(self):
         iplt.plot(self.cube, self.cube.coord('str_coord'))
@@ -41,6 +42,30 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.plot(self.cube.coord('str_coord'), self.cube)
         self.assertPointsTickLabels('xaxis')
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.plot(self.cube, self.cube.coord('str_coord'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.plot(self.cube.coord('str_coord'), self.cube, axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_plot_longitude(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.plot(self.lat_lon_cube.coord('longitude'),
+                  self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_points.py
+++ b/lib/iris/tests/unit/plot/test_points.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,32 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         iplt.points(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        iplt.points(self.cube, coords=('str_coord', 'bar'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        iplt.points(self.cube, coords=('bar', 'str_coord'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, iplt.points,
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_scatter.py
+++ b/lib/iris/tests/unit/plot/test_scatter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -33,6 +33,7 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def setUp(self):
         super(TestStringCoordPlot, self).setUp()
         self.cube = self.cube[0, :]
+        self.lat_lon_cube = self.lat_lon_cube[0, :]
 
     def test_xaxis_labels(self):
         iplt.scatter(self.cube.coord('str_coord'), self.cube)
@@ -41,6 +42,32 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_yaxis_labels(self):
         iplt.scatter(self.cube, self.cube.coord('str_coord'))
         self.assertBoundsTickLabels('yaxis')
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        iplt.scatter(self.cube.coord('str_coord'), self.cube, axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        iplt.scatter(self.cube, self.cube.coord('str_coord'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_scatter_longitude(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        iplt.scatter(self.lat_lon_cube,
+                     self.lat_lon_cube.coord('longitude'), axes=ax)
+        plt.close(fig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes it possible to pass an existing matplotlib ``Axes`` object to the various plotting functions in the plotting module. I realize that in PR #1112 drawing directly onto the axes was disabled, instead always drawing to the axis that is currently open using the ``plt`` function calls. While that is a good fix for users using the ``plt`` interface, which is useful for simple usage, when building more complex plots the object-oriented approach is the way to go. This is crucial for some of the functionality we're building as part of the [cube-explorer](https://github.com/CubeBrowser/cube-explorer) project integrating Iris functionality within [HoloViews](http://holoviews.org).

It's a fairly small set of changes but not being familiar with the code I may have missed something. I think only providing this functionality in plot but not quickplot makes sense since the latter is suited towards usage in an interactive interpreter anyway. I'd be happy to add examples, documentation and tests once we agree these are the correct changes.