### PR TITLE
Add GRIB product definition template 40

### DIFF
--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -1757,9 +1757,17 @@ def product_definition_template_0(section, metadata, rt_coord):
     data_cutoff(section['hoursAfterDataCutoff'],
                 section['minutesAfterDataCutoff'])
 
+    if 'forecastTime' in section.keys():
+        forecast_time = section['forecastTime']
+    # The gribapi encodes the forecast time as 'startStep' for pdt 4.4x;
+    # product_definition_template_40 makes use of this function. The
+    # following will be removed once the suspected bug is fixed.
+    elif 'startStep' in section.keys():
+        forecast_time = section['startStep']
+
     # Calculate the forecast period coordinate.
     fp_coord = forecast_period_coord(section['indicatorOfUnitOfTimeRange'],
-                                     section['forecastTime'])
+                                     forecast_time)
     # Add the forecast period coordinate to the metadata aux coords.
     metadata['aux_coords_and_dims'].append((fp_coord, None))
 
@@ -2002,6 +2010,35 @@ def product_definition_template_31(section, metadata, rt_coord):
         metadata['aux_coords_and_dims'].append((rt_coord, None))
 
 
+def product_definition_template_40(section, metadata, frt_coord):
+    """
+    Translate template representing an analysis or forecast at a horizontal
+    level or in a horizontal layer at a point in time for atmospheric chemical
+    constituents.
+
+    Updates the metadata in-place with the translations.
+
+    Args:
+
+    * section:
+        Dictionary of coded key/value pairs from section 4 of the message.
+
+    * metadata:
+        :class:`collectins.OrderedDict` of metadata.
+
+    * frt_coord:
+        The scalar forecast reference time :class:`iris.coords.DimCoord`.
+
+    """
+    # Perform identical message processing.
+    product_definition_template_0(section, metadata, frt_coord)
+
+    constituent_type = section['constituentType']
+
+    # Add the constituent type as  an attribute.
+    metadata['attributes']['WMO_constituent_type'] = constituent_type
+
+
 def product_definition_section(section, metadata, discipline, tablesVersion,
                                rt_coord):
     """
@@ -2051,6 +2088,8 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
     elif template == 31:
         # Process satellite product.
         product_definition_template_31(section, metadata, rt_coord)
+    elif template == 40:
+        product_definition_template_40(section, metadata, rt_coord)
     else:
         msg = 'Product definition template [{}] is not ' \
             'supported'.format(template)

--- a/lib/iris/fileformats/grib/_save_rules.py
+++ b/lib/iris/fileformats/grib/_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -973,6 +973,22 @@ def _product_definition_template_8_and_11(cube, grib):
     set_time_increment(cell_method, grib)
 
 
+def product_definition_template_40(cube, grib):
+    """
+    Set keys within the provided grib message based on Product
+    Definition Template 4.40.
+
+    Template 4.40 is used to represent an analysis or forecast at a horizontal
+    level or in a horizontal layer at a point in time for atmospheric chemical
+    constituents.
+
+    """
+    gribapi.grib_set(grib, "productDefinitionTemplateNumber", 40)
+    product_definition_template_common(cube, grib)
+    constituent_type = cube.attributes['WMO_constituent_type']
+    gribapi.grib_set(grib, "constituentType", constituent_type)
+
+
 def product_definition_section(cube, grib):
     """
     Set keys within the product definition section of the provided
@@ -980,8 +996,12 @@ def product_definition_section(cube, grib):
 
     """
     if not cube.coord("time").has_bounds():
-        # forecast (template 4.0)
-        product_definition_template_0(cube, grib)
+        if 'WMO_constituent_type' in cube.attributes:
+            # forecast for atmospheric chemical constiuent (template 4.40)
+            product_definition_template_40(cube, grib)
+        else:
+            # forecast (template 4.0)
+            product_definition_template_0(cube, grib)
     elif _cube_is_time_statistic(cube):
         if cube.coords('realization'):
             # time processed (template 4.11)

--- a/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_40.py
+++ b/lib/iris/tests/unit/fileformats/grib/load_convert/test_product_definition_template_40.py
@@ -1,0 +1,63 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function
+:func:`iris.fileformats.grib._load_convert.product_definition_template_40`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import iris.coords
+from iris.fileformats.grib._load_convert import product_definition_template_40
+from iris.tests.unit.fileformats.grib.load_convert import empty_metadata
+
+
+MDI = 0xffffffff
+
+
+def section_4():
+    return {'hoursAfterDataCutoff': MDI,
+            'minutesAfterDataCutoff': MDI,
+            'constituentType': 1,
+            'indicatorOfUnitOfTimeRange': 0,  # minutes
+            'startStep': 360,
+            'NV': 0,
+            'typeOfFirstFixedSurface': 103,
+            'scaleFactorOfFirstFixedSurface': 0,
+            'scaledValueOfFirstFixedSurface': 9999,
+            'typeOfSecondFixedSurface': 255}
+
+
+class Test(tests.IrisTest):
+    def test_constituent_type(self):
+        metadata = empty_metadata()
+        rt_coord = iris.coords.DimCoord(24, 'forecast_reference_time',
+                                        units='hours since epoch')
+        product_definition_template_40(section_4(), metadata, rt_coord)
+        expected = empty_metadata()
+        expected['attributes']['WMO_constituent_type'] = 1
+        self.assertEqual(metadata['attributes'], expected['attributes'])
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_40.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_product_definition_template_40.py
@@ -1,0 +1,61 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for
+:func:`iris.fileformats.grib._save_rules.product_definition_template_40`
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from cf_units import Unit
+import gribapi
+
+from iris.coords import DimCoord
+from iris.tests import mock
+import iris.tests.stock as stock
+from iris.fileformats.grib._save_rules import product_definition_template_40
+
+
+class TestChemicalConstituentIdentifier(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.lat_lon_cube()
+        # Rename cube to avoid warning about unknown discipline/parameter.
+        self.cube.rename('atmosphere_mole_content_of_ozone')
+        coord = DimCoord(24, 'time',
+                         units=Unit('days since epoch', calendar='standard'))
+        self.cube.add_aux_coord(coord)
+        self.cube.attributes['WMO_constituent_type'] = 0
+
+    @mock.patch.object(gribapi, 'grib_set')
+    def test_constituent_type(self, mock_set):
+        cube = self.cube
+
+        product_definition_template_40(cube, mock.sentinel.grib)
+        mock_set.assert_any_call(mock.sentinel.grib,
+                                 "productDefinitionTemplateNumber", 40)
+        mock_set.assert_any_call(mock.sentinel.grib,
+                                 "constituentType", 0)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This adds support for product definition template 40.

The only difference between pdt 0 and 40 is the inclusion of "constituent type". 

Grib does have a mapping for the constituent type value (e.g. 0 is ozone) but for now this mapping hasn't been implemented. Instead this PR just sets the value as an attribute of the cube.

Saving to pdt 40 to come in the next commit...