### PR TITLE
Add linear scipy projected regridder

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.12/newfeature_2017-Jan-05_experimental_scipy_regridder.txt
+++ b/docs/iris/src/whatsnew/contributions_1.12/newfeature_2017-Jan-05_experimental_scipy_regridder.txt
@@ -1,0 +1,1 @@
+* Added experimental ProjectedUnstructured regridders which use scipy.interpolate.griddata to regrid unstructured data (see :class:`iris.experimental.regrid.ProjectedUnstructuredLinear` and :class:`iris.experimental.regrid.ProjectedUnstructuredNearest`)

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -21,6 +21,7 @@ Regridding functions.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from collections import namedtuple
 import copy

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1549,7 +1549,7 @@ class _ProjectedUnstructuredRegridder(object):
                                                             grid_x_coord,
                                                             grid_y_coord,
                                                             regrid_callback)
-                    result.add_aux_coord(result_coord, dims)
+                    result.add_aux_coord(result_coord, (dims[0], dims[0]+1))
                     coord_mapping[id(coord)] = result_coord
             try:
                 result.add_aux_factory(factory.updated(coord_mapping))
@@ -1624,6 +1624,63 @@ class _ProjectedUnstructuredRegridder(object):
                                      regrid_callback)
 
         return new_cube
+
+
+class ProjectedUnstructuredLinear(object):
+    """
+    This class describes the linear regridding scheme which uses the
+    scipy.interpolate.griddata to regrid unstructured data on to a grid.
+
+    The source cube and the target cube will be projected into a common
+    projection for the scipy calculation to be performed.
+
+    """
+    def __init__(self, projection=None):
+        """
+        Linear regridding scheme that uses scipy.interpolate.griddata on
+        projected unstructured data.
+
+        Optional Args:
+
+        * projection: `cartopy.crs instance`
+            The projection that the scipy calculation is performed in.
+            If None is given, a PlateCarree projection is used. Defaults to
+            None.
+
+        """
+        self.projection = projection
+
+    def regridder(self, src_cube, target_grid):
+        """
+        Creates a linear regridder to perform regridding, using
+        scipy.interpolate.griddata from unstructured source points to the
+        target grid. The regridding calculation is performed in the given
+        projection.
+
+        Typically you should use :meth:`iris.cube.Cube.regrid` for
+        regridding a cube. There are, however, some situations when
+        constructing your own regridder is preferable. These are detailed in
+        the :ref:`user guide <caching_a_regridder>`.
+
+        Args:
+
+        * src_cube:
+            The :class:`~iris.cube.Cube` defining the unstructured source
+            points.
+        * target_grid:
+            The :class:`~iris.cube.Cube` defining the target grid.
+
+        Returns:
+            A callable with the interface:
+
+                `callable(cube)`
+
+            where `cube` is a cube with the same grid as `src_cube`
+            that is to be regridded to the `target_grid`.
+
+        """
+        return _ProjectedUnstructuredRegridder(src_cube, target_grid,
+                                               'linear', self.projection)
 
 
 class ProjectedUnstructuredNearest(object):

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -839,7 +839,7 @@ class IrisTest(unittest.TestCase):
         # Return patch replacement object.
         return start_result
 
-    def assertArrayShapeStats(self, result, shape, mean, std_dev):
+    def assertArrayShapeStats(self, result, shape, mean, std_dev, rtol=1e-6):
         """
         Assert that the result, a cube, has the provided shape and that the
         mean and standard deviation of the data array are also as provided.
@@ -848,8 +848,8 @@ class IrisTest(unittest.TestCase):
 
         """
         self.assertEqual(result.shape, shape)
-        self.assertArrayAllClose(result.data.mean(), mean, rtol=1e-6)
-        self.assertArrayAllClose(result.data.std(), std_dev, rtol=1e-6)
+        self.assertArrayAllClose(result.data.mean(), mean, rtol=rtol)
+        self.assertArrayAllClose(result.data.std(), std_dev, rtol=rtol)
 
 
 get_result_path = IrisTest.get_result_path

