### PR TITLE
BUG: Iris AreaWeighted regrid float tolerance bug

### DIFF
--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -914,11 +914,11 @@ class LambertAzimuthalEqualArea(CoordSystem):
         return ("LambertAzimuthalEqualArea(latitude_of_projection_origin={!r},"
                 " longitude_of_projection_origin={!r}, false_easting={!r},"
                 " false_northing={!r}, ellipsoid={!r})").format(
-                   self.latitude_of_projection_origin,
-                   self.longitude_of_projection_origin,
-                   self.false_easting,
-                   self.false_northing,
-                   self.ellipsoid)
+                    self.latitude_of_projection_origin,
+                    self.longitude_of_projection_origin,
+                    self.false_easting,
+                    self.false_northing,
+                    self.ellipsoid)
 
     def as_cartopy_crs(self):
         if self.ellipsoid is not None:

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -137,8 +137,8 @@ def _within_bounds(src_bounds, tgt_bounds, orderswap=False):
         extremes of the source bounds.
 
     """
-    min_bound = np.min(src_bounds)
-    max_bound = np.max(src_bounds)
+    min_bound = np.min(src_bounds) - 1e-14
+    max_bound = np.max(src_bounds) + 1e-14
 
     # Swap upper-lower is necessary.
     if orderswap is True:

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -155,26 +155,31 @@ class TestWrapAround(tests.IrisTest):
         # Ensure that floating point numbers are treated appropriately when
         # introducing precision difference from wrap_around.
         source = Cube([[1]])
+        cs = GeogCS(6371229)
+
         bounds = np.array([[-91, 0]], dtype='float')
         points = bounds.mean(axis=1)
-        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude')
+        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude',
+                             units='degrees', coord_system=cs)
         source.add_aux_coord(lon_coord, 1)
 
         bounds = np.array([[-90, 90]], dtype='float')
         points = bounds.mean(axis=1)
-        lat_coord = DimCoord(points, bounds=bounds, standard_name='latitude')
+        lat_coord = DimCoord(points, bounds=bounds, standard_name='latitude',
+                             units='degrees', coord_system=cs)
         source.add_aux_coord(lat_coord, 0)
 
         grid = Cube([[0]])
         bounds = np.array([[270, 360]], dtype='float')
         points = bounds.mean(axis=1)
-        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude')
+        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude',
+                             units='degrees', coord_system=cs)
         grid.add_aux_coord(lon_coord, 1)
         grid.add_aux_coord(lat_coord, 0)
 
         res = regrid(source, grid)
         # The result should be equal to the source data and NOT be masked.
-        self.assertMaskedArrayEqual(res.data, np.array([1.0]))
+        self.assertArrayEqual(res.data, np.array([1.0]))
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -148,6 +148,33 @@ class TestMdtol(tests.IrisTest):
         # Set threshold (mdtol) to less than 0.5 (50%).
         res = regrid(src_cube, grid_cube, mdtol=0.4)
         self.assertEqual(ma.count_masked(res.data), 1)
+
+
+class TestWrapAround(tests.IrisTest):
+    def test_float_tolerant_equality(self):
+        # Ensure that floating point numbers are treated appropriately when
+        # introducing precision difference from wrap_around.
+        source = Cube([[1]])
+        bounds = np.array([[-91, 0]], dtype='float')
+        points = bounds.mean(axis=1)
+        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude')
+        source.add_aux_coord(lon_coord, 1)
+
+        bounds = np.array([[-90, 90]], dtype='float')
+        points = bounds.mean(axis=1)
+        lat_coord = DimCoord(points, bounds=bounds, standard_name='latitude')
+        source.add_aux_coord(lat_coord, 0)
+
+        grid = Cube([[0]])
+        bounds = np.array([[270, 360]], dtype='float')
+        points = bounds.mean(axis=1)
+        lon_coord = DimCoord(points, bounds=bounds, standard_name='longitude')
+        grid.add_aux_coord(lon_coord, 1)
+        grid.add_aux_coord(lat_coord, 0)
+
+        res = regrid(source, grid)
+        # The result should be equal to the source data and NOT be masked.
+        self.assertMaskedArrayEqual(res.data, np.array([1.0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Floating point equality without tolerance within `iris.experimental.regrid._within_bounds` produces masked results under circumstances where different longitude ranges are wrapped by wrap_lons [here](https://github.com/cpelley/iris/blob/077701b303741c7271ac19fd0fadaa9f9a67c79a/lib/iris/experimental/regrid.py#L728) when we expect them to be equal (i.e. there is a loss of precision).

Here is a break point at within_bounds for the case where the source longitude extent is [-91, 0] and the target longitude extent is [270, 360]:

``` Python
(Pdb) src_bounds
array([[-1.58824962,  0.        ]])
(Pdb) tgt_bounds
array([[ -1.57079633e+00,   6.66133815e-16]]
```

You will note the 6.66133815e-16 value which makes the equality checks fail, since 0 != 6.66133815e-16.

See the added unittest for the full working example.
