### PR TITLE
BUG: Concatenation with anonymous dimensions sensitive to dimension mapping

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -322,6 +322,7 @@ class _CubeSignature(object):
         self.ndim = cube.ndim
         self.scalar_coords = []
         self.cell_measures_and_dims = cube._cell_measures_and_dims
+        self.dim_mapping = []
 
         # Determine whether there are any anonymous cube dimensions.
         covered = set(cube.coord_dims(coord)[0] for coord in self.dim_coords)
@@ -333,9 +334,11 @@ class _CubeSignature(object):
         #
         # Collate the dimension coordinate metadata.
         #
-        for coord in self.dim_coords:
-            metadata = _CoordMetaData(coord, cube.coord_dims(coord))
+        for ind, coord in enumerate(self.dim_coords):
+            dims = cube.coord_dims(coord)
+            metadata = _CoordMetaData(coord, dims)
             self.dim_metadata.append(metadata)
+            self.dim_mapping.append(dims[0])
 
         #
         # Collate the auxiliary coordinate metadata and scalar coordinates.
@@ -493,6 +496,7 @@ class _CoordSignature(object):
         """
         self.aux_coords_and_dims = cube_signature.aux_coords_and_dims
         self.dim_coords = cube_signature.dim_coords
+        self.dim_mapping = cube_signature.dim_mapping
         self.dim_extents = []
         self.dim_order = [metadata.kwargs['order']
                           for metadata in cube_signature.dim_metadata]
@@ -548,12 +552,12 @@ class _CoordSignature(object):
         candidate_axes = []
 
         # Compare dimension coordinates.
-        for dim, coord in enumerate(self.dim_coords):
-            result, candidate_axis = self._cmp(coord,
-                                               other.dim_coords[dim])
+        for ind, coord in enumerate(self.dim_coords):
+            result, candidate_axis = self._cmp(coord, other.dim_coords[ind])
             if not result:
                 break
             if candidate_axis:
+                dim = self.dim_mapping[ind]
                 candidate_axes.append(dim)
 
         # Only permit one degree of dimensional freedom when
@@ -643,7 +647,8 @@ class _ProtoCube(object):
         """
         if len(self._skeletons) > 1:
             skeletons = self._skeletons
-            order = self._coord_signature.dim_order[self.axis]
+            dim_ind = self._coord_signature.dim_mapping.index(self.axis)
+            order = self._coord_signature.dim_order[dim_ind]
             cube_signature = self._cube_signature
 
             # Sequence the skeleton segments into the correct order
@@ -721,7 +726,8 @@ class _ProtoCube(object):
 
         # Check for compatible coordinate extents.
         if match:
