### PR TITLE
Support anonymous dimension plotting.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-13_plot_anonymous.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-13_plot_anonymous.txt
@@ -1,0 +1,3 @@
+* The :mod:`iris.plot` routines :func:`~iris.plot.contour`, :func:`~iris.plot.countourf`, :func:`~iris.plot.outline`, :func:`~iris.plot.pcolor`, :func:`~iris.plot.pcolormesh` and :func:`~iris.plot.points` now support plotting cubes with anonymous dimensions by specifying the *numeric index* of the anonymous dimension within the ``coords`` keyword argument.
+
+  Note that, the axis of the anonymous dimension will be plotted in index space.

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -68,9 +68,9 @@ def _get_plot_defn_custom_coords_picked(cube, coords, mode, ndims=2):
         if isinstance(coord, int):
             # Pass through valid dimension indexes.
             if coord >= ndims:
-                emsg = 'The data dimension ({}) is out of range for ' \
-                    'the dimensionality of the required plot ({})'
-                raise ValueError(emsg.format(coord, ndims))
+                emsg = ('The data dimension ({}) is out of range for '
+                        'the dimensionality of the required plot ({})')
+                raise IndexError(emsg.format(coord, ndims))
         else:
             coord = cube.coord(coord)
         return coord
@@ -284,7 +284,7 @@ def _draw_2d_from_bounds(draw_method_name, cube, *args, **kwargs):
             if coord is None:
                 values = np.arange(data.shape[data_dim] + 1)
             elif isinstance(coord, int):
-                dim = int(not bool(coord)) if plot_defn.transpose else coord
+                dim = 1 - coord if plot_defn.transpose else coord
                 values = np.arange(data.shape[dim] + 1)
             else:
                 if coord.points.dtype.char in 'SU':
@@ -342,7 +342,7 @@ def _draw_2d_from_points(draw_method_name, arg_func, cube, *args, **kwargs):
         if u_coord is None:
             u = np.arange(data.shape[1])
         elif isinstance(u_coord, int):
-            dim = int(not bool(u_coord)) if plot_defn.transpose else u_coord
+            dim = 1 - u_coord if plot_defn.transpose else u_coord
             u = np.arange(data.shape[dim])
         else:
             u = u_coord.points
@@ -351,7 +351,7 @@ def _draw_2d_from_points(draw_method_name, arg_func, cube, *args, **kwargs):
         if v_coord is None:
             v = np.arange(data.shape[0])
         elif isinstance(v_coord, int):
-            dim = int(not bool(v_coord)) if plot_defn.transpose else v_coord
+            dim = 1 - v_coord if plot_defn.transpose else v_coord
             v = np.arange(data.shape[dim])
         else:
             v = v_coord.points

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -45,7 +45,7 @@ def _use_symbol(units):
 
 
 def _title(cube_or_coord, with_units):
-    if cube_or_coord is None:
+    if cube_or_coord is None or isinstance(cube_or_coord, int):
         title = ''
     else:
         title = cube_or_coord.name().replace('_', ' ').capitalize()

--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from iris.tests.stock import simple_2d, lat_lon_cube
+from iris.plot import _broadcast_2d as broadcast
 from iris.coords import AuxCoord
+from iris.tests.stock import simple_2d, lat_lon_cube
 
 
 @tests.skip_plot
@@ -63,3 +64,61 @@ class TestGraphicStringCoord(tests.GraphicsTest):
         actual = self.tick_loc_and_label(axis, axes)
         expected = [(0.0, 'a'), (1.0, 'b'), (2.0, 'c'), (3.0, 'd')]
         self.assertEqual(expected, actual)
