### PR TITLE
fill_value and dtype

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -414,6 +414,12 @@ class _CubeSignature(object):
         return result
 
     def promote_defn(self):
+        """
+        Update the metadata definition to match that of a similar but lazy cube.
+        A cube with lazy masked integral data must have its :attr:`metadata.dtype`
+        set appropriately.
+
+        """
         defn = self.defn
         kwargs = defn._asdict()
         if kwargs['dtype'] is None and self.data_type.kind == 'i':
@@ -452,6 +458,8 @@ class _CubeSignature(object):
 
         # Check cube definitions.
         if self.defn != other.defn:
+            # Attempt to match metadata for the lazy masked integral
+            # dtype case.
             promoted = self.promote_defn()
             if promoted != other.promote_defn():
                 # Note that the case of different phenomenon names is dealt
@@ -459,6 +467,7 @@ class _CubeSignature(object):
                 msg = 'Cube metadata differs for phenomenon: {}'
                 msgs.append(msg.format(self.defn.name()))
             else:
+                # Persist the promoted metadata dtype match case.
                 self.defn = promoted
         # Check dim coordinates.
         if self.dim_metadata != other.dim_metadata:

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -415,9 +415,9 @@ class _CubeSignature(object):
 
     def promote_defn(self):
         """
-        Update the metadata definition to match that of a similar but lazy cube.
-        A cube with lazy masked integral data must have its :attr:`metadata.dtype`
-        set appropriately.
+        Update the metadata definition to match that of a similar but lazy
+        cube. A cube with lazy masked integral data must have its
+        :attr:`metadata.dtype` set appropriately.
 
         """
         defn = self.defn

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -563,7 +563,9 @@ class _Aggregator(object):
             The collapsed cube with its aggregated data payload.
 
         """
+        cube_fill_value = collapsed_cube.fill_value
         collapsed_cube.data = data_result
+        collapsed_cube.fill_value = cube_fill_value
         return collapsed_cube
 
     def aggregate_shape(self, **kwargs):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1639,10 +1639,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     @dtype.setter
     def dtype(self, dtype):
         if dtype != self.dtype:
-            if not self.has_lazy_data():
-                emsg = 'Cube does not have lazy data, cannot set dtype.'
-                raise ValueError(emsg)
             if dtype is not None:
+                if not self.has_lazy_data():
+                    emsg = 'Cube does not have lazy data, cannot set dtype.'
+                    raise ValueError(emsg)
                 dtype = np.dtype(dtype)
                 if dtype.kind != 'i':
                     emsg = ('Can only cast lazy data to integral dtype, '

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1777,7 +1777,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             self._dask_array = None
 
         # Cancel any 'realisation' datatype conversion, and fill value.
-        self._dtype = None
+        self.dtype = None
         self.fill_value = None
 
     def has_lazy_data(self):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1664,7 +1664,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # Perform rounding when converting floats to ints.
                 fill_value = np.rint(fill_value)
             try:
-                fill_value = np.asarray([fill_value], dtype=target_dtype)[0]
+                [fill_value] = np.asarray([fill_value], dtype=target_dtype)
             except OverflowError:
                 emsg = 'Fill value of {!r} invalid for cube {!r}.'
                 raise ValueError(emsg.format(fill_value, self.dtype))

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1658,9 +1658,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     @fill_value.setter
     def fill_value(self, fill_value):
         if fill_value is not None:
+            # Convert the given value to the dtype of the cube.
+            fill_value = np.asarray([fill_value])[0]
+            target_dtype = self.dtype
+            if fill_value.dtype.kind == 'f' and target_dtype.kind == 'i':
+                # Perform rounding when converting floats to ints.
+                fill_value = np.rint(fill_value)
             try:
-                fill_value = np.asarray([fill_value],
-                                        dtype=self.dtype)[0]
+                fill_value = np.asarray([fill_value], dtype=target_dtype)[0]
             except OverflowError:
                 emsg = 'Fill value of {!r} invalid for cube {!r}.'
                 raise ValueError(emsg.format(fill_value, self.dtype))
@@ -1763,12 +1768,17 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 raise ValueError('Require cube data with shape %r, got '
                                  '%r.' % (self.shape, value.shape))
 
+        # Set lazy or real data, and reset the other.
         if is_lazy_data(value):
             self._dask_array = value
             self._numpy_array = None
-
         else:
             self._numpy_array = value
+            self._dask_array = None
+
+        # Cancel any 'realisation' datatype conversion, and fill value.
+        self._dtype = None
+        self.fill_value = None
 
     def has_lazy_data(self):
         return self._numpy_array is None

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -754,8 +754,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # We need to set the dtype before the fill_value,
         # as the fill_value is checked against self.dtype.
         self._dtype = None
-        if dtype is not None:
-            self.dtype = dtype
+        self.dtype = dtype
         self.fill_value = fill_value
 
         identities = set()

--- a/lib/iris/tests/results/FF/air_temperature_1.cml
+++ b/lib/iris/tests/results/FF/air_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/air_temperature_2.cml
+++ b/lib/iris/tests/results/FF/air_temperature_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/soil_temperature_1.cml
+++ b/lib/iris/tests/results/FF/soil_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="soil_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/surface_altitude_1.cml
+++ b/lib/iris/tests/results/FF/surface_altitude_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="surface_altitude" units="m">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/addition_coord_x.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_coord_y.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="object" dtype="float32" fill_value="-1e+30" units="kelvin^2">
+  <cube core-dtype="object" dtype="object" fill_value="-1e+30" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="object" dtype="float32" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="object" dtype="object" fill_value="-1e+30" units="unknown">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_singular_coord.cml
+++ b/lib/iris/tests/results/analysis/division_by_singular_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="kelvin^4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="kelvin^4">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="kelvin^4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="kelvin^4">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_x.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_y.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1e+30" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1073741824.0" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="processing" value="fast-ff"/>

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
@@ -26,7 +26,7 @@
     <cellMethods/>
     <data checksum="0x65252ed2" dtype="float64" shape="(1, 60, 181, 360)"/>
   </cube>
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/trajectory/constant_latitude.cml
+++ b/lib/iris/tests/results/trajectory/constant_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/single_point.cml
+++ b/lib/iris/tests/results/trajectory/single_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="9.96921e+36" long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
+  <cube core-dtype="float64" dtype="float64" fill_value="9.96921e+36" long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
     <attributes>
       <attribute name="Conventions" value="CF-1.1"/>
       <attribute name="DOMAIN_DIM_N001" value="x"/>

--- a/lib/iris/tests/results/trajectory/zigzag.cml
+++ b/lib/iris/tests/results/trajectory/zigzag.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -192,10 +192,12 @@ class TestAnalysisBasic(tests.IrisTest):
         file = tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp'))
         cubes = iris.load(file)
         self.cube = cubes[0]
+        self.cube_fill_val = self.cube.fill_value
         self.assertCML(self.cube, ('analysis', 'original.cml'))
 
     def _common(self, name, aggregate, original_name='original_common.cml', *args, **kwargs):
         self.cube.data = self.cube.data.astype(np.float64)
+        self.cube.fill_value = self.cube_fill_val
 
         self.assertCML(self.cube, ('analysis', original_name))
 
@@ -221,6 +223,7 @@ class TestAnalysisBasic(tests.IrisTest):
     def test_hmean(self):
         # harmonic mean requires data > 0
         self.cube.data *= self.cube.data
+        self.cube.fill_value = self.cube_fill_val
         self._common('hmean', iris.analysis.HMEAN, 'original_hmean.cml', rtol=1e-05)
 
     def test_gmean(self):

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -39,7 +39,11 @@ import iris.tests.stock
 class TestBasicMaths(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
+        # We require to preserve the cube fill_value
+        # across the cube data setter operation.
+        fill_value = self.cube.fill_value
         self.cube.data = self.cube.data - 260
+        self.cube.fill_value = fill_value
 
     def test_abs(self):
         a = self.cube
@@ -360,7 +364,11 @@ class TestBasicMaths(tests.IrisTest):
 class TestDivideAndMultiply(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
+        # We require to preserve the cube fill_value
+        # across the cube data setter operation.
+        fill_value = self.cube.fill_value
         self.cube.data = self.cube.data - 260
+        self.cube.fill_value = fill_value
 
     def test_divide(self):
         a = self.cube
@@ -503,11 +511,17 @@ class TestDivideAndMultiply(tests.IrisTest):
 class TestExponentiate(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
+        # We require to preserve the cube fill_value
+        # across the cube data setter operation.
+        self.fill_value = self.cube.fill_value
         self.cube.data = self.cube.data - 260
+        self.cube.fill_value = self.fill_value
 
     def test_exponentiate(self):
         a = self.cube
         a.data = a.data.astype(np.float64)
+        # We require to preserve the cube fill_value after setting the data.
+        a.fill_value = self.fill_value
         e = pow(a, 4)
         self.assertCMLApproxData(e, ('analysis', 'exponentiate.cml'))
 
@@ -515,6 +529,8 @@ class TestExponentiate(tests.IrisTest):
         # Make sure we have something which we can take the root of.
         a = self.cube
         a.data = abs(a.data)
+        # We require to preserve the cube fill_value after setting the data.
+        a.fill_value = self.fill_value
         a.units **= 2
 
         e = a ** 0.5

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -428,7 +428,7 @@ class TestDivideAndMultiply(tests.IrisTest):
         # Check that the division has had no effect on the original
         self.assertCML(a, ('analysis', 'maths_original.cml'))
 
-    def test_divide_by_singluar_coordinate(self):
+    def test_divide_by_singular_coordinate(self):
         a = self.cube
 
         coord = iris.coords.DimCoord(points=2, long_name='foo', units='1')

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -791,7 +791,7 @@ class TestCubeAPI(TestCube2d):
 
     def test_metadata_tuple(self):
         metadata = ('air_pressure', 'foo', 'bar', '', {'random': '12'}, (),
-                    -99, np.dtype('f8'))
+                    np.dtype('f8'), -99)
         self.t.metadata = metadata
         self.assertEqual(self.t.standard_name, 'air_pressure')
         self.assertEqual(self.t.long_name, 'foo')

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -35,7 +35,8 @@ import iris.tests.stock as stock
 
 
 def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
-               dtype=np.dtype('float32'), fill_value=None):
+               dtype=np.dtype('float32'), fill_value=None,
+               mask=None):
     """
     A convenience test function that creates a custom 2D cube.
 
