### PR TITLE
Extend point in cell

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -849,18 +849,20 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
 
     """
     regrid_info = \
-        _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+        _regrid_weighted_curvilinear_to_rectilinear__prepare(
             src_cube, weights, grid_cube)
-    result = _regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
+    result = _regrid_weighted_curvilinear_to_rectilinear__perform(
         src_cube, regrid_info)
     return result
 
 
-def _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+def _regrid_weighted_curvilinear_to_rectilinear__prepare(
         src_cube, weights, grid_cube):
     """
-    Check inputs and calculate the sparse info needed for the
-    'regrid_weighted_curvilinear_to_rectilinear' calculation.
+    First (setup) part of 'regrid_weighted_curvilinear_to_rectilinear'.
+
+    Check inputs and calculate the sparse regrid matrix and related info.
+    The 'regrid info' returned can be re-used over many 2d slices.
 
     """
     if src_cube.aux_factories:
@@ -1074,11 +1076,12 @@ def _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
     return regrid_info
 
 
-def _regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
+def _regrid_weighted_curvilinear_to_rectilinear__perform(
         src_cube, regrid_info):
     """
-    Perform actual regrid calculation for
-    'regrid_weighted_curvilinear_to_rectilinear'.
+    Second (regrid) part of 'regrid_weighted_curvilinear_to_rectilinear'.
+
+    Perform the prepared regrid calculation on a single 2d cube.
 
     """
     sparse_matrix, sum_weights, rows, grid_cube = regrid_info
@@ -1238,10 +1241,12 @@ class _CurvilinearRegridder(object):
             if regrid_info is None:
                 # Calculate the basic regrid info just once.
                 regrid_info = \
-                    _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+                    _regrid_weighted_curvilinear_to_rectilinear__prepare(
                         slice_cube, self.weights, self._target_cube)
-            result_slices.append(_regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
-                slice_cube, regrid_info))
+            slice_result = \
+                _regrid_weighted_curvilinear_to_rectilinear__perform(
+                    slice_cube, regrid_info)
+            result_slices.append(slice_result)
         result = result_slices.merge_cube()
         return result
 

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1095,7 +1095,6 @@ def _regrid_weighted_curvilinear_to_rectilinear__perform(
         # Zero any masked source points so they add nothing in output sums.
         if np.ma.is_masked(src_cube.data):
             mask = src_cube.data.mask
-            valid = ~mask
             data[mask] = 0.0
 
     # Calculate sum in each target cell, over contributions from each source
@@ -1105,10 +1104,13 @@ def _regrid_weighted_curvilinear_to_rectilinear__perform(
     # Create a template for the weighted mean result.
     weighted_mean = ma.masked_all(numerator.shape, dtype=numerator.dtype)
 
-    # Account for missing input data points.
+    # Account for any missing input data points.
     if np.ma.is_masked(src_cube.data):
         # Calculate a new 'sum_weights' to account for missing source points.
-        src_cell_validity_factors = sparse_diags(np.array(valid, dtype=int), 0)
+        valid_src_cells = ~mask.flat[:]
+        src_cell_validity_factors = sparse_diags(
+            np.array(valid_src_cells, dtype=int),
+            0)
         valid_weights = sparse_matrix * src_cell_validity_factors
         sum_weights = valid_weights.sum(axis=1)
         sum_weights = np.maximum(1, sum_weights).getA()

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1231,13 +1231,12 @@ class _CurvilinearRegridder(object):
                              'source grid as this regridder.')
 
         # Call the regridder function.
-#        res = regrid_weighted_curvilinear_to_rectilinear(
-#            src, self.weights, self._target_cube)
-#        return res
         # This includes repeating over any non-XY dimensions, because the
         # underlying routine does not support this.
-        # Just for now, we will use cube.slices and merge to achieve this,
+        # FOR NOW: we will use cube.slices and merge to achieve this,
         # though that is not a terribly efficient method ...
+        # TODO: create a template result cube and paste data slices into it,
+        # which would be more efficient.
         result_slices = iris.cube.CubeList([])
         for slice_cube in src.slices(sx):
             if self._regrid_info is None:

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1135,7 +1135,7 @@ class _CurvilinearRegridder(object):
     between a curvilinear source grid and a rectilinear target grid.
 
     """
-    def __init__(self, src_grid_cube, target_grid_cube, weights):
+    def __init__(self, src_grid_cube, target_grid_cube, weights=None):
         """
         Create a regridder for conversions between the source
         and target grids.
@@ -1146,10 +1146,14 @@ class _CurvilinearRegridder(object):
             The :class:`~iris.cube.Cube` providing the source grid.
         * tgt_grid_cube:
             The :class:`~iris.cube.Cube` providing the target grid.
+
+        Optional Args:
+
         * weights:
             A :class:`numpy.ndarray` instance that defines the weights
             for the grid cells of the source grid. Must have the same shape
             as the data of the source grid.
+            If unspecified, equal weighting is assumed.
 
         """
         # Validity checks.
