### PR TITLE
Correct PP deprecation notices

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2030,16 +2030,16 @@ def add_save_rules(filename):
     .. deprecated:: 1.10
 
         If you need to customise pp field saving, please refer to the functions
-        :func:`as_fields`, :func:`as_pairs` and :func:`save_fields` for an
-        alternative solution.
+        :func:`as_fields`, :func:`save_pairs_from_cube` and :func:`save_fields`
+        for an alternative solution.
 
     """
     warn_deprecated(
         'custom pp save rules are deprecated from v1.10.\n'
         'If you need to customise pp field saving, please refer to the '
         'functions iris.fileformats.pp.as_fields, '
-        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
-        'for an alternative solution.')
+        'iris.fileformats.pp.save_pairs_from_cube and '
+        'iris.fileformats.pp.save_fields for an alternative solution.')
     _ensure_save_rules_loaded()
     _save_rules.import_rules(filename)
 
@@ -2051,16 +2051,16 @@ def reset_save_rules():
     .. deprecated:: 1.10
 
         If you need to customise pp field saving, please refer to the functions
-        :func:`as_fields`, :func:`as_pairs` and :func:`save_fields` for an
-        alternative solution.
+        :func:`as_fields`, :func:`save_pairs_from_cube` and :func:`save_fields`
+        for an alternative solution.
 
     """
     warn_deprecated(
         'custom pp save rules are deprecated from v1.10.\n'
         'If you need to customise pp field saving, please refer to the '
         'functions iris.fileformats.pp.as_fields, '
-        'iris.fileformats.pp.as_pairs and iris.fileformats.pp.save_fields '
-        'for an alternative solution.')
+        'iris.fileformats.pp.save_pairs_from_cube and '
+        'iris.fileformats.pp.save_fields for an alternative solution.')
     # Uses this module-level variable
     global _save_rules
 


### PR DESCRIPTION
The PP load/save pipeline has been substantially changed for v1.10, with a number of old bits of functionality being deprecated. Unfortunately the deprecation messaged for two of the deprecated functions (being `add_save_rules` and `reset_save_rules`) actually pointed the user to go and use another function (`as_pairs`) that had itself been deprecated by `save_pairs_from_cubes`.

This PR corrects the deprecation warning messages to point to the non-deprecated function rather than the deprecated function.