@@ -67,6 +68,10 @@ def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
     * scalar:
         Create a 'height' scalar coordinate with the given value.
 
+    * mask:
+        Create cube masked data with the specified mask. Boolean or
+        array indicies of points to be masked.
+
     Returns:
         The newly created 2D :class:`iris.cube.Cube`.
 
@@ -75,9 +80,18 @@ def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
     y_range = np.arange(*y, dtype=dtype)
     x_size = len(x_range)
     y_size = len(y_range)
+    shape = (y_size, x_size)
 
-    cube_data = np.empty((y_size, x_size), dtype=dtype)
-    cube_data[:] = data
+    if mask is not None:
+        cube_data = ma.empty(shape, dtype=dtype)
+        cube_data.data[:] = data
+        if isinstance(mask, bool):
+            cube_data.mask = mask
+        else:
+            cube_data[mask] = ma.masked
+    else:
+        cube_data = np.empty(shape, dtype=dtype)
+        cube_data[:] = data
     cube = iris.cube.Cube(cube_data, fill_value=fill_value)
     coord = DimCoord(y_range, long_name='y')
     coord.guess_bounds()
@@ -217,15 +231,18 @@ def concatenate(cubes, order=None):
     result = cubelist.concatenate()
 
     for cube in result:
+        # Setting the cube.data clears the cube.dtype and cube.fill_value.
+        # We want to maintain the fill_value for testing purposes, even
+        # though we have lost the lazy data in order to pin down the array
+        # data order to overcome testing on different architectures.
+        fill_value = cube.fill_value
         if ma.isMaskedArray(cube.data):