--- a/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
+++ b/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
+++ b/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
@@ -53,7 +53,9 @@ class TestProjectedUnstructured(tests.IrisTest):
     def test_nearest(self):
         res = self.src.regrid(self.global_grid, ProjectedUnstructuredNearest())
         self.assertArrayShapeStats(res, (1, 6, 73, 96),
-                                   315.8913582, 11.00063766248)
+                                   315.8913582, 11.00063922733, rtol=1e-8)
+        self.assertArrayShapeStats(res[:, 0], (1, 73, 96),
+                                   299.99993826, 3.9226378869e-5)
 
     def test_nearest_sinusoidal(self):
         crs = ccrs.Sinusoidal()
@@ -61,6 +63,8 @@ class TestProjectedUnstructured(tests.IrisTest):
                               ProjectedUnstructuredNearest(crs))
         self.assertArrayShapeStats(res, (1, 6, 73, 96),
                                    315.891358296, 11.000639227, rtol=1e-8)
+        self.assertArrayShapeStats(res[:, 0], (1, 73, 96),
+                                   299.99993826, 3.9223839688e-5)
 
     def test_nearest_gnomonic_uk_domain(self):
         crs = ccrs.Gnomonic(central_latitude=60.0)
@@ -70,6 +74,8 @@ class TestProjectedUnstructured(tests.IrisTest):
 
         self.assertArrayShapeStats(res, (1, 6, 17, 11),
                                    315.8873266, 11.0006664668, rtol=1e-8)
+        self.assertArrayShapeStats(res[:, 0], (1, 17, 11),
+                                   299.99993826, 4.1356150388e-5)
         expected_subset = np.array([[318.936829, 318.936829, 318.936829],
                                     [318.936829, 318.936829, 318.936829],
                                     [318.935163, 318.935163, 318.935163]])
@@ -98,30 +104,22 @@ class TestProjectedUnstructured(tests.IrisTest):
         res = src.regrid(self.global_grid, ProjectedUnstructuredNearest())
 
         self.assertArrayShapeStats(res, (1, 6, 73, 96),
-                                   315.8913582, 11.00063766248)
+                                   315.8913582, 11.000639227334, rtol=1e-8)
+        self.assertArrayShapeStats(res[:, 0], (1, 73, 96),
+                                   299.99993826, 3.9226378869e-5)
         self.assertEqual(res.coord('altitude').shape, (6, 73, 96))
 
     def test_linear_sinusoidal(self):
         res = self.src.regrid(self.global_grid, ProjectedUnstructuredLinear())
         self.assertArrayShapeStats(res, (1, 6, 73, 96),
                                    315.8914839, 11.0006338412, rtol=1e-8)
+        self.assertArrayShapeStats(res[:, 0], (1, 73, 96),
+                                   299.99993826, 3.775024069e-5)
         expected_subset = np.array([[299.999987, 299.999996, 299.999999],
                                     [299.999984, 299.999986, 299.999988],
                                     [299.999973, 299.999977, 299.999982]])
         self.assertArrayAlmostEqual(expected_subset,
                                     res.data[0, 0, 20:23, 40:43].data)
-
-    def test_use_default_rtol(self):
-        # TODO Remove before this change is merged in.
-        linear_res = self.src.regrid(self.global_grid,
-                                     ProjectedUnstructuredLinear())
-        nearest_res = self.src.regrid(self.global_grid,
-                                      ProjectedUnstructuredNearest())
-
-        self.assertArrayShapeStats(linear_res, (1, 6, 73, 96),
-                                   315.891483943, 11.0006338412)
-        self.assertArrayShapeStats(nearest_res, (1, 6, 73, 96),
-                                   315.891483943, 11.0006338412)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
+++ b/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
@@ -28,9 +28,11 @@ from cf_units import Unit
 import numpy as np
 
 import iris
+import iris.aux_factory
 from iris.coord_systems import GeogCS
 from iris.tests.stock import global_pp
-from iris.experimental.regrid import ProjectedUnstructuredNearest
+from iris.experimental.regrid import (ProjectedUnstructuredLinear,
+                                      ProjectedUnstructuredNearest)
 
 
 @tests.skip_data
