### PR TITLE
Fix Cube.data, ensure it always returns an np.ndarray

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-18_fix-cube-data.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-18_fix-cube-data.txt
@@ -1,0 +1,2 @@
+* Fixed a bug with :meth:`iris.cube.Cube.data` where an :class:`numpy.ndarray`
+ was not being returned for scalar cubes with lazy data

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1682,10 +1682,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 msg = msg.format(self.shape, data.dtype)
                 raise MemoryError(msg)
             # Unmask the array only if it is filled.
-            if ma.count_masked(data) == 0:
-                data = data.data
-            self._my_data = data
-        return data
+            if isinstance(data, np.ndarray) and ma.count_masked(data) == 0:
+                data = data.data 
+            # data may be a numeric type, so ensure an np.ndarray is returned
+            self._my_data = np.asanyarray(data)
+        return self._my_data
 
     @data.setter
     def data(self, value):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1683,7 +1683,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 raise MemoryError(msg)
             # Unmask the array only if it is filled.
             if isinstance(data, np.ndarray) and ma.count_masked(data) == 0:
-                data = data.data 
+                data = data.data
             # data may be a numeric type, so ensure an np.ndarray is returned
             self._my_data = np.asanyarray(data)
         return self._my_data

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -102,5 +102,63 @@ class Test_Lazy_Maths(tests.IrisTest):
         self.assert_elementwise(c1, None, result, np.divide)
 
 
+class Test_Scalar_Cube_Lazy_Maths(tests.IrisTest):
+    def build_lazy_cube(self, value):
+        data = np.array(value)
+        data = biggus.NumpyArrayAdapter(data)
+        return iris.cube.Cube(data, standard_name='air_temperature', units='K')
+
+    def setUp(self):
+        self.c1 = self.build_lazy_cube(3)
+        self.c2 = self.build_lazy_cube(4)
+
+    def test_add_scalar(self):
+        cube = self.c1 + 5
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_add_cubes(self):
+        cube = self.c1 + self.c2
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_mul_scalar(self):
+        cube = self.c1 * 5
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_mul_cubes(self):
+        cube = self.c1 * self.c2
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_sub_scalar(self):
+        cube = self.c1 - 5
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_sub_cubes(self):
+        cube = self.c1 - self.c2
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_div_scalar(self):
+        cube = self.c1 / 5
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
+    def test_div_cubes(self):
+        cube = self.c1 / self.c2
+        data = cube.data
+        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertEqual(data.shape, ())
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2016, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
In certain cases, `Cube.data` fails to return an array. This is due to the underlying biggus array sometimes returning a numpy numeric type when evaluated (see https://github.com/SciTools/biggus/issues/175). `Cube.data` then returns the underlying buffer of this object.

This fix ensures an `np.ndarray` is returned by `Cube.data`