### PR TITLE
reduce http get overhead

### DIFF
--- a/lib/iris/tests/test_image_json.py
+++ b/lib/iris/tests/test_image_json.py
@@ -52,8 +52,9 @@ class TestImageFile(tests.IrisTest):
             repo = json.load(codecs.getreader('utf-8')(fi))
         uris = set(itertools.chain.from_iterable(six.itervalues(repo)))
 
-        amsg = 'Images are referenced in imagerepo.json but not published:\n{}'
-        amsg = amsg.format(uris.difference(known_image_uris))
+        amsg = ('Images are referenced in imagerepo.json but not published in '
+                'https://scitools.github.io/test-iris-imagehash/images:\n{}')
+        amsg = amsg.format('\n'.join(list(uris.difference(known_image_uris))))
 
         self.assertTrue(uris.issubset(known_image_uris), msg=amsg)
 

--- a/lib/iris/tests/test_image_json.py
+++ b/lib/iris/tests/test_image_json.py
@@ -25,74 +25,37 @@ import six
 import iris.tests as tests
 
 import codecs
+import itertools
 import json
 import logging
 import os
 import requests
-from collections import deque
-from itertools import chain
-from six.moves.queue import Queue
-from threading import Thread
-
-
-# Maximum number of threads for multi-threading code.
-MAXTHREADS = 8
-
-# Turn down requests logging.
-logging.getLogger("requests").setLevel(logging.CRITICAL)
-
-
-class _ResolveWorkerThread(Thread):
-    """
-    A :class:threading.Thread which moves objects from an input queue to an
-    output deque using a 'dowork' method, as defined by a subclass.
-
-    """
-    def __init__(self, aqueue, adeque, exceptions):
-        self.queue = aqueue
-        self.deque = adeque
-        self.exceptions = exceptions
-        Thread.__init__(self)
-        self.daemon = True
-
-    def run(self):
-        while not self.queue.empty():
-            resource = self.queue.get()
-            try:
-                result = requests.head(resource)
-                if result.status_code == 200:
-                    self.deque.append(resource)
-                else:
-                    msg = '{} is not resolving correctly.'.format(resource)
-                    self.exceptions.append(ValueError(msg))
-            except Exception as e:
-                self.exceptions.append(e)
-            self.queue.task_done()
 
 
 @tests.skip_inet
 class TestImageFile(tests.IrisTest):
     def test_resolve(self):
+
+        iuri = ('https://api.github.com/repos/scitools/test-iris-imagehash/'
+                'contents/images')
+        r = requests.get(iuri)
+        if r.status_code != 200:
+            raise ValueError('Github API get failed: {}'.format(iuri))
+        rj = r.json()
+        prefix = 'https://scitools.github.io/test-iris-imagehash/images/'
+
+        known_image_uris = set([prefix + rji['name'] for rji in rj])
+
         repo_fname = os.path.join(os.path.dirname(__file__), 'results',
                                   'imagerepo.json')
         with open(repo_fname, 'rb') as fi:
             repo = json.load(codecs.getreader('utf-8')(fi))
-        uris = list(chain.from_iterable(six.itervalues(repo)))
-        uri_list = deque()
-        exceptions = deque()
-        uri_queue = Queue()
-        prefix = 'https://scitools.github.io/test-iris-imagehash'
-        for uri in uris:
-            if uri.startswith(prefix):
-                uri_queue.put(uri)
-            else:
-                msg = '{} is not a valid resource.'.format(uri)
-                exceptions.append(ValueError(msg))
+        uris = set(itertools.chain.from_iterable(six.itervalues(repo)))
 
-        for i in range(MAXTHREADS):
-            _ResolveWorkerThread(uri_queue, uri_list, exceptions).start()
-        uri_queue.join()
-        self.assertEqual(deque(), exceptions)
+        amsg = 'Images are referenced in imagerepo.json but not published:\n{}'
+        amsg = amsg.format(uris.difference(known_image_uris))
+
+        self.assertTrue(uris.issubset(known_image_uris), msg=amsg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
an attempt to reduce the sporadic incidence of 

```
======================================================================

FAIL: test_resolve (iris.tests.test_image_json.TestImageFile)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/Iris-1.12.0.dev0-py3.4-linux-x86_64.egg/iris/tests/test_image_json.py", line 95, in test_resolve

    self.assertEqual(deque(), exceptions)

AssertionError: deque([]) != deque([ConnectionError(MaxRetryError("HTTPSConne[372 chars]),)])

----------------------------------------------------------------------
```

e.g. #2267 

ping @lbdreyer 