### PR TITLE
CML cube file_value and dtype refactor.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1624,15 +1624,29 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     @property
     def dtype(self):
-        if self._dtype is None:
-            result = self.core_data.dtype
-        else:
-            result = self._dtype
-        return result
+        dtype = self._dtype
+        if dtype is None:
+            dtype = self.core_data.dtype
+        return dtype
 
     @dtype.setter
     def dtype(self, dtype):
         self._dtype = dtype
+
+    @property
+    def fill_value(self):
+        fill_value = self._fill_value
+        if fill_value is not None:
+            try:
+                fill_value = np.asarray([self._fill_value],
+                                        dtype=self.dtype)[0]
+            except OverflowError:
+                fill_value = None
+        return fill_value
+
+    @fill_value.setter
+    def fill_value(self, fill_value):
+        self._fill_value = fill_value
 
     @property
     def ndim(self):
@@ -2892,6 +2906,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if self.var_name:
             cube_xml_element.setAttribute('var_name', self.var_name)
         cube_xml_element.setAttribute('units', str(self.units))
+        if self.fill_value is not None:
+            cube_xml_element.setAttribute('fill_value', str(self.fill_value))
+        cube_xml_element.setAttribute('dtype', self.dtype.name)
 
         if self.attributes:
             attributes_element = doc.createElement('attributes')
@@ -2970,8 +2987,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 else:
                     crc = 'no-masked-elements'
                 data_xml_element.setAttribute("mask_checksum", crc)
-                data_xml_element.setAttribute('fill_value',
-                                              str(data.fill_value))
             else:
                 crc = '0x%08x' % (zlib.crc32(normalise(data)) & 0xffffffff, )
                 data_xml_element.setAttribute("checksum", crc)

--- a/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
+++ b/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -523,7 +523,7 @@
     <cellMethods/>
     <data checksum="0x9554cc14" dtype="float32" shape="(6, 10, 83, 83)"/>
   </cube>
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1046,7 +1046,7 @@
     <cellMethods/>
     <data checksum="0xd9d57b21" dtype="float32" shape="(6, 10, 83, 83)"/>
   </cube>
-  <cube standard_name="surface_altitude" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/air_temperature_1.cml
+++ b/lib/iris/tests/results/FF/air_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/air_temperature_2.cml
+++ b/lib/iris/tests/results/FF/air_temperature_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/soil_temperature_1.cml
+++ b/lib/iris/tests/results/FF/soil_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="soil_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -44,6 +44,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x6d6010c1" dtype="float32" fill_value="-1.07374e+09" mask_checksum="0xd796e332" shape="(73, 96)"/>
+    <data checksum="0x6d6010c1" dtype="float32" mask_checksum="0xd796e332" shape="(73, 96)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/FF/surface_altitude_1.cml
+++ b/lib/iris/tests/results/FF/surface_altitude_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_altitude" units="m">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/abs.cml
+++ b/lib/iris/tests/results/analysis/abs.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition.cml
+++ b/lib/iris/tests/results/analysis/addition.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_coord_x.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_coord_y.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/addition_different_std_name.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_in_place.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_in_place_coord.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_scalar.cml
+++ b/lib/iris/tests/results/analysis/addition_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/easy.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/easy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float32" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="77a50eb5" points="[0.0, 0.0, 10.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/aggregated_by/multi.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_shared.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord bounds="[[19, 17],

--- a/lib/iris/tests/results/analysis/aggregated_by/single.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_rms.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_rms.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_shared.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_shared_circular.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_shared_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0.0, 0.0],

--- a/lib/iris/tests/results/analysis/apply_ifunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="squared temperature" units="kelvin^2">
+  <cube dtype="float32" fill_value="-1e+30" long_name="squared temperature" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_original.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="squared temperature" units="kelvin^2">
+  <cube dtype="float32" fill_value="-1e+30" long_name="squared temperature" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="unknown">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc_original.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/areaweights_original.cml
+++ b/lib/iris/tests/results/analysis/areaweights_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/count_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/count_bar_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/count_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/count_foo_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/count_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/count_foo_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0, 5],

--- a/lib/iris/tests/results/analysis/count_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/count_foo_bar_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/division.cml
+++ b/lib/iris/tests/results/analysis/division.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" fill_value="-1e+30" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_array.cml
+++ b/lib/iris/tests/results/analysis/division_by_array.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_latitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="57.2957795130823 kelvin-radian^-1">
+  <cube dtype="float32" fill_value="-1e+30" units="57.2957795130823 kelvin-radian^-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_longitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="57.2957795130823 kelvin-radian^-1">
+  <cube dtype="float32" fill_value="-1e+30" units="57.2957795130823 kelvin-radian^-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_singular_coord.cml
+++ b/lib/iris/tests/results/analysis/division_by_singular_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_scalar.cml
+++ b/lib/iris/tests/results/analysis/division_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/exp.cml
+++ b/lib/iris/tests/results/analysis/exp.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float64" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0, 1],

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^4">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin^4">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0, 5],

--- a/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/first_quartile_foo_bar_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/circular_vs_non_circular.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/circular_vs_non_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <auxCoord id="0ca9496e" long_name="other" points="[10.0, 7.33333333333, 6.0]" shape="(3,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/circular_wrapping/positive
+++ b/lib/iris/tests/results/analysis/interpolation/linear/circular_wrapping/positive
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord circular="True" id="62e940e0" points="[-360, -315, -270, -225, -180, -135, -90, -45, 0,

--- a/lib/iris/tests/results/analysis/interpolation/linear/circular_wrapping/symmetric
+++ b/lib/iris/tests/results/analysis/interpolation/linear/circular_wrapping/symmetric
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord circular="True" id="62e940e0" points="[-360, -315, -270, -225, -180, -135, -90, -45, 0,

--- a/lib/iris/tests/results/analysis/interpolation/linear/dim_to_aux.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/dim_to_aux.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_casting_datatype.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_casting_datatype.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint1.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint2.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_linear_extrapolation_multipoint2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_nan_extrapolation.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_coord_nan_extrapolation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_coords.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_coords.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_coords_extrapolation.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_coords_extrapolation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points_circular.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_multiple_points_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ed8e5576" long_name="r" points="[0.1, 0.2, 0.3, 0.4, 0.5]" shape="(5,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_shared_axis.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_shared_axis.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/simple_single_point.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/simple_single_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="kelvin">
+  <cube dtype="float32" long_name="test 2d dimensional cube" units="kelvin">
     <coords>
       <coord>
         <auxCoord id="5d06ffff" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_0
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_0
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_1
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_1
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[1.0, 2.0, 3.0, 4.0]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_nan
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_nan
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_same
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_many_same
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_same_pt
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_same_pt
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_0
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_0
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_1
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_1
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord>
         <dimCoord id="77a50eb5" points="[1.0]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_nan
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_scalar_nan
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_0
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_0
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_1
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_1
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[1.0]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_nan
+++ b/lib/iris/tests/results/analysis/interpolation/linear/single_pt_to_single_pt_nan
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[90, 0, -90]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int64"/>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_notmasked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[90, 0, -90]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int64"/>

--- a/lib/iris/tests/results/analysis/log.cml
+++ b/lib/iris/tests/results/analysis/log.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="ln(re 1 kelvin)">
+  <cube dtype="float32" fill_value="-1e+30" units="ln(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log10.cml
+++ b/lib/iris/tests/results/analysis/log10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="lg(re 1 kelvin)">
+  <cube dtype="float32" fill_value="-1e+30" units="lg(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log2.cml
+++ b/lib/iris/tests/results/analysis/log2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="lb(re 1 kelvin)">
+  <cube dtype="float32" fill_value="-1e+30" units="lb(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/maths_original.cml
+++ b/lib/iris/tests/results/analysis/maths_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/multiply.cml
+++ b/lib/iris/tests/results/analysis/multiply.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/multiply_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/multiply_different_std_name.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/original.cml
+++ b/lib/iris/tests/results/analysis/original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/proportion_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/proportion_bar_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/proportion_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/proportion_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0, 5],

--- a/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/proportion_foo_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_bar_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_both_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_both_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_grid.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_grid.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_src.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_src.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_srcmissingmask.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_srcmissingmask.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_masked_altitude.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_masked_altitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_non_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_non_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_partial_overlap.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_partial_overlap.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_anon.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_anon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_both_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_both_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_grid.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_grid.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_src.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_src.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_srcmissingmask.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_srcmissingmask.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_masked_altitude.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_masked_altitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_non_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_non_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_partial_overlap.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_partial_overlap.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_anon.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_anon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/no_overlap.cml
+++ b/lib/iris/tests/results/analysis/regrid/no_overlap.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_weighted_2d.cml
+++ b/lib/iris/tests/results/analysis/rms_weighted_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0, 5],

--- a/lib/iris/tests/results/analysis/rolling_window/simple_latitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/simple_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[0.0, 5.0],
@@ -15,6 +15,6 @@
         <coord name="latitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x84da2750" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" shape="(2, 4)"/>
