### PR TITLE
Simplify the deprecation of 'iris.fileformats.ff'.

### DIFF
--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -809,6 +809,11 @@ def load_cubes(filenames, callback, constraints=None):
         file (order is not preserved when there is a field with
         orography references).
 
+    .. deprecated:: 1.10
+            The module :mod:`iris.fileformats.ff` is deprecated.
+            Please use :func:`iris.fileformats.um.load_cubes` in place of
+            :func:`iris.fileformats.ff.load_cubes`.
+
     """
     return pp._load_cubes_variable_loader(filenames, callback, FF2PP,
                                           constraints=constraints)
@@ -821,6 +826,11 @@ def load_cubes_32bit_ieee(filenames, callback, constraints=None):
     .. seealso::
 
         :func:`load_cubes` for keyword details
+
+    .. deprecated:: 1.10
+            The module :mod:`iris.fileformats.ff` is deprecated.
+            Please use :func:`iris.fileformats.um.load_cubes_32bit_ieee`
+            in place of :func:`iris.fileformats.ff.load_cubes_32bit_ieee`.
 
     """
     return pp._load_cubes_variable_loader(filenames, callback, FF2PP,

--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -36,25 +36,13 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
-from functools import wraps
 import warnings
 
-from iris.fileformats import _ff
-from iris.fileformats import pp
-from iris._deprecation_helpers import ClassWrapperSameDocstring
-
-
-_FF_DEPRECATION_WARNING = "The module 'iris.fileformats.ff' is deprecated."
-
-
-# Define a standard mechanism for deprecation messages.
-def _warn_deprecated(message=None):
-    if message is None:
-        message = _FF_DEPRECATION_WARNING
-    warnings.warn(message)
-
 # Issue a deprecation message when the module is loaded.
-_warn_deprecated()
+warnings.warn("The module 'iris.fileformats.ff' is deprecated. "
+              "Please use iris.fileformats.um as a replacement, which "
+              "contains equivalents for all important features.")
+
 
 # Directly import various simple data items from the 'old' ff module.
 from iris.fileformats._ff import (
@@ -75,106 +63,26 @@ from iris.fileformats._ff import (
     REAL_FIRST_LAT,
     REAL_FIRST_LON,
     REAL_POLE_LAT,
-    REAL_POLE_LON
+    REAL_POLE_LON,
+    Grid,
+    ArakawaC,
+    NewDynamics,
+    ENDGame,
+    FFHeader,
+    FF2PP,
+    load_cubes,
+    load_cubes_32bit_ieee
 )
 
-
-# Define wrappers to all public classes, that emit deprecation warnings.
-# Note: it seems we are obliged to provide an __init__ with a suitable matching
-# signature for each one, as Sphinx will take its constructor signature from
-# any overriding definition of __init__ or __new__.
-# So without this, the docs don't look right.
-
-class Grid(six.with_metaclass(ClassWrapperSameDocstring, _ff.Grid)):
-    @wraps(_ff.Grid.__init__)
-    def __init__(self, column_dependent_constants, row_dependent_constants,
-                 real_constants, horiz_grid_type):
-        _warn_deprecated()
-        super(Grid, self).__init__(
-            column_dependent_constants, row_dependent_constants,
-            real_constants, horiz_grid_type)
-
-
-class ArakawaC(six.with_metaclass(ClassWrapperSameDocstring, _ff.ArakawaC)):
-    @wraps(_ff.ArakawaC.__init__)
-    def __init__(self, column_dependent_constants, row_dependent_constants,
-                 real_constants, horiz_grid_type):
-        _warn_deprecated()
-        super(ArakawaC, self).__init__(
-            column_dependent_constants, row_dependent_constants,
-            real_constants, horiz_grid_type)
-
-
-class NewDynamics(six.with_metaclass(ClassWrapperSameDocstring,
-                                     _ff.NewDynamics)):
-    @wraps(_ff.NewDynamics.__init__)
-    def __init__(self, column_dependent_constants, row_dependent_constants,
-                 real_constants, horiz_grid_type):
-        _warn_deprecated()
-        super(NewDynamics, self).__init__(
-            column_dependent_constants, row_dependent_constants,
-            real_constants, horiz_grid_type)
-
-
-class ENDGame(six.with_metaclass(ClassWrapperSameDocstring, _ff.ENDGame)):
-    @wraps(_ff.ENDGame.__init__)
-    def __init__(self, column_dependent_constants, row_dependent_constants,
-                 real_constants, horiz_grid_type):
-        _warn_deprecated()
-        super(ENDGame, self).__init__(
-            column_dependent_constants, row_dependent_constants,
-            real_constants, horiz_grid_type)
-
-
-class FFHeader(six.with_metaclass(ClassWrapperSameDocstring, _ff.FFHeader)):
-    @wraps(_ff.FFHeader.__init__)
-    def __init__(self, filename, word_depth=DEFAULT_FF_WORD_DEPTH):
-        _warn_deprecated()
-        super(FFHeader, self).__init__(filename, word_depth=word_depth)
-
-
-class FF2PP(six.with_metaclass(ClassWrapperSameDocstring, _ff.FF2PP)):
-    @wraps(_ff.FF2PP.__init__)
-    def __init__(self, filename, read_data=False,
-                 word_depth=DEFAULT_FF_WORD_DEPTH):
-        # Provide an enhanced deprecation message for this one.
-        msg = (_FF_DEPRECATION_WARNING + '\n' +
-               "Please use 'iris.fileformats.um.um_to_pp' in place of "
-               "'iris.fileformats.ff.FF2PP.")
-        _warn_deprecated(msg)
-        super(FF2PP, self).__init__(filename, read_data=read_data,
-                                    word_depth=word_depth)
-
-
-# Provide alternative loader functions which issue a deprecation warning,
-# using the original dosctrings with an appended deprecation warning.
-
-def load_cubes(filenames, callback, constraints=None):
-    _warn_deprecated("The module 'iris.fileformats.ff' is deprecated. "
-                     "\nPlease use 'iris.fileformat.um.load_cubes' "
-                     "in place of 'iris.fileformats.ff.load_cubes'.")
-    return pp._load_cubes_variable_loader(filenames, callback, FF2PP,
-                                          constraints=constraints)
-
-load_cubes.__doc__ = _ff.load_cubes.__doc__ + """
-    .. deprecated:: 1.10
-        Please use :meth:`iris.fileformats.um.load_cubes` as a replacement.
-
-"""
-
-
-def load_cubes_32bit_ieee(filenames, callback, constraints=None):
-    _warn_deprecated("The module 'iris.fileformats.ff' is deprecated. "
-                     "\nPlease use 'iris.fileformat.um.load_cubes_32bit_ieee' "
-                     "in place of 'iris.fileformats.ff.load_cubes_32bit_ieee'"
-                     ".")
-    return pp._load_cubes_variable_loader(filenames, callback, FF2PP,
-                                          {'word_depth': 4},
-                                          constraints=constraints)
-
-load_cubes_32bit_ieee.__doc__ = _ff.load_cubes_32bit_ieee.__doc__ + """
-    .. deprecated:: 1.10
-        Please use :meth:`iris.fileformats.um.load_cubes_32bit_ieee` as a
-        replacement.
-
-"""
+# Ensure we reproduce documentation as it appeared in v1.9,
+# but with a somewhat improved order of appearance.
+__all__ = (
+    'load_cubes',
+    'load_cubes_32bit_ieee',
+    'FF2PP',
+    'Grid',
+    'ArakawaC',
+    'NewDynamics',
+    'ENDGame',
+    'FFHeader',
+)

--- a/lib/iris/tests/unit/fileformats/ff/test__ff_equivalents.py
+++ b/lib/iris/tests/unit/fileformats/ff/test__ff_equivalents.py
@@ -122,7 +122,6 @@ class Mixin_Grid_Tests(object):
                                     row_dependent_constants,
                                     real_constants,
                                     horiz_grid_type)]
