### PR TITLE
Add support for loading NetCDF files with Mercator projections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="b7cde63a73a4762a09acf356db9901e9b9305508"
+  - export IRIS_TEST_DATA_REF="1f5ee1e51175103c4a668570f268b9aeec6a5a47"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="e292fc4ef99b0664de726774684dbeff56531b63"

--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-24_add_mercator_projection.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-24_add_mercator_projection.txt
@@ -1,0 +1,2 @@
+* The Mercator projection is now supported with defaults for some parameters (_false easting_, _false northing_ and _scale factor at projection origin_).
+* NetCDF files which define a Mercator projection where the _false easting_, _false northing_ and _scale factor at projection origin_ match the defaults will have the projection loaded correctly. Otherwise, a warning will be issued for each parameter that does not match the default and the projection will not be loaded.

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -817,6 +817,53 @@ class LambertConformal(CoordSystem):
             false_easting=self.false_easting,
             false_northing=self.false_northing,
             globe=globe, cutoff=cutoff, **conic_position)
+
+    def as_cartopy_projection(self):
+        return self.as_cartopy_crs()
+
+
+class Mercator(CoordSystem):
+    """
+    A coordinate system in the Mercator projection.
+
+    """
+
+    grid_mapping_name = "mercator"
+
+    def __init__(self, longitude_of_projection_origin=0, ellipsoid=None):
+        """
+        Constructs a Mercator coord system.
+
+        Args:
+
+            * longitude_of_projection_origin
+                    True longitude of planar origin in degrees.
+
+        Kwargs:
+
+            * ellipsoid
+                    :class:`GeogCS` defining the ellipsoid.
+
+        """
+
+        #: True longitude of planar origin in degrees.
+        self.longitude_of_projection_origin = longitude_of_projection_origin
+        #: Ellipsoid definition.
+        self.ellipsoid = ellipsoid
+
+    def __repr__(self):
+        res = "Mercator(longitude_of_projection_origin={!r}, ellipsoid={!r})"
+        return res.format(self.longitude_of_projection_origin, self.ellipsoid)
+
+    def as_cartopy_crs(self):
+        if self.ellipsoid is not None:
+            globe = self.ellipsoid.as_cartopy_globe()
+        else:
+            globe = ccrs.Globe()
+
+        return ccrs.Mercator(
+            central_longitude=self.longitude_of_projection_origin,
+            globe=globe)
 
     def as_cartopy_projection(self):
         return self.as_cartopy_crs()

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2012, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -96,6 +96,25 @@ fc_provides_grid_mapping_transverse_mercator
         facts_cf.provides(coordinate_system, transverse_mercator)
         python engine.rule_triggered.add(rule.name)
 
+#
+# Context:
+#   This rule will trigger iff a grid_mapping() case specific fact
+#   has been asserted that refers to a Mercator.
+#
+# Purpose:
+#   Creates the Mercator coordinate system.
+#
+fc_provides_grid_mapping_mercator
+    foreach
+        facts_cf.grid_mapping($grid_mapping)
+        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_MERCATOR)
+        check has_supported_mercator_parameters(engine, $grid_mapping)
+    assert
+        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
+        python coordinate_system = build_mercator_coordinate_system(engine, cf_grid_var)
+        python engine.provides['coordinate_system'] = coordinate_system
+        facts_cf.provides(coordinate_system, mercator)
+        python engine.rule_triggered.add(rule.name)
 #
 # Context:
 #   This rule will trigger iff a coordinate() case specific fact
@@ -540,6 +559,45 @@ fc_build_coordinate_projection_y_transverse_mercator
 
 #
 # Context:
+#   This rule will trigger iff a projection_x_coordinate coordinate exists and
+#   a Mercator coordinate system exists.
+#
+# Purpose:
+#   Add the projection_x_coordinate coordinate into the cube.
+#
+fc_build_coordinate_projection_x_mercator
+    foreach
+        facts_cf.provides(coordinate, projection_x_coordinate, $coordinate)
+        facts_cf.provides(coordinate_system, mercator)
+    assert
+        python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
+        python build_dimension_coordinate(engine, cf_coord_var,
+                                          coord_name=CF_VALUE_STD_NAME_PROJ_X,
+                                          coord_system=engine.provides['coordinate_system'])
+        python engine.rule_triggered.add(rule.name)
+
+
+#
+# Context:
+#   This rule will trigger iff a projection_y_coordinate coordinate exists and
+#   a Mercator coordinate system exists.
+#
+# Purpose:
+#   Add the projection_y_coordinate coordinate into the cube.
+#
+fc_build_coordinate_projection_y_mercator
+    foreach
+        facts_cf.provides(coordinate, projection_y_coordinate, $coordinate)
+        facts_cf.provides(coordinate_system, mercator)
+    assert
+        python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
+        python build_dimension_coordinate(engine, cf_coord_var,
+                                          coord_name=CF_VALUE_STD_NAME_PROJ_Y,
+                                          coord_system=engine.provides['coordinate_system'])
+        python engine.rule_triggered.add(rule.name)
+
+#
+# Context:
 #   This rule will trigger iff a CF time coordinate exists.
 #
 # Purpose:
