### PR TITLE
ENH: Lazy in-place Cube transpose

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-20_lazy_cube_transpose.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-20_lazy_cube_transpose.txt
@@ -1,0 +1,1 @@
+* The transpose method of a Cube now results in a transposed view of the original data rather than a transposed copy.

--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-20_lazy_cube_transpose.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-20_lazy_cube_transpose.txt
@@ -1,1 +1,1 @@
-* The transpose method of a Cube now results in a transposed view of the original data rather than a transposed copy.
+* The transpose method of a Cube now results in a lazy transposed view of the original rather than realising the data then transposing it.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2806,10 +2806,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         elif len(new_order) != self.data.ndim:
             raise ValueError('Incorrect number of dimensions.')
 
-        # The data needs to be copied, otherwise this view of the transposed
-        # data will not be contiguous. Ensure not to assign via the cube.data
-        # setter property since we are reshaping the cube payload in-place.
-        self._my_data = np.transpose(self.data, new_order).copy()
+        self._my_data = self.lazy_data().transpose(new_order)
 
         dim_mapping = {src: dest for dest, src in enumerate(new_order)}
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2802,11 +2802,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         if new_order is None:
-            new_order = np.arange(self.data.ndim)[::-1]
-        elif len(new_order) != self.data.ndim:
+            new_order = np.arange(self.ndim)[::-1]
+        elif len(new_order) != self.ndim:
             raise ValueError('Incorrect number of dimensions.')
 
-        self._my_data = self.lazy_data().transpose(new_order)
+        if self.has_lazy_data():
+            self._my_data = self.lazy_data().transpose(new_order)
+        else:
+            self._my_data = self.data.transpose(new_order)
 
         dim_mapping = {src: dest for dest, src in enumerate(new_order)}
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1410,5 +1410,14 @@ class TestCellMeasures(tests.IrisTest):
             cm_dims = self.cube.cell_measure_dims(a_cell_measure)
 
 
+class Test_transpose(tests.IrisTest):
+    def test_lazy_data(self):
+        data = np.arange(12).reshape(3, 4)
+        cube = Cube(biggus.NumpyArrayAdapter(data))
+        cube.transpose()
+        self.assertTrue(cube.has_lazy_data())
+        self.assertArrayEqual(data.T, cube.data)
+
+
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1418,6 +1418,14 @@ class Test_transpose(tests.IrisTest):
         self.assertTrue(cube.has_lazy_data())
         self.assertArrayEqual(data.T, cube.data)
 
+    def test_not_lazy_data(self):
+        data = np.arange(12).reshape(3, 4)
+        cube = Cube(data)
+        cube.transpose()
+        self.assertFalse(cube.has_lazy_data())
+        self.assertIs(data.base, cube.data.base)
+        self.assertArrayEqual(data.T, cube.data)
+
 
 if __name__ == '__main__':
     tests.main()


### PR DESCRIPTION
1. Simply utilises the capabilities of biggus to provide a transposed version of the data rather than making a copy (necessary with the sizes of data we are working with).
2. ~~Using 1, also provides in-place dimension inversion (intentionally constrained implementation).~~ - now moving to a new PR after the merge of this one.
