### PR TITLE
Give all Iris deprecation warnings a common identity.

### DIFF
--- a/docs/iris/src/developers_guide/deprecations.rst
+++ b/docs/iris/src/developers_guide/deprecations.rst
@@ -23,9 +23,13 @@ deprecation is accompanied by the introduction of a new public API.
 
 Under these circumstances the following points apply:
 
- - Using the deprecated API must result in a concise deprecation
-   warning.
- - Where possible, your deprecation warning should include advice on
+ - Using the deprecated API must result in a concise deprecation warning which
+   is an instance of :class:`iris.IrisDeprecation`.
+   It is easiest to call
+   :func:`iris._deprecation.warn_deprecated`, which is a
+   simple wrapper to :func:`warnings.warn` with the signature
+   `warn_deprecation(message, **kwargs)`.
+- Where possible, your deprecation warning should include advice on
    how to avoid using the deprecated API. For example, you might
    reference a preferred API, or more detailed documentation elsewhere.
  - You must update the docstring for the deprecated API to include a

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -109,6 +109,7 @@ import threading
 import iris.config
 import iris.cube
 import iris._constraints
+from iris._deprecation import IrisDeprecation
 import iris.fileformats
 import iris.io
 
@@ -119,7 +120,8 @@ __version__ = '1.10.0-DEV'
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',
            'save', 'Constraint', 'AttributeConstraint', 'sample_data_path',
-           'site_configuration', 'Future', 'FUTURE']
+           'site_configuration', 'Future', 'FUTURE',
+           'IrisDeprecation']
 
 
 # When required, log the usage of Iris.

--- a/lib/iris/_deprecation.py
+++ b/lib/iris/_deprecation.py
@@ -24,10 +24,21 @@ import six
 
 import warnings
 
+from iris.exceptions import IrisError
+
+
+class IrisDeprecation(UserWarning):
+    """An Iris deprecation warning."""
+    pass
+
+
+def warn_deprecated(msg, **kwargs):
+    warnings.warn(msg, IrisDeprecation, **kwargs)
+
 
 # A Mixin for a wrapper class that copies the docstring of the wrapped class
 # into the wrapper.
-# This is useful in producing wrapper classes that nede to mimic the original
+# This is useful in producing wrapper classes that need to mimic the original
 # but emit deprecation warnings when used.
 class ClassWrapperSameDocstring(type):
     def __new__(metacls, classname, bases, class_dict):

--- a/lib/iris/analysis/_interpolate_private.py
+++ b/lib/iris/analysis/_interpolate_private.py
@@ -40,6 +40,7 @@ from iris.analysis import Linear
 import iris.cube
 import iris.coord_systems
 import iris.coords
+from iris._deprecation import warn_deprecated
 import iris.exceptions
 
 
@@ -132,7 +133,9 @@ def nearest_neighbour_indices(cube, sample_points):
 
     """
     if isinstance(sample_points, dict):
-        warnings.warn('Providing a dictionary to specify points is deprecated. Please provide a list of (coordinate, values) pairs.')
+        msg = ('Providing a dictionary to specify points is deprecated. '
+               'Please provide a list of (coordinate, values) pairs.')
+        warn_deprecated(msg)
         sample_points = list(sample_points.items())
 
     if sample_points:
@@ -207,7 +210,9 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
     # We get the nearest neighbour using this sample space cube.
 
     if isinstance(sample_point, dict):
-        warnings.warn('Providing a dictionary to specify points is deprecated. Please provide a list of (coordinate, values) pairs.')
+        msg = ('Providing a dictionary to specify points is deprecated. '
+               'Please provide a list of (coordinate, values) pairs.')
+        warn_deprecated(msg)
         sample_point = list(sample_point.items())
 
     if sample_point:

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -26,11 +26,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import re
-import warnings
 
 import cf_units
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 import iris.cube
 import iris.coords
 import iris.coord_systems
@@ -91,8 +91,8 @@ def _construct_midpoint_coord(coord, circular=None):
     if circular is None:
         circular = getattr(coord, 'circular', False)
     elif circular != getattr(coord, 'circular', False):
-        warnings.warn('circular flag and Coord.circular attribute do '
-                      'not match')
+        warn_deprecated('circular flag and Coord.circular attribute do '
+                        'not match')
 
     if coord.ndim != 1:
         raise iris.exceptions.CoordinateMultiDimError(coord)
@@ -525,8 +525,8 @@ def curl(i_cube, j_cube, k_cube=None, ignore=None):
     """
     if ignore is not None:
         ignore = None
