### PR TITLE
passing tests unskipped

### DIFF
--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -382,7 +382,7 @@ def exponentiate(cube, exponent, in_place=False):
             return operator.pow(data, exponent)
     else:
         def power(data, out=None):
-            return np.pow(data, exponent, out)
+            return np.power(data, exponent, out)
 
     return _math_op_common(cube, power, cube.units ** exponent,
                            in_place=in_place)

--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -368,7 +368,6 @@ class TestAreaWeightedRegrid(tests.IrisTest):
         res = regrid_area_weighted(src, dest)
         self.assertCMLApproxData(res, RESULT_DIR + ('hybridheight.cml',))
 
-    @tests.skip_biggus
     def test_missing_data(self):
         src = self.simple_cube.copy()
         src.data = ma.masked_array(src.data)
@@ -379,7 +378,6 @@ class TestAreaWeightedRegrid(tests.IrisTest):
         mask[slice(2, 5), slice(4, 7)] = True
         self.assertArrayEqual(res.data.mask, mask)
 
-    @tests.skip_biggus
     def test_no_x_overlap(self):
         src = self.simple_cube
         dest = _scaled_and_offset_grid(src, 1.0, 1.0,
@@ -389,7 +387,6 @@ class TestAreaWeightedRegrid(tests.IrisTest):
         res = regrid_area_weighted(src, dest)
         self.assertTrue(res.data.mask.all())
 
-    @tests.skip_biggus
     def test_no_y_overlap(self):
         src = self.simple_cube
         dest = _scaled_and_offset_grid(src, 1.0, 1.0,
@@ -455,7 +452,6 @@ class TestAreaWeightedRegrid(tests.IrisTest):
         self.assertCMLApproxData(res, RESULT_DIR +
                                  ('const_lon_cross_section.cml',))
 
-    @tests.skip_biggus
     def test_scalar_source_cube(self):
         src = self.simple_cube[1, 2]
         # Extend dest beyond src grid
@@ -536,7 +532,6 @@ class TestAreaWeightedRegrid(tests.IrisTest):
         res = regrid_area_weighted(src, dest)
         self.assertArrayShapeStats(res, (40, 7), 285.653967, 15.212710)
 
-    @tests.skip_biggus
     @tests.skip_data
     def test_non_circular_subset(self):
         src = iris.tests.stock.global_pp()

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -128,7 +128,7 @@ def _donothing_context_manager():
     yield
 
 
-@tests.skip_biggus
+#@tests.skip_biggus
 @skip_esmf
 class TestConservativeRegrid(tests.IrisTest):
 
@@ -195,7 +195,7 @@ class TestConservativeRegrid(tests.IrisTest):
         # check area sums again
         self.assertArrayAllClose(c1to2to1_areasum, c1_areasum)
 
-    @tests.skip_biggus
+    #@tests.skip_biggus
     def test_simple_missing_data(self):
         """
         Check for missing data handling.
@@ -600,7 +600,7 @@ class TestConservativeRegrid(tests.IrisTest):
         with self.assertRaises(ValueError):
             regrid_conservative_via_esmpy(c1, c2)
 
-    @tests.skip_biggus
+    #@tests.skip_biggus
     def test_rotated(self):
         """
         Test area-weighted regrid on more complex area.
@@ -686,7 +686,7 @@ class TestConservativeRegrid(tests.IrisTest):
         c2toc1_areasum = _cube_area_sum(c2toc1)
         self.assertArrayAllClose(c2toc1_areasum, c2_areasum, rtol=0.004)
 
-    @tests.skip_biggus
+    #@tests.skip_biggus
     def test_missing_data_rotated(self):
         """
         Check missing-data handling between different coordinate systems.

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -128,7 +128,6 @@ def _donothing_context_manager():
     yield
 
 
-#@tests.skip_biggus
 @skip_esmf
 class TestConservativeRegrid(tests.IrisTest):
 
@@ -195,7 +194,6 @@ class TestConservativeRegrid(tests.IrisTest):
         # check area sums again
         self.assertArrayAllClose(c1to2to1_areasum, c1_areasum)
 
-    #@tests.skip_biggus
     def test_simple_missing_data(self):
         """
         Check for missing data handling.
@@ -600,7 +598,6 @@ class TestConservativeRegrid(tests.IrisTest):
         with self.assertRaises(ValueError):
             regrid_conservative_via_esmpy(c1, c2)
 
-    #@tests.skip_biggus
     def test_rotated(self):
         """
         Test area-weighted regrid on more complex area.
@@ -686,7 +683,6 @@ class TestConservativeRegrid(tests.IrisTest):
         c2toc1_areasum = _cube_area_sum(c2toc1)
         self.assertArrayAllClose(c2toc1_areasum, c2_areasum, rtol=0.004)
 
-    #@tests.skip_biggus
     def test_missing_data_rotated(self):
         """
         Check missing-data handling between different coordinate systems.

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -425,7 +425,6 @@ class TestPackedData(tests.IrisTest):
                 else:
                     self.assertArrayEqual(cube.data, packedcube.data)
 
-    @tests.skip_biggus
     def test_multi_packed_single_dtype(self):
         """Test saving multiple packed cubes with the same pack_dtype."""
         # Read PP input file.

--- a/lib/iris/tests/integration/test_regrid_equivalence.py
+++ b/lib/iris/tests/integration/test_regrid_equivalence.py
@@ -120,7 +120,6 @@ class MixinCheckingCode(object):
         _debug_data(result_cube, "matching RESULt")
         self.assertArrayAllClose(result_cube.data, expected_result)
 
-    @tests.skip_biggus
     def test_source_mask(self):
         src_x = [40.0, 50.0, 60.0]
         src_y = [40.0, 50.0, 60.0]

--- a/lib/iris/tests/integration/test_trajectory.py
+++ b/lib/iris/tests/integration/test_trajectory.py
@@ -190,7 +190,6 @@ class TestTriPolar(tests.IrisTest):
         self.assertRaises(ValueError, traj_interpolate,
                           self.cube, self.sample_points, method="linekar")
 
-    @tests.skip_biggus
     def test_tri_polar__nearest(self):
         # Check a smallish nearest-neighbour interpolation against a result
         # snapshot.

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -401,7 +401,6 @@ class TestAggregateBy(tests.IrisTest):
         np.testing.assert_almost_equal(aggregateby_cube.data,
                                        np.array(row, dtype=np.float32))
 
-    @tests.skip_biggus
     def test_single_missing(self):
         # aggregation correctly handles masked data
         mask = np.vstack(
@@ -441,7 +440,6 @@ class TestAggregateBy(tests.IrisTest):
         self.assertMaskedArrayAlmostEqual(aggregateby_cube.data,
                                           single_expected)
 
-    @tests.skip_biggus
     def test_multi_missing(self):
         # aggregation correctly handles masked data
         mask = np.vstack(

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -286,7 +286,6 @@ class TestMissingData(tests.IrisTest):
         np.testing.assert_array_equal(cube.data, np.array([6, 18, 17]))
 
 
-@tests.skip_biggus
 class TestAggregator_mdtol_keyword(tests.IrisTest):
     def setUp(self):
         data = ma.array([[1, 2], [4, 5]], dtype=np.float32,

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -35,7 +35,6 @@ import iris.exceptions
 import iris.tests.stock
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestBasicMaths(tests.IrisTest):
     def setUp(self):
@@ -357,7 +356,6 @@ class TestBasicMaths(tests.IrisTest):
             iris.analysis.maths.add('not a cube', 123)
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestDivideAndMultiply(tests.IrisTest):
     def setUp(self):
@@ -501,7 +499,6 @@ class TestDivideAndMultiply(tests.IrisTest):
                                          in_place=True)
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestExponentiate(tests.IrisTest):
     def setUp(self):
@@ -531,7 +528,6 @@ class TestExponentiate(tests.IrisTest):
             iris.analysis.maths.exponentiate('not a cube', 2)
 
 
-@tests.skip_biggus
 class TestExponential(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.simple_1d()
@@ -541,7 +537,6 @@ class TestExponential(tests.IrisTest):
         self.assertCMLApproxData(e, ('analysis', 'exp.cml'))
 
 
-@tests.skip_biggus
 class TestApplyUfunc(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.simple_2d()
@@ -573,7 +568,6 @@ class TestApplyUfunc(tests.IrisTest):
         self.assertArrayAlmostEqual(b2.data, ans)
 
 
-@tests.skip_biggus
 class TestIFunc(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.simple_2d()
@@ -625,7 +619,6 @@ class TestIFunc(tests.IrisTest):
         self.assertArrayAlmostEqual(b.data, ans)
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestLog(tests.IrisTest):
     def setUp(self):
@@ -644,7 +637,6 @@ class TestLog(tests.IrisTest):
         self.assertCMLApproxData(e, ('analysis', 'log10.cml'), rtol=1e-6)
 
 
-@tests.skip_biggus
 class TestMaskedArrays(tests.IrisTest):
     ops = (operator.add, operator.sub, operator.mul)
     iops = (operator.iadd, operator.isub, operator.imul)

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -873,7 +873,6 @@ class TestCubeEquality(TestCube2d):
     def test_simple_equality(self):
         self.assertEqual(self.t, self.t.copy())
 
-    @tests.skip_biggus
     def test_data_inequality(self):
         self.assertNotEqual(self.t, self.t + 1)
     

--- a/lib/iris/tests/test_ff.py
+++ b/lib/iris/tests/test_ff.py
@@ -114,7 +114,6 @@ class TestFF2PP2Cube(tests.IrisTest):
     def setUp(self):
         self.filename = tests.get_data_path(('FF', 'n48_multi_field'))
 
-    @tests.skip_biggus
     def test_unit_pass_0(self):
         # Test FieldsFile to PPFields cube load.
         cube_by_name = collections.defaultdict(int)

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -84,7 +84,6 @@ class TestNetCDFLoad(tests.IrisTest):
             dataset.close()
             cube = iris.load_cube(filename, 'eastward_wind')
 
-    @tests.skip_biggus
     def test_load_global_xyzt_gems(self):
         # Test loading single xyzt CF-netCDF file (multi-cube).
         cubes = iris.load(tests.get_data_path(('NetCDF', 'global', 'xyz_t',
@@ -98,7 +97,6 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertTrue(ma.isMaskedArray(lnsp.data))
         self.assertEqual(-32767.0, lnsp.data.fill_value)
 
-    @tests.skip_biggus
     def test_load_global_xyzt_gems_iter(self):
         # Test loading stepped single xyzt CF-netCDF file (multi-cube).
         for i, cube in enumerate(sorted(
@@ -127,7 +125,6 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertCML(cube, ('netcdf',
                               'netcdf_rotated_xyt_precipitation.cml'))
 
-    @tests.skip_biggus
     def test_load_tmerc_grid_and_clim_bounds(self):
         # Test loading a single CF-netCDF file with a transverse Mercator
         # grid_mapping and a time variable with climatology.
@@ -158,7 +155,6 @@ class TestNetCDFLoad(tests.IrisTest):
         self.assertEqual(cube.coord('projection_y_coordinate').coord_system,
                          expected)
 
-    @tests.skip_biggus
     def test_load_lcc_grid(self):
         # Test loading a single CF-netCDF file with Lambert conformal conic
         # grid mapping.
@@ -187,7 +183,6 @@ class TestNetCDFLoad(tests.IrisTest):
                                  'toa_brightness_temperature.nc')))
         self.assertCML(cube, ('netcdf', 'netcdf_merc.cml'))
 
-    @tests.skip_biggus
     def test_load_stereographic_grid(self):
         # Test loading a single CF-netCDF file with a stereographic
         # grid_mapping.

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -72,7 +72,6 @@ class TestAsSeries(tests.IrisTest):
         self.assertArrayEqual(series, cube.data)
         self.assertArrayEqual(series.index, expected_index)
 
-    @tests.skip_biggus
     def test_masked(self):
         data = np.ma.MaskedArray([0, 1, 2, 3, 4.4], mask=[0, 1, 0, 1, 0])
         cube = Cube(data, long_name="foo")
@@ -141,7 +140,6 @@ class TestAsSeries(tests.IrisTest):
         series[0] = 99
         self.assertEqual(cube.data[0], 0)
 
-    @tests.skip_biggus
     def test_copy_masked_false(self):
         data = np.ma.MaskedArray([0, 1, 2, 3, 4], mask=[0, 1, 0, 1, 0])
         cube = Cube(data, long_name="foo")
@@ -201,7 +199,6 @@ class TestAsDataFrame(tests.IrisTest):
         self.assertArrayEqual(data_frame.index, expected_index)
         self.assertArrayEqual(data_frame.columns, expected_columns)
 
-    @tests.skip_biggus
     def test_masked(self):
         data = np.ma.MaskedArray([[0, 1, 2, 3, 4.4], [5, 6, 7, 8, 9]],
                                  mask=[[0, 1, 0, 1, 0], [1, 0, 1, 0, 1]])
@@ -283,7 +280,6 @@ class TestAsDataFrame(tests.IrisTest):
         data_frame[0][0] = 99
         self.assertEqual(cube.data[0, 0], 0)
 
-    @tests.skip_biggus
     def test_copy_masked_false(self):
         data = np.ma.MaskedArray([[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
                                  mask=[[0, 1, 0, 1, 0], [1, 0, 1, 0, 1]])
@@ -292,7 +288,6 @@ class TestAsDataFrame(tests.IrisTest):
             data_frame = iris.pandas.as_data_frame(cube, copy=False)
 
 
-@tests.skip_biggus
 @skip_pandas
 class TestSeriesAsCube(tests.IrisTest):
 
@@ -360,7 +355,6 @@ class TestSeriesAsCube(tests.IrisTest):
         self.assertEqual(series[5], 99)
 
 
-@tests.skip_biggus
 @skip_pandas
 class TestDataFrameAsCube(tests.IrisTest):
 

--- a/lib/iris/tests/test_peak.py
+++ b/lib/iris/tests/test_peak.py
@@ -176,7 +176,6 @@ class TestPeakAggregator(tests.IrisTest):
         self.assertTrue(np.isnan(collapsed_cube.data).all())
         self.assertEqual(collapsed_cube.data.shape, (1,))
 
-    @tests.skip_biggus
     def test_peak_with_mask(self):
         # Single value in column masked.
         latitude = iris.coords.DimCoord(np.arange(0, 5, 1),
@@ -204,7 +203,6 @@ class TestPeakAggregator(tests.IrisTest):
         self.assertTrue(ma.isMaskedArray(collapsed_cube.data))
         self.assertEqual(collapsed_cube.data.shape, (1,))
 
-    @tests.skip_biggus
     def test_peak_with_nan_and_mask(self):
         # Single nan in column with single value masked.
         latitude = iris.coords.DimCoord(np.arange(0, 5, 1),

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -332,7 +332,6 @@ class Test1dQuickplotScatter(Test1dScatter):
 
 @tests.skip_data
 @tests.skip_plot
-@tests.skip_biggus
 class TestAttributePositive(tests.GraphicsTest):
     def test_1d_positive_up(self):
         path = tests.get_data_path(('NetCDF', 'ORCA2', 'votemper.nc'))
@@ -929,7 +928,6 @@ class TestPlottingExceptions(tests.IrisTest):
 
 @tests.skip_data
 @tests.skip_plot
-@tests.skip_biggus
 class TestPlotOtherCoordSystems(tests.GraphicsTest):
     def test_plot_tmerc(self):
         filename = tests.get_data_path(('NetCDF', 'transverse_mercator',

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -81,7 +81,6 @@ def callback_aaxzc_n10r13xy_b_pp(cube, field, filename):
 
 
 @tests.skip_data
-@tests.skip_biggus
 class TestAll(tests.IrisTest, pp.PPTest):
     _ref_dir = ('usecases', 'pp_to_cf_conversion')
 

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -138,7 +138,6 @@ class TestAll(tests.IrisTest):
         self.assertEqual(extent, [-17005833.33052523, 17005833.33052523,
                                   -8625155.12857459, 8625155.12857459])
 
-    @tests.skip_biggus
     @tests.skip_data
     def test_cube(self):
         cube = low_res_4d()

--- a/lib/iris/tests/unit/analysis/interpolate/test_linear.py
+++ b/lib/iris/tests/unit/analysis/interpolate/test_linear.py
@@ -64,7 +64,6 @@ class Test(tests.IrisTest):
         self._assert_expected_call(sample_points, sample_points_call)
 
 
-@tests.skip_biggus
 @tests.skip_data
 class Test_masks(tests.IrisTest):
     def test_mask_retention(self):

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -32,7 +32,6 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
-@tests.skip_biggus
 @tests.skip_data
 @tests.iristest_timing_decorator
 class TestBroadcasting(tests.IrisTest_nometa,

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -675,7 +675,6 @@ class Test___call____bad_linear_units(tests.IrisTest):
             Regridder(ok, bad, 'linear', 'mask')
 
 
-@tests.skip_biggus
 class Test___call____no_coord_systems(tests.IrisTest):
     # Test behaviour in the absence of any coordinate systems.
 
@@ -758,7 +757,6 @@ class Test___call____no_coord_systems(tests.IrisTest):
                 regridder(uk)
 
 
-@tests.skip_biggus
 class Test___call____extrapolation_modes(tests.IrisTest):
     values = [[np.nan, 6, 7, np.nan],
               [9, 10, 11, np.nan],
@@ -1128,7 +1126,6 @@ class Test___call____rotated_to_lat_lon(tests.IrisTest):
             cml = RESULT_DIR + ('{}_subset_anon.cml'.format(method),)
             self.assertCMLApproxData(result, cml)
 
-    @tests.skip_biggus
     def test_grid_subset_missing_data_1(self):
         # The destination grid points are entirely contained within the
         # src grid points AND we have missing data.
@@ -1142,7 +1139,6 @@ class Test___call____rotated_to_lat_lon(tests.IrisTest):
             cml = RESULT_DIR + ('{}_subset_masked_1.cml'.format(method),)
             self.assertCMLApproxData(result, cml)
 
-    @tests.skip_biggus
     def test_grid_subset_missing_data_2(self):
         # The destination grid points are entirely contained within the
         # src grid points AND we have missing data.
@@ -1156,7 +1152,6 @@ class Test___call____rotated_to_lat_lon(tests.IrisTest):
             cml = RESULT_DIR + ('{}_subset_masked_2.cml'.format(method),)
             self.assertCMLApproxData(result, cml)
 
-    @tests.skip_biggus
     def test_grid_partial_overlap(self):
         # The destination grid points are partially contained within the
         # src grid points.
@@ -1169,7 +1164,6 @@ class Test___call____rotated_to_lat_lon(tests.IrisTest):
             cml = RESULT_DIR + ('{}_partial_overlap.cml'.format(method),)
             self.assertCMLApproxData(result, cml)
 
-    @tests.skip_biggus
     def test_grid_no_overlap(self):
         # The destination grid points are NOT contained within the
         # src grid points.
@@ -1213,7 +1207,6 @@ class Test___call____NOP(tests.IrisTest):
         self.assertEqual(result, self.src)
 
 
-@tests.skip_biggus
 @tests.skip_data
 class Test___call____circular(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
+++ b/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
@@ -31,7 +31,6 @@ import iris.analysis.stats as stats
 from iris.exceptions import CoordinateNotFoundError
 
 
-@tests.skip_biggus
 @tests.skip_data
 class Test(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -40,7 +40,6 @@ from iris.tests.experimental.regrid.\
     _resampled_grid
 
 
-@tests.skip_biggus
 class TestMdtol(tests.IrisTest):
     # Tests to check the masking behaviour controlled by mdtol kwarg.
     def setUp(self):

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
@@ -45,7 +45,6 @@ from iris.experimental.regrid \
 PLAIN_LATLON_CS = GeogCS(EARTH_RADIUS)
 
 
-@tests.skip_biggus
 class Test(tests.IrisTest):
     def setUp(self):
         # Source cube.

--- a/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
+++ b/lib/iris/tests/unit/fileformats/grib/save_rules/test_data_section.py
@@ -39,7 +39,6 @@ GRIB_API = 'iris.fileformats.grib._save_rules.gribapi'
 GRIB_MESSAGE = mock.sentinel.GRIB_MESSAGE
 
 
-@tests.skip_biggus
 class TestMDI(tests.IrisTest):
     def assertBitmapOff(self, grib_api):
         # Check the use of a mask has been turned off via:


### PR DESCRIPTION
Currently unsure whether the tests in 'lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py' pass, because they are all skipped due to not having esmpy.

If they pass the Travis tests, I will remove them.  Otherwise, I will replace them.