### PR TITLE
PPfield core_data

### DIFF
--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -782,13 +782,13 @@ class FF2PP(object):
                             # Read the actual bytes. This can then be converted
                             # to a numpy array at a higher level.
                             ff_file_seek(data_offset, os.SEEK_SET)
-                            result_field._data = pp.LoadedArrayBytes(
+                            result_field.data = pp.LoadedArrayBytes(
                                 ff_file.read(data_depth), data_type)
                         else:
                             # Provide enough context to read the data bytes
                             # later.
-                            result_field._data = (self._filename, data_offset,
-                                                  data_depth, data_type)
+                            result_field.data = (self._filename, data_offset,
+                                                 data_depth, data_type)
 
                         data_offset += data_depth
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -900,20 +900,13 @@ ConversionMetadata = collections.namedtuple('ConversionMetadata',
 def _make_cube(field, converter):
     # Convert the field to a Cube.
     metadata = converter(field)
-    # This horrible try:except pattern is bound into our testing strategy.
-    # it enables the magicmocking to amgically fail, fall over to data
-    # then use that to make it's tests pass.
-    # To be fixed!!
-    try:
-        data = da.from_array(field._data, chunks=field._data.shape)
-    except AttributeError:
-        data = field.data
-    cube = iris.cube.Cube(data,
+
+    cube = iris.cube.Cube(field.core_data,
                           attributes=metadata.attributes,
                           cell_methods=metadata.cell_methods,
                           dim_coords_and_dims=metadata.dim_coords_and_dims,
                           aux_coords_and_dims=metadata.aux_coords_and_dims,
-                          fill_value=field.bmdi, dtype=data.dtype)
+                          fill_value=field.bmdi, dtype=field.core_data.dtype)
     
 
     # Temporary code to deal with invalid standard names in the

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -96,8 +96,12 @@ class FieldCollation(object):
             for size in vector_dims_list:
                 self._data_cache = [da.stack(self._data_cache[i:i+size]) for i
                                     in range(0, len(self._data_cache), size)]
-        self._data_cache, = self._data_cache
+            self._data_cache, = self._data_cache
         return self._data_cache
+
+    @property
+    def core_data(self):
+        return self.data
 
     @property
     def data_proxy(self):

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -154,10 +154,10 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
-                                   bzx=350, bdx=1.5, bzy=40, bdy=1.5,
-                                   lbuser=[0] * 7, lbrsvd=[0] * 4)
+            field = mock.MagicMock(
+                core_data=np.arange(1200).reshape(y, x) * scale, lbcode=[1],
+                lbnpt=x, lbrow=y, bzx=350, bdx=1.5, bzy=40, bdy=1.5,
+                lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'
             field._y_coord_name = lambda: 'latitude'
             field.coord_system = lambda: None
@@ -233,10 +233,10 @@ class TestVertical(tests.IrisTest):
     def test_hybrid_pressure_with_duplicate_references(self):
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
-                                   bzx=350, bdx=1.5, bzy=40, bdy=1.5,
-                                   lbuser=[0] * 7, lbrsvd=[0] * 4)
+            field = mock.MagicMock(
+                core_data=np.arange(1200).reshape(y, x) * scale, lbcode=[1],
+                lbnpt=x, lbrow=y, bzx=350, bdx=1.5, bzy=40, bdy=1.5,
+                lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'
             field._y_coord_name = lambda: 'latitude'
             field.coord_system = lambda: None
@@ -346,10 +346,10 @@ class TestVertical(tests.IrisTest):
         # LBCODE, support len().
         def field_with_data(scale=1):
             x, y = 40, 30
-            field = mock.MagicMock(_data=np.arange(1200).reshape(y, x) * scale,
-                                   lbcode=[1], lbnpt=x, lbrow=y,
-                                   bzx=350, bdx=1.5, bzy=40, bdy=1.5,
-                                   lbuser=[0] * 7, lbrsvd=[0] * 4)
+            field = mock.MagicMock(
+                core_data=np.arange(1200).reshape(y, x) * scale, lbcode=[1],
+                lbnpt=x, lbrow=y, bzx=350, bdx=1.5, bzy=40, bdy=1.5,
+                lbuser=[0] * 7, lbrsvd=[0] * 4)
             field._x_coord_name = lambda: 'longitude'
             field._y_coord_name = lambda: 'latitude'
             field.coord_system = lambda: None

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -32,10 +32,10 @@ from iris.tests import mock
 
 class Test__create_field_data(tests.IrisTest):
     def test_loaded_bytes(self):
-        # Check that a field with LoadedArrayBytes in _data gets the
+        # Check that a field with LoadedArrayBytes in core_data gets the
         # result of a suitable call to _data_bytes_to_shaped_array().
         mock_loaded_bytes = mock.Mock(spec=pp.LoadedArrayBytes)
-        field = mock.Mock(_data=mock_loaded_bytes)
+        field = mock.Mock(core_data=mock_loaded_bytes)
         data_shape = mock.Mock()
         land_mask = mock.Mock()
         with mock.patch('iris.fileformats.pp._data_bytes_to_shaped_array') as \
@@ -43,7 +43,7 @@ class Test__create_field_data(tests.IrisTest):
             convert_bytes.return_value = mock.sentinel.array
             pp._create_field_data(field, data_shape, land_mask)
 
-        self.assertIs(field._data, mock.sentinel.array)
+        self.assertIs(field.data, mock.sentinel.array)
         convert_bytes.assert_called_once_with(mock_loaded_bytes.bytes,
                                               field.lbpack,
                                               field.boundary_packing,
@@ -52,7 +52,7 @@ class Test__create_field_data(tests.IrisTest):
                                               field.bmdi, land_mask)
 
     def test_deferred_bytes(self):
-        # Check that a field with deferred array bytes in _data gets a
+        # Check that a field with deferred array bytes in core_data gets a
         # dask array.
         fname = mock.sentinel.fname
         position = mock.sentinel.position
@@ -60,20 +60,21 @@ class Test__create_field_data(tests.IrisTest):
         newbyteorder = mock.Mock(return_value=mock.sentinel.dtype)
         dtype = mock.Mock(newbyteorder=newbyteorder)
         deferred_bytes = (fname, position, n_bytes, dtype)
-        field = mock.Mock(_data=deferred_bytes)
+        field = mock.Mock(core_data=deferred_bytes)
         data_shape = (100, 120)
         land_mask = mock.Mock()
         proxy = mock.Mock(dtype=np.dtype('f4'), shape=data_shape,
                           spec=pp.PPDataProxy)
         # We can't directly inspect the concrete data source underlying
-        # the biggus array (it's a private attribute), so instead we
-        # patch the proxy creation and check it's being created and
-        # invoked correctly.
+        # the dask array, so instead we patch the proxy creation and check it's
+        # being created and invoked correctly.
         with mock.patch('iris.fileformats.pp.PPDataProxy') as PPDataProxy:
             PPDataProxy.return_value = proxy
             pp._create_field_data(field, data_shape, land_mask)
-        self.assertEqual(field._data.shape, data_shape)
-        self.assertEqual(field._data.dtype, np.dtype('f4'))
+        # The data should be assigned via field.data. As this is a mock object
+        # we can check the attribute directly.
+        self.assertEqual(field.data.shape, data_shape)
+        self.assertEqual(field.data.dtype, np.dtype('f4'))
         # Is it making use of a correctly configured proxy?
         # NB. We know it's *using* the result of this call because
         # that's where the dtype came from above.

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -92,7 +92,7 @@ class Test(tests.IrisTest):
         with open_fh as open_fh_ctx:
             expected_deferred_bytes = ('mocked', open_fh_ctx.tell(),
                                        4, np.dtype('>f4'))
-        self.assertEqual(pp_field._data, expected_deferred_bytes)
+        self.assertEqual(pp_field.data, expected_deferred_bytes)
 
     def test_read_data_call(self):
         # Checks that data is read if read_data is True.
@@ -106,7 +106,7 @@ class Test(tests.IrisTest):
         with open_fh as open_fh_ctx:
             expected_loaded_bytes = pp.LoadedArrayBytes(open_fh_ctx.read(),
                                                         np.dtype('>f4'))
-        self.assertEqual(pp_field._data, expected_loaded_bytes)
+        self.assertEqual(pp_field.data, expected_loaded_bytes)
 
     def test_invalid_header_release(self):
         # Check that an unknown LBREL value just results in a warning

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -36,13 +36,14 @@ class Test__interpret_fields__land_packed_fields(tests.IrisTest):
         self.pp_field = mock.Mock(lblrec=1, lbext=0, lbuser=[0] * 7,
                                   lbrow=0, lbnpt=0,
                                   raw_lbpack=20,
-                                  _data=('dummy', 0, 0, np.dtype('f4')))
+                                  core_data=('dummy', 0, 0, np.dtype('f4')))
         # The field specifying the land/seamask.
         lbuser = [None, None, None, 30, None, None, 1]  # m01s00i030
         self.land_mask_field = mock.Mock(lblrec=1, lbext=0, lbuser=lbuser,
                                          lbrow=3, lbnpt=4,
                                          raw_lbpack=0,
-                                         _data=('dummy', 0, 0, np.dtype('f4')))
+                                         core_data=('dummy', 0, 0,
+                                                    np.dtype('f4')))
 
     def test_non_deferred_fix_lbrow_lbnpt(self):
         # Checks the fix_lbrow_lbnpt is applied to fields which are not
