### PR TITLE
Support 'iris_grib'; deprecate 'iris.fileformats.grib'.

### DIFF
--- a/docs/iris/example_code/General/polar_stereo.py
+++ b/docs/iris/example_code/General/polar_stereo.py
@@ -15,18 +15,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the grib load uses the mechanism
-    # intended for future Iris versions.
-    iris.FUTURE.external_grib_support = True
-
-    # What if anything is needed here for the first version of iris_grib ?
-    # - we don't actually know yet ...
-    # What we might need in future...
-    #    import iris_grib
-    #    iris_grib.FUTURE.strict_grib_load = True
-    # FOR NOW: a nasty kluge, as setting this is now *itself* deprecated.
-    iris.FUTURE.__dict__['strict_grib_load'] = True
-
     file_path = iris.sample_data_path('polar_stereo.grib2')
     cube = iris.load_cube(file_path)
     qplt.contourf(cube)

--- a/docs/iris/example_code/General/polar_stereo.py
+++ b/docs/iris/example_code/General/polar_stereo.py
@@ -15,9 +15,17 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the grib load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.strict_grib_load = True
+    # Enable a future option, to ensure that the grib load uses the mechanism
+    # intended for future Iris versions.
+    iris.FUTURE.external_grib_support = True
+
+    # What if anything is needed here for the first version of iris_grib ?
+    # - we don't actually know yet ...
+    # What we might need in future...
+    #    import iris_grib
+    #    iris_grib.FUTURE.strict_grib_load = True
+    # FOR NOW: a nasty kluge, as setting this is now *itself* deprecated.
+    iris.FUTURE.__dict__['strict_grib_load'] = True
 
     file_path = iris.sample_data_path('polar_stereo.grib2')
     cube = iris.load_cube(file_path)

--- a/docs/iris/example_tests/extest_util.py
+++ b/docs/iris/example_tests/extest_util.py
@@ -90,6 +90,9 @@ def fail_any_deprecation_warnings():
         # Detect and error all and any Iris deprecation warnings.
         warnings.simplefilter("error", IrisDeprecation)
         # Run with all default settings in iris.FUTURE.
-        default_future_kwargs = iris.Future().__dict__
+        default_future_kwargs = iris.Future().__dict__.copy()
+        for dead_option in iris.Future.deprecated_options:
+            # Avoid a warning when setting these !
+            del default_future_kwargs[dead_option]
         with iris.FUTURE.context(**default_future_kwargs):
             yield

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -144,8 +144,7 @@ class Future(threading.local):
     """Run-time configuration controller."""
 
     def __init__(self, cell_datetime_objects=False, netcdf_promote=False,
-                 strict_grib_load=False, external_grib_support=False,
-                 netcdf_no_unlimited=False,
+                 strict_grib_load=False, netcdf_no_unlimited=False,
                  clip_latitudes=False):
         """
         A container for run-time options controls.
@@ -189,11 +188,8 @@ class Future(threading.local):
             The 'strict_grib_load' option is now deprecated, as it affects
             only the internal grib module :mod:`iris.fileformats.grib`,
             which is now itself deprecated in favour of 'iris_grib'.
-            See the "external_grib_support" option.
-
-        The option `external_grib_support` controls whether GRIB files are
-        processed using the 'iris_grib' package, in place of the old iris
-        internal module :mod:`iris.fileformats.grib`.
+            Please remove code which sets this, and instead install the
+            'iris_grib' package : <https://github.com/SciTools/iris-grib>.
 
         The option `netcdf_no_unlimited`, when True, changes the
         behaviour of the netCDF saver, such that no dimensions are set to
@@ -208,17 +204,15 @@ class Future(threading.local):
         self.__dict__['cell_datetime_objects'] = cell_datetime_objects
         self.__dict__['netcdf_promote'] = netcdf_promote
         self.__dict__['strict_grib_load'] = strict_grib_load
-        self.__dict__['external_grib_support'] = external_grib_support
         self.__dict__['netcdf_no_unlimited'] = netcdf_no_unlimited
         self.__dict__['clip_latitudes'] = clip_latitudes
 
     def __repr__(self):
         msg = ('Future(cell_datetime_objects={}, netcdf_promote={}, '
-               'strict_grib_load={}, external_grib_support={}, '
-               'netcdf_no_unlimited={}, clip_latitudes={})')
+               'strict_grib_load={}, netcdf_no_unlimited={}, '
+               'clip_latitudes={})')
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
-                          self.strict_grib_load, self.external_grib_support,
-                          self.netcdf_no_unlimited,
+                          self.strict_grib_load, self.netcdf_no_unlimited,
                           self.clip_latitudes)
 
     deprecated_options = ['strict_grib_load']

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -144,7 +144,8 @@ class Future(threading.local):
     """Run-time configuration controller."""
 
     def __init__(self, cell_datetime_objects=False, netcdf_promote=False,
-                 strict_grib_load=False, netcdf_no_unlimited=False,
+                 strict_grib_load=False, external_grib_support=False,
+                 netcdf_no_unlimited=False,
                  clip_latitudes=False):
         """
         A container for run-time options controls.