+
+
+@tests.skip_plot
+class MixinCoords(object):
+    """
+    Mixin class of common plotting tests providing 2-dimensional
+    permutations of coordinates and anonymous dimensions.
+
+    """
+    def _check(self, u, v, data=None):
+        self.assertEqual(self.this.call_count, 1)
+        if data is not None:
+            (actual_u, actual_v, actual_data), _ = self.this.call_args
+            self.assertArrayEqual(actual_data, data)
+        else:
+            (actual_u, actual_v), _ = self.this.call_args
+        self.assertArrayEqual(actual_u, u)
+        self.assertArrayEqual(actual_v, v)
+
+    def test_foo_bar(self):
+        self.draw(self.cube, coords=('foo', 'bar'))
+        u, v = broadcast(self.foo, self.bar)
+        self._check(u, v, self.data)
+
+    def test_bar_foo(self):
+        self.draw(self.cube, coords=('bar', 'foo'))
+        u, v = broadcast(self.bar, self.foo)
+        self._check(u, v, self.dataT)
+
+    def test_foo_0(self):
+        self.draw(self.cube, coords=('foo', 0))
+        u, v = broadcast(self.foo, self.bar_index)
+        self._check(u, v, self.data)
+
+    def test_1_bar(self):
+        self.draw(self.cube, coords=(1, 'bar'))
+        u, v = broadcast(self.foo_index, self.bar)
+        self._check(u, v, self.data)
+
+    def test_1_0(self):
+        self.draw(self.cube, coords=(1, 0))
+        u, v = broadcast(self.foo_index, self.bar_index)
+        self._check(u, v, self.data)
+
+    def test_0_foo(self):
+        self.draw(self.cube, coords=(0, 'foo'))
+        u, v = broadcast(self.bar_index, self.foo)
+        self._check(u, v, self.dataT)
+
+    def test_bar_1(self):
+        self.draw(self.cube, coords=('bar', 1))
+        u, v = broadcast(self.bar, self.foo_index)
+        self._check(u, v, self.dataT)
+
+    def test_0_1(self):
+        self.draw(self.cube, coords=(0, 1))
+        u, v = broadcast(self.bar_index, self.foo_index)
+        self._check(u, v, self.dataT)

--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -89,7 +89,7 @@ class MixinCoords(object):
         self._check(u, v, self.data)
 
     def test_bar_foo(self):
-        self.draw_func(self.cube, coords=('bar', 'foo'))t
+        self.draw_func(self.cube, coords=('bar', 'foo'))
         u, v = broadcast(self.bar, self.foo)
         self._check(u, v, self.dataT)
 

