### PR TITLE
idiv vs itruediv test fixed

### DIFF
--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -638,6 +638,8 @@ class TestLog(tests.IrisTest):
 class TestMaskedArrays(tests.IrisTest):
     ops = (operator.add, operator.sub, operator.mul)
     iops = (operator.iadd, operator.isub, operator.imul)
+    # This is to ensure compatibility for both Python2 (which uses div and
+    # idiv) and Python3 (which uses truediv and itruediv).
     try:
         ops = ops + (operator.div, )
         iops = iops + (operator.idiv, )
@@ -646,8 +648,10 @@ class TestMaskedArrays(tests.IrisTest):
         iops = iops + (operator.itruediv, )
 
     def setUp(self):
-        self.data1 = ma.MaskedArray([[9, 9, 9], [8, 8, 8,]], mask=[[0, 1, 0], [0, 0, 1]])
-        self.data2 = ma.MaskedArray([[3, 3, 3], [2, 2, 2,]], mask=[[0, 1, 0], [0, 1, 1]])
+        self.data1 = ma.MaskedArray([[9, 9, 9], [8, 8, 8,]],
+                                    mask=[[0, 1, 0], [0, 0, 1]])
+        self.data2 = ma.MaskedArray([[3, 3, 3], [2, 2, 2,]],
+                                    mask=[[0, 1, 0], [0, 1, 1]])
 
         self.cube1 = iris.cube.Cube(self.data1)
         self.cube2 = iris.cube.Cube(self.data2)
@@ -662,7 +666,15 @@ class TestMaskedArrays(tests.IrisTest):
     def test_operator_in_place(self):
         for test_op in self.iops:
             test_op(self.cube1, self.cube2)
-            test_op(self.data1, self.data2)
+            if test_op == operator.itruediv:
+                # Python3 itruediv requires floats to return floats, numpy1.10:
+                # "TypeError: ufunc 'true_divide' output (typecode 'd') could
+                # not be coerced to provided output parameter (typecode 'l')
+                # according to the casting rule ''same_kind''"
+                test_op(ma.MaskedArray(self.data1, dtype='float'),
+                        ma.MaskedArray(self.data2, dtype='float'))
+            else:
+                test_op(self.data1, self.data2)
 
             np.testing.assert_array_equal(self.cube1.data, self.data1)
 

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -671,8 +671,7 @@ class TestMaskedArrays(tests.IrisTest):
                 # "TypeError: ufunc 'true_divide' output (typecode 'd') could
                 # not be coerced to provided output parameter (typecode 'l')
                 # according to the casting rule ''same_kind''"
-                test_op(ma.MaskedArray(self.data1, dtype='float'),
-                        ma.MaskedArray(self.data2, dtype='float'))
+                test_op(self.data1.astype('float'), self.data2.astype('float'))
             else:
                 test_op(self.data1, self.data2)
 


### PR DESCRIPTION
This test was dividing an integer array by another integer array and then failing when it found that it has floats in its resulting array.  This only occurs in the Python3 function 'itruediv' (the previously used Python2 function 'idiv' rounded to answer to an integer, so didn't encounter the casting error).

The change here catches the event of itruediv being used, and casts the arrays to float arrays rather than integers so that it can quite happily produce a floating point array as a result.

I have tested this with Python3 and numpy1.10 with success.