### PR TITLE
DOC: mention sample data in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,7 @@ the following command::
 
 If you wish to run any of the code examples
 (see http://scitools.org.uk/iris/docs/latest/examples/index.html) you will also
-need the Iris sample data. This can also be installed using Conda::
+need the Iris sample data. This can also be installed using conda::
 
   conda install -c scitools iris_sample_data
 

--- a/INSTALL
+++ b/INSTALL
@@ -16,6 +16,12 @@ the following command::
 
   conda install -c scitools iris
 
+If you wish to run any of the code examples
+(see http://scitools.org.uk/iris/docs/latest/examples/index.html) you will also
+need the Iris sample data. This can also be installed using Conda::
+
+  conda install -c scitools iris_sample_data
+
 Further documentation on using conda and the features it provides can be found
 at http://conda.pydata.org/docs/intro.html.
 

--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@ Installing using conda
 ----------------------
 
 Iris is available using conda for the following platforms:
- * Linux 32-bit and 64-bit,
+ * Linux 64-bit,
  * Mac OSX 64-bit, and
  * Windows 32-bit and 64-bit.
 


### PR DESCRIPTION
If you wish to run any of the code examples you need access to the Iris sample data, which can now be easily installed from Conda. This, however, may not be very clear to new users, so I'm proposing that we add mention of the Iris sample data to the `INSTALL` document.

Addresses part of #2232. 