### PR TITLE
catch setting of coordiantes and bounds for netcdf saver (string typing)

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,9 +2,9 @@
 # conda create -n <name> --file conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.14.0
+biggus
 cartopy
-matplotlib=1.3.1
+matplotlib
 netcdf4
 numpy
 pyke

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,9 +2,9 @@
 # conda create -n <name> --file conda-requirements.txt
 
 # Mandatory dependencies
-biggus
+biggus>=0.14.0
 cartopy
-matplotlib
+matplotlib=1.3.1
 netcdf4
 numpy
 pyke

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1100,8 +1100,8 @@ class Saver(object):
         # Add CF-netCDF auxiliary coordinate variable references to the
         # CF-netCDF data variable.
         if auxiliary_coordinate_names:
-            cf_var_cube.coordinates = ' '.join(
-                sorted(auxiliary_coordinate_names))
+            coord_variable_names = ' '.join(sorted(auxiliary_coordinate_names))
+            _setncattr(cf_var_cube, 'coordinates', coord_variable_names)
 
     def _add_cell_measures(self, cube, cf_var_cube, dim_names):
         """
@@ -1381,7 +1381,7 @@ class Saver(object):
                 # Create the bounds dimension with the appropriate extent.
                 self._dataset.createDimension(bounds_dimension_name, n_bounds)
 
-            cf_var.bounds = cf_name + '_bnds'
+            _setncattr(cf_var, 'bounds', cf_name + '_bnds')
             cf_var_bounds = self._dataset.createVariable(
                 cf_var.bounds, bounds.dtype.newbyteorder('='),
                 cf_var.dimensions + (bounds_dimension_name,))

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1135,8 +1135,8 @@ class Saver(object):
         # Add CF-netCDF cell measure variable references to the
         # CF-netCDF data variable.
         if cell_measure_names:
-            cf_var_cube.cell_measures = ' '.join(
-                sorted(cell_measure_names))
+            cm_var_names = ' '.join(sorted(cell_measure_names))
+            _setncattr(cf_var_cube, 'cell_measures', cm_var_names)
 
     def _add_dim_coords(self, cube, dimension_names):
         """
@@ -1225,7 +1225,7 @@ class Saver(object):
                                                             primary_coord)
                             cf_var = self._dataset.variables[name]
                             _setncattr(cf_var, 'standard_name', std_name)
-                            cf_var.axis = 'Z'
+                            _setncattr(cf_var, 'axis', 'Z')
                             # Update the formula terms.
                             ft = formula_terms.split()
                             ft = [name if t == cf_name else t for t in ft]
@@ -1235,10 +1235,11 @@ class Saver(object):
                         # Update the associated cube variable.
                         coords = cf_var_cube.coordinates.split()
                         coords = [name if c == cf_name else c for c in coords]
-                        cf_var_cube.coordinates = ' '.join(coords)
+                        _setncattr(cf_var_cube, 'coordinates',
+                                   ' '.join(coords))
                 else:
                     _setncattr(cf_var, 'standard_name', std_name)
-                    cf_var.axis = 'Z'
+                    _setncattr(cf_var, 'axis', 'Z')
                     _setncattr(cf_var, 'formula_terms', formula_terms)
 
     def _get_dim_names(self, cube):
@@ -1480,7 +1481,7 @@ class Saver(object):
         cf_var[:] = data
 
         if cell_measure.units != 'unknown':
-            cf_var.units = str(cell_measure.units)
+            _setncattr(cf_var, 'units', str(cell_measure.units))
 
         if cell_measure.standard_name is not None:
             _setncattr(cf_var, 'standard_name', cell_measure.standard_name)
@@ -1576,7 +1577,7 @@ class Saver(object):
             if coord in cf_coordinates:
                 axis = iris.util.guess_coord_axis(coord)
                 if axis is not None and axis.lower() in SPATIO_TEMPORAL_AXES:
-                    cf_var.axis = axis.upper()
+                    _setncattr(cf_var, 'axis', axis.upper())
 
             # Add the data to the CF-netCDF variable.
             cf_var[:] = points
@@ -1588,7 +1589,7 @@ class Saver(object):
         standard_name, long_name, units = self._cf_coord_identity(coord)
 
         if units != 'unknown':
-            cf_var.units = units
+            _setncattr(cf_var, 'units', units)
 
         if standard_name is not None:
             _setncattr(cf_var, 'standard_name', standard_name)
@@ -1788,7 +1789,7 @@ class Saver(object):
                 self._coord_systems.append(cs)
 
             # Refer to grid var
-            cf_var_cube.grid_mapping = cs.grid_mapping_name
+            _setncattr(cf_var_cube, 'grid_mapping', cs.grid_mapping_name)
 
     def _create_cf_data_variable(self, cube, dimension_names, local_keys=None,
                                  **kwargs):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -520,7 +520,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_rotated_geog_cs(self):
         coord_system = RotatedGeogCS(37.5, 177.5, ellipsoid=GeogCS(6371229.0))
