### PR TITLE
Reinstate `as_lazy_data`

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -66,7 +66,8 @@ def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
 
     """
     if not is_lazy_data(data):
-        data = array_masked_to_nans(data)
+        if isinstance(data, np.ma.MaskedArray):
+            data = array_masked_to_nans(data)
         data = da.from_array(data, chunks=chunks)
     return data
 

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -25,6 +25,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import dask.array as da
 import numpy as np
+import numpy.ma as ma
 
 
 def is_lazy_data(data):
@@ -66,7 +67,7 @@ def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
 
     """
     if not is_lazy_data(data):
-        if isinstance(data, np.ma.MaskedArray):
+        if isinstance(data, ma.MaskedArray):
             data = array_masked_to_nans(data)
             data = data.data
         data = da.from_array(data, chunks=chunks)

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -40,11 +40,43 @@ def is_lazy_data(data):
     return result
 
 
+# A magic value, borrowed from biggus
+_MAX_CHUNK_SIZE = 8 * 1024 * 1024 * 2
+
+
+def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
+    """
+    Convert the input array `data` to a lazy dask array.
+
+    Args:
+
+    * data:
+        An array. This will be converted to a lazy dask array.
+
+    Kwargs:
+
+    * chunks:
+        Describes how the created dask array should be split up. Defaults to a
+        value first defined in biggus (being `8 * 1024 * 1024 * 2`).
+        For more information see
+        http://dask.pydata.org/en/latest/array-creation.html#chunks.
+
+    Returns:
+        The input array converted to a lazy dask array.
+
+    """
+    if not is_lazy_data(data):
+        data = array_masked_to_nans(data)
+        data = da.from_array(data, chunks=chunks)
+    return data
+
+
 def array_masked_to_nans(array, mask=None):
     """
-    Convert a masked array to a normal array with NaNs at masked points.
+    Convert a masked array to an `ndarray` with NaNs at masked points.
     This is used for dask integration, as dask does not support masked arrays.
     Note that any fill value will be lost.
+
     """
     if mask is None:
         mask = array.mask

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -68,6 +68,7 @@ def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
     if not is_lazy_data(data):
         if isinstance(data, np.ma.MaskedArray):
             data = array_masked_to_nans(data)
+            data = data.data
         data = da.from_array(data, chunks=chunks)
     return data
 

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -33,7 +33,7 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
-from iris._lazy_data import array_masked_to_nans, as_lazy_data, is_lazy_data 
+from iris._lazy_data import array_masked_to_nans, as_lazy_data, is_lazy_data
 import iris.cube
 import iris.coords
 import iris.exceptions
@@ -1231,10 +1231,6 @@ class ProtoCube(object):
                 if is_lazy_data(data):
                     all_have_data = False
                 else:
-                    if isinstance(data, ma.MaskedArray):
-                        if ma.is_masked(data):
-                            data = array_masked_to_nans(data)
-                        data = data.data
                     data = as_lazy_data(data, chunks=data.shape)
                 stack[nd_index] = data
 

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -33,7 +33,7 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
-from iris._lazy_data import is_lazy_data, array_masked_to_nans
+from iris._lazy_data import array_masked_to_nans, as_lazy_data, is_lazy_data 
 import iris.cube
 import iris.coords
 import iris.exceptions
@@ -1235,7 +1235,7 @@ class ProtoCube(object):
                         if ma.is_masked(data):
                             data = array_masked_to_nans(data)
                         data = data.data
-                    data = da.from_array(data, chunks=data.shape)
+                    data = as_lazy_data(data, chunks=data.shape)
                 stack[nd_index] = data
 
             merged_data = _multidim_daskstack(stack)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1658,9 +1658,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             result = self._dask_array
         else:
             data = self._numpy_array
-            if isinstance(data, ma.masked_array):
-                data = array_masked_to_nans(data)
-                data = data.data
             result = as_lazy_data(data, chunks=data.shape)
         return result
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1658,7 +1658,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             result = self._dask_array
         else:
             data = self._numpy_array
