### PR TITLE
Fix as_compatible_shape for transposed auxcoords

### DIFF
--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -80,7 +80,7 @@ class TestMonotonic(unittest.TestCase):
         b = np.array([3, 5.3, 5.3])
         self.assertNotMonotonic(b, strict=True)
         self.assertMonotonic(b, direction=1)
-        
+
         b = b[::-1]
         self.assertNotMonotonic(b, strict=True)
         self.assertMonotonic(b, direction=-1)
@@ -182,7 +182,7 @@ class TestClipString(unittest.TestCase):
             expected_length,
             'Mismatch in expected length of clipped string. Length was %s, '
             'expected value is %s' % (len(result), expected_length))
-        
+
 
 class TestDescribeDiff(iris.tests.IrisTest):
     def test_identical(self):
@@ -199,16 +199,16 @@ class TestDescribeDiff(iris.tests.IrisTest):
         # test incompatible attributes
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
-        
+
         test_cube_a.attributes['Conventions'] = 'CF-1.5'
         test_cube_b.attributes['Conventions'] = 'CF-1.6'
-        
+
         return_sio = six.StringIO()
         iris.util.describe_diff(test_cube_a, test_cube_b, output_file=return_sio)
         return_str = return_sio.getvalue()
-        
+
         self.assertString(return_str, 'incompatible_attr.str.txt')
-        
+
         # test incompatible names
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
@@ -224,15 +224,15 @@ class TestDescribeDiff(iris.tests.IrisTest):
         # test incompatible unit
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d()
-        
+
         test_cube_a.units = cf_units.Unit('m')
 
         return_sio = six.StringIO()
         iris.util.describe_diff(test_cube_a, test_cube_b, output_file=return_sio)
         return_str = return_sio.getvalue()
-        
+
         self.assertString(return_str, 'incompatible_unit.str.txt')
-        
+
         # test incompatible methods
         test_cube_a = stock.realistic_4d()
         test_cube_b = stock.realistic_4d().collapsed('model_level_number', iris.analysis.MEAN)
@@ -333,6 +333,25 @@ class TestAsCompatibleShape(tests.IrisTest):
         dim_to_aux(expected, 'grid_latitude')
         res = iris.util.as_compatible_shape(src, cube)
         self.assertEqual(res, expected)
+
+    def test_2d_auxcoord_transpose(self):
+        dim_coord1 = iris.coords.DimCoord(range(3), long_name='first_dim')
+        dim_coord2 = iris.coords.DimCoord(range(4), long_name='second_dim')
+        aux_coord_2d = iris.coords.AuxCoord(np.arange(12).reshape(3, 4),
+                                            long_name='spanning')
+        aux_coord_2d_T = iris.coords.AuxCoord(np.arange(12).reshape(3, 4).T,
+                                              long_name='spanning')
+        src = iris.cube.Cube(
+            np.ones((3, 4)),
+            dim_coords_and_dims=[(dim_coord1, 0), (dim_coord2, 1)],
+            aux_coords_and_dims=[(aux_coord_2d, (0, 1))])
+        target = iris.cube.Cube(
+            np.ones((4, 3)),
+            dim_coords_and_dims=[(dim_coord1, 1), (dim_coord2, 0)],
+            aux_coords_and_dims=[(aux_coord_2d_T, (0, 1))])
+
+        res = iris.util.as_compatible_shape(src, target)
+        self.assertEqual(res[0], target[0])
 
 
 if __name__ == '__main__':

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1177,9 +1177,16 @@ def as_compatible_shape(src_cube, target_cube):
     # for subsequent use in creating updated aux_factories.
     coord_mapping = {}
 
+    reverse_mapping = {v: k for k, v in dim_mapping.items() if v is not None}
+
     def add_coord(coord):
         """Closure used to add a suitably reshaped coord to new_cube."""
-        dims = target_cube.coord_dims(coord)
+        all_dims = target_cube.coord_dims(coord)
+        src_dims = [dim for dim in src_cube.coord_dims(coord) if
+                    src_cube.shape[dim] > 1]
+        mapped_dims = [reverse_mapping[dim] for dim in src_dims]
+        length1_dims = [dim for dim in all_dims if new_cube.shape[dim] == 1]
+        dims = length1_dims + mapped_dims
         shape = [new_cube.shape[dim] for dim in dims]
         if not shape:
             shape = [1]


### PR DESCRIPTION
A minor fix for `as_compatible_shape`.

Sometimes Cube dimensions are transposed by the operation.  If an AuxCoord spans these dimensions, we need to either transpose the AuxCoord's points or rearrange its associated dims.  I went for the latter, making it consistent with the `cube.transpose()` treatment.