### PR TITLE
Fix the plot rendering within sphinx.

### DIFF
--- a/docs/iris/example_code/Meteorology/wind_speed.py
+++ b/docs/iris/example_code/Meteorology/wind_speed.py
@@ -8,6 +8,7 @@ are co-located in space in this case.
 
 For the second plot, the data used for the arrows is normalised to produce
 arrows with a uniform size on the plot.
+
 """
 
 import matplotlib.pyplot as plt
@@ -49,6 +50,7 @@ def main():
     lakes = cfeat.NaturalEarthFeature('physical', 'lakes', '50m',
                                       facecolor='none')
 
+    plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.add_feature(lakes)
 
@@ -62,12 +64,13 @@ def main():
     plt.quiver(x, y, u, v, pivot='middle', transform=transform)
 
     plt.title("Wind speed over Lake Victoria")
-    plt.show()
+    qplt.show()
 
     # Normalise the data for uniform arrow size
     u_norm = u / np.sqrt(u ** 2.0 + v ** 2.0)
     v_norm = v / np.sqrt(u ** 2.0 + v ** 2.0)
 
+    plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.add_feature(lakes)
 
@@ -76,7 +79,7 @@ def main():
     plt.quiver(x, y, u_norm, v_norm, pivot='middle', transform=transform)
 
     plt.title("Wind speed over Lake Victoria")
-    plt.show()
+    qplt.show()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
1. Sphinx splits the code when it sees `plt.show` which creates invalid syntax for code with this kind of structure. We use `qplt.show` to avoid that, as for the other examples.
2. Because sphinx doesn't get to do its splitting thing, we have to explicitly create a new figure after each show().

Fixes #1979.