### PR TITLE
Make iris.util.new_axis handle lazy data

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-Jun-13_lazy_new_axis.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-Jun-13_lazy_new_axis.txt
@@ -1,0 +1,1 @@
+* Promoting a scalar coordinate to a dimension coordinate with `iris.util.new_axis` no longer loads deferred data.

--- a/lib/iris/tests/integration/test_new_axis.py
+++ b/lib/iris/tests/integration/test_new_axis.py
@@ -1,0 +1,43 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for :func:`iris.util.new_axis`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import iris
+from iris.util import new_axis
+
+
+class Test(tests.IrisTest):
+
+    @tests.skip_data
+    def test_lazy_data(self):
+        filename = tests.get_data_path(('PP', 'globClim1', 'theta.pp'))
+        cube = iris.load_cube(filename)
+        new_cube = new_axis(cube, 'time')
+        self.assertTrue(cube.has_lazy_data())
+        self.assertTrue(new_cube.has_lazy_data())
+        self.assertEqual(new_cube.shape, (1,) + cube.shape)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ import copy
 import numpy as np
 import unittest
 
+from biggus import NumpyArrayAdapter
 import iris
 from iris.util import new_axis
 
@@ -133,6 +134,14 @@ class Test(tests.IrisTest):
 
         self.assertEqual(res, com)
         self._assert_cube_notis(res, cube)
+
+    def test_lazy_data(self):
+        cube = iris.cube.Cube(NumpyArrayAdapter(self.data))
+        cube.add_aux_coord(iris.coords.DimCoord([1], standard_name='time'))
+        res = new_axis(cube, 'time')
+        self.assertTrue(cube.has_lazy_data())
+        self.assertTrue(res.has_lazy_data())
+        self.assertEqual(res.shape, (1,) + cube.shape)
 
 
 if __name__ == '__main__':

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1076,18 +1076,13 @@ def new_axis(src_cube, scalar_coord=None):
         >>> ncube.shape
         (1, 360, 360)
 
-    .. warning::
-
-        Calling this method will trigger any deferred loading, causing the
-        data array of the cube to be loaded into memory.
-
     """
     if scalar_coord is not None:
         scalar_coord = src_cube.coord(scalar_coord)
 
     # Indexing numpy arrays requires loading deferred data here returning a
     # copy of the data with a new leading dimension.
-    new_cube = iris.cube.Cube(src_cube.data[None])
+    new_cube = iris.cube.Cube(src_cube.lazy_data()[None])
     new_cube.metadata = src_cube.metadata
 
     for coord in src_cube.aux_coords:


### PR DESCRIPTION
Make `iris.util.new_axis` work without loading a deferred data payload. I've used `iris.cube.Cube.lazy_data()` for this, I didn't use a check to see if the cube actually has lazy data, it seems not to matter, but advice is welcome.