### PR TITLE
More stable area weights computation

### DIFF
--- a/docs/iris/src/whatsnew/1.12.rst
+++ b/docs/iris/src/whatsnew/1.12.rst
@@ -104,6 +104,8 @@ Iris 1.12 Features
 
 * The transpose method of a Cube now results in a lazy transposed view of the original rather than realising the data then transposing it.
 
+* The :func:`iris.analysis.cartography.area_weights` function is now more accurate for single precision input bounds.
+
 Deprecations
 ============
 * The module :mod:`iris.experimental.fieldsfile` has been deprecated, in favour

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -340,7 +340,7 @@ def _spherical_area(y_bounds, x_bounds, radius=1.0):
 
     """
     return iris.analysis.cartography._quadrant_area(
-        y_bounds + np.pi / 2.0, x_bounds, radius)
+        y_bounds, x_bounds, radius)
 
 
 def _get_bounds_in_units(coord, units, dtype):

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -642,11 +642,11 @@ class TestAreaWeights(tests.IrisTest):
         small_cube.coord('longitude').guess_bounds()
         area_weights = iris.analysis.cartography.area_weights(small_cube)
         expected_results = np.array(
-            [[3.11955916e+12, 3.11956058e+12, 3.11955916e+12, 3.11956058e+12],
-             [5.21950793e+12, 5.21951031e+12, 5.21950793e+12, 5.21951031e+12],
-             [6.68991432e+12, 6.68991737e+12, 6.68991432e+12, 6.68991737e+12],
-             [7.35341320e+12, 7.35341655e+12, 7.35341320e+12, 7.35341655e+12],
-             [7.12998265e+12, 7.12998589e+12, 7.12998265e+12, 7.12998589e+12]],
+            [[3.11955866e+12, 3.11956008e+12, 3.11955866e+12, 3.11956008e+12],
+             [5.21951065e+12, 5.21951303e+12, 5.21951065e+12, 5.21951303e+12],
+             [6.68991281e+12, 6.68991585e+12, 6.68991281e+12, 6.68991585e+12],
+             [7.35341305e+12, 7.35341640e+12, 7.35341305e+12, 7.35341640e+12],
+             [7.12998335e+12, 7.12998660e+12, 7.12998335e+12, 7.12998660e+12]],
             dtype=np.float64)
         self.assertArrayAllClose(area_weights, expected_results, rtol=1e-8)
 

--- a/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
+++ b/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
@@ -35,15 +35,15 @@ from iris.analysis.cartography import DEFAULT_SPHERICAL_EARTH_RADIUS
 
 class TestExampleCases(tests.IrisTest):
 
-    def _radian_bounds(self, coord_list, offset=0, dtype=np.float64):
-        bound_deg = np.array(coord_list, dtype=dtype) + offset
+    def _radian_bounds(self, coord_list, dtype):
+        bound_deg = np.array(coord_list, dtype=dtype)
         bound_deg = np.atleast_2d(bound_deg)
         degrees = cf_units.Unit("degrees")
         radians = cf_units.Unit("radians")
         return degrees.convert(bound_deg, radians)
 
     def _as_bounded_coords(self, lats, lons, dtype=np.float64):
-        return (self._radian_bounds(lats, offset=90, dtype=dtype),
+        return (self._radian_bounds(lats, dtype=dtype),
                 self._radian_bounds(lons, dtype=dtype))
 
     def test_area_in_north(self):

--- a/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
+++ b/lib/iris/tests/unit/analysis/cartography/test__quadrant_area.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -35,16 +35,16 @@ from iris.analysis.cartography import DEFAULT_SPHERICAL_EARTH_RADIUS
 
 class TestExampleCases(tests.IrisTest):
 
-    def _radian_bounds(self, coord_list, offset=0):
-        bound_deg = np.array(coord_list) + offset
+    def _radian_bounds(self, coord_list, offset=0, dtype=np.float64):
+        bound_deg = np.array(coord_list, dtype=dtype) + offset
         bound_deg = np.atleast_2d(bound_deg)
         degrees = cf_units.Unit("degrees")
         radians = cf_units.Unit("radians")
         return degrees.convert(bound_deg, radians)
 
-    def _as_bounded_coords(self, lats, lons):
-        return (self._radian_bounds(lats, offset=90),
-                self._radian_bounds(lons))
+    def _as_bounded_coords(self, lats, lons, dtype=np.float64):
+        return (self._radian_bounds(lats, offset=90, dtype=dtype),
+                self._radian_bounds(lons, dtype=dtype))
 
     def test_area_in_north(self):
         lats, lons = self._as_bounded_coords([0, 10], [0, 10])
@@ -83,6 +83,22 @@ class TestExampleCases(tests.IrisTest):
         self.assertArrayAllClose(area, [[3.19251846e+11, 6.38503692e+11],
                                         [1.22880059e+12, 2.45760119e+12],
                                         [3.19251846e+11, 6.38503692e+11]])
+
+    def test_symmetric_64_bit(self):
+        lats, lons = self._as_bounded_coords([[-90, -89.375],
+                                              [89.375, 90]],
+                                             [0, 10],
+                                             dtype=np.float64)
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, area[::-1])
+
+    def test_symmetric_32_bit(self):
+        lats, lons = self._as_bounded_coords([[-90, -89.375],
+                                              [89.375, 90]],
+                                             [0, 10],
+                                             dtype=np.float32)
+        area = _quadrant_area(lats, lons, DEFAULT_SPHERICAL_EARTH_RADIUS)
+        self.assertArrayAllClose(area, area[::-1])
 
 
 class TestErrorHandling(tests.IrisTest):


### PR DESCRIPTION
This PR changes the computation of area weights to a more numerically stable form. The previous form converted latitude to colatitude and used difference of cosines in the cell area computation. This formulation uses latitude and difference of sines. The conversion from latitude to colatitude at lower precision causes errors when computing the cell areas (see [this google group thread](https://groups.google.com/forum/?fromgroups=#!topic/scitools-iris/yTw387ZXRAk)). This should be considered a bug fix in my opinion.

I've provided 2 new tests, the 32-bit test fails with the old formulation but passes with the new one. All the existing tests still pass.