-            result = as_lazy_data(data, chunks=data.shape)
+            result = as_lazy_data(data)
         return result
 
     @property

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -42,7 +42,7 @@ from iris._cube_coord_common import CFVariableMixin
 import iris._concatenate
 import iris._constraints
 from iris._deprecation import warn_deprecated
-from iris._lazy_data import is_lazy_data, array_masked_to_nans
+from iris._lazy_data import array_masked_to_nans, as_lazy_data, is_lazy_data
 import iris._merge
 import iris.analysis
 from iris.analysis.cartography import wrap_lons
@@ -1661,7 +1661,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if isinstance(data, ma.masked_array):
                 data = array_masked_to_nans(data)
                 data = data.data
-            result = da.from_array(data, chunks=data.shape)
+            result = as_lazy_data(data, chunks=data.shape)
         return result
 
     @property

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1003,7 +1003,6 @@ fc_extras
     import warnings
 
     import cf_units
-    import dask.array as da
     import netCDF4
     import numpy as np
     import numpy.ma as ma
@@ -1018,6 +1017,7 @@ fc_extras
     import iris.exceptions
     import iris.std_names
     import iris.util
+    from iris._lazy_data import as_lazy_data
     
     
     #
@@ -1630,7 +1630,7 @@ fc_extras
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)
-            return da.from_array(proxy, chunks=proxy.shape)
+            return as_lazy_data(proxy, chunks=proxy.shape)
 
         # Get any coordinate point data.
         if isinstance(cf_coord_var, cf.CFLabelVariable):
@@ -1701,7 +1701,7 @@ fc_extras
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)
-            return da.from_array(proxy, chunks=proxy.shape)
+            return as_lazy_data(proxy, chunks=proxy.shape)
 
         data = cf_var_as_array(cf_cm_attr)
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -38,7 +38,6 @@ import string
 import warnings
 
 import biggus
-import dask.array as da
 import netCDF4
 import numpy as np
 import numpy.ma as ma
@@ -57,7 +56,7 @@ import iris.fileformats.cf
 import iris.fileformats._pyke_rules
 import iris.io
 import iris.util
-from iris._lazy_data import array_masked_to_nans
+from iris._lazy_data import array_masked_to_nans, as_lazy_data
 
 # Show Pyke inference engine statistics.
 DEBUG = False
@@ -508,7 +507,7 @@ def _load_cube(engine, cf, cf_var, filename):
 
     proxy = NetCDFDataProxy(cf_var.shape, dummy_data.dtype,
                             filename, cf_var.cf_name, fill_value)
-    data = da.from_array(proxy, chunks=100)
+    data = as_lazy_data(proxy, chunks=cf_var.shape)
     cube = iris.cube.Cube(data, fill_value=fill_value, dtype=dummy_data.dtype)
 
     # Reset the pyke inference engine.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -37,14 +37,13 @@ import cf_units
 import numpy as np
 import numpy.ma as ma
 import netcdftime
-import dask.array as da
 
 from iris._deprecation import warn_deprecated
 import iris.config
 import iris.fileformats.rules
 import iris.fileformats.pp_rules
 import iris.coord_systems
-from iris._lazy_data import is_lazy_data, array_masked_to_nans
+from iris._lazy_data import array_masked_to_nans, as_lazy_data, is_lazy_data
 
 try:
     import mo_pack
@@ -1881,7 +1880,7 @@ def _create_field_data(field, data_shape, land_mask):
                             field.boundary_packing,
                             field.bmdi, land_mask)
         block_shape = data_shape if 0 not in data_shape else (1, 1)
-        field.data = da.from_array(proxy, block_shape)
+        field.data = as_lazy_data(proxy, chunks=block_shape)
 
 
 def _field_gen(filename, read_data_bytes, little_ended=False):

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -36,6 +36,7 @@ from iris.fileformats.um._optimal_array_structuring import \
     optimal_array_structure
 
 from iris.fileformats.pp import PPField3
