### PR TITLE
Fix issues where +=, -= were being used on arrays with incompatible dtypes

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -953,10 +953,10 @@ def _regrid_weighted_curvilinear_to_rectilinear__prepare(
         min_sx, min_tx = np.min(sx.points), np.min(tx.points)
         if min_sx < 0 and min_tx >= 0:
             indices = np.where(sx_points < 0)
-            sx_points[indices] += modulus
+            sx_points[indices] = sx_points[indices] + modulus
         elif min_sx >= 0 and min_tx < 0:
             indices = np.where(sx_points > (modulus / 2))
-            sx_points[indices] -= modulus
+            sx_points[indices] = sx_points[indices] - modulus
 
     # Create target grid cube x and y cell boundaries.
     tx_depth, ty_depth = tx.points.size, ty.points.size

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -954,12 +954,14 @@ def _regrid_weighted_curvilinear_to_rectilinear__prepare(
         if min_sx < 0 and min_tx >= 0:
             indices = np.where(sx_points < 0)
             # Ensure += doesn't raise a TypeError
-            sx_points = sx_points.astype(type(modulus), casting='safe')
+            if not np.can_cast(modulus, sx_points.dtype):
+                sx_points = sx_points.astype(type(modulus), casting='safe')
             sx_points[indices] += modulus
         elif min_sx >= 0 and min_tx < 0:
             indices = np.where(sx_points > (modulus / 2))
-            # Ensure += doesn't raise a TypeError
-            sx_points = sx_points.astype(type(modulus), casting='safe')
+            # Ensure -= doesn't raise a TypeError
+            if not np.can_cast(modulus, sx_points.dtype):
+                sx_points = sx_points.astype(type(modulus), casting='safe')
             sx_points[indices] -= modulus
 
     # Create target grid cube x and y cell boundaries.

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -953,10 +953,14 @@ def _regrid_weighted_curvilinear_to_rectilinear__prepare(
         min_sx, min_tx = np.min(sx.points), np.min(tx.points)
         if min_sx < 0 and min_tx >= 0:
             indices = np.where(sx_points < 0)
-            sx_points[indices] = sx_points[indices] + modulus
+            # Ensure += doesn't raise a TypeError
+            sx_points = sx_points.astype(type(modulus), casting='safe')
+            sx_points[indices] += modulus
         elif min_sx >= 0 and min_tx < 0:
             indices = np.where(sx_points > (modulus / 2))
-            sx_points[indices] = sx_points[indices] - modulus
+            # Ensure += doesn't raise a TypeError
+            sx_points = sx_points.astype(type(modulus), casting='safe')
+            sx_points[indices] -= modulus
 
     # Create target grid cube x and y cell boundaries.
     tx_depth, ty_depth = tx.points.size, ty.points.size

--- a/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
@@ -141,7 +141,7 @@ class Test_aggregate(tests.IrisTest):
         actual = WPERCENTILE.aggregate(data, axis=0, percent=percent,
                                        weights=weights)
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
-        expected = np.tile(np.arange(shape[-1]), percent.size)
+        expected = np.tile(np.arange(shape[-1]), percent.size).astype('f8')
         expected = expected.reshape(percent.size, shape[-1]).T
         expected[:, 1:-1] += (percent[1:-1]-25)*0.2
         expected[:, -1] += 10.
@@ -156,7 +156,7 @@ class Test_aggregate(tests.IrisTest):
         actual = WPERCENTILE.aggregate(data, axis=0, percent=percent,
                                        weights=weights)
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
-        expected = np.tile(np.arange(shape[-1]), percent.size)
+        expected = np.tile(np.arange(shape[-1]), percent.size).astype('f8')
         expected = expected.reshape(percent.size, shape[-1]).T
         expected[:, 1:-1] += (percent[1:-1]-25)*0.4
         expected[:, -1] += 20.

--- a/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015-2016, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_WPERCENTILE.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015-2016, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
In Numpy1.10, you cannot use in-place operators on arrays where the RHS cannot be upcast to the LHS, e.g., `int += float`