### PR TITLE
Add SAMPLE_DATA_DIR deprecation warning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Please update the cartopy, test data, and sample data git references
-# below if appropriate.
+# Please update the test data git references below if appropriate.
 #
 # Note: Contrary to the travis documentation,
 # http://about.travis-ci.org/docs/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs
@@ -25,9 +24,6 @@ git:
 install:
   - export IRIS_TEST_DATA_REF="76177575c4836e0b94ffa33ad91ef84c61b635ce"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
-
-  - export IRIS_SAMPLE_DATA_REF="e292fc4ef99b0664de726774684dbeff56531b63"
-  - export IRIS_SAMPLE_DATA_SUFFIX=$(echo "${IRIS_SAMPLE_DATA_REF}" | sed "s/^v//")
 
   # Install miniconda
   # -----------------
@@ -79,11 +75,6 @@ install:
   - unzip -q iris-test-data.zip
   - ln -s $(pwd)/iris-test-data-${IRIS_TEST_DATA_SUFFIX} iris-test-data
 
-# iris sample data
-  - wget -O iris-sample-data.zip https://github.com/SciTools/iris-sample-data/archive/${IRIS_SAMPLE_DATA_REF}.zip
-  - unzip -q iris-sample-data.zip
-  - ln -s $(pwd)/iris-sample-data-${IRIS_SAMPLE_DATA_SUFFIX} iris-sample-data
-
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib
   - if [[ $TEST_TARGET -ne 'coding' ]]; then
@@ -96,7 +87,6 @@ install:
 # set config paths
   - SITE_CFG=$IRIS/etc/site.cfg
   - echo "[Resources]" > $SITE_CFG
-  - echo "sample_data_dir = $(pwd)/iris-sample-data/sample_data" >> $SITE_CFG
   - echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> $SITE_CFG
   - echo "doc_dir = $(pwd)/docs/iris" >> $SITE_CFG
   - echo "[System]" >> $SITE_CFG

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -19,6 +19,7 @@ mock
 nose
 pep8=1.5.7
 sphinx
+iris_sample_data
 
 # Optional iris dependencies
 ecmwf_grib

--- a/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Jun-16_sample_data_dir.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/deprecate_2016-Jun-16_sample_data_dir.txt
@@ -1,0 +1,2 @@
+* The use of :data:`iris.config.SAMPLE_DATA_DIR` has been deprecated and replaced by the now importable :mod:`iris_sample_data` package.
+ 

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -110,7 +110,7 @@ import threading
 import iris.config
 import iris.cube
 import iris._constraints
-from iris._deprecation import IrisDeprecation
+from iris._deprecation import IrisDeprecation, warn_deprecated
 import iris.fileformats
 import iris.io
 
@@ -456,6 +456,10 @@ def sample_data_path(*path_to_join):
     if _SAMPLE_DATA_AVAILABLE:
         target = os.path.join(iris_sample_data.path, target)
     else:
+        wmsg = ('iris.config.SAMPLE_DATA_DIR was deprecated in v1.10.0 and '
+                'will be removed in a future Iris release. Install the '
+                'iris_sample_data package.')
+        warn_deprecated(wmsg)
         target = os.path.join(iris.config.SAMPLE_DATA_DIR, target)
     if not glob.glob(target):
         raise ValueError('Sample data file(s) at {!r} not found.\n'

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -118,9 +118,7 @@ import iris.io
 try:
     import iris_sample_data
 except ImportError:
-    _SAMPLE_DATA_AVAILABLE = False
-else:
-    _SAMPLE_DATA_AVAILABLE = True
+    iris_sample_data = None
 
 
 # Iris revision.
@@ -453,12 +451,12 @@ def sample_data_path(*path_to_join):
                          'NB. This function is only for locating files in the '
                          'iris sample data collection. It is not needed or '
                          'appropriate for general file access.'.format(target))
-    if _SAMPLE_DATA_AVAILABLE:
+    if iris_sample_data is not None:
         target = os.path.join(iris_sample_data.path, target)
     else:
-        wmsg = ('iris.config.SAMPLE_DATA_DIR was deprecated in v1.10.0 and '
-                'will be removed in a future Iris release. Install the '
-                'iris_sample_data package.')
+        wmsg = ("iris.config.SAMPLE_DATA_DIR was deprecated in v1.10.0 and "
+                "will be removed in a future Iris release. Install the "
+                "'iris_sample_data' package.")
         warn_deprecated(wmsg)
         target = os.path.join(iris.config.SAMPLE_DATA_DIR, target)
     if not glob.glob(target):

--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -30,6 +30,8 @@ defined by :mod:`ConfigParser`.
     directory supports the Iris gallery. Directory contents accessed via
     :func:`iris.sample_data_path`.
 
+    .. deprecated:: 1.10
+
 .. py:data:: iris.config.TEST_DATA_DIR
 
     Local directory where test data exists.  Defaults to "test_data"

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -91,6 +91,13 @@ else:
     GRIB_AVAILABLE = True
     from iris.fileformats.grib.message import GribMessage
 
+try:
+    import iris_sample_data
+except ImportError:
+    SAMPLE_DATA_AVAILABLE = False
+else:
+    SAMPLE_DATA_AVAILABLE = True
+
 
 #: Basepath for test results.
 _RESULT_PATH = os.path.join(os.path.dirname(__file__), 'results')
