### PR TITLE
Remove restriction on whitespace in netCDF variable names

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -142,13 +142,9 @@ class CFVariableMixin(object):
 
     @var_name.setter
     def var_name(self, name):
-        if name is not None:
-            if not name:
-                raise ValueError('An empty string is not a valid CF variable '
-                                 'name.')
-            elif set(name).intersection(string.whitespace):
-                raise ValueError('{!r} is not a valid CF variable name because'
-                                 ' it contains whitespace.'.format(name))
+        if name is not None and not name:
+            raise ValueError('An empty string is not a valid CF variable '
+                             'name.')
         self._var_name = name
 
     @property


### PR DESCRIPTION
The netCDF conventions state:

> Variable, dimension and attribute names should begin with a letter and be composed of letters, digits, and underscores. 

However, the netCDF4 Python library does not enforce this convention. Is there any reason Iris should too?

I have a user with a netCDF file with a variable containing whitespace that can't be used in Iris due to this restriction. I imagine there are others who have encountered the issue as well.

So, what are the arguments against relaxing the restriction?