### PR TITLE
Relax data length constraint in PP load

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1950,10 +1950,12 @@ def _field_gen(filename, read_data_bytes, little_ended=False):
                 '%cL' % dtype_endian_char,
                 pp_file_read(PP_WORD_DEPTH))[0]
             if len_of_data_plus_extra != pp_field.lblrec * PP_WORD_DEPTH:
-                raise ValueError('LBLREC has a different value to the integer '
-                                 'recorded after the header in the file (%s '
-                                 'and %s).' % (pp_field.lblrec * PP_WORD_DEPTH,
-                                               len_of_data_plus_extra))
+                wmsg = ('LBLREC has a different value to the integer recorded '
+                        'after the header in the file (%s and %s).'
+                        'Skipping the remainder of the file.')
+                warnings.warn(wmsg.format(pp_field.lblrec * PP_WORD_DEPTH,
+                                          len_of_data_plus_extra))
+                break
 
             # calculate the extra length in bytes
             extra_len = pp_field.lbext * PP_WORD_DEPTH

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1951,7 +1951,7 @@ def _field_gen(filename, read_data_bytes, little_ended=False):
                 pp_file_read(PP_WORD_DEPTH))[0]
             if len_of_data_plus_extra != pp_field.lblrec * PP_WORD_DEPTH:
                 wmsg = ('LBLREC has a different value to the integer recorded '
-                        'after the header in the file (%s and %s).'
+                        'after the header in the file ({} and {}). '
                         'Skipping the remainder of the file.')
                 warnings.warn(wmsg.format(pp_field.lblrec * PP_WORD_DEPTH,
                                           len_of_data_plus_extra))

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,7 @@ import iris.tests as tests
 
 import contextlib
 import io
+import warnings
 
 import numpy as np
 
@@ -66,12 +67,13 @@ class Test(tests.IrisTest):
     def test_lblrec_invalid(self):
         pp_field = mock.Mock(lblrec=2,
                              lbext=0)
-        with self.assertRaises(ValueError) as err:
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
             self.gen_fields([pp_field])
-        self.assertEqual(str(err.exception),
-                         ('LBLREC has a different value to the integer '
-                          'recorded after the header in the file (8 '
-                          'and 4).'))
+        self.assertEqual(len(warn), 1)
+        wmsg = ('LBLREC has a different value to the .* the header in the '
+                'file \(8 and 4\)\. Skipping .*')
+        six.assertRegex(self, str(warn[0].message), wmsg)
 
     def test_read_headers_call(self):
         # Checks that the two calls to np.fromfile are called in the


### PR DESCRIPTION
If the length of a PP field's data record as specified by the field's header and the integer word that follows the header do not match, Iris very reasonably currently fails to load the whole PP file.

This PR reduces the barrier in such a case so that the PP loader pipeline will raise a warning in such a case and then exit, returning all successfully loaded fields up to this point. This at least means that Iris users can get to most of a PP file rather than none of it.

This PR very much follows the approach introduced in #1444 for relaxing loading of bad PP headers.

~~Note: no testing.~~