### PR TITLE
Added support for netCDF data packing.

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -33,8 +33,7 @@ class LimitedAttributeDict(dict):
                        'calendar', 'leap_month', 'leap_year', 'month_lengths',
                        'coordinates', 'grid_mapping', 'climatology',
                        'cell_methods', 'formula_terms', 'compress',
-                       'missing_value', 'add_offset', 'scale_factor',
-                       '_FillValue')
+                       'missing_value', '_FillValue')
 
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_multi_dtype.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_multi_dtype.cdl
@@ -4,13 +4,12 @@ dimensions:
 	latitude = 73 ;
 	longitude = 96 ;
 variables:
-	short air_temperature(time, latitude, longitude) ;
-		air_temperature:_FillValue = -32767s ;
+	float air_temperature(time, latitude, longitude) ;
+		air_temperature:scale_factor = 0.0024257504786326 ;
+		air_temperature:add_offset = 261.648002426021 ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
-		air_temperature:add_offset = 261.648002426021 ;
-		air_temperature:scale_factor = 0.0024257504786326 ;
 		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -46,24 +45,22 @@ variables:
 		height:units = "m" ;
 		height:standard_name = "height" ;
 		height:positive = "up" ;
+	float precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:standard_name = "precipitation_flux" ;
+		precipitation_flux:units = "kg m-2 s-1" ;
+		precipitation_flux:um_stash_source = "m01s05i216" ;
+		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
+		precipitation_flux:grid_mapping = "latitude_longitude" ;
+		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
 	float air_temperature_0(time, latitude, longitude) ;
-		air_temperature_0:_FillValue = -1.e+30f ;
+		air_temperature_0:scale_factor = 0.0020141666756075 ;
+		air_temperature_0:add_offset = 176.7872f ;
 		air_temperature_0:standard_name = "air_temperature" ;
 		air_temperature_0:units = "K" ;
 		air_temperature_0:um_stash_source = "m01s03i236" ;
 		air_temperature_0:cell_methods = "time: minimum (interval: 1 hour)" ;
 		air_temperature_0:grid_mapping = "latitude_longitude" ;
 		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