-            # cube.data = ma.copy(cube.data, order=order)
             data = np.array(cube.data.data, copy=True, order=order)
             mask = np.array(cube.data.mask, copy=True, order=order)
-            fill_value = cube.data.fill_value
-            cube.data = ma.array(data, mask=mask, fill_value=fill_value)
+            cube.data = ma.array(data, mask=mask)
         else:
-            # cube.data = np.copy(cube.data, order=order)
             cube.data = np.array(cube.data, copy=True, order=order)
+        cube.fill_value = fill_value
 
     return result
 
@@ -321,12 +338,10 @@ class TestNoConcat(tests.IrisTest):
     def test_masked_fill_value(self):
         cubes = []
         y = (0, 2)
-        cube = _make_cube((0, 2), y, 1)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((0, 2), y, 1, mask=True)
         cube.fill_value = 10
         cubes.append(cube)
-        cube = _make_cube((2, 4), y, 1)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((2, 4), y, 1, mask=True)
         cube.fill_value = 20
         cubes.append(cube)
         result = concatenate(cubes)
@@ -337,8 +352,7 @@ class Test2D(tests.IrisTest):
     def test_masked_and_unmasked(self):
         cubes = []
         y = (0, 2)
-        cube = _make_cube((0, 2), y, 1)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((0, 2), y, 1, mask=True)
         cubes.append(cube)
         cubes.append(_make_cube((2, 4), y, 2))
         result = concatenate(cubes)
