### PR TITLE
Prevent dot_path tests from corrupting the stored path.

### DIFF
--- a/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
+++ b/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
@@ -28,7 +28,7 @@ import subprocess
 
 import mock
 
-from iris.fileformats.dot import _dot_path
+from iris.fileformats.dot import _dot_path, _DOT_EXECUTABLE_PATH
 
 
 class Test(tests.IrisTest):
@@ -37,6 +37,11 @@ class Test(tests.IrisTest):
         # reset the caching status to allow us to see what happens
         # under different circumstances.
         self.patch('iris.fileformats.dot._DOT_CHECKED', new=False)
+        # Also patch the private path variable to the existing value (i.e. no
+        # change), and restore it after each test:  As these tests modify it,
+        # that can potentially break subsequent 'normal' behaviour.
+        self.patch('iris.fileformats.dot._DOT_EXECUTABLE_PATH',
+                   _DOT_EXECUTABLE_PATH)
 
     def test_valid_absolute_path(self):
         # Override the configuration value for System.dot_path


### PR DESCRIPTION
replaces #2220 
same code, but targeted at v1.11.x