@@ -183,6 +184,17 @@ class Future(threading.local):
         encounters a GRIB message which uses a template not supported
         by the conversion.
 
+        .. note::
+            .. deprecated:: 1.10
+            The 'strict_grib_load' option is now deprecated, as it affects
+            only the internal grib module :mod:`iris.fileformats.grib`,
+            which is now itself deprecated in favour of 'iris_grib'.
+            See the "external_grib_support" option.
+
+        The option `external_grib_support` controls whether GRIB files are
+        processed using the 'iris_grib' package, in place of the old iris
+        internal module :mod:`iris.fileformats.grib`.
+
         The option `netcdf_no_unlimited`, when True, changes the
         behaviour of the netCDF saver, such that no dimensions are set to
         unlimited.  The current default is that the leading dimension is
@@ -196,18 +208,26 @@ class Future(threading.local):
         self.__dict__['cell_datetime_objects'] = cell_datetime_objects
         self.__dict__['netcdf_promote'] = netcdf_promote
         self.__dict__['strict_grib_load'] = strict_grib_load
+        self.__dict__['external_grib_support'] = external_grib_support
         self.__dict__['netcdf_no_unlimited'] = netcdf_no_unlimited
         self.__dict__['clip_latitudes'] = clip_latitudes
 
     def __repr__(self):
         msg = ('Future(cell_datetime_objects={}, netcdf_promote={}, '
-               'strict_grib_load={}, netcdf_no_unlimited={}, '
-               'clip_latitudes={})')
+               'strict_grib_load={}, external_grib_support={}, '
+               'netcdf_no_unlimited={}, clip_latitudes={})')
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
-                          self.strict_grib_load, self.netcdf_no_unlimited,
+                          self.strict_grib_load, self.external_grib_support,
+                          self.netcdf_no_unlimited,
                           self.clip_latitudes)
 
+    deprecated_options = ['strict_grib_load']
+
     def __setattr__(self, name, value):
+        if name in self.deprecated_options:
+            msg = ("the 'Future' object property {!r} is now deprecated. "
+                   "Please remove code which uses this.")
+            warn_deprecated(msg.format(name))
         if name not in self.__dict__:
             msg = "'Future' object has no attribute {!r}".format(name)
             raise AttributeError(msg)

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -27,10 +27,6 @@ from iris.io.format_picker import (FileExtension, FormatAgent,
                                    UriProtocol, LeadingLine)
 from . import abf
 from . import um
-try:
-    from . import grib
-except ImportError:
-    grib = None
 from . import name
 from . import netcdf
 from . import nimrod