--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -74,51 +74,51 @@ class MixinCoords(object):
 
     """
     def _check(self, u, v, data=None):
-        self.assertEqual(self.this.call_count, 1)
+        self.assertEqual(self.mpl_patch.call_count, 1)
         if data is not None:
-            (actual_u, actual_v, actual_data), _ = self.this.call_args
+            (actual_u, actual_v, actual_data), _ = self.mpl_patch.call_args
             self.assertArrayEqual(actual_data, data)
         else:
-            (actual_u, actual_v), _ = self.this.call_args
+            (actual_u, actual_v), _ = self.mpl_patch.call_args
         self.assertArrayEqual(actual_u, u)
         self.assertArrayEqual(actual_v, v)
 
     def test_foo_bar(self):
-        self.draw(self.cube, coords=('foo', 'bar'))
+        self.draw_func(self.cube, coords=('foo', 'bar'))
         u, v = broadcast(self.foo, self.bar)
         self._check(u, v, self.data)
 
     def test_bar_foo(self):
-        self.draw(self.cube, coords=('bar', 'foo'))
+        self.draw_func(self.cube, coords=('bar', 'foo'))t
         u, v = broadcast(self.bar, self.foo)
         self._check(u, v, self.dataT)
 
     def test_foo_0(self):
-        self.draw(self.cube, coords=('foo', 0))
+        self.draw_func(self.cube, coords=('foo', 0))
         u, v = broadcast(self.foo, self.bar_index)
         self._check(u, v, self.data)
 
     def test_1_bar(self):
-        self.draw(self.cube, coords=(1, 'bar'))
+        self.draw_func(self.cube, coords=(1, 'bar'))
         u, v = broadcast(self.foo_index, self.bar)
         self._check(u, v, self.data)
 
     def test_1_0(self):
-        self.draw(self.cube, coords=(1, 0))
+        self.draw_func(self.cube, coords=(1, 0))
         u, v = broadcast(self.foo_index, self.bar_index)
         self._check(u, v, self.data)
 
     def test_0_foo(self):
-        self.draw(self.cube, coords=(0, 'foo'))
+        self.draw_func(self.cube, coords=(0, 'foo'))
         u, v = broadcast(self.bar_index, self.foo)
         self._check(u, v, self.dataT)
 
     def test_bar_1(self):
-        self.draw(self.cube, coords=('bar', 1))
+        self.draw_func(self.cube, coords=('bar', 1))
         u, v = broadcast(self.bar, self.foo_index)
         self._check(u, v, self.dataT)
 
     def test_0_1(self):
-        self.draw(self.cube, coords=(0, 1))
+        self.draw_func(self.cube, coords=(0, 1))
         u, v = broadcast(self.bar_index, self.foo_index)
         self._check(u, v, self.dataT)

--- a/lib/iris/tests/unit/plot/test_contour.py
+++ b/lib/iris/tests/unit/plot/test_contour.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -60,6 +64,21 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         ax = fig.add_subplot(111)
         self.assertRaises(TypeError, iplt.contour, self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.contour')
+        self.draw = iplt.contour
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_contour.py
+++ b/lib/iris/tests/unit/plot/test_contour.py
@@ -77,8 +77,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.contour')
-        self.draw = iplt.contour
+        self.mpl_patch = self.patch('matplotlib.pyplot.contour')
+        self.draw_func = iplt.contour
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -80,9 +80,9 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.data = self.cube.data
         self.dataT = self.data.T
         mocker = mock.Mock(alpha=0, antialiased=False)
-        self.this = self.patch('matplotlib.pyplot.contourf',
-                               return_value=mocker)
-        self.draw = iplt.contourf
+        self.mpl_patch = self.patch('matplotlib.pyplot.contourf',
+                                    return_value=mocker)
+        self.draw_func = iplt.contourf
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -25,6 +25,7 @@ import iris.tests as tests
 
 import numpy as np
 
+from iris.tests import mock
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
@@ -78,7 +79,9 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.contourf')
+        mocker = mock.Mock(alpha=0, antialiased=False)
+        self.this = self.patch('matplotlib.pyplot.contourf',
+                               return_value=mocker)
         self.draw = iplt.contourf
 
 

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -61,6 +65,21 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         self.assertRaises(TypeError, iplt.contourf,
                           self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.contourf')
+        self.draw = iplt.contourf
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_outline.py
+++ b/lib/iris/tests/unit/plot/test_outline.py
@@ -82,8 +82,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolormesh')
-        self.draw = iplt.outline
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw_func = iplt.outline
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_outline.py
+++ b/lib/iris/tests/unit/plot/test_outline.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -63,6 +67,23 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         self.assertRaises(TypeError, iplt.outline,
                           self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw = iplt.outline
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -63,6 +67,24 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         self.assertRaises(TypeError, iplt.pcolor,
                           self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolor')
+        self.draw = iplt.pcolor
+
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -82,8 +82,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolor')
-        self.draw = iplt.pcolor
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolor')
+        self.draw_func = iplt.pcolor
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -82,8 +82,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolormesh')
-        self.draw = iplt.pcolormesh
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw_func = iplt.pcolormesh
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -63,6 +67,23 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         self.assertRaises(TypeError, iplt.pcolormesh,
                           self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw = iplt.pcolormesh
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_points.py
+++ b/lib/iris/tests/unit/plot/test_points.py
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -63,6 +67,21 @@ class TestStringCoordPlot(TestGraphicStringCoord):
         self.assertRaises(TypeError, iplt.points,
                           self.lat_lon_cube, axes=ax)
         plt.close(fig)
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = None
+        self.dataT = None
+        self.this = self.patch('matplotlib.pyplot.scatter')
+        self.draw = iplt.points
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_points.py
+++ b/lib/iris/tests/unit/plot/test_points.py
@@ -80,8 +80,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = None
         self.dataT = None
-        self.this = self.patch('matplotlib.pyplot.scatter')
-        self.draw = iplt.points
+        self.mpl_patch = self.patch('matplotlib.pyplot.scatter')
+        self.draw_func = iplt.points
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_contour.py
+++ b/lib/iris/tests/unit/quickplot/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,21 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.contour(self.cube, coords=('str_coord', 'bar'))
         self.assertPointsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.contour')
+        self.draw = qplt.contour
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_contour.py
+++ b/lib/iris/tests/unit/quickplot/test_contour.py
@@ -54,8 +54,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.contour')
-        self.draw = qplt.contour
+        self.mpl_patch = self.patch('matplotlib.pyplot.contour')
+        self.draw_func = qplt.contour
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,23 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.contourf(self.cube, coords=('str_coord', 'bar'))
         self.assertPointsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.contourf')
+        # Also need to mock the colorbar.
+        self.patch('matplotlib.pyplot.colorbar')
+        self.draw = qplt.contourf
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -56,11 +56,11 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.data = self.cube.data
         self.dataT = self.data.T
         mocker = mock.Mock(alpha=0, antialiased=False)
-        self.this = self.patch('matplotlib.pyplot.contourf',
-                               return_value=mocker)
+        self.mpl_patch = self.patch('matplotlib.pyplot.contourf',
+                                    return_value=mocker)
         # Also need to mock the colorbar.
         self.patch('matplotlib.pyplot.colorbar')
-        self.draw = qplt.contourf
+        self.draw_func = qplt.contourf
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -25,6 +25,7 @@ import iris.tests as tests
 
 import numpy as np
 
+from iris.tests import mock
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
@@ -54,7 +55,9 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.contourf')
+        mocker = mock.Mock(alpha=0, antialiased=False)
+        self.this = self.patch('matplotlib.pyplot.contourf',
+                               return_value=mocker)
         # Also need to mock the colorbar.
         self.patch('matplotlib.pyplot.colorbar')
         self.draw = qplt.contourf

--- a/lib/iris/tests/unit/quickplot/test_outline.py
+++ b/lib/iris/tests/unit/quickplot/test_outline.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,23 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.outline(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw = qplt.outline
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_outline.py
+++ b/lib/iris/tests/unit/quickplot/test_outline.py
@@ -56,8 +56,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolormesh')
-        self.draw = qplt.outline
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolormesh')
+        self.draw_func = qplt.outline
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_pcolor.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolor.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,23 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.pcolor(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolor', return_value=None)
+        self.draw = qplt.pcolor
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_pcolor.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolor.py
@@ -56,8 +56,9 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolor', return_value=None)
-        self.draw = qplt.pcolor
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolor',
+                                    return_value=None)
+        self.draw_func = qplt.pcolor
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolormesh.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,24 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.pcolormesh(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.this = self.patch('matplotlib.pyplot.pcolormesh',
+                               return_value=None)
+        self.draw = qplt.pcolormesh
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/quickplot/test_pcolormesh.py
@@ -56,9 +56,9 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(coord.points.size + 1)
         self.data = self.cube.data
         self.dataT = self.data.T
-        self.this = self.patch('matplotlib.pyplot.pcolormesh',
-                               return_value=None)
-        self.draw = qplt.pcolormesh
+        self.mpl_patch = self.patch('matplotlib.pyplot.pcolormesh',
+                                    return_value=None)
+        self.draw_func = qplt.pcolormesh
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_points.py
+++ b/lib/iris/tests/unit/quickplot/test_points.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,7 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from iris.tests.unit.plot import TestGraphicStringCoord
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 
 if tests.MPL_AVAILABLE:
     import iris.quickplot as qplt
@@ -37,6 +41,21 @@ class TestStringCoordPlot(TestGraphicStringCoord):
     def test_xaxis_labels(self):
         qplt.points(self.cube, coords=('str_coord', 'bar'))
         self.assertBoundsTickLabels('xaxis')
+
+
+@tests.skip_plot
+class TestCoords(tests.IrisTest, MixinCoords):
+    def setUp(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=False)
+        self.foo = self.cube.coord('foo').points
+        self.foo_index = np.arange(self.foo.size)
+        self.bar = self.cube.coord('bar').points
+        self.bar_index = np.arange(self.bar.size)
+        self.data = None
+        self.dataT = None
+        self.this = self.patch('matplotlib.pyplot.scatter')
+        self.draw = qplt.points
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/quickplot/test_points.py
+++ b/lib/iris/tests/unit/quickplot/test_points.py
@@ -54,8 +54,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = None
         self.dataT = None
-        self.this = self.patch('matplotlib.pyplot.scatter')
-        self.draw = qplt.points
+        self.mpl_patch = self.patch('matplotlib.pyplot.scatter')
+        self.draw_func = qplt.points
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR extends the capability of the `iris.plot` and `iris.quickplot` functions:

- contour
- contourf
- outline
- pcolor
- pcolormesh
- points

to plot cubes with anonymous dimensions. This is done via the `coords` kwarg, which can now take the offset of the anonymous dimension that represents the required plot axis e.g.

```python
>>> print cube
air_temperature / (K)               (latitude: 73; -- : 96)
     Dimension coordinates:
          latitude                           x        -
     Scalar coordinates:
          forecast_period: 6477 hours, bound=(-28083.0, 6477.0) hours
          forecast_reference_time: 1998-03-01 03:00:00
          pressure: 1000.0 hPa
          time: 1998-12-01 00:00:00, bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     Attributes:
          STASH: m01s16i203
          source: Data from Met Office Unified Model
     Cell methods:
          mean within years: time
          mean over years: time
>>> iplt.contourf(cube, coords=(1, 'latitude'))
```
Note that, the axis for the anonymous dimension will be plotted in index space.