-        warnings.warn('The ignore keyword to iris.analysis.calculus.curl '
-                      'is deprecated, ignoring is now done automatically.')
+        warn_deprecated('The ignore keyword to iris.analysis.calculus.curl '
+                        'is deprecated, ignoring is now done automatically.')
 
     # Get the vector quantity names.
     # (i.e. ['easterly', 'northerly', 'vertical'])

--- a/lib/iris/analysis/interpolate.py
+++ b/lib/iris/analysis/interpolate.py
@@ -34,24 +34,20 @@ import six
 
 import collections
 from functools import wraps
-import warnings
 
 import numpy as np
 import scipy
 import scipy.spatial
 from scipy.interpolate.interpolate import interp1d
 
+from iris._deprecation import (warn_deprecated as iris_warn_deprecated,
+                               ClassWrapperSameDocstring)
 from iris.analysis import Linear
 import iris.cube
 import iris.coord_systems
 import iris.coords
 import iris.exceptions
 import iris.analysis._interpolate_private as oldinterp
-
-# Import deprecation support from the underlying module.
-# Put it there so we can use it from elsewhere without triggering the
-# deprecation warning (!)
-from iris._deprecation_helpers import ClassWrapperSameDocstring
 
 
 _INTERPOLATE_DEPRECATION_WARNING = \
@@ -62,7 +58,7 @@ _INTERPOLATE_DEPRECATION_WARNING = \
 def _warn_deprecated(msg=None):
     if msg is None:
         msg = _INTERPOLATE_DEPRECATION_WARNING
-    warnings.warn(msg)
+    iris_warn_deprecated(msg)
 
 # Issue a deprecation message when the module is loaded.
 _warn_deprecated()

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ import inspect
 import cf_units
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 import iris.analysis
 import iris.coords
 import iris.cube