@@ -347,10 +361,10 @@ class Test2D(tests.IrisTest):
     def test_masked_and_unmasked_int16(self):
         cubes = []
         y = (0, 2)
-        cube = _make_cube((0, 2), y, 1, dtype=np.dtype('int16'))
-        cube.data = ma.asarray(cube.data)
+        dtype = np.dtype('int16')
+        cube = _make_cube((0, 2), y, 1, dtype=dtype, mask=True)
         cubes.append(cube)
-        cubes.append(_make_cube((2, 4), y, 2, dtype=np.dtype('int16')))
+        cubes.append(_make_cube((2, 4), y, 2, dtype=dtype))
         result = concatenate(cubes)
         self.assertEqual(len(result), 1)
 
@@ -358,8 +372,7 @@ class Test2D(tests.IrisTest):
         cubes = []
         y = (0, 2)
         cubes.append(_make_cube((0, 2), y, 1))
-        cube = _make_cube((2, 4), y, 2)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((2, 4), y, 2, mask=True)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertEqual(len(result), 1)
@@ -367,9 +380,9 @@ class Test2D(tests.IrisTest):
     def test_unmasked_and_masked_int16(self):
         cubes = []
         y = (0, 2)
-        cubes.append(_make_cube((0, 2), y, 1, dtype=np.dtype('int16')))
-        cube = _make_cube((2, 4), y, 2, dtype=np.dtype('int16'))
-        cube.data = ma.asarray(cube.data)
+        dtype = np.dtype('int16')
+        cubes.append(_make_cube((0, 2), y, 1, dtype=dtype))
+        cube = _make_cube((2, 4), y, 2, dtype=dtype, mask=True)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertEqual(len(result), 1)
@@ -377,12 +390,10 @@ class Test2D(tests.IrisTest):
     def test_masked_fill_value(self):
         cubes = []
         y = (0, 2)
-        cube = _make_cube((0, 2), y, 1)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((0, 2), y, 1, mask=True)
         cube.data.fill_value = 10
         cubes.append(cube)
-        cube = _make_cube((2, 4), y, 1)
-        cube.data = ma.asarray(cube.data)
+        cube = _make_cube((2, 4), y, 1, mask=True)
         cube.data.fill_value = 20
         cubes.append(cube)
         result = concatenate(cubes)
@@ -391,13 +402,11 @@ class Test2D(tests.IrisTest):
     def test_concat_masked_2x2d(self):
         cubes = []
         y = (0, 2)
-        cube = _make_cube((0, 2), y, 1)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (0, 1)] = ma.masked
+        mask = [(0, 1), (0, 1)]
+        cube = _make_cube((0, 2), y, 1, mask=mask)
         cubes.append(cube)
-        cube = _make_cube((2, 4), y, 2)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (1, 0)] = ma.masked
+        mask = [(0, 1), (1, 0)]
+        cube = _make_cube((2, 4), y, 2, mask=mask)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertCML(result, ('concatenate', 'concat_masked_2x2d.cml'))
@@ -410,13 +419,11 @@ class Test2D(tests.IrisTest):
     def test_concat_masked_2y2d(self):
         cubes = []
         x = (0, 2)
