### PR TITLE
Replace absolute with relative tolerance.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -848,8 +848,8 @@ class IrisTest(unittest.TestCase):
 
         """
         self.assertEqual(result.shape, shape)
-        self.assertAlmostEqual(result.data.mean(), mean, places=5)
-        self.assertAlmostEqual(result.data.std(), std_dev, places=5)
+        self.assertArrayAllClose(result.data.mean(), mean, rtol=1e-6)
+        self.assertArrayAllClose(result.data.std(), std_dev, rtol=1e-6)
 
 
 get_result_path = IrisTest.get_result_path


### PR DESCRIPTION
I'm proposing this because I think it's always better to use relative tolerances than absolute in a general values check -- as otherwise you are assuming the general 'size' of the values tested.
Hence, **this is changing "5 decimal places" to "6 significant figures"**.

As it was, the routine was testing everything to +/-0.00001 (or maybe half that),
so E.G.  0.0001 +/- 0.00001 would be only to 10%,
but 10000 +/- 0.00001 must match to about 0.001ppm

As it happens, all the (few) places where we ***currently*** use this have values of magnitude greater than 10.0, so this is effectively relaxing all those testing levels.
I think that is ok for now.

Otherwise, I think ArrayShapeStats is a great idea, and certainly loads better than assertCML for a whole lot of purposes !
