### PR TITLE
BUG: as_pairs usage removal within iris

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2442,8 +2442,8 @@ def as_fields(cube, field_coords=None, target=None):
         A filename or open file handle.
 
     """
-    return (field for cube, field in as_pairs(cube, field_coords=field_coords,
-                                              target=target))
+    return (field for cube, field in save_pairs_from_cube(
+        cube, field_coords=field_coords, target=target))
 
 
 def save_fields(fields, target, append=False):


### PR DESCRIPTION
Issue is [here](https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/pp.py#L2445/commit/098a87e).

```python
def as_fields(cube, field_coords=None, target=None):
    ...
-    return (field for cube, field in as_pairs(cube, field_coords=field_coords,
                                               target=target))
+    return (field for cube, field in save_pairs_from_cube(cube,
          field_coords=field_coords, target=target))
```

This means that our users are currently being issued a warning about using deprecated behaviour when they are not (made worse by the fact that warnings do not give a traceback).