### PR TITLE
Fix for setting protected attributes on NetCDF variable objects

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1298,7 +1298,7 @@ class Saver(object):
 
             # Don't clobber existing attributes.
             if not hasattr(cf_var, name):
-                setattr(cf_var, name, value)
+                cf_var.setncattr(name, value)
 
         return cf_name
 
@@ -1416,7 +1416,7 @@ class Saver(object):
 
             # Don't clobber existing attributes.
             if not hasattr(cf_var, name):
-                setattr(cf_var, name, value)
+                cf_var.setncattr(name, value)
 
         return cf_name
 
@@ -1684,7 +1684,7 @@ class Saver(object):
                       'global attribute.'.format(attr_name=attr_name)
                 warnings.warn(msg)
 
-            setattr(cf_var, attr_name, value)
+            cf_var.setncattr(attr_name, value)
 
         # Create the CF-netCDF data variable cell method attribute.
         cell_methods = self._create_cf_cell_methods(cube, dimension_names)

--- a/lib/iris/tests/unit/fileformats/netcdf/test_save.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -58,6 +58,24 @@ class Test_attributes(tests.IrisTest):
             res = ds.getncattr('bar')
             ds.close()
         self.assertArrayEqual(res, np.arange(2))
+
+    def test_no_special_attribute_clash(self):
+        # Ensure that saving multiple cubes with netCDF4 protected attributes
+        # works as expected.
+        # Note that here we are testing variable attribute clashes only - by
+        # saving multiple cubes the attributes are saved as variable
+        # attributes rather than global attributes.
+        c1 = Cube([0], var_name='test', attributes={'name': 'bar'})
+        c2 = Cube([0], var_name='test_1', attributes={'name': 'bar_1'})
+
+        with self.temp_filename('foo.nc') as nc_out:
+            save([c1, c2], nc_out)
+            ds = nc.Dataset(nc_out)
+            res = ds.variables['test'].getncattr('name')
+            res_1 = ds.variables['test_1'].getncattr('name')
+            ds.close()
+        self.assertEqual(res, 'bar')
+        self.assertEqual(res_1, 'bar_1')
 
 
 class Test_unlimited_dims(tests.IrisTest):


### PR DESCRIPTION
I hit an issue trying to save cubes with variable attributes including 'name', which is related (but not the same as #1167) when using netcdf4>=1.2. This is a test which reproduces the problem and an associated fix.