@@ -70,9 +66,19 @@ FORMAT_AGENT.add_spec(
 # GRIB files.
 #
 def _load_grib(*args, **kwargs):
-    if grib is None:
-        raise RuntimeError('Unable to load GRIB file - the ECMWF '
-                           '`gribapi` package is not installed.')
+    import iris
+    if iris.FUTURE.external_grib_support:
+        import iris_grib as grib
+    else:
+        try:
+            from . import grib
+        except ImportError:
+            grib = None
+
+        if grib is None:
+            raise RuntimeError('Unable to load GRIB file - the ECMWF '
+                               '`gribapi` package is not installed.')
+
     return grib.load_cubes(*args, **kwargs)
 
 

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -27,6 +27,14 @@ from iris.io.format_picker import (FileExtension, FormatAgent,
                                    UriProtocol, LeadingLine)
 from . import abf
 from . import um
+try:
+    import iris_grib as grib
+except ImportError:
+    try:
+        from . import grib
+    except ImportError:
+        grib = None
+
 from . import name
 from . import netcdf
 from . import nimrod
@@ -66,19 +74,9 @@ FORMAT_AGENT.add_spec(
 # GRIB files.
 #
 def _load_grib(*args, **kwargs):
-    import iris
-    if iris.FUTURE.external_grib_support:
-        import iris_grib as grib
-    else:
-        try:
-            from . import grib
-        except ImportError:
-            grib = None
-
-        if grib is None:
-            raise RuntimeError('Unable to load GRIB file - the ECMWF '
-                               '`gribapi` package is not installed.')
-
+    if grib is None:
+        raise RuntimeError('Unable to load GRIB file - the ECMWF '
+                           '`gribapi` package is not installed.')
     return grib.load_cubes(*args, **kwargs)
 
 

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -25,15 +25,6 @@ See also: `ECMWF GRIB API <https://software.ecmwf.int/wiki/display/GRIB/Home>`_.
     the separate package
     `iris_grib <http://https://github.com/SciTools/iris-grib>`_ instead.
 
-    To enable Iris to use iris_grib for all
-    grib file operations, use the :data:`iris.FUTURE` option
-    :data:`iris.FUTURE.external_grib_support`
-
-    .. For example::
-     >>> iris.FUTURE.external_grib_support = True
-     >>> path = tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2'))
-     >>> data = iris.load_cube(path)
-
 """
 
 from __future__ import (absolute_import, division, print_function)
@@ -66,8 +57,7 @@ import iris.fileformats.grib.load_rules
 # Issue a blanket deprecation for this module.
 warn_deprecated(
     "The module iris.fileformats.grib is deprecated since v1.10. "
-    "Please use the separate package 'iris_grib' package, and enable Iris to "
-    "use it by setting iris.FUTURE.external_grib_support=True.")
+    "Please install the package 'iris_grib' package instead.")
 
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -19,6 +19,21 @@ Conversion of cubes to/from GRIB.
 
 See also: `ECMWF GRIB API <https://software.ecmwf.int/wiki/display/GRIB/Home>`_.
 
+.. deprecated:: 1.10
+
+    This module is now deprecated.  For GRIB file support in iris, please use
+    the separate package
+    `iris_grib <http://https://github.com/SciTools/iris-grib>`_ instead.
+
+    To enable Iris to use iris_grib for all
+    grib file operations, use the :data:`iris.FUTURE` option
+    :data:`iris.FUTURE.external_grib_support`
+
+    .. For example::
+     >>> iris.FUTURE.external_grib_support = True
+     >>> path = tests.get_data_path(('GRIB', 'fp_units', 'hours.grib2'))
+     >>> data = iris.load_cube(path)
+
 """
 
 from __future__ import (absolute_import, division, print_function)
@@ -47,6 +62,12 @@ from iris.fileformats.grib import _save_rules
 import iris.fileformats.grib._load_convert
 from iris.fileformats.grib.message import GribMessage
 import iris.fileformats.grib.load_rules
+
+# Issue a blanket deprecation for this module.
+warn_deprecated(
+    "The module iris.fileformats.grib is deprecated since v1.10. "
+    "Please use the separate package 'iris_grib' package, and enable Iris to "
+    "use it by setting iris.FUTURE.external_grib_support=True.")
 
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -247,14 +247,15 @@ def _grib_save(cube, target, append=False, **kwargs):
     # allows the saver to be registered without having `gribapi`
     # installed.
     try:
-        import gribapi
-    except ImportError:
-        raise RuntimeError('Unable to save GRIB file - the ECMWF '
-                           '`gribapi` package is not installed.')
-    if iris.FUTURE.external_grib_support:
         import iris_grib as grib
-    else:
+    except ImportError:
+        try:
+            import gribapi
+        except ImportError:
+            raise RuntimeError('Unable to save GRIB file - the ECMWF '
+                               '`gribapi` package is not installed.')
         from iris.fileformats import grib
+
     return grib.save_grib2(cube, target, append, **kwargs)
 
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -251,7 +251,11 @@ def _grib_save(cube, target, append=False, **kwargs):
     except ImportError:
         raise RuntimeError('Unable to save GRIB file - the ECMWF '
                            '`gribapi` package is not installed.')
-    return iris.fileformats.grib.save_grib2(cube, target, append, **kwargs)
+    if iris.FUTURE.external_grib_support:
+        import iris_grib as grib
+    else:
+        from iris.fileformats import grib
+    return grib.save_grib2(cube, target, append, **kwargs)
 
 
 def _check_init_savers():

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -85,11 +85,16 @@ else:
     GDAL_AVAILABLE = True
 
 try:
-    import gribapi
-except ImportError:
-    GRIB_AVAILABLE = False
-else:
+    import iris_grib
     GRIB_AVAILABLE = True
+    from iris_grib.message import GribMessage
+except ImportError:
+    try:
+        import gribapi
+        GRIB_AVAILABLE = True
+        from iris.fileformats.grib.message import GribMessage
+    except ImportError:
+        GRIB_AVAILABLE = False
 
 try:
     import iris_sample_data
@@ -763,18 +768,6 @@ class GraphicsTest(IrisTest):
             plt.close('all')
 
 
-def _ensure_lazy_import_GribMessage():
-    # Import "GribMessage" only when we really need to, so that the caller can
-    # set "iris.FUTURE.external_grib_support" first to control it.
-    # Without this, our check for deprecation warnings in the examples tests
-    # doesn't work properly.
-    global GribMessage
-    if iris.FUTURE.external_grib_support:
-        from iris_grib.message import GribMessage
-    else:
-        from iris.fileformats.grib.message import GribMessage
-
-
 class TestGribMessage(IrisTest):
 
     def assertGribMessageContents(self, filename, contents):
@@ -789,7 +782,6 @@ class TestGribMessage(IrisTest):
             An iterable of GRIB message keys and expected values.
 
         """
-        _ensure_lazy_import_GribMessage()
         messages = GribMessage.messages_from_filename(filename)
         for message in messages:
             for element in contents:
@@ -815,7 +807,6 @@ class TestGribMessage(IrisTest):
             An iterable of section numbers to ignore during comparison.
 
         """
-        _ensure_lazy_import_GribMessage()
         messages1 = list(GribMessage.messages_from_filename(filename1))
         messages2 = list(GribMessage.messages_from_filename(filename2))
         self.assertEqual(len(messages1), len(messages2))

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -90,7 +90,6 @@ except ImportError:
     GRIB_AVAILABLE = False
 else:
     GRIB_AVAILABLE = True
-    from iris.fileformats.grib.message import GribMessage
 
 try:
     import iris_sample_data
@@ -764,6 +763,18 @@ class GraphicsTest(IrisTest):
             plt.close('all')
 
 
+def _ensure_lazy_import_GribMessage():
+    # Import "GribMessage" only when we really need to, so that the caller can
+    # set "iris.FUTURE.external_grib_support" first to control it.
+    # Without this, our check for deprecation warnings in the examples tests
+    # doesn't work properly.
+    global GribMessage
+    if iris.FUTURE.external_grib_support:
+        from iris_grib.message import GribMessage
+    else:
+        from iris.fileformats.grib.message import GribMessage
+
+
 class TestGribMessage(IrisTest):
 
     def assertGribMessageContents(self, filename, contents):
@@ -778,6 +789,7 @@ class TestGribMessage(IrisTest):
             An iterable of GRIB message keys and expected values.
 
         """
+        _ensure_lazy_import_GribMessage()
         messages = GribMessage.messages_from_filename(filename)
         for message in messages:
             for element in contents:
@@ -803,6 +815,7 @@ class TestGribMessage(IrisTest):
             An iterable of section numbers to ignore during comparison.
 
         """
+        _ensure_lazy_import_GribMessage()
         messages1 = list(GribMessage.messages_from_filename(filename1))
         messages2 = list(GribMessage.messages_from_filename(filename2))
         self.assertEqual(len(messages1), len(messages2))

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -38,10 +38,16 @@ from iris.util import is_regular
 
 # gribapi is an optional dependency
 try:
+    # Try to load new independent 'iris_grib' module.
+    from iris_grib import load_pairs_from_fields
+    from iris_grib.message import GribMessage
+except ImportError:
+    # Try to load old inbuilt module instead (N.B. also requires gribapi).
     import gribapi
     from iris.fileformats.grib import load_pairs_from_fields
     from iris.fileformats.grib.message import GribMessage
 except ImportError:
+    # Failed : ought to be okay anyway as it will skip the tests below.
     pass
 
 

--- a/lib/iris/tests/results/integration/grib2/TestGDT40/reduced.cml
+++ b/lib/iris/tests/results/integration/grib2/TestGDT40/reduced.cml
@@ -12,8 +12,8 @@
         <dimCoord id="9c8bdf81" points="[377688.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="37a3e9a4" points="[88.572168514, 88.572168514, 88.572168514, ...,
-		-88.572168514, -88.572168514, -88.572168514]" shape="(13280,)" standard_name="latitude" units="Unit('degrees_north')" value_type="float64">
+        <auxCoord id="77a50eb5" points="[88.572168514, 88.572168514, 88.572168514, ...,
+		-88.572168514, -88.572168514, -88.572168514]" shape="(13280,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
           <geogCS earth_radius="6371229.0"/>
         </auxCoord>
       </coord>
@@ -21,7 +21,7 @@
         <dimCoord id="c9091dc6" long_name="level_pressure" points="[2.00004005432]" shape="(1,)" units="Unit('Pa')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="ddf5ffb8" points="[0.0, 18.0, 36.0, ..., 306.0, 324.0, 342.0]" shape="(13280,)" standard_name="longitude" units="Unit('degrees_east')" value_type="float64">
+        <auxCoord id="f913a8b3" points="[0.0, 18.0, 36.0, ..., 306.0, 324.0, 342.0]" shape="(13280,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
           <geogCS earth_radius="6371229.0"/>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/results/integration/grib2/TestGDT40/regular.cml
+++ b/lib/iris/tests/results/integration/grib2/TestGDT40/regular.cml
@@ -9,13 +9,13 @@
         <dimCoord id="9c8bdf81" points="[382320.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="37a3e9a4" points="[88.572168514, 86.7225309547, 84.861970292, ...,
-		-84.861970292, -86.7225309547, -88.572168514]" shape="(96,)" standard_name="latitude" units="Unit('degrees_north')" value_type="float64">
+        <dimCoord id="77a50eb5" points="[88.572168514, 86.7225309547, 84.861970292, ...,
+		-84.861970292, -86.7225309547, -88.572168514]" shape="(96,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord circular="True" id="ddf5ffb8" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees_east')" value_type="float64">
+        <dimCoord circular="True" id="f913a8b3" points="[0.0, 1.875, 3.75, ..., 354.375, 356.25, 358.125]" shape="(192,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
       </coord>


### PR DESCRIPTION
Will not check out until we actually have a functional "iris_grib".
Even then the examples need a further tweak.

Closes #2019