### PR TITLE
netcdf4-python datetime casting

### DIFF
--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -480,10 +480,15 @@ def _convert_time_coords(lbcode, lbtim, epoch_hours_unit,
 
     """
     def date2hours(t):
-        epoch_hours = epoch_hours_unit.date2num(t)
+        # netcdf4python has changed it's behaviour, at version 1.2, such
+        # that a date2num calculation returns a python float, not
+        # numpy.float64.  The behaviour of round is to recast this to an
+        # int, which is not the desired behaviour for PP files.
+        # So, cast the answer to numpy.float_ to be safe.
+        epoch_hours = np.float_(epoch_hours_unit.date2num(t))
         if t.minute == 0 and t.second == 0:
             epoch_hours = round(epoch_hours)
-        return float(epoch_hours)
+        return epoch_hours
 
     def date2year(t_in):
         return t_in.year

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -483,7 +483,7 @@ def _convert_time_coords(lbcode, lbtim, epoch_hours_unit,
         epoch_hours = epoch_hours_unit.date2num(t)
         if t.minute == 0 and t.second == 0:
             epoch_hours = round(epoch_hours)
-        return epoch_hours
+        return float(epoch_hours)
 
     def date2year(t_in):
         return t_in.year


### PR DESCRIPTION
possible fix for netcdf4-python behaviour change

in pp_rules date time calculations used to return floats, and still do in python2 but not in python3
https://github.com/SciTools/iris/blob/1c195e01ad5638e06910f2862662ac8c731aeea4/lib/iris/fileformats/pp_rules.py#L486

this manifested as a change in a doctest, but looks like a widespread issue where cubes are created using 
`hours_from_t1_to_t2`
and such like
https://github.com/SciTools/iris/blob/1c195e01ad5638e06910f2862662ac8c731aeea4/lib/iris/fileformats/pp_rules.py#L507

this work around may fix the problem