+from iris._lazy_data import as_lazy_data
 
 
 class FieldCollation(object):
@@ -88,7 +89,7 @@ class FieldCollation(object):
         if not self._structure_calculated:
             self._calculate_structure()
         if self._data_cache is None:
-            data_arrays = [da.from_array(f._data, f._data.shape)
+            data_arrays = [as_lazy_data(f._data, chunks=f._data.shape)
                            for f in self.fields]
             vector_dims_list = list(self.vector_dims_shape)
             vector_dims_list.reverse()

--- a/lib/iris/tests/integration/test_trajectory.py
+++ b/lib/iris/tests/integration/test_trajectory.py
@@ -24,11 +24,11 @@ import six
 # importing anything else
 import iris.tests as tests
 
-import dask.array as da
 import numpy as np
 
 import iris
 import iris.tests.stock as istk
+from iris._lazy_data import as_lazy_data
 
 from iris.analysis.trajectory import (Trajectory,
                                       interpolate as traj_interpolate)
@@ -233,7 +233,7 @@ class TestLazyData(tests.IrisTest):
     def test_hybrid_height(self):
         cube = istk.simple_4d_with_hybrid_height()
         # Put a biggus array on the cube so we can test deferred loading.
-        cube.data = da.from_array(cube.data, chunks=cube.data.shape)
+        cube.data = as_lazy_data(cube.data)
 
         traj = (('grid_latitude', [20.5, 21.5, 22.5, 23.5]),
                 ('grid_longitude', [31, 32, 33, 34]))

--- a/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
@@ -28,7 +28,7 @@ import iris.tests as tests
 
 import datetime
 
-import dask.array as da
+from iris._lazy_data import as_lazy_data
 import numpy as np
 
 import iris
@@ -481,7 +481,7 @@ class Test___call___lazy_data(ThreeDimCube):
         # of loading it again and again.
 
         # Modify self.cube to have lazy data.
-        self.cube.data = da.from_array(self.data, chunks=self.data.shape)
+        self.cube.data = as_lazy_data(self.data)
         self.assertTrue(self.cube.has_lazy_data())
 
         # Perform interpolation and check the data has been loaded.

--- a/lib/iris/tests/unit/analysis/test_MEAN.py
+++ b/lib/iris/tests/unit/analysis/test_MEAN.py
@@ -23,7 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import dask.array as da
+from iris._lazy_data import as_lazy_data
 import numpy as np
 import numpy.ma as ma
 
@@ -34,7 +34,7 @@ class Test_lazy_aggregate(tests.IrisTest):
     def setUp(self):
         self.data = np.arange(12.0).reshape(3, 4)
         self.data[2, 1:] = np.nan
-        self.array = da.from_array(self.data, chunks=self.data.shape)
+        self.array = as_lazy_data(self.data)
         masked_data = ma.masked_array(self.data,
                                       mask=np.isnan(self.data))
         self.axis = 0
@@ -66,7 +66,7 @@ class Test_lazy_aggregate(tests.IrisTest):
     def test_multi_axis(self):
         data = np.arange(24.0).reshape((2, 3, 4))
         collapse_axes = (0, 2)
-        lazy_data = da.from_array(data, chunks=1e6)
+        lazy_data = as_lazy_data(data)
         agg = MEAN.lazy_aggregate(lazy_data, axis=collapse_axes)
         expected = np.mean(data, axis=collapse_axes)
         self.assertArrayAllClose(agg.compute(), expected)

--- a/lib/iris/tests/unit/analysis/test_STD_DEV.py
+++ b/lib/iris/tests/unit/analysis/test_STD_DEV.py
@@ -44,12 +44,12 @@ class Test_lazy_aggregate(tests.IrisTest):
         self.assertMaskedArrayAlmostEqual(masked_result, masked_expected)
 
     def test_ddof_one(self):
-        array = as_lazy_data(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8))
         var = STD_DEV.lazy_aggregate(array, axis=0, ddof=1)
         self.assertArrayAlmostEqual(var.compute(), np.array(2.449489))
 
     def test_ddof_zero(self):
