### PR TITLE
Make assertMaskedArrayXxx with nonmasked results.

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -515,6 +515,7 @@ class IrisTest(unittest.TestCase):
         # Define helper function to extract unmasked values as a 1d
         # array.
         def unmasked_data_as_1d_array(array):
+            array = ma.asarray(array)
             if array.ndim == 0:
                 if array.mask:
                     data = np.array([])

--- a/lib/iris/tests/unit/tests/test_IrisTest.py
+++ b/lib/iris/tests/unit/tests/test_IrisTest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -84,6 +84,47 @@ class Test_assertMaskedArrayEqual(_MaskedArrayEquality, tests.IrisTest):
     @property
     def _func(self):
         return self.assertMaskedArrayEqual
+
+
+class Test_assertMaskedArrayEqual__Nonmaasked(tests.IrisTest):
+    def test_nonmasked_same(self):
+        # Masked test can be used on non-masked arrays.
+        arr1 = np.array([1, 2])
+        self.assertMaskedArrayEqual(arr1, arr1)
+
+    def test_masked_nonmasked_same(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=None.
+        arr1 = np.ma.masked_array([1, 2])
+        arr2 = np.array([1, 2])
+        self.assertMaskedArrayEqual(arr1, arr2)
+
+    def test_masked_nonmasked_different(self):
+        arr1 = np.ma.masked_array([1, 2])
+        arr2 = np.array([1, 3])
+        with self.assertRaisesRegexp(AssertionError, 'Arrays are not equal'):
+            self.assertMaskedArrayEqual(arr1, arr2)
+
+    def test_nonmasked_masked_same(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=None.
+        arr1 = np.array([1, 2])
+        arr2 = np.ma.masked_array([1, 2])
+        self.assertMaskedArrayEqual(arr1, arr2)
+
+    def test_masked_nonmasked_same_falsemask(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=False.
+        arr1 = np.ma.masked_array([1, 2], mask=False)
+        arr2 = np.array([1, 2])
+        self.assertMaskedArrayEqual(arr1, arr2)
+
+    def test_masked_nonmasked_same_emptymask(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=zeros.
+        arr1 = np.ma.masked_array([1, 2], mask=[False, False])
+        arr2 = np.array([1, 2])
+        self.assertMaskedArrayEqual(arr1, arr2)
 
 
 class Test_assertMaskedArrayAlmostEqual(_MaskedArrayEquality, tests.IrisTest):


### PR DESCRIPTION
This was producing unhelpful messages when a tested result is unexpectedly *not* a masked array.
This should make it consider an unmasked array "equal to" a masked one with an empty mask.

Applies to ```assertMaskedArrayEqual``` and ```assertMaskedArrayAlmostEqual```
( n.b. *we don't have* an "```assertMaskedArrayAllClose```" )

**NOTE:** in dask work, but targetting master 