-        return self
 
     def test__basic(self):
         # Call with four unnamed args.
@@ -189,7 +188,6 @@ class Test_FFHeader(Mixin_ConstructorTest, tests.IrisTest):
         # It's global because in use, we do not have the right 'self' here.
         # Note: as we append, it contains a full call history.
         constructor_calls_data += [(filename, word_depth)]
-        return self
 
     def setUp(self):
         self.constructor_setup()
@@ -199,7 +197,7 @@ class Test_FFHeader(Mixin_ConstructorTest, tests.IrisTest):
         # NOTE: this ignores "our" constructor word_depth default, as the
         # default is now re-implemented in the wrapper class definition.
         self.check_call(['filename'], {},
-                        expected_result=('filename', 8))
+                        expected_result=('filename', 12345))
 
     def test__word_depth(self):
         # Call with a word-depth.
@@ -230,7 +228,6 @@ class Test_FF2PP(Mixin_ConstructorTest, tests.IrisTest):
         # It's global because in use, we do not have the right 'self' here.
         # Note: as we append, it contains a full call history.
         constructor_calls_data += [(filename, read_data, word_depth)]
-        return self
 
     def setUp(self):
         self.constructor_setup()
@@ -240,12 +237,12 @@ class Test_FF2PP(Mixin_ConstructorTest, tests.IrisTest):
         # NOTE: this ignores "our" constructor word_depth default, as the
         # default is now re-implemented in the wrapper class definition.
         self.check_call(['filename'], {},
-                        expected_result=('filename', False, 8))
+                        expected_result=('filename', False, 12345))
 
     def test__read_data(self):
         # Call with a word-depth.
         self.check_call(['filename', True], {},
-                        expected_result=('filename', True, 8))
+                        expected_result=('filename', True, 12345))
 
     def test__word_depth(self):
         # Call with a word-depth keyword.


### PR DESCRIPTION
As @rhattersley pointed out yesterday, the previous effort is over-complicated in it's attempt to provide runtime deprecation warnings for everything in the interface.
We need only ensure that importing "iris.fileformats.ff" itself produces a warning :  The others are not needed, which makes it all much simpler.

It has proved awkward in several of these deprecation efforts to ensure the Sphinx documentation is still equivalent.
I think this still achieves that, but you may want to check it out.