+    <data checksum="0x84da2750" dtype="float64" mask_checksum="no-masked-elements" shape="(2, 4)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/rolling_window/simple_longitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/simple_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[0.0, 5.0, 10.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float64"/>
@@ -16,6 +16,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x8d40e131" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" shape="(3, 3)"/>
+    <data checksum="0x8d40e131" dtype="float64" mask_checksum="no-masked-elements" shape="(3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/rolling_window/size_4_longitude.cml
+++ b/lib/iris/tests/results/analysis/rolling_window/size_4_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="kelvin">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[0.0, 5.0, 10.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float64"/>
@@ -14,6 +14,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x87d91555" dtype="float64" fill_value="1e+20" mask_checksum="no-masked-elements" shape="(3, 1)"/>
+    <data checksum="0x87d91555" dtype="float64" mask_checksum="no-masked-elements" shape="(3, 1)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/sqrt.cml
+++ b/lib/iris/tests/results/analysis/sqrt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin">
+  <cube dtype="float32" fill_value="-1e+30" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/subtract.cml
+++ b/lib/iris/tests/results/analysis/subtract.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_array.cml
+++ b/lib/iris/tests/results/analysis/subtract_array.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_x.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_y.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_scalar.cml
+++ b/lib/iris/tests/results/analysis/subtract_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube dtype="float32" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_weighted_1d.cml
+++ b/lib/iris/tests/results/analysis/sum_weighted_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/sum_weighted_2d.cml
+++ b/lib/iris/tests/results/analysis/sum_weighted_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/third_quartile_foo_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_lat.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test_data" units="1">
+  <cube dtype="float64" long_name="test_data" units="1">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="9010c8c9" long_name="dummy" points="[0.0, 1.0, 2.0]" shape="(3,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_latlon.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_latlon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test_data" units="1">
+  <cube dtype="float64" long_name="test_data" units="1">
     <coords>
       <coord>
         <auxCoord bounds="[[0.0, 2.0]]" id="9010c8c9" long_name="dummy" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_lon.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test_data" units="1">
+  <cube dtype="float64" long_name="test_data" units="1">
     <coords>
       <coord>
         <auxCoord bounds="[[0.0, 2.0]]" id="9010c8c9" long_name="dummy" points="[1.0]" shape="(1,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_original.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_source.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_source.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test_data" units="1">
+  <cube dtype="float32" long_name="test_data" units="1">
     <coords>
       <coord datadims="[1]">
         <auxCoord id="9010c8c9" long_name="dummy" points="[0.0, 1.0, 2.0]" shape="(3,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/categorisation/customcheck.cml
+++ b/lib/iris/tests/results/categorisation/customcheck.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test cube" units="metres">
+  <cube dtype="int32" long_name="test cube" units="metres">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="3cbe93e2" long_name="season_numbers" points="[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 0, 0, 0,

--- a/lib/iris/tests/results/categorisation/quickcheck.cml
+++ b/lib/iris/tests/results/categorisation/quickcheck.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test cube" units="metres">
+  <cube dtype="int32" long_name="test cube" units="metres">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="965fdc2b" long_name="my_day_of_month" points="[1, 28, 24, 23, 19, 16, 12, 9, 5, 1, 28, 25, 21,

--- a/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/test_simple_cube_intersection.cml
+++ b/lib/iris/tests/results/cdm/test_simple_cube_intersection.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="temperature" units="K">
+  <cube dtype="int32" long_name="temperature" units="K">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3c412707" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
@@ -19,7 +19,7 @@
     <cellMethods/>
     <data checksum="0xda82ec24" dtype="int32" shape="(5, 3)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="int32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3c412707" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/concatenate/concat_2x2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_bounds.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_bounds.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_x_y_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy_bounds.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_xy_bounds.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2x2d_aux_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2x2d_aux_y_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_x_y_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_y.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_2y2d_aux_y_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d_aux_y_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_3d_simple.cml
+++ b/lib/iris/tests/results/concatenate/concat_3d_simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[2]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4mix2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4x2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_4y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_9mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9mix2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_9x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9x2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_9y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_9y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_anonymous.cml
+++ b/lib/iris/tests/results/concatenate/concat_anonymous.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],
@@ -16,7 +16,7 @@
     <cellMethods/>
     <data checksum="0x4fc3cae2" dtype="float32" shape="(2, 4)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],
@@ -14,6 +14,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x60ea409e" dtype="float32" fill_value="1e+20" mask_checksum="0x8c31ad31" shape="(2, 4)"/>
+    <data checksum="0x60ea409e" dtype="float32" mask_checksum="0x8c31ad31" shape="(2, 4)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],
@@ -14,6 +14,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x5528b2e9" dtype="float32" fill_value="1e+20" mask_checksum="0x8c31ad31" shape="(4, 2)"/>
+    <data checksum="0x5528b2e9" dtype="float32" mask_checksum="0x8c31ad31" shape="(4, 2)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/concatenate/concat_masked_2y2d_int16.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2y2d_int16.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int16" fill_value="-37" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],
@@ -14,6 +14,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x9a0283b3" dtype="int16" fill_value="-37" mask_checksum="0x8c31ad31" shape="(4, 2)"/>
+    <data checksum="0x9a0283b3" dtype="int16" mask_checksum="0x8c31ad31" shape="(4, 2)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4mix2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4x2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_merged_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_merged_scalar_4y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4mix2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -21,7 +21,7 @@
     <cellMethods/>
     <data checksum="0xef17165b" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -42,7 +42,7 @@
     <cellMethods/>
     <data checksum="0x324b04c8" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -63,7 +63,7 @@
     <cellMethods/>
     <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4x2_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4x2_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -21,7 +21,7 @@
     <cellMethods/>
     <data checksum="0xef17165b" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -42,7 +42,7 @@
     <cellMethods/>
     <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -63,7 +63,7 @@
     <cellMethods/>
     <data checksum="0xecaf14ea" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_pre_merged_scalar_4y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -21,7 +21,7 @@
     <cellMethods/>
     <data checksum="0xef17165b" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -42,7 +42,7 @@
     <cellMethods/>
     <data checksum="0x50668cbb" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>
