### PR TITLE
Extended usage of iris.Future

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -230,6 +230,22 @@ class Future(threading.local):
             self.__dict__.clear()
             self.__dict__.update(current_state)
 
+    def all_option_names(self):
+        """List all the  control option names."""
+        return self.__dict__.keys()
+
+    def enable_all(self):
+        """
+        Enable all control options.
+
+        This ensures complete future compatibility:
+        Code that runs under this condition, and emits no deprecation warnings,
+        is guaranteed to work the same with the next Iris release.
+
+        """
+        for option in self.all_option_names():
+            setattr(self, option, True)
+
 
 #: Object containing all the Iris run-time options.
 FUTURE = Future()


### PR DESCRIPTION
I'm putting this up for discussion, as I'm not sure if the idea flies or not.
So, please comment on whether the whole idea is wrong before criticising the implementation (!).

Background:
I made a start on  updating all our examples to "current best practice", meaning (amongst other things) that we avoid deprecated behaviours -- see #1989
At this point, I was concerned that in some cases we would be making multiple assignments to iris.FUTURE, which could be messy
(though in fact, the existing examples don't really seem to have that problem).
We currently have 5 possible Future options, so it _could_ get messy.

I thought it would be useful to simply say "enable all options" in some way.
That would ensure that if your code works at version (X).999... it will work at (X+1).0
Unfortunately if you blindly turn on _all_ available options, your code can break when we add a new Future behaviour that upsets it, even at a **_minor**_ release, 

So, this PR proposes a way of embedding the current version number when you write the code:
e.g. `iris.Future.enable_all_at_version(2.4)`
This asserts compatibility with all future options known at a given release.

Naturally, this adds nothing but convenience :  It ensures you have tested your code with all future options in the given release, without your needing to state them all explicity.
Your code will still work at the next minor release, but that is already true.
It does **_not**_ solve the problem of major releases, sadly : If your code enables all futures of X.Y, but not all those of X.(Y+1), then it can still break at (X+1).0

A "blind" version is still available as `iris.Future.enable_all_at_version(iris.__version__)`, but I guess we would discourage that.
