### PR TITLE
Gracefully handle long time intervals

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -732,7 +732,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             fmt = '{cls}({points}{bounds}' \
                   ', standard_name={self.standard_name!r}' \
                   ', calendar={self.units.calendar!r}{other_metadata})'
-            points = self._str_dates(self.points)
+            if self.units.is_long_time_interval():
+                # A time unit with a long time interval ("months" or "years")
+                # cannot be converted to a date using `num2date` so gracefully
+                # fall back to printing points as numbers, not datetimes.
+                points = self.points
+            else:
+                points = self._str_dates(self.points)
             bounds = ''
             if self.has_bounds():
                 bounds = ', bounds=' + self._str_dates(self.bounds)

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -323,6 +323,7 @@ class Test_convert_units(tests.IrisTest):
         with self.assertRaisesRegexp(UnitConversionError, emsg):
             coord.convert_units('degrees')
 
+
 class Test___str__(tests.IrisTest):
 
     def test_short_time_interval(self):

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -323,5 +323,29 @@ class Test_convert_units(tests.IrisTest):
         with self.assertRaisesRegexp(UnitConversionError, emsg):
             coord.convert_units('degrees')
 
+class Test___str__(tests.IrisTest):
+
+    def test_short_time_interval(self):
+        coord = DimCoord([5], standard_name='time',
+                         units='days since 1970-01-01')
+        expected = ("DimCoord([1970-01-06 00:00:00], standard_name='time', "
+                    "calendar='gregorian')")
+        result = coord.__str__()
+        self.assertEqual(expected, result)
+
+    def test_long_time_interval(self):
+        coord = DimCoord([5], standard_name='time',
+                         units='years since 1970-01-01')
+        expected = "DimCoord([5], standard_name='time', calendar='gregorian')"
+        result = coord.__str__()
+        self.assertEqual(expected, result)
+
+    def test_non_time_unit(self):
+        coord = DimCoord([1.])
+        expected = repr(coord)
+        result = coord.__str__()
+        self.assertEqual(expected, result)
+
+
 if __name__ == '__main__':
     tests.main()

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -9,5 +9,5 @@ netcdf4
 numpy
 scipy
 # pyke (not pip installable)  #conda: pyke
-cf_units
+cf_units>=1.2
 dask>=0.17.1


### PR DESCRIPTION
The `netcdftime` library does not handle time units with long time intervals (months or years). You can, however, use `UDUNITS2` to create a time coordinate with the time interval set to months or years. This gap in functionality means that it is possible that printing an Iris cube (containing a coordinate with a long time interval) will result in an exception being raised. This situation is _far from ideal_.

This PR prevents the exception being raised by gracefully falling back to printing the numerical points values for long time interval coordinates so that the exception is not raised. The check for a long time interval is made using new functionality introduced in https://github.com/SciTools/cf_units/pull/72, which this PR is dependent on. Note that this means that the tests in this PR will fail until the cf_units change is merged and released.