@@ -63,7 +63,7 @@
     <cellMethods/>
     <data checksum="0xecaf14ea" dtype="float32" shape="(2, 2, 2)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="ecc4ad5a" long_name="height" points="[10.0, 20.0]" shape="(2,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4mix2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4mix2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
@@ -27,7 +27,7 @@
     <cellMethods/>
     <data checksum="0x56451659" dtype="float32" shape="(4, 4)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4x2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4x2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
@@ -27,7 +27,7 @@
     <cellMethods/>
     <data checksum="0x56451659" dtype="float32" shape="(4, 4)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/concatenate/concat_scalar_4y2d_aux_xy.cml
+++ b/lib/iris/tests/results/concatenate/concat_scalar_4y2d_aux_xy.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[10.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>
@@ -27,7 +27,7 @@
     <cellMethods/>
     <data checksum="0xa905726d" dtype="float32" shape="(4, 4)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <auxCoord id="ecc4ad5a" long_name="height" points="[20.0]" shape="(1,)" units="Unit('m')" value_type="float32"/>

--- a/lib/iris/tests/results/constrained_load/all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="specific_humidity" units="kg kg-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -102,7 +102,7 @@
     </cellMethods>
     <data checksum="0x0f9c7d63" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -154,7 +154,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -53,7 +53,7 @@
     </cellMethods>
     <data checksum="0x152ab762" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube standard_name="specific_humidity" units="kg kg-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -106,7 +106,7 @@
     </cellMethods>
     <data checksum="0x38f24240" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -160,7 +160,7 @@
     </cellMethods>
     <data checksum="0x777b79f0" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/attribute_constraint.cml
+++ b/lib/iris/tests/results/constrained_load/attribute_constraint.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="my_attribute" value="foobar"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -191,7 +191,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="specific_humidity" units="kg kg-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -242,7 +242,7 @@
     </cellMethods>
     <data checksum="0x0f9c7d63" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -294,7 +294,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/coord_api/nd_bounds.cml
+++ b/lib/iris/tests/results/coord_api/nd_bounds.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int64" long_name="thingness" units="1">
     <coords>
       <coord>
         <auxCoord bounds="[[0, 60]]" id="434cbbd8" long_name="bar" points="[30.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_collapsed/latitude_longitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_longitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/latitude_longitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_longitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/latitude_model_level_number_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_model_level_number_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/latitude_model_level_number_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_model_level_number_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/latitude_time_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_time_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/latitude_time_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/latitude_time_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_latitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_latitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_latitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_latitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_model_level_number_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_model_level_number_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_model_level_number_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_model_level_number_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_time_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_time_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/longitude_time_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/longitude_time_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_latitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_latitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_latitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_latitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_longitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_longitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_longitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_longitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_time_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_time_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/model_level_number_time_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/model_level_number_time_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/original.cml
+++ b/lib/iris/tests/results/cube_collapsed/original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_latitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_latitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_latitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_latitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_longitude_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_longitude_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_longitude_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_longitude_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_model_level_number_dual_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_model_level_number_dual_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/time_model_level_number_single_stage.cml
+++ b/lib/iris/tests/results/cube_collapsed/time_model_level_number_single_stage.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/triple_collapse_lat_ml_pt.cml
+++ b/lib/iris/tests/results/cube_collapsed/triple_collapse_lat_ml_pt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_collapsed/triple_collapse_ml_pt_lon.cml
+++ b/lib/iris/tests/results/cube_collapsed/triple_collapse_ml_pt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/cube_io/pickling/cubelist.cml
+++ b/lib/iris/tests/results/cube_io/pickling/cubelist.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -516,7 +516,7 @@
     <cellMethods/>
     <data checksum="0x7a31dc88" dtype="float32" shape="(6, 70, 100, 100)"/>
   </cube>
-  <cube standard_name="surface_altitude" units="m">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pickling/single_cube.cml
+++ b/lib/iris/tests/results/cube_io/pickling/single_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pp/load/global.cml
+++ b/lib/iris/tests/results/cube_io/pp/load/global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_merge/multidim_coord_merge.cml
+++ b/lib/iris/tests/results/cube_merge/multidim_coord_merge.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord bounds="[[[0, 5],

--- a/lib/iris/tests/results/cube_merge/multidim_coord_merge_transpose.cml
+++ b/lib/iris/tests/results/cube_merge/multidim_coord_merge_transpose.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[2, 1]">
         <auxCoord bounds="[[[0, 5],

--- a/lib/iris/tests/results/cube_merge/test_orig_point_cube.cml
+++ b/lib/iris/tests/results/cube_merge/test_orig_point_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="434cbbd8" long_name="bar" points="[2.5, 7.5, 12.5]" shape="(3,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_merge/test_simple_attributes1.cml
+++ b/lib/iris/tests/results/cube_merge/test_simple_attributes1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <attributes>
       <attribute name="my_attr1" value="foo"/>
     </attributes>
@@ -18,7 +18,7 @@
     <cellMethods/>
     <data checksum="0xb6520b51" dtype="int32" shape="(3, 4)"/>
   </cube>
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="434cbbd8" long_name="bar" points="[2.5, 7.5, 12.5]" shape="(3,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_merge/test_simple_attributes2.cml
+++ b/lib/iris/tests/results/cube_merge/test_simple_attributes2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <attributes>
       <attribute name="my_attr1" value="foo"/>
     </attributes>
@@ -18,7 +18,7 @@
     <cellMethods/>
     <data checksum="0xb6520b51" dtype="int32" shape="(3, 4)"/>
   </cube>
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <attributes>
       <attribute name="my_attr1" value="bar"/>
     </attributes>

--- a/lib/iris/tests/results/cube_merge/test_simple_attributes3.cml
+++ b/lib/iris/tests/results/cube_merge/test_simple_attributes3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <attributes>
       <attribute name="my_attr1" value="foo"/>
     </attributes>

--- a/lib/iris/tests/results/cube_merge/test_simple_bound_merge.cml
+++ b/lib/iris/tests/results/cube_merge/test_simple_bound_merge.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[0, 5],

--- a/lib/iris/tests/results/cube_merge/test_simple_merge.cml
+++ b/lib/iris/tests/results/cube_merge/test_simple_merge.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="int32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="434cbbd8" long_name="bar" points="[2.5, 7.5, 12.5]" shape="(3,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_intersect_and_reverse.cml
+++ b/lib/iris/tests/results/cube_slice/2d_intersect_and_reverse.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_orig.cml
+++ b/lib/iris/tests/results/cube_slice/2d_orig.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_0d_cube_slice.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_0d_cube_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice2.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice3.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_1d_cube_multi_slice3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_1d_cube_slice.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_1d_cube_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_to_2d_revesed.cml
+++ b/lib/iris/tests/results/cube_slice/2d_to_2d_revesed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/2d_transposed.cml
+++ b/lib/iris/tests/results/cube_slice/2d_transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="test 2d dimensional cube" units="meters">
+  <cube dtype="int32" long_name="test 2d dimensional cube" units="meters">
     <coords>
       <coord>
         <auxCoord id="da892976" long_name="an_other" points="[3.0]" shape="(1,)" units="Unit('meters')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
+++ b/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_to_pp/no_forecast_period.cml
+++ b/lib/iris/tests/results/cube_to_pp/no_forecast_period.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int32" units="unknown">
     <coords>
       <coord>
         <dimCoord id="f78ece3e" points="[2.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('weeks since 2013-05-07', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/cube_to_pp/no_forecast_time.cml
+++ b/lib/iris/tests/results/cube_to_pp/no_forecast_time.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-1, 0, 1]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/derived/column.cml
+++ b/lib/iris/tests/results/derived/column.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/derived/no_orog.cml
+++ b/lib/iris/tests/results/derived/no_orog.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/derived/removed_orog.cml
+++ b/lib/iris/tests/results/derived/removed_orog.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/derived/removed_sigma.cml
+++ b/lib/iris/tests/results/derived/removed_sigma.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/derived/transposed.cml
+++ b/lib/iris/tests/results/derived/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/basic_orthogonal_cube.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/basic_orthogonal_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord id="434cbbd8" long_name="bar" points="[[2.5, 7.5],

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_1d_squashed.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_1d_squashed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0, 1]">
         <auxCoord id="434cbbd8" long_name="bar" points="[[2.5, 7.5],

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_1d_squashed_2.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_1d_squashed_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0, 1]">
         <auxCoord id="434cbbd8" long_name="bar" points="[[2.5, 7.5],

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float64" standard_name="air_temperature" units="K">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord id="9041e969" points="[[-660.0, -610.0, -560.0, -510.0, -460.0, -410.0],
@@ -35,6 +35,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x679c96e1" dtype="float64" fill_value="1e+20" mask_checksum="0xc8092ec8" shape="(3, 4, 6)"/>
+    <data checksum="0x679c96e1" dtype="float64" mask_checksum="0xc8092ec8" shape="(3, 4, 6)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0, 1]">
         <auxCoord bounds="[[[0, 5],

--- a/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd_2_coords.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd_2_coords.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord>
         <auxCoord id="434cbbd8" long_name="bar" points="[25.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd_with_extrapolation.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/linear_nd_with_extrapolation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="thingness" units="1">
+  <cube dtype="float32" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0, 1]">
         <auxCoord bounds="[[[0, 5],

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="processing" value="fast-ff"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple_callback.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple_callback.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="processing" value="fast-pp"/>

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/const_lat_cross_section.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/const_lat_cross_section.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/const_lon_cross_section.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/const_lon_cross_section.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/higher.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/higher.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-0.99999, -0.699992],

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/hybridheight.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/hybridheight.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/latlonreduced.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/latlonreduced.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-1.0, 1.0],

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/lonhalved.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/lonhalved.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-0.99999, 3.33333333324e-06],

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/lower.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/lower.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-0.99999, 0.5],

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/simple.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord bounds="[[-1.0, 0.0],

--- a/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/trasposed.cml
+++ b/lib/iris/tests/results/experimental/regrid/regrid_area_weighted_rectilinear_src_and_grid/trasposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord>
         <dimCoord bounds="[[-1.0, 2.0]]" id="77a50eb5" points="[-1]" shape="(1,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/file_load/theta_levels.cml
+++ b/lib/iris/tests/results/file_load/theta_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x17763b08" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -102,7 +102,7 @@
     </cellMethods>
     <data checksum="0xc185be42" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -153,7 +153,7 @@
     </cellMethods>
     <data checksum="0xe65750bc" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -204,7 +204,7 @@
     </cellMethods>
     <data checksum="0x816283f9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -255,7 +255,7 @@
     </cellMethods>
     <data checksum="0x56b85efa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -306,7 +306,7 @@
     </cellMethods>
     <data checksum="0xe96a203f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -357,7 +357,7 @@
     </cellMethods>
     <data checksum="0xce07f637" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -408,7 +408,7 @@
     </cellMethods>
     <data checksum="0x1cfc905c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -459,7 +459,7 @@
     </cellMethods>
     <data checksum="0xe239fdec" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -510,7 +510,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -561,7 +561,7 @@
     </cellMethods>
     <data checksum="0xb12f6572" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -612,7 +612,7 @@
     </cellMethods>
     <data checksum="0x0e3c5965" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -663,7 +663,7 @@
     </cellMethods>
     <data checksum="0x6347d5bd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -714,7 +714,7 @@
     </cellMethods>
     <data checksum="0x77273f7e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -765,7 +765,7 @@
     </cellMethods>
     <data checksum="0x4bd3a5eb" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -816,7 +816,7 @@
     </cellMethods>
     <data checksum="0x129ae43d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -867,7 +867,7 @@
     </cellMethods>
     <data checksum="0x10f0c12e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -918,7 +918,7 @@
     </cellMethods>
     <data checksum="0x2bb76c16" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -969,7 +969,7 @@
     </cellMethods>
     <data checksum="0xf5b26d1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1020,7 +1020,7 @@
     </cellMethods>
     <data checksum="0x9b8c7031" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1071,7 +1071,7 @@
     </cellMethods>
     <data checksum="0xc310cc9a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1122,7 +1122,7 @@
     </cellMethods>
     <data checksum="0xb41fa10f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1173,7 +1173,7 @@
     </cellMethods>
     <data checksum="0xefab27e4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1224,7 +1224,7 @@
     </cellMethods>
     <data checksum="0x946cabe8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1275,7 +1275,7 @@
     </cellMethods>
     <data checksum="0x5998cbc6" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1326,7 +1326,7 @@
     </cellMethods>
     <data checksum="0xb0a6552e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1377,7 +1377,7 @@
     </cellMethods>
     <data checksum="0xab0a810b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1428,7 +1428,7 @@
     </cellMethods>
     <data checksum="0x9ab0fdd8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1479,7 +1479,7 @@
     </cellMethods>
     <data checksum="0x34f06e6a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1530,7 +1530,7 @@
     </cellMethods>
     <data checksum="0x47c31d91" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1581,7 +1581,7 @@
     </cellMethods>
     <data checksum="0x8569fd3f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1632,7 +1632,7 @@
     </cellMethods>
     <data checksum="0x3ace76f3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1683,7 +1683,7 @@
     </cellMethods>
     <data checksum="0xbc11c8a9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1734,7 +1734,7 @@
     </cellMethods>
     <data checksum="0xbf693c7d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1785,7 +1785,7 @@
     </cellMethods>
     <data checksum="0xc100ff09" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1836,7 +1836,7 @@
     </cellMethods>
     <data checksum="0x43595449" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1887,7 +1887,7 @@
     </cellMethods>
     <data checksum="0x377b59d4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/u_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/u_wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x127b39e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0x088c4545" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0xc896dcd3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0x3df23f98" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xa97d11dd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x24173b24" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0x16761c14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0xf6f56e25" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x57a3823b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0xc43c2a0b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x08bf7abd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x5870c1e0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x7cac5103" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0xcd2d62b1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x4e1b7ef5" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x104081c2" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0x392ef79f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xdf6dbef7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x871b4ee8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x3cee95b4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x76208cc7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xa0f56a0a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0xc5654966" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xde1441e7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xf70c5634" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xe2d29281" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0xcfe34b4d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0x4cb07673" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0x47c8d38a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x6c15a2c3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb922530c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0x5020a5d1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0xe308ebfa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x50f626b0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x19624929" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x4c54b2ff" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/v_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/v_wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x50e427ed" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0xa4593dbf" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0x00ff91f2" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0xa03492c0" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xc61368b3" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x9a20e5c6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0xfbcb2a96" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0x31c19cd4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x6b0cc25a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0x31d04486" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0x7e2cc5b6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x26741d4b" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x2c2d97dd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x6a294180" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0x92eb6ab4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x39456c40" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x4963cfd6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0xe81e8be7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xfb9b0ed6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x2057f49e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x9bb6020a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x05970b5d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xb013389c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0x208fa829" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xe2582bbd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xb964b7d7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xc8a5b95e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0x4bd4eae9" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0xe0549b09" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0xf6e3546d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x5525ab2a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb48c5eb1" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0xcfb28f0d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0x4290df26" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x82c0d953" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x49202448" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x04b1c44c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/wind_levels.cml
