### PR TITLE
Add __array_priority__ to Cell to fix comparison with numpy types

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-23_cell-comparison.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-23_cell-comparison.txt
@@ -1,1 +1,0 @@
-* Fixed a bug where comparisons between :class:`iris.coords.Cell` objects and NumPy numeric types would produce unexpected behaviour

--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-23_cell-comparison.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Feb-23_cell-comparison.txt
@@ -1,0 +1,1 @@
+* Fixed a bug where comparisons between :class:`iris.coords.Cell` objects and NumPy numeric types would produce unexpected behaviour

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -176,6 +176,9 @@ class Cell(collections.namedtuple('Cell', ['point', 'bound'])):
     # This subclass adds no attributes.
     __slots__ = ()
 
+    # Make this class's comparison operators override those of numpy
+    __array_priority__ = 100
+
     def __new__(cls, point=None, bound=None):
         """
         Construct a Cell from point or point-and-bound information.

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -157,6 +157,7 @@ class Test_numpy_comparison(tests.IrisTest):
             bool(cell > n)
             bool(cell >= n)
             bool(cell == n)
+            bool(cell != n)
         except:
             self.fail(
                 "Result of comparison could not be used as a truth value")
@@ -171,6 +172,7 @@ class Test_numpy_comparison(tests.IrisTest):
             bool(n > cell)
             bool(n >= cell)
             bool(n == cell)
+            bool(n != cell)
         except:
             self.fail(
                 "Result of comparison could not be used as a truth value")

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import datetime
+import numpy as np
 
 import netcdftime
 
@@ -141,6 +142,38 @@ class Test_contains_point(tests.IrisTest):
         with self.assertRaisesRegexp(TypeError, 'bounded region for datetime'):
             cell.contains_point(point)
 
+
+class Test_numpy_comparison(tests.IrisTest):
+    """
+    Unit tests to check that the results of comparisons with numpy types can be
+    used as truth values."""
+    def test_cell_lhs(self):
+        cell = Cell(point=1.5)
+        n = np.float64(1.2)
+
+        try:
+            bool(cell < n)
+            bool(cell <= n)
+            bool(cell > n)
+            bool(cell >= n)
+            bool(cell == n)
+        except:
+            self.fail(
+                "Result of comparison could not be used as a truth value")
+
+    def test_cell_rhs(self):
+        cell = Cell(point=1.5)
+        n = np.float64(1.2)
+
+        try:
+            bool(n < cell)
+            bool(n <= cell)
+            bool(n > cell)
+            bool(n >= cell)
+            bool(n == cell)
+        except:
+            self.fail(
+                "Result of comparison could not be used as a truth value")
 
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
Since `iris.coords.Cell` inherits from `tuple`, comparisons with NumPy numeric types produce unexpected results. For example:

```
from iris.coords import Cell
import numpy as np

c = Cell(1.)
f = np.float64(2.)
print f < c
```

outputs:

`[False False]`

Setting an [`__array_priority__`](http://docs.scipy.org/doc/numpy-1.10.1/user/c-info.beyond-basics.html#ndarray.__array_priority__) class variable to a number greater than 0.0 causes the `Cell` comparison operators to override those of NumPy types.

I'm not sure if this is the right fix to the problem, but I'm hoping something will come out of the discussion.