@@ -264,10 +265,11 @@ def _add_subtract_common(operation_function, operation_name, cube, other,
 
         # provide a deprecation warning if the ignore keyword has been set
         if ignore is not True:
-            warnings.warn('The "ignore" keyword has been deprecated in '
-                          'add/subtract. This functionality is now automatic. '
-                          'The provided value to "ignore" has been ignored, '
-                          'and has been automatically calculated.')
+            msg = ('The "ignore" keyword has been deprecated in '
+                   'add/subtract. This functionality is now automatic. '
+                   'The provided value to "ignore" has been ignored, '
+                   'and has been automatically calculated.')
+            warn_deprecated(msg)
 
         bad_coord_grps = (coord_comp['ungroupable_and_dimensioned'] +
                           coord_comp['resamplable'])

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ import zlib
 import cf_units
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 from iris._cube_coord_common import CFVariableMixin
 import iris.coords
 import iris.util
@@ -136,8 +137,8 @@ class LazyArray(_LazyArray):
             Defaults to None to signify the dtype is unknown.
 
         """
-        warnings.warn('LazyArray is deprecated and will be removed '
-                      'in a future release.', stacklevel=2)
+        warn_deprecated('LazyArray is deprecated and will be removed '
+                        'in a future release.', stacklevel=2)
         super(LazyArray, self).__init__(shape, func, dtype)
 
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -36,6 +36,7 @@ import biggus
 import numpy as np
 import numpy.ma as ma
 
+from iris._deprecation import warn_deprecated
 import iris.analysis
 from iris.analysis.cartography import wrap_lons
 import iris.analysis.maths
@@ -1282,18 +1283,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Handle deprecated kwargs
         if name is not None:
             name_or_coord = name
-            warnings.warn('the name kwarg is deprecated and will be removed '
-                          'in a future release. Consider converting '
-                          'existing code to use the name_or_coord '
-                          'kwarg as a replacement.',
-                          stacklevel=2)
+            warn_deprecated('the name kwarg is deprecated and will be removed '
+                            'in a future release. Consider converting '
+                            'existing code to use the name_or_coord '
+                            'kwarg as a replacement.',
+                            stacklevel=2)
         if coord is not None:
             name_or_coord = coord
-            warnings.warn('the coord kwarg is deprecated and will be removed '
-                          'in a future release. Consider converting '
-                          'existing code to use the name_or_coord '
-                          'kwarg as a replacement.',
-                          stacklevel=2)
+            warn_deprecated('the coord kwarg is deprecated and will be '
+                            'removed in a future release. Consider converting '
+                            'existing code to use the name_or_coord '
+                            'kwarg as a replacement.',
+                            stacklevel=2)
         # Finish handling deprecated kwargs
 
         name = None
@@ -1409,18 +1410,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Handle deprecated kwargs
         if name is not None:
             name_or_coord = name
-            warnings.warn('the name kwarg is deprecated and will be removed '
-                          'in a future release. Consider converting '
-                          'existing code to use the name_or_coord '
-                          'kwarg as a replacement.',
-                          stacklevel=2)
+            warn_deprecated('the name kwarg is deprecated and will be removed '
+                            'in a future release. Consider converting '
+                            'existing code to use the name_or_coord '
+                            'kwarg as a replacement.',
+                            stacklevel=2)
         if coord is not None:
             name_or_coord = coord
-            warnings.warn('the coord kwarg is deprecated and will be removed '
-                          'in a future release. Consider converting '
-                          'existing code to use the name_or_coord '
-                          'kwarg as a replacement.',
-                          stacklevel=2)
+            warn_deprecated('the coord kwarg is deprecated and will be '
+                            'removed in a future release. Consider converting '
+                            'existing code to use the name_or_coord '
+                            'kwarg as a replacement.',
+                            stacklevel=2)
         # Finish handling deprecated kwargs
 
         coords = self.coords(name_or_coord=name_or_coord,
@@ -2119,7 +2120,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         .. deprecated:: 0.8
 
         """
-        warnings.warn('Cube.assert_valid() has been deprecated.')
+        warn_deprecated('Cube.assert_valid() has been deprecated.')
 
     def __str__(self):
         # six has a decorator for this bit, but it doesn't do errors='replace'.
@@ -3101,9 +3102,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             attr:`~iris.cube.Cube.attributes` as needed.
 
         """
-        warnings.warn("Cube.add_history() has been deprecated - "
-                      "please modify/create cube.attributes['history'] "
-                      "as needed.")
+        warn_deprecated("Cube.add_history() has been deprecated - "
+                        "please modify/create cube.attributes['history'] "
+                        "as needed.")
 
         timestamp = datetime.datetime.now().strftime("%d/%m/%y %H:%M:%S")
         string = '%s Iris: %s' % (timestamp, string)

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -22,8 +22,6 @@ Exceptions specific to the Iris package.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import iris.coords
-
 
 class IrisError(Exception):
     """Base class for errors in the Iris package."""
@@ -48,6 +46,8 @@ class CellMeasureNotFoundError(KeyError):
 class CoordinateMultiDimError(ValueError):
     """Raised when a routine doesn't support multi-dimensional coordinates."""
     def __init__(self, msg):
+        # N.B. deferred import to avoid a circular import dependency.
+        import iris.coords
         if isinstance(msg, iris.coords.Coord):
             fmt = "Multi-dimensional coordinate not supported: '%s'"
             msg = fmt % msg.name()

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -39,6 +39,7 @@ import netCDF4
 import numpy as np
 import numpy.ma as ma
 
+from iris._deprecation import warn_deprecated
 import iris.util
 
 
@@ -1136,4 +1137,4 @@ def _netcdf_promote_warning():
            'vertical coordinates as independent Cubes. This behaviour is '
            'deprecated in favour of automatic promotion to Cubes. To switch '
            'to the new behaviour, set iris.FUTURE.netcdf_promote to True.')
