### PR TITLE
Grib dep2

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Mar-17_GribWrapper.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Mar-17_GribWrapper.txt
@@ -1,0 +1,5 @@
+* deprecated:
+ iris.fileformats.grib.hindcast_workaround,
+ :class: `iris.fileformats.grib.GribWrapper`.
+ The class :class:`iris.fileformats.grib.message.GribMessage` provides
+ alternative means of working with GRIB message instances.

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -44,7 +44,7 @@ from iris.exceptions import TranslationError
 from iris.fileformats.grib import grib_phenom_translation as gptx
 from iris.fileformats.grib import _save_rules
 import iris.fileformats.grib._load_convert
-from iris.fileformats.grib._message import _GribMessage
+from iris.fileformats.grib.message import GribMessage
 import iris.fileformats.grib.load_rules
 
 
@@ -55,6 +55,7 @@ __all__ = ['as_messages', 'as_pairs', 'grib_generator', 'load_cubes',
 
 #: Set this flag to True to enable support of negative forecast periods
 #: when loading and saving GRIB files.
+#: .. deprecated:: 1.10
 hindcast_workaround = False
 
 
@@ -175,8 +176,14 @@ class GribWrapper(object):
     """
     Contains a pygrib object plus some extra keys of our own.
 
+    .. deprecated:: 1.10
+
+    The class :class:`iris.fileformats.grib.message.GribMessage`
+    provides alternative means of working with GRIB message instances.
+
     """
     def __init__(self, grib_message, grib_fh=None, auto_regularise=True):
+        warnings.warn('Deprecated at version 1.10')
         """Store the grib message and compute our extra keys."""
         self.grib_message = grib_message
         deferred = grib_fh is not None
@@ -834,6 +841,12 @@ def grib_generator(filename, auto_regularise=True):
     Returns a generator of :class:`~iris.fileformats.grib.GribWrapper`
     fields from the given filename.
 
+    .. deprecated:: 1.10
+
+    The function:
+    :meth:`iris.fileformats.grib.message.GribMessage.messages_from_filename`
+    provides alternative means of obtainig GRIB messages from a file.
+
     Args:
 
     * filename (string):
@@ -849,6 +862,7 @@ def grib_generator(filename, auto_regularise=True):
         reduced grid to an equivalent regular grid.
 
     """
+    warnings.warn('Deprecated at version 1.10')
     with open(filename, 'rb') as grib_fh:
         while True:
             grib_message = gribapi.grib_new_from_file(grib_fh)
@@ -892,7 +906,7 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
     """
     if iris.FUTURE.strict_grib_load:
         grib_loader = iris.fileformats.rules.Loader(
-            _GribMessage.messages_from_filename,
+            GribMessage.messages_from_filename,
             {},
             iris.fileformats.grib._load_convert.convert)
     else:
@@ -962,7 +976,7 @@ def as_pairs(cube):
 def as_messages(cube):
     """
     Convert one or more cubes to GRIB messages.
-    Returns an iterable of grib_api GRIB messages.
+    Returns an iterable of grib_api GRIB message IDs.
 
     Args:
         * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -55,6 +55,7 @@ __all__ = ['as_messages', 'as_pairs', 'grib_generator', 'load_cubes',
 
 #: Set this flag to True to enable support of negative forecast periods
 #: when loading and saving GRIB files.
+#:
 #: .. deprecated:: 1.10
 hindcast_workaround = False
 

--- a/lib/iris/fileformats/grib/message.py
+++ b/lib/iris/fileformats/grib/message.py
@@ -49,8 +49,8 @@ class _OpenFileRef(object):
 class GribMessage(object):
     """
     An in-memory representation of a GribMessage, providing
-    access to the :meth:`GribMessage.data` payload and the metadata
-    elements by section via the :meth:`GribMessage.sections` property.
+    access to the :meth:`~GribMessage.data` payload and the metadata
+    elements by section via the :meth:`~GribMessage.sections` property.
 
     """
 
@@ -82,7 +82,7 @@ class GribMessage(object):
     def __init__(self, raw_message, recreate_raw, file_ref=None):
         """
         It is recommended to obtain GribMessage instance from the static method
-        :meth:`GribMessage.messages_from_filename`, rather than creating
+        :meth:`~GribMessage.messages_from_filename`, rather than creating
         them directly.
 
         """
@@ -102,15 +102,13 @@ class GribMessage(object):
         Return the key-value pairs of the message keys, grouped by containing
         section.
 
-        Key-value pairs are collected into a dictionary of
-        :class:`Section` objects. One such object is made for
-        each section in the message, such that the section number is the
-        object's key in the containing dictionary. Each object contains
-        key-value pairs for all of the message keys in the given section.
+        Sections in a message are indexed by GRIB section-number,
+        and values in a section are indexed by key strings.
 
-        For example::
+        .. For example::
 
-            print(grib_message[4]['parameterNumber'])
+            print(grib_message.sections[4]['parameterNumber'])
+            grib_message.sections[1]['minute'] = 0
 
         """
         return self._raw_message.sections

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -89,7 +89,7 @@ except ImportError:
     GRIB_AVAILABLE = False
 else:
     GRIB_AVAILABLE = True
-    from iris.fileformats.grib._message import _GribMessage
+    from iris.fileformats.grib.message import GribMessage
 
 
 #: Basepath for test results.
@@ -768,7 +768,7 @@ class TestGribMessage(IrisTest):
             An iterable of GRIB message keys and expected values.
 
         """
-        messages = _GribMessage.messages_from_filename(filename)
+        messages = GribMessage.messages_from_filename(filename)
         for message in messages:
             for element in contents:
                 section, key, val = element
@@ -793,8 +793,8 @@ class TestGribMessage(IrisTest):
             An iterable of section numbers to ignore during comparison.
 
         """
-        messages1 = list(_GribMessage.messages_from_filename(filename1))
-        messages2 = list(_GribMessage.messages_from_filename(filename2))
+        messages1 = list(GribMessage.messages_from_filename(filename1))
+        messages2 = list(GribMessage.messages_from_filename(filename2))
         self.assertEqual(len(messages1), len(messages2))
         for m1, m2 in zip(messages1, messages2):
             m1_sect = set(m1.sections.keys())

--- a/lib/iris/tests/integration/test_pickle.py
+++ b/lib/iris/tests/integration/test_pickle.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,25 +27,25 @@ import six.moves.cPickle as pickle
 
 if tests.GRIB_AVAILABLE:
     import gribapi
-    from iris.fileformats.grib import _GribMessage
+    from iris.fileformats.grib.message import GribMessage
 
 
 @tests.skip_data
 @tests.skip_grib
 class TestGribMessage(tests.IrisTest):
     def test(self):
-        # Check that a _GribMessage pickles without errors.
+        # Check that a GribMessage pickles without errors.
         path = tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2'))
-        messages = _GribMessage.messages_from_filename(path)
+        messages = GribMessage.messages_from_filename(path)
         message = next(messages)
         with self.temp_filename('.pkl') as filename:
             with open(filename, 'wb') as f:
                 pickle.dump(message, f)
 
     def test_data(self):
-        # Check that _GribMessage.data pickles without errors.
+        # Check that GribMessage.data pickles without errors.
         path = tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2'))
-        messages = _GribMessage.messages_from_filename(path)
+        messages = GribMessage.messages_from_filename(path)
         message = next(messages)
         with self.temp_filename('.pkl') as filename:
             with open(filename, 'wb') as f:

--- a/lib/iris/tests/unit/fileformats/grib/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -19,11 +19,11 @@
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-from iris.fileformats.grib._message import _GribMessage
+from iris.fileformats.grib.message import GribMessage
 from iris.tests import mock
 
 
 def _make_test_message(sections):
     raw_message = mock.Mock(sections=sections)
     recreate_raw = mock.Mock(return_value=raw_message)
-    return _GribMessage(raw_message, recreate_raw)
+    return GribMessage(raw_message, recreate_raw)

--- a/lib/iris/tests/unit/fileformats/grib/message/__init__.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the :mod:`iris.fileformats.grib._message` package."""
+"""Unit tests for the :mod:`iris.fileformats.grib.message` package."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the `iris.fileformats.grib.message._GribMessage` class.
+Unit tests for the `iris.fileformats.grib.message.GribMessage` class.
 
 """
 
@@ -33,7 +33,7 @@ import biggus
 import numpy as np
 
 from iris.exceptions import TranslationError
-from iris.fileformats.grib._message import _GribMessage
+from iris.fileformats.grib.message import GribMessage
 from iris.tests import mock
 from iris.tests.unit.fileformats.grib import _make_test_message
 
@@ -46,8 +46,18 @@ class Test_messages_from_filename(tests.IrisTest):
     def test(self):
         filename = tests.get_data_path(('GRIB', '3_layer_viz',
                                         '3_layer.grib2'))
-        messages = list(_GribMessage.messages_from_filename(filename))
+        messages = list(GribMessage.messages_from_filename(filename))
         self.assertEqual(len(messages), 3)
+
+    def test_release_file(self):
+        filename = tests.get_data_path(('GRIB', '3_layer_viz',
+                                        '3_layer.grib2'))
+        my_file = open(filename)
+        self.patch('__builtin__.open', mock.Mock(return_value=my_file))
+        messages = list(GribMessage.messages_from_filename(filename))
+        self.assertFalse(my_file.closed)
+        del messages
+        self.assertTrue(my_file.closed)
 
 
 class Test_sections(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/message/test_Section.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test_Section.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for `iris.fileformats.grib._message._Section`.
+Unit tests for `iris.fileformats.grib.message.Section`.
 
 """
 
@@ -29,7 +29,7 @@ import iris.tests as tests
 import gribapi
 import numpy as np
 
-from iris.fileformats.grib._message import _Section
+from iris.fileformats.grib.message import Section
 
 
 @tests.skip_data
@@ -40,27 +40,27 @@ class Test___getitem__(tests.IrisTest):
             self.grib_id = gribapi.grib_new_from_file(grib_fh)
 
     def test_scalar(self):
-        section = _Section(self.grib_id, None, ['Ni'])
+        section = Section(self.grib_id, None, ['Ni'])
         self.assertEqual(section['Ni'], 47)
 
     def test_array(self):
-        section = _Section(self.grib_id, None, ['codedValues'])
+        section = Section(self.grib_id, None, ['codedValues'])
         codedValues = section['codedValues']
         self.assertEqual(codedValues.shape, (1551,))
         self.assertArrayAlmostEqual(codedValues[:3],
                                     [-1.78140259, -1.53140259, -1.28140259])
 
     def test_typeOfFirstFixedSurface(self):
-        section = _Section(self.grib_id, None, ['typeOfFirstFixedSurface'])
+        section = Section(self.grib_id, None, ['typeOfFirstFixedSurface'])
         self.assertEqual(section['typeOfFirstFixedSurface'], 100)
 
     def test_numberOfSection(self):
         n = 4
-        section = _Section(self.grib_id, n, ['numberOfSection'])
+        section = Section(self.grib_id, n, ['numberOfSection'])
         self.assertEqual(section['numberOfSection'], n)
 
     def test_invalid(self):
-        section = _Section(self.grib_id, None, ['Ni'])
+        section = Section(self.grib_id, None, ['Ni'])
         with self.assertRaisesRegexp(KeyError, 'Nii'):
             section['Nii']
 
@@ -76,7 +76,7 @@ class Test__getitem___pdt_31(tests.IrisTest):
                      'scaledValueOfCentralWaveNumber']
 
     def test_array(self):
