### PR TITLE
Fix import bug.

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -33,6 +33,7 @@ import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
 from scipy.sparse import csc_matrix, diags as sparse_diags
+import six
 
 import iris.analysis.cartography
 from iris.analysis._interpolation import (get_xy_dim_coords, get_xy_coords,


### PR DESCRIPTION
My editor (Eclipse/PyDev) does some static analysis and it flags up [this line](https://github.com/SciTools/iris/blob/f10eb54d527cdf094c5f38179a800a68e0c9e19f/lib/iris/experimental/regrid.py#L1539) as a bug, because 'six' is not imported.
I guess this has never actually been exercised ?

I s'pose, ideally, all codepaths would be tested ...