+++ b/lib/iris/tests/results/file_load/wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x127b39e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0x088c4545" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0xc896dcd3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0x3df23f98" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xa97d11dd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x24173b24" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0x16761c14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0xf6f56e25" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x57a3823b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0xc43c2a0b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x08bf7abd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x5870c1e0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x7cac5103" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0xcd2d62b1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x4e1b7ef5" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x104081c2" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0x392ef79f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xdf6dbef7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x871b4ee8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x3cee95b4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x76208cc7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xa0f56a0a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0xc5654966" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xde1441e7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xf70c5634" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xe2d29281" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0xcfe34b4d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0x4cb07673" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0x47c8d38a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x6c15a2c3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb922530c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0x5020a5d1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0xe308ebfa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x50f626b0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x19624929" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x4c54b2ff" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1976,7 +1976,7 @@
     </cellMethods>
     <data checksum="0x4cd24d81" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2028,7 +2028,7 @@
     </cellMethods>
     <data checksum="0x50e427ed" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2080,7 +2080,7 @@
     </cellMethods>
     <data checksum="0xa4593dbf" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2132,7 +2132,7 @@
     </cellMethods>
     <data checksum="0x00ff91f2" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2184,7 +2184,7 @@
     </cellMethods>
     <data checksum="0xa03492c0" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2236,7 +2236,7 @@
     </cellMethods>
     <data checksum="0xc61368b3" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2288,7 +2288,7 @@
     </cellMethods>
     <data checksum="0x9a20e5c6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2340,7 +2340,7 @@
     </cellMethods>
     <data checksum="0xfbcb2a96" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2392,7 +2392,7 @@
     </cellMethods>
     <data checksum="0x31c19cd4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2444,7 +2444,7 @@
     </cellMethods>
     <data checksum="0x6b0cc25a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2496,7 +2496,7 @@
     </cellMethods>
     <data checksum="0x31d04486" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2548,7 +2548,7 @@
     </cellMethods>
     <data checksum="0x7e2cc5b6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2600,7 +2600,7 @@
     </cellMethods>
     <data checksum="0x26741d4b" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2652,7 +2652,7 @@
     </cellMethods>
     <data checksum="0x2c2d97dd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2704,7 +2704,7 @@
     </cellMethods>
     <data checksum="0x6a294180" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2756,7 +2756,7 @@
     </cellMethods>
     <data checksum="0x92eb6ab4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2808,7 +2808,7 @@
     </cellMethods>
     <data checksum="0x39456c40" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2860,7 +2860,7 @@
     </cellMethods>
     <data checksum="0x4963cfd6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2912,7 +2912,7 @@
     </cellMethods>
     <data checksum="0xe81e8be7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2964,7 +2964,7 @@
     </cellMethods>
     <data checksum="0xfb9b0ed6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3016,7 +3016,7 @@
     </cellMethods>
     <data checksum="0x2057f49e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3068,7 +3068,7 @@
     </cellMethods>
     <data checksum="0x9bb6020a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3120,7 +3120,7 @@
     </cellMethods>
     <data checksum="0x05970b5d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3172,7 +3172,7 @@
     </cellMethods>
     <data checksum="0xb013389c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3224,7 +3224,7 @@
     </cellMethods>
     <data checksum="0x208fa829" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3276,7 +3276,7 @@
     </cellMethods>
     <data checksum="0xe2582bbd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3328,7 +3328,7 @@
     </cellMethods>
     <data checksum="0xb964b7d7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3380,7 +3380,7 @@
     </cellMethods>
     <data checksum="0xc8a5b95e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3432,7 +3432,7 @@
     </cellMethods>
     <data checksum="0x4bd4eae9" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3484,7 +3484,7 @@
     </cellMethods>
     <data checksum="0xe0549b09" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3536,7 +3536,7 @@
     </cellMethods>
     <data checksum="0xf6e3546d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3588,7 +3588,7 @@
     </cellMethods>
     <data checksum="0x5525ab2a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3640,7 +3640,7 @@
     </cellMethods>
     <data checksum="0xb48c5eb1" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3692,7 +3692,7 @@
     </cellMethods>
     <data checksum="0xcfb28f0d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3744,7 +3744,7 @@
     </cellMethods>
     <data checksum="0x4290df26" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3796,7 +3796,7 @@
     </cellMethods>
     <data checksum="0x82c0d953" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3848,7 +3848,7 @@
     </cellMethods>
     <data checksum="0x49202448" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3900,7 +3900,7 @@
     </cellMethods>
     <data checksum="0x04b1c44c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
+++ b/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="cube" value="hh1"/>
@@ -64,7 +64,7 @@
     <cellMethods/>
     <data checksum="0x2acdccca" dtype="int64" shape="(3, 4, 5, 6)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature_0">
+  <cube dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature_0">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="cube" value="hh2"/>

--- a/lib/iris/tests/results/iterate/izip_nd_ortho.cml
+++ b/lib/iris/tests/results/iterate/izip_nd_ortho.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -23,7 +23,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -46,7 +46,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -69,7 +69,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -92,7 +92,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -115,7 +115,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -138,7 +138,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -161,7 +161,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -184,7 +184,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],
@@ -207,7 +207,7 @@
     <cellMethods/>
     <data checksum="0xd8e50ea8" dtype="float64" shape="(5, 5, 5, 5)"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[2, 3]">
         <auxCoord id="78a0dfe8" long_name="x" points="[[0, 1, 2, 3, 4],

--- a/lib/iris/tests/results/merge/a_aux_b_aux.cml
+++ b/lib/iris/tests/results/merge/a_aux_b_aux.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/a_aux_b_dim.cml
+++ b/lib/iris/tests/results/merge/a_aux_b_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/a_dim_b_aux.cml
+++ b/lib/iris/tests/results/merge/a_dim_b_aux.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/a_dim_b_dim.cml
+++ b/lib/iris/tests/results/merge/a_dim_b_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/dec.cml
+++ b/lib/iris/tests/results/merge/dec.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="specific_humidity" units="kg kg-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -280,7 +280,7 @@
     </cellMethods>
     <data checksum="0x28056617" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="x_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -421,7 +421,7 @@
     </cellMethods>
     <data checksum="0xe099eee0" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube standard_name="y_wind" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/multi_split.cml
+++ b/lib/iris/tests/results/merge/multi_split.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0, 1, 2]" shape="(3,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/separable_combination.cml
+++ b/lib/iris/tests/results/merge/separable_combination.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="78c32bc2" long_name="a" points="[2005, 2005, 2005, 2026, 2026, 2026, 2002, 2002,

--- a/lib/iris/tests/results/merge/single_split.cml
+++ b/lib/iris/tests/results/merge/single_split.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0, 1, 2]" shape="(3,)" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/string_a_b.cml
+++ b/lib/iris/tests/results/merge/string_a_b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>

--- a/lib/iris/tests/results/merge/string_a_with_aux.cml
+++ b/lib/iris/tests/results/merge/string_a_with_aux.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>

--- a/lib/iris/tests/results/merge/string_a_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_a_with_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="78c32bc2" long_name="a" points="[a, b, c, d]" shape="(4,)" units="Unit('1')" value_type="string"/>

--- a/lib/iris/tests/results/merge/string_b_with_dim.cml
+++ b/lib/iris/tests/results/merge/string_b_with_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="78c32bc2" long_name="a" points="[0.0, 1.0, 2.0, 3.0]" shape="(4,)" units="Unit('1')" value_type="float32"/>

--- a/lib/iris/tests/results/merge/theta.cml
+++ b/lib/iris/tests/results/merge/theta.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/theta_two_times.cml
+++ b/lib/iris/tests/results/merge/theta_two_times.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/time_triple_duplicate_data.cml
+++ b/lib/iris/tests/results/merge/time_triple_duplicate_data.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="75879334" points="[0, 1]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>
@@ -21,7 +21,7 @@
     <cellMethods/>
     <data dtype="float32" shape="(2, 4, 5)" state="loaded"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="75879334" points="[0, 1]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_independent.cml
+++ b/lib/iris/tests/results/merge/time_triple_independent.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="75879334" points="[0, 1]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_merging1.cml
+++ b/lib/iris/tests/results/merge/time_triple_merging1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="75879334" points="[0, 1, 2]" shape="(3,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_merging2.cml
+++ b/lib/iris/tests/results/merge/time_triple_merging2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="75879334" points="[0, 1, 2]" shape="(3,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_merging3.cml
+++ b/lib/iris/tests/results/merge/time_triple_merging3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="75879334" points="[0, 1, 2, 0, 1]" shape="(5,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_merging4.cml
+++ b/lib/iris/tests/results/merge/time_triple_merging4.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="75879334" points="[0, 1]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_merging5.cml
+++ b/lib/iris/tests/results/merge/time_triple_merging5.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="75879334" points="[0, 0, 0, 1, 1]" shape="(5,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_non_expanding.cml
+++ b/lib/iris/tests/results/merge/time_triple_non_expanding.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord>
         <dimCoord id="75879334" points="[0]" shape="(1,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_series.cml