-        array = as_lazy_data(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8))
         var = STD_DEV.lazy_aggregate(array, axis=0, ddof=0)
         self.assertArrayAlmostEqual(var.compute(), np.array(2.291287))
 

--- a/lib/iris/tests/unit/analysis/test_STD_DEV.py
+++ b/lib/iris/tests/unit/analysis/test_STD_DEV.py
@@ -23,8 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from iris._lazy_data import as_lazy_data
 import numpy as np
-import dask.array as da
 
 from iris.analysis import STD_DEV
 
@@ -35,7 +35,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         array = np.array([[1., 2., 1., 2.],
                           [1., 2., 3., na],
                           [1., 2., na, na]])
-        array = da.from_array(array, chunks=1e6)
+        array = as_lazy_data(array)
         var = STD_DEV.lazy_aggregate(array, axis=1, mdtol=0.3)
         result = var.compute()
         masked_result = np.ma.masked_array(result, mask=np.isnan(result))
@@ -44,12 +44,12 @@ class Test_lazy_aggregate(tests.IrisTest):
         self.assertMaskedArrayAlmostEqual(masked_result, masked_expected)
 
     def test_ddof_one(self):
-        array = da.from_array(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8), chunks=1e6)
         var = STD_DEV.lazy_aggregate(array, axis=0, ddof=1)
         self.assertArrayAlmostEqual(var.compute(), np.array(2.449489))
 
     def test_ddof_zero(self):
-        array = da.from_array(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8), chunks=1e6)
         var = STD_DEV.lazy_aggregate(array, axis=0, ddof=0)
         self.assertArrayAlmostEqual(var.compute(), np.array(2.291287))
 

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -23,7 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import dask.array as da
+from iris._lazy_data import as_lazy_data
 import numpy as np
 import numpy.ma as ma
 
@@ -69,12 +69,12 @@ class Test_masked(tests.IrisTest):
 
 class Test_lazy_aggregate(tests.IrisTest):
     def test_ddof_one(self):
-        array = da.from_array(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8))
         var = VARIANCE.lazy_aggregate(array, axis=0, ddof=1)
         self.assertArrayAlmostEqual(var.compute(), np.array(6.0))
 
     def test_ddof_zero(self):
-        array = da.from_array(np.arange(8), chunks=1e6)
+        array = as_lazy_data(np.arange(8))
         var = VARIANCE.lazy_aggregate(array, axis=0, ddof=0)
         self.assertArrayAlmostEqual(var.compute(), np.array(5.25))
 

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -26,8 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import iris._lazy_data
-import dask.array as da
+from iris._lazy_data import as_lazy_data, is_lazy_data
 import numpy as np
 
 import iris.coords
@@ -58,25 +57,25 @@ class Test__nd_points(tests.IrisTest):
 
     def test_lazy_simple(self):
         raw_points = np.arange(12).reshape(4, 3)
-        points = da.from_array(raw_points, 1)
+        points = as_lazy_data(raw_points, 1)
         coord = iris.coords.AuxCoord(points)
-        self.assertTrue(iris._lazy_data.is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord._points))
         result = AuxCoordFactory._nd_points(coord, (0, 1), 2)
         # Check we haven't triggered the loading of the coordinate values.
-        self.assertTrue(iris._lazy_data.is_lazy_data(coord._points))
-        self.assertTrue(iris._lazy_data.is_lazy_data(result))
+        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(result))
         expected = raw_points
         self.assertArrayEqual(result, expected)
 
     def test_lazy_complex(self):
         raw_points = np.arange(12).reshape(4, 3)
-        points = da.from_array(raw_points, 1)
+        points = as_lazy_data(raw_points, 1)
         coord = iris.coords.AuxCoord(points)
