### PR TITLE
Structured load pseudolevels

### DIFF
--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -221,7 +221,22 @@ def _um_collation_key_function(field):
     'phenomenon', as described for :meth:`group_structured_fields`.
 
     """
-    return (field.lbuser[3], field.lbproc, field.lbuser[6])
+    return (field.lbuser[3],  # stashcode first
+            field.lbproc,  # then stats processing
+            field.lbuser[6],  # then model
+            field.lbuser[4]  # then pseudo-level : this one is a KLUDGE.
+            )
+    # NOTE: including pseudo-level here makes it treat different pseudo-levels
+    # as different phenomena.  These will later be merged in the "ordinary"
+    # post-load merge.
+    # The current structured-load code fails to handle multiple pseudo-levels
+    # correctly :  As pseudo-level is not on in its list of "things that may
+    # vary within a phenomenon", it will create a scalar pseudo-level
+    # coordinate when it should have been a vector of values.
+    # This kludge fixes the error, but it is inefficient because it bypasses
+    # the structured load, producing n-levels times more 'raw' cubes.
+    # TODO: it should be fairly easy to do this properly -- i.e. create a
+    # vector pseudo-level coordinate directly in the structured load analysis.
 
 
 def group_structured_fields(field_iterator):

--- a/lib/iris/tests/integration/fast_load/test_fast_load.py
+++ b/lib/iris/tests/integration/fast_load/test_fast_load.py
@@ -521,7 +521,7 @@ class MixinDimsAndOrdering(object):
         self.assertEqual(results, expected)
 
 
-class MixinFailCases(object):
+class MixinProblemCases(object):
     def test_FAIL_scalar_vector_concatenate(self):
         # Structured load can produce a scalar coordinate from one file, and a
         # matching vector one from another file, but these won't "combine".
@@ -595,26 +595,31 @@ class MixinFailCases(object):
                            pse='123123123')
         file = self.save_fieldcubes(flds)
         results = iris.load(file)
-        if not self.do_fast_loads:
-            expected = CubeList(flds).merge()
-        else:
-            # Structured loading doesn't understand pseudo-level.
-            # The result is rather horrible...
+        expected = CubeList(flds).merge()
 
-            # First get a cube over 9 timepoints.
-            flds = self.fields(c_t='012345678',
-                               pse=1)  # result gets level==2, not clear why.
-
-            # Replace the time coord with an AUX coord.
-            nine_timepoints_cube = CubeList(flds).merge_cube()
-            co_time = nine_timepoints_cube.coord('time')
-            nine_timepoints_cube.remove_coord(co_time)
-            nine_timepoints_cube.add_aux_coord(AuxCoord.from_coord(co_time), 0)
-            # Set the expected timepoints equivalent to '000111222'.
-            nine_timepoints_cube.coord('time').points = \
-                np.array([0.0, 0.0, 0.0, 24.0, 24.0, 24.0, 48.0, 48.0, 48.0])
-            # Make a cubelist with this single cube.
-            expected = CubeList([nine_timepoints_cube])
+# NOTE: this problem is now fixed : Structured load gives the same answer.
+#
+#        if not self.do_fast_loads:
+#            expected = CubeList(flds).merge()
+#        else:
+#            # Structured loading doesn't understand pseudo-level.
+#            # The result is rather horrible...
+#
+#            # First get a cube over 9 timepoints.
+#            flds = self.fields(c_t='012345678',
+#                               pse=1)  # result gets level==2, not clear why.
+#
+#            # Replace the time coord with an AUX coord.
+#            nine_timepoints_cube = CubeList(flds).merge_cube()
+#            co_time = nine_timepoints_cube.coord('time')
+#            nine_timepoints_cube.remove_coord(co_time)
+#            nine_timepoints_cube.add_aux_coord(AuxCoord.from_coord(co_time),
+#                                               0)
+#            # Set the expected timepoints equivalent to '000111222'.
+#            nine_timepoints_cube.coord('time').points = \
+#                np.array([0.0, 0.0, 0.0, 24.0, 24.0, 24.0, 48.0, 48.0, 48.0])
+#            # Make a cubelist with this single cube.
+#            expected = CubeList([nine_timepoints_cube])
 
         self.assertEqual(results, expected)
 
@@ -657,15 +662,15 @@ class TestDimsAndOrdering__Fast(Mixin_FieldTest, MixinDimsAndOrdering,
     do_fast_loads = True
 
 
-class TestFails__Iris(Mixin_FieldTest, MixinFailCases, tests.IrisTest):
+class TestProblems__Iris(Mixin_FieldTest, MixinProblemCases, tests.IrisTest):
     # Finally, an actual test-class (unittest.TestCase) :
     # run the 'failure cases' tests with *normal* loading.
     do_fast_loads = False
 
 
-class TestFails__Fast(Mixin_FieldTest, MixinFailCases, tests.IrisTest):
+class TestProblems__Fast(Mixin_FieldTest, MixinProblemCases, tests.IrisTest):
     # Finally, an actual test-class (unittest.TestCase) :
-    # run the 'failure cases' tests with *normal* loading.
+    # run the 'failure cases' tests with *FAST* loading.
     do_fast_loads = True
 
 


### PR DESCRIPTION
This should allow structured-loading to work with most files where pseudo-levels are used.

If 'ordinary' levels (LBLEV values) and 'pseudo-levels' (LBUSER5) both vary at once, this rather inelegant solution could still have problems, potentially producing 2 vertical coordinates.
But only if that occurs ***within*** a phenomenon, which we think is probably not realistic ?

Note: 
Possibly needs tidying a bit further.
? Should I remove that commented-out 'fixed' failure code in ```tests.integration.fast_load.MixinProblemCases.test_FAIL_pseudo_levels``` ?
I have left it, assuming it is a useful statement of what the key problem actually is.