+++ b/lib/iris/tests/results/merge/time_triple_series.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="75879334" points="[0, 0, 0, 1, 2]" shape="(5,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_single_forecast.cml
+++ b/lib/iris/tests/results/merge/time_triple_single_forecast.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="75879334" points="[0, 1, 2, 3]" shape="(4,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_successive_forecasts.cml
+++ b/lib/iris/tests/results/merge/time_triple_successive_forecasts.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="75879334" points="[0, 1, 2, 3]" shape="(4,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_time_non_dim_coord.cml
+++ b/lib/iris/tests/results/merge/time_triple_time_non_dim_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="75879334" points="[5, 10]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_time_vs_forecast.cml
+++ b/lib/iris/tests/results/merge/time_triple_time_vs_forecast.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="75879334" points="[0, 1, 2]" shape="(3,)" standard_name="forecast_period" units="Unit('1')" value_type="int32"/>

--- a/lib/iris/tests/results/merge/time_triple_time_vs_ref_time.cml
+++ b/lib/iris/tests/results/merge/time_triple_time_vs_ref_time.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" units="unknown">
     <coords>
       <coord datadims="[0, 1]">
         <auxCoord id="75879334" points="[[2, 1, 0],

--- a/lib/iris/tests/results/name/NAMEIII_field.cml
+++ b/lib/iris/tests/results/name/NAMEIII_field.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g s / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g s / m^3">
     <attributes>
       <attribute name="End of release" value="02/11/2009 21:00 UTC"/>
       <attribute name="Ensemble Av" value="No ensemble averaging"/>
@@ -61,7 +61,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
     <attributes>
       <attribute name="End of release" value="02/11/2009 21:00 UTC"/>
       <attribute name="Ensemble Av" value="No ensemble averaging"/>
@@ -122,7 +122,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_DRY_DEPOSITION" units="g / m^2">
+  <cube dtype="float32" long_name="TRACER_DRY_DEPOSITION" units="g / m^2">
     <attributes>
       <attribute name="End of release" value="02/11/2009 21:00 UTC"/>
       <attribute name="Ensemble Av" value="No ensemble averaging"/>
@@ -182,7 +182,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_WET_DEPOSITION" units="g / m^2">
+  <cube dtype="float32" long_name="TRACER_WET_DEPOSITION" units="g / m^2">
     <attributes>
       <attribute name="End of release" value="02/11/2009 21:00 UTC"/>
       <attribute name="Ensemble Av" value="No ensemble averaging"/>
@@ -242,7 +242,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_DEPOSITION" units="g / m^2">
+  <cube dtype="float32" long_name="TRACER_DEPOSITION" units="g / m^2">
     <attributes>
       <attribute name="End of release" value="02/11/2009 21:00 UTC"/>
       <attribute name="Ensemble Av" value="No ensemble averaging"/>

--- a/lib/iris/tests/results/name/NAMEIII_timeseries.cml
+++ b/lib/iris/tests/results/name/NAMEIII_timeseries.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="CAESIUM-137_AIR_CONCENTRATION" units="Bq / m^3">
+  <cube dtype="float64" long_name="CAESIUM-137_AIR_CONCENTRATION" units="Bq / m^3">
     <attributes>
       <attribute name="End of release" value="17/11/2010 13:00 UTC"/>
       <attribute name="Ens Av" value="No ensemble averaging"/>
@@ -67,7 +67,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(72,)" state="loaded"/>
   </cube>
-  <cube long_name="CAESIUM-137_AIR_CONCENTRATION" units="Bq s / m^3">
+  <cube dtype="float64" long_name="CAESIUM-137_AIR_CONCENTRATION" units="Bq s / m^3">
     <attributes>
       <attribute name="End of release" value="17/11/2010 13:00 UTC"/>
       <attribute name="Ens Av" value="No ensemble averaging"/>
@@ -134,7 +134,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(72,)" state="loaded"/>
   </cube>
-  <cube long_name="CAESIUM-137_DRY_DEPOSITION_RATE" units="Bq / (m^2 s)">
+  <cube dtype="float64" long_name="CAESIUM-137_DRY_DEPOSITION_RATE" units="Bq / (m^2 s)">
     <attributes>
       <attribute name="End of release" value="17/11/2010 13:00 UTC"/>
       <attribute name="Ens Av" value="No ensemble averaging"/>
@@ -200,7 +200,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(72,)" state="loaded"/>
   </cube>
-  <cube long_name="CAESIUM-137_WET_DEPOSITION_RATE" units="Bq / (m^2 s)">
+  <cube dtype="float64" long_name="CAESIUM-137_WET_DEPOSITION_RATE" units="Bq / (m^2 s)">
     <attributes>
       <attribute name="End of release" value="17/11/2010 13:00 UTC"/>
       <attribute name="Ens Av" value="No ensemble averaging"/>
@@ -266,7 +266,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(72,)" state="loaded"/>
   </cube>
-  <cube long_name="CAESIUM-137_DEPOSITION_RATE" units="Bq / (m^2 s)">
+  <cube dtype="float64" long_name="CAESIUM-137_DEPOSITION_RATE" units="Bq / (m^2 s)">
     <attributes>
       <attribute name="End of release" value="17/11/2010 13:00 UTC"/>
       <attribute name="Ens Av" value="No ensemble averaging"/>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="U Turb" units="unknown">
+  <cube dtype="float64" long_name="U Turb" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -38,7 +38,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="V Turb" units="unknown">
+  <cube dtype="float64" long_name="V Turb" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -76,7 +76,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="W Turb" units="unknown">
+  <cube dtype="float64" long_name="W Turb" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -114,7 +114,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="U Ambient" units="unknown">
+  <cube dtype="float64" long_name="U Ambient" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -152,7 +152,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="V Ambient" units="unknown">
+  <cube dtype="float64" long_name="V Ambient" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -190,7 +190,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="W Ambient" units="unknown">
+  <cube dtype="float64" long_name="W Ambient" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -228,7 +228,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Sigma UU" units="unknown">
+  <cube dtype="float64" long_name="Sigma UU" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -266,7 +266,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Sigma VV" units="unknown">
+  <cube dtype="float64" long_name="Sigma VV" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -304,7 +304,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Sigma WW" units="unknown">
+  <cube dtype="float64" long_name="Sigma WW" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -342,7 +342,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Temperature" units="unknown">
+  <cube dtype="float64" long_name="Temperature" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -380,7 +380,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Pressure" units="unknown">
+  <cube dtype="float64" long_name="Pressure" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -418,7 +418,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Potential Temp" units="unknown">
+  <cube dtype="float64" long_name="Potential Temp" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -456,7 +456,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="BL Depth" units="unknown">
+  <cube dtype="float64" long_name="BL Depth" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -494,7 +494,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Cloud (oktas)" units="unknown">
+  <cube dtype="float64" long_name="Cloud (oktas)" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -532,7 +532,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Rel Humidity" units="unknown">
+  <cube dtype="float64" long_name="Rel Humidity" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -570,7 +570,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Wind Speed" units="unknown">
+  <cube dtype="float64" long_name="Wind Speed" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>
@@ -608,7 +608,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(836,)" state="loaded"/>
   </cube>
-  <cube long_name="Wind Direction" units="unknown">
+  <cube dtype="float64" long_name="Wind Direction" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>

--- a/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
+++ b/lib/iris/tests/results/name/NAMEIII_trajectory0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="U Turb" units="unknown">
+  <cube dtype="float64" long_name="U Turb" units="unknown">
     <coords>
       <coord>
         <dimCoord id="a98d134c" long_name="PP Index" points="[1.0]" shape="(1,)" units="Unit('unknown')" value_type="float64"/>

--- a/lib/iris/tests/results/name/NAMEIII_version2.cml
+++ b/lib/iris/tests/results/name/NAMEIII_version2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
     <attributes>
       <attribute name="End of release" value="19/12/2015 06:00 UTC"/>
       <attribute name="Ensemble av info" value="No ensemble averaging"/>
@@ -82,7 +82,7 @@
     <cellMethods/>
     <data dtype="float32" shape="(24, 10)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
     <attributes>
       <attribute name="End of release" value="19/12/2015 06:00 UTC"/>
       <attribute name="Ensemble av info" value="No ensemble averaging"/>
@@ -164,7 +164,7 @@
     <cellMethods/>
     <data dtype="float32" shape="(24, 10)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
     <attributes>
       <attribute name="End of release" value="19/12/2015 06:00 UTC"/>
       <attribute name="Ensemble av info" value="No ensemble averaging"/>
@@ -246,7 +246,7 @@
     <cellMethods/>
     <data dtype="float32" shape="(24, 10)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g / m^3">
     <attributes>
       <attribute name="End of release" value="19/12/2015 06:00 UTC"/>
       <attribute name="Ensemble av info" value="No ensemble averaging"/>

--- a/lib/iris/tests/results/name/NAMEII_field.cml
+++ b/lib/iris/tests/results/name/NAMEII_field.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="TRACER_AIR_CONCENTRATION" units="g/m3">
+  <cube dtype="float32" long_name="TRACER_AIR_CONCENTRATION" units="g/m3">
     <attributes>
       <attribute name="End of release" value="1200UTC 26/01/2010"/>
       <attribute name="Forecast duration" value="3 hours"/>
@@ -57,7 +57,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_DOSAGE" units="g s/m3">
+  <cube dtype="float32" long_name="TRACER_DOSAGE" units="g s/m3">
     <attributes>
       <attribute name="End of release" value="1200UTC 26/01/2010"/>
       <attribute name="Forecast duration" value="3 hours"/>
@@ -114,7 +114,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_WET_DEPOSITION" units="g/m2">
+  <cube dtype="float32" long_name="TRACER_WET_DEPOSITION" units="g/m2">
     <attributes>
       <attribute name="End of release" value="1200UTC 26/01/2010"/>
       <attribute name="Forecast duration" value="3 hours"/>
