### PR TITLE
Remove plot locking.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ install:
     fi
 
   # Perceptual image hashing (TBD: push recipe to conda-forge!)
-  - conda install pip
   - pip install imagehash
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="e8e62ab79a2f8789f01f8dfa9829915984a39b2a"
+  - export IRIS_TEST_DATA_REF="a754fc977d30fdcdacb820b5a5fabd91056afc7b"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   # Install miniconda
@@ -75,9 +75,11 @@ install:
   - python -c 'import cartopy; cartopy.io.shapereader.natural_earth()'
 
 # iris test data
-  - wget -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip
-  - unzip -q iris-test-data.zip
-  - ln -s $(pwd)/iris-test-data-${IRIS_TEST_DATA_SUFFIX} iris-test-data
+  - if [[ "$TEST_MINIMAL" != true ]]; then
+      wget -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip;
+      unzip -q iris-test-data.zip;
+      ln -s $(pwd)/iris-test-data-${IRIS_TEST_DATA_SUFFIX} iris-test-data;
+    fi
 
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -27,8 +27,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import collections
 import datetime
-from functools import wraps
-import threading
 
 import cartopy.crs as ccrs
 import cartopy.mpl.geoaxes
@@ -55,26 +53,6 @@ import iris.palette
 BREWER_CITE = 'Colours based on ColorBrewer.org'
 
 PlotDefn = collections.namedtuple('PlotDefn', ('coords', 'transpose'))
-
-# Threading reentrant lock to ensure thread-safe plotting.
-_lock = threading.RLock()
-
-
-def _locker(func):
-    """
-    Decorator that ensures a thread-safe atomic operation is
-    performed by the decorated function.
-
-    Uses a shared threading reentrant lock to provide thread-safe
-    plotting by public API functions.
-
-    """
-    @wraps(func)
-    def decorated_func(*args, **kwargs):
-        with _lock:
-            result = func(*args, **kwargs)
-        return result
-    return decorated_func
 
 
 def _get_plot_defn_custom_coords_picked(cube, coords, mode, ndims=2):
@@ -686,7 +664,6 @@ def _map_common(draw_method_name, arg_func, mode, cube, plot_defn,
     return plotfn(*new_args, **kwargs)
 
 
-@_locker
 def contour(cube, *args, **kwargs):
     """
     Draws contour lines based on the given Cube.
@@ -711,7 +688,6 @@ def contour(cube, *args, **kwargs):
     return result
 
 
-@_locker
 def contourf(cube, *args, **kwargs):
     """
     Draws filled contours based on the given Cube.
@@ -838,7 +814,6 @@ def _fill_orography(cube, coords, mode, vert_plot, horiz_plot, style_args):
     return result
 
 
-@_locker
 def orography_at_bounds(cube, facecolor='#888888', coords=None, axes=None):
     """Plots orography defined at cell boundaries from the given Cube."""
 
@@ -869,7 +844,6 @@ def orography_at_bounds(cube, facecolor='#888888', coords=None, axes=None):
                            horiz_plot, style_args)
 
 
-@_locker
 def orography_at_points(cube, facecolor='#888888', coords=None, axes=None):
     """Plots orography defined at sample points from the given Cube."""
 
@@ -891,7 +865,6 @@ def orography_at_points(cube, facecolor='#888888', coords=None, axes=None):
                            horiz_plot, style_args)
 
 
-@_locker
 def outline(cube, coords=None, color='k', linewidth=None, axes=None):
     """
     Draws cell outlines based on the given Cube.
@@ -929,7 +902,6 @@ def outline(cube, coords=None, color='k', linewidth=None, axes=None):
     return result
 
 
-@_locker
 def pcolor(cube, *args, **kwargs):
     """
     Draws a pseudocolor plot based on the given Cube.
@@ -956,7 +928,6 @@ def pcolor(cube, *args, **kwargs):
     return result
 
 
-@_locker
 def pcolormesh(cube, *args, **kwargs):
     """
     Draws a pseudocolor plot based on the given Cube.
@@ -981,7 +952,6 @@ def pcolormesh(cube, *args, **kwargs):
     return result
 
 
-@_locker
 def points(cube, *args, **kwargs):
     """
     Draws sample point positions based on the given Cube.
@@ -1009,7 +979,6 @@ def points(cube, *args, **kwargs):
                                 *args, **kwargs)
 
 
