### PR TITLE
Save rules for maximum and minimum values corrected

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Mar-05_set_lbproc_for_minimum.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Mar-05_set_lbproc_for_minimum.txt
@@ -1,0 +1,3 @@
+* LBPROC is set correctly when a cube containing the minimum of a variable is
+ saved to a PP file. The IA component of LBTIM is set correctly when saving
+ maximum or minimum values.

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2014, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -150,6 +150,35 @@ IF
 THEN
     pp.lbtim.ia = 0
 
+IF
+    # If the cell methods contain a minimum then overwrite lbtim.ia with this
+    # interval
+    scalar_coord(cm, 'time') is not None
+    scalar_coord(cm, 'time').has_bounds()
+    scalar_coord(cm, 'clim_season') is None
+    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
+    scalar_cell_method(cm, 'minimum', 'time') is not None
+    scalar_cell_method(cm, 'minimum', 'time').intervals != ()
+    scalar_cell_method(cm, 'minimum', 'time').intervals[0].endswith('hour')
+THEN
+    # set lbtim.ia with the integer part of the cell method's interval
+    # e.g. if interval is '24 hour' then lbtim.ia becomes 24
+    pp.lbtim.ia = int(scalar_cell_method(cm, 'minimum', 'time').intervals[0][:-5])
+
+IF
+    # If the cell methods contain a maximum then overwrite lbtim.ia with this
+    # interval
+    scalar_coord(cm, 'time') is not None
+    scalar_coord(cm, 'time').has_bounds()
+    scalar_coord(cm, 'clim_season') is None
+    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
+    scalar_cell_method(cm, 'maximum', 'time') is not None
+    scalar_cell_method(cm, 'maximum', 'time').intervals != ()
+    scalar_cell_method(cm, 'maximum', 'time').intervals[0].endswith('hour')
+THEN
+    # set lbtim.ia with the integer part of the cell method's interval
+    # e.g. if interval is '1 hour' then lbtim.ia becomes 1
+    pp.lbtim.ia = int(scalar_cell_method(cm, 'maximum', 'time').intervals[0][:-5])
 
 #climatiological time mean - single year
 IF
@@ -521,6 +550,13 @@ IF
     scalar_cell_method(cm, 'mean', 'time') is not None
 THEN
     pp.lbproc += 128
+
+#time-minimum
+IF
+    # Look for a CellMethod which is a "minimum" over "time".
+    scalar_cell_method(cm, 'minimum', 'time') is not None
+THEN
+    pp.lbproc += 4096
 
 #time-maximum
 IF

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,7 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from iris.coords import DimCoord
+from iris.coords import DimCoord, CellMethod
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
 from iris.tests import mock
@@ -159,6 +159,30 @@ class TestLbsrceProduction(tests.IrisTest):
     def test_um_version(self):
         self.check_cube_um_source_yields_lbsrce(
             'Data from Met Office Unified Model 12.17', '25.36', 25361111)
+
+
+class Test_Save__LbprocProduction(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.realistic_3d()
+
+    def test_no_cell_methods(self):
+        lbproc = _pp_save_ppfield_values(self.cube).lbproc
+        self.assertEqual(lbproc, 0)
+
+    def test_mean(self):
+        self.cube.cell_methods = (CellMethod('mean', 'time', '1 hour'),)
+        lbproc = _pp_save_ppfield_values(self.cube).lbproc
+        self.assertEqual(lbproc, 128)
+
+    def test_minimum(self):
+        self.cube.cell_methods = (CellMethod('minimum', 'time', '1 hour'),)
+        lbproc = _pp_save_ppfield_values(self.cube).lbproc
+        self.assertEqual(lbproc, 4096)
+
+    def test_maximum(self):
+        self.cube.cell_methods = (CellMethod('maximum', 'time', '1 hour'),)
+        lbproc = _pp_save_ppfield_values(self.cube).lbproc
+        self.assertEqual(lbproc, 8192)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a problem where LBPROC is not set when saving a minimum to a PP file. It also sets the IA component of LBTIM when saving a maximum or a minimum.

I have really struggled with the unit tests for these fixes. I have one for LBPROC, although this creates 84 warnings when run. I can't write a unit test for the LBTIM fix. When using the mock approach that other tests in the unit test module use, LBTIM is always set to an integer and so the IA, IB and IC components can't be set. I tried creating an additional mock for LBTIM that replaced it with an object with these components, but this was overwritten with an integer.

I also looked at the approach used in tests/integration/test_pp.py but got an error: "TypeError: 'NoneType' object has no attribute '__getitem__'" when I called "iris.fileformats.pp._save_rules.verify(cube, field)".

I have tested the fixes on real PP data and they work well with that.