### PR TITLE
naming type for CellMethod changed

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jul-22_cell-method-coord-name.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/bugfix_2016-Jul-22_cell-method-coord-name.txt
@@ -1,0 +1,1 @@
+Altered Cell Methods to display coordinate's standard_name rather than var_name where appropriate to avoid human confusion.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -531,6 +531,24 @@ def _load_cube(engine, cf, cf_var, filename):
     for attr_name, attr_value in tmpvar:
         _set_attributes(cube.attributes, attr_name, attr_value)
 
+    names_dict = {}
+    for coord in cube.coords():
+        names_dict[coord.var_name] = coord.name()
+
+    for i in range(len(cube.cell_methods)):
+        for j in range(len(cube.cell_methods[i].coord_names)):
+            method = cube.cell_methods[i].method[j]
+            intervals = cube.cell_methods[i].intervals[j]
+            comments = cube.cell_methods[i].comments
+            pattern = re.compile(r'\b(' + '|'.join(names_dict.keys()) + r')\b')
+            new_name = pattern.sub(lambda x: names_dict[x.group()],
+                                   cube.cell_methods[i].coord_names[j])
+            cube.cell_methods = (iris.coords.CellMethod(method=method,
+                                                        coords=new_name,
+                                                        intervals=intervals,
+                                                        comments=comments),)
+
+
     # Show pyke session statistics.
     _pyke_stats(engine, cf_var.cf_name)
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -531,22 +531,15 @@ def _load_cube(engine, cf, cf_var, filename):
     for attr_name, attr_value in tmpvar:
         _set_attributes(cube.attributes, attr_name, attr_value)
 
-    names_dict = {}
-    for coord in cube.coords():
-        names_dict[coord.var_name] = coord.name()
+    names_dict = {coord.var_name: coord.name() for coord in cube.coords()}
 
-    for i in range(len(cube.cell_methods)):
-        for j in range(len(cube.cell_methods[i].coord_names)):
-            method = cube.cell_methods[i].method[j]
-            intervals = cube.cell_methods[i].intervals[j]
-            comments = cube.cell_methods[i].comments
-            pattern = re.compile(r'\b(' + '|'.join(names_dict.keys()) + r')\b')
-            new_name = pattern.sub(lambda x: names_dict[x.group()],
-                                   cube.cell_methods[i].coord_names[j])
-            cube.cell_methods = (iris.coords.CellMethod(method=method,
-                                                        coords=new_name,
-                                                        intervals=intervals,
-                                                        comments=comments),)
+    cube.cell_methods = [iris.coords.CellMethod(method=method.method,
+                                                intervals=method.intervals,
+                                                comments=method.comments,
+                                                coords=[names_dict[coord_name]
+                                                        for coord_name in
+                                                        method.coord_names])
+                         for method in cube.cell_methods]
 
     # Show pyke session statistics.
     _pyke_stats(engine, cf_var.cf_name)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -534,14 +534,15 @@ def _load_cube(engine, cf, cf_var, filename):
     names = {coord.var_name: coord.standard_name or coord.var_name or 'unknown'
              for coord in cube.coords()}
 
-    cube.cell_methods = [iris.coords.CellMethod(
-                             method=method.method,
-                             intervals=method.intervals,
-                             comments=method.comments,
-                             coords=[names[coord_name]
-                                     if coord_name in names else coord_name
-                                     for coord_name in method.coord_names])
-                         for method in cube.cell_methods]
+    cube.cell_methods = [
+        iris.coords.CellMethod(
+            method=method.method,
+            intervals=method.intervals,
+            comments=method.comments,
+            coords=[names[coord_name] if
+                    coord_name in names else coord_name
+                    for coord_name in method.coord_names])
+        for method in cube.cell_methods]
 
     # Show pyke session statistics.
     _pyke_stats(engine, cf_var.cf_name)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -548,7 +548,6 @@ def _load_cube(engine, cf, cf_var, filename):
                                                         intervals=intervals,
                                                         comments=comments),)
 
-
     # Show pyke session statistics.
     _pyke_stats(engine, cf_var.cf_name)
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -534,14 +534,13 @@ def _load_cube(engine, cf, cf_var, filename):
     names = {coord.var_name: coord.standard_name or coord.var_name or 'unknown'
              for coord in cube.coords()}
 
