### PR TITLE
Update version number on master

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -122,7 +122,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '1.10.0-DEV'
+__version__ = '1.11.0-DEV'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',


### PR DESCRIPTION
Simply update the version number on master. Doesn't matter if it ends up being 2.0.0, this will do for now, the crucial thing is that v1.10.0 already left the building so the version number on master must be increased.