### PR TITLE
Make image has tests register as failures rather than errors

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -764,7 +764,7 @@ class IrisTest_nometa(unittest.TestCase):
                 else:
                     figure.savefig(result_fname)
                     emsg = 'Missing image test result: {}.'
-                    raise ValueError(emsg.format(unique_id))
+                    raise AssertionError(emsg.format(unique_id))
             else:
                 uris = repo[unique_id]
                 # Create the expected perceptual image hashes from the uris.
@@ -789,7 +789,7 @@ class IrisTest_nometa(unittest.TestCase):
                             print(emsg.format(msg))
                         else:
                             emsg = 'Image comparison failed: {}'
-                            raise ValueError(emsg.format(msg))
+                            raise AssertionError(emsg.format(msg))
 
             if _DISPLAY_FIGURES:
                 plt.show()


### PR DESCRIPTION
When an image hash check fails, a `ValueError` is raised, causing unit tests to register as errors rather than failures. This PR changes `ValueError` to `AssertionError`.