### PR TITLE
BUG: Tolerant crs comparison

### DIFF
--- a/lib/iris/tests/unit/coord_systems/test_GeogCS.py
+++ b/lib/iris/tests/unit/coord_systems/test_GeogCS.py
@@ -1,0 +1,79 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :class:`iris.coord_systems.GeogCS` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+from iris.coord_systems import GeogCS
+
+
+class Test___eq__(tests.IrisTest):
+    def test_derived_quantities_eq(self):
+        # Ensure that derived quantities are equal.
+        crs1 = GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)
+        crs2 = GeogCS(semi_major_axis=6377563.396,
+                      inverse_flattening=299.324)
+        self.assertEqual(crs1, crs2)
+
+    def test_32bit_derived_quantities_eq(self):
+        # Ensure that 32-bit coerced quantities don't fail equality.
+        crs1 = GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)
+        crs2 = GeogCS(semi_major_axis=np.float32(6377563.396),
+                      inverse_flattening=np.float32(299.324))
+        self.assertEqual(crs1, crs2)
+
+    def test_derived_quantities_neq(self):
+        # Ensure that derived quantities are not equal.
+        crs1 = GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)
+        crs2 = GeogCS(semi_major_axis=6377563.396,
+                      inverse_flattening=299.33)
+        self.assertFalse(crs1 == crs2)
+
+    def test_straight_eq(self):
+        # No derived quantities.
+        crs1 = GeogCS(6377560)
+        crs2 = GeogCS(6377570)
+        self.assertEqual(crs1, crs2)
+
+    def test_straight_neq(self):
+        # No derived quantities.
+        crs1 = GeogCS(6377500)
+        crs2 = GeogCS(6377600)
+        self.assertFalse(crs1 == crs2)
+
+    def test_straight_32bit_eq(self):
+        # No derived quantities.
+        crs1 = GeogCS(6377560)
+        crs2 = GeogCS(np.float32(6377570))
+        self.assertEqual(crs1, crs2)
+
+    def test_straight_32bit_neq(self):
+        # No derived quantities.
+        crs1 = GeogCS(6377500)
+        crs2 = GeogCS(np.float32(6377600))
+        self.assertFalse(crs1 == crs2)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Provide tolerant coordinate system comparison in iris.

Currently, coordinate system comparison in iris has the following issues associated that this PR addresses:
1. Some attributes for specifying a crs can be specified or derived (this makes floating point comparison flawd) e.g. inverse flattening for defining the ellipse rather than defining both semi major AND minor axes.
2. crs attributes can be specified as 32-bit floats (consider pp as a source for the instantiation of the crs (see #716 for an illustrative case).
3. crs equality was using the class name in its equality measure.

**Solution:**

I make a 'tolerant' dict comparison between the coordinate systems (also I remove the requirement for both to be defined from the same class).  Tolerance value derived by the unittests written (see  [lib/iris/tests/unit/coord_systems/test_GeogCS.py](https://github.com/SciTools/iris/pull/2062/files#diff-c049627b2a11991ec3132128f483e441)).

**Context:**

In our current project, we are monkey-patching the `iris.coord_system.Coor.__eq__` method in order that all coordinate systems can be handled effectively.  This PR is about removing the need for our own project hack.

Closes #716

**DO NOT MERGE**
