### PR TITLE
Fix to allow zero spaces after colon in cell_method for NetCDF

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -148,7 +148,7 @@ _CM_INTERVAL = 'interval'
 _CM_METHOD = 'method'
 _CM_NAME = 'name'
 _CM_PARSE = re.compile(r'''
-                           (?P<name>([\w_]+\s*?:\s+)+)
+                           (?P<name>([\w_]+\s*?:\s*?)+)
                            (?P<method>[\w_\s]+(?![\w_]*\s*?:))\s*
                            (?:
                                \(\s*

--- a/lib/iris/tests/unit/fileformats/netcdf/test_parse_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_parse_cell_methods.py
@@ -36,6 +36,7 @@ class Test(tests.IrisTest):
         cell_method_strings = [
             'time: mean',
             'time : mean',
+            'time :mean',
             ]
         expected = (CellMethod(method='mean', coords='time'),)
         for cell_method_str in cell_method_strings:


### PR DESCRIPTION
At present, iris requires a cell method to have at least one space after the colon for a cell_method in a NetCDF file.  For example, this is valid:

> 'time: mean'

While this is not recognised:

> 'time:mean'

This PR fixes that.

As an aside, for the invalid cell method example above, iris currently silently removes the cell method.  Would a warning (or possibly exception) be more appropriate - something like 'cell method foo:bar not recognised'?
