### PR TITLE
Prevent a docs build from breaking the tests.

### DIFF
--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -348,6 +348,7 @@ class TestFutureImports(unittest.TestCase):
         '*/iris/fileformats/_pyke_rules/compiled_krb/compiled_pyke_files.py',
         '*/iris/fileformats/_pyke_rules/compiled_krb/fc_rules_cf_fc.py',
         '*/docs/iris/example_code/*/*.py',
+        '*/docs/iris/src/examples/*/*.py',
         '*/docs/iris/src/developers_guide/documenting/*.py',
     )
 


### PR DESCRIPTION
The tests still run after building the docs !

The existing testing problem relates to the 'future imports test', ```iris.test.test_coding.standards.TestFutureImports```.
This test is _already_ excluded from checking the example code files, in {{"\*/docs/iris/example_code/*/*.py"}}.
However, building the docs copies ```/docs/iris/example_code/*``` to ```/docs/iris/src/examples```, and the test is checking + failing them there.