### PR TITLE
Reinstated lost whatsnew items, now to appear in the 1.12 whatsnew.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_1.12/deprecate_2016-Nov-09_experimental_fieldsfile.txt
+++ b/docs/iris/src/whatsnew/contributions_1.12/deprecate_2016-Nov-09_experimental_fieldsfile.txt
@@ -1,0 +1,3 @@
+* The :mod:`iris.experimental.fieldsfile` has been deprecated, in favour of the
+  new fast-loading mechanism provided by
+  :meth:`iris.fileformats.um.structured_um_loading`.

--- a/docs/iris/src/whatsnew/contributions_1.12/newfeature_2016-May-20_lazy_cube_transpose.txt
+++ b/docs/iris/src/whatsnew/contributions_1.12/newfeature_2016-May-20_lazy_cube_transpose.txt
@@ -1,0 +1,1 @@
+* The transpose method of a Cube now results in a lazy transposed view of the original rather than realising the data then transposing it.

--- a/docs/iris/src/whatsnew/contributions_1.12/newfeature_2016-Nov-09_structured_um_loading.txt
+++ b/docs/iris/src/whatsnew/contributions_1.12/newfeature_2016-Nov-09_structured_um_loading.txt
@@ -1,0 +1,81 @@
+* Support for "fast" loading of UM files has been added.
+  This can dramatically accelerate loading speeds of fieldsfiles and PP files,
+  if they meet certain common structural requirements, typical for these types
+  of datafile.
+
+  See : :meth:`iris.fileformats.um.structured_um_loading`.
+
+  .. Note:
+
+    This updates and replaces the experimental code in
+    :mod:`iris.experimental.fieldsfile`, which is now deprecated in favour of
+    the new, supported facility.
+
+  [[
+  **NOTE TO RELEASE COMPILER**
+  This needs highlighting, and a better explanation than the plain reference
+  documentation.  We probably want a "featured item" section in the whatsnew,
+  along the following lines ...
+  ]]
+
+  Fast UM file loading:
+  ---------------------
+  Support has been added for accelerated loading of UM files (PP and
+  Fieldsfile), when these have a suitable regular 'structured' form.
+
+  A context manager is used to enable fast um loading in all the regular iris
+  load functions, such as :meth:`iris.load` and :meth:`iris.load_cube`,
+  when loading data from UM file types.
+  For example:
+
+        >>> import iris
+        >>> filepath = iris.sample_data_path('uk_hires.pp')
+        >>> from iris.fileformats.um import structured_um_loading
+        >>> with structured_um_loading():
+        ...     cube = iris.load_cube(filepath, 'air_potential_temperature')
+
+  This approach can deliver loading which is 10 times faster or more.
+  For example :
+
+  * a 78 Gb fieldsfile of 51,840 fields loads in about 13 rather than 190
+    seconds.
+  * a set of 25 800Mb PP files loads in about 21 rather than 220 seconds.
+
+  For full details, see : :meth:`iris.fileformats.um.structured_um_loading`.
+
+  You can load data with structured loading and compare the results with those
+  from "normal" loading to check whether they are equivalent.
+
+  * The results will normally differ, if at all, only in having dimensions in a
+    different order or a different choice of dimension coordinates.
+    **In these cases, structured loading can be used with confidence.**
+
+  * Ordinary Fieldsfiles (i.e. model outputs) are generally suitable for
+    structured loading.  Many PP files also are, especially if produced
+    directly from Fieldsfiles, and retaining the same field ordering.
+
+  * Some inputs however (generally PP) will be unsuitable for structured
+    loading :  For instance if a particular combination of vertical levels and
+    time has been omitted, or some fields appear out of order.
+
+  * There are also some known unsupported cases, including data which is
+    produced on pseudo-levels.  See the detail documentation on this.
+
+  It is the user's responsibility to use structured loading only with suitable
+  inputs.  Otherwise, odd behaviour and even incorrect loading can result, as
+  input files are not checked as fully as in a normal load.
+
+  Although the user loading call for structured loading can be just the same,
+  and the returned results are also often identical, structured loading is not
+  in fact an exact *identical* replacement for normal loading:
+
+  *  results are often somewhat different, especially regarding the order
+     of dimensions and the choice of dimension coordinates.
+
+  *  although both constraints and user callbacks are supported, callback
+     routines will generally need to be re-written.  This is because a
+     'raw' cube in structured loading generally covers *multiple* PPfields,
+     which therefore need to be handled as a collection :  A grouping object
+     containing them is passed to the callback 'field' argument.  
+     An example showing callbacks suitable for both normal and structured
+     loading can be seen `here <https://github.com/pp-mo/iris/blob/9042b4217ab6dd78dcfccfec19584170a5a6250a/lib/iris/tests/integration/fast_load/test_fast_load.py#L409>`_.


### PR DESCRIPTION
I think this fixes a problem introduced by #2286
These changes were proposed before recent releases, but only now merged, so the whatsnew contributions now belong to 1.12.

Actually, I think it would be better if we did ***not*** include the version in the name of the contributions directory, but just had a fixed name for it.  Then we wouldn't need to destroy + recreate it either.
It's not a trivial change though, so I've made a separate issue to cover it : #2289
