### PR TITLE
DOC: usage example for nearest_neighbour_indices

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1168,6 +1168,14 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         Only works for one-dimensional coordinates.
 
+        For example:
+
+        >>> cube = iris.load_cube(iris.sample_data_path('ostia_monthly.nc'))
+        >>> cube.coord('latitude').nearest_neighbour_index(0)
+        9
+        >>> cube.coord('longitude').nearest_neighbour_index(10)
+        12
+
         .. note:: If the coordinate contains bounds, these will be used to
             determine the nearest neighbour instead of the point values.
 


### PR DESCRIPTION
Iris 1.10 deprecated `iris.analysis.interpolate.nearest_neighbour_indices` in favour of `iris.coords.Coord.nearest_neighbour_index`, which was a nice step forward in deprecating the interpolate module. The docs for the interpolate function contained a usage example, however, that was not ported to the docs for the new function. This PR addresses that oversight.