### PR TITLE
Fix to automatic deriving of units when saving in netcdf format

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-18_fix-determining-units.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-18_fix-determining-units.txt
@@ -1,0 +1,4 @@
+* When saving in netcdf format, the 'units' of 'latitude' and 'longitude'
+ coordinates specified in 'degrees' are saved as 'degrees_north' and
+ 'degrees_east' respectively, as defined in the CF conventions for netCDF
+ files: sections 4.1 and 4.2.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1118,20 +1118,16 @@ class Saver(object):
         """
 
         units = str(coord.units)
-
-        # TODO: Use #61 to get the units.
-        if isinstance(coord.coord_system, iris.coord_systems.GeogCS):
-            if "latitude" in coord.standard_name:
+        # Set the 'units' of 'latitude' and 'longitude' coordinates specified
+        # in 'degrees' to 'degrees_north' and 'degrees_east' respectively,
+        # as defined in the CF conventions for netCDF files: sections 4.1 and
+        # 4.2.
+        if ((isinstance(coord.coord_system, iris.coord_systems.GeogCS) or
+                coord.coord_system is None) and coord.units == 'degrees'):
+            if coord.standard_name == "latitude":
                 units = 'degrees_north'
-            elif "longitude" in coord.standard_name:
+            elif coord.standard_name == "longitude":
                 units = 'degrees_east'
-
-        elif isinstance(coord.coord_system, iris.coord_systems.RotatedGeogCS):
-            units = 'degrees'
-
-        elif isinstance(coord.coord_system,
-                        iris.coord_systems.TransverseMercator):
-            units = 'm'
 
         return coord.standard_name, coord.long_name, units
 

--- a/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_ndim_auxiliary.cdl
@@ -36,11 +36,11 @@ variables:
 		rlon:standard_name = "grid_longitude" ;
 		rlon:long_name = "rotated longitude" ;
 	float lat(rlat, rlon) ;
-		lat:units = "degrees" ;
+		lat:units = "degrees_north" ;
 		lat:standard_name = "latitude" ;
 		lat:long_name = "latitude" ;
 	float lon(rlat, rlon) ;
-		lon:units = "degrees" ;
+		lon:units = "degrees_east" ;
 		lon:standard_name = "longitude" ;
 		lon:long_name = "longitude" ;
 

--- a/lib/iris/tests/results/netcdf/netcdf_save_wcoord.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_wcoord.cdl
@@ -8,7 +8,7 @@ variables:
 		temp:units = "K" ;
 	int64 lon(lon) ;
 		lon:axis = "X" ;
-		lon:units = "degree_east" ;
+		lon:units = "degrees_east" ;
 		lon:standard_name = "longitude" ;
 	int64 lat(lat) ;
 		lat:units = "degree_north" ;

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -608,24 +608,24 @@ class TestNetCDFSave(tests.IrisTest):
         coord_system3 = icoord_systems.RotatedGeogCS(30, 30)
 
         c1.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'latitude', long_name='1',
+            np.arange(1, 3), 'latitude', long_name='1', units='degrees',
             coord_system=coord_system), 1)
         c1.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'longitude', long_name='1',
+            np.arange(1, 3), 'longitude', long_name='1', units='degrees',
             coord_system=coord_system), 0)
 
         c2.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'latitude', long_name='2',
+            np.arange(1, 3), 'latitude', long_name='2', units='degrees',
             coord_system=coord_system2), 1)
         c2.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'longitude', long_name='2',
+            np.arange(1, 3), 'longitude', long_name='2', units='degrees',
             coord_system=coord_system2), 0)
 
         c3.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'grid_latitude', long_name='3',
+            np.arange(1, 3), 'grid_latitude', long_name='3', units='degrees',
             coord_system=coord_system3), 1)
         c3.add_dim_coord(iris.coords.DimCoord(
-            np.arange(1, 3), 'grid_longitude', long_name='3',
+            np.arange(1, 3), 'grid_longitude', long_name='3', units='degrees',
             coord_system=coord_system3), 0)
 
         cubes = iris.cube.CubeList([c1, c2, c3])


### PR DESCRIPTION
Make coords with standard name 'latitude' and 'longitude' which have no coordsystem to be saved with units 'degree_north' and 'degree_east' respectively in netcdf files. Remove other unsafe unit changes.

Change some unit test expected output to recognise these changes.