### PR TITLE
Set clabel inline=False to fix contout plot

### DIFF
--- a/docs/iris/src/userguide/plotting_examples/cube_contour.py
+++ b/docs/iris/src/userguide/plotting_examples/cube_contour.py
@@ -18,6 +18,6 @@ contour = qplt.contour(temperature_cube)
 plt.gca().coastlines()
 
 # Add contour labels based on the contour we have just created.
-plt.clabel(contour)
+plt.clabel(contour, inline=False)
 
 plt.show()


### PR DESCRIPTION
The example in the userguide section for [plotting a contour of a cube](http://scitools.org.uk/iris/docs/latest/userguide/plotting_a_cube.html?highlight=clabel#cube-contour) is not correct. The are spurious horizontal lines across the image.

Not being terribly familiar with how clabel works, I suspect that this is due to clabel removing some of the contour near where it wants to put the label, so that the label is more visible.
By setting inline to be False, clabel does not remove any of the contour so it renders correctly but it does make it a little harder to see

![air_temp_inline_false](https://cloud.githubusercontent.com/assets/8101163/21820119/61147134-d766-11e6-9760-2696c4594fc1.png)

This is not an iris issue, I think the issue is in matplotlib itself. Below I have plotted the data in the cube using just matplotlib and I still get an error with missing contours
![clabel_behaviour](https://cloud.githubusercontent.com/assets/8101163/21820156/8b613968-d766-11e6-8834-5b81ff8da9aa.png)
