### PR TITLE
Fix non-lazy pp loading

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1288,6 +1288,9 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
     def data(self, value):
         self._data = value
 
+    def has_lazy_data(self):
+        return not isinstance(self._data, LoadedArrayBytes)
+
     @property
     def calendar(self):
         """Return the calendar of the field."""

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -905,7 +905,10 @@ def _make_cube(field, converter):
     # then use that to make it's tests pass.
     # To be fixed!!
     try:
-        data = da.from_array(field._data, chunks=field._data.shape)
+        if field.has_lazy_data():
+            data = da.from_array(field._data, chunks=field._data.shape)
+        else
+            data = field._data
     except AttributeError:
         data = field.data
     cube = iris.cube.Cube(data,


### PR DESCRIPTION
The code on the current dask_timed branch doesn't function correctly in the case of loading a PP file in a non-lazy way; the `_data` attribute is always wrapped up as a dask array before being passed into the `Cube` constructor.

Actually I think we need to make bigger changes to the ones I've suggested in this PR. The problem has arisen because `PPField._data` is, in the lazy case, a `PPFieldProxy` object, and so can't be used directly in  `Cube.__init__`. Using `_data` outside of `PPField` class methods is probably a bad idea anyway.