-    warnings.warn(msg)
+    warn_deprecated(msg)

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -38,11 +38,12 @@ import six
 
 import warnings
 
-# Issue a deprecation message when the module is loaded.
-warnings.warn("The module 'iris.fileformats.ff' is deprecated. "
-              "Please use iris.fileformats.um as a replacement, which "
-              "contains equivalents for all important features.")
+from iris._deprecation import warn_deprecated
 
+# Issue a deprecation message when the module is loaded.
+warn_deprecated("The module 'iris.fileformats.ff' is deprecated. "
+                "Please use iris.fileformats.um as a replacement, which "
+                "contains equivalents for all important features.")
 
 # Directly import various simple data items from the 'old' ff module.
 from iris.fileformats._ff import (

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -37,6 +37,7 @@ import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
 
+from iris._deprecation import warn_deprecated
 from iris.analysis._interpolate_private import Linear1dExtrapolator
 import iris.coord_systems as coord_systems
 from iris.exceptions import TranslationError
@@ -126,7 +127,7 @@ def reset_load_rules():
     .. deprecated:: 1.7
 
     """
-    warnings.warn('reset_load_rules was deprecated in v1.7.')
+    warn_deprecated('reset_load_rules was deprecated in v1.7.')
 
 
 class GribDataProxy(object):
@@ -185,7 +186,7 @@ class GribWrapper(object):
 
     """
     def __init__(self, grib_message, grib_fh=None, auto_regularise=True):
-        warnings.warn('Deprecated at version 1.10')
+        warn_deprecated('Deprecated at version 1.10')
         """Store the grib message and compute our extra keys."""
         self.grib_message = grib_message
         deferred = grib_fh is not None
@@ -864,7 +865,7 @@ def grib_generator(filename, auto_regularise=True):
         reduced grid to an equivalent regular grid.
 
     """
-    warnings.warn('Deprecated at version 1.10')
+    warn_deprecated('Deprecated at version 1.10')
     with open(filename, 'rb') as grib_fh:
         while True:
             grib_message = gribapi.grib_new_from_file(grib_fh)
@@ -915,11 +916,12 @@ def load_cubes(filenames, callback=None, auto_regularise=True):
         if auto_regularise is not None:
             # The old loader supports the auto_regularise keyword, but in
             # deprecation mode, so warning if it is found.
-            warnings.warn('the`auto_regularise` kwarg is deprecated and '
-                          'will be removed in a future release. Resampling '
-                          'quasi-regular grids on load will no longer be '
-                          'available.  Resampling should be done on the '
-                          'loaded cube instead using Cube.regrid.')
+            msg = ('the`auto_regularise` kwarg is deprecated and '
+                   'will be removed in a future release. Resampling '
+                   'quasi-regular grids on load will no longer be '
+                   'available.  Resampling should be done on the '
+                   'loaded cube instead using Cube.regrid.')
+            warn_deprecated(msg)
 
         grib_loader = iris.fileformats.rules.Loader(
             grib_generator, {'auto_regularise': auto_regularise},
@@ -1011,8 +1013,8 @@ def as_pairs(cube):
 
 
     """
-    warnings.warn('as_pairs is deprecated in v1.10; please use'
-                  ' save_pairs_from_cube instead.')
+    warn_deprecated('as_pairs is deprecated in v1.10; please use'
+                    ' save_pairs_from_cube instead.')
     return save_pairs_from_cube(cube)
 
 

--- a/lib/iris/fileformats/grib/load_rules.py
+++ b/lib/iris/fileformats/grib/load_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ import warnings
 from cf_units import CALENDAR_GREGORIAN, Unit
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 from iris.aux_factory import HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
 from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
@@ -65,7 +66,7 @@ def convert(grib):
               'Please report issues you experience to:\n'
               'https://groups.google.com/forum/#!topic/scitools-iris-dev/'
               'lMsOusKNfaU')
