### PR TITLE
Tighten purpose of `array_masked_to_nans`

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -81,7 +81,7 @@ def array_masked_to_nans(array):
 
     Args:
 
-    * masked_array:
+    * array:
         A NumPy `ndarray` or masked array.
 
     Returns:
@@ -100,10 +100,11 @@ def array_masked_to_nans(array):
     if not ma.isMaskedArray(array):
         result = array
     else:
-        if array.dtype.kind == 'i':
-            array = array.astype(np.dtype('f8'))
-        mask = array.mask
-        array[mask] = np.nan
+        if ma.is_masked(array):
+            if array.dtype.kind == 'i':
+                array = array.astype(np.dtype('f8'))
+            mask = array.mask
+            array[mask] = np.nan
         result = array.data
     return result
 

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -73,7 +73,7 @@ def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
     return data
 
 
-def array_masked_to_nans(masked_array):
+def array_masked_to_nans(array):
     """
     Convert a masked array to a NumPy `ndarray` filled with NaN values. Input
     NumPy arrays with no mask are returned unchanged.
@@ -82,29 +82,29 @@ def array_masked_to_nans(masked_array):
     Args:
 
     * masked_array:
-        A NumPy array. If masked, the masked points will be filled with
-        `np.nan` values.
+        A NumPy `ndarray` or masked array.
 
     Returns:
-        The input array if unmasked, or a NaN-filled masked array of
-        floating-point values if masked.
+        A NumPy `ndarray`. This is the input array if unmasked, or an array
+        of floating-point values with NaN values where the mask was `True` if
+        the input array is masked.
 
     .. note::
         The fill value and mask of the input masked array will be lost.
 
     .. note::
-        Integer masked arrays are cast to floats because NaN is a
+        Integer masked arrays are cast to 8-byte floats because NaN is a
         floating-point value.
 
     """
-    if not hasattr(masked_array, 'mask'):
-        result = masked_array
+    if not ma.isMaskedArray(array):
+        result = array
     else:
-        if masked_array.dtype.kind == 'i':
-            masked_array = masked_array.astype(np.dtype('f8'))
-        mask = masked_array.mask
-        masked_array[mask] = np.nan
-        result = masked_array.data
+        if array.dtype.kind == 'i':
+            array = array.astype(np.dtype('f8'))
+        mask = array.mask
+        array[mask] = np.nan
+        result = array.data
     return result
 
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -396,7 +396,6 @@ class NetCDFDataProxy(object):
             dataset.close()
         if isinstance(var, ma.MaskedArray):
             var = array_masked_to_nans(var)
