### PR TITLE
Fix test runner override and no-data

### DIFF
--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -132,12 +132,11 @@ TEST_DATA_DIR = get_dir_option(_RESOURCE_SECTION, 'test_data_dir',
 # Override the data repository if the appropriate environment variable
 # has been set.  This is used in setup.py in the TestRunner command to
 # enable us to simulate the absence of external data.
-override = os.environ.get("override_test_data_repository")
+override = os.environ.get("OVERRIDE_TEST_DATA_REPOSITORY")
 if override:
-    if override == '1':
-        TEST_DATA_DIR = None
-    else:
-        TEST_DATA_DIR = override
+    TEST_DATA_DIR = None
+    if os.path.isdir(os.path.expanduser(override)):
+        TEST_DATA_DIR = os.path.abspath(override)
 
 PALETTE_PATH = get_dir_option(_RESOURCE_SECTION, 'palette_path',
                               os.path.join(CONFIG_PATH, 'palette'))

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -107,7 +107,8 @@ class TestRunner():
         # processes that nose.run creates.
         if self.no_data:
             print('Running tests in no-data mode...')
-            os.environ['override_test_data_repository'] = 'true'
+            import iris.config
+            iris.config.TEST_DATA_DIR = None
         if self.create_missing:
             os.environ['IRIS_TEST_CREATE_MISSING'] = 'true'
 


### PR DESCRIPTION
This PR corrects the use of the `override_test_data_repository` environment variable, and applies the standard naming convention of using upper-case environment variables :pray: 

It also fixes the broken test runner option `--no-data` to **actually** ignore the test data.

This corrects #2211 and addresses the ignored [comment](https://github.com/SciTools/iris/pull/2211#discussion_r84714014)

@dkillick and @lbdreyer 