### PR TITLE
Update code examples to avoid deprecations.

### DIFF
--- a/docs/iris/example_code/General/SOI_filtering.py
+++ b/docs/iris/example_code/General/SOI_filtering.py
@@ -52,6 +52,8 @@ def low_pass_weights(window, cutoff):
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
 
     # Load the monthly-valued Southern Oscillation Index (SOI) time-series.
     fname = iris.sample_data_path('SOI_Darwin.nc')

--- a/docs/iris/example_code/General/anomaly_log_colouring.py
+++ b/docs/iris/example_code/General/anomaly_log_colouring.py
@@ -36,6 +36,9 @@ import matplotlib.colors as mcols
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Load a sample air temperatures sequence.
     file_path = iris.sample_data_path('E1_north_america.nc')
     temperatures = iris.load_cube(file_path)

--- a/docs/iris/example_code/General/cross_section.py
+++ b/docs/iris/example_code/General/cross_section.py
@@ -15,8 +15,11 @@ import iris.quickplot as qplt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     fname = iris.sample_data_path('hybrid_height.nc')
-    theta = iris.load_cube(fname)
+    theta = iris.load_cube(fname, 'air_potential_temperature')
 
     # Extract a single height vs longitude cross-section. N.B. This could
     # easily be changed to extract a specific slice, or even to loop over *all*

--- a/docs/iris/example_code/General/custom_aggregation.py
+++ b/docs/iris/example_code/General/custom_aggregation.py
@@ -65,6 +65,9 @@ def count_spells(data, threshold, axis, spell_length):
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Load the whole time-sequence as a single cube.
     file_path = iris.sample_data_path('E1_north_america.nc')
     cube = iris.load_cube(file_path)

--- a/docs/iris/example_code/General/custom_file_loading.py
+++ b/docs/iris/example_code/General/custom_file_loading.py
@@ -59,6 +59,8 @@ import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 
+from cf_units import Unit, CALENDAR_GREGORIAN
+
 import iris
 import iris.coords as icoords
 import iris.coord_systems as icoord_systems
@@ -203,8 +205,7 @@ def NAME_to_cube(filenames, callback):
 
             # define the time unit and use it to serialise the datetime for the
             # time coordinate