-	ushort precipitation_flux(time, latitude, longitude) ;
-		precipitation_flux:_FillValue = 65535US ;
-		precipitation_flux:standard_name = "precipitation_flux" ;
-		precipitation_flux:units = "kg m-2 s-1" ;
-		precipitation_flux:um_stash_source = "m01s05i216" ;
-		precipitation_flux:add_offset = -5.911585e-22f ;
-		precipitation_flux:scale_factor = 2.9897383798121e-08 ;
-		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
-		precipitation_flux:grid_mapping = "latitude_longitude" ;
-		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
 
 // global attributes:
 		:source = "Data from Met Office Unified Model" ;

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_multi_dtype.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_multi_dtype.cdl
@@ -1,0 +1,71 @@
+dimensions:
+	time = UNLIMITED ; // (360 currently)
+	bnds = 2 ;
+	latitude = 73 ;
+	longitude = 96 ;
+variables:
+	short air_temperature(time, latitude, longitude) ;
+		air_temperature:_FillValue = -32767s ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_stash_source = "m01s03i236" ;
+		air_temperature:add_offset = 261.648002426021 ;
+		air_temperature:scale_factor = 0.0024257504786326 ;
+		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
+		air_temperature:grid_mapping = "latitude_longitude" ;
+		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
+	int latitude_longitude ;
+		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
+		latitude_longitude:longitude_of_prime_meridian = 0. ;
+		latitude_longitude:earth_radius = 6371229. ;
+	double time(time) ;
+		time:axis = "T" ;
+		time:bounds = "time_bnds" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
+		time:standard_name = "time" ;
+		time:calendar = "360_day" ;
+	double time_bnds(time, bnds) ;
+	float latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "degrees_north" ;
+		latitude:standard_name = "latitude" ;
+	float longitude(longitude) ;
+		longitude:axis = "X" ;
+		longitude:units = "degrees_east" ;
+		longitude:standard_name = "longitude" ;
+	double forecast_period(time) ;
+		forecast_period:bounds = "forecast_period_bnds" ;
+		forecast_period:units = "hours" ;
+		forecast_period:standard_name = "forecast_period" ;
+	double forecast_period_bnds(time, bnds) ;
+	double forecast_reference_time ;
+		forecast_reference_time:units = "hours since 1970-01-01 00:00:00" ;
+		forecast_reference_time:standard_name = "forecast_reference_time" ;
+		forecast_reference_time:calendar = "360_day" ;
+	double height ;
+		height:units = "m" ;
+		height:standard_name = "height" ;
+		height:positive = "up" ;
+	float air_temperature_0(time, latitude, longitude) ;
+		air_temperature_0:_FillValue = -1.e+30f ;
+		air_temperature_0:standard_name = "air_temperature" ;
+		air_temperature_0:units = "K" ;
+		air_temperature_0:um_stash_source = "m01s03i236" ;
+		air_temperature_0:cell_methods = "time: minimum (interval: 1 hour)" ;
+		air_temperature_0:grid_mapping = "latitude_longitude" ;
+		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
+	ushort precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:_FillValue = 65535US ;
+		precipitation_flux:standard_name = "precipitation_flux" ;
+		precipitation_flux:units = "kg m-2 s-1" ;
+		precipitation_flux:um_stash_source = "m01s05i216" ;
+		precipitation_flux:add_offset = -5.911585e-22f ;
+		precipitation_flux:scale_factor = 2.9897383798121e-08 ;
+		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
+		precipitation_flux:grid_mapping = "latitude_longitude" ;
+		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
+
+// global attributes:
+		:source = "Data from Met Office Unified Model" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_single_dtype.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_single_dtype.cdl
@@ -1,0 +1,73 @@
+dimensions:
+	time = UNLIMITED ; // (360 currently)
+	bnds = 2 ;
+	latitude = 73 ;
+	longitude = 96 ;
+variables:
+	short air_temperature(time, latitude, longitude) ;
+		air_temperature:_FillValue = -32767s ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_stash_source = "m01s03i236" ;
+		air_temperature:add_offset = 261.648002426021 ;
+		air_temperature:scale_factor = 0.0024257504786326 ;
+		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
+		air_temperature:grid_mapping = "latitude_longitude" ;
+		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
+	int latitude_longitude ;
+		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
+		latitude_longitude:longitude_of_prime_meridian = 0. ;
+		latitude_longitude:earth_radius = 6371229. ;
+	double time(time) ;
+		time:axis = "T" ;
+		time:bounds = "time_bnds" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
+		time:standard_name = "time" ;
+		time:calendar = "360_day" ;
+	double time_bnds(time, bnds) ;
+	float latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "degrees_north" ;
+		latitude:standard_name = "latitude" ;
+	float longitude(longitude) ;
+		longitude:axis = "X" ;
+		longitude:units = "degrees_east" ;
+		longitude:standard_name = "longitude" ;
+	double forecast_period(time) ;
+		forecast_period:bounds = "forecast_period_bnds" ;
+		forecast_period:units = "hours" ;
+		forecast_period:standard_name = "forecast_period" ;
+	double forecast_period_bnds(time, bnds) ;
+	double forecast_reference_time ;
+		forecast_reference_time:units = "hours since 1970-01-01 00:00:00" ;
+		forecast_reference_time:standard_name = "forecast_reference_time" ;
+		forecast_reference_time:calendar = "360_day" ;
+	double height ;
+		height:units = "m" ;
+		height:standard_name = "height" ;
+		height:positive = "up" ;
+	short air_temperature_0(time, latitude, longitude) ;
+		air_temperature_0:_FillValue = -32767s ;
+		air_temperature_0:standard_name = "air_temperature" ;
+		air_temperature_0:units = "K" ;
+		air_temperature_0:um_stash_source = "m01s03i236" ;
+		air_temperature_0:add_offset = 242.787445071619 ;
+		air_temperature_0:scale_factor = 0.0020141666756075 ;
+		air_temperature_0:cell_methods = "time: minimum (interval: 1 hour)" ;
+		air_temperature_0:grid_mapping = "latitude_longitude" ;
+		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
+	short precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:_FillValue = -32767s ;
+		precipitation_flux:standard_name = "precipitation_flux" ;
+		precipitation_flux:units = "kg m-2 s-1" ;
+		precipitation_flux:um_stash_source = "m01s05i216" ;
+		precipitation_flux:add_offset = 0.000979677472296829 ;
+		precipitation_flux:scale_factor = 2.9897383798121e-08 ;
+		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
+		precipitation_flux:grid_mapping = "latitude_longitude" ;
+		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
+
+// global attributes:
+		:source = "Data from Met Office Unified Model" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_single_dtype.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/multi_packed_single_dtype.cdl
@@ -4,13 +4,12 @@ dimensions:
 	latitude = 73 ;
 	longitude = 96 ;
 variables:
