### PR TITLE
Added a mailmap to tidy up git commit authors.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Mark Hedley <markh@scitools.org.uk>             <markh@metarelate.net>
+Mark Hedley <markh@scitools.org.uk>             <markh@scitools.org.uk>
+Ed Campbell <drescampbell@gmail.com>            <drescampbell@gmail.com>
+Andrew Dawson <ajdawson@acm.org>                <ajdatm@gmail.com>
+Andrew Dawson <ajdawson@acm.org>                <dawson@atm.ox.ac.uk>
+Andrew Dawson <ajdawson@acm.org>                <a.dawson@geos.com>
+Ian Edwards <iedwards.pub@gmail.com>            <ian.edwards@metoffice.gov.uk>
+Danny Rice <danny.met97@gmail.com>              <danrice@eld244.desktop.frd.metoffice.com>
+<bill.james.little@gmail.com>                   <bill.little@metoffice.gov.uk>
+Laura Dreyer <laura.dreyer@metoffice.gov.uk>    <lbdreyer@users.noreply.github.com>
+<laura.dreyer@metoffice.gov.uk>                 <laura_dreyer@yahoo.co.uk>
+Ruth Comer <ruth.comer@metoffice.gov.uk>        <hadru@eld237.desktop.frd.metoffice.com>
+<patrick.peglar@metoffice.gov.uk>               <ppeglar@metoffice.gov.uk>


### PR DESCRIPTION
In an attempt to sanitise the git author log, I have added the appropriate mailmap file.
Happy to adjust this in any way - remember this information is all stored in the git-log anyway, I'm just trying to map multiple "git authors" to individuals....

https://git-scm.com/docs/git-shortlog#_mapping_authors