### PR TITLE
Bump the nose multiprocess timeout

### DIFF
--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -163,7 +163,7 @@ class TestRunner():
 
         args = ['', None, '--processes=%s' % n_processors,
                 '--verbosity=2', regexp_pat,
-                '--process-timeout=250']
+                '--process-timeout=600']
         try:
             import gribapi
         except ImportError:


### PR DESCRIPTION
For the first time I've seen some `nose.plugins.multiprocess.TimedOutException` being raised on `travis-ci` ... so I've bumped up the `--process-timeout`

We might have been on the edge with the current timeout of `250` seconds and introducing the thread-safe plotting may be pushing it just over the edge (plus also given the variable load on `travis-ci`)