### PR TITLE
Add support for loading stereographic grid mappings from netCDF files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="1f5ee1e51175103c4a668570f268b9aeec6a5a47"
+  - export IRIS_TEST_DATA_REF="76177575c4836e0b94ffa33ad91ef84c61b635ce"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   - export IRIS_SAMPLE_DATA_REF="e292fc4ef99b0664de726774684dbeff56531b63"

--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-24_stereographic_projection_netcdf.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-May-24_stereographic_projection_netcdf.txt
@@ -1,0 +1,1 @@
+* NetCDF files which define a steroegraphic projection where the _scale factor at projection origin_ is equal to 1.0 will have the projection loaded correctly. Otherwise, a warning will be issued and the projection will not be loaded.

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -96,6 +96,7 @@ fc_provides_grid_mapping_transverse_mercator
         facts_cf.provides(coordinate_system, transverse_mercator)
         python engine.rule_triggered.add(rule.name)
 
+
 #
 # Context:
 #   This rule will trigger iff a grid_mapping() case specific fact
@@ -115,6 +116,29 @@ fc_provides_grid_mapping_mercator
         python engine.provides['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, mercator)
         python engine.rule_triggered.add(rule.name)
+
+
+#
+# Context:
+#   This rule will trigger iff a grid_mapping() case specific fact 
+#   has been asserted that refers to a stereographic.
+#
+# Purpose:
+#   Creates the stereographic coordinate system.
+#
+fc_provides_grid_mapping_stereographic
+    foreach
+        facts_cf.grid_mapping($grid_mapping)
+        check is_grid_mapping(engine, $grid_mapping, CF_GRID_MAPPING_STEREO)
+        check has_supported_stereographic_parameters(engine, $grid_mapping)
+    assert
+        python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
+        python coordinate_system = build_stereographic_coordinate_system(engine, cf_grid_var)
+        python engine.provides['coordinate_system'] = coordinate_system
+        facts_cf.provides(coordinate_system, stereographic)
+        python engine.rule_triggered.add(rule.name)
+
+
 #
 # Context:
 #   This rule will trigger iff a coordinate() case specific fact
@@ -576,7 +600,6 @@ fc_build_coordinate_projection_x_mercator
                                           coord_system=engine.provides['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
-
 #
 # Context:
 #   This rule will trigger iff a projection_y_coordinate coordinate exists and
@@ -595,6 +618,45 @@ fc_build_coordinate_projection_y_mercator
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
                                           coord_system=engine.provides['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
+
+#
+# Context:
+#   This rule will trigger iff a projection_x_coordinate coordinate exists and
+#   a sterographic coordinate system exists.
+#
+# Purpose:
+#   Add the projection_x_coordinate coordinate into the cube.
+#
+fc_build_coordinate_projection_x_stereographic
+    foreach
+        facts_cf.provides(coordinate, projection_x_coordinate, $coordinate)
+        facts_cf.provides(coordinate_system, stereographic)
+    assert
+        python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
+        python build_dimension_coordinate(engine, cf_coord_var,
+                                          coord_name=CF_VALUE_STD_NAME_PROJ_X,
+                                          coord_system=engine.provides['coordinate_system'])
+        python engine.rule_triggered.add(rule.name)
+
+#
+# Context:
+#   This rule will trigger iff a projection_y_coordinate coordinate exists and
+#   a stereographic coordinate system exists.
+#
+# Purpose:
+#   Add the projection_y_coordinate coordinate into the cube.
+#
+fc_build_coordinate_projection_y_stereographic
+    foreach
+        facts_cf.provides(coordinate, projection_y_coordinate, $coordinate)
+        facts_cf.provides(coordinate_system, stereographic)
+    assert
+        python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
+        python build_dimension_coordinate(engine, cf_coord_var,
+                                          coord_name=CF_VALUE_STD_NAME_PROJ_Y,
+                                          coord_system=engine.provides['coordinate_system'])
+        python engine.rule_triggered.add(rule.name)
+
 
 #
 # Context:
@@ -1090,6 +1152,39 @@ fc_extras
 
         return cs
 
+    ################################################################################
+    def build_stereographic_coordinate_system(engine, cf_grid_var):
+        """
+        Create a stereographic coordinate system from the CF-netCDF
+        grid mapping variable.
+
+        """
+        major, minor, inverse_flattening = _get_ellipsoid(cf_grid_var)
+
+        latitude_of_projection_origin = getattr(
+            cf_grid_var, CF_ATTR_GRID_LAT_OF_PROJ_ORIGIN, None)
+        longitude_of_projection_origin = getattr(
+            cf_grid_var, CF_ATTR_GRID_LON_OF_PROJ_ORIGIN, None)
+        false_easting = getattr(
+            cf_grid_var, CF_ATTR_GRID_FALSE_EASTING, None)
+        false_northing = getattr(
+            cf_grid_var, CF_ATTR_GRID_FALSE_NORTHING, None)
+        # Iris currently only supports Stereographic projections with a scale
+        # factor of 1.0. This is checked elsewhere.
+
+        ellipsoid = None
+        if major is not None or minor is not None or \
+                inverse_flattening is not None:
+            ellipsoid = iris.coord_systems.GeogCS(major, minor,
+                                                  inverse_flattening)
+
+        cs = iris.coord_systems.Stereographic(
+            latitude_of_projection_origin, longitude_of_projection_origin,
+            false_easting, false_northing,
+            true_scale_lat=None,
+            ellipsoid=ellipsoid)
+
+        return cs
 
     ################################################################################
     def build_mercator_coordinate_system(engine, cf_grid_var):
@@ -1672,6 +1767,26 @@ fc_extras
                 standard_parallel != 0:
             warnings.warn('Standard parallels other than 0.0 not yet '
                           'supported for Mercator projections')
+            is_valid = False
+
+        return is_valid
+
+
+    ################################################################################
+    def has_supported_stereographic_parameters(engine, cf_name):
+        """Determine whether the CF grid mapping variable has a value of 1.0
+        for the scale_factor_at_projection_origin attribute.""" 
+        
+        is_valid = True
+        cf_grid_var = engine.cf_var.cf_group[cf_name]
+
+        scale_factor_at_projection_origin = getattr(
+            cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None)
+
+        if scale_factor_at_projection_origin is not None and \
+                scale_factor_at_projection_origin != 1:
+            warnings.warn('Scale factors other than 1.0 not yet supported for '
+                          'stereographic projections')
             is_valid = False
 
         return is_valid

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1550,6 +1550,25 @@ class Saver(object):
                     cf_var_grid.false_northing = 0.0
                     cf_var_grid.scale_factor_at_projection_origin = 1.0
 
+                # stereo
+                elif isinstance(cs, iris.coord_systems.Stereographic):
+                    if cs.true_scale_lat is not None:
+                        warnings.warn('Stereographic coordinate systems with '
+                                      'true scale latitude specified are not '
+                                      'yet handled')
+                    else:
+                        if cs.ellipsoid:
+                            add_ellipsoid(cs.ellipsoid)
+                        cf_var_grid.longitude_of_projection_origin = (
+                            cs.central_lon)
+                        cf_var_grid.latitude_of_projection_origin = (
+                            cs.central_lat)
+                        cf_var_grid.false_easting = cs.false_easting
+                        cf_var_grid.false_northing = cs.false_northing
+                        # The Stereographic class has an implicit scale
+                        # factor
+                        cf_var_grid.scale_factor_at_projection_origin = 1.0
+
                 # osgb (a specific tmerc)
                 elif isinstance(cs, iris.coord_systems.OSGB):
                     warnings.warn('OSGB coordinate system not yet handled')

--- a/lib/iris/tests/results/coord_systems/Stereographic.xml
+++ b/lib/iris/tests/results/coord_systems/Stereographic.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<stereographic central_lat="-90.0" central_lon="-45.0" ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="100.0" false_northing="200.0" true_scale_lat="None"/>

--- a/lib/iris/tests/results/netcdf/netcdf_stereo.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_stereo.cml
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.5"/>
+      <attribute name="Note" value="This dataset is for test purposes only"/>
+      <attribute name="acknowledgement" value="EUMETSAT"/>
+      <attribute name="creator_email" value="sat_systems@metoffice.gov.uk"/>
+      <attribute name="creator_name" value="Satellite Applications, Met Office"/>
+      <attribute name="creator_type" value="group"/>
+      <attribute name="geospatial_lat_max" value="2.24208e-44"/>
+      <attribute name="geospatial_lat_min" value="0.0"/>
+      <attribute name="geospatial_lon_max" value="0.0"/>
+      <attribute name="geospatial_lon_min" value="0.0"/>
+      <attribute name="history" value="Created: 2016-05-23T09:40:00Z"/>
+      <attribute name="institution" value="Met Office, UK"/>
+      <attribute name="instrument" value="SEVIRI"/>
+      <attribute name="keywords" value="Infra-red, brightness temperature, MSG, SEVIRI"/>
+      <attribute name="platform" value="MSG"/>
+      <attribute name="source" value="EUMETSAT"/>
+      <attribute name="standard_name_vocabulary" value="CF Standard Name Table v27"/>
+      <attribute name="summary" value="Infra-red channel top of atmosphere brightness temperature, central wavelength of 10.80 microns, Stereographic projection"/>
+      <attribute name="title" value="TOA brightness temperature, 10.80 micron (MSG)"/>
+    </attributes>
+    <coords>
+      <coord datadims="[0, 1]">
+        <auxCoord id="4a0cb9d8" points="[[67.961, 68.2429, 68.5243, ..., 34.1096,
+ 		33.8638, 33.6184],
+		[67.8378, 68.1179, 68.3976, ..., 34.0729,
+ 		33.8273, 33.5822],
+		[67.7109, 67.9893, 68.2671, ..., 34.0349,
+ 		33.7896, 33.5448],
+		..., 
+		[32.8965, 32.9768, 33.0561, ..., 17.4017,
+ 		17.2537, 17.1056],
+		[32.6643, 32.7441, 32.8228, ..., 17.2567,
+ 		17.1094, 16.962],
+		[32.4325, 32.5117, 32.5898, ..., 17.1116,
+ 		16.9649, 16.8182]]" shape="(160, 256)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="lat"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord id="62e940e0" points="[[-101.722, -101.394, -101.058, ..., 46.6587,
+ 		46.702, 46.7449],
+		[-100.974, -100.638, -100.294, ..., 46.3615,
+ 		46.4063, 46.4507],
+		[-100.235, -99.8915, -99.5392, ..., 46.0648,
+ 		46.1111, 46.157],
+		..., 
+		[-54.193, -53.9159, -53.6379, ..., 10.6062,
+ 		10.7575, 10.9081],
+		[-54.0971, -53.8212, -53.5444, ..., 10.4515,
+ 		10.6029, 10.7534],
+		[-54.0022, -53.7274, -53.4518, ..., 10.2976,
+ 		10.449, 10.5996]]" shape="(160, 256)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="lon"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="3aaada22" points="[-2.28188e+06, -2.24639e+06, -2.21091e+06, ...,
+		6.69544e+06, 6.73092e+06, 6.7664e+06]" shape="(256,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float32" var_name="x">
+          <stereographic central_lat="90.0" central_lon="-35.0" ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" true_scale_lat="None"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="27f71466" points="[-981693.0, -1.01719e+06, -1.05269e+06, ...,
+		-6.55525e+06, -6.59075e+06, -6.62625e+06]" shape="(160,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float32" var_name="y">
+          <stereographic central_lat="90.0" central_lon="-35.0" ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" true_scale_lat="None"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="cb784457" points="[406500.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float32" var_name="time"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0xa4b27b3b" dtype="float32" fill_value="-1.07374e+09" mask_checksum="0xdb4fbb14" shape="(160, 256)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/stereographic.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/stereographic.cdl
@@ -1,0 +1,26 @@
+dimensions:
+	projection_y_coordinate = UNLIMITED ; // (3 currently)
+	projection_x_coordinate = 4 ;
+variables:
+	int64 air_pressure_anomaly(projection_y_coordinate, projection_x_coordinate) ;
+		air_pressure_anomaly:standard_name = "air_pressure_anomaly" ;
+		air_pressure_anomaly:grid_mapping = "stereographic" ;
+	int stereographic ;
+		stereographic:grid_mapping_name = "stereographic" ;
+		stereographic:longitude_of_prime_meridian = 0. ;
+		stereographic:semi_major_axis = 6377563.396 ;
+		stereographic:semi_minor_axis = 6356256.909 ;
+		stereographic:longitude_of_projection_origin = 20. ;
+		stereographic:latitude_of_projection_origin = -10. ;
+		stereographic:false_easting = 500000. ;
+		stereographic:false_northing = -200000. ;
+		stereographic:scale_factor_at_projection_origin = 1. ;
+	int64 projection_y_coordinate(projection_y_coordinate) ;
+		projection_y_coordinate:axis = "Y" ;
+		projection_y_coordinate:units = "m" ;
+		projection_y_coordinate:standard_name = "projection_y_coordinate" ;
+	int64 projection_x_coordinate(projection_x_coordinate) ;
+		projection_x_coordinate:axis = "X" ;
+		projection_x_coordinate:units = "m" ;
+		projection_x_coordinate:standard_name = "projection_x_coordinate" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/stereographic_no_ellipsoid.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/stereographic_no_ellipsoid.cdl
@@ -1,0 +1,23 @@
+dimensions:
+	projection_y_coordinate = UNLIMITED ; // (3 currently)
+	projection_x_coordinate = 4 ;
+variables:
+	int64 air_pressure_anomaly(projection_y_coordinate, projection_x_coordinate) ;
+		air_pressure_anomaly:standard_name = "air_pressure_anomaly" ;
+		air_pressure_anomaly:grid_mapping = "stereographic" ;
+	int stereographic ;
+		stereographic:grid_mapping_name = "stereographic" ;
+		stereographic:longitude_of_projection_origin = 20. ;
+		stereographic:latitude_of_projection_origin = -10. ;
+		stereographic:false_easting = 500000. ;
+		stereographic:false_northing = -200000. ;
+		stereographic:scale_factor_at_projection_origin = 1. ;
+	int64 projection_y_coordinate(projection_y_coordinate) ;
+		projection_y_coordinate:axis = "Y" ;
+		projection_y_coordinate:units = "m" ;
+		projection_y_coordinate:standard_name = "projection_y_coordinate" ;
+	int64 projection_x_coordinate(projection_x_coordinate) ;
+		projection_x_coordinate:axis = "X" ;
+		projection_x_coordinate:units = "m" ;
+		projection_x_coordinate:standard_name = "projection_x_coordinate" ;
+}

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -47,6 +47,12 @@ def merc():
     return Mercator(longitude_of_projection_origin=90.0,
                     ellipsoid=GeogCS(6377563.396, 6356256.909))
 
+def stereo():
+    return Stereographic(central_lat=-90, central_lon=-45,
+                         false_easting=100, false_northing=200,
+                         ellipsoid=GeogCS(6377563.396, 6356256.909))
+
+
 class TestCoordSystemLookup(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.lat_lon_cube()
@@ -311,6 +317,69 @@ class Test_TransverseMercator_as_cartopy_projection(tests.IrisTest):
         res = tmerc_cs.as_cartopy_projection()
         self.assertEqual(res, expected)
 
+class Test_Stereographic_construction(tests.IrisTest):
+    def test_stereo(self):
+        st = stereo()
+        self.assertXMLElement(st, ("coord_systems", "Stereographic.xml"))
+
+
+class Test_Stereographic_repr(tests.IrisTest):
+    def test_stereo(self):
+        st = stereo()
+        expected = "Stereographic(central_lat=-90.0, central_lon=-45.0, "\
+                    "false_easting=100.0, false_northing=200.0, true_scale_lat=None, "\
+                    "ellipsoid=GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909))"
+        self.assertEqual(expected, repr(st))
+
+
+class Test_Stereographic_as_cartopy_crs(tests.IrisTest):
+    def test_as_cartopy_crs(self):
+        latitude_of_projection_origin=-90.0
+        longitude_of_projection_origin=-45.0
+        false_easting=100.0
+        false_northing=200.0
+        ellipsoid=GeogCS(6377563.396, 6356256.909)
+
+        st = Stereographic(central_lat=latitude_of_projection_origin,
+            central_lon=longitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+            ellipsoid=ellipsoid)
+        expected = ccrs.Stereographic(
+            central_latitude=latitude_of_projection_origin,
+            central_longitude=longitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
+
+        res = st.as_cartopy_crs()
+        self.assertEqual(res, expected)
+
+
+class Test_Stereographic_as_cartopy_projection(tests.IrisTest):
+    def test_as_cartopy_projection(self):
+        latitude_of_projection_origin=-90.0
+        longitude_of_projection_origin=-45.0
+        false_easting=100.0
+        false_northing=200.0
+        ellipsoid=GeogCS(6377563.396, 6356256.909)
+
+        st = Stereographic(central_lat=latitude_of_projection_origin,
+            central_lon=longitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+            ellipsoid=ellipsoid)
+        expected = ccrs.Stereographic(
+            central_latitude=latitude_of_projection_origin,
+            central_longitude=longitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+            globe=ccrs.Globe(semimajor_axis=6377563.396,
+                             semiminor_axis=6356256.909, ellipse=None))
+
+        res = st.as_cartopy_projection()
+        self.assertEqual(res, expected)
 
 class Test_LambertConformal(tests.GraphicsTest):
 

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -172,6 +172,14 @@ class TestNetCDFLoad(tests.IrisTest):
                                  'toa_brightness_temperature.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_merc.cml'))
 
+    def test_load_stereographic_grid(self):
+        # Test loading a single CF-netCDF file with a stereographic
+        # grid_mapping.
+        cube = iris.load_cube(
+            tests.get_data_path(('NetCDF', 'stereographic',
+                                 'toa_brightness_temperature.nc')))
+        self.assertCML(cube, ('netcdf', 'netcdf_stereo.cml'))
+
     def test_cell_methods(self):
         # Test exercising CF-netCDF cell method parsing.
         cubes = iris.load(tests.get_data_path(('NetCDF', 'testing',

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_stereographic_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_stereographic_coordinate_system.py
@@ -1,0 +1,88 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.build_sterographic_coordinate_system`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.coord_systems import Stereographic
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    build_stereographic_coordinate_system
+from iris.tests import mock
+
+
+class TestBuildStereographicCoordinateSystem(tests.IrisTest):
+    def test_valid(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            latitude_of_projection_origin=0,
+            longitude_of_projection_origin=0,
+            false_easting=-100,
+            false_northing=200,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+
+        cs = build_stereographic_coordinate_system(None, cf_grid_var)
+
+        expected = Stereographic(
+            central_lat=cf_grid_var.latitude_of_projection_origin,
+            central_lon=cf_grid_var.longitude_of_projection_origin,
+            false_easting=cf_grid_var.false_easting,
+            false_northing=cf_grid_var.false_northing,
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                cf_grid_var.semi_minor_axis))
+        self.assertEqual(cs, expected)
+
+    def test_inverse_flattening(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            latitude_of_projection_origin=0,
+            longitude_of_projection_origin=0,
+            false_easting=-100,
+            false_northing=200,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            inverse_flattening=299.3249646)
+
+        cs = build_stereographic_coordinate_system(None, cf_grid_var)
+
+        expected = Stereographic(
+            central_lat=cf_grid_var.latitude_of_projection_origin,
+            central_lon=cf_grid_var.longitude_of_projection_origin,
+            false_easting=cf_grid_var.false_easting,
+            false_northing=cf_grid_var.false_northing,
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                inverse_flattening=cf_grid_var.inverse_flattening))
+        self.assertEqual(cs, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
@@ -1,0 +1,88 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.has_supported_stereographic_parameters`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import warnings
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+from iris.coord_systems import Stereographic
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
+    has_supported_stereographic_parameters
+from iris.tests import mock
+
+
+def _engine(cf_grid_var, cf_name):
+    cf_group = {cf_name: cf_grid_var}
+    cf_var = mock.Mock(cf_group=cf_group)
+    return mock.Mock(cf_var=cf_var)
+
+
+class TestHasSupportedStereographicParameters(tests.IrisTest):
+    def test_valid(self):
+        cf_name = 'stereographic'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            latitude_of_projection_origin=0,
+            longitude_of_projection_origin=0,
+            false_easting=-100,
+            false_northing=200,
+            scale_factor_at_projection_origin=1,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        is_valid = has_supported_stereographic_parameters(engine, cf_name)
+
+        self.assertTrue(is_valid)
+
+    def test_invalid_scale_factor(self):
+        # Iris does not yet support scale factors other than one for
+        # stereographic projections
+        cf_name = 'stereographic'
+        cf_grid_var = mock.Mock(
+            spec=[],
+            latitude_of_projection_origin=0,
+            longitude_of_projection_origin=0,
+            false_easting=-100,
+            false_northing=200,
+            scale_factor_at_projection_origin=0.9,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909)
+        engine = _engine(cf_grid_var, cf_name)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            is_valid = has_supported_stereographic_parameters(engine, cf_name)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(len(warns), 1)
+        self.assertRegexpMatches(str(warns[0]), 'Scale factor')
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
Add support for loading stereographic grid mappings from netCDF files where the scale factor at projection origin is 1