### PR TITLE
Consistent check for masked array types

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -67,7 +67,7 @@ def as_lazy_data(data, chunks=_MAX_CHUNK_SIZE):
 
     """
     if not is_lazy_data(data):
-        if isinstance(data, ma.MaskedArray):
+        if ma.isMaskedArray(data):
             data = array_masked_to_nans(data)
         data = da.from_array(data, chunks=chunks)
     return data

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1186,7 +1186,7 @@ def _count(array, function, axis, **kwargs):
 def _proportion(array, function, axis, **kwargs):
     # if the incoming array is masked use that to count the total number of
     # values
-    if isinstance(array, ma.MaskedArray):
+    if ma.isMaskedArray(array):
         # calculate the total number of non-masked values across the given axis
         total_non_masked = _count(array.mask, np.logical_not,
                                   axis=axis, **kwargs)

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1079,7 +1079,7 @@ def _weighted_quantile_1D(data, weights, quantiles, **kwargs):
         of weights is zero or masked)
     """
     # Return np.nan if no useable points found
-    if np.isclose(weights.sum(), 0.) or weights.sum() is ma.masked:
+    if np.isclose(weights.sum(), 0.) or ma.is_masked(weights.sum()):
         return np.resize(np.array(np.nan), len(quantiles))
     # Sort the data
     ind_sorted = ma.argsort(data)

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -101,7 +101,7 @@ def extend_circular_data(data, coord_dim):
     coord_slice_in_cube = [slice(None)] * data.ndim
     coord_slice_in_cube[coord_dim] = slice(0, 1)
 
-    mod = ma if isinstance(data, ma.MaskedArray) else np
+    mod = ma if ma.isMaskedArray(data) else np
     data = mod.concatenate((data,
                             data[tuple(coord_slice_in_cube)]),
                            axis=coord_dim)
@@ -366,7 +366,7 @@ class RectilinearInterpolator(object):
             self._interpolator.values = src_mask
             mask_fraction = self._interpolator(interp_points)
             new_mask = (mask_fraction > 0)
-            if isinstance(data, ma.MaskedArray) or np.any(new_mask):
+            if ma.isMaskedArray(data) or np.any(new_mask):
                 result = np.ma.MaskedArray(result, new_mask)
 
         return result

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -223,7 +223,7 @@ class RectilinearRegridder(object):
             if dtype.kind == 'i':
                 dtype = np.promote_types(dtype, np.float16)
 
-        if isinstance(src_data, ma.MaskedArray):
+        if ma.isMaskedArray(src_data):
             data = ma.empty(shape, dtype=dtype)
             data.mask = np.zeros(data.shape, dtype=np.bool)
         else:
@@ -319,7 +319,7 @@ class RectilinearRegridder(object):
             interpolator.fill_value = mode.fill_value
             data[tuple(index)] = interpolate(src_subset)
 
-            if isinstance(data, ma.MaskedArray) or mode.force_mask:
+            if ma.isMaskedArray(data) or mode.force_mask:
                 # NB. np.ma.getmaskarray returns an array of `False` if
                 # `src_subset` is not a masked array.
                 src_mask = np.ma.getmaskarray(src_subset)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -721,7 +721,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             self._numpy_array = None
         else:
             self._dask_array = None
-            if not isinstance(data, ma.MaskedArray):
+            if not ma.isMaskedArray(data):
                 data = np.asarray(data)
             self._numpy_array = data
 
@@ -2262,7 +2262,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         data = copy.deepcopy(data)
 
         # We can turn a masked array into a normal array if it's full.
-        if isinstance(data, ma.core.MaskedArray):
+        if ma.isMaskedArray(data):
             if ma.count_masked(data) == 0:
                 data = data.filled()
 
@@ -3001,7 +3001,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     data.dtype = data.dtype.newbyteorder('<')
                 return data
 
-            if isinstance(data, ma.MaskedArray):
+            if ma.isMaskedArray(data):
                 # Fill in masked values to avoid the checksum being
                 # sensitive to unused numbers. Use a fixed value so
                 # a change in fill_value doesn't affect the
