### PR TITLE
Don't use lazy wrappers for cube shape and dtype.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1592,13 +1592,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     @property
     def shape(self):
         """The shape of the data of this cube."""
-        shape = self.lazy_data().shape
+        shape = self._my_data.shape
         return shape
 
     @property
     def dtype(self):
         """The :class:`numpy.dtype` of the data of this cube."""
-        return self.lazy_data().dtype
+        return self._my_data.dtype
 
     @property
     def ndim(self):


### PR DESCRIPTION
This fixes the severe test slownesses we have been seeing.

I think there was ***no*** good reason to implement cube.dtype and cube.shape via cube.lazy_data().
The cube._my_data will always have viable dtype and shape properties, whether real or lazy.