### PR TITLE
Creq tidy

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -70,7 +70,7 @@ postfix) in addition to the core packages.
 python 2.7 or 3.4 (http://www.python.org/)
     Iris requires Python 2.7 or Python 3.4.
 
-numpy 1.6 or later (http://numpy.scipy.org/)
+numpy 1.9 or later (http://numpy.scipy.org/)
     Python package for scientific computing including a powerful N-dimensional
     array object.
 
@@ -121,6 +121,10 @@ grib-api 1.9.16 or later
     API for the encoding and decoding WMO FM-92 GRIB edition 1 and 
     edition 2 messages. A compression library such as Jasper is required 
     to read JPEG2000 compressed GRIB2 files.
+
+iris-grib 0.9 or later
+    (https://github.com/scitools/iris-grib)
+    Iris interface to ECMWF's GRIB API
 
 matplotlib 1.2.0 (http://matplotlib.sourceforge.net/)
     Python package for 2D plotting.  

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,7 +2,7 @@
 # conda create -n <name> --file conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.14.0
+biggus
 cartopy
 matplotlib
 netcdf4
@@ -25,10 +25,9 @@ filelock
 # Optional iris dependencies
 nc_time_axis
 iris_grib
-ecmwf_grib
 esmpy>=7.0
 gdal
 libmo_unpack
 pandas
 pyugrid
-mo_pack=0.2.0
+mo_pack

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -20,3 +20,6 @@ nose
 pep8=1.5.7
 sphinx
 filelock
+
+# Optional iris dependencies
+mo_pack

--- a/minimal-conda-requirements.txt
+++ b/minimal-conda-requirements.txt
@@ -2,7 +2,7 @@
 # conda create -n <name> --file minimal-conda-requirements.txt
 
 # Mandatory dependencies
-biggus>=0.14.0
+biggus
 cartopy
 matplotlib
 netcdf4
@@ -20,10 +20,3 @@ nose
 pep8=1.5.7
 sphinx
 filelock
-
-# Optional iris dependencies
-gdal
-libmo_unpack
-pandas
-pyugrid
-mo_pack=0.2.0


### PR DESCRIPTION
tiyd up INSTALL and conda-requirements

reduce the scope of minimal-conda-requirements, which isn't especially minimal at the moment

i wonder whether our graphics test skip patterns are such that we could remove matplotlib as a dependency, but I think that cartopy might bring it in anyway via conda. I have not investigated this further