### PR TITLE
Trajectories by time

### DIFF
--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -83,6 +83,8 @@ def read_header(file_handle):
     for line in file_handle:
         words = line.split(':', 1)
         if len(words) != 2:
+            if 'Forward' or 'Backward' in line:
+                header['Trajectory direction'] = words[0]
             break
         key, value = [word.strip() for word in words]
         header[key] = value
@@ -1174,6 +1176,12 @@ def load_NAMEIII_trajectory(filename):
         name, units = _split_name_and_units(name)
         cube = iris.cube.Cube(values, units=units)
         cube.rename(name)
+        # Add the Main Headings as attributes.
+        for key, value in six.iteritems(header):
+            if value is not None and value != '' and \
+                    key not in headings:
+                cube.attributes[key] = value
+        # Add coordinates
         for coord in coords:
             dim = 0 if len(coord.points) > 1 else None
             if dim == 0 and coord.name() == "time":

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -34,9 +34,12 @@ import iris.cube
 from iris.exceptions import TranslationError
 import iris.util
 
+from operator import itemgetter
+
 
 EARTH_RADIUS = 6371229.0
 NAMEIII_DATETIME_FORMAT = '%d/%m/%Y  %H:%M %Z'
+NAMETRAJ_DATETIME_FORMAT = '%d/%m/%Y  %H:%M:%S %Z'
 NAMEII_FIELD_DATETIME_FORMAT = '%H%M%Z %d/%m/%Y'
 NAMEII_TIMESERIES_DATETIME_FORMAT = '%d/%m/%Y  %H:%M:%S'
 
@@ -1099,14 +1102,18 @@ def load_NAMEIII_trajectory(filename):
             values = [v.strip() for v in line.split(",")]
             for c, v in enumerate(values):
                 if "UTC" in v:
-                    v = v.replace(":00 ", " ")  # Strip out milliseconds.
-                    v = datetime.datetime.strptime(v, NAMEIII_DATETIME_FORMAT)
+                    v = datetime.datetime.strptime(v, NAMETRAJ_DATETIME_FORMAT)
                 else:
                     try:
                         v = float(v)
                     except ValueError:
                         pass
                 columns[c].append(v)
+
+    # Sort columns according to PP Index
+    columns_t = list(map(list, zip(*columns)))
+    columns_t.sort(key=itemgetter(1))
+    columns = list(map(list, zip(*columns_t)))
 
     # Where's the Z column?
     z_column = None
@@ -1169,7 +1176,9 @@ def load_NAMEIII_trajectory(filename):
         cube.rename(name)
         for coord in coords:
             dim = 0 if len(coord.points) > 1 else None
-            if isinstance(coord, DimCoord) and coord.name() == "time":
+            if dim == 0 and coord.name() == "time":
+                cube.add_dim_coord(coord.copy(), dim)
+            elif dim == 0 and coord.name() == 'PP Index':
                 cube.add_dim_coord(coord.copy(), dim)
             else:
                 cube.add_aux_coord(coord.copy(), dim)

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -83,8 +83,8 @@ def read_header(file_handle):
     for line in file_handle:
         words = line.split(':', 1)
         if len(words) != 2:
-            if 'Forward' or 'Backward' in line:
-                header['Trajectory direction'] = words[0]
+            if 'Forward' in line or 'Backward' in line:
+                header['Trajectory direction'] = words[0].strip()
             break
         key, value = [word.strip() for word in words]
         header[key] = value

--- a/lib/iris/tests/results/name/NAMEIII_trajectory.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory.cml
@@ -1,6 +1,13 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube long_name="U Turb" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -39,6 +46,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="V Turb" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -77,6 +91,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="W Turb" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -115,6 +136,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="U Ambient" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -153,6 +181,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="V Ambient" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -191,6 +226,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="W Ambient" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -229,6 +271,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Sigma UU" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -267,6 +316,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Sigma VV" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -305,6 +361,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Sigma WW" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -343,6 +406,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Temperature" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -381,6 +451,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Pressure" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -419,6 +496,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Potential Temp" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -457,6 +541,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="BL Depth" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -495,6 +586,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Cloud (oktas)" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -533,6 +631,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Rel Humidity" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -571,6 +676,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Wind Speed" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -609,6 +721,13 @@
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
   <cube long_name="Wind Direction" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
@@ -6,7 +6,7 @@
       <attribute name="NAME Version" value="NAME III (version 5.4)"/>
       <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
       <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
-      <attribute name="Trajectory direction" value=" Forward trajectories+"/>
+      <attribute name="Trajectory direction" value=" Forward trajectories"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
@@ -6,7 +6,7 @@
       <attribute name="NAME Version" value="NAME III (version 5.4)"/>
       <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
       <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
-      <attribute name="Trajectory direction" value=" Forward trajectories"/>
+      <attribute name="Trajectory direction" value="Forward trajectories"/>
     </attributes>
     <coords>
       <coord>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
@@ -1,6 +1,13 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
   <cube long_name="U Turb" units="unknown">
+    <attributes>
+      <attribute name="Met data" value="NWP Flow.Global_PT1_flow; NWP Flow.Global_PT2_flow; NWP Flow.Global_PT3_flow; NWP Flow.Global_PT4_flow; NWP Flow.Global_PT5_flow; NWP Flow.Global_PT6_flow; NWP Flow.Global_PT7_flow; NWP Flow.Global_PT8_flow; NWP Flow.Global_PT9_flow; NWP Flow.Global_PT10_flow; NWP Flow.Global_PT11_flow; NWP Flow.Global_PT12_flow; NWP Flow.Global_PT13_flow; NWP Flow.Global_PT14_flow"/>
+      <attribute name="NAME Version" value="NAME III (version 5.4)"/>
+      <attribute name="Run name" value="USER_DEFINED_LL 15112011 1129"/>
+      <attribute name="Run time" value="15/11/2011 14:21:56.345 UTC"/>
+      <attribute name="Trajectory direction" value=" Forward trajectories+"/>
+    </attributes>
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>


### PR DESCRIPTION
Added code to allow the reading of NAME trajectories stored by time instead of by particle number. This results in a cube with a dimension coordinate of ppindex (c.f. trajectories stored by particle number will produce a cube with a dimension coordinate of time). Also added some of the file header information into the cube attributes.