### PR TITLE
examples removed from date2num and num2date

### DIFF
--- a/lib/iris/unit.py
+++ b/lib/iris/unit.py
@@ -1972,19 +1972,6 @@ class Unit(iris.util._OrderedHashable):
 
         Returns:
             float or numpy.ndarray of float.
-
-        For example:
-
-            >>> import cf_units as unit
-            >>> import datetime
-            >>> u = unit.Unit('hours since 1970-01-01 00:00:00',
-            ...               calendar=unit.CALENDAR_STANDARD)
-            >>> u.date2num(datetime.datetime(1970, 1, 1, 5))
-            5.00000000372529
-            >>> u.date2num([datetime.datetime(1970, 1, 1, 5),
-            ...             datetime.datetime(1970, 1, 1, 6)])
-            array([ 5.,  6.])
-
         """
 
         cdf_utime = self.utime()
@@ -2016,18 +2003,6 @@ class Unit(iris.util._OrderedHashable):
 
         Returns:
             datetime, or numpy.ndarray of datetime object.
-
-        For example:
-
-            >>> import cf_units as unit
-            >>> u = unit.Unit('hours since 1970-01-01 00:00:00',
-            ...               calendar=unit.CALENDAR_STANDARD)
-            >>> u.num2date(6)
-            datetime.datetime(1970, 1, 1, 6, 0)
-            >>> u.num2date([6, 7])
-            array([datetime.datetime(1970, 1, 1, 6, 0),
-                   datetime.datetime(1970, 1, 1, 7, 0)], dtype=object)
-
         """
         cdf_utime = self.utime()
         return cdf_utime.num2date(time_value)


### PR DESCRIPTION
There were doctest failures in the Travis build, noticed in PR#2124.  These were popping up because of a precision change due to a change in numpy versions.  This has been fixed for cf-units, but not for iris.units (because it is being deprecated).  There is no point running the doctests on examples which are not going to be used, so I have just taken them out.  