-        warnings.warn(msg)
+        warn_deprecated(msg)
 
     if \
             (grib.gridType=="reduced_gg"):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -40,6 +40,7 @@ import numpy as np
 import numpy.ma as ma
 from pyke import knowledge_engine
 
+from iris._deprecation import warn_deprecated
 import iris.analysis
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory, \
     OceanSigmaZFactory, OceanSigmaFactory, OceanSFactory, OceanSg1Factory, \
@@ -1880,4 +1881,4 @@ def _no_unlim_dep_warning():
            'deprecated, in favour of no automatic assignment. To switch '
            'to the new behaviour, set iris.FUTURE.netcdf_no_unlimited to '
            'True.')
-    warnings.warn(msg)
+    warn_deprecated(msg)

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -39,6 +39,7 @@ import numpy as np
 import numpy.ma as ma
 import netcdftime
 
+from iris._deprecation import warn_deprecated
 import iris.config
 import iris.fileformats.rules
 import iris.fileformats.pp_rules
@@ -574,7 +575,7 @@ class BitwiseInt(SplittableInt):
     def __init__(self, value, num_bits=None):
         # intentionally empty docstring as all covered in the class docstring.
         """ """
-        warnings.warn('BitwiseInt is deprecated - please use `int` instead.')
+        warn_deprecated('BitwiseInt is deprecated - please use `int` instead.')
 
         SplittableInt.__init__(self, value)
         self.flags = ()
@@ -664,16 +665,16 @@ class BitwiseInt(SplittableInt):
 
 def _make_flag_getter(value):
     def getter(self):
-        warnings.warn('The `flag` attributes are deprecated - please use '
-                      'integer bitwise operators instead.')
+        warn_deprecated('The `flag` attributes are deprecated - please use '
+                        'integer bitwise operators instead.')
         return int(bool(self._value & value))
     return getter
 
 
 def _make_flag_setter(value):
     def setter(self, flag):
-        warnings.warn('The `flag` attributes are deprecated - please use '
-                      'integer bitwise operators instead.')
+        warn_deprecated('The `flag` attributes are deprecated - please use '
+                        'integer bitwise operators instead.')
         if not isinstance(flag, bool):
             raise TypeError('Can only set bits to True or False')
         if flag:
@@ -722,7 +723,7 @@ class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
             The value of a BitwiseInt only makes sense in base-two.
 
         """
-        warnings.warn('Length is deprecated')
+        warn_deprecated('Length is deprecated')
         return len(str(self._value))
 
     def __setattr__(self, name, value):
@@ -737,7 +738,7 @@ class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
             The value of an _LBProc only makes sense in base-two.
 
         """
-        warnings.warn('Indexing is deprecated')
+        warn_deprecated('Indexing is deprecated')
         try:
             value = int('0' + str(self._value)[::-1][key][::-1])
         except IndexError:
@@ -757,7 +758,7 @@ class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
             The value of an _LBProc only makes sense in base-two.
 
         """
-        warnings.warn('Indexing is deprecated')
+        warn_deprecated('Indexing is deprecated')
         if (not isinstance(value, int) or value < 0):
             msg = 'Can only set {} as a positive integer value.'.format(key)
             raise ValueError(msg)
@@ -820,8 +821,8 @@ class _LBProc(six.with_metaclass(_FlagMetaclass, BitwiseInt)):
 
     @property
     def flags(self):
-        warnings.warn('The `flags` attribute is deprecated - please use '
-                      'integer bitwise operators instead.')
+        warn_deprecated('The `flags` attribute is deprecated - please use '
+                        'integer bitwise operators instead.')
         return tuple(2 ** i for i in range(self.NUM_BITS)
                      if self._value & 2 ** i)
 
@@ -934,7 +935,7 @@ def _data_bytes_to_shaped_array(data_bytes, lbpack, boundary_packing,
                   'deprecated and will be removed in a future release. ' \
                   'Install mo_pack to make use of the new unpacking ' \
                   'functionality.'
-            warnings.warn(msg)
+            warn_deprecated(msg)
             decompress_wgdos = pp_packing.wgdos_unpack
         else:
             msg = 'Unpacking PP fields with LBPACK of {} ' \
@@ -949,7 +950,7 @@ def _data_bytes_to_shaped_array(data_bytes, lbpack, boundary_packing,
                   'deprecated and will be removed in a future release. ' \
                   'Install/upgrade mo_pack to make use of the new unpacking ' \
                   'functionality.'
-            warnings.warn(msg)
+            warn_deprecated(msg)
             decompress_rle = pp_packing.rle_decode
         else:
             msg = 'Unpacking PP fields with LBPACK of {} ' \
@@ -2001,7 +2002,7 @@ def reset_load_rules():
     .. deprecated:: 1.7
 
     """
