### PR TITLE
Consistency in lon/lat return order

### DIFF
--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -162,7 +162,7 @@ def rotate_pole(lons, lats, pole_lon, pole_lat):
     return rotated_lon, rotated_lat
 
 
-def _get_lat_lon_coords(cube):
+def _get_lon_lat_coords(cube):
     lat_coords = [coord for coord in cube.coords()
                   if "latitude" in coord.name()]
     lon_coords = [coord for coord in cube.coords()
@@ -173,7 +173,7 @@ def _get_lat_lon_coords(cube):
             " is currently disallowed")
     lat_coord = lat_coords[0]
     lon_coord = lon_coords[0]
-    return (lat_coord, lon_coord)
+    return (lon_coord, lat_coord)
 
 
 def _xy_range(cube, mode=None):
@@ -575,7 +575,7 @@ def project(cube, target_proj, nx=None, ny=None):
 
     """
     try:
-        lat_coord, lon_coord = _get_lat_lon_coords(cube)
+        lon_coord, lat_coord = _get_lon_lat_coords(cube)
     except IndexError:
         raise ValueError('Cannot get latitude/longitude '
                          'coordinates from cube {!r}.'.format(cube.name()))

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -169,7 +169,7 @@ def _get_lon_lat_coords(cube):
                   if "longitude" in coord.name()]
     if len(lat_coords) > 1 or len(lon_coords) > 1:
         raise ValueError(
-            "Calling _get_lat_lon_coords() with multiple lat or lon coords"
+            "Calling `_get_lon_lat_coords` with multiple lat or lon coords"
             " is currently disallowed")
     lat_coord = lat_coords[0]
     lon_coord = lon_coords[0]
@@ -379,7 +379,7 @@ def area_weights(cube, normalize=False):
 
     # Get the lon and lat coords and axes
     try:
-        lat, lon = _get_lat_lon_coords(cube)
+        lon, lat = _get_lon_lat_coords(cube)
     except IndexError:
         raise ValueError('Cannot get latitude/longitude '
                          'coordinates from cube {!r}.'.format(cube.name()))


### PR DESCRIPTION
In `iris.analysis.cartography`, there are three functions that return lons and lats. Two of them return `lon(s), lat(s)`, one returns `(lat, lon)`. This changes the order of the latter to match the order of the former. The best thing is the latter (`_get_lat_lon_coords`, which I've renamed to the now more appropriate `_get_lon_lat_coords`) is a private method, so we don't need a major release for this change.

Amazingly enough, this addresses #51.