### PR TITLE
ENH: Enable writing valid_range valid_min and valid_max on NetCDF save

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-Aug-02_netcdf_valid_range_attribute.txt
+++ b/docs/iris/src/whatsnew/contributions_1.10/newfeature_2016-Aug-02_netcdf_valid_range_attribute.txt
@@ -1,0 +1,2 @@
+* NetCDF saving of valid_range, valid_min and valid_max cube attributes is
+ now allowed.

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -34,7 +34,7 @@ class LimitedAttributeDict(dict):
                        'coordinates', 'grid_mapping', 'climatology',
                        'cell_methods', 'formula_terms', 'compress',
                        'missing_value', 'add_offset', 'scale_factor',
-                       'valid_max', 'valid_min', 'valid_range', '_FillValue')
+                       '_FillValue')
 
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -973,7 +973,6 @@ class Saver(object):
                 new_val = _coerce_value(val_attr, val_attr_value, data_dtype)
                 container.attributes[val_attr] = new_val
 
-
     def update_global_attributes(self, attributes=None, **kwargs):
         """
         Update the CF global attributes based on the provided

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -84,7 +84,7 @@ _CF_ATTRS = ['add_offset', 'ancillary_variables', 'axis', 'bounds', 'calendar',
              'coordinates', '_FillValue', 'formula_terms', 'grid_mapping',
              'leap_month', 'leap_year', 'long_name', 'missing_value',
              'month_lengths', 'scale_factor', 'standard_error_multiplier',
-             'standard_name', 'units', 'valid_max', 'valid_min', 'valid_range']
+             'standard_name', 'units']
 
 # CF attributes that should not be global.
 _CF_DATA_ATTRS = ['flag_masks', 'flag_meanings', 'flag_values',
@@ -885,6 +885,10 @@ class Saver(object):
             # being raised if mandatory requirements are not satisfied.
             profile = iris.site_configuration['cf_profile'](cube)
 
+        # Ensure that attributes are CF compliant and if possible to make them
+        # compliant.
+        self.check_attribute_compliance(cube)
+
         # Get suitable dimension names.
         dimension_names = self._get_dim_names(cube)
 
@@ -935,6 +939,36 @@ class Saver(object):
                 msg = 'cf_profile is available but no {} defined.'.format(
                     'cf_patch')
                 warnings.warn(msg)
+
+    def check_attribute_compliance(self, cube):
+        def _coerce_value(val_attr, val_attr_value, data_dtype):
+            val_attr_tmp = np.array(val_attr_value, dtype=data_dtype)
+            if (val_attr_tmp != val_attr_value).any():
+                msg = '"{}" is not of a suitable value ({})'
+                raise ValueError(msg.format(val_attr, val_attr_value))
+            return val_attr_tmp
+
+        data_dtype = cube.lazy_data().dtype
+
+        # Ensure that conflicting attributes are not provided.
+        if ((cube.attributes.get('valid_min') is not None or
+                cube.attributes.get('valid_max') is not None) and
+                cube.attributes.get('valid_range') is not None):
+            msg = ('Both "valid_range" and "valid_min" or "valid_max" '
+                   'attributes present.')
+            raise ValueError(msg)
+
+        # Ensure correct datatype
+        for val_attr in ['valid_range', 'valid_min', 'valid_max']:
+            val_attr_value = cube.attributes.get(val_attr)
+            if val_attr_value is not None:
+                val_attr_value = np.asarray(val_attr_value)
+                if data_dtype.itemsize is 1:
+                    # Allow signed integral type
+                    if val_attr_value.dtype.kind == 'i':
+                        continue
+                new_val = _coerce_value(val_attr, val_attr_value, data_dtype)
+                cube.attributes[val_attr] = new_val
 
     def update_global_attributes(self, attributes=None, **kwargs):
         """

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -60,7 +60,7 @@
 		[3504.46, 4001.16],
 		[4001.16, 4500.02],
 		[4500.02, 5000.0],
