### PR TITLE
Small changes to ESMF api; add ESMPy as dependency, for Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
       conda install --quiet --file minimal-conda-requirements.txt;
     else
       if [[ "$TRAVIS_PYTHON_VERSION" == 3* ]]; then
-        sed -e '/ecmwf_grib/d' -e 's/#.\+$//' conda-requirements.txt | xargs conda install --quiet;
+        sed -e '/ecmwf_grib/d' -e '/esmpy/d' -e 's/#.\+$//' conda-requirements.txt | xargs conda install --quiet;
       else
         conda install --quiet --file conda-requirements.txt;
       fi

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -22,6 +22,7 @@ sphinx
 
 # Optional iris dependencies
 ecmwf_grib
+esmpy>=7.0
 gdal
 libmo_unpack
 pandas

--- a/lib/iris/experimental/regrid_conservative.py
+++ b/lib/iris/experimental/regrid_conservative.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -87,7 +87,7 @@ def _make_esmpy_field(x_coord, y_coord, ref_name='field',
     lon_bounds, lat_bounds = _convert_latlons(grid_crs, x_bounds, y_bounds)
 
     # Add grid 'coord' element for corners, and fill with corner values.
-    grid.add_coords(staggerlocs=[ESMF.StaggerLoc.CORNER])
+    grid.add_coords(staggerloc=ESMF.StaggerLoc.CORNER)
     grid_corners_x = grid.get_coords(0, ESMF.StaggerLoc.CORNER)
     grid_corners_x[:] = lon_bounds.T
     grid_corners_y = grid.get_coords(1, ESMF.StaggerLoc.CORNER)
@@ -117,7 +117,7 @@ def _make_esmpy_field(x_coord, y_coord, ref_name='field',
     lon_points, lat_points = _convert_latlons(grid_crs, x_points, y_points)
 
     # Add grid 'coord' element for centres + fill with centre-points values.
-    grid.add_coords(staggerlocs=[ESMF.StaggerLoc.CENTER])
+    grid.add_coords(staggerloc=ESMF.StaggerLoc.CENTER)
     grid_centers_x = grid.get_coords(0, ESMF.StaggerLoc.CENTER)
     grid_centers_x[:] = lon_points.T
     grid_centers_y = grid.get_coords(1, ESMF.StaggerLoc.CENTER)
@@ -258,7 +258,7 @@ def regrid_conservative_via_esmpy(source_cube, grid_cube):
                                     unmapped_action=ESMF.UnmappedAction.IGNORE,
                                     dst_frac_field=coverage_field)
         regrid_method(src_field, dst_field)
-        data = dst_field.data
+        data = np.ma.masked_array(dst_field.data)
 
         # Convert destination 'coverage fraction' into a missing-data mask.
         # Set = wherever part of cell goes outside source grid, or overlaps a

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -130,22 +130,6 @@ def _donothing_context_manager():
 
 @skip_esmf
 class TestConservativeRegrid(tests.IrisTest):
-    @classmethod
-    def setUpClass(cls):
-        # Pre-initialise ESMF, just to avoid warnings about no logfile.
-        # NOTE: noisy if logging is off, and no control of filepath.  Boo!!
-        if ESMF is not None:
-            # WARNING: nosetest calls class setUp/tearDown even when "skipped".
-            cls._emsf_logfile_path = os.path.join(os.getcwd(), 'ESMF_LogFile')
-            ESMF.Manager(logkind=ESMF.LogKind.SINGLE, debug=False)
-
-    @classmethod
-    def tearDownClass(cls):
-        # remove the logfile if we can, just to be tidy
-        if ESMF is not None:
-            # WARNING: nosetest calls class setUp/tearDown even when "skipped".
-            if os.path.exists(cls._emsf_logfile_path):
-                os.remove(cls._emsf_logfile_path)
 
     def setUp(self):
         # Compute basic test data cubes.
@@ -377,7 +361,7 @@ class TestConservativeRegrid(tests.IrisTest):
         c2.add_dim_coord(x_coord_2, 1)
 
         # NOTE: at present, this causes an error inside ESMF ...
-        context = self.assertRaises(NameError)
+        context = self.assertRaises(ValueError)
         global_cell_supported = False
         if global_cell_supported:
             context = _donothing_context_manager()


### PR DESCRIPTION
Some ***very*** simple fixes to make our old "regrid_conservative_via_esmpy" routine work with ESMPy v7.0.0

For now, this is getting its ESMPy from scitools
See [conda-recipes-scitools#149](https://github.com/SciTools/conda-recipes-scitools/pull/149)