### PR TITLE
Patch page 404 mailing list url replaced

### DIFF
--- a/docs/iris/src/developers_guide/gitwash/this_project.inc
+++ b/docs/iris/src/developers_guide/gitwash/this_project.inc
@@ -2,4 +2,4 @@
 .. _`iris`: http://scitools.org.uk/iris
 .. _`iris github`: http://github.com/SciTools/iris
 
-.. _`iris mailing list`: http://scitools.org.uk/mailman/listinfo
+.. _`iris mailing list`: https://groups.google.com/forum/#!forum/scitools-iris


### PR DESCRIPTION
@pelson: 
I have changed the mailing list url (that was harder to find than I expected, but I feel good about myself now).

Hope this is ok.