### PR TITLE
Fix bug in PP file 'extra data' error message

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1461,7 +1461,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
                     raise IOError('PP files cannot write extra data with more'
                                   ' than 1000 elements. Tried to write "%s"'
                                   ' which has %s elements.'
-                                  % (extra_data_attr_name, ib)
+                                  % (extra_data_attr_name, ia)
                                   )
 
         # populate lbext in WORDS


### PR DESCRIPTION
The error message uses `ib` as 'number of elements' but this is represented by `ia`:  https://code.metoffice.gov.uk/doc/um/vn10.3/papers/umdp_F03.pdf#page=34&zoom=auto,-274,830

Why does this limit exist anyway? I can't see any reference to it in the specification.
