### PR TITLE
Add scoping to docs.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -2165,16 +2165,17 @@ class Linear(object):
 
 class AreaWeighted(object):
     """
-    This class describes the area-weighted regridding scheme for regridding
-    over one or more orthogonal coordinates, typically for use with
-    :meth:`iris.cube.Cube.regrid()`.
+    This class describes an area-weighted regridding scheme for regridding
+    between 'ordinary' horizontal grids with separated X and Y coordinates in a
+    common coordinate system.
+    Typically for use with :meth:`iris.cube.Cube.regrid()`.
 
     """
 
     def __init__(self, mdtol=1):
         """
-        Area-weighted regridding scheme suitable for regridding one or more
-        orthogonal coordinates.
+        Area-weighted regridding scheme suitable for regridding between
+        different orthogonal XY grids in the same coordinate system.
 
         Kwargs:
 
@@ -2186,6 +2187,12 @@ class AreaWeighted(object):
             data is tolerated while mdtol=1 will mean the resulting element
             will be masked if and only if all the overlapping elements of the
             source grid are masked. Defaults to 1.
+
+        .. Note:
+            Both sourge and target cubes must have an XY grid defined by
+            separate X and Y dimensions with dimension coordinates.
+            All of the XY dimension coordinates must also be bounded, and have
+            the same cooordinate system.
 
         """
         if not (0 <= mdtol <= 1):

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -53,6 +53,13 @@ class AreaWeightedRegridder(object):
             if all the contributing elements of data are masked.
             Defaults to 1.
 
+        .. Note::
+
+            Both sourge and target cubes must have an XY grid defined by
+            separate X and Y dimensions with dimension coordinates.
+            All of the XY dimension coordinates must also be bounded, and have
+            the same cooordinate system.
+
         """
         # Snapshot the state of the cubes to ensure that the regridder is
         # impervious to external changes to the original source cubes.


### PR DESCRIPTION
Just to clarify the usage scope of 'AreaWeighted'.
Existing notes are a bit wrong, it looks like they were copied from Linear/Nearest, which work in a different way and are not specific to X/Y dimensions.