### PR TITLE
Remove obsolete import of iris.fileformats.dot

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -30,7 +30,6 @@ import re
 import collections
 
 import iris.fileformats
-import iris.fileformats.dot
 import iris.cube
 import iris.exceptions
 


### PR DESCRIPTION
This explicit import should not be needed - the import is [intended to be deferred](https://github.com/rhattersley/iris/blob/20d3a7841b9d80aa7dfcc0fbb9c8910d22cf8ba4/lib/iris/io/__init__.py#L229-L242).