-	short air_temperature(time, latitude, longitude) ;
-		air_temperature:_FillValue = -32767s ;
+	float air_temperature(time, latitude, longitude) ;
+		air_temperature:scale_factor = 0.0024257504786326 ;
+		air_temperature:add_offset = 261.648002426021 ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
-		air_temperature:add_offset = 261.648002426021 ;
-		air_temperature:scale_factor = 0.0024257504786326 ;
 		air_temperature:cell_methods = "time: maximum (interval: 1 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height" ;
@@ -46,26 +45,24 @@ variables:
 		height:units = "m" ;
 		height:standard_name = "height" ;
 		height:positive = "up" ;
-	short air_temperature_0(time, latitude, longitude) ;
-		air_temperature_0:_FillValue = -32767s ;
-		air_temperature_0:standard_name = "air_temperature" ;
-		air_temperature_0:units = "K" ;
-		air_temperature_0:um_stash_source = "m01s03i236" ;
-		air_temperature_0:add_offset = 242.787445071619 ;
-		air_temperature_0:scale_factor = 0.0020141666756075 ;
-		air_temperature_0:cell_methods = "time: minimum (interval: 1 hour)" ;
-		air_temperature_0:grid_mapping = "latitude_longitude" ;
-		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
-	short precipitation_flux(time, latitude, longitude) ;
-		precipitation_flux:_FillValue = -32767s ;
+	float precipitation_flux(time, latitude, longitude) ;
+		precipitation_flux:scale_factor = 2.9897383798121e-08 ;
+		precipitation_flux:add_offset = 0.000979677472296829 ;
 		precipitation_flux:standard_name = "precipitation_flux" ;
 		precipitation_flux:units = "kg m-2 s-1" ;
 		precipitation_flux:um_stash_source = "m01s05i216" ;
-		precipitation_flux:add_offset = 0.000979677472296829 ;
-		precipitation_flux:scale_factor = 2.9897383798121e-08 ;
 		precipitation_flux:cell_methods = "time: mean (interval: 1 hour)" ;
 		precipitation_flux:grid_mapping = "latitude_longitude" ;
 		precipitation_flux:coordinates = "forecast_period forecast_reference_time" ;