@@ -847,6 +905,7 @@ fc_extras
     CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN = 'scale_factor_at_projection_origin'
     CF_ATTR_GRID_SCALE_FACTOR_AT_CENT_MERIDIAN = 'scale_factor_at_central_meridian'
     CF_ATTR_GRID_LON_OF_CENT_MERIDIAN = 'longitude_of_central_meridian'
+    CF_ATTR_GRID_STANDARD_PARALLEL = 'standard_parallel'
     CF_ATTR_POSITIVE = 'positive'
     CF_ATTR_STD_NAME = 'standard_name'
     CF_ATTR_LONG_NAME = 'long_name'
@@ -1028,6 +1087,35 @@ fc_extras
             latitude_of_projection_origin, longitude_of_central_meridian,
             false_easting, false_northing, scale_factor_at_central_meridian,
             ellipsoid)
+
+        return cs
+
+
+    ################################################################################
+    def build_mercator_coordinate_system(engine, cf_grid_var):
+        """
+        Create a Mercator coordinate system from the CF-netCDF
+        grid mapping variable.
+
+        """
+        major, minor, inverse_flattening = _get_ellipsoid(cf_grid_var)
+
+        longitude_of_projection_origin = getattr(
+            cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        # Iris currently only supports Mercator projections with specific
+        # values for false_easting, false_northing,
+        # scale_factor_at_projection_origin and standard_parallel. These are
+        # checked elsewhere.
+      
+        ellipsoid = None
+        if major is not None or minor is not None or \
+                inverse_flattening is not None:
+            ellipsoid = iris.coord_systems.GeogCS(major, minor,
+                                                  inverse_flattening)
+
+        cs = iris.coord_systems.Mercator(
+            longitude_of_projection_origin,
+            ellipsoid=ellipsoid)
 
         return cs
 
@@ -1546,6 +1634,47 @@ fc_extras
     def is_rotated_longitude(engine, cf_name):
         """Determine whether the CF coordinate variable is rotated longitude."""
         return _is_rotated(engine, cf_name, CF_VALUE_STD_NAME_GRID_LON)
+
+
+    ################################################################################
+    def has_supported_mercator_parameters(engine, cf_name):
+        """Determine whether the CF grid mapping variable has the supported
+        values for the parameters of the Mercator projection."""
+        
+        is_valid = True
+        cf_grid_var = engine.cf_var.cf_group[cf_name]
+
+        false_easting = getattr(
+            cf_grid_var, CF_ATTR_GRID_FALSE_EASTING, None)
+        false_northing = getattr(
+            cf_grid_var, CF_ATTR_GRID_FALSE_NORTHING, None)
+        scale_factor_at_projection_origin = getattr(
+            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
+        standard_parallel = getattr(
+            cf_grid_var, CF_ATTR_GRID_STANDARD_PARALLEL, None)
+
+        if false_easting is not None and \
+                false_easting != 0:
+            warnings.warn('False eastings other than 0.0 not yet supported '
+                          'for Mercator projections')
+            is_valid = False
+        if false_northing is not None and \
+                false_northing != 0:
+            warnings.warn('False northings other than 0.0 not yet supported '
+                          'for Mercator projections')
+            is_valid = False
+        if scale_factor_at_projection_origin is not None and \
+                scale_factor_at_projection_origin != 1:
+            warnings.warn('Scale factors other than 1.0 not yet supported for '
+                          'Mercator projections')
+            is_valid = False
+        if standard_parallel is not None and \
+                standard_parallel != 0:
+            warnings.warn('Standard parallels other than 0.0 not yet '
+                          'supported for Mercator projections')
+            is_valid = False
+
+        return is_valid
 
 
     ################################################################################

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1538,6 +1538,18 @@ class Saver(object):
                     cf_var_grid.scale_factor_at_central_meridian = (
                         cs.scale_factor_at_central_meridian)
 
+                # merc
+                elif isinstance(cs, iris.coord_systems.Mercator):
+                    if cs.ellipsoid:
+                        add_ellipsoid(cs.ellipsoid)
+                    cf_var_grid.longitude_of_projection_origin = (
+                        cs.longitude_of_projection_origin)
+                    # The Mercator class has implicit defaults for certain
+                    # parameters
+                    cf_var_grid.false_easting = 0.0
+                    cf_var_grid.false_northing = 0.0
+                    cf_var_grid.scale_factor_at_projection_origin = 1.0
+
                 # osgb (a specific tmerc)
                 elif isinstance(cs, iris.coord_systems.OSGB):
                     warnings.warn('OSGB coordinate system not yet handled')

--- a/lib/iris/tests/results/coord_systems/Mercator.xml
+++ b/lib/iris/tests/results/coord_systems/Mercator.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<mercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" longitude_of_projection_origin="90.0"/>

--- a/lib/iris/tests/results/netcdf/netcdf_merc.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_merc.cml
@@ -1,0 +1,74 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="Note" value="This dataset is for test purposes only"/>
+      <attribute name="acknowledgement" value="EUMETSAT"/>
+      <attribute name="creator_email" value="sat_systems@metoffice.gov.uk"/>
+      <attribute name="creator_name" value="Satellite Applications, Met Office"/>
+      <attribute name="creator_type" value="group"/>
+      <attribute name="geospatial_lat_max" value="0.0"/>
+      <attribute name="geospatial_lat_min" value="0.0"/>
+      <attribute name="geospatial_lon_max" value="0.0"/>
+      <attribute name="geospatial_lon_min" value="0.0"/>
+      <attribute name="history" value="Created: 2016-05-23T09:40:00Z"/>
+      <attribute name="institution" value="Met Office, UK"/>
+      <attribute name="instrument" value="SEVIRI"/>
+      <attribute name="keywords" value="Infra-red, brightness temperature, MSG, SEVIRI"/>
+      <attribute name="platform" value="MSG"/>
+      <attribute name="source" value="EUMETSAT"/>
+      <attribute name="standard_name_vocabulary" value="CF Standard Name Table v27"/>
+      <attribute name="summary" value="Infra-red channel top of atmosphere brightness temperature, central wavelength of 10.80 microns, Mercator projection"/>
+      <attribute name="title" value="TOA brightness temperature, 10.80 micron (MSG)"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0, 1]">
+        <auxCoord id="4a0cb9d8" points="[[42.0, 42.0, 42.0, ..., 42.0, 42.0, 42.0],
+		[41.6396, 41.6396, 41.6396, ..., 41.6396,
+ 		41.6396, 41.6396],
+		[41.2772, 41.2772, 41.2772, ..., 41.2772,
+ 		41.2772, 41.2772],
+		..., 
+		[-41.0039, -41.0039, -41.0039, ..., -41.0039,
+ 		-41.0039, -41.0039],
+		[-41.3678, -41.3678, -41.3678, ..., -41.3678,
+ 		-41.3678, -41.3678],
+		[-41.7297, -41.7297, -41.7297, ..., -41.7297,
+ 		-41.7297, -41.7297]]" shape="(192, 192)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="lat"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="62e940e0" points="[[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993],
+		[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993],
+		[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993],
+		..., 
+		[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993],
+		[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993],
+		[-46.362, -45.8784, -45.3949, ..., 45.0322,
+ 		45.5158, 45.9993]]" shape="(192, 192)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="lon"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="a2415886" points="[-5.16102e+06, -5.10719e+06, -5.05336e+06, ...,
+		5.01299e+06, 5.06682e+06, 5.12065e+06]" shape="(192,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float32" var_name="x">
+          <mercator ellipsoid="GeogCS(6378169.0)" longitude_of_projection_origin="0.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="41466ff9" points="[5.16101e+06, 5.10718e+06, 5.05335e+06, ...,
+		-5.01294e+06, -5.06678e+06, -5.12061e+06]" shape="(192,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float32" var_name="y">
+          <mercator ellipsoid="GeogCS(6378169.0)" longitude_of_projection_origin="0.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="cb784457" points="[406500.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float32" var_name="time"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x4fd67588" dtype="float32" shape="(192, 192)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator.cdl
@@ -1,0 +1,25 @@
+dimensions:
+	projection_y_coordinate = UNLIMITED ; // (3 currently)
+	projection_x_coordinate = 4 ;
+variables:
+	int64 air_pressure_anomaly(projection_y_coordinate, projection_x_coordinate) ;
+		air_pressure_anomaly:standard_name = "air_pressure_anomaly" ;
+		air_pressure_anomaly:grid_mapping = "mercator" ;
+	int mercator ;
+		mercator:grid_mapping_name = "mercator" ;
+		mercator:longitude_of_prime_meridian = 0. ;
+		mercator:semi_major_axis = 6377563.396 ;
+		mercator:semi_minor_axis = 6356256.909 ;
+		mercator:longitude_of_projection_origin = 49. ;
+		mercator:false_easting = 0. ;
+		mercator:false_northing = 0. ;
+		mercator:scale_factor_at_projection_origin = 1. ;
+	int64 projection_y_coordinate(projection_y_coordinate) ;
+		projection_y_coordinate:axis = "Y" ;
+		projection_y_coordinate:units = "m" ;
+		projection_y_coordinate:standard_name = "projection_y_coordinate" ;
+	int64 projection_x_coordinate(projection_x_coordinate) ;
+		projection_x_coordinate:axis = "X" ;
+		projection_x_coordinate:units = "m" ;
+		projection_x_coordinate:standard_name = "projection_x_coordinate" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator_no_ellipsoid.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator_no_ellipsoid.cdl
@@ -1,0 +1,22 @@
+dimensions:
+	projection_y_coordinate = UNLIMITED ; // (3 currently)
+	projection_x_coordinate = 4 ;
+variables:
+	int64 air_pressure_anomaly(projection_y_coordinate, projection_x_coordinate) ;
+		air_pressure_anomaly:standard_name = "air_pressure_anomaly" ;
+		air_pressure_anomaly:grid_mapping = "mercator" ;
+	int mercator ;
+		mercator:grid_mapping_name = "mercator" ;
+		mercator:longitude_of_projection_origin = 49. ;
+		mercator:false_easting = 0. ;
+		mercator:false_northing = 0. ;
+		mercator:scale_factor_at_projection_origin = 1. ;
+	int64 projection_y_coordinate(projection_y_coordinate) ;
+		projection_y_coordinate:axis = "Y" ;
+		projection_y_coordinate:units = "m" ;
+		projection_y_coordinate:standard_name = "projection_y_coordinate" ;
+	int64 projection_x_coordinate(projection_x_coordinate) ;
+		projection_x_coordinate:axis = "X" ;
+		projection_x_coordinate:units = "m" ;
+		projection_x_coordinate:standard_name = "projection_x_coordinate" ;
+}

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -43,6 +43,9 @@ def osgb():
                               scale_factor_at_central_meridian=0.9996012717,
                               ellipsoid=GeogCS(6377563.396, 6356256.909))
 
+def merc():
+    return Mercator(longitude_of_projection_origin=90.0,
+                    ellipsoid=GeogCS(6377563.396, 6356256.909))
 
 class TestCoordSystemLookup(tests.IrisTest):
     def setUp(self):
@@ -320,6 +323,59 @@ class Test_LambertConformal(tests.GraphicsTest):
         lcc = LambertConformal(0, 0, secant_latitudes=(-30, -60))
         ccrs = lcc.as_cartopy_crs()
         self.assertEqual(ccrs.cutoff, 30)
+
+
+class Test_Mercator_construction(tests.IrisTest):
+    def test_merc(self):
+        tm = merc()
+        self.assertXMLElement(tm, ("coord_systems", "Mercator.xml"))
+
+
+class Test_Mercator_repr(tests.IrisTest):
+    def test_merc(self):
+        tm = merc()
+        expected = "Mercator(longitude_of_projection_origin=90.0, "\
+                   "ellipsoid=GeogCS(semi_major_axis=6377563.396, "\
+                   "semi_minor_axis=6356256.909))"
+        self.assertEqual(expected, repr(tm))
+
+
+class Test_Mercator_as_cartopy_crs(tests.IrisTest):
+    def test_as_cartopy_crs(self):
+        longitude_of_projection_origin = 90.0
+        ellipsoid = GeogCS(semi_major_axis=6377563.396,
+                           semi_minor_axis=6356256.909)
+
+        merc_cs = Mercator(
+            longitude_of_projection_origin,
+            ellipsoid=ellipsoid)
+
+        expected = ccrs.Mercator(
+            central_longitude=longitude_of_projection_origin,
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
+
+        res = merc_cs.as_cartopy_crs()
+        self.assertEqual(res, expected)
+
+
+class Test_Mercator_as_cartopy_projection(tests.IrisTest):
+    def test_as_cartopy_projection(self):
+        longitude_of_projection_origin = 90.0
+        ellipsoid = GeogCS(semi_major_axis=6377563.396,
+                           semi_minor_axis=6356256.909)
+
+        merc_cs = Mercator(
+            longitude_of_projection_origin,
+            ellipsoid=ellipsoid)
+
+        expected = ccrs.Mercator(
+            central_longitude=longitude_of_projection_origin,
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
+
+        res = merc_cs.as_cartopy_projection()
+        self.assertEqual(res, expected)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -165,6 +165,13 @@ class TestNetCDFLoad(tests.IrisTest):
             dataset.close()
             cube = iris.load_cube(filename, 'Mean temperature')
 
+    def test_load_merc_grid(self):
+        # Test loading a single CF-netCDF file with a Mercator grid_mapping
+        cube = iris.load_cube(
+            tests.get_data_path(('NetCDF', 'mercator',
+                                 'toa_brightness_temperature.nc')))
+        self.assertCML(cube, ('netcdf', 'netcdf_merc.cml'))
+
     def test_cell_methods(self):
         # Test exercising CF-netCDF cell method parsing.
         cubes = iris.load(tests.get_data_path(('NetCDF', 'testing',

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_mercator_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_mercator_coordinate_system.py
@@ -1,0 +1,76 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.build_mercator_coordinate_system`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.coord_systems import Mercator
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    build_mercator_coordinate_system
+from iris.tests import mock
+
+
+class TestBuildMercatorCoordinateSystem(tests.IrisTest):
+    def test_valid(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=-90,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+
+        cs = build_mercator_coordinate_system(None, cf_grid_var)
+
+        expected = Mercator(
+            longitude_of_projection_origin=(
+                cf_grid_var.longitude_of_projection_origin),
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                cf_grid_var.semi_minor_axis))
+        self.assertEqual(cs, expected)
+
+    def test_inverse_flattening(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=-90,
+            semi_major_axis=6377563.396,
+            inverse_flattening=299.3249646)
+
+        cs = build_mercator_coordinate_system(None, cf_grid_var)
+
+        expected = Mercator(
+            longitude_of_projection_origin=(
+                cf_grid_var.longitude_of_projection_origin),
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                inverse_flattening=cf_grid_var.inverse_flattening))
+        self.assertEqual(cs, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
@@ -1,0 +1,151 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.has_supported_mercator_parameters`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import warnings
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    has_supported_mercator_parameters
+from iris.tests import mock
+
+
+def _engine(cf_grid_var, cf_name):
+    cf_group = {cf_name: cf_grid_var}
+    cf_var = mock.Mock(cf_group=cf_group)
+    return mock.Mock(cf_var=cf_var)
+
+
+class TestHasSupportedMercatorParameters(tests.IrisTest):
+
+    def test_valid(self):
+        cf_name = 'mercator'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=-90,
+            false_easting=0,
+            false_northing=0,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertTrue(is_valid)
+
+    def test_invalid_scale_factor(self):
+        # Iris does not yet support scale factors other than one for
+        # Mercator projections
+        cf_name = 'mercator'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=0,
+            false_easting=0,
+            false_northing=0,
+            scale_factor_at_projection_origin=0.9,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(len(warns), 1)
+        self.assertRegexpMatches(str(warns[0]), 'Scale factor')
+
+    def test_invalid_standard_parallel(self):
+        # Iris does not yet support standard parallels other than zero for
+        # Mercator projections
+        cf_name = 'mercator'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=0,
+            false_easting=0,
+            false_northing=0,
+            standard_parallel=30,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(len(warns), 1)
+        self.assertRegexpMatches(str(warns[0]), 'Standard parallel')
+
+    def test_invalid_false_easting(self):
+        # Iris does not yet support false eastings other than zero for
+        # Mercator projections
+        cf_name = 'mercator'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=0,
+            false_easting=100,
+            false_northing=0,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(len(warns), 1)
+        self.assertRegexpMatches(str(warns[0]), 'False easting')
+
+    def test_invalid_false_northing(self):
+        # Iris does not yet support false northings other than zero for
+        # Mercator projections
+        cf_name = 'mercator'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=0,
+            false_easting=0,
+            false_northing=100,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(len(warns), 1)
+        self.assertRegexpMatches(str(warns[0]), 'False northing')
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This change supports loading and saving NetCDF files with a Mercator projection with some parameters restricted (`false_easting == false_northing == 0, scale_factor_at_projection_origin == 1`). This allows some support for Mercator projections without needing to modify Cartopy.

This pull request requires additional test data (https://github.com/SciTools/iris-test-data/pull/42).

 