### PR TITLE
remove named tuples from rules.py

### DIFF
--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -2131,7 +2131,7 @@ def convert(field):
         raise TranslationError(msg)
 
     # Initialise the cube metadata.
-    metadata = OrderedDict()
+    metadata = {}
     metadata['factories'] = []
     metadata['references'] = []
     metadata['standard_name'] = None
@@ -2145,4 +2145,4 @@ def convert(field):
     # Convert GRIB2 message to cube metadata.
     grib2_convert(field, metadata)
 
-    return ConversionMetadata._make(metadata.values())
+    return ConversionMetadata(**metadata)

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_scalar_vertical_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -31,6 +31,7 @@ from iris.coords import DimCoord, AuxCoord
 from iris.aux_factory import HybridPressureFactory, HybridHeightFactory
 from iris.fileformats.pp import SplittableInt, STASH
 from iris.fileformats.pp_rules import Reference
+from iris.fileformats.rules import Factory
 from iris.tests.unit.fileformats import TestField
 
 
@@ -271,10 +272,10 @@ class TestLBVC009_HybridPressure(TestField):
                 (AuxCoord([0.15],
                           long_name='sigma',
                           bounds=[brlev, brsvd1]), None)]
-            expect_factories = [(HybridPressureFactory,
-                                 [{'long_name': 'level_pressure'},
-                                  {'long_name': 'sigma'},
-                                  Reference('surface_air_pressure')])]
+            expect_factories = [Factory(HybridPressureFactory,
+                                        [{'long_name': 'level_pressure'},
+                                         {'long_name': 'sigma'},
+                                         Reference('surface_air_pressure')])]
         else:
             expect_coords_and_dims = []
             expect_factories = []
@@ -308,10 +309,10 @@ class TestLBVC065_HybridHeight(TestField):
                           attributes={'positive': 'up'}), None),
                 (AuxCoord([0.35],
                           long_name='sigma', bounds=[bhrlev, brsvd2]), None)]
-            expect_factories = [(HybridHeightFactory,
-                                 [{'long_name': 'level_height'},
-                                  {'long_name': 'sigma'},
-                                  Reference('orography')])]
+            expect_factories = [Factory(HybridHeightFactory,
+                                        [{'long_name': 'level_height'},
+                                         {'long_name': 'sigma'},
+                                         Reference('orography')])]
         else:
             expect_coords_and_dims = []
             expect_factories = []

--- a/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_rules/test__convert_vertical_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -33,6 +33,7 @@ from iris.coords import DimCoord, AuxCoord
 from iris.aux_factory import HybridPressureFactory, HybridHeightFactory
 from iris.fileformats.pp import SplittableInt, STASH
 from iris.fileformats.pp_rules import Reference, _convert_vertical_coords
+from iris.fileformats.rules import Factory
 from iris.tests.unit.fileformats import TestField
 
 
@@ -402,10 +403,10 @@ class TestLBVC009_HybridPressure(TestField):
             (AuxCoord(blev,
                       long_name='sigma',
                       bounds=np.vstack((brlev, brsvd1)).T), dim))
-        expect_factories = [(HybridPressureFactory,
-                             [{'long_name': 'level_pressure'},
-                              {'long_name': 'sigma'},
-                              Reference('surface_air_pressure')])]
+        expect_factories = [Factory(HybridPressureFactory,
+                                    [{'long_name': 'level_pressure'},
+                                     {'long_name': 'sigma'},
+                                     Reference('surface_air_pressure')])]
         self.assertCoordsAndDimsListsMatch(coords_and_dims,
                                            expect_coords_and_dims)
         self.assertEqual(factories, expect_factories)
@@ -454,10 +455,10 @@ class TestLBVC065_HybridHeight(TestField):
             (AuxCoord(bhlev,
                       long_name='sigma',
                       bounds=np.vstack((bhrlev, brsvd2)).T), dim))
-        expect_factories = [(HybridHeightFactory,
-                             [{'long_name': 'level_height'},
-                              {'long_name': 'sigma'},
-                              Reference('orography')])]
+        expect_factories = [Factory(HybridHeightFactory,
+                                    [{'long_name': 'level_height'},
+                                     {'long_name': 'sigma'},
+                                     Reference('orography')])]
         self.assertCoordsAndDimsListsMatch(coords_and_dims,
                                            expect_coords_and_dims)
         self.assertEqual(factories, expect_factories)


### PR DESCRIPTION
for public API cleanliness and documentation improvements, e.g.:

```
attributes

    Alias for field number 5

```

http://scitools.org.uk/iris/docs/latest/iris/iris/fileformats/rules.html#iris.fileformats.rules.ConversionMetadata

et al isn't very user friendly