@@ -1249,17 +1253,18 @@ class PointInCell(object):
     :meth:`iris.cube.Cube.regrid()`.
 
     """
-    def __init__(self, weights):
+    def __init__(self, weights=None):
         """
         Point-in-cell regridding scheme suitable for regridding over one
         or more orthogonal coordinates.
 
-        Args:
+        Optional Args:
 
         * weights:
             A :class:`numpy.ndarray` instance that defines the weights
             for the grid cells of the source grid. Must have the same shape
             as the data of the source grid.
+            If unspecified, equal weighting is assumed.
 
         """
         self.weights = weights

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1171,6 +1171,7 @@ class _CurvilinearRegridder(object):
         self._src_cube = src_grid_cube.copy()
         self._target_cube = target_grid_cube.copy()
         self.weights = weights
+        self._regrid_info = None
 
     @staticmethod
     def _get_horizontal_coord(cube, axis):
@@ -1237,17 +1238,16 @@ class _CurvilinearRegridder(object):
         # underlying routine does not support this.
         # Just for now, we will use cube.slices and merge to achieve this,
         # though that is not a terribly efficient method ...
-        regrid_info = None
         result_slices = iris.cube.CubeList([])
         for slice_cube in src.slices(sx):
-            if regrid_info is None:
+            if self._regrid_info is None:
                 # Calculate the basic regrid info just once.
-                regrid_info = \
+                self._regrid_info = \
                     _regrid_weighted_curvilinear_to_rectilinear__prepare(
                         slice_cube, self.weights, self._target_cube)
             slice_result = \
                 _regrid_weighted_curvilinear_to_rectilinear__perform(
-                    slice_cube, regrid_info)
+                    slice_cube, self._regrid_info)
             result_slices.append(slice_result)
         result = result_slices.merge_cube()
         return result

--- a/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
@@ -89,7 +89,7 @@ class Test___call__(tests.IrisTest):
         self.weights = np.ones(self.src_grid.shape, self.src_grid.dtype)
         # Define an actual, dummy cube for the internal partial result, so we
         # can do a cubelist merge on it, which is too complicated to mock out.
-        self.mock_slice_result = Cube([1])
+        self.dummy_slice_result = Cube([1])
 
     def test_same_src_as_init(self):
         # Check the regridder call calls the underlying routines as expected.
@@ -100,7 +100,7 @@ class Test___call__(tests.IrisTest):
                         return_value=mock.sentinel.regrid_info) as patch_setup:
             with mock.patch(
                     self.func_operate,
-                    return_value=self.mock_slice_result) as patch_operate:
+                    return_value=self.dummy_slice_result) as patch_operate:
                 result = regridder(src_grid)
         patch_setup.assert_called_once_with(
             src_grid, self.weights, target_grid)
@@ -108,21 +108,18 @@ class Test___call__(tests.IrisTest):
             src_grid, mock.sentinel.regrid_info)
         # The result is a re-merged version of the internal result, so it is
         # therefore '==' but not the same object.
-        self.assertEqual(result, self.mock_slice_result)
+        self.assertEqual(result, self.dummy_slice_result)
 
     def test_no_weights(self):
         # Check we can use the regridder without weights.
         src_grid = self.src_grid
         target_grid = self.tgt_grid
         regridder = Regridder(src_grid, target_grid)
-        # Note: for now, patch the internal partial result to a "real" cube,
-        # so we can do a cubelist merge, which is too complicated to mock out.
-        mock_slice_result = Cube([1])
         with mock.patch(self.func_setup,
                         return_value=mock.sentinel.regrid_info) as patch_setup:
             with mock.patch(
                     self.func_operate,
-                    return_value=self.mock_slice_result) as patch_operate:
+                    return_value=self.dummy_slice_result) as patch_operate:
                 result = regridder(src_grid)
         patch_setup.assert_called_once_with(
             src_grid, None, target_grid)
@@ -133,9 +130,6 @@ class Test___call__(tests.IrisTest):
         src_grid = self.src_grid
         target_grid = self.tgt_grid
         regridder = Regridder(src_grid, target_grid, self.weights)
-        # Note: for now, patch the internal partial result to a "real" cube,
-        # so we can do a cubelist merge, which is too complicated to mock out.
-        mock_slice_result = Cube([1])
         # Provide a "different" cube for the actual regrid.
         different_src_cube = self.src_grid.copy()
         # Rename so we can distinguish them.
@@ -144,7 +138,7 @@ class Test___call__(tests.IrisTest):
                         return_value=mock.sentinel.regrid_info) as patch_setup:
             with mock.patch(
                     self.func_operate,
-                    return_value=self.mock_slice_result) as patch_operate:
+                    return_value=self.dummy_slice_result) as patch_operate:
                 result = regridder(different_src_cube)
         patch_operate.assert_called_once_with(
             different_src_cube, mock.sentinel.regrid_info)
@@ -155,14 +149,13 @@ class Test___call__(tests.IrisTest):
         src_grid = self.src_grid
         target_grid = self.tgt_grid
         regridder = Regridder(src_grid, target_grid, self.weights)
-        mock_slice_result = Cube([1])
         different_src_cube = self.src_grid.copy()
         different_src_cube.rename('Different_source')
         with mock.patch(self.func_setup,
                         return_value=mock.sentinel.regrid_info) as patch_setup:
             with mock.patch(
                     self.func_operate,
-                    return_value=self.mock_slice_result) as patch_operate:
+                    return_value=self.dummy_slice_result) as patch_operate:
                 result1 = regridder(src_grid)
                 result2 = regridder(different_src_cube)
         patch_setup.assert_called_once_with(
@@ -298,7 +291,7 @@ class Test__call__multidimensional(tests.IrisTest):
         self.assertEqual(result.coord('latitude'),
                          grid_cube.coord('latitude'))
         self.assertMaskedArrayAlmostEqual(result.data, expected_result)
-        t_dbg = 0
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
@@ -166,9 +166,9 @@ class Test___call__(tests.IrisTest):
             src_grid, self.weights, target_grid)
         self.assertEqual(len(patch_operate.call_args_list), 2)
         self.assertEqual(
-             patch_operate.call_args_list,
-             [mock.call(src_grid, mock.sentinel.regrid_info),
-              mock.call(different_src_cube, mock.sentinel.regrid_info)])
+            patch_operate.call_args_list,
+            [mock.call(src_grid, mock.sentinel.regrid_info),
+             mock.call(different_src_cube, mock.sentinel.regrid_info)])
 
 
 @tests.skip_data

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
@@ -42,7 +42,7 @@ from iris.experimental.regrid \
     import regrid_weighted_curvilinear_to_rectilinear as regrid
 
 
-_PLAIN_LATLON_CS = GeogCS(EARTH_RADIUS)
+PLAIN_LATLON_CS = GeogCS(EARTH_RADIUS)
 
 
 class Test(tests.IrisTest):
@@ -69,12 +69,12 @@ class Test(tests.IrisTest):
             points,
             standard_name='longitude',
             units='degrees',
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
         self.src_x_transpose = iris.coords.AuxCoord(
             points.T,
             standard_name='longitude',
             units='degrees',
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
         points = np.array([[-180, -176, -170, -150],
                            [-180, -179, -178, -177],
                            [-170, -168, -159, -140]])
@@ -82,7 +82,7 @@ class Test(tests.IrisTest):
             points,
             standard_name='longitude',
             units='degrees',
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
 
         # Source cube y-coordinates.
         points = np.array([[0, 4, 3, 1],
@@ -92,12 +92,12 @@ class Test(tests.IrisTest):
             points,
             standard_name='latitude',
             units='degrees',
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
         self.src_y_transpose = iris.coords.AuxCoord(
             points.T,
             standard_name='latitude',
             units='degrees',
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
 
         # Weights.
         self.weight_factor = 10
@@ -113,14 +113,14 @@ class Test(tests.IrisTest):
             units='degrees',
             bounds=[[180, 190],
                     [190, 220]],
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
         self.grid_x_dec = iris.coords.DimCoord(
             [200, 187],
             standard_name='longitude',
             units='degrees',
             bounds=[[220, 190],
                     [190, 180]],
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
 
         # Target grid cube y-coordinates.
         self.grid_y_inc = iris.coords.DimCoord(
@@ -129,14 +129,14 @@ class Test(tests.IrisTest):
             units='degrees',
             bounds=[[0, 5],
                     [5, 30]],
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
         self.grid_y_dec = iris.coords.DimCoord(
             [10, 2],
             standard_name='latitude',
             units='degrees',
             bounds=[[30, 5],
                     [5, 0]],
-            coord_system=_PLAIN_LATLON_CS)
+            coord_system=PLAIN_LATLON_CS)
 
     def _weighted_mean(self, points):
         points = np.asarray(points, dtype=np.float)


### PR DESCRIPTION
Adapt PointInCell regridder to make it work for cross-coordinate-system regridding, including non-latlon systems.

NOTE: this removes certain input requirements, but also adds some, so is not totally backwards-compatible :
**requirements removed:**
  * source and target must have the same coordinate system
  * coord systems must be latlon
  * source data X and Y coords must be 2d (can now have any dimensionality)

**requirements added:**
  * source and target must both have a **defined** coord-system
    * previously 'None' was acceptable, but that is problematic now it isn't limited to latlon systems
  * source data X and Y coordinates must now have **the same** cube dimensions
    * previously they had to be 2d, and the same size, but could have different dimension ordering

**I think these changes are acceptable, as it is experimental**
It basically *will* work for all existing cases, with just simple adaptations in certain cases