### PR TITLE
Curl docs change

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -443,7 +443,12 @@ def _trig_method(coord, trig_function):
 
 def curl(i_cube, j_cube, k_cube=None, ignore=None):
     r'''
-    Calculate the 3d curl of the given vector of cubes.
+    Calculate the 2-dimensional or 3-dimensional spherical or cartesian
+    curl of the given vector of cubes.
+
+    As well as the standard x and y coordinates, this function requires each
+    cube to possess a vertical or z-like coordinate (representing some form
+    of height or pressure).  This can be a scalar or dimension coordinate.
 
     Args:
 
@@ -458,15 +463,31 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
         The k cube of the vector to operate on
     * ignore
         This argument is not used.
+
         .. deprecated:: 0.8
             The coordinates to ignore are determined automatically.
 
     Return (i_cmpt_curl_cube, j_cmpt_curl_cube, k_cmpt_curl_cube)
 
+    If the k-cube is not passed in then the 2-dimensional curl will
+    be calculated, yielding a single cube representing the vertical component
+    as the result.  If the k-cube is passed in, the 3-dimensional curl will
+    be calculated, returning 3 component cubes.
+
+    All cubes passed in must have the same data units, and those units
+    must be spatially-derived (i.e. m/s or km/h).
+
     The calculation of curl is dependent on the type of
-    :func:`iris.coord_systems.CoordSystem` in the cube:
+    :func:`iris.coord_systems.CoordSystem` in the cube.
+    If the :func:`iris.coord_systems.CoordSystem` is either
+    GeogCS or RotatedGeogCS, the spherical curl will be calculated; otherwise
+    the cartesian curl will be calculated:
 
         Cartesian curl
+
+            When cartesian calculus is used, i_cube is the u vector component
+            (e.g. eastward), j_cube is the v component (e.g. northward) and
+            k_cube is the w component(vertical).
 
             The Cartesian curl is defined as:
 

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -470,24 +470,23 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
     Return (i_cmpt_curl_cube, j_cmpt_curl_cube, k_cmpt_curl_cube)
 
     If the k-cube is not passed in then the 2-dimensional curl will
-    be calculated, yielding a single cube representing the vertical component
-    as the result.  If the k-cube is passed in, the 3-dimensional curl will
+    be calculated, yielding the result: [None, None, k_cube].
+    If the k-cube is passed in, the 3-dimensional curl will
     be calculated, returning 3 component cubes.
 
     All cubes passed in must have the same data units, and those units
-    must be spatially-derived (i.e. m/s or km/h).
+    must be spatially-derived (e.g. 'm/s' or 'km/h').
 
     The calculation of curl is dependent on the type of
-    :func:`iris.coord_systems.CoordSystem` in the cube.
-    If the :func:`iris.coord_systems.CoordSystem` is either
+    :func:`~iris.coord_systems.CoordSystem` in the cube.
+    If the :func:`~iris.coord_systems.CoordSystem` is either
     GeogCS or RotatedGeogCS, the spherical curl will be calculated; otherwise
     the cartesian curl will be calculated:
 
         Cartesian curl
 
-            When cartesian calculus is used, i_cube is the u vector component
-            (e.g. eastward), j_cube is the v component (e.g. northward) and
-            k_cube is the w component(vertical).
+            When cartesian calculus is used, i_cube is the u component,
+            j_cube is the v component and k_cube is the w component.
 
             The Cartesian curl is defined as:
 
@@ -502,8 +501,8 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
         Spherical curl
 
-            When spherical calculus is used, i_cube is the :math:\phi vector
-            component (e.g. eastward), j_cube is the :math:\theta component
+            When spherical calculus is used, i_cube is the :math:`\phi` vector
+            component (e.g. eastward), j_cube is the :math:`\theta` component
             (e.g. northward) and k_cube is the radial component.
 
             The spherical curl is defined as:
@@ -566,10 +565,10 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
     horiz_cs = i_cube.coord_system('CoordSystem')
 
-    # Planar (non spherical) coords?
-    ellipsoidal = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
+    # Non-spherical coords?
+    spherical = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
                                         iris.coord_systems.RotatedGeogCS))
-    if not ellipsoidal:
+    if not spherical:
 
         # TODO Implement some mechanism for conforming to a common grid
         dj_dx = _curl_differentiate(j_cube, x_coord)

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -442,7 +442,7 @@ def _trig_method(coord, trig_function):
 
 
 def curl(i_cube, j_cube, k_cube=None, ignore=None):
-    r'''
+    r"""
     Calculate the 2-dimensional or 3-dimensional spherical or cartesian
     curl of the given vector of cubes.
 
@@ -522,7 +522,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
             where phi is longitude, theta is latitude.
 
-    '''
+    """
     if ignore is not None:
         ignore = None
         warnings.warn('The ignore keyword to iris.analysis.calculus.curl '
@@ -567,7 +567,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
     # Non-spherical coords?
     spherical = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
-                                        iris.coord_systems.RotatedGeogCS))
+                                      iris.coord_systems.RotatedGeogCS))
     if not spherical:
 
         # TODO Implement some mechanism for conforming to a common grid

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -567,7 +567,7 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
     # Non-spherical coords?
     spherical_coords = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
-                                      iris.coord_systems.RotatedGeogCS))
+                                  iris.coord_systems.RotatedGeogCS))
     if not spherical_coords:
 
         # TODO Implement some mechanism for conforming to a common grid

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -566,9 +566,9 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
     horiz_cs = i_cube.coord_system('CoordSystem')
 
     # Non-spherical coords?
-    spherical = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
+    spherical_coords = isinstance(horiz_cs, (iris.coord_systems.GeogCS,
                                       iris.coord_systems.RotatedGeogCS))
-    if not spherical:
+    if not spherical_coords:
 
         # TODO Implement some mechanism for conforming to a common grid
         dj_dx = _curl_differentiate(j_cube, x_coord)

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -502,8 +502,8 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
 
         Spherical curl
 
-            When spherical calculus is used, i_cube is the phi vector
-            component (e.g. eastward), j_cube is the theta component
+            When spherical calculus is used, i_cube is the :math:\phi vector
+            component (e.g. eastward), j_cube is the :math:\theta component
             (e.g. northward) and k_cube is the radial component.
 
             The spherical curl is defined as:


### PR DESCRIPTION
@pp-mo @rhattersley @marqh @pelson 
The documentation for this function was very vague and unclear, so I have added paragraphs which should make it more clear and understandable.  It now states the type of units that need to be on the cube data and what the different results will be when the k-component cube is and is not used.  It also states which coordinate systems will lead to the spherical calculus being used.

Please tell me if this documentation is clear and makes sense.  I would be very keen to hear feedback and suggestions.