-        cube = _make_cube(x, (0, 2), 1)
-        cube.data = np.ma.asarray(cube.data)
-        cube.data[(0, 1), (0, 1)] = ma.masked
+        mask = [(0, 1), (0, 1)]
+        cube = _make_cube(x, (0, 2), 1, mask=mask)
         cubes.append(cube)
-        cube = _make_cube(x, (2, 4), 2)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (1, 0)] = ma.masked
+        mask = [(0, 1), (1, 0)]
+        cube = _make_cube(x, (2, 4), 2, mask=mask)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertCML(result, ('concatenate', 'concat_masked_2y2d.cml'))
@@ -431,13 +438,15 @@ class Test2D(tests.IrisTest):
     def test_concat_masked_2y2d_int16(self):
         cubes = []
         x = (0, 2)
-        cube = _make_cube(x, (0, 2), 1, dtype=np.int16, fill_value=-37)
-        cube.data = np.ma.asarray(cube.data)
-        cube.data[(0, 1), (0, 1)] = ma.masked
+        dtype = np.dtype('int16')
+        fill_value = -37
+        mask = [(0, 1), (0, 1)]
+        cube = _make_cube(x, (0, 2), 1, dtype=dtype, fill_value=fill_value,
+                          mask=mask)
         cubes.append(cube)
-        cube = _make_cube(x, (2, 4), 2, dtype=np.int16, fill_value=-37)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (1, 0)] = ma.masked
+        mask = [(0, 1), (1, 0)]
+        cube = _make_cube(x, (2, 4), 2, dtype=dtype, fill_value=fill_value,
+                          mask=mask)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertCML(result, ('concatenate', 'concat_masked_2y2d_int16.cml'))
@@ -452,16 +461,17 @@ class Test2D(tests.IrisTest):
     def test_concat_masked_2y2d_int16_with_concrete_and_lazy(self):
         cubes = []
         x = (0, 2)
-        cube = _make_cube(x, (0, 2), 1, dtype=np.int16, fill_value=-37)
-        cube.data = np.ma.asarray(cube.data)
-        cube.data[(0, 1), (0, 1)] = ma.masked
+        dtype = np.dtype('int16')
+        fill_value = -37
+        mask = [(0, 1), (0, 1)]
+        cube = _make_cube(x, (0, 2), 1, dtype=dtype, fill_value=fill_value,
+                          mask=mask)
         cubes.append(cube)
-        cube = _make_cube(x, (2, 4), 2, dtype=np.int16)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (1, 0)] = ma.masked
+        mask = [(0, 1), (1, 0)]
+        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask)
         cube.data = cube.lazy_data()
-        cube.dtype = np.dtype('int16')
-        cube.fill_value = -37
+        cube.dtype = dtype
+        cube.fill_value = fill_value
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertCML(result, ('concatenate', 'concat_masked_2y2d_int16.cml'))
@@ -476,16 +486,17 @@ class Test2D(tests.IrisTest):
     def test_concat_masked_2y2d_int16_with_lazy_and_concrete(self):
         cubes = []
         x = (0, 2)
-        cube = _make_cube(x, (2, 4), 2, dtype=np.int16)
-        cube.data = ma.asarray(cube.data)
-        cube.data[(0, 1), (1, 0)] = ma.masked
+        dtype = np.dtype('int16')
+        fill_value = -37
+        mask = [(0, 1), (1, 0)]
+        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask)
         cube.data = cube.lazy_data()
-        cube.dtype = np.dtype('int16')
-        cube.fill_value = -37
+        cube.dtype = dtype
+        cube.fill_value = fill_value
         cubes.append(cube)
-        cube = _make_cube(x, (0, 2), 1, dtype=np.int16, fill_value=-37)
-        cube.data = np.ma.asarray(cube.data)
-        cube.data[(0, 1), (0, 1)] = ma.masked
+        mask = [(0, 1), (0, 1)]
+        cube = _make_cube(x, (0, 2), 1, dtype=dtype, fill_value=fill_value,
+                          mask=mask)
         cubes.append(cube)
         result = concatenate(cubes)
         self.assertCML(result, ('concatenate', 'concat_masked_2y2d_int16.cml'))

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -327,7 +327,7 @@ class TestNoConcat(tests.IrisTest):
         result = concatenate(cubes)
         self.assertEqual(len(result), 2)
 
