### PR TITLE
Fix the 'Nearest' scheme to return the same datatype as the input.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Apr-07_nearest_types.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Apr-07_nearest_types.txt
@@ -1,0 +1,4 @@
+Fixed a bug where regridding or interpolation with the
+  :class:`~iris.analysis.Nearest` scheme returned floating-point results even
+  when the source data was integer typed.
+  It now always returns the same type as the source data.

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -216,11 +216,12 @@ class RectilinearRegridder(object):
         shape[y_dim] = sample_grid_x.shape[0]
         shape[x_dim] = sample_grid_x.shape[1]
 
-        # If we're given integer values, convert them to the smallest
-        # possible float dtype that can accurately preserve the values.
         dtype = src_data.dtype
-        if dtype.kind == 'i':
-            dtype = np.promote_types(dtype, np.float16)
+        if method == 'linear':
+            # If we're given integer values, convert them to the smallest
+            # possible float dtype that can accurately preserve the values.
+            if dtype.kind == 'i':
+                dtype = np.promote_types(dtype, np.float16)
 
         if isinstance(src_data, ma.MaskedArray):
             data = ma.empty(shape, dtype=dtype)


### PR DESCRIPTION
Stumbled on this while refactoring regridding code.

I want Nearest() to behave sensibly so I can use it to replace the usage of the obsolete methods we are deprecating.  Refer : https://github.com/pp-mo/iris/pull/20 