-		[5000.0, 5500.55]]" id="79c1bf07" long_name="Vertical T levels" points="[4.99994, 15.0003, 25.0018, 35.0054, 45.0133,
+		[5000.0, 5500.55]]" id="91b33a78" long_name="Vertical T levels" points="[4.99994, 15.0003, 25.0018, 35.0054, 45.0133,
 		55.0295, 65.0618, 75.1255, 85.2504, 95.4943,
 		105.97, 116.896, 128.698, 142.195, 158.961,
 		181.963, 216.648, 272.477, 364.303, 511.535,
@@ -70,22 +70,28 @@
           <attributes>
             <attribute name="positive" value="down"/>
             <attribute name="title" value="deptht"/>
+            <attribute name="valid_max" value="5250.23"/>
+            <attribute name="valid_min" value="4.99994"/>
           </attributes>
         </dimCoord>
       </coord>
       <coord datadims="[2]">
-        <auxCoord id="a76b6ea8" long_name="Latitude" points="[-78.1906, -78.1906, -78.1906, ..., 83.8392,
+        <auxCoord id="3d7b9ef8" long_name="Latitude" points="[-78.1906, -78.1906, -78.1906, ..., 83.8392,
 		86.2794, 87.9471]" shape="(90,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <attributes>
             <attribute name="nav_model" value="Default grid"/>
+            <attribute name="valid_max" value="89.6139"/>
+            <attribute name="valid_min" value="-78.1906"/>
           </attributes>
         </auxCoord>
       </coord>
       <coord datadims="[2]">
-        <auxCoord id="730f5d37" long_name="Longitude" points="[-84.0002, -90.0001, -90.0001, ..., -86.9366,
+        <auxCoord id="947b46dd" long_name="Longitude" points="[-84.0002, -90.0001, -90.0001, ..., -86.9366,
 		-88.8945, -100.0]" shape="(90,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
           <attributes>
             <attribute name="nav_model" value="Default grid"/>
+            <attribute name="valid_max" value="180.0"/>
+            <attribute name="valid_min" value="-179.751"/>
           </attributes>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -261,9 +261,9 @@ class TestLoad(tests.IrisTest):
             sorted(cube.coord('longitude').attributes.items()), 
             [('data_type', 'float'), 
              ('modulo', 360), 
-             ('topology', 'circular')
-            ]
-        )
+             ('topology', 'circular'),
+             ('valid_max', 359.0),
+             ('valid_min', 0.0)])
 
     def test_cell_methods(self):
         filename = tests.get_data_path(('NetCDF', 'global', 'xyt', 'SMALL_hires_wind_u_for_ipcc4.nc'))

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -242,7 +242,7 @@ class Test_write(tests.IrisTest):
             self.assertEqual(res, 'something something_else')
 
 
-class Test_write__valid_x(tests.IrisTest):
+class Test_write__valid_x_cube_attributes(tests.IrisTest):
     """Testing valid_range, valid_min and valid_max attributes."""
 
     def test_valid_range_saved(self):
@@ -282,72 +282,180 @@ class Test_write__valid_x(tests.IrisTest):
             self.assertArrayEqual(ds.valid_max, 2)
             ds.close()
 
-    def test_valid_range_type_coerce(self):
+
+class Test_write__valid_x_coord_attributes(tests.IrisTest):
+    """Testing valid_range, valid_min and valid_max attributes."""
+
+    def test_valid_range_saved(self):
         cube = tests.stock.lat_lon_cube()
         cube.data = cube.data.astype('int32')
 
-        vrange = np.array([1, 2], dtype='float')
-        cube.attributes['valid_range'] = vrange
+        vrange = np.array([1, 2], dtype='int32')
+        cube.coord(axis='x').attributes['valid_range'] = vrange
         with self.temp_filename('.nc') as nc_path:
             with Saver(nc_path, 'NETCDF4') as saver:
                 saver.write(cube, unlimited_dimensions=[])
             ds = nc.Dataset(nc_path)
-            self.assertEqual(ds.valid_range.dtype, cube.data.dtype)
+            self.assertArrayEqual(ds.variables['longitude'].valid_range,
+                                  vrange)
             ds.close()
+
+    def test_valid_min_saved(self):
+        cube = tests.stock.lat_lon_cube()
+        cube.data = cube.data.astype('int32')
+
+        cube.coord(axis='x').attributes['valid_min'] = 1
+        with self.temp_filename('.nc') as nc_path:
+            with Saver(nc_path, 'NETCDF4') as saver:
+                saver.write(cube, unlimited_dimensions=[])
+            ds = nc.Dataset(nc_path)
+            self.assertArrayEqual(ds.variables['longitude'].valid_min, 1)
+            ds.close()
+
+    def test_valid_max_saved(self):
+        cube = tests.stock.lat_lon_cube()
+        cube.data = cube.data.astype('int32')
+
+        cube.coord(axis='x').attributes['valid_max'] = 2
+        with self.temp_filename('.nc') as nc_path:
+            with Saver(nc_path, 'NETCDF4') as saver:
+                saver.write(cube, unlimited_dimensions=[])
+            ds = nc.Dataset(nc_path)
+            self.assertArrayEqual(ds.variables['longitude'].valid_max, 2)
+            ds.close()
+
+
+class _Common__check_attribute_compliance(object):
+    def setUp(self):
+        self.container = mock.Mock(name='container', attributes={})
+        self.data = np.array(1, dtype='int32')
+
+        patch = mock.patch('netCDF4.Dataset')
+        mock_netcdf_dataset = patch.start()
+        self.addCleanup(patch.stop)
+
+    def set_attribute(self, value):
+        self.container.attributes[self.attribute] = value
+
+    def assertAttribute(self, value):
+        self.assertEqual(
+            np.asarray(self.container.attributes[self.attribute]).dtype,
+            value)
+
+    def check_attribute_compliance_call(self, value):
+        self.set_attribute(value)
+        with Saver(mock.Mock(), 'NETCDF4') as saver:
+            saver.check_attribute_compliance(self.container, self.data)
+
+
+class Test_check_attribute_compliance__valid_range(
+        _Common__check_attribute_compliance, tests.IrisTest):
+
+    @property
+    def attribute(self):
+        return 'valid_range'
+
+    def test_valid_range_type_coerce(self):
+        value = np.array([1, 2], dtype='float')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(self.data.dtype)
 
     def test_valid_range_unsigned_int8_data_signed_range(self):