-    def test_order(self):
+    def test_order_difference(self):
         cubes = []
         y = (0, 2)
         cubes.append(_make_cube((0, 2), y, 1))
@@ -335,7 +335,7 @@ class TestNoConcat(tests.IrisTest):
         result = concatenate(cubes)
         self.assertEqual(len(result), 2)
 
-    def test_masked_fill_value(self):
+    def test_masked_fill_value_difference(self):
         cubes = []
         y = (0, 2)
         cube = _make_cube((0, 2), y, 1, mask=True)

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -387,7 +387,7 @@ class Test2D(tests.IrisTest):
         result = concatenate(cubes)
         self.assertEqual(len(result), 1)
 
-    def test_masked_fill_value(self):
+    def test_masked_with_data_fill_value_difference(self):
         cubes = []
         y = (0, 2)
         cube = _make_cube((0, 2), y, 1, mask=True)

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,7 +26,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import numpy.ma as ma
 from scipy.interpolate import interp1d
 
 import iris
@@ -43,7 +42,9 @@ def normalise_order(cube):
     #     function when the circular flag is true.
     #   * scipy.interpolate.interp1d in 0.11.0 which is used in
     #     `Linear1dExtrapolator`.
+    cube_fill_val = cube.fill_value
     cube.data = np.ascontiguousarray(cube.data)
+    cube.fill_value = cube_fill_val
 
 
 class TestLinearExtrapolator(tests.IrisTest):

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -80,6 +80,8 @@ def callback_aaxzc_n10r13xy_b_pp(cube, field, filename):
     cube.add_aux_coord(height_coord)
 
 
+# XXX: Issue with integer.b.pp and invalid bmdi fill_value for int32 dtype
+@tests.skip_biggus
 @tests.skip_data
 class TestAll(tests.IrisTest, pp.PPTest):
     _ref_dir = ('usecases', 'pp_to_cf_conversion')

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -1262,7 +1262,9 @@ class Test___call____circular(tests.IrisTest):
         # instead of being an array.
         src = self.src
         src.coord('longitude').circular = True
+        src_fill_value = src.fill_value
         src.data = np.ma.MaskedArray(src.data)
+        src.fill_value = src_fill_value
         self.assertEqual(src.data.mask, False)
         method_results = self._check_circular_results(src, 'missingmask')
         for method_result in method_results:

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1240,6 +1240,151 @@ class Test_dtype(tests.IrisTest):
         self.assertTrue(cube.has_lazy_data())
 
 