-    cube.cell_methods = [iris.coords.CellMethod(method=method.method,
-                                                intervals=method.intervals,
-                                                comments=method.comments,
-                                                coords=
-                                                [names[coord_name] if
-                                                 coord_name in names else
-                                                 coord_name for coord_name in
-                                                 method.coord_names])
+    cube.cell_methods = [iris.coords.CellMethod(
+                             method=method.method,
+                             intervals=method.intervals,
+                             comments=method.comments,
+                             coords=[names[coord_name]
+                                     if coord_name in names else coord_name
+                                     for coord_name in method.coord_names])
                          for method in cube.cell_methods]
 
     # Show pyke session statistics.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -537,9 +537,10 @@ def _load_cube(engine, cf, cf_var, filename):
                                                 intervals=method.intervals,
                                                 comments=method.comments,
                                                 coords=[names[coord_name]
+                                                        if coord_name in names
+                                                        else coord_name
                                                         for coord_name in
-                                                        method.coord_names if
-                                                        coord_name in names])
+                                                        method.coord_names])
                          for method in cube.cell_methods]
 
     # Show pyke session statistics.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -531,16 +531,17 @@ def _load_cube(engine, cf, cf_var, filename):
     for attr_name, attr_value in tmpvar:
         _set_attributes(cube.attributes, attr_name, attr_value)
 
-    names = {coord.var_name: coord.name() for coord in cube.coords()}
+    names = {coord.var_name: coord.standard_name or coord.var_name or 'unknown'
+             for coord in cube.coords()}
 
     cube.cell_methods = [iris.coords.CellMethod(method=method.method,
                                                 intervals=method.intervals,
                                                 comments=method.comments,
-                                                coords=[names[coord_name]
-                                                        if coord_name in names
-                                                        else coord_name
-                                                        for coord_name in
-                                                        method.coord_names])
+                                                coords=
+                                                [names[coord_name] if
+                                                 coord_name in names else
+                                                 coord_name for coord_name in
+                                                 method.coord_names])
                          for method in cube.cell_methods]
 
     # Show pyke session statistics.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -531,14 +531,15 @@ def _load_cube(engine, cf, cf_var, filename):
     for attr_name, attr_value in tmpvar:
         _set_attributes(cube.attributes, attr_name, attr_value)
 
-    names_dict = {coord.var_name: coord.name() for coord in cube.coords()}
+    names = {coord.var_name: coord.name() for coord in cube.coords()}
 
     cube.cell_methods = [iris.coords.CellMethod(method=method.method,
                                                 intervals=method.intervals,
                                                 comments=method.comments,
-                                                coords=[names_dict[coord_name]
+                                                coords=[names[coord_name]
                                                         for coord_name in
-                                                        method.coord_names])
+                                                        method.coord_names if
+                                                        coord_name in names])
                          for method in cube.cell_methods]
 
     # Show pyke session statistics.

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -14,8 +14,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord name="lat"/>
-        <coord name="lon"/>
+        <coord name="latitude"/>
+        <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -35,8 +35,8 @@
     <cellMethods>
       <cellMethod method="mean">
         <coord name="time"/>
-        <coord name="lat"/>
-        <coord name="lon"/>
+        <coord name="latitude"/>
+        <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -58,10 +58,10 @@
         <coord name="time"/>
       </cellMethod>
       <cellMethod method="maximum">
-        <coord name="lat"/>
+        <coord name="latitude"/>
       </cellMethod>
       <cellMethod method="minimum">
-        <coord name="lon"/>
+        <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -83,8 +83,8 @@
         <coord name="time"/>
       </cellMethod>
       <cellMethod method="maximum">
-        <coord name="lat"/>
-        <coord name="lon"/>
+        <coord name="latitude"/>
+        <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -103,8 +103,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord name="lat"/>
-        <coord name="lon"/>
+        <coord name="latitude"/>
+        <coord name="longitude"/>
       </cellMethod>
       <cellMethod method="maximum">
         <coord name="time"/>
