### PR TITLE
Fix concatenation with singleton dimensions

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -742,6 +742,17 @@ class _ProtoCube(object):
             # Declare the nominated axis of concatenation.
             self._axis = candidate_axis
 
+        if match:
+            # If the protocube dimension order is constant (indicating it was
+            # created from a cube with a length 1 dimension coordinate) but
+            # a subsequently registered cube has a non-constant dimension
+            # order we should use that instead of _CONSTANT to make sure all
+            # the ordering checks and sorts work as expected.
+            existing_order = self._coord_signature.dim_order[self.axis]
+            this_order = coord_signature.dim_order[self.axis]
+            if existing_order == _CONSTANT and this_order != _CONSTANT:
+                self._coord_signature.dim_order[self.axis] = this_order
+
         return match
 
     def _add_skeleton(self, coord_signature, data):

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -194,6 +194,30 @@ class TestOrder(tests.IrisTest):
         result = concatenate([top, bottom])
         self.assertEqual(len(result), 1)
 
+    def test_asc_points_with_singleton_ordered(self):
+        top = self._make_cube([5])
+        bottom = self._make_cube([15, 25])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_asc_points_with_singleton_unordered(self):
+        top = self._make_cube([25])
+        bottom = self._make_cube([5, 15])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_asc_bounds_with_singleton_ordered(self):
+        top = self._make_cube([5], [[0, 10]])
+        bottom = self._make_cube([15, 25], [[10, 20], [20, 30]])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_asc_bounds_with_singleton_unordered(self):
+        top = self._make_cube([25], [[20, 30]])
+        bottom = self._make_cube([5, 15], [[0, 10], [10, 20]])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
     def test_desc_points(self):
         top = self._make_cube([90, 70, 50, 30, 10])
         bottom = self._make_cube([-10, -30, -50, -70, -90])
@@ -205,6 +229,57 @@ class TestOrder(tests.IrisTest):
         bottom = self._make_cube([-22.5, -67.5], [[0, -45], [-45, -90]])
         result = concatenate([top, bottom])
         self.assertEqual(len(result), 1)
+
+    def test_desc_points_with_singleton_ordered(self):
+        top = self._make_cube([25])
+        bottom = self._make_cube([15, 5])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_desc_points_with_singleton_unordered(self):
+        top = self._make_cube([5])
+        bottom = self._make_cube([25, 15])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_desc_bounds_with_singleton_ordered(self):
+        top = self._make_cube([25], [[30, 20]])
+        bottom = self._make_cube([15, 5], [[20, 10], [10, 0]])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_desc_bounds_with_singleton_unordered(self):
+        top = self._make_cube([5], [[10, 0]])
+        bottom = self._make_cube([25, 15], [[30, 20], [20, 10]])
+        result = concatenate([top, bottom])
+        self.assertEqual(len(result), 1)
+
+    def test_points_all_singleton(self):
+        top = self._make_cube([5])
+        bottom = self._make_cube([15])
+        result1 = concatenate([top, bottom])
+        result2 = concatenate([bottom, top])
+        self.assertEqual(len(result1), 1)
+        self.assertEqual(len(result2), 1)
+        self.assertEqual(result1, result2)
+
+    def test_asc_bounds_all_singleton(self):
+        top = self._make_cube([5], [0, 10])
+        bottom = self._make_cube([15], [10, 20])
+        result1 = concatenate([top, bottom])
+        result2 = concatenate([bottom, top])
+        self.assertEqual(len(result1), 1)
+        self.assertEqual(len(result2), 1)
+        self.assertEqual(result1, result2)
+
+    def test_desc_bounds_all_singleton(self):
+        top = self._make_cube([5], [10, 0])
+        bottom = self._make_cube([15], [20, 10])
+        result1 = concatenate([top, bottom])
+        result2 = concatenate([bottom, top])
+        self.assertEqual(len(result1), 1)
+        self.assertEqual(len(result2), 1)
+        self.assertEqual(result1, result2)
 
 
 class TestConcatenateBiggus(tests.IrisTest):


### PR DESCRIPTION
This PR fixes a bug reported in #2021. The problem arises when we concatenate a list of cubes where the first one has a singleton dimension and one of the others doesn't. The dimension ordering determined by the `_ProtoCube` would be based only on the first cube, and be set to `_CONSTANT`. This later implies sorting coordinate points in ascending order, which is only correct if the non-singleton dimension is ascending.

This PR addresses the issue by ensuring a `_ProtoCube` with a `_CONSTANT` dimension order checks the dimension order of subsequently registered cubes and chooses the first non-constant one it finds for the dimension order. This ultimately ensures that the sorting is done in the correct order and the cubes will concatenate as expected.