+class Test_data_dtype_fillvalue(tests.IrisTest):
+    def _sample_data(self, dtype='f4', masked=False, lazy=False):
+        data = np.arange(6).reshape((2, 3))
+        dtype = np.dtype(dtype)
+        data = data.astype(dtype)
+        if masked:
+            data = np.ma.masked_array(data, mask=[[0, 1, 0], [0, 0, 0]])
+        if lazy:
+            data = as_lazy_data(data)
+        return data
+
+    def _sample_cube(self, dtype='f4', masked=False, lazy=False,
+                     cube_dtype=None, cube_fill_value=None):
+        data = self._sample_data(dtype=dtype, masked=masked, lazy=lazy)
+        if cube_dtype is None:
+            cube_dtype = dtype
+            # NOTE: with masked lazy integers, the resulting data dtype will
+            # be changed, so we must set the cube to the 'original' dtype.
+        else:
+            cube_dtype = np.dtype(cube_dtype)
+        cube = Cube(data, dtype=cube_dtype, fill_value=cube_fill_value)
+        return cube
+
+    def test_realdata_change(self):
+        # Check that re-assigning real data resets dtype and fill_value.
+        cube = self._sample_cube(cube_fill_value=27.3)
+        self.assertEqual(cube.dtype, np.dtype('f4'))
+        self.assertArrayAllClose(cube.fill_value, 27.3)
+        new_data = self._sample_data(dtype=np.int32)
+        cube.data = new_data
+        self.assertIs(cube.core_data, new_data)
+        self.assertEqual(cube.dtype, np.dtype('i4'))
+        self.assertIsNone(cube.fill_value)
+
+    def test_realise_unmasked(self):
+        # Check that touching unmasked lazy data retains the fill_value.
+        cube = self._sample_cube(cube_fill_value=27.3, lazy=True)
+        data = cube.data
+        self.assertIs(cube.core_data, data)
+        self.assertArrayAllClose(cube.fill_value, 27.3)
+
+    def test_realise_masked(self):
+        # Check that touching masked lazy data retains the fill_value.
+        cube = self._sample_cube(cube_fill_value=27.3, masked=True, lazy=True)
+        data = cube.data
+        self.assertIs(cube.core_data, data)
+        self.assertArrayAllClose(cube.fill_value, 27.3)
+
+    def test_realise_maskedints(self):
+        # Check that touching masked integer lazy data retains the fill_value.
+        cube = self._sample_cube(dtype=np.int16, masked=True, lazy=True,
+                                 cube_fill_value=999)
+        self.assertIs(cube.core_data.dtype, np.dtype('f8'))
+        data = cube.data
+        self.assertIs(cube.core_data.dtype, np.dtype('i2'))
+        self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
+        self.assertArrayAllClose(cube.fill_value, 999)
+
+    def test_lazydata_change(self):
+        # Check that re-assigning lazy data resets dtype and fill_value.
+        cube = self._sample_cube(dtype=np.float32, lazy=True,
+                                 cube_dtype=np.int16,
+                                 cube_fill_value=27.3)
+        # Set a modified dtype to check it gets reset.
+        self.assertEqual(cube.dtype, np.dtype('i2'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('f4'))
+        self.assertArrayAllClose(cube.fill_value, 27)
+        new_data = self._sample_data(np.float64, lazy=True)
+        cube.data = new_data
+        self.assertEqual(cube.dtype, np.dtype('f8'))
+        self.assertIsNone(cube.fill_value)
+
+    def test_realdata_dtype_change(self):
+        # Check that cannot change real data dtype.
+        cube = self._sample_cube()
+        with self.assertRaisesRegexp(ValueError, "cannot set dtype"):
+            cube.dtype = np.dtype('i8')
+
+    def test_lazydata_nonmaskedints(self):
+        # Check that lazy ints retain their dtype.
+        data_original = self._sample_data(dtype=np.int32)
+        data_lazy = as_lazy_data(data_original)
+        cube = Cube(data_lazy)
+        self.assertEqual(cube.dtype, np.dtype('i4'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('i4'))
+        data = cube.data
+        self.assertArrayEqual(data, data_original)
+
+    def test_lazydata_maskedints(self):
+        # Check that lazy masked ints have a modified dtype.
+        masked_data_original = self._sample_data(dtype=np.int32, masked=True)
+        masked_data_lazy = as_lazy_data(masked_data_original)
+        cube = Cube(masked_data_lazy)
+        cube.dtype = masked_data_original.dtype
+        self.assertEqual(cube.dtype, np.dtype('i4'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
+        data = cube.data
+        self.assertTrue(np.ma.is_masked(data))
+        self.assertMaskedArrayEqual(data, masked_data_original)
+
+    def test_lazydata_floating_dtype_change(self):
+        # Check that re-assigning dtype won't allow a floating type.
+        cube = self._sample_cube(dtype=np.float32, lazy=True,
+                                 cube_fill_value=23.7)
+        self.assertArrayAllClose(cube.fill_value, 23.7)
+        msg = "Can only cast lazy data to integral dtype"
+        with self.assertRaisesRegexp(ValueError, msg):
+            cube.dtype = np.float64
+
+    def test_lazydata_dtype_change(self):
+        # Check that re-assigning dtype resets fill_value.
+        cube = self._sample_cube(dtype=np.float32, lazy=True,
+                                 cube_fill_value=23.7)
+        self.assertArrayAllClose(cube.fill_value, 23.7)
+        cube.dtype = np.int16
+        self.assertEqual(cube.dtype, np.dtype('i2'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('f4'))
+        self.assertIsNone(cube.fill_value)
+
+
+    def test_lazydata_maskedints_dtype_change(self):
+        # Check that re-assigning dtype resets fill_value.
+        cube = self._sample_cube(dtype=np.int16, masked=True, lazy=True,
+                                 cube_fill_value=199)
+        self.assertEqual(cube.dtype, np.dtype('i2'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
+        self.assertArrayAllClose(cube.fill_value, 199)
+        cube.dtype = np.int64
+        self.assertEqual(cube.dtype, np.dtype('i8'))
+        self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
+        self.assertIsNone(cube.fill_value)
+
+    def test_fill_value__int_dtype_to_float(self):
+        # Check that fill_value is cast to dtype, e.g. float --> int.
+        cube = self._sample_cube(dtype=np.float32, cube_fill_value=1735)
+        self.assertEqual(cube.fill_value.dtype, np.dtype('f4'))
+        self.assertArrayAllClose(cube.fill_value, 1735.0)
+
+    def test_fill_value__float_dtype_to_int(self):
+        # Check that fill_value is rounded to dtype, e.g. float --> int.
+        cube = self._sample_cube(dtype=np.int16, cube_fill_value=1734.99999)
+        self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
+        self.assertArrayAllClose(cube.fill_value, 1735)
+
+
 class TestSubset(tests.IrisTest):
     def test_scalar_coordinate(self):
         cube = Cube(0, long_name='apricot', units='1')

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1359,7 +1359,6 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         self.assertEqual(cube.core_data.dtype, np.dtype('f4'))
         self.assertIsNone(cube.fill_value)
 
-
     def test_lazydata_maskedints_dtype_change(self):
         # Check that re-assigning dtype resets fill_value.
         cube = self._sample_cube(dtype=np.int16, masked=True, lazy=True,
@@ -1383,6 +1382,31 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         cube = self._sample_cube(dtype=np.int16, cube_fill_value=1734.99999)
         self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
         self.assertArrayAllClose(cube.fill_value, 1735)
+
+    def test_set_fill_value(self):
+        cube = self._sample_cube()
+        cube.fill_value = -74.6
+        self.assertEqual(cube.fill_value.dtype, np.dtype('f4'))
+        self.assertArrayAllClose(cube.fill_value, -74.6)
+
+    def test_set_fill_value__typecast(self):
+        cube = self._sample_cube(dtype=np.int16)
+        cube.fill_value = -74.6
+        self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
+        self.assertArrayAllClose(cube.fill_value, -75)
+
+    def test_set_fill_value__casterror(self):
+        cube = self._sample_cube(dtype=np.int16)
+        msg = "invalid for cube dtype\('int16'\)"
+        with self.assertRaisesRegexp(ValueError, msg):
+            # NOTE: this doesn't actually work properly in most cases.
+            # E.G. it will happily assign 1e12 to an int16 and gets 4096.
+            cube.fill_value = -1.0e23
+
+    def test_clear_fill_value(self):
+        cube = self._sample_cube(cube_fill_value=123.768)
+        cube.fill_value = None
+        self.assertIsNone(cube.fill_value)
 
 
 class TestSubset(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -139,7 +139,7 @@ class TestCoordAttributes(tests.IrisTest):
 
         cf_var = mock.MagicMock(spec=iris.fileformats.cf.CFVariable,
                                 dtype=np.dtype('i4'),
-                                cf_data=mock.Mock(),
+                                cf_data=mock.Mock(_FillValue=None),
                                 cf_name='DUMMY_VAR',
                                 cf_group=coords,
                                 shape=(1,))


### PR DESCRIPTION
This PR addresses the issue of dealing with the `dtype` and `fill_value` of the cube.

We need to deal with fact that `dask` does not support masked arrays, and so we need to take care to correctly handle the intended `dtype` and `fill_value` of the data payload in the cube.

The `dtype` and `fill_value` have now been promoted to be cube metadata attributes, because we care about them and define what a cube is. In the case of a `dask` lazy, masked data payload, we need to preserve the case where the intended `dtype` is integral.

We also have a shift in how `fill_value` is handled, in that previously we handed that off to `biggus` and `numpy.ma` in the hope that it would do the right thing. Now we deal with this directly within the cube through `cube.fill_value`, which is used as the intended `fill_value` of any masked data payload. 