### PR TITLE
Clip guessed latitude bounds to [-90, 90].

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -135,7 +135,8 @@ class Future(threading.local):
     """Run-time configuration controller."""
 
     def __init__(self, cell_datetime_objects=False, netcdf_promote=False,
-                 strict_grib_load=False, netcdf_no_unlimited=False):
+                 strict_grib_load=False, netcdf_no_unlimited=False,
+                 clip_latitudes=False):
         """
         A container for run-time options controls.
 
@@ -178,17 +179,24 @@ class Future(threading.local):
         unlimited.  The current default is that the leading dimension is
         unlimited unless otherwise specified.
 
+        The option `clip_latitudes` controls whether the
+        :meth:`iris.coords.Coord.guess_bounds()` method limits the
+        guessed bounds to [-90, 90] for latitudes.
+
         """
         self.__dict__['cell_datetime_objects'] = cell_datetime_objects
         self.__dict__['netcdf_promote'] = netcdf_promote
         self.__dict__['strict_grib_load'] = strict_grib_load
         self.__dict__['netcdf_no_unlimited'] = netcdf_no_unlimited
+        self.__dict__['clip_latitudes'] = clip_latitudes
 
     def __repr__(self):
         msg = ('Future(cell_datetime_objects={}, netcdf_promote={}, '
-               'strict_grib_load={}, netcdf_no_unlimited={})')
+               'strict_grib_load={}, netcdf_no_unlimited={}, '
+               'clip_latitudes={})')
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
-                          self.strict_grib_load, self.netcdf_no_unlimited)
+                          self.strict_grib_load, self.netcdf_no_unlimited,
+                          self.clip_latitudes)
 
     def __setattr__(self, name, value):
         if name not in self.__dict__:

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1011,8 +1011,9 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         Kwargs:
 
-        * bound_position - The desired position of the bounds relative to the
-                           position of the points.
+        * bound_position:
+            The desired position of the bounds relative to the position
+            of the points.
 
         Returns:
             A numpy array of shape (len(self.points), 2).
@@ -1023,10 +1024,12 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         .. note::
 
-            If `iris.FUTURE.clip_latitudes` is True, then this
-            method will clip the coordinate bounds to the range
-            [-90, 90] for latitude and grid_latitude coordinates
-            measured in degrees.
+            If `iris.FUTURE.clip_latitudes` is True, then this method
+            will clip the coordinate bounds to the range [-90, 90] when:
+
+            - it is a `latitude` or `grid_latitude` coordinate,
+            - the units are degrees,
+            - all the points are in the range [-90, 90].
 
         """
         # XXX Consider moving into DimCoord
@@ -1087,8 +1090,9 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         Kwargs:
 
-        * bound_position - The desired position of the bounds relative to the
-                           position of the points.
+        * bound_position:
+            The desired position of the bounds relative to the position
+            of the points.
 
         .. note::
 
@@ -1103,10 +1107,12 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         .. note::
 
-            If `iris.FUTURE.clip_latitudes` is True, then this
-            method will clip the coordinate bounds to the range
-            [-90, 90] for latitude and grid_latitude coordinates
-            measured in degrees.
+            If `iris.FUTURE.clip_latitudes` is True, then this method
+            will clip the coordinate bounds to the range [-90, 90] when:
+
+            - it is a `latitude` or `grid_latitude` coordinate,
+            - the units are degrees,
+            - all the points are in the range [-90, 90].
 
         """
         self.bounds = self._guess_bounds(bound_position)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1021,6 +1021,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
             This method only works for coordinates with ``coord.ndim == 1``.
 
+        .. note::
+
+            If `iris.FUTURE.clip_latitudes` is True, then this
+            method will clip the coordinate bounds to the range
+            [-90, 90] for latitude and grid_latitude coordinates
+            measured in degrees.
+
         """
         # XXX Consider moving into DimCoord
         # ensure we have monotonic points
@@ -1056,6 +1063,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         bounds = np.array([min_bounds, max_bounds]).transpose()
 
+        if (iris.FUTURE.clip_latitudes and
+                self.name() in ('latitude', 'grid_latitude') and
+                self.units == 'degree'):
+            points = self.points
+            if (points >= -90).all() and (points <= 90).all():
+                np.clip(bounds, -90, 90, out=bounds)
+
         return bounds
 
     def guess_bounds(self, bound_position=0.5):
@@ -1086,6 +1100,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             Unevenly spaced values, such from a wrapped longitude range, can
             produce unexpected results :  In such cases you should assign
             suitable values directly to the bounds property, instead.
+
+        .. note::
+
+            If `iris.FUTURE.clip_latitudes` is True, then this
+            method will clip the coordinate bounds to the range
+            [-90, 90] for latitude and grid_latitude coordinates
+            measured in degrees.
 
         """
         self.bounds = self._guess_bounds(bound_position)

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -44,6 +44,12 @@ class Test___setattr__(tests.IrisTest):
         new_value = not future.strict_grib_load
         future.strict_grib_load = new_value
         self.assertEqual(future.strict_grib_load, new_value)
+
+    def test_valid_clip_latitudes(self):
+        future = Future()
+        new_value = not future.clip_latitudes
+        future.clip_latitudes = new_value
+        self.assertEqual(future.clip_latitudes, new_value)
 
     def test_invalid_attribute(self):
         future = Future()


### PR DESCRIPTION
Using `Coord.guess_bounds()` on a latitude coordinate which extends too close to the poles gives rise to "silly" bounds that extend beyond the range [-90, 90]. (e.g. The sample data `GloSea4/ensemble_001.pp`.)

This PR checks for a latitude coordinate, and if all the _points_ are inside the range [-90, 90] then it clips the guessed bounds to [-90, 90].

NB. Because this is a backwards-incompatible change of behaviour I've controlled it via an `iris.FUTURE.clip_latitudes` flag.