@@ -3047,7 +3047,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 if array_byteorder is not None:
                     data_xml_element.setAttribute('byteorder', array_byteorder)
 
-            if order and isinstance(data, ma.core.MaskedArray):
+            if order and ma.isMaskedArray(data):
                 data_xml_element.setAttribute('mask_order',
                                               _order(data.mask))
         else:
@@ -3579,7 +3579,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # Determine aggregation result data type for the aggregate-by cube
             # data on first pass.
             if i == 0:
-                if isinstance(self.data, ma.MaskedArray):
+                if ma.isMaskedArray(self.data):
                     aggregateby_data = ma.zeros(data_shape, dtype=result.dtype)
                 else:
                     aggregateby_data = np.zeros(data_shape, dtype=result.dtype)

--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -761,12 +761,12 @@ THEN
 
 #MDI
 IF
-    isinstance(cm.data, ma.core.MaskedArray)
+    ma.isMaskedArray(cm.data)
 THEN
     pp.bmdi = cm.data.fill_value
 
 IF
-    not isinstance(cm.data, ma.core.MaskedArray)
+    not ma.isMaskedArray(cm.data)
 THEN
     pp.bmdi = -1e30
 

--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
+import numpy.ma as ma
 from osgeo import gdal, osr
 
 import cf_units
@@ -97,7 +98,7 @@ def _gdal_write_array(x_min, x_step, y_max, y_step, coord_system, data, fname,
     gdal_dataset.SetGeoTransform(padf_transform)
 
     band = gdal_dataset.GetRasterBand(1)
-    if isinstance(data, np.ma.core.MaskedArray):
+    if ma.isMaskedArray(data):
         data = data.copy()
         data[data.mask] = data.fill_value
         band.SetNoDataValue(float(data.fill_value))

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -678,7 +678,7 @@ class CFLabelVariable(CFVariable):
         str_dim_name = str_dim_name[0]
         label_data = self[:]
 
-        if isinstance(label_data, ma.MaskedArray):
+        if ma.isMaskedArray(label_data):
             label_data = label_data.filled()
 
         # Determine whether we have a string-valued scalar label

--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/grib/_load_convert.py
+++ b/lib/iris/fileformats/grib/_load_convert.py
@@ -422,7 +422,7 @@ def ellipsoid(shapeOfTheEarth, major, minor, radius):
     elif shapeOfTheEarth == 1:
         # Earth assumed spherical with radius specified (in m) by
         # data producer.
-        if radius is ma.masked:
+        if ma.is_masked(radius):
             msg = 'Ellipsoid for shape of the earth {} requires a' \
                 'radius to be specified.'.format(shapeOfTheEarth)
             raise ValueError(msg)
@@ -432,9 +432,9 @@ def ellipsoid(shapeOfTheEarth, major, minor, radius):
         # specified (in km)/(in m) by data producer.
         emsg_oblate = 'Ellipsoid for shape of the earth [{}] requires a' \
             'semi-{} axis to be specified.'
-        if major is ma.masked:
+        if ma.is_masked(major):
             raise ValueError(emsg_oblate.format(shapeOfTheEarth, 'major'))
-        if minor is ma.masked:
+        if ma.is_masked(minor):
             raise ValueError(emsg_oblate.format(shapeOfTheEarth, 'minor'))
         # Check whether to convert from km to m.
         if shapeOfTheEarth == 3:

--- a/lib/iris/fileformats/grib/_save_rules.py
+++ b/lib/iris/fileformats/grib/_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/grib/_save_rules.py
+++ b/lib/iris/fileformats/grib/_save_rules.py
@@ -1029,7 +1029,7 @@ def product_definition_section(cube, grib):
 
 def data_section(cube, grib):
     # Masked data?
-    if isinstance(cube.data, ma.core.MaskedArray):
+    if ma.isMaskedArray(cube.data):
         # What missing value shall we use?
         if not np.isnan(cube.data.fill_value):
             # Use the data's fill value.

--- a/lib/iris/fileformats/grib/grib_save_rules.py
+++ b/lib/iris/fileformats/grib/grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/grib/grib_save_rules.py
+++ b/lib/iris/fileformats/grib/grib_save_rules.py
@@ -621,7 +621,7 @@ def product_template(cube, grib):
 
 def data(cube, grib):
     # Masked data?
-    if isinstance(cube.data, ma.core.MaskedArray):
+    if ma.isMaskedArray(cube.data):
         # What missing value shall we use?
         if not np.isnan(cube.data.fill_value):
             # Use the data's fill value.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -394,7 +394,7 @@ class NetCDFDataProxy(object):
             var = variable[keys]
         finally:
             dataset.close()
-        if isinstance(var, ma.MaskedArray):
+        if ma.isMaskedArray(var):
             var = array_masked_to_nans(var)
         return var
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1383,7 +1383,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         # Before we can actually write to file, we need to calculate the header
         # elements. First things first, make sure the data is big-endian
         data = self.data
-        if isinstance(data, ma.core.MaskedArray):
+        if ma.isMaskedArray(data):
             data = data.filled(fill_value=self.bmdi)
 
         if data.dtype.newbyteorder('>') != data.dtype:

--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ import cf_units
 from cf_units import Unit
 import netcdftime
 import numpy as np
+import numpy.ma as ma
 import pandas
 
 import iris
@@ -170,7 +171,7 @@ def as_series(cube, copy=True):
 
     """
     data = cube.data
-    if isinstance(data, np.ma.MaskedArray):
+    if ma.isMaskedArray(data):
         if not copy:
             raise ValueError("Masked arrays must always be copied.")
         data = data.astype('f').filled(np.nan)
@@ -216,7 +217,7 @@ def as_data_frame(cube, copy=True):
 
     """
     data = cube.data
-    if isinstance(data, np.ma.MaskedArray):
+    if ma.isMaskedArray(data):
         if not copy:
             raise ValueError("Masked arrays must always be copied.")
         data = data.astype('f').filled(np.nan)

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -418,7 +418,7 @@ class IrisTest_nometa(unittest.TestCase):
                 stats = json.load(reference_file)
                 self.assertEqual(stats.get('shape', []), list(cube.shape))
                 self.assertEqual(stats.get('masked', False),
-                                       isinstance(cube.data, ma.MaskedArray))
+                                 ma.isMaskedArray(cube.data))
                 nstats = np.array((stats.get('mean', 0.), stats.get('std', 0.),
                                    stats.get('max', 0.), stats.get('min', 0.)),
                                   dtype=np.float_)

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -433,7 +433,7 @@ class IrisTest_nometa(unittest.TestCase):
             self._ensure_folder(reference_path)
             logger.warning('Creating result file: %s', reference_path)
             masked = False
