### PR TITLE
make CDL tests independent of attribute string typing

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -205,6 +205,14 @@ class IrisTest(unittest.TestCase):
         iris.site_configuration['cf_profile'] = None
 
     def _assert_str_same(self, reference_str, test_str, reference_filename, type_comparison_name='Strings'):
+        # Work around to deal with alterations to attribute typing in
+        # netcdf4python, introduced in 1.1 and present in 1.2. see:
+        # https://github.com/Unidata/netcdf-c/issues/298
+        # https://github.com/Unidata/netcdf4-python/issues/529
+        # https://github.com/Unidata/netcdf4-python/issues/575
+        # amongst others for further details.
+        if type_comparison_name == 'CDL' and reference_str != test_str:
+            test_str = test_str.replace('\t\tstring ', '\t\t')
         if reference_str != test_str:
             diff = ''.join(difflib.unified_diff(reference_str.splitlines(1), test_str.splitlines(1),
                                                  'Reference', 'Test result', '', '', 0))

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -45,6 +45,7 @@ import io
 import logging
 import os
 import os.path
+import re
 import shutil
 import subprocess
 import sys
@@ -212,7 +213,12 @@ class IrisTest(unittest.TestCase):
         # https://github.com/Unidata/netcdf4-python/issues/575
         # amongst others for further details.
         if type_comparison_name == 'CDL' and reference_str != test_str:
-            test_str = test_str.replace('\t\tstring ', '\t\t')
+            # Match where a new line contains only:
+            # tab|tab|string |attr_definition.
+            pattern = re.compile('(^\t\t)string (.+)$', re.MULTILINE)
+            # Replace with tab|tab|attr_definition.
+            replacement = r'\t\t\2'
+            test_str = re.sub(pattern, replacement, test_str)
         if reference_str != test_str:
             diff = ''.join(difflib.unified_diff(reference_str.splitlines(1), test_str.splitlines(1),
                                                  'Reference', 'Test result', '', '', 0))


### PR DESCRIPTION
Behaviour changes in netCDF4-python have triggered test failures for v1.1 and 1.2 of netcdf4-python

With these versions, some attributes are typed at `string` where they previously were not.  There is ongoing work and discussion which may alter this behaviour again, somewhere in netcdf-c netcdf4-python and/or hdf5

see:
 https://github.com/Unidata/netcdf-c/issues/298
 https://github.com/Unidata/netcdf4-python/issues/529
 https://github.com/Unidata/netcdf4-python/issues/575
amongst others for further details.

My suggestion is an explicit work around through assertCDL, into _assert_str_same to allow outputs to be interpreted as the same, even though they are manifestly not

I'm not sure I like this approach, but I find myself suggesting it.