@@ -171,7 +171,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_DRY_DEPOSITION" units="g/m2">
+  <cube dtype="float32" long_name="TRACER_DRY_DEPOSITION" units="g/m2">
     <attributes>
       <attribute name="End of release" value="1200UTC 26/01/2010"/>
       <attribute name="Forecast duration" value="3 hours"/>
@@ -228,7 +228,7 @@
     </cellMethods>
     <data dtype="float32" shape="(200, 200)" state="loaded"/>
   </cube>
-  <cube long_name="TRACER_TOTAL_DEPOSITION" units="g/m2">
+  <cube dtype="float32" long_name="TRACER_TOTAL_DEPOSITION" units="g/m2">
     <attributes>
       <attribute name="End of release" value="1200UTC 26/01/2010"/>
       <attribute name="Forecast duration" value="3 hours"/>

--- a/lib/iris/tests/results/name/NAMEII_timeseries.cml
+++ b/lib/iris/tests/results/name/NAMEII_timeseries.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="VOLCANIC_ASH_AIR_CONCENTRATION" units="g/m3">
+  <cube dtype="float64" long_name="VOLCANIC_ASH_AIR_CONCENTRATION" units="g/m3">
     <attributes>
       <attribute name="End of release" value="0830UTC 28/03/2022"/>
       <attribute name="Forecast duration" value="87648 hours"/>
@@ -45,7 +45,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(132,)" state="loaded"/>
   </cube>
-  <cube long_name="VOLCANIC_ASH_AIR_CONCENTRATION" units="g/m3">
+  <cube dtype="float64" long_name="VOLCANIC_ASH_AIR_CONCENTRATION" units="g/m3">
     <attributes>
       <attribute name="End of release" value="0830UTC 28/03/2022"/>
       <attribute name="Forecast duration" value="87648 hours"/>

--- a/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="float64" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/int64_data_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_data_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="float64" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="cube_axes_0" units="1" var_name="cube_axes_0">
+  <cube dtype="int32" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -18,9 +18,9 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_1" units="1" var_name="cube_axes_1">
+  <cube dtype="int32" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -39,9 +39,9 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_2" units="1" var_name="cube_axes_2">
+  <cube dtype="int32" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -64,9 +64,9 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_3" units="1" var_name="cube_axes_3">
+  <cube dtype="int32" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -87,9 +87,9 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_axes_4" units="1" var_name="cube_axes_4">
+  <cube dtype="int32" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -110,9 +110,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_0" units="1" var_name="cube_comment_0">
+  <cube dtype="int32" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -129,9 +129,9 @@
         <coord comment="this is a time comment" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_1" units="1" var_name="cube_comment_1">
+  <cube dtype="int32" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -148,9 +148,9 @@
         <coord comment="this is a time comment" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_2" units="1" var_name="cube_comment_2">
+  <cube dtype="int32" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -168,9 +168,9 @@
         <coord comment="this is a shared comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_3" units="1" var_name="cube_comment_3">
+  <cube dtype="int32" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -188,9 +188,9 @@
         <coord comment="this is a lon comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_comment_4" units="1" var_name="cube_comment_4">
+  <cube dtype="int32" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -211,9 +211,9 @@
         <coord comment="this is a shared comment" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_0" units="1" var_name="cube_interval_0">
+  <cube dtype="int32" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -230,9 +230,9 @@
         <coord interval="1 day" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_1" units="1" var_name="cube_interval_1">
+  <cube dtype="int32" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -250,9 +250,9 @@
         <coord interval="0.1 degrees" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_2" units="1" var_name="cube_interval_2">
+  <cube dtype="int32" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -270,9 +270,9 @@
         <coord interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_3" units="1" var_name="cube_interval_3">
+  <cube dtype="int32" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -293,9 +293,9 @@
         <coord interval="0.1 degrees" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_interval_4" units="1" var_name="cube_interval_4">
+  <cube dtype="int32" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -318,9 +318,9 @@
         <coord interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_maximum" units="1" var_name="cube_maximum">
+  <cube dtype="int32" long_name="cube_maximum" units="1" var_name="cube_maximum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -331,9 +331,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mean" units="1" var_name="cube_mean">
+  <cube dtype="int32" long_name="cube_mean" units="1" var_name="cube_mean">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -344,9 +344,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_median" units="1" var_name="cube_median">
+  <cube dtype="int32" long_name="cube_median" units="1" var_name="cube_median">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -357,9 +357,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mid_range" units="1" var_name="cube_mid_range">
+  <cube dtype="int32" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -370,9 +370,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_minimum" units="1" var_name="cube_minimum">
+  <cube dtype="int32" long_name="cube_minimum" units="1" var_name="cube_minimum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -383,9 +383,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_mix_0" units="1" var_name="cube_mix_0">
+  <cube dtype="int32" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -402,9 +402,9 @@
         <coord comment="daily mean time" interval="1 day" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mix_1" units="1" var_name="cube_mix_1">
+  <cube dtype="int32" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -422,9 +422,9 @@
         <coord comment="area-weighted" interval="0.2 degree_e" name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mix_2" units="1" var_name="cube_mix_2">
+  <cube dtype="int32" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -445,9 +445,9 @@
         <coord comment="weekly sum" interval="7 days" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xecbb4b55" dtype="int32" fill_value="-2147483647" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
+    <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube long_name="cube_mode" units="1" var_name="cube_mode">
+  <cube dtype="int32" long_name="cube_mode" units="1" var_name="cube_mode">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -458,9 +458,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_point" units="1" var_name="cube_point">
+  <cube dtype="int32" long_name="cube_point" units="1" var_name="cube_point">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -471,9 +471,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
+  <cube dtype="int32" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -484,9 +484,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_sum" units="1" var_name="cube_sum">
+  <cube dtype="int32" long_name="cube_sum" units="1" var_name="cube_sum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -497,9 +497,9 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube long_name="cube_variance" units="1" var_name="cube_variance">
+  <cube dtype="int32" long_name="cube_variance" units="1" var_name="cube_variance">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -510,6 +510,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2144df1c" dtype="int32" fill_value="-2147483647" mask_checksum="0xa505df1b" shape="(1,)"/>
+    <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Zonal Surface Wind Speed" standard_name="eastward_wind" units="m s-1" var_name="uas">
+  <cube dtype="float32" fill_value="1e+20" long_name="Zonal Surface Wind Speed" standard_name="eastward_wind" units="m s-1" var_name="uas">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="cmor_version" value="0.96"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
@@ -26,7 +26,7 @@
     <cellMethods/>
     <data checksum="0x65252ed2" dtype="float64" shape="(1, 60, 181, 360)"/>
   </cube>
-  <cube long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
@@ -50,6 +50,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xc613a1f2" dtype="float64" fill_value="-32767.0" mask_checksum="0x5f099d34" shape="(1, 60, 181, 360)"/>
+    <data checksum="0xc613a1f2" dtype="float64" mask_checksum="0x5f099d34" shape="(1, 60, 181, 360)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
@@ -24,6 +24,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xc613a1f2" dtype="float64" fill_value="-32767.0" mask_checksum="0x5f099d34" shape="(1, 60, 181, 360)"/>
+    <data checksum="0xc613a1f2" dtype="float64" mask_checksum="0x5f099d34" shape="(1, 60, 181, 360)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_laea.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_laea.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i203"/>

--- a/lib/iris/tests/results/netcdf/netcdf_lcc.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_lcc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Daily Mean Near-Surface Air Temperature" standard_name="air_temperature" units="Celsius" var_name="tas">
+  <cube dtype="float64" fill_value="1e+20" long_name="Daily Mean Near-Surface Air Temperature" standard_name="air_temperature" units="Celsius" var_name="tas">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>
@@ -96,6 +96,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xe2560749" dtype="float64" fill_value="1e+20" mask_checksum="0x8cfaa70e" shape="(12, 60, 60)"/>
+    <data checksum="0xe2560749" dtype="float64" mask_checksum="0x8cfaa70e" shape="(12, 60, 60)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_merc.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_merc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
+  <cube dtype="float32" long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>

--- a/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
+  <cube dtype="float32" fill_value="1e+30" long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="NCO" value="4.1.0"/>

--- a/lib/iris/tests/results/netcdf/netcdf_stereo.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_stereo.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
+  <cube dtype="float32" fill_value="-1.07374e+09" long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>
@@ -70,6 +70,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xa4b27b3b" dtype="float32" fill_value="-1.07374e+09" mask_checksum="0xdb4fbb14" shape="(160, 256)"/>
+    <data checksum="0xa4b27b3b" dtype="float32" mask_checksum="0xdb4fbb14" shape="(160, 256)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Mean temperature" units="degrees_celsius" var_name="tmean">
+  <cube dtype="float32" fill_value="-9999.0" long_name="Mean temperature" units="degrees_celsius" var_name="tmean">
     <attributes>
       <attribute name="Conventions" value="CF-1.6"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>
@@ -73,6 +73,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x9f376918" dtype="float32" fill_value="-9999.0" mask_checksum="0xc0db3d4e" shape="(1, 290, 180)"/>
+    <data checksum="0x9f376918" dtype="float32" mask_checksum="0xc0db3d4e" shape="(1, 290, 180)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/netcdf/netcdf_units_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_units_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="kelvin" var_name="cube_0">
+  <cube dtype="int32" standard_name="air_temperature" units="kelvin" var_name="cube_0">
     <coords>
       <coord>
         <dimCoord id="f1596e20" points="[100]" shape="(1,)" standard_name="height" units="Unit('meters')" value_type="int32" var_name="height"/>

--- a/lib/iris/tests/results/netcdf/netcdf_units_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_units_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="unknown" var_name="cube_1">
+  <cube dtype="int32" standard_name="air_temperature" units="unknown" var_name="cube_1">
     <attributes>
       <attribute name="invalid_units" value="kevin"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="float64" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/uint32_data_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_data_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="surface_temperature" units="K" var_name="temp">
