### PR TITLE
Remove incorrect note from Unit.convert method

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1852,8 +1852,7 @@ class Unit(iris.util._OrderedHashable):
 
         .. note::
 
-            Conversion is done *in-place* for numpy arrays. Also note that,
-            conversion between unit calendars is not permitted.
+            Conversion between unit calendars is not permitted.
 
         """
         result = None


### PR DESCRIPTION
There is a note in the `Unit.convert` docstring that says "Conversion is done *in-place* for numpy arrays". However, this appears not to be the case. Using the example in the docstring:

```
% python2.7
Python 2.7.6 (default, Jan  3 2014, 16:42:21) 
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cf_units as unit
>>> import numpy as np
>>> c = unit.Unit('deg_c')
>>> f = unit.Unit('deg_f')
>>> a32 = np.arange(10, dtype=np.float32)
>>> c.convert(a32, f)
array([ 32.        ,  33.79999924,  35.59999847,  37.40000153,
        39.20000076,  41.        ,  42.79999924,  44.59999847,
        46.40000153,  48.20000076], dtype=float32)
>>> a32
array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.], dtype=float32)
```
This pull request just removes this incorrect note.