### PR TITLE
Added zonal (i.e. longitudinal) mean support to LBPROC save rule

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -544,6 +544,19 @@ IF
 THEN
     pp.lbproc += sum([iris.fileformats.pp.lbproc_map[name] for name in cm.attributes["ukmo__process_flags"]])
 
+#zonal-mean
+IF
+    # Look for a CellMethod which is a "mean" over "longitude".
+    scalar_cell_method(cm, 'mean', 'longitude') is not None
+THEN
+    pp.lbproc += 64
+
+IF
+    # Look for a CellMethod which is a "mean" over "grid longitude".
+    scalar_cell_method(cm, 'mean', 'grid_longitude') is not None
+THEN
+    pp.lbproc += 64
+
 #time-mean
 IF
     # Look for a CellMethod which is a "mean" over "time".
@@ -564,7 +577,6 @@ IF
     scalar_cell_method(cm, 'maximum', 'time') is not None
 THEN
     pp.lbproc += 8192
-
 
 ##########################
 ### vertical - lbuser5 ###


### PR DESCRIPTION
This is a fix to correctly set the LBPROC upon saving as a pp file for zonal mean data.  I have not included a test - if you can point me in the direction of where the tests should be for a pp_save_rules fix, I'd be grateful.  

For a bit of context, the closest test I could find was [here](https://github.com/SciTools/iris/blob/master/lib/iris/tests/test_cube_to_pp.py#L265)  However, that is acting on zonal mean being set in a particular cube attribute rather than the cube cell methods.  Simplifying that test down to just time and longitudinal mean yields this:

> cube = stock.lat_lon_cube()
cube.attributes["ukmo__process_flags"] = ['Time mean field', 'Zonal mean field']
temp_filename = iris.util.create_temp_filename(".pp")
iris.save(cube, temp_filename)
result = iris.fileformats.pp.load(temp_filename).next()
result.lbproc

Which correctly reports 192.  However, this snippet using cell methods instead reports 128 (i.e. just time mean):

> cube = stock.lat_lon_cube()
cube.cell_methods = (
    iris.coords.CellMethod(method=u'mean', coords=u'time'),
    iris.coords.CellMethod(method=u'mean', coords=u'longitude')
)
temp_filename = iris.util.create_temp_filename(".pp")
iris.save(cube, temp_filename)
result = iris.fileformats.pp.load(temp_filename).next()
result.lbproc

This PR corrects that.