+  <cube dtype="float64" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/nimrod/levels_below_ground.cml
+++ b/lib/iris/tests/results/nimrod/levels_below_ground.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord>
         <dimCoord id="8004d8b1" long_name="levels_below_ground" points="[42]" shape="(1,)" units="Unit('1')" value_type="int64">

--- a/lib/iris/tests/results/nimrod/load_2flds.cml
+++ b/lib/iris/tests/results/nimrod/load_2flds.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Visibility" units="unknown">
+  <cube dtype="int16" long_name="Visibility" units="unknown">
     <attributes>
       <attribute name="field_code" value="155"/>
       <attribute name="invalid_units" value="m/2-25k"/>

--- a/lib/iris/tests/results/nimrod/mockography.cml
+++ b/lib/iris/tests/results/nimrod/mockography.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="(MOCK) 2km mean orography" units="metres">
+  <cube dtype="int64" long_name="(MOCK) 2km mean orography" units="metres">
     <attributes>
       <attribute name="field_code" value="73"/>
       <attribute name="source" value="GLOBE DTM"/>

--- a/lib/iris/tests/results/nimrod/period_of_interest.cml
+++ b/lib/iris/tests/results/nimrod/period_of_interest.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord>
         <dimCoord bounds="[[379973.0, 379974.0]]" id="cb784457" points="[379974.0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='standard')" value_type="float64"/>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_datetime_gregorian.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_datetime_gregorian.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="d00b57c8" long_name="columns" points="[10, 11, 12, 13, 14]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(2, 5)"/>
+    <data checksum="0x5e85e4a4" dtype="int64" mask_checksum="no-masked-elements" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_masked.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="d00b57c8" long_name="columns" points="[12, 13, 14, 15, 16]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xd836458f" dtype="float64" fill_value="1e+20" mask_checksum="0xedea4d74" shape="(2, 5)"/>
+    <data checksum="0xd836458f" dtype="float64" mask_checksum="0xedea4d74" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_netcdftime_360.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_netcdftime_360.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="d00b57c8" long_name="columns" points="[10, 11, 12, 13, 14]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(2, 5)"/>
+    <data checksum="0x5e85e4a4" dtype="int64" mask_checksum="no-masked-elements" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_nonotonic.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_nonotonic.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <auxCoord id="d00b57c8" long_name="columns" points="[12, 12, 14, 15, 16]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(2, 5)"/>
+    <data checksum="0x5e85e4a4" dtype="int64" mask_checksum="no-masked-elements" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_simple.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="d00b57c8" long_name="columns" points="[12, 13, 14, 15, 16]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
@@ -10,6 +10,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x5e85e4a4" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(2, 5)"/>
+    <data checksum="0x5e85e4a4" dtype="int64" mask_checksum="no-masked-elements" shape="(2, 5)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_datetime_gregorian.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_datetime_gregorian.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="5816e14d" long_name="index" points="[271753.016944, 281282.033889, 290739.050833,
@@ -8,6 +8,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(5,)"/>
+    <data checksum="0x6c8f4e1c" dtype="int64" mask_checksum="no-masked-elements" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_masked.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_masked.cml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="343cbc01" long_name="index" points="[5, 6, 7, 8, 9]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x88b40b84" dtype="float64" fill_value="1e+20" mask_checksum="0x6785a139" shape="(5,)"/>
+    <data checksum="0x88b40b84" dtype="float64" mask_checksum="0x6785a139" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_netcdfimte_360.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_netcdfimte_360.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="5816e14d" long_name="index" points="[267841.016944, 277226.033889, 286611.050833,
@@ -8,6 +8,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(5,)"/>
+    <data checksum="0x6c8f4e1c" dtype="int64" mask_checksum="no-masked-elements" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_object.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_object.cml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="343cbc01" long_name="index" points="[A Thing, A Thing, A Thing, A Thing, A Thing]" shape="(5,)" units="Unit('unknown')" value_type="object"/>
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(5,)"/>
+    <data checksum="0x6c8f4e1c" dtype="int64" mask_checksum="no-masked-elements" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pandas/as_cube/series_simple.cml
+++ b/lib/iris/tests/results/pandas/as_cube/series_simple.cml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="343cbc01" long_name="index" points="[5, 6, 7, 8, 9]" shape="(5,)" units="Unit('unknown')" value_type="int64"/>
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x6c8f4e1c" dtype="int64" fill_value="999999" mask_checksum="no-masked-elements" shape="(5,)"/>
+    <data checksum="0x6c8f4e1c" dtype="int64" mask_checksum="no-masked-elements" shape="(5,)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/pp_rules/global.cml
+++ b/lib/iris/tests/results/pp_rules/global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
+++ b/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -37,7 +37,7 @@
     <cellMethods/>
     <data checksum="0x80e93a14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -78,7 +78,7 @@
     </cellMethods>
     <data checksum="0x85641c30" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -119,7 +119,7 @@
     </cellMethods>
     <data checksum="0x03d5c2e9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -160,7 +160,7 @@
     </cellMethods>
     <data checksum="0xac9bd3e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/lbtim_2.cml
+++ b/lib/iris/tests/results/pp_rules/lbtim_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/ocean_depth.cml
+++ b/lib/iris/tests/results/pp_rules/ocean_depth.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_water_potential_temperature" units="degC">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
+++ b/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_water_potential_temperature" units="degC">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/rotated_uk.cml
+++ b/lib/iris/tests/results/pp_rules/rotated_uk.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="wind_speed_of_gust" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="wind_speed_of_gust" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s03i463"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_pressure" units="Pa">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/bilinear_larger.cml
+++ b/lib/iris/tests/results/regrid/bilinear_larger.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/bilinear_larger_lon_extrapolate_left.cml
+++ b/lib/iris/tests/results/regrid/bilinear_larger_lon_extrapolate_left.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/bilinear_larger_lon_extrapolate_right.cml
+++ b/lib/iris/tests/results/regrid/bilinear_larger_lon_extrapolate_right.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/bilinear_smaller.cml
+++ b/lib/iris/tests/results/regrid/bilinear_smaller.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[1.5, 2.5]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/bilinear_smaller_lon_align_left.cml
+++ b/lib/iris/tests/results/regrid/bilinear_smaller_lon_align_left.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[1.5, 2.5]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/bilinear_smaller_lon_align_right.cml
+++ b/lib/iris/tests/results/regrid/bilinear_smaller_lon_align_right.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="unknown" units="1">
+  <cube dtype="float32" long_name="unknown" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[1.5, 2.5]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">

--- a/lib/iris/tests/results/regrid/low_med_high.cml
+++ b/lib/iris/tests/results/regrid/low_med_high.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-2, -1, 0, 1, 2]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">
@@ -16,7 +16,7 @@
     <cellMethods/>
     <data dtype="int64" shape="(5, 6)" state="loaded"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-2, -1, 0, 1, 2]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">
@@ -32,7 +32,7 @@
     <cellMethods/>
     <data dtype="int64" shape="(5, 6)" state="loaded"/>
   </cube>
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="77a50eb5" points="[-2, -1, 0, 1, 2]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="int32">

--- a/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/stock/realistic_4d.cml
+++ b/lib/iris/tests/results/stock/realistic_4d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/system/supported_filetype_.nc.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.nc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="wind_speed" units="m s-1" var_name="wind_speed">
+  <cube dtype="float32" standard_name="wind_speed" units="m s-1" var_name="wind_speed">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/system/supported_filetype_.pp.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.pp.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="wind_speed" units="m s-1">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="wind_speed" units="m s-1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[9.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/trajectory/constant_latitude.cml
+++ b/lib/iris/tests/results/trajectory/constant_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/hybrid_height.cml
+++ b/lib/iris/tests/results/trajectory/hybrid_height.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="int64" standard_name="air_temperature" units="K">
     <coords>
       <coord datadims="[1, 2, 3]">
         <auxCoord id="9041e969" points="[[[5040, 5090, 5140, 5190, 5240, 5290],
@@ -60,7 +60,7 @@
     <cellMethods/>
     <data checksum="0x2acdccca" dtype="int64" shape="(3, 4, 5, 6)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float64" standard_name="air_temperature" units="K">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord id="9041e969" points="[[5090, 5740, 6090, 6440],

--- a/lib/iris/tests/results/trajectory/single_point.cml
+++ b/lib/iris/tests/results/trajectory/single_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
+  <cube dtype="float32" fill_value="9.96921e+36" long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
     <attributes>
       <attribute name="Conventions" value="CF-1.1"/>
       <attribute name="DOMAIN_DIM_N001" value="x"/>

--- a/lib/iris/tests/results/trajectory/zigzag.cml
+++ b/lib/iris/tests/results/trajectory/zigzag.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/unit/analysis/cartography/project/TestAll/cube.cml
+++ b/lib/iris/tests/results/unit/analysis/cartography/project/TestAll/cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_all_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_all_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_last_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_last_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_middle_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_middle_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_zeroth_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/collapse_zeroth_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/slice.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/transposed.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/divide/TestBroadcasting/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1">
+  <cube dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/cube/Cube/intersection__Metadata/metadata.cml
+++ b/lib/iris/tests/results/unit/cube/Cube/intersection__Metadata/metadata.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="x_wind" units="ms-1">
+  <cube dtype="float32" standard_name="x_wind" units="ms-1">
     <coords>
       <coord datadims="[0, 1, 2]">
         <auxCoord id="9041e969" points="[[[1700.0, 1710.0, 1720.0, ..., 1880.0, 1890.0,

--- a/lib/iris/tests/results/unit/cube/Cube/intersection__Metadata/metadata_wrapped.cml
+++ b/lib/iris/tests/results/unit/cube/Cube/intersection__Metadata/metadata_wrapped.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="x_wind" units="ms-1">
+  <cube dtype="float32" standard_name="x_wind" units="ms-1">
     <coords>
       <coord datadims="[0, 1, 2]">
         <auxCoord id="9041e969" points="[[[3500.0, 3510.0, 3520.0, ..., 80.0, 90.0, 100.0],