-        self.assertTrue(iris._lazy_data.is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord._points))
         result = AuxCoordFactory._nd_points(coord, (3, 2), 5)
         # Check we haven't triggered the loading of the coordinate values.
-        self.assertTrue(iris._lazy_data.is_lazy_data(coord._points))
-        self.assertTrue(iris._lazy_data.is_lazy_data(result))
+        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(result))
         expected = raw_points.T[np.newaxis, np.newaxis, ..., np.newaxis]
         self.assertArrayEqual(result, expected)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -23,7 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
@@ -39,6 +38,7 @@ from iris.coords import AuxCoord, DimCoord, CellMeasure
 from iris.exceptions import CoordinateNotFoundError, CellMeasureNotFoundError
 from iris.tests import mock
 import iris.tests.stock as stock
+from iris._lazy_data import as_lazy_data
 
 
 class Test___init___data(tests.IrisTest):
@@ -147,7 +147,7 @@ class Test_xml(tests.IrisTest):
 class Test_collapsed__lazy(tests.IrisTest):
     def setUp(self):
         self.data = np.arange(6.0).reshape((2, 3))
-        self.lazydata = da.from_array(self.data, chunks=self.data.shape)
+        self.lazydata = as_lazy_data(self.data)
         cube = Cube(self.lazydata)
         for i_dim, name in enumerate(('y', 'x')):
             npts = cube.shape[i_dim]
@@ -545,7 +545,7 @@ class Test_slices_over(tests.IrisTest):
 def create_cube(lon_min, lon_max, bounds=False):
     n_lons = max(lon_min, lon_max) - min(lon_max, lon_min)
     data = np.arange(4 * 3 * n_lons, dtype='f4').reshape(4, 3, n_lons)