@@ -164,8 +164,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord comment="this is a shared comment" name="lat"/>
-        <coord comment="this is a shared comment" name="lon"/>
+        <coord comment="this is a shared comment" name="latitude"/>
+        <coord comment="this is a shared comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -184,8 +184,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord comment="this a lat comment" name="lat"/>
-        <coord comment="this is a lon comment" name="lon"/>
+        <coord comment="this a lat comment" name="latitude"/>
+        <coord comment="this is a lon comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -207,8 +207,8 @@
         <coord comment="this is a time comment" name="time"/>
       </cellMethod>
       <cellMethod method="mean">
-        <coord comment="this is a shared comment" name="lat"/>
-        <coord comment="this is a shared comment" name="lon"/>
+        <coord comment="this is a shared comment" name="latitude"/>
+        <coord comment="this is a shared comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -246,8 +246,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord interval="0.1 degrees" name="lat"/>
-        <coord interval="0.1 degrees" name="lon"/>
+        <coord interval="0.1 degrees" name="latitude"/>
+        <coord interval="0.1 degrees" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -266,8 +266,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord interval="0.1 degree_n" name="lat"/>
-        <coord interval="0.2 degree_e" name="lon"/>
+        <coord interval="0.1 degree_n" name="latitude"/>
+        <coord interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -289,8 +289,8 @@
         <coord interval="1 day" name="time"/>
       </cellMethod>
       <cellMethod method="minimum">
-        <coord interval="0.1 degrees" name="lat"/>
-        <coord interval="0.1 degrees" name="lon"/>
+        <coord interval="0.1 degrees" name="latitude"/>
+        <coord interval="0.1 degrees" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -312,10 +312,10 @@
         <coord interval="1 day" name="time"/>
       </cellMethod>
       <cellMethod method="minimum">
-        <coord interval="0.1 degree_n" name="lat"/>
+        <coord interval="0.1 degree_n" name="latitude"/>
       </cellMethod>
       <cellMethod method="mean">
-        <coord interval="0.2 degree_e" name="lon"/>
+        <coord interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -418,8 +418,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord comment="area-weighted" interval="0.1 degree_n" name="lat"/>
-        <coord comment="area-weighted" interval="0.2 degree_e" name="lon"/>
+        <coord comment="area-weighted" interval="0.1 degree_n" name="latitude"/>
+        <coord comment="area-weighted" interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
@@ -438,8 +438,8 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord comment="area-weighted" interval="0.1 degree_n" name="lat"/>
-        <coord comment="area-weighted" interval="0.2 degree_e" name="lon"/>
+        <coord comment="area-weighted" interval="0.1 degree_n" name="latitude"/>
+        <coord comment="area-weighted" interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
       <cellMethod method="sum">
         <coord comment="weekly sum" interval="7 days" name="time"/>

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -100,7 +100,7 @@
     </coords>
     <cellMethods>
       <cellMethod method="mean">
-        <coord name="time_counter"/>
+        <coord name="time"/>
       </cellMethod>
     </cellMethods>
     <data checksum="0xe9325dcb" dtype="float64" shape="(1, 31, 90)"/>


### PR DESCRIPTION
@pp-mo Previously the name used for Cell Methods was the var_name, but this was causing some human confusion and there was also a discrepancy between the name used in different ways:

```
precipitation_flux / (kg m-2 s-1)   (time: 30; latitude: 144; longitude: 192)
     Dimension coordinates:
          time                           x             -               -
          latitude                       -             x               -
          longitude                      -             -               x
     Auxiliary coordinates:
          forecast_period                x             -               -
     Scalar coordinates:
          forecast_reference_time: 1988-09-01 00:00:00
     Attributes:
          Conventions: CF-1.5
          source: Data from Met Office Unified Model
          um_version: 10.3
     Cell methods:
          mean: time_0 (1 hour)
```
```
In [24]: CellMethod('mean', cube.coord('time'), '1 hour')
Out[24]: CellMethod(method='mean', coord_names=(u'time',), intervals=('1 hour',), comments=())
```

There should be consistency in the naming type of the Cell Method, so I have added a post-processing method which changes the var_name to the standard_name.  

I am not convinced in the slightest that this is efficient, and I am also unsure that this will work correctly for cubes with multiple Cell Methods.  Advice would be much appreciated.