### PR TITLE
Reinstate grib as_messages.

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -17,7 +17,7 @@
 """
 Conversion of cubes to/from GRIB.
 
-See also: `ECMWF GRIB API <http://www.ecmwf.int/publications/manuals/grib_api/index.html>`_.
+See also: `ECMWF GRIB API <https://software.ecmwf.int/wiki/display/GRIB/Home>`_.
 
 """
 
@@ -50,7 +50,7 @@ import iris.fileformats.grib.load_rules
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages', 'GribWrapper',
-           'as_pairs', 'grib_generator', 'reset_load_rules',
+           'as_messages', 'as_pairs', 'grib_generator', 'reset_load_rules',
            'hindcast_workaround']
 
 
@@ -999,7 +999,7 @@ def save_grib2(cube, target, append=False, **kwargs):
     See also :func:`iris.io.save`.
 
     """
-    messages = (message for cube, message in save_pairs_from_cube(cube))
+    messages = as_messages(cube)
     save_messages(messages, target, append=append)
 
 
@@ -1038,6 +1038,22 @@ def save_pairs_from_cube(cube):
         grib_message = gribapi.grib_new_from_samples("GRIB2")
         _save_rules.run(slice2D, grib_message)
         yield (slice2D, grib_message)
+
+
+def as_messages(cube):
+    """
+    .. deprecated:: 1.10
+    Please use :func:`iris.fileformats.grib.save_pairs_from_cube` instead.
+
+    Convert one or more cubes to GRIB messages.
+    Returns an iterable of grib_api GRIB messages.
+
+    Args:
+        * cube      - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+                      list of cubes.
+
+    """
+    return (message for cube, message in save_pairs_from_cube(cube))
 
 
 def save_messages(messages, target, append=False):

--- a/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_as_messages.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the `iris.fileformats.grib.as_pairs` function."""
+"""Unit tests for the `iris.fileformats.grib.as_messages` function."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
@@ -30,18 +30,17 @@ from iris.tests import mock
 import iris.tests.stock as stock
 
 
-class TestAsPairs(tests.IrisTest):
+class TestAsMessages(tests.IrisTest):
     def setUp(self):
         self.cube = stock.realistic_3d()
 
-    def test_as_pairs(self):
+    def test_as_messages(self):
         realization = 2
         type_of_process = 4
         coord = DimCoord(realization, standard_name='realization', units='1')
         self.cube.add_aux_coord(coord)
-        slices_and_messages = grib.as_pairs(self.cube)
-        for aslice, message in slices_and_messages:
-            self.assertEqual(aslice.shape, (9, 11))
+        messages = grib.as_messages(self.cube)
+        for message in messages:
             self.assertEqual(gribapi.grib_get_long(message,
                                                    'typeOfProcessedData'),
                              type_of_process)


### PR DESCRIPTION
This function was removed by #1941, when it should just have been deprecated.
The test ```iris.tests.unit.fileformats.grib``` test "test_as_messages" is not reinstated, as "test_as_pairs" covers it.
As a complete aside, I also spotted the ECMWF link in the module header was broken + fixed that.
