### PR TITLE
Filespecs sorted absolute

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -147,23 +147,26 @@ def expand_filespecs(file_specs):
         File paths which may contain '~' elements or wildcards.
 
     Returns:
-        A list of matching file paths.  If any of the file-specs matches no
+        A list of matching absolute file paths.  If any of the file-specs matches no
         existing files, an exception is raised.
 
     """
-    # Remove any hostname component - currently unused
-    filenames = [os.path.expanduser(fn[2:] if fn.startswith('//') else fn)
+    # Remove any hostname component - currently unused - expand paths as absolutes
+    filenames = [os.path.abspath(os.path.expanduser(fn[2:] if fn.startswith('//') else fn))
                  for fn in file_specs]
 
     # Try to expand all filenames as globs
     glob_expanded = {fn : sorted(glob.glob(fn)) for fn in filenames}
 
     # If any of the specs expanded to an empty list then raise an error
-    value_lists = glob_expanded.values()
+    value_list_raw = glob_expanded.values()
+
+    # Here is a term to sort value_lists alphabetically, for consistency
+    value_lists = sorted(value_list_raw)
     if not all(value_lists):
         raise IOError("One or more of the files specified did not exist %s." %
         ["%s expanded to %s" % (pattern, expanded if expanded else "empty")
-         for pattern, expanded in six.iteritems(glob_expanded)])
+         for pattern, expanded in sorted(six.iteritems(glob_expanded))])
 
     return sum(value_lists, [])
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -172,7 +172,8 @@ def expand_filespecs(file_specs):
                 file_list = '\n       - {}'.format(', '.join(expanded))
             else:
                 file_list = ''
-            msg += '\n    - "{}" matched {} file(s){}'.format(pattern, len(expanded), file_list)
+            msg += '\n    - "{}" matched {} file(s){}'.format(
+                    pattern, len(expanded), file_list)
         raise IOError(msg)
 
     return [fname for fnames in all_expanded for fname in fnames]

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -249,6 +249,16 @@ class IrisTest_nometa(unittest.TestCase):
             relative_path = os.path.join(*relative_path)
         return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
+    def assertStringEqual(self, reference_str, test_str,
+                          type_comparison_name='strings'):
+        if reference_str != test_str:
+            diff = '\n'.join(difflib.unified_diff(reference_str.splitlines(),
+                                                test_str.splitlines(),
+                                                'Reference', 'Test result',
+                                                '', '', 0))
+            self.fail("{} do not match:\n{}".format(type_comparison_name,
+                                                    diff))
+
     def result_path(self, basename=None, ext=''):
         """
         Return the full path to a test result, generated from the \

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -1,0 +1,75 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris.io.expand_filespecs` function."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import os
+import tempfile
+import shutil
+
+import iris.io as iio
+
+
+class TestExpandFilespecs(tests.IrisTest):
+
+    def setUp(self):
+        tests.IrisTest.setUp(self)
+        self.tmpdir = tempfile.mkdtemp()
+        self.fnames = ['a.foo', 'b.txt']
+        for fname in self.fnames:
+            with open(os.path.join(self.tmpdir, fname), 'w') as fh:
+                fh.write('anything')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_absolute_path(self):
+        result = iio.expand_filespecs([os.path.join(self.tmpdir, '*')])
+        expected = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(result, expected)
+
+    def test_double_slash(self):
+        product = iio.expand_filespecs(['//' + os.path.join(self.tmpdir, '*')])
+        predicted = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(product, predicted)
+
+    def test_relative_path(self):
+        os.chdir(self.tmpdir)
+        item_out = iio.expand_filespecs(['*'])
+        item_in = [os.path.join(self.tmpdir, fname) for fname in self.fnames]
+        self.assertEqual(item_out, item_in)
+
+    def test_no_files_found(self):
+        msg = 'b expanded to empty'
+        with self.assertRaisesRegexp(IOError, msg):
+            iio.expand_filespecs([self.tmpdir + '_b'])
+
+    def test_files_and_none(self):
+        msg = 'b expanded to empty.*expanded to .*b.txt'
+        with self.assertRaisesRegexp(IOError, msg):
+            iio.expand_filespecs([self.tmpdir + '_b',
+                                 os.path.join(self.tmpdir, '*')])
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
I noticed that #2014 didn't quite make it over the line, but what it was attempting to fix is two rather quite an annoying Iris bugs.

* The first bug (and the one I'm less bothered about) relates to the fact that if you load a cube from a relative path, and then change CWD, lazy data will be read from the wrong place. Fix: make the paths absolute.

* The second bug is that we currently ignore the order of filenames that is passed to the ``iris.load`` functions. Imagine that we needed two files in order to be able to reference a HybridHeight coordinate appropriately. We might do ```iris.load([file_with_orog, file_that_needs_orog_to_reference])```, but this only works if the **filename** in ``file_with_orog`` sorts before ``file_that_needs_orog_to_reference``.