-        expected = {'grid_mapping_name': 'rotated_latitude_longitude',
+        expected = {'grid_mapping_name': b'rotated_latitude_longitude',
                     'north_pole_grid_longitude': 0.0,
                     'grid_north_pole_longitude': 177.5,
                     'grid_north_pole_latitude': 37.5,
@@ -531,7 +531,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_spherical_geog_cs(self):
         coord_system = GeogCS(6371229.0)
-        expected = {'grid_mapping_name': 'latitude_longitude',
+        expected = {'grid_mapping_name': b'latitude_longitude',
                     'longitude_of_prime_meridian': 0.0,
                     'earth_radius': 6371229.0
                     }
@@ -539,7 +539,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_elliptic_geog_cs(self):
         coord_system = GeogCS(637, 600)
-        expected = {'grid_mapping_name': 'latitude_longitude',
+        expected = {'grid_mapping_name': b'latitude_longitude',
                     'longitude_of_prime_meridian': 0.0,
                     'semi_minor_axis': 600.0,
                     'semi_major_axis': 637.0,
@@ -551,7 +551,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
                                         false_easting=-2, false_northing=-5,
                                         secant_latitudes=(38, 50),
                                         ellipsoid=GeogCS(6371000))
-        expected = {'grid_mapping_name': 'lambert_conformal_conic',
+        expected = {'grid_mapping_name': b'lambert_conformal_conic',
                     'latitude_of_projection_origin': 44,
                     'longitude_of_central_meridian': 2,
                     'false_easting': -2, 'false_northing': -5,

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -481,9 +481,11 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
                             createVariable=create_var_fn)
         saver = mock.Mock(spec=Saver, _coord_systems=[],
                           _dataset=dataset)
+
         class NCMock(mock.Mock):
             def setncattr(self, name, attr):
                 setattr(self, name, attr)
+
         variable = NCMock()
 
         # This is the method we're actually testing!

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -481,7 +481,10 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
                             createVariable=create_var_fn)
         saver = mock.Mock(spec=Saver, _coord_systems=[],
                           _dataset=dataset)
-        variable = mock.Mock()
+        class NCMock(mock.Mock):
+            def setncattr(self, name, attr):
+                setattr(self, name, attr)
+        variable = NCMock()
 
         # This is the method we're actually testing!
         Saver._create_cf_grid_mapping(saver, cube, variable)

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -493,7 +493,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
         self.assertEqual(create_var_fn.call_count, 1)
         self.assertEqual(variable.grid_mapping,
-                         grid_variable.grid_mapping_name)
+                         str.encode(grid_variable.grid_mapping_name))
         return grid_variable
 
     def _variable_attributes(self, coord_system):
@@ -520,7 +520,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_rotated_geog_cs(self):
         coord_system = RotatedGeogCS(37.5, 177.5, ellipsoid=GeogCS(6371229.0))
-        expected = {'grid_mapping_name': b'rotated_latitude_longitude',
+        expected = {'grid_mapping_name': 'rotated_latitude_longitude',
                     'north_pole_grid_longitude': 0.0,
                     'grid_north_pole_longitude': 177.5,
                     'grid_north_pole_latitude': 37.5,
@@ -531,7 +531,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_spherical_geog_cs(self):
         coord_system = GeogCS(6371229.0)
-        expected = {'grid_mapping_name': b'latitude_longitude',
+        expected = {'grid_mapping_name': 'latitude_longitude',
                     'longitude_of_prime_meridian': 0.0,
                     'earth_radius': 6371229.0
                     }
@@ -539,7 +539,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
 
     def test_elliptic_geog_cs(self):
         coord_system = GeogCS(637, 600)
-        expected = {'grid_mapping_name': b'latitude_longitude',
+        expected = {'grid_mapping_name': 'latitude_longitude',
                     'longitude_of_prime_meridian': 0.0,
                     'semi_minor_axis': 600.0,
                     'semi_major_axis': 637.0,
@@ -551,7 +551,7 @@ class Test__create_cf_grid_mapping(tests.IrisTest):
                                         false_easting=-2, false_northing=-5,
                                         secant_latitudes=(38, 50),
                                         ellipsoid=GeogCS(6371000))
-        expected = {'grid_mapping_name': b'lambert_conformal_conic',
+        expected = {'grid_mapping_name': 'lambert_conformal_conic',
                     'latitude_of_projection_origin': 44,
                     'longitude_of_central_meridian': 2,
                     'false_easting': -2, 'false_northing': -5,


### PR DESCRIPTION
fix to make #2158 functional for newer netcdf4-python

i am not convinced this catch all potential cases, only the ones we test

a few words prior to merge would be helpful