-        section = _Section(self.grib_id, None, self.keys)
+        section = Section(self.grib_id, None, self.keys)
         for key in self.keys:
             value = section[key]
             self.assertIsInstance(value, np.ndarray)
@@ -89,7 +89,7 @@ class Test_get_computed_key(tests.IrisTest):
         fname = tests.get_data_path(('GRIB', 'gaussian', 'regular_gg.grib2'))
         with open(fname, 'rb') as grib_fh:
             self.grib_id = gribapi.grib_new_from_file(grib_fh)
-            section = _Section(self.grib_id, None, [])
+            section = Section(self.grib_id, None, [])
         latitudes = section.get_computed_key('latitudes')
         self.assertTrue(88.55 < latitudes[0] < 88.59)
 

--- a/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,7 +30,7 @@ import numpy as np
 from numpy.random import randint
 
 from iris.exceptions import TranslationError
-from iris.fileformats.grib._message import _DataProxy
+from iris.fileformats.grib.message import _DataProxy
 
 
 class Test__bitmap(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__MessageLocation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,7 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from iris.fileformats.grib._message import _MessageLocation
+from iris.fileformats.grib.message import _MessageLocation
 from iris.tests import mock
 
 
@@ -34,7 +34,7 @@ class Test(tests.IrisTest):
     def test(self):
         message_location = _MessageLocation(mock.sentinel.filename,
                                             mock.sentinel.location)
-        patch_target = 'iris.fileformats.grib._message._RawGribMessage.' \
+        patch_target = 'iris.fileformats.grib.message._RawGribMessage.' \
                        'from_file_offset'
         expected = mock.sentinel.message
         with mock.patch(patch_target, return_value=expected) as rgm:

--- a/lib/iris/tests/unit/fileformats/grib/message/test__RawGribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__RawGribMessage.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,7 +28,7 @@ import iris.tests as tests
 
 import gribapi
 
-from iris.fileformats.grib._message import _RawGribMessage
+from iris.fileformats.grib.message import _RawGribMessage
 
 
 @tests.skip_data

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -62,11 +62,11 @@ class TestToggle(tests.IrisTest):
 
     def test_strict_mode(self):
         # Ensure that `load_cubes` uses:
-        #   iris.fileformats.grib._message._GribMessage.messages_from_filename
+        #   iris.fileformats.grib.message.GribMessage.messages_from_filename
         #   iris.fileformats.grib._load_convert.convert
         self._test(
             True,
-            iris.fileformats.grib._message._GribMessage.messages_from_filename,
+            iris.fileformats.grib.message.GribMessage.messages_from_filename,
             iris.fileformats.grib._load_convert.convert)
 
 


### PR DESCRIPTION
deprecations and publications for the GRIB loading, to prepare for strict_grib_load to become the default and to support as_cubes (#1941)