### PR TITLE
Coord system not added to horizontal aux coords

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -265,16 +265,21 @@ fc_build_auxiliary_coordinate_latitude
         facts_cf.auxiliary_coordinate($coordinate)
         check is_latitude(engine, $coordinate)
         check not is_rotated_latitude(engine, $coordinate)
+        facts_cf.grid_mapping($grid_mapping)
+        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_LAT_LON)
     assert
         python cf_coord_var = engine.cf_var.cf_group.auxiliary_coordinates[$coordinate]
+        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
+        python coordinate_system = build_coordinate_system(cf_grid_var)
         python build_auxiliary_coordinate(engine, cf_coord_var,
-                                          coord_name=CF_VALUE_STD_NAME_LAT)
+                                          coord_name=CF_VALUE_STD_NAME_LAT,
+                                          coord_system=coordinate_system)
         python engine.rule_triggered.add(rule.name)
 
 
 #
 # Context:
-#   This rule will trigger iff an auxiliary_coordiante() case specific fact
+#   This rule will trigger iff an auxiliary_coordinate() case specific fact
 #   has been asserted that refers to rotated pole latitude data.
 #
 # Purpose:
@@ -305,10 +310,15 @@ fc_build_auxiliary_coordinate_longitude
         facts_cf.auxiliary_coordinate($coordinate)
         check is_longitude(engine, $coordinate)
         check not is_rotated_longitude(engine, $coordinate)
+        facts_cf.grid_mapping($grid_mapping)
+        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_LAT_LON)
     assert
         python cf_coord_var = engine.cf_var.cf_group.auxiliary_coordinates[$coordinate]
+        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
+        python coordinate_system = build_coordinate_system(cf_grid_var)
         python build_auxiliary_coordinate(engine, cf_coord_var,
-                                          coord_name=CF_VALUE_STD_NAME_LON)
+                                          coord_name=CF_VALUE_STD_NAME_LON,
+                                          coord_system=coordinate_system)
         python engine.rule_triggered.add(rule.name)
 
 

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -265,15 +265,11 @@ fc_build_auxiliary_coordinate_latitude
         facts_cf.auxiliary_coordinate($coordinate)
         check is_latitude(engine, $coordinate)
         check not is_rotated_latitude(engine, $coordinate)
-        facts_cf.grid_mapping($grid_mapping)
-        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_LAT_LON)
     assert
         python cf_coord_var = engine.cf_var.cf_group.auxiliary_coordinates[$coordinate]
-        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
-        python coordinate_system = build_coordinate_system(cf_grid_var)
         python build_auxiliary_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LAT,
-                                          coord_system=coordinate_system)
+                                          coord_system=engine.provides['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -310,15 +306,11 @@ fc_build_auxiliary_coordinate_longitude
         facts_cf.auxiliary_coordinate($coordinate)
         check is_longitude(engine, $coordinate)
         check not is_rotated_longitude(engine, $coordinate)
-        facts_cf.grid_mapping($grid_mapping)
-        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_LAT_LON)
     assert
         python cf_coord_var = engine.cf_var.cf_group.auxiliary_coordinates[$coordinate]
-        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
-        python coordinate_system = build_coordinate_system(cf_grid_var)
         python build_auxiliary_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LON,
-                                          coord_system=coordinate_system)
+                                          coord_system=engine.provides['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 


### PR DESCRIPTION
Here's some changes to the NetCDF load rules that allow horizontal (specifically `latitude` and `longitude`) coordinates to be loaded with a coordinate system, if specified.

I've made no effort (yet) to get the tests passing as I'd like eyes on the proposed rules changes: are the changes _desirable_ or _sensible_? Given that I have a use case that requires the result (horizontal aux coords loaded from NetCDF with coord system intact), is there a better way of achieving this result?