-    warnings.warn('reset_load_rules was deprecated in v1.7.')
+    warn_deprecated('reset_load_rules was deprecated in v1.7.')
 
 
 def _ensure_save_rules_loaded():
@@ -2033,7 +2034,7 @@ def add_save_rules(filename):
         alternative solution.
 
     """
-    warnings.warn(
+    warn_deprecated(
         'custom pp save rules are deprecated from v1.10.\n'
         'If you need to customise pp field saving, please refer to the '
         'functions iris.fileformats.pp.as_fields, '
@@ -2054,7 +2055,7 @@ def reset_save_rules():
         alternative solution.
 
     """
-    warnings.warn(
+    warn_deprecated(
         'custom pp save rules are deprecated from v1.10.\n'
         'If you need to customise pp field saving, please refer to the '
         'functions iris.fileformats.pp.as_fields, '
@@ -2288,8 +2289,8 @@ def as_pairs(cube, field_coords=None, target=None):
     functionality.
 
     """
-    warnings.warn('as_pairs is deprecated in v1.10; please use'
-                  ' save_pairs_from_cube instead.')
+    warn_deprecated('as_pairs is deprecated in v1.10; please use'
+                    ' save_pairs_from_cube instead.')
     return save_pairs_from_cube(cube, field_coords=field_coords,
                                 target=target)
 

--- a/lib/iris/fileformats/pp_packing.py
+++ b/lib/iris/fileformats/pp_packing.py
@@ -28,8 +28,7 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
-import warnings
-
+from iris._deprecation import warn_deprecated
 from iris.fileformats import _old_pp_packing as old_pp_packing
 
 
@@ -49,18 +48,18 @@ _DEPRECATION_WARNING = (
 
 # Emit a deprecation warning when anyone tries to import this.
 # For quiet, can still use _old_pp_packing instead, as fileformats.pp does.
-warnings.warn(_DEPRECATION_WARNING)
+warn_deprecated(_DEPRECATION_WARNING)
 
 
 # Define simple wrappers for functions in pp_packing.
 # N.B. signatures must match the originals !
 def wgdos_unpack(data, lbrow, lbnpt, bmdi):
-    warnings.warn(_DEPRECATION_WARNING)
+    warn_deprecated(_DEPRECATION_WARNING)
     return old_pp_packing.wgdos_unpack(data, lbrow, lbnpt, bmdi)
 
 
 def rle_decode(data, lbrow, lbnpt, bmdi):
-    warnings.warn(_DEPRECATION_WARNING)
+    warn_deprecated(_DEPRECATION_WARNING)
     return old_pp_packing.rle_decode(data, lbrow, lbnpt, bmdi)
 
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -40,6 +40,7 @@ import cf_units
 import numpy as np
 import numpy.ma as ma
 
+from iris._deprecation import warn_deprecated
 from iris.analysis._interpolate_private import linear as regrid_linear
 import iris.config as config
 import iris.cube
@@ -196,12 +197,6 @@ def _prepare_rule_logger(verbose=False, log_dir=None):
 # A flag to control all the text-rules and rules-logging deprecation warnings.
 _enable_rules_deprecations = True
 
-# A local reference to warnings.warn.
-_warn_call = warnings.warn
-
-def _warn_deprecated_logging_and_rules(msg):
-    raise AssertionError(msg)
-
 # A context manager to avoid the deprecation warnings for internal calls.
 @contextmanager
 def _disable_deprecation_warnings():
@@ -222,7 +217,7 @@ _log_rules = _prepare_rule_logger()
 # Provide a public 'log' function, which issues a deprecation warning.
 def log(*args, **kwargs):
     if _enable_rules_deprecations:
-        _warn_deprecated_logging_and_rules(
+        warn_deprecated(
             "The `iris.fileformats.rules.log()` method is deprecated.")
     return _log_rules(*args, **kwargs)
 
@@ -235,7 +230,7 @@ class DebugString(str):
 
     """
     def __init__(self, *args, **kwargs):
-        _warn_deprecated_logging_and_rules(
+        warn_deprecated(
             "the `iris.fileformats.rules.DebugString class is deprecated.")
         super(DebugString, self).__init__(*args, **kwargs)
 
@@ -249,7 +244,7 @@ class CMAttribute(object):
     """
     __slots__ = ('name', 'value')
     def __init__(self, name, value):
-        _warn_deprecated_logging_and_rules(
+        warn_deprecated(
             "the `iris.fileformats.rules.CmAttribute class is deprecated.")
         self.name = name
         self.value = value
@@ -264,7 +259,7 @@ class CMCustomAttribute(object):
     """
     __slots__ = ('name', 'value')
     def __init__(self, name, value):
-        _warn_deprecated_logging_and_rules(
+        warn_deprecated(
             "the `iris.fileformats.rules.CmCustomAttribute class is "
             "deprecated.")
         self.name = name
@@ -279,7 +274,7 @@ class CoordAndDims(object):
 
     """
     def __init__(self, coord, dims=None):
-        _warn_deprecated_logging_and_rules(
+        warn_deprecated(
             "the `iris.fileformats.rules.CoordAndDims class is deprecated.")
         self.coord = coord
         if dims is None:
@@ -331,8 +326,8 @@ def calculate_forecast_period(time, forecast_reference_time):
     .. deprecated:: 1.10
 
     """
-    warnings.warn("the `iris.fileformats.rules.calculate_forecast_period "
-                  "method is deprecated.")
+    warn_deprecated("the `iris.fileformats.rules.calculate_forecast_period "
+                    "method is deprecated.")
 
     if time.points.size != 1:
         raise ValueError('Expected a time coordinate with a single '
@@ -379,7 +374,7 @@ class Rule(object):
     def __init__(self, conditions, actions):
         """Create instance methods from our conditions and actions."""
         if _enable_rules_deprecations:
-            _warn_deprecated_logging_and_rules(
+            warn_deprecated(
                 "the `iris.fileformats.rules.Rule class is deprecated.")
         if not hasattr(conditions, '__iter__'):
             raise TypeError('Variable conditions should be iterable, got: '+ type(conditions))
@@ -612,7 +607,7 @@ class RulesContainer(object):
         e.g for PP saving actions that do not return anything, such as *pp.lbuser[3] = 16203*
         """
         if _enable_rules_deprecations:
-            _warn_deprecated_logging_and_rules(
+            warn_deprecated(
                 "the `iris.fileformats.rules.RulesContainer class is deprecated.")
         self._rules = []
         self.rule_type = rule_type
@@ -886,8 +881,8 @@ class Loader(collections.namedtuple('Loader', _loader_attrs)):
 
         """
         if legacy_custom_rules is not None:
-            warnings.warn('The `legacy_custom_rules` attribute is '
-                          'deprecated.')
+            warn_deprecated('The `legacy_custom_rules` attribute is '
+                            'deprecated.')
         return tuple.__new__(cls, (field_generator, field_generator_kwargs,
                                    converter, legacy_custom_rules))
 
@@ -1031,8 +1026,8 @@ def load_cubes(filenames, user_callback, loader, filter_function=None):
     def loadcubes_user_callback_wrapper(cube, field, filename):
         # First run any custom user-provided rules.
         if loader.legacy_custom_rules:
-            warnings.warn('The `legacy_custom_rules` attribute of '
-                          'the `loader` is deprecated.')
+            warn_deprecated('The `legacy_custom_rules` attribute of '
+                            'the `loader` is deprecated.')
             loader.legacy_custom_rules.verify(cube, field)
 
         # Then also run user-provided original callback function.

--- a/lib/iris/proxy.py
+++ b/lib/iris/proxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,11 +28,12 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
 import sys
-import warnings
+
+from iris._deprecation import warn_deprecated
 
 
-warnings.warn('iris.proxy is deprecated in Iris v1.9. Please use lazy '
-              'imports instead.')
+warn_deprecated('iris.proxy is deprecated in Iris v1.9. Please use lazy '
+                'imports instead.')
 
 
 class FakeModule(object):

--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -44,12 +44,13 @@ import warnings
 import netcdftime
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 import iris.config
 import iris.util
 
 
-warnings.warn('iris.unit is deprecated in Iris v1.9. Please use cf_units '
-              '(https://github.com/SciTools/cf_units) instead.')
+warn_deprecated('iris.unit is deprecated in Iris v1.9. Please use cf_units '
+                '(https://github.com/SciTools/cf_units) instead.')
 
 
 __all__ = ['Unit', 'date2num', 'decode_time', 'encode_clock', 'encode_date',

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -33,12 +33,12 @@ import os.path
 import sys
 import tempfile
 import time
-import warnings
 
 import cf_units
 import numpy as np
 import numpy.ma as ma
 
+from iris._deprecation import warn_deprecated
 import iris
 import iris.exceptions
 
@@ -75,10 +75,10 @@ def broadcast_weights(weights, array, dims):
         longitude dimension in *array*.
 
     """
-    warnings.warn('broadcast_weights() is deprecated and will be removed '
-                  'in a future release. Consider converting existing code '
-                  'to use broadcast_to_shape() as a replacement.',
-                  stacklevel=2)
+    warn_deprecated('broadcast_weights() is deprecated and will be removed '
+                    'in a future release. Consider converting existing code '
+                    'to use broadcast_to_shape() as a replacement.',
+                    stacklevel=2)
     # Create a shape array, which *weights* can be re-shaped to, allowing
     # them to be broadcast with *array*.
     weights_shape = np.ones(array.ndim)
@@ -928,8 +928,8 @@ def clip_string(the_str, clip_length=70, rider="..."):
 
 def ensure_array(a):
     """.. deprecated:: 1.7"""
-    warnings.warn('ensure_array() is deprecated and will be removed '
-                  'in a future release.')
+    warn_deprecated('ensure_array() is deprecated and will be removed '
+                    'in a future release.')
     if not isinstance(a, (np.ndarray, ma.core.MaskedArray)):
         a = np.array([a])
     return a
@@ -948,16 +948,16 @@ class _Timers(object):
         self.timers = {}
 
     def start(self, name, step_name):
-        warnings.warn('Timers was deprecated in v1.7.0 and will be removed '
-                      'in future Iris releases.')
+        warn_deprecated('Timers was deprecated in v1.7.0 and will be removed '
+                        'in future Iris releases.')
         self.stop(name)
         timer = self.timers.setdefault(name, {})
         timer[step_name] = time.time()
         timer["active_timer_step"] = step_name
 
     def restart(self, name, step_name):
-        warnings.warn('Timers was deprecated in v1.7.0 and will be removed '
-                      'in future Iris releases.')
+        warn_deprecated('Timers was deprecated in v1.7.0 and will be removed '
+                        'in future Iris releases.')
         self.stop(name)
         timer = self.timers.setdefault(name, {})
         timer[step_name] = time.time() - timer.get(step_name, 0)


### PR DESCRIPTION
A helpful step towards #1989 :  To check for Iris deprecations within example tests.
The idea is to give all the Iris deprecation warnings a common class they inherit from, so we can filter on it.

Mostly humdrum (if noisy),
but note : tweaked iris.exceptions to remove a circular import.