### PR TITLE
scalar_cell_method now checks coord_name

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Mar-06_scalar_cell_method.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Mar-06_scalar_cell_method.txt
@@ -1,0 +1,2 @@
+* The coord_name parameter to scalar_cell_method() is now checked correctly and
+ unit tests have been written for this function.

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -709,9 +709,10 @@ def scalar_cell_method(cube, method, coord_name):
     for cell_method in cube.cell_methods:
         if cell_method.method == method and len(cell_method.coord_names) == 1:
             name = cell_method.coord_names[0]
-            coords = cube.coords(name)
-            if len(coords) == 1:
-                found_cell_method = cell_method
+            if name == coord_name:
+                coords = cube.coords(name)
+                if len(coords) == 1:
+                    found_cell_method = cell_method
     return found_cell_method
 
 

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -120,7 +120,6 @@ class StandardReportWithExclusions(pep8.StandardReport):
         '*/iris/tests/test_pp_to_cube.py',
         '*/iris/tests/test_quickplot.py',
         '*/iris/tests/test_regrid.py',
-        '*/iris/tests/test_rules.py',
         '*/iris/tests/test_std_names.py',
         '*/iris/tests/test_trajectory.py',
         '*/iris/tests/test_unit.py',


### PR DESCRIPTION
While doing some other work I noticed that scalar_cell_method() in lib/iris/fileformats/rules.py didn't check its coord_name argument, which I've now fixed.