+	float air_temperature_0(time, latitude, longitude) ;
+		air_temperature_0:scale_factor = 0.0020141666756075 ;
+		air_temperature_0:add_offset = 242.787445071619 ;
+		air_temperature_0:standard_name = "air_temperature" ;
+		air_temperature_0:units = "K" ;
+		air_temperature_0:um_stash_source = "m01s03i236" ;
+		air_temperature_0:cell_methods = "time: minimum (interval: 1 hour)" ;
+		air_temperature_0:grid_mapping = "latitude_longitude" ;
+		air_temperature_0:coordinates = "forecast_period forecast_reference_time height" ;
 
 // global attributes:
 		:source = "Data from Met Office Unified Model" ;

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_manual.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_manual.cdl
@@ -1,0 +1,50 @@
+dimensions:
+	latitude = UNLIMITED ; // (73 currently)
+	bnds = 2 ;
+	longitude = 96 ;
+variables:
+	short air_temperature(latitude, longitude) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_stash_source = "m01s03i236" ;
+		air_temperature:add_offset = 267.40062344802 ;
+		air_temperature:scale_factor = 0.00119806791576066 ;
+		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
+		air_temperature:grid_mapping = "latitude_longitude" ;
+		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
+	int latitude_longitude ;
+		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
+		latitude_longitude:longitude_of_prime_meridian = 0. ;
+		latitude_longitude:earth_radius = 6371229. ;
+	float latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "degrees_north" ;
+		latitude:standard_name = "latitude" ;
+	float longitude(longitude) ;
+		longitude:axis = "X" ;
+		longitude:units = "degrees_east" ;
+		longitude:standard_name = "longitude" ;
+	double forecast_period ;
+		forecast_period:bounds = "forecast_period_bnds" ;
+		forecast_period:units = "hours" ;
+		forecast_period:standard_name = "forecast_period" ;
+	double forecast_period_bnds(bnds) ;
+	double forecast_reference_time ;
+		forecast_reference_time:units = "hours since 1970-01-01 00:00:00" ;
+		forecast_reference_time:standard_name = "forecast_reference_time" ;
+		forecast_reference_time:calendar = "gregorian" ;
+	double height ;
+		height:units = "m" ;
+		height:standard_name = "height" ;
+		height:positive = "up" ;
+	double time ;
+		time:bounds = "time_bnds" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
+		time:standard_name = "time" ;
+		time:calendar = "gregorian" ;
+	double time_bnds(bnds) ;
+
+// global attributes:
+		:source = "Data from Met Office Unified Model" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_manual.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_manual.cdl
@@ -3,12 +3,12 @@ dimensions:
 	bnds = 2 ;
 	longitude = 96 ;
 variables:
-	short air_temperature(latitude, longitude) ;
+	float air_temperature(latitude, longitude) ;
+		air_temperature:scale_factor = 0.00119806791576066 ;
+		air_temperature:add_offset = 267.40062344802 ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
-		air_temperature:add_offset = 267.40062344802 ;
-		air_temperature:scale_factor = 0.00119806791576066 ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_signed.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_signed.cdl
@@ -1,0 +1,50 @@
+dimensions:
+	latitude = UNLIMITED ; // (73 currently)
+	bnds = 2 ;
+	longitude = 96 ;
+variables:
+	short air_temperature(latitude, longitude) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_stash_source = "m01s03i236" ;
+		air_temperature:add_offset = 267.40062344802 ;
+		air_temperature:scale_factor = 0.00119806791576066 ;
+		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
+		air_temperature:grid_mapping = "latitude_longitude" ;
+		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
+	int latitude_longitude ;
+		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
+		latitude_longitude:longitude_of_prime_meridian = 0. ;
+		latitude_longitude:earth_radius = 6371229. ;
+	float latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "degrees_north" ;
+		latitude:standard_name = "latitude" ;
+	float longitude(longitude) ;
+		longitude:axis = "X" ;
+		longitude:units = "degrees_east" ;
+		longitude:standard_name = "longitude" ;
+	double forecast_period ;
+		forecast_period:bounds = "forecast_period_bnds" ;
+		forecast_period:units = "hours" ;
+		forecast_period:standard_name = "forecast_period" ;
+	double forecast_period_bnds(bnds) ;
+	double forecast_reference_time ;
+		forecast_reference_time:units = "hours since 1970-01-01 00:00:00" ;
+		forecast_reference_time:standard_name = "forecast_reference_time" ;
+		forecast_reference_time:calendar = "gregorian" ;
+	double height ;
+		height:units = "m" ;
+		height:standard_name = "height" ;
+		height:positive = "up" ;
+	double time ;
+		time:bounds = "time_bnds" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
+		time:standard_name = "time" ;
+		time:calendar = "gregorian" ;
+	double time_bnds(bnds) ;
+
+// global attributes:
+		:source = "Data from Met Office Unified Model" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_signed.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_signed.cdl
@@ -3,12 +3,12 @@ dimensions:
 	bnds = 2 ;
 	longitude = 96 ;
 variables:
