### PR TITLE
Prevent tests failing to run with no GUI

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -69,6 +69,7 @@ import iris.util
 # (And remove matplotlib as an iris.tests dependency.)
 try:
     import matplotlib
+    matplotlib.use('agg')
     import matplotlib.testing.compare as mcompare
     import matplotlib.pyplot as plt
 except ImportError:
@@ -116,13 +117,10 @@ logger = logging.getLogger('tests')
 # Whether to display matplotlib output to the screen.
 _DISPLAY_FIGURES = False
 
-if MPL_AVAILABLE:
-    if '-d' in sys.argv:
-        sys.argv.remove('-d')
-        plt.switch_backend('tkagg')
-        _DISPLAY_FIGURES = True
-    else:
-        plt.switch_backend('agg')
+if (MPL_AVAILABLE and '-d' in sys.argv):
+    sys.argv.remove('-d')
+    plt.switch_backend('tkagg')
+    _DISPLAY_FIGURES = True
 
 _DEFAULT_IMAGE_TOLERANCE = 10.0
 


### PR DESCRIPTION
If you try to run the Iris tests via the command-line with _no_ GUI available at all (for example when using SSH) then the tests will fail:

```python
======================================================================
ERROR: Failure: RuntimeError (could not create GdkCursor object)
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
  File "/.../lib/iris/tests/__init__.py", line 73, in <module>
    import matplotlib.pyplot as plt
  ...
  File "/.../matplotlib-1.3.1-py2.7-linux-x86_64.egg/matplotlib/backends/backend_gtk.py", line 58, in <module>
    cursors.MOVE          : gdk.Cursor(gdk.FLEUR),
RuntimeError: could not create GdkCursor object
```

It looks like pyplot tries to set a GUI cursor thing at import time, assumedly because it defaults to using the `GTKagg` backend, before we change the backend to `Agg` for the purposes of the Iris tests.

This proposed fix rather crudely just captures the runtime error on pyplot import and sets the use matplotlib flag false, so that no visual tests are run in such cases.

Alternatively, I guess, we could set the backend as standard to `Agg` before importing pyplot, and not do this later on (i.e. on [`__init__.py` L125](https://github.com/SciTools/iris/blob/master/lib/iris/tests/__init__.py#L125)).