### PR TITLE
DOC: Correct link to GRIB saver

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -159,6 +159,7 @@ intersphinx_mapping = {
    'matplotlib': ('http://matplotlib.org/', None),
    'cartopy': ('http://scitools.org.uk/cartopy/docs/latest/', None),
    'biggus': ('https://biggus.readthedocs.io/en/latest/', None),
+   'iris-grib': ('http://iris-grib.readthedocs.io/en/latest/', None),
 }
 
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -323,9 +323,9 @@ def save(source, target, saver=None, **kwargs):
 
         * netCDF - the Unidata network Common Data Format:
             * see :func:`iris.fileformats.netcdf.save`
-        * GRIB2  - the WMO GRIdded Binary data format;
-            * see <http://https://github.com/SciTools/iris-grib>.
-        * PP     - the Met Office UM Post Processing Format.
+        * GRIB2 - the WMO GRIdded Binary data format:
+            * see :func:`iris-grib.save_grib2`.
+        * PP - the Met Office UM Post Processing Format:
             * see :func:`iris.fileformats.pp.save`
 
     A custom saver can be provided to the function to write to a different


### PR DESCRIPTION
Corrects the link to the grib saver in the reference documentation section on save. This link was entirely broken - it had been malformed and was pointing to the iris-grib homepage on GitHub, which is very definitely *not* documentation!

The link now points to the section on saving to GRIB2 in the (now-released) iris-grib docs on readthedocs. This has been achieved by adding a new intersphinx mapping to the Iris docs `conf.py` file.