@@ -917,6 +924,11 @@ def skip_plot(fn):
 
 skip_grib = unittest.skipIf(not GRIB_AVAILABLE, 'Test(s) require "gribapi", '
                                                 'which is not available.')
+
+
+skip_sample_data = unittest.skipIf(not SAMPLE_DATA_AVAILABLE,
+                                   ('Test(s) require "iris_sample_data", '
+                                    'which is not available.'))
 
 
 def no_warnings(func):

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -41,6 +41,7 @@ def _temp_file(sample_dir):
     return sample_path
 
 
+@tests.skip_sample_data
 class TestIrisSampleData_path(tests.IrisTest):
     def setUp(self):
         self.sample_dir = tempfile.mkdtemp()
@@ -49,22 +50,16 @@ class TestIrisSampleData_path(tests.IrisTest):
         shutil.rmtree(self.sample_dir)
 
     def test_path(self):
-        try:
-            with mock.patch('iris_sample_data.path', self.sample_dir):
-                import iris_sample_data
-                self.assertEqual(iris_sample_data.path, self.sample_dir)
-        except ImportError:
-            pass
+        with mock.patch('iris_sample_data.path', self.sample_dir):
+            import iris_sample_data
+            self.assertEqual(iris_sample_data.path, self.sample_dir)
 
     def test_call(self):
-        try:
-            sample_file = _temp_file(self.sample_dir)
-            with mock.patch('iris_sample_data.path', self.sample_dir):
-                import iris_sample_data
-                result = sample_data_path(os.path.basename(sample_file))
-                self.assertEqual(result, sample_file)
-        except ImportError:
-            pass
+        sample_file = _temp_file(self.sample_dir)
+        with mock.patch('iris_sample_data.path', self.sample_dir):
+            import iris_sample_data
+            result = sample_data_path(os.path.basename(sample_file))
+            self.assertEqual(result, sample_file)
 
 
 class TestConfig(tests.IrisTest):

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -41,18 +41,6 @@ def _temp_file(sample_dir):
     return sample_path
 
 
-class TestIrisSampleData__get_path(tests.IrisTest):
-    def test(self):
-        try:
-            path = mock.sentinel.path
-            with mock.patch('iris_sample_data._get_path', return_value=path):
-                import iris_sample_data
-                path = iris_sample_data._get_path()
-                self.assertEqual(path, self.path)
-        except ImportError:
-            pass
-
-
 class TestIrisSampleData_path(tests.IrisTest):
     def setUp(self):
         self.sample_dir = tempfile.mkdtemp()

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -57,7 +57,6 @@ class TestIrisSampleData_path(tests.IrisTest):
     def test_call(self):
         sample_file = _temp_file(self.sample_dir)
         with mock.patch('iris_sample_data.path', self.sample_dir):
-            import iris_sample_data
             result = sample_data_path(os.path.basename(sample_file))
             self.assertEqual(result, sample_file)
 
@@ -65,7 +64,7 @@ class TestIrisSampleData_path(tests.IrisTest):
 class TestConfig(tests.IrisTest):
     def setUp(self):
         # Force iris_sample_data to be unavailable.
-        self.patch('iris._SAMPLE_DATA_AVAILABLE', False)
+        self.patch('iris.iris_sample_data', None)
         # All of our tests are going to run with SAMPLE_DATA_DIR
         # redirected to a temporary directory.
         self.sample_dir = tempfile.mkdtemp()

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -31,6 +31,7 @@ import tempfile
 import mock
 
 from iris import sample_data_path
+from iris._deprecation import IrisDeprecation
 
 
 def _temp_file(sample_dir):
@@ -101,6 +102,16 @@ class TestConfig(tests.IrisTest):
     def test_glob_absolute(self):
         with self.assertRaisesRegexp(ValueError, 'Absolute path'):
             sample_data_path(os.path.abspath('foo.*'))
+
+    def test_warn_deprecated(self):
+        sample_path = _temp_file(self.sample_dir)
+        with mock.patch('warnings.warn') as warn:
+            sample_data_path(os.path.basename(sample_path))
+            self.assertEqual(warn.call_count, 1)
+            (warn_msg, warn_exception), _ = warn.call_args
+            msg = 'iris.config.SAMPLE_DATA_DIR was deprecated'
+            self.assertTrue(warn_msg.startswith(msg))
+            self.assertEqual(warn_exception, IrisDeprecation)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses the [comment](https://github.com/SciTools/iris/pull/2047#discussion_r66404539) raised by @pp-mo on PR #2047, and deprecates the use of `iris.config.SAMPLE_DATA_DIR` in favour of using the newly packaged and importable `iris_sample_data`.

**Caveat emptor** - Merging this PR means that we are committed to bundling `iris_sample_data` with iris and an update to the iris conda recipe is required, otherwise a deprecation warning will always be raised on using the `iris.sample_data_path` function ... (see discussion thread below)

To do
- [x] Release `iris_sample_data` at `v2.0.0`
- [x] Purge redundant tests `test_sample_data_path`
- [x] Check if `skip_sample_data` required
- [x] Add test coverage for deprecation warning being raised
- [x] Push conda recipe for `iris_sample_data` to the scitools `main` label, see [conda-recipes-scitools PR-169](https://github.com/SciTools/conda-recipes-scitools/pull/169)
- [x] Update the `conda-requirements.txt`
- [x] Passing travis-ci for `example_tests`
- [x] Update .travis.yml to purge `site.cfg` iris-sample-data download