### PR TITLE
Polish dask dev guide section

### DIFF
--- a/docs/iris/src/developers_guide/dask_interface.rst
+++ b/docs/iris/src/developers_guide/dask_interface.rst
@@ -1,23 +1,35 @@
 Iris Dask Interface
 *******************
 
-Iris uses dask (http://dask.pydata.org) to manage lazy data interfaces and processing graphs.  The key principles which define this interface are:
+Iris uses `dask <http://dask.pydata.org>`_ to manage lazy data interfaces and processing graphs.
+The key principles that define this interface are:
 
-* A call to `cube.data` will always load all of the data.
-  * Once this has happened:
-    * `cube.data` is a mutable numpy masked array or ndarray;
-    * `cube._numpy_array` is a private numpy masked array, accessible via `cube.data`, which may strip off the mask and return a reference to the bare ndarray.
-* `cube.data` may be used to set the data, this accepts:
-  * a numpy array (including masked array), which is assigned to `cube._numpy_array`;
-  * a dask array, which is assigned to `cube._dask_array` an `cube._numpy_array` is set to None.
-* `cube._dask_array` may be None, otherwise it is expected to be a dask graph:
-  * this may wrap a proxy to a file collection;
-  * this may wrap the numpy array in `cube._numpy_array`.
-* All dask graphs wrap array-like object where missing data is represented by `nan`:
-  * masked arrays derived from these arrays shall create their mask using the nan location;
-  * where dask wrapped `int` arrays require masks, these will first be cast to `float`.
-* In order to support this mask conversion, cube's have a `fill_value` as part of their metadata, which may be None.
+* A call to :attr:`cube.data` will always load all of the data.
+
+* Once this has happened:
+
+  * :attr:`cube.data` is a mutable NumPy masked array or ``ndarray``, and
+  * ``cube._numpy_array`` is a private NumPy masked array, accessible via :attr:`cube.data`, which may strip off the mask and return a reference to the bare ``ndarray``.
+
+* You can use :attr:`cube.data` to set the data. This accepts:
+
+  * a NumPy array (including masked array), which is assigned to ``cube._numpy_array``, or
+  * a dask array, which is assigned to ``cube._dask_array``, while ``cube._numpy_array`` is set to None.
+
+* ``cube._dask_array`` may be None, otherwise it is expected to be a dask array:
+
+  * this may wrap a proxy to a file collection, or
+  * this may wrap the NumPy array in ``cube._numpy_array``.
+
+* All dask arrays wrap array-like objects where missing data are represented by ``nan`` values:
+
+  * Masked arrays derived from these dask arrays create their mask using the locations of ``nan`` values.
+  * Where dask-wrapped arrays of ``int`` require masks, these arrays will first be cast to ``float``.
+
+* In order to support this mask conversion, cubes have a ``fill_value`` defined as part of their metadata, which may be ``None``.
+
 * Array copying is kept to an absolute minimum:
+
   * array references should always be passed, not new arrays created, unless an explicit copy operation is requested.
-* To test for the presence of a dask array of any sort, we use:
-  * `iris._lazy_data.is_lazy_data` which is implemented as `hasattr(data, 'compute')`.
+
+* To test for the presence of a dask array of any sort, we use :func:`iris._lazy_data.is_lazy_data`. This is implemented as ``hasattr(data, 'compute')``.


### PR DESCRIPTION
This quite large diff masks some small changes, primarily structural, to the developer guide section on the Iris-dask interface. Notably:

 * bulleted sections are spaced so that they render as bulleted sections
 * where there are cross-links to be made into docstrings, these have been added as sphinx markdown (note these don't work yet as the docs building has been temporarily disabled on this branch - but these are added for their future value)
 * code element describing words (such as `ndarray`) have been formatted so they will appear as pre-formatted text
 * a few changes to the actual text to correct terminology or improve legibility.