-            if isinstance(cube.data, ma.MaskedArray):
+            if ma.isMaskedArray(cube.data):
                 masked = True
             stats = {'mean': np.float_(cube.data.mean()),
                      'std': np.float_(cube.data.std()),

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1186,7 +1186,7 @@ class Test_copy(tests.IrisTest):
         self.assertIsNot(cube_copy, cube)
         self.assertEqual(cube_copy, cube)
         self.assertIsNot(cube_copy.data, cube.data)
-        if isinstance(cube.data, ma.MaskedArray):
+        if ma.isMaskedArray(cube.data):
             self.assertMaskedArrayEqual(cube_copy.data, cube.data)
             if cube.data.mask is not ma.nomask:
                 # "No mask" is a constant : all other cases must be distinct.

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -931,7 +931,7 @@ def ensure_array(a):
     """.. deprecated:: 1.7"""
     warn_deprecated('ensure_array() is deprecated and will be removed '
                     'in a future release.')
-    if not isinstance(a, (np.ndarray, ma.core.MaskedArray)):
+    if not isinstance(a, np.ndarray) and not ma.isMaskedArray(a):
         a = np.array([a])
     return a
 


### PR DESCRIPTION
Consistency! And using part of an API for what it was meant for (in this case checking that an object is of a certain type).

To wit, anything that looks like the former will now look like the latter:

 * `if isinstance(thing, ma.core.MaskedArray)` --> `if ma.isMaskedArray(thing)`
 * `if thing is ma.masked` --> `if ma.is_masked(thing)`