-@_locker
 def plot(*args, **kwargs):
     """
     Draws a line plot based on the given cube(s) or coordinate(s).
@@ -1054,7 +1023,6 @@ def plot(*args, **kwargs):
     return _draw_1d_from_points('plot', _plot_args, *args, **kwargs)
 
 
-@_locker
 def scatter(x, y, *args, **kwargs):
     """
     Draws a scatter plot based on the given cube(s) or coordinate(s).
@@ -1090,7 +1058,6 @@ def scatter(x, y, *args, **kwargs):
 show = plt.show
 
 
-@_locker
 def symbols(x, y, symbols, size, axes=None, units='inches'):
     """
     Draws fixed-size symbols.
@@ -1154,7 +1121,6 @@ def symbols(x, y, symbols, size, axes=None, units='inches'):
     axes.autoscale_view()
 
 
-@_locker
 def citation(text, figure=None, axes=None):
     """
     Add a text citation to a plot.

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -183,7 +183,10 @@ def get_data_path(relative_path):
     """
     if not isinstance(relative_path, six.string_types):
         relative_path = os.path.join(*relative_path)
-    data_path = os.path.join(iris.config.TEST_DATA_DIR, relative_path)
+    test_data_dir = iris.config.TEST_DATA_DIR
+    if test_data_dir is None:
+        test_data_dir = ''
+    data_path = os.path.join(test_data_dir, relative_path)
 
     if _EXPORT_DATAPATHS_FILE is not None:
         _EXPORT_DATAPATHS_FILE.write(data_path + '\n')

--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -155,6 +155,7 @@ def _resampled_grid(cube, x_samplefactor, y_samplefactor):
     return new_cube
 
 
+@tests.skip_data
 class TestAreaWeightedRegrid(tests.IrisTest):
     def setUp(self):
         # A cube with a hybrid height derived coordinate.

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -226,6 +226,7 @@ class TestConservativeRegrid(tests.IrisTest):
                                [True, False, False, False, True],
                                [True, True, True, True, True]])
 
+    @tests.skip_data
     def test_multidimensional(self):
         """
         Check valid operation on a multidimensional cube.

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -44,6 +44,7 @@ from iris.tests import mock
 import iris.tests.stock as stock
 
 
+@tests.skip_data
 class TestHybridPressure(tests.IrisTest):
     def setUp(self):
         # Modify stock cube so it is suitable to have a
@@ -79,6 +80,7 @@ class TestHybridPressure(tests.IrisTest):
             self.assertEqual(cube, other_cube)
 
 
+@tests.skip_data
 class TestSaveMultipleAuxFactories(tests.IrisTest):
     def test_hybrid_height_and_pressure(self):
         cube = stock.realistic_4d()
@@ -306,6 +308,7 @@ class TestCellMethod_unknown(tests.IrisTest):
             shutil.rmtree(temp_dirpath)
 
 