-    data = da.from_array(data, chunks=data.shape)
+    data = as_lazy_data(data)
     cube = Cube(data, standard_name='x_wind', units='ms-1')
     cube.add_dim_coord(iris.coords.DimCoord([0, 20, 40, 80],
                                             long_name='level_height',
@@ -1219,7 +1219,7 @@ class Test_copy(tests.IrisTest):
         self._check_copy(cube, cube.copy())
 
     def test__lazy(self):
-        cube = Cube(da.from_array(np.array([1, 0]), chunks=100))
+        cube = Cube(as_lazy_data(np.array([1, 0])))
         self._check_copy(cube, cube.copy())
 
 
@@ -1234,8 +1234,7 @@ class Test_dtype(tests.IrisTest):
 
     def test_lazy(self):
         data = np.arange(6, dtype=np.float32).reshape(2, 3)
-        lazydata = da.from_array(data, chunks=data.shape)
-        cube = Cube(lazydata)
+        cube = Cube(as_lazy_data(data))
         self.assertEqual(cube.dtype, np.float32)
         # Check that accessing the dtype does not trigger loading of the data.
         self.assertTrue(cube.has_lazy_data())
@@ -1414,7 +1413,7 @@ class TestCellMeasures(tests.IrisTest):
 class Test_transpose(tests.IrisTest):
     def test_lazy_data(self):
         data = np.arange(12).reshape(3, 4)
-        cube = Cube(da.from_array(data, chunks=data.shape))
+        cube = Cube(as_lazy_data(data))
         cube.transpose()
         self.assertTrue(cube.has_lazy_data())
         self.assertArrayEqual(data.T, cube.data)

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_FieldCollation.py
@@ -27,7 +27,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import dask.array as da
+from iris._lazy_data import as_lazy_data
 from netcdftime import datetime
 import numpy as np
 
@@ -70,7 +70,7 @@ def _make_field(lbyr=None, lbyrd=None, lbft=None,
 
 def _make_data(fill_value):
     shape = (10, 10)
-    return da.from_array(np.ones(shape)*fill_value, chunks=100)
+    return as_lazy_data(np.ones(shape)*fill_value)
 
 
 class Test_data(tests.IrisTest):

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Test :meth:`iris._lazy data.as_lazy_data` method."""
+"""Test the function :func:`iris._lazy data.as_lazy_data`."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -1,0 +1,65 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Test :meth:`iris._lazy data.as_lazy_data` method."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+import dask.array as da
+
+from iris._lazy_data import as_lazy_data, _MAX_CHUNK_SIZE
+
+
+class Test_as_lazy_data(tests.IrisTest):
+    def test_lazy(self):
+        data = da.from_array(np.arange(24).reshape((2, 3, 4)),
+                             chunks=_MAX_CHUNK_SIZE)
+        result = as_lazy_data(data)
+        self.assertIsInstance(result, da.core.Array)
+
+    def test_real(self):
+        data = np.arange(24).reshape((2, 3, 4))
+        result = as_lazy_data(data)
+        self.assertIsInstance(result, da.core.Array)
+
+    def test_masked(self):
+        data = np.ma.masked_greater(np.arange(24), 10)
+        result = as_lazy_data(data)
+        self.assertIsInstance(result, da.core.Array)
+
+    def test_non_default_chunks(self):
+        data = np.arange(24)
+        chunks = 12
+        lazy_data = as_lazy_data(data, chunks=chunks)
+        result, = np.unique(lazy_data.chunks)
+        self.assertEqual(result, chunks)
+
+    def test_non_default_chunks__chunks_already_set(self):
+        chunks = 12
+        data = da.from_array(np.arange(24), chunks=chunks)
+        lazy_data = as_lazy_data(data)
+        result, = np.unique(lazy_data.chunks)
+        self.assertEqual(result, chunks)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
@@ -26,13 +26,13 @@ import iris.tests as tests
 import numpy as np
 import dask.array as da
 
-from iris._lazy_data import is_lazy_data
+from iris._lazy_data import as_lazy_data, is_lazy_data, _MAX_CHUNK_SIZE
 
 
 class Test_is_lazy_data(tests.IrisTest):
     def test_lazy(self):
-        lazy_values = np.arange(30).reshape((2, 5, 3))
-        lazy_array = da.from_array(lazy_values, 1e6)
+        values = np.arange(30).reshape((2, 5, 3))
+        lazy_array = da.from_array(values, _MAX_CHUNK_SIZE)
         self.assertTrue(is_lazy_data(lazy_array))
 
     def test_real(self):

--- a/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
@@ -32,7 +32,7 @@ from iris._lazy_data import as_lazy_data, is_lazy_data, _MAX_CHUNK_SIZE
 class Test_is_lazy_data(tests.IrisTest):
     def test_lazy(self):
         values = np.arange(30).reshape((2, 5, 3))
-        lazy_array = da.from_array(values, _MAX_CHUNK_SIZE)
+        lazy_array = da.from_array(values, chunks=_MAX_CHUNK_SIZE)
         self.assertTrue(is_lazy_data(lazy_array))
 
     def test_real(self):

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -25,7 +25,7 @@ import iris.tests as tests
 import iris.tests.stock as stock
 
 import copy
-import dask.array as da
+from iris._lazy_data import as_lazy_data
 import numpy as np
 import unittest
 
@@ -137,7 +137,7 @@ class Test(tests.IrisTest):
         self._assert_cube_notis(res, cube)
 
     def test_lazy_data(self):
-        cube = iris.cube.Cube(da.from_array(self.data, chunks=self.data.shape))
+        cube = iris.cube.Cube(as_lazy_data(self.data))
         cube.add_aux_coord(iris.coords.DimCoord([1], standard_name='time'))
         res = new_axis(cube, 'time')
         self.assertTrue(cube.has_lazy_data())


### PR DESCRIPTION
The return of the `as_lazy_data` function, which acts as Iris' interface to `da.from_array`. I've added tests for the function and changed the Iris code and tests so that it always uses the new function and does not call `da.from_array` directly.