### PR TITLE
Add SAMPLE_DATA_DIR deprecation warning.

### DIFF
--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -30,6 +30,8 @@ defined by :mod:`ConfigParser`.
     directory supports the Iris gallery. Directory contents accessed via
     :func:`iris.sample_data_path`.
 
+    .. deprecated:: 1.10
+
 .. py:data:: iris.config.TEST_DATA_DIR
 
     Local directory where test data exists.  Defaults to "test_data"
@@ -69,6 +71,8 @@ from six.moves import configparser
 import os.path
 import warnings
 
+from iris._deprecation import warn_deprecated
+
 
 # Returns simple string options
 def get_option(section, option, default=None):
@@ -91,6 +95,11 @@ def get_dir_option(section, option, default=None):
     or does not represent a valid directory.
 
     """
+    if option == 'sample_data_dir':
+        wmsg = ('iris.config.SAMPLE_DATA_DIR was deprecated in v1.10.0 and '
+                'will be removed in a future Iris release. Install the '
+                'iris_sample_data package.')
+        warn_deprecated(wmsg)
     path = default
     if config.has_option(section, option):
         c_path = config.get(section, option)


### PR DESCRIPTION
This PR addresses the [comment](https://github.com/SciTools/iris/pull/2047#discussion_r66404539) raised by @pp-mo on PR #2047, and deprecates the use of `iris.config.SAMPLE_DATA_DIR` in favour of using the newly packaged and importable `iris_sample_data`.

**Caveat emptor** - Merging this PR means that we are committed to bundling `iris_sample_data` with iris. This means that an update to the iris conda recipe is required, otherwise a deprecation warning will always be raised on `import iris`.