### PR TITLE
Biggus version requirement update

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -74,7 +74,7 @@ numpy 1.6 or later (http://numpy.scipy.org/)
     Python package for scientific computing including a powerful N-dimensional
     array object.
 
-biggus 0.12 or later (https://github.com/SciTools/biggus)
+biggus 0.13 or later (https://github.com/SciTools/biggus)
     Virtual large arrays and lazy evaluation.
 
 scipy 0.10 or later (http://www.scipy.org/)

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,7 +2,7 @@
 # conda create -n <name> --file conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.12.0
+biggus>=0.13.0
 cartopy
 matplotlib=1.3.1
 netcdf4

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -2,7 +2,7 @@
 # conda create -n <name> --file minimal-conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.12.0
+biggus>=0.13.0
 cartopy
 matplotlib=1.3.1
 netcdf4


### PR DESCRIPTION
Updates the minimum version of biggus to v0.13 to help users avoid SciTools/biggus#166. I've also added a unit test that checks masked addition. This will fail with biggus < v0.13, and I've taken the unusual step of explaining this to the end user. This is felt to be necessary due to the possible mode of failure, where a masked array would lose its mask silently, endangering the correctness of scientific results. See #2034 for background and the basis for this new test.

Ping @matthew-mizielinski