-            time_unit = iris.unit.Unit('hours since epoch',
-                                       calendar=iris.unit.CALENDAR_GREGORIAN)
+            time_unit = Unit('hours since epoch', calendar=CALENDAR_GREGORIAN)
             time_coord = icoords.AuxCoord(
                 time_unit.date2num(field_headings['time']),
                 standard_name='time',

--- a/docs/iris/example_code/General/custom_file_loading.py
+++ b/docs/iris/example_code/General/custom_file_loading.py
@@ -158,8 +158,8 @@ def load_NAME_III(filename):
             # Cast the x and y grid positions to floats and convert them to
             # zero based indices (the numbers are 1 based grid positions where
             # 0.5 represents half a grid point.)
-            x = float(vals[0]) - 1.5
-            y = float(vals[1]) - 1.5
+            x = int(float(vals[0]) - 1.5)
+            y = int(float(vals[1]) - 1.5)
 
             # Populate the data arrays (i.e. all columns but the leading 4).
             for i, data_array in enumerate(data_arrays):

--- a/docs/iris/example_code/General/orca_projection.py
+++ b/docs/iris/example_code/General/orca_projection.py
@@ -22,6 +22,9 @@ import iris.quickplot as qplt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Load data
     filepath = iris.sample_data_path('orca2_votemper.nc')
     cube = iris.load_cube(filepath)

--- a/docs/iris/example_code/General/polar_stereo.py
+++ b/docs/iris/example_code/General/polar_stereo.py
@@ -15,6 +15,9 @@ import iris.quickplot as qplt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.strict_grib_load = True
+
     file_path = iris.sample_data_path('polar_stereo.grib2')
     cube = iris.load_cube(file_path)
     qplt.contourf(cube)

--- a/docs/iris/example_code/General/polynomial_fit.py
+++ b/docs/iris/example_code/General/polynomial_fit.py
@@ -16,6 +16,10 @@ import iris.quickplot as qplt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
+    # Load some test data.
     fname = iris.sample_data_path('A1B_north_america.nc')
     cube = iris.load_cube(fname)
 

--- a/docs/iris/example_code/General/projections_and_annotations.py
+++ b/docs/iris/example_code/General/projections_and_annotations.py
@@ -106,6 +106,9 @@ def make_plot(projection_name, projection_crs):
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Demonstrate with two different display projections.
     make_plot('Equidistant Cylindrical', ccrs.PlateCarree())
     make_plot('North Polar Stereographic', ccrs.NorthPolarStereo())

--- a/docs/iris/example_code/General/rotated_pole_mapping.py
+++ b/docs/iris/example_code/General/rotated_pole_mapping.py
@@ -21,6 +21,10 @@ import iris.analysis.cartography
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
+    # Load some test data.
     fname = iris.sample_data_path('rotated_pole.nc')
     air_pressure = iris.load_cube(fname)
 

--- a/docs/iris/example_code/Meteorology/COP_1d_plot.py
+++ b/docs/iris/example_code/Meteorology/COP_1d_plot.py
@@ -37,6 +37,9 @@ import matplotlib.dates as mdates
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Load data into three Cubes, one for each set of NetCDF files.
     e1 = iris.load_cube(iris.sample_data_path('E1_north_america.nc'))
 

--- a/docs/iris/example_code/Meteorology/TEC.py
+++ b/docs/iris/example_code/Meteorology/TEC.py
@@ -20,6 +20,9 @@ import iris.quickplot as qplt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
+
     # Load the "total electron content" cube.
     filename = iris.sample_data_path('space_weather.nc')
     cube = iris.load_cube(filename, 'total electron content')

--- a/docs/iris/example_code/Meteorology/hovmoller.py
+++ b/docs/iris/example_code/Meteorology/hovmoller.py
@@ -14,13 +14,14 @@ import matplotlib.dates as mdates
 import iris
 import iris.plot as iplt
 import iris.quickplot as qplt
-import iris.unit
 
 
 def main():
-    fname = iris.sample_data_path('ostia_monthly.nc')
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
 
     # load a single cube of surface temperature between +/- 5 latitude
+    fname = iris.sample_data_path('ostia_monthly.nc')
     cube = iris.load_cube(fname,
                           iris.Constraint('surface_temperature',
                                           latitude=lambda v: -5 < v < 5))

--- a/docs/iris/example_code/Oceanography/atlantic_profiles.py
+++ b/docs/iris/example_code/Oceanography/atlantic_profiles.py
@@ -22,6 +22,8 @@ import matplotlib.pyplot as plt
 
 
 def main():
+    # Enable future options to avoid deprecations.
+    iris.FUTURE.netcdf_promote = True
 
     # Load the gridded temperature and salinity data.
     fname = iris.sample_data_path('atlantic_profiles.nc')

--- a/docs/iris/example_tests/extest_util.py
+++ b/docs/iris/example_tests/extest_util.py
@@ -79,8 +79,18 @@ def show_replaced_by_check_graphic(test_case, tol=_DEFAULT_IMAGE_TOLERANCE):
 def fail_any_deprecation_warnings():
     # Provide a context in which any deprecation warning will cause an error.
     with warnings.catch_warnings():
-        # Note: we detect "deprecation warnings" just by string matching, which
-        # seems a bit weak.  However, we don't use the provided
-        # DeprecationWarning class because that is ignored by default (!)
+        # Detect our "deprecation warnings", by string matching.  This may seem
+        # a bit weak, but Iris isn't using DeprecationWarning because Python
+        # currently ignores those by default (!)
         warnings.filterwarnings("error", ".*deprecat.*")
+        # Also catch any actual DeprecationWarning.
+        warnings.simplefilter("error", DeprecationWarning)
+        # Filter *out* a specific error.
+        # This is triggered in dateutil (2.4.1 tested) by matplotlib (1.3.1).
+        # N.B. must be added *afterward* to override the other filters.
+        msg_catch_re = (".*"
+                        "Using both 'count' and 'until' is inconsistent with "
+                        "RFC 2445"
+                        ".*")
+        warnings.filterwarnings("ignore", msg_catch_re)
         yield

--- a/docs/iris/example_tests/extest_util.py
+++ b/docs/iris/example_tests/extest_util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import contextlib
 import os.path
+import warnings
 import sys
 
 import matplotlib.pyplot as plt
@@ -72,3 +73,14 @@ def show_replaced_by_check_graphic(test_case, tol=_DEFAULT_IMAGE_TOLERANCE):
     plt.show = iplt.show = qplt.show = replacement_show
     yield
     plt.show = iplt.show = qplt.show = orig_show
+
+
+@contextlib.contextmanager
+def fail_any_deprecation_warnings():
+    # Provide a context in which any deprecation warning will cause an error.
+    with warnings.catch_warnings():
+        # Note: we detect "deprecation warnings" just by string matching, which
+        # seems a bit weak.  However, we don't use the provided
+        # DeprecationWarning class because that is ignored by default (!)
+        warnings.filterwarnings("error", ".*deprecat.*")
+        yield

--- a/docs/iris/example_tests/test_COP_1d_plot.py
+++ b/docs/iris/example_tests/test_COP_1d_plot.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import COP_1d_plot
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestCOP1DPlot(tests.GraphicsTest):
     """Test the COP_1d_plot example code."""
     def test_COP_1d_plot(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            COP_1d_plot.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import COP_1d_plot
+            with show_replaced_by_check_graphic(self):
+                COP_1d_plot.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_COP_maps.py
+++ b/docs/iris/example_tests/test_COP_maps.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import COP_maps
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestCOPMaps(tests.GraphicsTest):
     """Test the COP_maps example code."""
     def test_cop_maps(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            COP_maps.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import COP_maps
+            with show_replaced_by_check_graphic(self):
+                COP_maps.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_SOI_filtering.py
+++ b/docs/iris/example_tests/test_SOI_filtering.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import SOI_filtering
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestSOIFiltering(tests.GraphicsTest):
     """Test the SOI_filtering example code."""
     def test_soi_filtering(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            SOI_filtering.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import SOI_filtering
+            with show_replaced_by_check_graphic(self):
+                SOI_filtering.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_TEC.py
+++ b/docs/iris/example_tests/test_TEC.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import TEC
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestTEC(tests.GraphicsTest):
     """Test the TEC example code."""
     def test_TEC(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            TEC.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import TEC
+            with show_replaced_by_check_graphic(self):
+                TEC.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_anomaly_log_colouring.py
+++ b/docs/iris/example_tests/test_anomaly_log_colouring.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import anomaly_log_colouring
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestAnomalyLogColouring(tests.GraphicsTest):
     """Test the anomaly colouring example code."""
     def test_anomaly_log_colouring(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            anomaly_log_colouring.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import anomaly_log_colouring
+            with show_replaced_by_check_graphic(self):
+                anomaly_log_colouring.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_atlantic_profiles.py
+++ b/docs/iris/example_tests/test_atlantic_profiles.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import atlantic_profiles
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestAtlanticProfiles(tests.GraphicsTest):
     """Test the atlantic_profiles example code."""
     def test_atlantic_profiles(self):
-        with extest_util.show_replaced_by_check_graphic(self, tol=14.0):
-            atlantic_profiles.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import atlantic_profiles
+            with show_replaced_by_check_graphic(self, tol=14.0):
+                atlantic_profiles.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_cross_section.py
+++ b/docs/iris/example_tests/test_cross_section.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import cross_section
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestCrossSection(tests.GraphicsTest):
     """Test the cross_section example code."""
     def test_cross_section(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            cross_section.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import cross_section
+            with show_replaced_by_check_graphic(self):
+                cross_section.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_custom_aggregation.py
+++ b/docs/iris/example_tests/test_custom_aggregation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/docs/iris/example_tests/test_custom_aggregation.py
+++ b/docs/iris/example_tests/test_custom_aggregation.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import custom_aggregation
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestCustomAggregation(tests.GraphicsTest):
     """Test the custom aggregation example code."""
     def test_custom_aggregation(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            custom_aggregation.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import custom_aggregation
+            with show_replaced_by_check_graphic(self):
+                custom_aggregation.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_custom_file_loading.py
+++ b/docs/iris/example_tests/test_custom_file_loading.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import custom_file_loading
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestCustomFileLoading(tests.GraphicsTest):
     """Test the custom_file_loading example code."""
     def test_custom_file_loading(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            custom_file_loading.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import custom_file_loading
+            with show_replaced_by_check_graphic(self):
+                    custom_file_loading.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_deriving_phenomena.py
+++ b/docs/iris/example_tests/test_deriving_phenomena.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import deriving_phenomena
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestDerivingPhenomena(tests.GraphicsTest):
     """Test the deriving_phenomena example code."""
     def test_deriving_phenomena(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            deriving_phenomena.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import deriving_phenomena
+            with show_replaced_by_check_graphic(self):
+                deriving_phenomena.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_global_map.py
+++ b/docs/iris/example_tests/test_global_map.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import global_map
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestGlobalMap(tests.GraphicsTest):
     """Test the global_map example code."""
     def test_global_map(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            global_map.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import global_map
+            with show_replaced_by_check_graphic(self):
+                global_map.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_hovmoller.py
+++ b/docs/iris/example_tests/test_hovmoller.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import hovmoller
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestGlobalMap(tests.GraphicsTest):
     """Test the hovmoller example code."""
     def test_hovmoller(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            hovmoller.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import hovmoller
+            with show_replaced_by_check_graphic(self):
+                hovmoller.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_inset_plot.py
+++ b/docs/iris/example_tests/test_inset_plot.py
@@ -23,17 +23,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import inset_plot
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestInsetPlot(tests.GraphicsTest):
     """Test the inset plot example code."""
     def test_inset_plot(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            inset_plot.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import inset_plot
+            with show_replaced_by_check_graphic(self):
+                inset_plot.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_lagged_ensemble.py
+++ b/docs/iris/example_tests/test_lagged_ensemble.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import lagged_ensemble
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestLaggedEnsemble(tests.GraphicsTest):
     """Test the lagged ensemble example code."""
     def test_lagged_ensemble(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            lagged_ensemble.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import lagged_ensemble
+            with show_replaced_by_check_graphic(self):
+                lagged_ensemble.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_lineplot_with_legend.py
+++ b/docs/iris/example_tests/test_lineplot_with_legend.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import lineplot_with_legend
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestLineplotWithLegend(tests.GraphicsTest):
     """Test the lineplot_with_legend example code."""
     def test_lineplot_with_legend(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            lineplot_with_legend.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import lineplot_with_legend
+            with show_replaced_by_check_graphic(self):
+                lineplot_with_legend.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_orca_projection.py
+++ b/docs/iris/example_tests/test_orca_projection.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import orca_projection
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestOrcaProjection(tests.GraphicsTest):
     """Test the orca projection example code."""
     def test_orca_projection(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            orca_projection.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import orca_projection
+            with show_replaced_by_check_graphic(self):
+                orca_projection.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_orca_projection.py
+++ b/docs/iris/example_tests/test_orca_projection.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/docs/iris/example_tests/test_polar_stereo.py
+++ b/docs/iris/example_tests/test_polar_stereo.py
@@ -22,18 +22,20 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import polar_stereo
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 @tests.skip_grib
 class TestPolarStereo(tests.GraphicsTest):
     """Test the polar_stereo example code."""
     def test_polar_stereo(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            polar_stereo.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import polar_stereo
+            with show_replaced_by_check_graphic(self):
+                polar_stereo.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_polynomial_fit.py
+++ b/docs/iris/example_tests/test_polynomial_fit.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import polynomial_fit
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestPolynomialFit(tests.GraphicsTest):
     """Test the polynomial_fit example code."""
     def test_polynomial_fit(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            polynomial_fit.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import polynomial_fit
+            with show_replaced_by_check_graphic(self):
+                polynomial_fit.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_polynomial_fit.py
+++ b/docs/iris/example_tests/test_polynomial_fit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/docs/iris/example_tests/test_projections_and_annotations.py
+++ b/docs/iris/example_tests/test_projections_and_annotations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/docs/iris/example_tests/test_projections_and_annotations.py
+++ b/docs/iris/example_tests/test_projections_and_annotations.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import projections_and_annotations
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestProjectionsAndAnnotations(tests.GraphicsTest):
     """Test the atlantic_profiles example code."""
     def test_projections_and_annotations(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            projections_and_annotations.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import projections_and_annotations
+            with show_replaced_by_check_graphic(self):
+                projections_and_annotations.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_rotated_pole_mapping.py
+++ b/docs/iris/example_tests/test_rotated_pole_mapping.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import rotated_pole_mapping
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestRotatedPoleMapping(tests.GraphicsTest):
     """Test the rotated_pole_mapping example code."""
     def test_rotated_pole_mapping(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            rotated_pole_mapping.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import rotated_pole_mapping
+            with show_replaced_by_check_graphic(self):
+                rotated_pole_mapping.main()
 
 
 if __name__ == '__main__':

--- a/docs/iris/example_tests/test_wind_speed.py
+++ b/docs/iris/example_tests/test_wind_speed.py
@@ -22,17 +22,19 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from . import extest_util
-
-with extest_util.add_examples_to_path():
-    import wind_speed
+from .extest_util import (add_examples_to_path,
+                          show_replaced_by_check_graphic,
+                          fail_any_deprecation_warnings)
 
 
 class TestWindSpeed(tests.GraphicsTest):
     """Test the wind_speed example code."""
     def test_wind_speed(self):
-        with extest_util.show_replaced_by_check_graphic(self):
-            wind_speed.main()
+        with fail_any_deprecation_warnings():
+            with add_examples_to_path():
+                import wind_speed
+            with show_replaced_by_check_graphic(self):
+                wind_speed.main()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've added FUTURE options to avoid any deprecations in the examples code.
I also fixed all examples tests so they will fail if they hit a deprecation.
Rationale : the example code is supposed to be "best practice", but we have failed to keep it up-to-date.  In future, we'll see that they need updating when they fail.

N.B. They could probably still do with a critical review.
This is just one semi-automatic improvement.