### PR TITLE
Regrid fix circular extend

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Apr-01_regrid_masked_circular.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Apr-01_regrid_masked_circular.txt
@@ -1,0 +1,4 @@
+Fixed a bug where regridding circular data would ignore any source masking.
+  This affected any regridding using the :class:`~iris.analysis.Linear` and
+  :class:`~iris.analysis.Nearest` schemes, and also
+  :func:`iris.analysis.interpolate.linear`.

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -101,27 +101,10 @@ def extend_circular_data(data, coord_dim):
     coord_slice_in_cube = [slice(None)] * data.ndim
     coord_slice_in_cube[coord_dim] = slice(0, 1)
 
-    # TODO: Restore this code after resolution of the following issue:
-    # https://github.com/numpy/numpy/issues/478
-    # data = np.append(cube.data,
-    #                  cube.data[tuple(coord_slice_in_cube)],
-    #                  axis=sample_dim)
-    # This is the alternative, temporary workaround.
-    # It doesn't use append on an nD mask.
-    if not (isinstance(data, ma.MaskedArray) and
-            not isinstance(data.mask, np.ndarray)) or \
-            len(data.mask.shape) == 0:
-        data = np.append(data,
-                         data[tuple(coord_slice_in_cube)],
-                         axis=coord_dim)
-    else:
-        new_data = np.append(data.data,
-                             data.data[tuple(coord_slice_in_cube)],
-                             axis=coord_dim)
-        new_mask = np.append(data.mask,
-                             data.mask[tuple(coord_slice_in_cube)],
-                             axis=coord_dim)
-        data = ma.array(new_data, mask=new_mask)
+    mod = ma if isinstance(data, ma.MaskedArray) else np
+    data = mod.concatenate((data,
+                            data[tuple(coord_slice_in_cube)]),
+                           axis=coord_dim)
     return data
 
 

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -510,25 +510,6 @@ class TestLinear1dInterpolation(tests.IrisTest):
         # this test tries to extract a float from an array of type integer. the result should be of type float.
         r = iris.analysis.interpolate.linear(self.simple2d_cube_extended, [('shared_x_coord', 7.5)])
         self.assertCML(r, ('analysis', 'interpolation', 'linear', 'simple_casting_datatype.cml'))
-        
-    def test_mask(self):
-        # Test np.append bug with masked arrays.
-        # Based on the bug reported in https://github.com/SciTools/iris/issues/106
-        cube = tests.stock.realistic_4d_w_missing_data()
-        cube = cube[0, 2, 18::-1]
-        cube.coord('grid_longitude').circular = True
-        _ = iris.analysis.interpolate.linear(cube, [('grid_longitude', 0), ('grid_latitude', 0)])
-        # Did np.append go wrong?
-        self.assertArrayEqual(cube.data.data.shape, cube.data.mask.shape)
-    
-    def test_scalar_mask(self):
-        # Testing the bug raised in https://github.com/SciTools/iris/pull/123#issuecomment-9309872
-        # (the fix workaround for the np.append bug failed for scalar masks) 
-        cube = tests.stock.realistic_4d_w_missing_data()
-        cube.data = ma.arange(np.product(cube.shape), dtype=np.float32).reshape(cube.shape)
-        cube.coord('grid_longitude').circular = True
-        # There's no result to test, just make sure we don't cause an exception with the scalar mask.
-        _ = iris.analysis.interpolate.linear(cube, [('grid_longitude', 0), ('grid_latitude', 0)])
 
 
 @tests.skip_data


### PR DESCRIPTION
Addresses a reported problem whereby regridded data came out with large values instead of the expected masked points.
There was already a longstanding workaround for this, related to a known problem with numpy 'append', but it had a bug in its own logic.
I replaced the earlier fix with one using either np.concatenate or np.ma.concatenate, as required.  This seemed necessary to ensure the required result type, i.e. masked-for-masked-input and also unmasked-for-unmasked-input.