-            var = var.data
         return var
 
     def __repr__(self):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1039,7 +1039,8 @@ def _data_bytes_to_shaped_array(data_bytes, lbpack, boundary_packing,
 
     # Mask the array?
     if mdi in data:
-        data = array_masked_to_nans(data, data == mdi)
+        data = np.ma.masked_array(data, data == mdi)
+        data = array_masked_to_nans(data)
 
     return data
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1037,10 +1037,11 @@ def _data_bytes_to_shaped_array(data_bytes, lbpack, boundary_packing,
         # Reform in row-column order
         data.shape = data_shape
 
-    # Mask the array?
+    # Convert mdi to NaN.
     if mdi in data:
-        data = np.ma.masked_array(data, data == mdi)
-        data = array_masked_to_nans(data)
+        if data.dtype.kind == 'i':
+            data = data.astype(np.dtype('f8'))
+        data[data == mdi] = np.nan
 
     return data
 

--- a/lib/iris/tests/results/unit/merge/ProtoCube/register__CubeSig/noise.txt
+++ b/lib/iris/tests/results/unit/merge/ProtoCube/register__CubeSig/noise.txt
@@ -4,4 +4,4 @@ failed to merge into a single cube.
   cube.attributes keys differ: 'stuffed'
   cube.cell_methods differ
   cube.shape differs: (3,) != (2,)
-  cube data dtype differs: int64 != float64
+  cube data dtype differs: int64 != int8

--- a/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
+++ b/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
@@ -31,41 +31,45 @@ from iris._lazy_data import array_masked_to_nans
 
 
 class Test(tests.IrisTest):
-    def test_masked(self):
-        masked_array = ma.masked_array([[1.0, 2.0], [3.0, 4.0]],
-                                       mask=[[0, 1], [0, 0]])
-
-        result = array_masked_to_nans(masked_array).data
-
+    def _common_checks(self, result):
         self.assertIsInstance(result, np.ndarray)
         self.assertFalse(isinstance(result, ma.MaskedArray))
         self.assertFalse(ma.is_masked(result))
 
+    def test_masked_input(self):
+        masked_array = ma.masked_array([[1.0, 2.0], [3.0, 4.0]],
+                                       mask=[[0, 1], [0, 0]])
+
+        result = array_masked_to_nans(masked_array)
+
+        self._common_checks(result)
         self.assertArrayAllClose(np.isnan(result),
                                  [[False, True], [False, False]])
         result[0, 1] = 777.7
         self.assertArrayAllClose(result, [[1.0, 777.7], [3.0, 4.0]])
 
+    def test_unmasked_input(self):
+        unmasked_array = np.array([1.0, 2.0])
+        result = array_masked_to_nans(unmasked_array)
+        # Non-masked array is returned as-is, without copying.
+        self.assertIs(result, unmasked_array)
+
     def test_empty_mask(self):
         masked_array = ma.masked_array([1.0, 2.0], mask=[0, 0])
 
-        result = array_masked_to_nans(masked_array).data
+        result = array_masked_to_nans(masked_array)
 
-        self.assertIsInstance(result, np.ndarray)
-        self.assertFalse(isinstance(result, ma.MaskedArray))
-        self.assertFalse(ma.is_masked(result))
-
-        # self.assertIs(result, masked_array.data)
-        # NOTE: Wanted to check that result in this case is delivered without
-        # copying.  However, it seems that ".data" is not just an internal
-        # reference, so copying *does* occur in this case.
+        self._common_checks(result)
         self.assertArrayAllClose(result, masked_array.data)
 
-    def test_non_masked(self):
-        unmasked_array = np.array([1.0, 2.0])
-        result = array_masked_to_nans(unmasked_array, mask=False)
-        # Non-masked array is returned as-is, without copying.
-        self.assertIs(result, unmasked_array)
+    def test_integer_array(self):
+        masked_array = ma.masked_array([[1, 2], [3, 4]],
+                                       mask=[[0, 1], [0, 0]])
+
+        result = array_masked_to_nans(masked_array)
+
+        self._common_checks(result)
+        self.assertEqual(result.dtype, np.dtype('f8'))
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
+++ b/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
@@ -36,14 +36,13 @@ class Test(tests.IrisTest):
         self.assertFalse(ma.isMaskedArray(result))
 
     def test_masked(self):
-        masked_array = ma.masked_array([[1.0, 2.0], [3.0, 4.0]],
-                                       mask=[[0, 1], [0, 0]])
+        mask = [[False, True], [False, False]]
+        masked_array = ma.masked_array([[1.0, 2.0], [3.0, 4.0]], mask=mask)
 
         result = array_masked_to_nans(masked_array)
 
         self._common_checks(result)
-        self.assertArrayAllClose(np.isnan(result),
-                                 [[False, True], [False, False]])
+        self.assertArrayAllClose(np.isnan(result), mask)
         result[0, 1] = 777.7
         self.assertArrayAllClose(result, [[1.0, 777.7], [3.0, 4.0]])
 
@@ -70,15 +69,14 @@ class Test(tests.IrisTest):
         self.assertArrayAllClose(result, masked_array.data)
 
     def test_masked__integers(self):
-        masked_array = ma.masked_array([[1, 2], [3, 4]],
-                                       mask=[[0, 1], [0, 0]])
+        mask = [[False, True], [False, False]]
+        masked_array = ma.masked_array([[1, 2], [3, 4]], mask=mask)
 
         result = array_masked_to_nans(masked_array)
 
         self._common_checks(result)
         self.assertEqual(result.dtype, np.dtype('f8'))
-        self.assertArrayAllClose(np.isnan(result),
-                                 [[False, True], [False, False]])
+        self.assertArrayAllClose(np.isnan(result), mask)
         result[0, 1] = 777.7
         self.assertArrayAllClose(result, [[1.0, 777.7], [3.0, 4.0]])
 

--- a/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
+++ b/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
@@ -34,9 +34,8 @@ class Test(tests.IrisTest):
     def _common_checks(self, result):
         self.assertIsInstance(result, np.ndarray)
         self.assertFalse(ma.isMaskedArray(result))
-        self.assertFalse(ma.is_masked(result))
 
-    def test_masked_input(self):
+    def test_masked(self):
         masked_array = ma.masked_array([[1.0, 2.0], [3.0, 4.0]],
                                        mask=[[0, 1], [0, 0]])
 
@@ -48,14 +47,8 @@ class Test(tests.IrisTest):
         result[0, 1] = 777.7
         self.assertArrayAllClose(result, [[1.0, 777.7], [3.0, 4.0]])
 
-    def test_unmasked_input(self):
+    def test_unmasked(self):
         unmasked_array = np.array([1.0, 2.0])
-        result = array_masked_to_nans(unmasked_array)
-        # Non-masked array is returned as-is, without copying.
-        self.assertIs(result, unmasked_array)
-
-    def test_unmasked_ints_input(self):
-        unmasked_array = np.array([1, 2])
         result = array_masked_to_nans(unmasked_array)
         # Non-masked array is returned as-is, without copying.
         self.assertIs(result, unmasked_array)
@@ -76,9 +69,27 @@ class Test(tests.IrisTest):
         self._common_checks(result)
         self.assertArrayAllClose(result, masked_array.data)
 
-    def test_integer_array(self):
+    def test_masked__integers(self):
         masked_array = ma.masked_array([[1, 2], [3, 4]],
                                        mask=[[0, 1], [0, 0]])
+
+        result = array_masked_to_nans(masked_array)
+
+        self._common_checks(result)
+        self.assertEqual(result.dtype, np.dtype('f8'))
+        self.assertArrayAllClose(np.isnan(result),
+                                 [[False, True], [False, False]])
+        result[0, 1] = 777.7
+        self.assertArrayAllClose(result, [[1.0, 777.7], [3.0, 4.0]])
+
+    def test_unmasked__integers(self):
+        unmasked_array = np.array([1, 2])
+        result = array_masked_to_nans(unmasked_array)
+        # Non-masked array is returned as-is, without copying.
+        self.assertIs(result, unmasked_array)
+
+    def test_no_mask__integers(self):
+        masked_array = ma.masked_array([1, 2], mask=ma.nomask)
 
         result = array_masked_to_nans(masked_array)
 

--- a/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
+++ b/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
@@ -33,7 +33,7 @@ from iris._lazy_data import array_masked_to_nans
 class Test(tests.IrisTest):
     def _common_checks(self, result):
         self.assertIsInstance(result, np.ndarray)
-        self.assertFalse(isinstance(result, ma.MaskedArray))
+        self.assertFalse(ma.isMaskedArray(result))
         self.assertFalse(ma.is_masked(result))
 
     def test_masked_input(self):
@@ -54,8 +54,22 @@ class Test(tests.IrisTest):
         # Non-masked array is returned as-is, without copying.
         self.assertIs(result, unmasked_array)
 
+    def test_unmasked_ints_input(self):
+        unmasked_array = np.array([1, 2])
+        result = array_masked_to_nans(unmasked_array)
+        # Non-masked array is returned as-is, without copying.
+        self.assertIs(result, unmasked_array)
+
     def test_empty_mask(self):
         masked_array = ma.masked_array([1.0, 2.0], mask=[0, 0])
+
+        result = array_masked_to_nans(masked_array)
+
+        self._common_checks(result)
+        self.assertArrayAllClose(result, masked_array.data)
+
+    def test_no_mask(self):
+        masked_array = ma.masked_array([1.0, 2.0], mask=ma.nomask)
 
         result = array_masked_to_nans(masked_array)
 

--- a/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
+++ b/lib/iris/tests/unit/lazy_data/test_array_masked_to_nans.py
@@ -89,12 +89,13 @@ class Test(tests.IrisTest):
         self.assertIs(result, unmasked_array)
 
     def test_no_mask__integers(self):
-        masked_array = ma.masked_array([1, 2], mask=ma.nomask)
+        datatype = np.dtype('i4')
+        masked_array = ma.masked_array([1, 2], dtype=datatype, mask=ma.nomask)
 
         result = array_masked_to_nans(masked_array)
 
         self._common_checks(result)
-        self.assertEqual(result.dtype, np.dtype('f8'))
+        self.assertEqual(result.dtype, datatype)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think that `array_masked_to_nans` should _always_ return a `numpy.ndarray` and not a `ma.core.masked_array` as used to happen. This means we don't have to call `data = data.data` after every time we use `array_masked_to_nans` in Iris code.

I've also removed the optional `mask` argument from `array_masked_to_nans` as it was only used once and ran the risk of confusing the usage of the function. At its worst, it would have been possible to pass a masked array and an unmatched mask, at which point the function would have returned an array that was not completely filled with `nan`s.