### PR TITLE
1.9.2 docs

### DIFF
--- a/docs/iris/src/whatsnew/1.9.rst
+++ b/docs/iris/src/whatsnew/1.9.rst
@@ -1,8 +1,8 @@
 What's New in Iris 1.9
 **********************
 
-:Release: 1.9.1
-:Date: 5th January 2016
+:Release: 1.9.2
+:Date: 28th January 2016
 
 This document explains the new/changed features of Iris in version 1.9
 (:doc:`View all changes <index>`.)
@@ -98,6 +98,16 @@ Bugs Fixed
 Version 1.9.1
 -------------
 * Fixed a unicode bug preventing standard names from being built cleanly when installing in Python3
+
+Version 1.9.2
+-------------
+* New warning regarding data loss if writing to an open file which is also open to read, with lazy data.
+* Removal of a warning about data payload loading from concatenate.
+* Updates to concatenate documentation.
+* Fixed a bug with a name change in the netcdf4-python package.
+* Fixed a bug building the documentation examples.
+* Fixed a bug avoiding sorting classes directly when :meth:`iris.cube.Cube.coord_system` is used in Python3.
+* Fixed a bug regarding unsuccessful dot import.
 
 Incompatible Changes
 ====================


### PR DESCRIPTION
the last changes from 1.9.2 were not merged back onto master.  

These should be in 1.10, which will be merged back onto master following the release