### PR TITLE
Fix _assert_shared

### DIFF
--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -130,8 +130,14 @@ def _assert_shared(np_obj, pandas_obj):
     else:
         base = pandas_obj[0].base
 
-    if pandas_obj.values is np_obj:
-        return
+    # Prior to Pandas 0.17, when pandas_obj is a Series, pandas_obj.values
+    # returns a view of the underlying array, and pandas_obj.base, which calls
+    # pandas_obj.values.base, returns the underlying array. In 0.17 and 0.18
+    # pandas_obj.values returns the underlying array, so base may be None even
+    # if the array is shared.
+    if base is None:
+        base = pandas_obj.values
+
     # Chase the stack of NumPy `base` references back to see if any of
     # them are our original array.
     while base is not None:

--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -129,6 +129,9 @@ def _assert_shared(np_obj, pandas_obj):
         base = pandas_obj.base
     else:
         base = pandas_obj[0].base
+
+    if pandas_obj.values is np_obj:
+        return
     # Chase the stack of NumPy `base` references back to see if any of
     # them are our original array.
     while base is not None:


### PR DESCRIPTION
This fixes the issue that now the `_assert_shared` function can't detect when a pandas object shares its data with a numpy array.

I'm not really happy with this solution. There's nothing in the pandas documentation that says `values` returns the original data object (indeed, in 0.16.2 it doesn't). But I can't find another way.

As an aside, a note in the doctring of ~~`_assert_shared`~~ `as_series` states

>     .. note::
>
>        Pandas will sometimes make a copy of the array,
>        for example when creating from an int32 array.
>        Iris will detect this and raise an exception if copy=False.

This doesn't appear to be the case any more. At least, `values` always seems to return the original array, and the buffer objects of a `pandas.Series` and the NumPy array from which it was created always seem to point to the same location in memory, if `cope=False` is specified. 