-	short air_temperature(latitude, longitude) ;
+	float air_temperature(latitude, longitude) ;
+		air_temperature:scale_factor = 0.00119806791576066 ;
+		air_temperature:add_offset = 267.40062344802 ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
-		air_temperature:add_offset = 267.40062344802 ;
-		air_temperature:scale_factor = 0.00119806791576066 ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_unsigned.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_unsigned.cdl
@@ -1,0 +1,50 @@
+dimensions:
+	latitude = UNLIMITED ; // (73 currently)
+	bnds = 2 ;
+	longitude = 96 ;
+variables:
+	ubyte air_temperature(latitude, longitude) ;
+		air_temperature:standard_name = "air_temperature" ;
+		air_temperature:units = "K" ;
+		air_temperature:um_stash_source = "m01s03i236" ;
+		air_temperature:add_offset = 228.1423f ;
+		air_temperature:scale_factor = 0.30790345435049 ;
+		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
+		air_temperature:grid_mapping = "latitude_longitude" ;
+		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;
+	int latitude_longitude ;
+		latitude_longitude:grid_mapping_name = "latitude_longitude" ;
+		latitude_longitude:longitude_of_prime_meridian = 0. ;
+		latitude_longitude:earth_radius = 6371229. ;
+	float latitude(latitude) ;
+		latitude:axis = "Y" ;
+		latitude:units = "degrees_north" ;
+		latitude:standard_name = "latitude" ;
+	float longitude(longitude) ;
+		longitude:axis = "X" ;
+		longitude:units = "degrees_east" ;
+		longitude:standard_name = "longitude" ;
+	double forecast_period ;
+		forecast_period:bounds = "forecast_period_bnds" ;
+		forecast_period:units = "hours" ;
+		forecast_period:standard_name = "forecast_period" ;
+	double forecast_period_bnds(bnds) ;
+	double forecast_reference_time ;
+		forecast_reference_time:units = "hours since 1970-01-01 00:00:00" ;
+		forecast_reference_time:standard_name = "forecast_reference_time" ;
+		forecast_reference_time:calendar = "gregorian" ;
+	double height ;
+		height:units = "m" ;
+		height:standard_name = "height" ;
+		height:positive = "up" ;
+	double time ;
+		time:bounds = "time_bnds" ;
+		time:units = "hours since 1970-01-01 00:00:00" ;
+		time:standard_name = "time" ;
+		time:calendar = "gregorian" ;
+	double time_bnds(bnds) ;
+
+// global attributes:
+		:source = "Data from Met Office Unified Model" ;
+		:Conventions = "CF-1.5" ;
+}

--- a/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_unsigned.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/save/single_packed_unsigned.cdl
@@ -3,12 +3,12 @@ dimensions:
 	bnds = 2 ;
 	longitude = 96 ;
 variables:
-	ubyte air_temperature(latitude, longitude) ;
+	float air_temperature(latitude, longitude) ;
+		air_temperature:scale_factor = 0.30790345435049 ;
+		air_temperature:add_offset = 228.1423f ;
 		air_temperature:standard_name = "air_temperature" ;
 		air_temperature:units = "K" ;
 		air_temperature:um_stash_source = "m01s03i236" ;
-		air_temperature:add_offset = 228.1423f ;
-		air_temperature:scale_factor = 0.30790345435049 ;
 		air_temperature:cell_methods = "time: mean (interval: 6 hour)" ;
 		air_temperature:grid_mapping = "latitude_longitude" ;
 		air_temperature:coordinates = "forecast_period forecast_reference_time height time" ;