+@tests.skip_data
 class TestCoordSystem(tests.IrisTest):
     def test_load_laea_grid(self):
         cube = iris.load_cube(

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -637,6 +637,7 @@ class TestSaveLBPROC(tests.IrisTest):
         self.assertEqual(int(field.lbproc), 192)
 
 
+@tests.skip_data
 class TestCallbackLoad(tests.IrisTest):
     def setUp(self):
         self.pass_name = 'air_potential_temperature'

--- a/lib/iris/tests/stock.py
+++ b/lib/iris/tests/stock.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -471,8 +471,9 @@ def realistic_4d():
 #    >>> arrays.append(theta.data)
 #    >>> arrays.append(theta.coord('sigma').coord_system.orography.data)
 #    >>> np.savez('stock_arrays.npz', *arrays)
-
-    data_path = os.path.join(os.path.dirname(__file__), 'stock_arrays.npz')
+    data_path = tests.get_data_path(('stock', 'stock_arrays.npz'))
+    if not os.path.isfile(data_path):
+        raise IOError('Test data is not available at {}.'.format(data_path))
     r = np.load(data_path)
     # sort the arrays based on the order they were originally given. The names given are of the form 'arr_1' or 'arr_10'
     _, arrays =  zip(*sorted(six.iteritems(r), key=lambda item: int(item[0][4:])))
@@ -526,7 +527,9 @@ def realistic_4d_no_derived():
 
 
 def realistic_4d_w_missing_data():
-    data_path = os.path.join(os.path.dirname(__file__), 'stock_mdi_arrays.npz')
+    data_path = tests.get_data_path(('stock', 'stock_mdi_arrays.npz'))
+    if not os.path.isfile(data_path):
+        raise IOError('Test data is not available at {}.'.format(data_path))
     data_archive = np.load(data_path)
     data = ma.masked_array(data_archive['arr_0'], mask=data_archive['arr_1'])
 

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -656,6 +656,7 @@ class TestAreaWeights(tests.IrisTest):
         self.assertCML(small_cube, ('analysis', 'areaweights_original.cml'),
                        checksum=False)
 
+@tests.skip_data
 class TestAreaWeightGeneration(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -37,6 +37,7 @@ from iris.tests.test_interpolation import normalise_order
 
 
 class TestCubeDelta(tests.IrisTest):
+    @tests.skip_data
     def test_invalid(self):
         cube = iris.tests.stock.realistic_4d()
         with self.assertRaises(iris.exceptions.CoordinateMultiDimError):

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -214,6 +214,7 @@ class TestBasicCubeConstruction(tests.IrisTest):
             dims[0] = 1
 
 
+@tests.skip_data
 class TestStockCubeStringRepresentations(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.realistic_4d()
@@ -276,10 +277,12 @@ class TestCubeStringRepresentations(IrisDotTest):
         del cube.attributes['my_attribute']
        
     # TODO hybrid height and dot output - relatitionship links
+    @tests.skip_data
     def test_dot_4d(self):
         cube = iris.tests.stock.realistic_4d()
         self.check_dot(cube, ('file_load', '4d_pp.dot'))
 
+    @tests.skip_data
     def test_missing_coords(self):
         cube = iris.tests.stock.realistic_4d()
         cube.remove_coord('time')
@@ -289,6 +292,7 @@ class TestCubeStringRepresentations(IrisDotTest):
         self.assertString(str(cube),
                           ('cdm', 'str_repr', 'missing_coords_cube.str.txt'))
 
+    @tests.skip_data
     def test_cubelist_string(self):
         cube_list = iris.cube.CubeList([iris.tests.stock.realistic_4d(),
                                         iris.tests.stock.global_pp()])
@@ -1069,8 +1073,9 @@ class TestCubeCollapsed(tests.IrisTest):
 
         # Ensure no side effects
         self.assertCML(cube, ('cube_collapsed', 'original.cml'))
-        
-        
+
+
+@tests.skip_data
 class TestTrimAttributes(tests.IrisTest):
     def test_non_string_attributes(self):
         cube = iris.tests.stock.realistic_4d()
@@ -1155,6 +1160,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
             self.assertEqual(merged_cube.data.fill_value, 123456)
 
 
+@tests.skip_data
 class TestConversionToCoordList(tests.IrisTest):
     def test_coord_conversion(self):
         cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -43,8 +43,11 @@ def workaround_pending_1262(cubes):
             cubes[i] = cube[::-1]
 
 
+@tests.skip_data
 class TestSimple(tests.IrisTest):
-    slices = iris.cube.CubeList(stock.realistic_4d().slices(['grid_latitude', 'grid_longitude']))
+    def setUp(self):
+        names = ['grid_latitude', 'grid_longitude']
+        self.slices = iris.cube.CubeList(stock.realistic_4d().slices(names))
 
     def test_constraints(self):
         constraint = iris.Constraint(model_level_number=10)

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -106,6 +106,7 @@ class TestLazy(unittest.TestCase):
         self._check_shared_data(self.coord)
 
 
+@tests.skip_data
 class TestCoordSlicing(unittest.TestCase):
     def setUp(self):
         cube = iris.tests.stock.realistic_4d()
@@ -207,6 +208,7 @@ class TestCoordIntersection(tests.IrisTest):
         self.a.units = 'kilometer'
         self.assertRaises(ValueError, self.a.intersect, self.b)
 
+    @tests.skip_data
     def test_commutative(self):
         cube = iris.tests.stock.realistic_4d()
         coord = cube.coord('grid_longitude')
@@ -232,6 +234,7 @@ class TestXML(tests.IrisTest):
         self.assertXMLElement(coord, ('coord_api', 'complex.xml'))
 
 
+@tests.skip_data
 class TestCoord_ReprStr_nontime(tests.IrisTest):
     def setUp(self):
         self.lat = iris.tests.stock.realistic_4d().coord('grid_latitude')[:10]
@@ -253,6 +256,7 @@ class TestCoord_ReprStr_nontime(tests.IrisTest):
                           ('coord_api', 'str_repr', 'aux_nontime_str.txt'))
 
 
+@tests.skip_data
 class TestCoord_ReprStr_time(tests.IrisTest):
     def setUp(self):
         self.time = iris.tests.stock.realistic_4d().coord('time')
@@ -596,6 +600,7 @@ class TestCoordCollapsed(tests.IrisTest):
         self.assertCML(pcube, ("coord_api", "nd_bounds.cml"))
 
 
+@tests.skip_data
 class TestGetterSetter(tests.IrisTest):
     def test_get_set_points_and_bounds(self):
         cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -297,7 +297,8 @@ class TestPPSaveRules(tests.IrisTest, pp.PPTest):
             self.assertEqual(self.lbproc_from_pp(temp_filename), lbproc)
 
             os.remove(temp_filename)
-            
+
+    @tests.skip_data
     def test_lbvc(self):
         cube = stock.realistic_4d_no_derived()[0, :4, ...]
         

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -37,6 +37,7 @@ import iris.tests.stock
 
 
 @tests.skip_plot
+@tests.skip_data
 class TestRealistic4d(tests.GraphicsTest):
     def setUp(self):
         super(TestRealistic4d, self).setUp()
@@ -160,6 +161,7 @@ class TestRealistic4d(tests.GraphicsTest):
             bounds = altitude.bounds
 
 
+@tests.skip_data
 class TestHybridPressure(tests.IrisTest):
     def setUp(self):
         # Convert the hybrid-height into hybrid-pressure...

--- a/lib/iris/tests/test_iterate.py
+++ b/lib/iris/tests/test_iterate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -40,6 +40,7 @@ import iris.tests.stock
 from functools import reduce
 
 
+@tests.skip_data
 class TestIterateFunctions(tests.IrisTest):
 
     def setUp(self):

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -47,8 +47,11 @@ _DEFAULT_GLOBE = ccrs.Globe(semimajor_axis=6371229.0,
 
 
 @tests.skip_plot
+@tests.skip_data
 class TestBasic(tests.GraphicsTest):
-    cube = iris.tests.stock.realistic_4d()
+    def setUp(self):
+        super(TestBasic, self).setUp()
+        self.cube = iris.tests.stock.realistic_4d()
 
     def test_contourf(self):
         cube = self.cube[0, 0]

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -300,6 +300,7 @@ class SaverPermissions(tests.IrisTest):
             os.rmdir(dir_name)
 
 
+@tests.skip_data
 class TestSave(tests.IrisTest):
     def test_hybrid(self):
         cube = stock.realistic_4d()

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -42,6 +42,7 @@ if tests.MPL_AVAILABLE:
     import iris.symbols
 
 
+@tests.skip_data
 def simple_cube():
     cube = iris.tests.stock.realistic_4d()
     cube = cube[:, 0, 0, :]
@@ -102,6 +103,7 @@ class TestMissingCS(tests.GraphicsTest):
 
 
 @tests.skip_plot
+@tests.skip_data
 class TestHybridHeight(tests.GraphicsTest):
     def setUp(self):
         super(TestHybridHeight, self).setUp()
@@ -151,6 +153,7 @@ class TestHybridHeight(tests.GraphicsTest):
 
 
 @tests.skip_plot
+@tests.skip_data
 class Test1dPlotMultiArgs(tests.GraphicsTest):
     # tests for iris.plot using multi-argument calling convention
 
@@ -367,6 +370,7 @@ def cache(fn, cache={}):
 
 
 @cache
+@tests.skip_data
 def _load_4d_testcube():
     # Load example 4d data (TZYX).
     test_cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_trajectory.py
+++ b/lib/iris/tests/test_trajectory.py
@@ -29,6 +29,7 @@ import iris.analysis.trajectory
 import iris.tests.stock
 
 
+@tests.skip_data
 class TestSimple(tests.IrisTest):
     def test_invalid_coord(self):
         cube = iris.tests.stock.realistic_4d()

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -184,6 +184,7 @@ class TestClipString(unittest.TestCase):
             'expected value is %s' % (len(result), expected_length))
 
 
+@tests.skip_data
 class TestDescribeDiff(iris.tests.IrisTest):
     def test_identical(self):
         test_cube_a = stock.realistic_4d()
@@ -262,6 +263,7 @@ class TestDescribeDiff(iris.tests.IrisTest):
                               'incompatible_cubes.str.txt')
 
 
+@tests.skip_data
 class TestAsCompatibleShape(tests.IrisTest):
     def test_slice(self):
         cube = tests.stock.realistic_4d()

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -70,28 +70,33 @@ class TestAll(tests.IrisTest):
         self.assertIsNot(res.coord('projection_x_coordinate').coord_system,
                          self.tcs)
 
+    @tests.skip_data
     def test_bad_resolution_negative(self):
         cube = low_res_4d()
         with self.assertRaises(ValueError):
             project(cube, ROBINSON, nx=-200, ny=200)
 
+    @tests.skip_data
     def test_bad_resolution_non_numeric(self):
         cube = low_res_4d()
         with self.assertRaises(ValueError):
             project(cube, ROBINSON, nx=200, ny='abc')
 
+    @tests.skip_data
     def test_missing_lat(self):
         cube = low_res_4d()
         cube.remove_coord('grid_latitude')
         with self.assertRaises(ValueError):
             project(cube, ROBINSON)
 
+    @tests.skip_data
     def test_missing_lon(self):
         cube = low_res_4d()
         cube.remove_coord('grid_longitude')
         with self.assertRaises(ValueError):
             project(cube, ROBINSON)
 
+    @tests.skip_data
     def test_missing_latlon(self):
         cube = low_res_4d()
         cube.remove_coord('grid_longitude')
@@ -99,40 +104,47 @@ class TestAll(tests.IrisTest):
         with self.assertRaises(ValueError):
             project(cube, ROBINSON)
 
+    @tests.skip_data
     def test_default_resolution(self):
         cube = low_res_4d()
         new_cube, extent = project(cube, ROBINSON)
         self.assertEqual(new_cube.shape, cube.shape)
 
+    @tests.skip_data
     def test_explicit_resolution(self):
         cube = low_res_4d()
         nx, ny = 5, 4
         new_cube, extent = project(cube, ROBINSON, nx=nx, ny=ny)
         self.assertEqual(new_cube.shape, cube.shape[:2] + (ny, nx))
 
+    @tests.skip_data
     def test_explicit_resolution_single_point(self):
         cube = low_res_4d()
         nx, ny = 1, 1
         new_cube, extent = project(cube, ROBINSON, nx=nx, ny=ny)
         self.assertEqual(new_cube.shape, cube.shape[:2] + (ny, nx))
 
+    @tests.skip_data
     def test_mismatched_coord_systems(self):
         cube = low_res_4d()
         cube.coord('grid_longitude').coord_system = None
         with self.assertRaises(ValueError):
             project(cube, ROBINSON)
 
+    @tests.skip_data
     def test_extent(self):
         cube = low_res_4d()
         _, extent = project(cube, ROBINSON)
         self.assertEqual(extent, [-17005833.33052523, 17005833.33052523,
                                   -8625155.12857459, 8625155.12857459])
 
+    @tests.skip_data
     def test_cube(self):
         cube = low_res_4d()
         new_cube, _ = project(cube, ROBINSON)
         self.assertCMLApproxData(new_cube)
 
+    @tests.skip_data
     def test_no_coord_system(self):
         cube = low_res_4d()
         cube.coord('grid_longitude').coord_system = None

--- a/lib/iris/tests/unit/analysis/interpolate/test_linear.py
+++ b/lib/iris/tests/unit/analysis/interpolate/test_linear.py
@@ -64,6 +64,7 @@ class Test(tests.IrisTest):
         self._assert_expected_call(sample_points, sample_points_call)
 
 
+@tests.skip_data
 class Test_masks(tests.IrisTest):
     def test_mask_retention(self):
         cube = stock.realistic_4d_w_missing_data()

--- a/lib/iris/tests/unit/analysis/interpolation/test_get_xy_dim_coords.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_get_xy_dim_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -38,6 +38,7 @@ import iris.tests.stock
 
 
 class TestGetXYCoords(tests.IrisTest):
+    @tests.skip_data
     def test_grid_lat_lon(self):
         cube = iris.tests.stock.realistic_4d()
         x, y = get_xy_dim_coords(cube)
@@ -58,18 +59,21 @@ class TestGetXYCoords(tests.IrisTest):
         self.assertIs(x, cube.coord('projection_x_coordinate'))
         self.assertIs(y, cube.coord('projection_y_coordinate'))
 
+    @tests.skip_data
     def test_missing_x_coord(self):
         cube = iris.tests.stock.realistic_4d()
         cube.remove_coord('grid_longitude')
         with self.assertRaises(ValueError):
             get_xy_dim_coords(cube)
 
+    @tests.skip_data
     def test_missing_y_coord(self):
         cube = iris.tests.stock.realistic_4d()
         cube.remove_coord('grid_latitude')
         with self.assertRaises(ValueError):
             get_xy_dim_coords(cube)
 
+    @tests.skip_data
     def test_multiple_coords(self):
         cube = iris.tests.stock.realistic_4d()
         cs = iris.coord_systems.GeogCS(6371229)

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
+@tests.skip_data
 class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -32,6 +32,7 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
+@tests.skip_data
 class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
+@tests.skip_data
 class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
+@tests.skip_data
 class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -1188,6 +1188,7 @@ class Test___call____rotated_to_lat_lon(tests.IrisTest):
             self.assertCMLApproxData(result, cml)
 
 
+@tests.skip_data
 class Test___call____NOP(tests.IrisTest):
     def setUp(self):
         # The destination grid points are exactly the same as the

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -409,6 +409,7 @@ class Test_rolling_window(tests.IrisTest):
         self.assertMaskedArrayEqual(expected_result, res_cube.data)
 
 
+@tests.skip_data
 class Test_slices_over(tests.IrisTest):
     def setUp(self):
         self.cube = stock.realistic_4d()

--- a/lib/iris/tests/unit/fileformats/test_rules.py
+++ b/lib/iris/tests/unit/fileformats/test_rules.py
@@ -78,6 +78,7 @@ class TestConcreteReferenceTarget(tests.IrisTest):
         dest.long_name = src.long_name
         self.assertEqual(dest, src)
 
+    @tests.skip_data
     def test_multiple_cubes_no_transform(self):
         target = ConcreteReferenceTarget('foo')
         src = stock.realistic_4d()
@@ -87,6 +88,7 @@ class TestConcreteReferenceTarget(tests.IrisTest):
         self.assertIsNot(dest, src)
         self.assertEqual(dest, src)
 
+    @tests.skip_data
     def test_multiple_cubes_with_transform(self):
         def transform(cube):
             return {'long_name': 'wibble'}
@@ -152,6 +154,7 @@ class TestLoadCubes(tests.IrisTest):
         self.assertTrue(hasattr(aux_factory, 'fake_args'))
         self.assertEqual(aux_factory.fake_args, ({'name': 'foo'},))
 
+    @tests.skip_data
     def test_cross_reference(self):
         # Test the creation process for a factory definition which uses
         # a cross-reference.

--- a/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
+++ b/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -38,6 +38,7 @@ class Test(tests.IrisTest):
         self.assertEqual(cube_b.dim_coords,
                          (cube_a.coord('latitude'), cube_a.coord('longitude')))
 
+    @tests.skip_data
     def test_argument_is_coord_instance(self):
         cube_a = stock.realistic_4d()
         cube_b = cube_a.copy()

--- a/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
+++ b/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -44,6 +44,7 @@ class Test(tests.IrisTest):
         promote_aux_coord_to_dim_coord(cube_b, 'model_level_number')
         self.assertTrue(cube_a.coord('level_height') in cube_b.aux_coords)
 
+    @tests.skip_data
     def test_argument_is_coord_instance(self):
         cube_a = stock.realistic_4d()
         cube_b = cube_a.copy()
@@ -53,6 +54,7 @@ class Test(tests.IrisTest):
                           cube_a.coord('grid_latitude'),
                           cube_a.coord('grid_longitude')))
 
+    @tests.skip_data
     def test_dimension_is_anonymous(self):
         cube_a = stock.realistic_4d()
         cube_b = cube_a.copy()


### PR DESCRIPTION
This PR addresses the post-merge issues raised by @dkillick on https://github.com/SciTools/iris/pull/2206.

Locking at the iris plot level will not guarantee to the user thread-safe plotting. There is still the possibility of an iris plot using an mpl figure from a different thread in certain circumstances. In the case of https://github.com/SciTools/iris/pull/2206, the implementation introduced a locking mechanism at the iris plotting api level, which is in fact at **too low** a level.

If a user insists on using iris plotting in a threaded context, then we should advocate that they take responsibility for locking themselves (which, to be fair, is pretty simple to do) in combination with creating the target mpl figure/axes.

Note that, for clarity, we do require to maintain non re-entrant locking at the individual graphics test case level to avoid the issues raised in https://github.com/SciTools/iris/issues/2195.

Closes https://github.com/SciTools/iris/issues/2210.