### PR TITLE
Fix userguide save process customisation example

### DIFF
--- a/docs/iris/src/userguide/saving_iris_cubes.rst
+++ b/docs/iris/src/userguide/saving_iris_cubes.rst
@@ -19,7 +19,6 @@ and the keyword argument `saver` is not required.
     >>> import iris
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cubes = iris.load(filename)
-    >>> cube = cubes[0]
     >>> iris.save(cubes, '/tmp/uk_hires.nc')
 
 .. warning::
@@ -46,13 +45,13 @@ Controlling the save process
 The :py:func:`iris.save` function passes all other keywords through to the saver function defined, or automatically set from the file extension.  This enables saver specific functionality to be called.
 
     >>> # Save a cube to PP
-    >>> iris.save(cube, "myfile.pp")
+    >>> iris.save(cubes[0], "myfile.pp")
     >>> # Save a cube list to a PP file, appending to the contents of the file
     >>> # if it already exists
     >>> iris.save(cubes, "myfile.pp", append=True)
     >>> # Save a cube to netCDF, defaults to NETCDF4 file format
-    >>> iris.save(cube, "myfile.nc")
-    >>> # Save a cube list to netCDF, using the NETCDF4_CLASSIC storage option
+    >>> iris.save(cubes[0], "myfile.nc")
+    >>> # Save a cube list to netCDF, using the NETCDF3_CLASSIC storage option
     >>> iris.save(cubes, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
 
 See 
@@ -74,11 +73,11 @@ For example, a GRIB2 message with a particular known long_name may need to be sa
             for cube, grib_message in iris.fileformats.grib.as_pairs(cube):
                 # post process the GRIB2 message, prior to saving
                 if cube.name() == 'carefully_customised_precipitation_amount':
-		    gribapi.grib_set_long(grib_message, "typeOfStatisticalProcess", 1)
+                    gribapi.grib_set_long(grib_message, "typeOfStatisticalProcess", 1)
                     gribapi.grib_set_long(grib_message, "parameterCategory", 1)
                     gribapi.grib_set_long(grib_message, "parameterNumber", 1)
-                yield message
-        iris.fileformats.grib.save_messages(tweaked_messages(cube), '/tmp/agrib2.grib2')
+                yield grib_message
+        iris.fileformats.grib.save_messages(tweaked_messages(cubes[0]), '/tmp/agrib2.grib2')
 
 Similarly a PP field may need to be written out with a specific value for LBEXP.  This can be achieved by::
 
@@ -86,11 +85,11 @@ Similarly a PP field may need to be written out with a specific value for LBEXP.
             for cube, field in iris.fileformats.pp.as_pairs(cube):
                 # post process the PP field, prior to saving
                 if cube.name() == 'air_pressure':
-		    field.lbexp = 'meaxp'
-		elif cube.name() == 'air_density':
-		    field.lbexp = 'meaxr'
+                    field.lbexp = 'meaxp'
+                elif cube.name() == 'air_density':
+                    field.lbexp = 'meaxr'
                 yield field
-        iris.fileformats.pp.save_fields(tweaked_fields(cube), '/tmp/app.pp')
+        iris.fileformats.pp.save_fields(tweaked_fields(cubes[0]), '/tmp/app.pp')
 
 
 netCDF

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -362,7 +362,7 @@ def save(source, target, saver=None, **kwargs):
         # Save a cube to netCDF, defaults to NETCDF4 file format
         iris.save(my_cube, "myfile.nc")
 
-        # Save a cube list to netCDF, using the NETCDF4_CLASSIC storage option
+        # Save a cube list to netCDF, using the NETCDF3_CLASSIC storage option
         iris.save(my_cube_list, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
 
     .. warning::


### PR DESCRIPTION
I noticed a slight error in the "Customising the save process" code example. This fixes ` message` to be `grid_message`

Whilst I was on the page, I also noticed something (admittedly very minor) that I don't like in the first code example block:
```python
import iris
filename = iris.sample_data_path('uk_hires.pp')
cubes = iris.load(filename)
cube = cubes[0]
iris.save(cubes, '/tmp/uk_hires.nc')
```
I don't like the fact that a cube is indexed from the cubelist, but then the next line is saving the original cubelist. Someone would never do this so it shouldn't be example code.

I understand that the indexing is done as, further down, there are examples that use `cube` to demonstrate that a single cube can also be saved. Instead, I propose that the indexing should be done at the point of saving or perhaps just do the indexing at a later point (e.g. in the 'Controlling the save process' example code.

The other option would be to save the single cube, but then save it to a different filename, i.e.
```python
import iris
filename = iris.sample_data_path('uk_hires.pp')
cubes = iris.load(filename)
cube = cubes[0]
iris.save(cube, '/tmp/new_file.nc')
```

As I said, this is minor, and I am (sort of) happy to remove it from this PR.

