### PR TITLE
Add code coverage and integrate with Coveralls 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+#
+# .coveragerc to control coverage.py
+#
+
+[run]
+branch = True
+omit =
+    test*.py
+    setup.py
+
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,8 +5,9 @@
 [run]
 branch = True
 omit =
-    test*.py
+    lib/iris/tests/*
     setup.py
+source = lib/iris
 
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@
 [run]
 branch = True
 omit =
+    lib/iris/fileformats/_pyke_rules/compiled_krb/*
     lib/iris/tests/*
     setup.py
 source = lib/iris

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
 
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib
-  - if [[ $TEST_TARGET != 'coding' -a  $COVERAGE != true ]]; then
+  - if [[ $TEST_TARGET != 'coding' &&  $COVERAGE != true ]]; then
       IRIS=$(ls -d1 build/lib*/iris);
       mkdir $IRIS/etc;
     else
@@ -96,7 +96,7 @@ install:
 
   # The coding standards tests expect all the standard names and PyKE
   # modules to be present.
-  - if [[ $TEST_TARGET == 'coding' -o $COVERAGE == true ]]; then
+  - if [[ $TEST_TARGET == 'coding' || $COVERAGE == true ]]; then
       python setup.py std_names;
       PYTHONPATH=lib python setup.py pyke_rules;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 
 env:
   - TEST_TARGET=default
+  - TEST_TARGET=default COVERAGE=true
   - TEST_TARGET=default TEST_MINIMAL=true
   - TEST_TARGET=coding
   - TEST_TARGET=example
@@ -59,6 +60,7 @@ install:
         conda install --quiet --file conda-requirements.txt;
       fi
     fi
+  - pip install coveralls
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 
@@ -101,11 +103,18 @@ install:
 
 # iris
   - python setup.py --quiet --with-unpack build
-  - python setup.py --quiet --with-unpack install
+  - python setup.py --quiet --with-unpack install --user
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
+      if [[ $COVERAGE == true ]]; then
+        SITECUSTOMIZE=$PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages/sitecustomize.py;
+        echo 'import coverage; coverage.process_startup()' > "$SITECUSTOMIZE";
+        export COVERAGE_PROCESS_START="$PWD/.coveragerc";
+        coverage run --concurrency=multiprocessing -pm iris.tests.runner --default-tests --system-tests --print-failed-images;
+      else
+        python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
+      fi
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
       python -m iris.tests.runner --example-tests --print-failed-images;
@@ -127,4 +136,9 @@ script:
     fi
   - if [[ $TEST_TARGET == 'coding' ]]; then
       python setup.py test --coding-tests;
+    fi
+after_success:
+  - if [[ $COVERAGE == true ]]; then
+      coverage combine;
+      coveralls;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
 
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib
-  - if [[ $TEST_TARGET -ne 'coding' ]]; then
+  - if [[ $TEST_TARGET != 'coding' -a  $COVERAGE != true ]]; then
       IRIS=$(ls -d1 build/lib*/iris);
       mkdir $IRIS/etc;
     else
@@ -96,14 +96,14 @@ install:
 
   # The coding standards tests expect all the standard names and PyKE
   # modules to be present.
-  - if [[ $TEST_TARGET == 'coding' ]]; then
+  - if [[ $TEST_TARGET == 'coding' -o $COVERAGE == true ]]; then
       python setup.py std_names;
       PYTHONPATH=lib python setup.py pyke_rules;
     fi
 
 # iris
   - python setup.py --quiet --with-unpack build
-  - python setup.py --quiet --with-unpack install --user
+  - python setup.py --quiet --with-unpack install
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
@@ -111,7 +111,7 @@ script:
         SITECUSTOMIZE=$PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages/sitecustomize.py;
         echo 'import coverage; coverage.process_startup()' > "$SITECUSTOMIZE";
         export COVERAGE_PROCESS_START="$PWD/.coveragerc";
-        coverage run --concurrency=multiprocessing -pm iris.tests.runner --default-tests --system-tests --print-failed-images;
+        coverage run --concurrency=multiprocessing -p setup.py test --default-tests --system-tests --print-failed-images;
       else
         python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
       fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Iris
 
 [![Build Status](https://api.travis-ci.org/repositories/SciTools/iris.svg?branch=master)](http://travis-ci.org/SciTools/iris/branches)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.51860.svg)](http://dx.doi.org/10.5281/zenodo.51860)
+[![Coverage Status](https://coveralls.io/repos/github/SciTools/iris/badge.svg?branch=master)](https://coveralls.io/github/SciTools/iris?branch=master)
 
 (C) British Crown Copyright 2010 - 2015, Met Office
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -9,7 +9,7 @@ netcdf4
 numpy
 pyke
 udunits2
-cf_units
+cf_units<1.1.1
 
 # Iris build dependencies
 setuptools


### PR DESCRIPTION
Coveralls (http://coveralls.io) is a utility that can be integrated with a GitHub repository to display a code coverage percentage. It can be used with a variety of languages, but for Python it uses a utility called Coverage (https://coverage.readthedocs.io/en/coverage-4.2), which you can run in a terminal to produce text based reports.

This PR gets coverage/coveralls working on Iris via Travis. It's based on some initial work that @marqh did. Since I encountered a lot of obstacles trying to get it to work, and since I'm leaving for two weeks, I'll document the steps I needed to take.

Firstly, since the Iris tests run in parallel using Nose, it's necessary to set up Coverage to run on all the sub-processes. Coverage needs to be able run some set-up code for every process, and one way the docs suggest to do this is to add code to `sitecustomize.py`, which is run whenever the Python interpreter starts up. It's also necessary to set an environment variable `COVERAGE_PROCESS_START` with an absolute path to the Coverage configuration file to use. When calling the `coverage` command, it's necessary to specify both `-p` (parallel) and `--concurrency=LIB`, where `LIB` is replaced with the concurrency library used (`multiprocessing` for nose).

When running in parallel mode, Coverage produces a separate output file for each processor; these need to be combined using `coverage combine` before generating a report.

By default Coverage won't report on any libraries installed in the Python library directory. Additionally, for the web utility to be able to match the covered files to those in the GitHub repository, the files need to be run from where they are when Travis clones the repo. While it's not strictly necessary to be able to match the files, if they can't be matched one won't be able to inspect individual files at http://coveralls.io, which is quite useful. So, rather than running `setup.py` to install the files elsewhere and calling `iris.tests.runner`, I've changed the Travis script to run `setup.py test`.

I've added a new configuration to Travis that runs coverage with the default tests, rather than modifying the existing default configuration. This may or may not be necessary. I'm happy for it to be changed if not.

I've also restricted the version of `cf_units` to <1.1.1 (I tried making it =1.1.0, but it didn't work for some reason), because currently the Iris tests are failing with 1.1.2 (https://github.com/SciTools/iris/pull/2144 will fix them). Obviously the version should be unrestricted when merging.

Although the first commit shows @marqh as author, a lot of the changes in it were made by me. I only mention this so that people don't ask him questions about it expecting him to know the answer.

I've made sure certain files are omitted by Coverage when recording data (e.g. those in `lib/iris/tests`). Some additions could probably be made to these omissions.
