### PR TITLE
fix for MaskedConstant errors

### DIFF
--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -143,6 +143,15 @@ class Test(tests.IrisTest):
         self.assertTrue(res.has_lazy_data())
         self.assertEqual(res.shape, (1,) + cube.shape)
 
+    def test_masked_unit_array(self):
+        cube = tests.stock.simple_3d_mask()
+        test_cube = cube[0, 0, 0]
+        test_cube = new_axis(test_cube, 'longitude')
+        test_cube = new_axis(test_cube, 'latitude')
+        data_shape = test_cube.data.shape
+        mask_shape = test_cube.data.mask.shape
+        self.assertEqual(data_shape, mask_shape)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1082,7 +1082,16 @@ def new_axis(src_cube, scalar_coord=None):
 
     # Indexing numpy arrays requires loading deferred data here returning a
     # copy of the data with a new leading dimension.
-    new_cube = iris.cube.Cube(src_cube.lazy_data()[None])
+    # If the source cube is a Masked Constant, it is changed here to a Masked
+    # Array to allow the mask to gain an extra dimension with the data.
+    if src_cube.has_lazy_data():
+        new_cube = iris.cube.Cube(src_cube.lazy_data()[None])
+    else:
+        if isinstance(src_cube.data, ma.core.MaskedConstant):
+            new_data = ma.array([np.nan], mask=[True])
+        else:
+            new_data = src_cube.data[None]
+        new_cube = iris.cube.Cube(new_data)
     new_cube.metadata = src_cube.metadata
 
     for coord in src_cube.aux_coords:


### PR DESCRIPTION
iris.util.new_axis cannot handle masked constants, so this is a check to turn masked constants into scalar masked arrays, at which point they can be handled correctly.

This fix is checked by a test in PR#2130: https://github.com/SciTools/iris/pull/2130