@@ -58,15 +60,68 @@ class TestProjectedUnstructured(tests.IrisTest):
         res = self.src.regrid(self.global_grid,
                               ProjectedUnstructuredNearest(crs))
         self.assertArrayShapeStats(res, (1, 6, 73, 96),
-                                   315.891358296, 11.000639227)
+                                   315.891358296, 11.000639227, rtol=1e-8)
 
     def test_nearest_gnomonic_uk_domain(self):
         crs = ccrs.Gnomonic(central_latitude=60.0)
         uk_grid = self.global_grid.intersection(longitude=(-20, 20),
                                                 latitude=(40, 80))
         res = self.src.regrid(uk_grid, ProjectedUnstructuredNearest(crs))
+
         self.assertArrayShapeStats(res, (1, 6, 17, 11),
-                                   315.8873266, 11.0006664668)
+                                   315.8873266, 11.0006664668, rtol=1e-8)
+        expected_subset = np.array([[318.936829, 318.936829, 318.936829],
+                                    [318.936829, 318.936829, 318.936829],
+                                    [318.935163, 318.935163, 318.935163]])
+        self.assertArrayAlmostEqual(expected_subset,
+                                    res.data[0, 3, 5:8, 4:7].data)
+
+    def test_nearest_aux_factories(self):
+        src = self.src
+
+        xy_dim_len, = src.coord(axis='X').shape
+        z_dim_len, = src.coord('levels').shape
+
+        src.add_aux_coord(iris.coords.AuxCoord(np.arange(z_dim_len)+40,
+                                               long_name="level_height",
+                                               units="m"), 1)
+        src.add_aux_coord(iris.coords.AuxCoord(np.arange(z_dim_len)+50,
+                                               long_name="sigma",
+                                               units="1"), 1)
+        src.add_aux_coord(iris.coords.AuxCoord(np.arange(xy_dim_len)+100,
+                                               long_name="surface_altitude",
+                                               units="m"), 2)
+        src.add_aux_factory(iris.aux_factory.HybridHeightFactory(
+            delta=src.coord("level_height"),
+            sigma=src.coord("sigma"),
+            orography=src.coord("surface_altitude")))
+        res = src.regrid(self.global_grid, ProjectedUnstructuredNearest())
+
+        self.assertArrayShapeStats(res, (1, 6, 73, 96),
+                                   315.8913582, 11.00063766248)
+        self.assertEqual(res.coord('altitude').shape, (6, 73, 96))
+
+    def test_linear_sinusoidal(self):
+        res = self.src.regrid(self.global_grid, ProjectedUnstructuredLinear())
+        self.assertArrayShapeStats(res, (1, 6, 73, 96),
+                                   315.8914839, 11.0006338412, rtol=1e-8)
+        expected_subset = np.array([[299.999987, 299.999996, 299.999999],
+                                    [299.999984, 299.999986, 299.999988],
+                                    [299.999973, 299.999977, 299.999982]])
+        self.assertArrayAlmostEqual(expected_subset,
+                                    res.data[0, 0, 20:23, 40:43].data)
+
+    def test_use_default_rtol(self):
+        # TODO Remove before this change is merged in.
+        linear_res = self.src.regrid(self.global_grid,
+                                     ProjectedUnstructuredLinear())
+        nearest_res = self.src.regrid(self.global_grid,
+                                      ProjectedUnstructuredNearest())
+
+        self.assertArrayShapeStats(linear_res, (1, 6, 73, 96),
+                                   315.891483943, 11.0006338412)
+        self.assertArrayShapeStats(nearest_res, (1, 6, 73, 96),
+                                   315.891483943, 11.0006338412)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the linear scheme of the regridder that uses `scipy.interpolate.griddata`.

I have also added some more tests for the nearest-neighbour scheme as source cubes with aux_factories weren't being tested, as highlighted by @pp-mo in #2263 

Note the test data doesn't have much variation in the data within the layers themselves (between the layers there's quite a difference, hence the large values for the standard deviation which is calculated for the **_whole_** cube), so I was getting similar values for mean and standard deviation, regardless of whether I used the linear or nearest (see the test `TestProjectedUnstructured.test_use_default_rtol`, which I do intend to remove, I just added it to prove what I had found).
I have solved this problem by allowing the tolerance to be set but I don't think this is necessarily a great solution. Another option would be to calculate the mean and standard deviation for a level.