@@ -54,7 +55,7 @@ class Test__interpret_fields__land_packed_fields(tests.IrisTest):
         self.assertEqual(f1.lbrow, 3)
         self.assertEqual(f1.lbnpt, 4)
         # Check the data's shape has been updated too.
-        self.assertEqual(f1._data.shape, (3, 4))
+        self.assertEqual(f1.data.shape, (3, 4))
 
     def test_fix_lbrow_lbnpt_no_mask_available(self):
         # Check a warning is issued when loading a land masked field
@@ -96,7 +97,8 @@ class Test__interpret_fields__land_packed_fields(tests.IrisTest):
         f2 = deepcopy(self.pp_field)
         self.assertIsNot(f1, f2)
         with mock.patch('iris.fileformats.pp.PPDataProxy') as PPDataProxy:
-            PPDataProxy.return_value = mock.MagicMock()
+            PPDataProxy.return_value = mock.MagicMock(shape=(3, 4),
+                                                      dtype=np.float32)
             list(pp._interpret_fields([f1, self.land_mask_field, f2]))
         for call in PPDataProxy.call_args_list:
             positional_args = call[0]


### PR DESCRIPTION
In at least one place (`iris.fileformats.pp._make_cube()`) there is code to handle an object which may be either a `PPField` or a `FieldCollation`. The code in `_make_cube()` does this with try/except on the existence of a `_data` attribute, which is only present on PPField and is intended to be either lazy or not, akin to `Cube._my_data`. As mentioned in a code comment, this is causing tests using `MagicMock`s to magically pass.

The code on the current dask_timed branch doesn't function correctly in the non-lazy case; the `_data` attribute is always wrapped up as a dask array before being passed into the `Cube` constructor.

This PR adds a `core_data` property to both the `PPField` and the `FieldCollation` classes, which behaves similarly to `Cube.core_data` in the `PPField` case, and simply calls `data` in the `FieldCollation` case. I've also made the `_data` attribute of `PPField` a dask array again.