-            match = self._sequence(coord_signature.dim_extents[candidate_axis],
+            dim_ind = self._coord_signature.dim_mapping.index(candidate_axis)
+            match = self._sequence(coord_signature.dim_extents[dim_ind],
                                    candidate_axis)
 
         # Check for compatible AuxCoords.
@@ -748,10 +754,11 @@ class _ProtoCube(object):
             # a subsequently registered cube has a non-constant dimension
             # order we should use that instead of _CONSTANT to make sure all
             # the ordering checks and sorts work as expected.
-            existing_order = self._coord_signature.dim_order[self.axis]
-            this_order = coord_signature.dim_order[self.axis]
+            dim_ind = self._coord_signature.dim_mapping.index(candidate_axis)
+            existing_order = self._coord_signature.dim_order[dim_ind]
+            this_order = coord_signature.dim_order[dim_ind]
             if existing_order == _CONSTANT and this_order != _CONSTANT:
-                self._coord_signature.dim_order[self.axis] = this_order
+                self._coord_signature.dim_order[dim_ind] = this_order
 
         return match
 
@@ -858,18 +865,19 @@ class _ProtoCube(object):
         # Setup convenience hooks.
         skeletons = self._skeletons
         axis = self.axis
-        defn = self._cube_signature.dim_metadata[axis].defn
-        circular = self._cube_signature.dim_metadata[axis].kwargs['circular']
+        dim_ind = self._cube_signature.dim_mapping.index(axis)
+        metadata = self._cube_signature.dim_metadata[dim_ind]
+        defn, circular = metadata.defn, metadata.kwargs['circular']
 
         # Concatenate the points together for the nominated dimension.
-        points = [skeleton.signature.dim_coords[axis].points
+        points = [skeleton.signature.dim_coords[dim_ind].points
                   for skeleton in skeletons]
         points = np.concatenate(tuple(points))
 
         # Concatenate the bounds together for the nominated dimension.
         bounds = None
-        if self._cube_signature.dim_coords[axis].has_bounds():
-            bounds = [skeleton.signature.dim_coords[axis].bounds
+        if self._cube_signature.dim_coords[dim_ind].has_bounds():
+            bounds = [skeleton.signature.dim_coords[dim_ind].bounds
                       for skeleton in skeletons]
             bounds = np.concatenate(tuple(bounds))
 
@@ -881,7 +889,8 @@ class _ProtoCube(object):
 
         # Generate all the dimension coordinates for the new concatenated cube.
         dim_coords_and_dims = []
-        for dim, coord in enumerate(self._cube_signature.dim_coords):
+        for ind, coord in enumerate(self._cube_signature.dim_coords):
+            dim = self._cube_signature.dim_mapping[ind]
             if dim == axis:
                 dim_coords_and_dims.append((dim_coord, dim))
             else:
@@ -911,12 +920,13 @@ class _ProtoCube(object):
         result = True
 
         # Add the new extent to the current extents collection.
-        dim_extents = [skeleton.signature.dim_extents[axis]
+        dim_ind = self._coord_signature.dim_mapping.index(axis)
+        dim_extents = [skeleton.signature.dim_extents[dim_ind]
                        for skeleton in self._skeletons]
         dim_extents.append(extent)
 
         # Sort into the appropriate dimension order.
-        order = self._coord_signature.dim_order[axis]
+        order = self._coord_signature.dim_order[dim_ind]
         dim_extents.sort(reverse=(order == _DECREASING))
 
         # Ensure that the extents don't overlap.

--- a/lib/iris/tests/integration/concatenate/test_concatenate.py
+++ b/lib/iris/tests/integration/concatenate/test_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -33,6 +33,7 @@ import numpy as np
 import iris.coords
 from iris._concatenate import concatenate
 import iris.cube
+import iris.tests.stock as stock
 from iris.util import unify_time_units
 
 
@@ -186,6 +187,53 @@ class Test_anonymous_dims(tests.IrisTest):
 
         result = concatenate([cube1, cube2])
         self.assertEqual(len(result), 2)
+
+    def _get_3d_cube(self):
+        cube = stock.simple_3d()
+        coord = cube.coord('wibble')
+        cube.remove_coord(coord)
+        cube.add_aux_coord(coord, 0)
+        return cube
+
+    def test_concatenate_anom_1st_dim(self):
+        # Check that concatenation along a non anonymous dimension is
+        # insensitive to the dimension which is anonymous.
+        # Concatenate along longitude.
+        # DIM: cube(--, lat, lon)   & cube(--, lat, lon')
+        # AUX: cube(wibble, --, --) & cube(wibble, --, --)
+        cube = self._get_3d_cube()
+        cube1 = cube[..., :2]
+        cube2 = cube[..., 2:]
+        result = concatenate([cube1, cube2])
+        self.assertEqual(len(result), 1)
+
+    def test_concatenate_anom_2nd_dim(self):
+        # Check that concatenation along a non anonymous dimension is
+        # insensitive to the dimension which is anonymous.
+        # Concatenate along longitude.
+        # DIM: cube(lon, --, lat)   & cube(lon', ---, lat)
+        # AUX: cube(--, wibble, --) & cube(--, wibble, --)
+        cube = self._get_3d_cube()
+        cube1 = cube[..., :2]
+        cube2 = cube[..., 2:]
+        cube1.transpose((2, 0, 1))
+        cube2.transpose((2, 0, 1))
+        result = concatenate([cube1, cube2])
+        self.assertEqual(len(result), 1)
+
+    def test_concatenate_anom_3rd_dim(self):
+        # Check that concatenation along a non anonymous dimension is
+        # insensitive to the dimension which is anonymous.
+        # Concatenate along longitude.
+        # DIM: cube(lat, lon, --)   & cube(lat, lon', --)
+        # AUX: cube(--, --, wibble) & cube(--, --, wibble)
+        cube = self._get_3d_cube()
+        cube1 = cube[..., :2]
+        cube2 = cube[..., 2:]
+        cube1.transpose((1, 2, 0))
+        cube2.transpose((1, 2, 0))
+        result = concatenate([cube1, cube2])
+        self.assertEqual(len(result), 1)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/integration/concatenate/test_concatenate.py
+++ b/lib/iris/tests/integration/concatenate/test_concatenate.py
@@ -188,12 +188,15 @@ class Test_anonymous_dims(tests.IrisTest):
         result = concatenate([cube1, cube2])
         self.assertEqual(len(result), 2)
 
-    def _get_3d_cube(self):
-        cube = stock.simple_3d()
-        coord = cube.coord('wibble')
-        cube.remove_coord(coord)
-        cube.add_aux_coord(coord, 0)
-        return cube
+
+class Test_anonymous_dims_alternate_mapping(tests.IrisTest):
+    # Ensure that anonymous concatenation is not sensitive to dimension mapping
+    # of the anonymous dimension.
+    def setUp(self):
+        self.cube = stock.simple_3d()
+        coord = self.cube.coord('wibble')
+        self.cube.remove_coord(coord)
+        self.cube.add_aux_coord(coord, 0)
 
     def test_concatenate_anom_1st_dim(self):
         # Check that concatenation along a non anonymous dimension is
@@ -201,9 +204,8 @@ class Test_anonymous_dims(tests.IrisTest):
         # Concatenate along longitude.
         # DIM: cube(--, lat, lon)   & cube(--, lat, lon')
         # AUX: cube(wibble, --, --) & cube(wibble, --, --)
-        cube = self._get_3d_cube()
-        cube1 = cube[..., :2]
-        cube2 = cube[..., 2:]
+        cube1 = self.cube[..., :2]
+        cube2 = self.cube[..., 2:]
         result = concatenate([cube1, cube2])
         self.assertEqual(len(result), 1)
 
@@ -213,9 +215,8 @@ class Test_anonymous_dims(tests.IrisTest):
         # Concatenate along longitude.
         # DIM: cube(lon, --, lat)   & cube(lon', ---, lat)
         # AUX: cube(--, wibble, --) & cube(--, wibble, --)
-        cube = self._get_3d_cube()
-        cube1 = cube[..., :2]
-        cube2 = cube[..., 2:]
+        cube1 = self.cube[..., :2]
+        cube2 = self.cube[..., 2:]
         cube1.transpose((2, 0, 1))
         cube2.transpose((2, 0, 1))
         result = concatenate([cube1, cube2])
@@ -227,9 +228,8 @@ class Test_anonymous_dims(tests.IrisTest):
         # Concatenate along longitude.
         # DIM: cube(lat, lon, --)   & cube(lat, lon', --)
         # AUX: cube(--, --, wibble) & cube(--, --, wibble)
-        cube = self._get_3d_cube()
-        cube1 = cube[..., :2]
-        cube2 = cube[..., 2:]
+        cube1 = self.cube[..., :2]
+        cube2 = self.cube[..., 2:]
         cube1.transpose((1, 2, 0))
         cube2.transpose((1, 2, 0))
         result = concatenate([cube1, cube2])


### PR DESCRIPTION
This PR adds three new unittests (two of which fail), demonstrating how concatenation behaviour in the presence of anonymous dimensions is sensitive to which dimension mapping the concatenation occurs along (note this is not about concatenation along the anonymous dimension itself).