### PR TITLE
Dot test import

### DIFF
--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -41,6 +41,7 @@ import iris.analysis
 import iris.coords
 import iris.cube
 import iris.fileformats
+import iris.fileformats.dot
 import iris.tests.pp as pp
 import iris.tests.stock
 


### PR DESCRIPTION
Without this, the test fails when run in isolation,
with a couple of errors like "AttributeError: 'module' object has no attribute 'dot'".

It doesn't **usually** fail when running all tests, presumably because some other test imports it first.
However, think this error has occurred sometimes.

I believe the order of running tests is not dependable.
In any case, this is an obvious bug, as we _shouldn't_ have such dependencies.