### PR TITLE
Fix expand filespecs

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -164,7 +164,7 @@ def expand_filespecs(file_specs):
     if not all(value_lists):
         raise IOError("One or more of the files specified did not exist %s." %
         ["%s expanded to %s" % (pattern, expanded if expanded else "empty")
-         for pattern, expanded in six.iteritems(glob_expanded)])
+         for pattern, expanded in sorted(six.iteritems(glob_expanded))])
 
     return sum(value_lists, [])
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -148,12 +148,12 @@ def expand_filespecs(file_specs):
         File paths which may contain '~' elements or wildcards.
 
     Returns:
-        A list of matching file paths.  If any of the file-specs matches no
+        A list of matching absolute file paths.  If any of the file-specs matches no
         existing files, an exception is raised.
 
     """
-    # Remove any hostname component - currently unused
-    filenames = [os.path.expanduser(fn[2:] if fn.startswith('//') else fn)
+    # Remove any hostname component - currently unused - expand paths as absolutes
+    filenames = [os.path.abspath(os.path.expanduser(fn[2:] if fn.startswith('//') else fn))
                  for fn in file_specs]
 
     # Try to expand all filenames as globs

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -160,7 +160,10 @@ def expand_filespecs(file_specs):
     glob_expanded = {fn : sorted(glob.glob(fn)) for fn in filenames}
 
     # If any of the specs expanded to an empty list then raise an error
-    value_lists = glob_expanded.values()
+    value_list_raw = glob_expanded.values()
+
+    # Here is a term to sort value_lists alphabetically, for consistency
+    value_lists = sorted(value_list_raw)
     if not all(value_lists):
         raise IOError("One or more of the files specified did not exist %s." %
         ["%s expanded to %s" % (pattern, expanded if expanded else "empty")

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -1,0 +1,75 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.io.expand_filespecs` function."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import os
+import tempfile
+import shutil
+
+import iris.io
+
+
+class Test_expand_filespecs(tests.IrisTest):
+    def setUp(self):
+        tests.IrisTest.setUp(self)
+        self.tmpdir = tempfile.mkdtemp()
+        self.fnames = ['a.foo', 'wibble.txt']
+        for fname in self.fnames:
+            with open(os.path.join(self.tmpdir, fname), 'w') as fh:
+                fh.write('anything')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_absolute_path(self):
+        self.assertEqual(iris.io.expand_filespecs([os.path.join(self.tmpdir, '*')]),
+                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
+
+    def test_double_slash(self):
+        self.assertEqual(iris.io.expand_filespecs(['//' + os.path.join(self.tmpdir, '*')]),
+                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
+
+    def test_relative_path(self):
+	os.chdir(self.tmpdir)
+        self.assertEqual(iris.io.expand_filespecs(['*']),
+                         self.fnames)
+
+    def test_no_files_found(self):
+        msg = 'wibble expanded to empty'
+        with self.assertRaisesRegexp(IOError, msg):
+            iris.io.expand_filespecs([self.tmpdir + '_wibble'])
+
+    def test_files_and_none(self):
+        # A function to test when there's both a valid file and an invalid one
+        # Does this make sense?
+        msg = 'wibble expanded to empty.*expanded to .*wibble.txt'
+        with self.assertRaisesRegexp(IOError, msg):
+            iris.io.expand_filespecs([self.tmpdir + '_wibble', os.path.join(self.tmpdir, '*')])
+
+
+
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -27,10 +27,11 @@ import os
 import tempfile
 import shutil
 
-import iris.io
+import iris.io as iio
 
 
 class TestExpandFilespecs(tests.IrisTest):
+
     def setUp(self):
         tests.IrisTest.setUp(self)
         self.tmpdir = tempfile.mkdtemp()
@@ -43,33 +44,31 @@ class TestExpandFilespecs(tests.IrisTest):
         shutil.rmtree(self.tmpdir)
 
     def test_absolute_path(self):
-        self.assertEqual(iris.io.expand_filespecs(
-                                 [os.path.join(self.tmpdir, '*')]),
-                         [os.path.join(self.tmpdir, fname)
-                          for fname in self.fnames])
+        result = iio.expand_filespecs([os.path.join(self.tmpdir, '*')])
+        expected = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(result, expected)
 
     def test_double_slash(self):
-        self.assertEqual(iris.io.expand_filespecs(
-            ['//' + os.path.join(self.tmpdir, '*')]),
-                         [os.path.join(self.tmpdir, fname)
-                          for fname in self.fnames])
+        product = iio.expand_filespecs(['//' + os.path.join(self.tmpdir, '*')])
+        predicted = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(product, predicted)
 
     def test_relative_path(self):
         os.chdir(self.tmpdir)
-        self.assertEqual(iris.io.expand_filespecs(['*']),
-                        [os.path.join(self.tmpdir, fname)
-                         for fname in self.fnames])
+        item_out = iio.expand_filespecs(['*'])
+        item_in = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(item_out, item_in)
 
     def test_no_files_found(self):
         msg = 'b expanded to empty'
         with self.assertRaisesRegexp(IOError, msg):
-            iris.io.expand_filespecs([self.tmpdir + '_b'])
+            iio.expand_filespecs([self.tmpdir + '_b'])
 
     def test_files_and_none(self):
         msg = 'b expanded to empty.*expanded to .*b.txt'
         with self.assertRaisesRegexp(IOError, msg):
-            iris.io.expand_filespecs([self.tmpdir + '_b',
-                                      os.path.join(self.tmpdir, '*')])
+            iio.expand_filespecs([self.tmpdir + '_b',
+                                 os.path.join(self.tmpdir, '*')])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -34,7 +34,7 @@ class Test_expand_filespecs(tests.IrisTest):
     def setUp(self):
         tests.IrisTest.setUp(self)
         self.tmpdir = tempfile.mkdtemp()
-        self.fnames = ['a.foo', 'wibble.txt']
+        self.fnames = ['a.foo', 'b.txt']
         for fname in self.fnames:
             with open(os.path.join(self.tmpdir, fname), 'w') as fh:
                 fh.write('anything')
@@ -53,22 +53,17 @@ class Test_expand_filespecs(tests.IrisTest):
     def test_relative_path(self):
 	os.chdir(self.tmpdir)
         self.assertEqual(iris.io.expand_filespecs(['*']),
-                         self.fnames)
+                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
 
     def test_no_files_found(self):
-        msg = 'wibble expanded to empty'
+        msg = 'b expanded to empty'
         with self.assertRaisesRegexp(IOError, msg):
-            iris.io.expand_filespecs([self.tmpdir + '_wibble'])
+            iris.io.expand_filespecs([self.tmpdir + '_b'])
 
     def test_files_and_none(self):
-        # A function to test when there's both a valid file and an invalid one
-        # Does this make sense?
-        msg = 'wibble expanded to empty.*expanded to .*wibble.txt'
+        msg = 'b expanded to empty.*expanded to .*b.txt'
         with self.assertRaisesRegexp(IOError, msg):
-            iris.io.expand_filespecs([self.tmpdir + '_wibble', os.path.join(self.tmpdir, '*')])
-
-
-
+            iris.io.expand_filespecs([self.tmpdir + '_b', os.path.join(self.tmpdir, '*')])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -30,7 +30,7 @@ import shutil
 import iris.io
 
 
-class Test_expand_filespecs(tests.IrisTest):
+class TestExpandFilespecs(tests.IrisTest):
     def setUp(self):
         tests.IrisTest.setUp(self)
         self.tmpdir = tempfile.mkdtemp()
@@ -43,17 +43,22 @@ class Test_expand_filespecs(tests.IrisTest):
         shutil.rmtree(self.tmpdir)
 
     def test_absolute_path(self):
-        self.assertEqual(iris.io.expand_filespecs([os.path.join(self.tmpdir, '*')]),
-                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
+        self.assertEqual(iris.io.expand_filespecs(
+                                 [os.path.join(self.tmpdir, '*')]),
+                         [os.path.join(self.tmpdir, fname)
+                          for fname in self.fnames])
 
     def test_double_slash(self):
-        self.assertEqual(iris.io.expand_filespecs(['//' + os.path.join(self.tmpdir, '*')]),
-                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
+        self.assertEqual(iris.io.expand_filespecs(
+            ['//' + os.path.join(self.tmpdir, '*')]),
+                         [os.path.join(self.tmpdir, fname)
+                          for fname in self.fnames])
 
     def test_relative_path(self):
-	os.chdir(self.tmpdir)
+        os.chdir(self.tmpdir)
         self.assertEqual(iris.io.expand_filespecs(['*']),
-                         [os.path.join(self.tmpdir, fname) for fname in self.fnames])
+                        [os.path.join(self.tmpdir, fname)
+                         for fname in self.fnames])
 
     def test_no_files_found(self):
         msg = 'b expanded to empty'
@@ -63,7 +68,8 @@ class Test_expand_filespecs(tests.IrisTest):
     def test_files_and_none(self):
         msg = 'b expanded to empty.*expanded to .*b.txt'
         with self.assertRaisesRegexp(IOError, msg):
-            iris.io.expand_filespecs([self.tmpdir + '_b', os.path.join(self.tmpdir, '*')])
+            iris.io.expand_filespecs([self.tmpdir + '_b',
+                                      os.path.join(self.tmpdir, '*')])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a fix for issue #1508 . The proposed fix changes filepath expansions in expand_filespecs() from relative paths to absolute ones.

In addition, the fix also adds a suitable test for the expand_filespecs function.

(Edit: removal of an unnecessary URL.)