-        cube = tests.stock.lat_lon_cube()
-        cube.data = cube.data.astype('uint8')
-
-        vrange = np.array([1, 2], dtype='int8')
-        cube.attributes['valid_range'] = vrange
-        with self.temp_filename('.nc') as nc_path:
-            with Saver(nc_path, 'NETCDF4') as saver:
-                saver.write(cube, unlimited_dimensions=[])
-            ds = nc.Dataset(nc_path)
-            self.assertEqual(ds.valid_range.dtype, vrange.dtype)
-            ds.close()
+        self.data = self.data.astype('uint8')
+        value = np.array([1, 2], dtype='int8')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(value.dtype)
 
     def test_valid_range_cannot_coerce(self):
-        # Ensure that we are unable to save a compliant valid_range
-        cube = tests.stock.lat_lon_cube()
-        cube.data = cube.data.astype('int8')
-
-        vrange = np.array([1.5, 2.5], dtype='float64')
-        cube.attributes['valid_range'] = vrange
+        value = np.array([1.5, 2.5], dtype='float64')
         msg = '"valid_range" is not of a suitable value'
-        with self.temp_filename('.nc') as nc_path:
-            with Saver(nc_path, 'NETCDF4') as saver:
-                with self.assertRaisesRegexp(ValueError, msg):
-                    saver.write(cube)
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.check_attribute_compliance_call(value)
 
-    def test_valid_range_iterable(self):
-        # Ensure we handle the case where an iterable is provided rather than
-        # a numpy array.
-        cube = tests.stock.lat_lon_cube()
-        cube.data = cube.data.astype('int8')
+    def test_valid_range_not_numpy_array(self):
+        # Ensure we handle the case when not a numpy array is provided.
+        self.data = self.data.astype('int8')
+        value = [1, 2]
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(np.int64)
 
-        vrange = [1, 2]
-        cube.attributes['valid_range'] = vrange
-        with self.temp_filename('.nc') as nc_path:
-            with Saver(nc_path, 'NETCDF4') as saver:
-                saver.write(cube, unlimited_dimensions=[])
-            ds = nc.Dataset(nc_path)
-            self.assertEqual(ds.valid_range.dtype, np.int64)
-            ds.close()
+
+class Test_check_attribute_compliance__valid_min(
+        _Common__check_attribute_compliance, tests.IrisTest):
+
+    @property
+    def attribute(self):
+        return 'valid_min'
+
+    def test_valid_range_type_coerce(self):
+        value = np.array(1, dtype='float')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(self.data.dtype)
+
+    def test_valid_range_unsigned_int8_data_signed_range(self):
+        self.data = self.data.astype('uint8')
+        value = np.array(1, dtype='int8')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(value.dtype)
+
+    def test_valid_range_cannot_coerce(self):
+        value = np.array(1.5, dtype='float64')
+        msg = '"valid_min" is not of a suitable value'
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.check_attribute_compliance_call(value)
+
+    def test_valid_range_not_numpy_array(self):
+        # Ensure we handle the case when not a numpy array is provided.
+        self.data = self.data.astype('int8')
+        value = 1
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(np.int64)
+
+
+class Test_check_attribute_compliance__valid_max(
+        _Common__check_attribute_compliance, tests.IrisTest):
+
+    @property
+    def attribute(self):
+        return 'valid_max'
+
+    def test_valid_range_type_coerce(self):
+        value = np.array(2, dtype='float')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(self.data.dtype)
+
+    def test_valid_range_unsigned_int8_data_signed_range(self):
+        self.data = self.data.astype('uint8')
+        value = np.array(2, dtype='int8')
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(value.dtype)
+
+    def test_valid_range_cannot_coerce(self):
+        value = np.array(2.5, dtype='float64')
+        msg = '"valid_max" is not of a suitable value'
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.check_attribute_compliance_call(value)
+
+    def test_valid_range_not_numpy_array(self):
+        # Ensure we handle the case when not a numpy array is provided.
+        self.data = self.data.astype('int8')
+        value = 2
+        self.check_attribute_compliance_call(value)
+        self.assertAttribute(np.int64)
+
+
+class Test_check_attribute_compliance__exception_handlng(
+        _Common__check_attribute_compliance, tests.IrisTest):
 
     def test_valid_range_and_valid_min_valid_max_provided(self):
         # Conflicting attributes should raise a suitable exception.
