### PR TITLE
Readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Iris
 ====
 
-[![Build Status](https://secure.travis-ci.org/SciTools/iris.png)](http://travis-ci.org/SciTools/iris)
+[![Build Status](https://api.travis-ci.org/repositories/SciTools/iris.svg?branch=master)](http://travis-ci.org/SciTools/iris/branches)
 
 (C) British Crown Copyright 2010 - 2015, Met Office
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Iris
 ====
 
 [![Build Status](https://api.travis-ci.org/repositories/SciTools/iris.svg?branch=master)](http://travis-ci.org/SciTools/iris/branches)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.51860.svg)](http://dx.doi.org/10.5281/zenodo.51860)
 
 (C) British Crown Copyright 2010 - 2015, Met Office
 


### PR DESCRIPTION
This PR makes two changes to the README badges. The first commit changes the Travis CI badge to point at the master branch only, since we don't want to see PR build failures on the front page.

The second commit adds a new badge for the Zenodo DOI. This may be somewhat annoying as it references the specific DOI for the 1.9.2 release, and will need updating as each release is made.