--- a/lib/iris/tests/unit/fileformats/netcdf/test_save.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_save.py
@@ -110,7 +110,7 @@ class Test_packed_data(tests.IrisTest):
         if masked:
             scale_factor = (cmax - cmin)/(2**n-2)
         else:
-            scale_factor = (cmax-cmin)/(2**n-1)
+            scale_factor = (cmax - cmin)/(2**n-1)
         if dt.kind == 'u':
             add_offset = cmin
         elif dt.kind == 'i':
@@ -208,6 +208,9 @@ class Test_packed_data(tests.IrisTest):
                                       'save',
                                       'multi_packed_single_dtype.cdl'))
             packedcubes = iris.load(file_out)
+            # ensure cube order is the same:
+            cubes.sort(key=lambda cube: cube.cell_methods[0].method)
+            packedcubes.sort(key=lambda cube: cube.cell_methods[0].method)
             for cube, packedcube in zip(cubes, packedcubes):
                 sf, ao = self._get_scale_factor_add_offset(cube, dtype)
                 decimal = int(-np.log10(sf))
@@ -230,6 +233,9 @@ class Test_packed_data(tests.IrisTest):
                                       'save',
                                       'multi_packed_multi_dtype.cdl'))
             packedcubes = iris.load(file_out)
+            # ensure cube order is the same:
+            cubes.sort(key=lambda cube: cube.cell_methods[0].method)
+            packedcubes.sort(key=lambda cube: cube.cell_methods[0].method)
             for cube, packedcube, dtype in zip(cubes, packedcubes, dtypes):
                 if dtype:
                     sf, ao = self._get_scale_factor_add_offset(cube, dtype)


### PR DESCRIPTION
NetCDF has support for variable packing; by specifying attributes scale_factor and add_offset, data can be packed into smaller data types. 16 bit short integers provide more than enough quantization for suitably scaled temperature data, for instance. See: http://unidata.ucar.edu/software/netcdf/docs/BestPractices.html#bp_Packed-Data-Values
Iris already supports loading of packed netCDF because it is automatically handled by the netCDF4 module. However, there is currently no way to save data with packing.

https://github.com/SciTools/iris/issues/2148

This PR adds an optional pack_dtype argument to the netcdf save and Saver.write methods. From the docstring: 
* pack_dtype (type or string or list):
    A numpy integer datatype (signed or unsigned) or a string that
    describes a numpy integer dtype (i.e. 'i2', 'short', 'u4'). This
    provides support for netCDF data packing as described in
    http://www.unidata.ucar.edu/software/netcdf/docs/BestPractices.html#bp_Packed-Data-Values
    If either `scale_factor` or `add_offset` are set in `cube.attributes`,
    those values are used. If neither is set, appropriate values of
    `scale_factor` and `add_offset` are calculated based on `cube.data`,
    `pack_dtype` and possible masking (see the link for details). Note
    that automatic calculation of `scale_factor` and `add_offset` will
    trigger loading of lazy_data; set `scale_factor` and `add_offset`
    manually in `cube.attributes` if you wish to avoid this. For
    masked data, `fill_values` are taken from `netCDF4.default_fillvals`.
    If the argument to `cube` is an iterable and different datatypes are
    desired for each cube, `pack_dtype` can also be a list with the same
    number of elements as the iterable. The default is `None`, in which
    case the datatype is determined from the cube and no packing will
    occur.

One of the first things that sold me on Iris was how wonderfully convenient netCDF input and output was, but I couldn't use it when I needed packing (which was fairly often).  This fixes that, and with automatic calculation of packing attributes adds even more convenience.

Although you can set the packing attributes (scale_factor and add_offset) manually, there is no way to set a custom fill value for masked data. I doubt this will be missed, but I could be wrong.

There is an error in the tests, but it is due to changes in cf_units, as has been noted previously. All tests associated with this change pass.