-        cube = tests.stock.lat_lon_cube()
-        cube.data = np.ma.array(cube.data, dtype='int8')
-
-        cube.attributes['valid_range'] = [1, 2]
-        cube.attributes['valid_min'] = 1
+        self.data = self.data.astype('int8')
+        self.container.attributes['valid_range'] = [1, 2]
+        self.container.attributes['valid_min'] = [1]
         msg = 'Both "valid_range" and "valid_min"'
-        with self.temp_filename('.nc') as nc_path:
-            with Saver(nc_path, 'NETCDF4') as saver:
-                with self.assertRaisesRegexp(ValueError, msg):
-                    saver.write(cube)
+        with Saver(mock.Mock(), 'NETCDF4') as saver:
+            with self.assertRaisesRegexp(ValueError, msg):
+                saver.check_attribute_compliance(self.container, self.data)
 
 
 class Test__create_cf_grid_mapping(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -123,6 +123,9 @@ class TestCoordAttributes(tests.IrisTest):
         self.flag_masks = mock.sentinel.flag_masks
         self.flag_meanings = mock.sentinel.flag_meanings
         self.flag_values = mock.sentinel.flag_values
+        self.valid_range = mock.sentinel.valid_range
+        self.valid_min = mock.sentinel.valid_min
+        self.valid_max = mock.sentinel.valid_max
 
     def _make(self, names, attrs):
         coords = [DimCoord(i, long_name=name) for i, name in enumerate(names)]
@@ -162,14 +165,20 @@ class TestCoordAttributes(tests.IrisTest):
                   ('wibble', 'wibble')],
                  [('flag_meanings', self.flag_meanings),
                   ('add_offset', 'add_offset')],
-                 [('flag_values', self.flag_values)]]
+                 [('flag_values', self.flag_values)],
+                 [('valid_range', self.valid_range)],
+                 [('valid_min', self.valid_min)],
+                 [('valid_max', self.valid_max)]]
         cf, cf_var = self._make(names, attrs)
         cube = _load_cube(self.engine, cf, cf_var, self.filename)
         self.assertEqual(len(cube.coords()), 3)
         self.assertEqual(set([c.name() for c in cube.coords()]), set(names))
         expected = [attrs[0],
                     [attrs[1][0]],
-                    attrs[2]]
+                    attrs[2],
+                    attrs[3],
+                    attrs[4],
+                    attrs[5]]
         for name, expect in zip(names, expected):
             attributes = cube.coord(name).attributes
             self.assertEqual(set(attributes.items()), set(expect))
@@ -187,6 +196,9 @@ class TestCubeAttributes(tests.IrisTest):
         self.flag_masks = mock.sentinel.flag_masks
         self.flag_meanings = mock.sentinel.flag_meanings
         self.flag_values = mock.sentinel.flag_values
+        self.valid_range = mock.sentinel.valid_range
+        self.valid_min = mock.sentinel.valid_min
+        self.valid_max = mock.sentinel.valid_max
 
     def _make(self, attrs):
         cf_attrs_unused = mock.Mock(return_value=attrs)
@@ -216,8 +228,14 @@ class TestCubeAttributes(tests.IrisTest):
                  ('flag_meanings', self.flag_meanings),
                  ('add_offset', 'add_offset'),
                  ('flag_values', self.flag_values),
-                 ('standard_name', 'air_temperature')]
-        expected = set([attrs[0], attrs[1], attrs[2], attrs[4]])
+                 ('standard_name', 'air_temperature'),
+                 ('valid_range', self.valid_range),
+                 ('valid_min', self.valid_min),
+                 ('valid_max', self.valid_max)]
+
+        # Expect everything from above to be returned except those
+        # corresponding to exclude_ind.
+        expected = set([attrs[ind] for ind in [0, 1, 2, 4, 6, 7, 8]])
         cf_var = self._make(attrs)
         cube = _load_cube(self.engine, self.cf, cf_var, self.filename)
         self.assertEqual(len(cube.attributes), len(expected))


### PR DESCRIPTION
Self described PR name.  This PR simply removes these three attributes from the list of special attributes we are not normally allowed to save from iris.

The driver for this ticket is in describing logical data in a NetCDF file (i.e. specifying a valid range of [0, 1] as an attribute on the cube).  It can also be used for saving unsigned integer NetCDF4-classic fields too.

**Information:**
http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html
http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#_data_types