### PR TITLE
Revert "github api management"

### DIFF
--- a/lib/iris/tests/test_image_json.py
+++ b/lib/iris/tests/test_image_json.py
@@ -34,7 +34,6 @@ import time
 
 
 @tests.skip_inet
-@tests.skip_data
 class TestImageFile(tests.IrisTest):
     def test_resolve(self):
 
@@ -44,8 +43,7 @@ class TestImageFile(tests.IrisTest):
         headers = {'User-Agent': 'SciTools'}
         r = requests.get(iuri, headers=headers)
         if r.status_code != 200:
-            raise ValueError('Github API get failed: {}\n{}'.format(iuri,
-                                                                    r.text))
+            raise ValueError('Github API get failed: {}'.format(iuri))
         rj = r.json()
         prefix = 'https://scitools.github.io/test-iris-imagehash/images/'
 


### PR DESCRIPTION
Reverts SciTools/iris#2326
this is not a useful change and will conflict with better implementations