--- a/lib/iris/tests/results/unit/cube/Cube/xml/checksum_ignores_masked_values.cml
+++ b/lib/iris/tests/results/unit/cube/Cube/xml/checksum_ignores_masked_values.cml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords/>
     <cellMethods/>
-    <data checksum="0x254c379c" dtype="int64" fill_value="999999" mask_checksum="0xb08915ca" shape="(3, 4)"/>
+    <data checksum="0x254c379c" dtype="int64" mask_checksum="0xb08915ca" shape="(3, 4)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_realization.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_realization.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="75879334" points="[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_triple.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_extra_triple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="75879334" points="[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_realization.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/combination_with_realization.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
         <auxCoord id="75879334" points="[0, 0, 0, 0, 1, 1, 1, 1]" shape="(8,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>

--- a/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/orthogonal_with_realization.cml
+++ b/lib/iris/tests/results/unit/cube/CubeList/merge__time_triple/orthogonal_with_realization.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="75879334" points="[0, 1]" shape="(2,)" standard_name="forecast_period" units="Unit('1')" value_type="int64"/>

--- a/lib/iris/tests/results/uri_callback/pp_global.cml
+++ b/lib/iris/tests/results/uri_callback/pp_global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="filename" value="global.pp"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.000128.1990.12.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.004224.1990.12.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.03.236.008320.1990.12.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/000003000000.16.202.000128.1860.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m" var_name="geopotential_height">
+  <cube dtype="float32" standard_name="geopotential_height" units="m" var_name="geopotential_height">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_surface_height_above_geoid" units="m" var_name="sea_surface_height_above_geoid">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_surface_height_above_geoid" units="m" var_name="sea_surface_height_above_geoid">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>
@@ -28,6 +28,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xb9c558a8" dtype="float32" fill_value="-1e+30" mask_checksum="0xd542cf4a" shape="(94, 128)"/>
+    <data checksum="0xb9c558a8" dtype="float32" mask_checksum="0xd542cf4a" shape="(94, 128)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1" var_name="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>
@@ -43,6 +43,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xff96b2ff" dtype="float32" fill_value="-1e+30" mask_checksum="0x4c8ff994" shape="(20, 73)"/>
+    <data checksum="0xff96b2ff" dtype="float32" mask_checksum="0x4c8ff994" shape="(20, 73)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1" var_name="unknown">
+  <cube dtype="float32" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/12187.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1" var_name="change_over_time_in_upward_air_velocity_due_to_advection">
+  <cube dtype="float32" long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1" var_name="change_over_time_in_upward_air_velocity_due_to_advection">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s12i187"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/HadCM2_ts_SAT_ann_18602100.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="Celsius" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="Celsius" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_level_lat_orig.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_level_lat_orig.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m" var_name="geopotential_height">
+  <cube dtype="float32" standard_name="geopotential_height" units="m" var_name="geopotential_height">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_press_orig.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_press_orig.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m" var_name="geopotential_height">
+  <cube dtype="float32" standard_name="geopotential_height" units="m" var_name="geopotential_height">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_several.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_lon_lat_several.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_n10r13xy.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_time_press.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m" var_name="geopotential_height">
+  <cube dtype="float32" standard_name="geopotential_height" units="m" var_name="geopotential_height">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/aaxzc_tseries.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_1.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s03i236"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_2.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abcza_pa19591997_daily_29.b_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="precipitation_flux" units="kg m-2 s-1" var_name="precipitation_flux">
+  <cube dtype="float32" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="precipitation_flux">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s05i216"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abxpa_press_lat.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/abxpa_press_lat.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m" var_name="geopotential_height">
+  <cube dtype="float32" standard_name="geopotential_height" units="m" var_name="geopotential_height">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i202"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/integer.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/integer.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="land_binary_mask" units="1" var_name="land_binary_mask">
+  <cube dtype="int32" standard_name="land_binary_mask" units="1" var_name="land_binary_mask">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/model.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/model.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube dtype="float32" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s16i203"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_water_potential_temperature" units="degC" var_name="sea_water_potential_temperature">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC" var_name="sea_water_potential_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i101"/>
@@ -57,6 +57,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x91244c3f" dtype="float32" fill_value="-1e+30" mask_checksum="0x2f42f34e" shape="(20, 144)"/>
+    <data checksum="0x91244c3f" dtype="float32" mask_checksum="0x2f42f34e" shape="(20, 144)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1" var_name="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>
@@ -33,6 +33,6 @@
         <coord interval="2 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xffea495f" dtype="float32" fill_value="-1e+30" mask_checksum="0x99fa2aae" shape="(144, 288)"/>
+    <data checksum="0xffea495f" dtype="float32" mask_checksum="0x99fa2aae" shape="(144, 288)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="1" var_name="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>
@@ -46,6 +46,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2ae7eecc" dtype="float32" fill_value="-1e+30" mask_checksum="0x6d576d49" shape="(4, 4, 20, 143)"/>
+    <data checksum="0x2ae7eecc" dtype="float32" mask_checksum="0x6d576d49" shape="(4, 4, 20, 143)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="northward_ocean_heat_transport" units="PW" var_name="northward_ocean_heat_transport">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="northward_ocean_heat_transport" units="PW" var_name="northward_ocean_heat_transport">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s30i211"/>
@@ -41,6 +41,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xb499afb2" dtype="float32" fill_value="-1e+30" mask_checksum="0xf60458f1" shape="(4, 4, 143, 1)"/>
+    <data checksum="0xb499afb2" dtype="float32" mask_checksum="0xf60458f1" shape="(4, 4, 143, 1)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/001000000000.00.000.000000.1860.01.01.00.00.f.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/001000000000.00.000.000000.1860.01.01.00.00.f.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_surface_height_above_geoid" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_surface_height_above_geoid" units="m">
     <coords>
       <coord>
         <dimCoord bounds="[[-86400.0, 0.0]]" id="1d45e087" points="[-43200.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
@@ -25,6 +25,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xb9c558a8" dtype="float32" fill_value="-1e+30" mask_checksum="0xd542cf4a" shape="(94, 128)"/>
+    <data checksum="0xb9c558a8" dtype="float32" mask_checksum="0xd542cf4a" shape="(94, 128)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -42,6 +42,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xff96b2ff" dtype="float32" fill_value="-1e+30" mask_checksum="0x4c8ff994" shape="(20, 73)"/>
+    <data checksum="0xff96b2ff" dtype="float32" mask_checksum="0x4c8ff994" shape="(20, 73)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1">
+  <cube dtype="float32" fill_value="-1.07374e+09" long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s12i187"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="Celsius">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="Celsius">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -63,7 +63,7 @@
     </cellMethods>
     <data checksum="0x82b10a0a" dtype="float32" shape="(360, 73, 96)"/>
   </cube>
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -126,7 +126,7 @@
     </cellMethods>
     <data checksum="0xd9f6eff7" dtype="float32" shape="(360, 73, 96)"/>
   </cube>
-  <cube standard_name="precipitation_flux" units="kg m-2 s-1">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="precipitation_flux" units="kg m-2 s-1">
     <attributes>
       <attribute name="STASH" value="m01s05i216"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential_height" units="m">
+  <cube dtype="float32" fill_value="-1.07374e+09" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/integer.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/integer.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="land_binary_mask" units="1">
+  <cube dtype="int32" standard_name="land_binary_mask" units="1">
     <attributes>
       <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_temperature" units="K">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="sea_water_potential_temperature" units="degC">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -56,6 +56,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x91244c3f" dtype="float32" fill_value="-1e+30" mask_checksum="0x2f42f34e" shape="(20, 144)"/>
+    <data checksum="0x91244c3f" dtype="float32" mask_checksum="0x2f42f34e" shape="(20, 144)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -32,6 +32,6 @@
         <coord interval="2 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xffea495f" dtype="float32" fill_value="-1e+30" mask_checksum="0x99fa2aae" shape="(144, 288)"/>
+    <data checksum="0xffea495f" dtype="float32" mask_checksum="0x99fa2aae" shape="(144, 288)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube dtype="float32" fill_value="-1e+30" units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -45,6 +45,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x2ae7eecc" dtype="float32" fill_value="-1e+30" mask_checksum="0x6d576d49" shape="(4, 4, 20, 143)"/>
+    <data checksum="0x2ae7eecc" dtype="float32" mask_checksum="0x6d576d49" shape="(4, 4, 20, 143)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="northward_ocean_heat_transport" units="PW">
+  <cube dtype="float32" fill_value="-1e+30" standard_name="northward_ocean_heat_transport" units="PW">
     <attributes>
       <attribute name="STASH" value="m02s30i211"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -40,6 +40,6 @@
         <coord name="time"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0xb499afb2" dtype="float32" fill_value="-1e+30" mask_checksum="0xf60458f1" shape="(4, 4, 143, 1)"/>
+    <data checksum="0xb499afb2" dtype="float32" mask_checksum="0xf60458f1" shape="(4, 4, 143, 1)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/util/as_compatible_shape_collapsed.cml
+++ b/lib/iris/tests/results/util/as_compatible_shape_collapsed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -35,7 +35,7 @@ import iris.tests.stock as stock
 
 
 def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
-               dtype=np.float32, fill_value=None):
+               dtype=np.dtype('float32'), fill_value=None):
     """
     A convenience test function that creates a custom 2D cube.
 


### PR DESCRIPTION
This PR addresses the issue of adding `fill_value` and `dtype` to the metadata of the cube.

We now need to see this shift in metadata reflected in the CML test results.

Also, this PR aligns with the new philosophy that we don't care about the `fill_value` on any concrete cube masked data, but we do care about the `fill_value` on the cube.

Note that, the associated CML for skipped tests have not be altered. We will trip over this change later, as we unskip those CML tests.