### PR TITLE
Remove some `@tests.skip_biggus` that are now unnecessary

### DIFF
--- a/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
+++ b/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
@@ -66,7 +66,6 @@ class TestProjectedUnstructured(tests.IrisTest):
         self.assertArrayShapeStats(res[:, 0], (1, 73, 96),
                                    299.99993826, 3.9223839688e-5)
 
-    @tests.skip_biggus
     def test_nearest_gnomonic_uk_domain(self):
         crs = ccrs.Gnomonic(central_latitude=60.0)
         uk_grid = self.global_grid.intersection(longitude=(-20, 20),
@@ -110,7 +109,6 @@ class TestProjectedUnstructured(tests.IrisTest):
                                    299.99993826, 3.9226378869e-5)
         self.assertEqual(res.coord('altitude').shape, (6, 73, 96))
 
-    @tests.skip_biggus
     def test_linear_sinusoidal(self):
         res = self.src.regrid(self.global_grid, ProjectedUnstructuredLinear())
         self.assertArrayShapeStats(res, (1, 6, 73, 96),

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -28,7 +28,6 @@ from iris.analysis import MEAN
 from iris._lazy_data import is_lazy_data
 
 
-@tests.skip_biggus
 class Test_aggregated_by(tests.IrisTest):
     @tests.skip_data
     def test_agg_by_aux_coord(self):

--- a/lib/iris/tests/integration/test_regridding.py
+++ b/lib/iris/tests/integration/test_regridding.py
@@ -34,7 +34,6 @@ from iris.tests.stock import global_pp, simple_3d
 from iris.analysis import UnstructuredNearest
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestOSGBToLatLon(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/results/analysis/calculus/curl_contrived_cartesian2.cml
+++ b/lib/iris/tests/results/analysis/calculus/curl_contrived_cartesian2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="u curl of wind" units="0.277777777777778 hertz">
+  <cube core-dtype="float64" dtype="float64" long_name="u curl of wind" units="0.277777777777778 hertz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,
@@ -31,7 +31,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(10, 25, 49)" state="loaded"/>
   </cube>
-  <cube long_name="v curl of wind" units="0.277777777777778 hertz">
+  <cube core-dtype="float64" dtype="float64" long_name="v curl of wind" units="0.277777777777778 hertz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,
@@ -62,7 +62,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(10, 25, 49)" state="loaded"/>
   </cube>
-  <cube long_name="w curl of wind" units="0.277777777777778 hertz">
+  <cube core-dtype="float64" dtype="float64" long_name="w curl of wind" units="0.277777777777778 hertz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_simple_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_simple_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_in_x_wind_wrt_x" units="km/h">
+  <cube core-dtype="float32" dtype="float32" long_name="change_in_x_wind_wrt_x" units="km/h">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="61a1c174" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_in_x_wind_wrt_latitude" units="km/h">
+  <cube core-dtype="float32" dtype="float32" long_name="change_in_x_wind_wrt_latitude" units="km/h">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_in_x_wind_wrt_longitude" units="km/h">
+  <cube core-dtype="float32" dtype="float32" long_name="change_in_x_wind_wrt_longitude" units="km/h">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_in_x_wind_wrt_x" units="km/h">
+  <cube core-dtype="float32" dtype="float32" long_name="change_in_x_wind_wrt_x" units="km/h">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_y.cml
+++ b/lib/iris/tests/results/analysis/calculus/delta_handmade_wrt_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="change_in_x_wind_wrt_y" units="km/h">
+  <cube core-dtype="float32" dtype="float32" long_name="change_in_x_wind_wrt_y" units="km/h">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived1.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
+  <cube core-dtype="float64" dtype="float64" long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="620d7656" points="[-87.0, -81.0, -75.0, -69.0, -63.0, -57.0, -51.0,

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived2.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
+  <cube core-dtype="float64" dtype="float64" long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="620d7656" points="[-88.7143, -86.1429, -83.5714, -81.0, -78.4286,

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived_non_spherical1.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived_non_spherical1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="w curl of wind" units="0.277777777777778 hertz">
+  <cube core-dtype="float64" dtype="float64" long_name="w curl of wind" units="0.277777777777778 hertz">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,

--- a/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-87.75, -83.25, -78.75, -74.25, -69.75, -65.25,

--- a/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -85.5, -81.0, -76.5, -72.0, -67.5, -63.0,

--- a/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="61a1c174" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube long_name="derivative_of_x_wind_wrt_y" units="0.277777777777778 meter-second^-1">
+  <cube core-dtype="float32" dtype="float32" long_name="derivative_of_x_wind_wrt_y" units="0.277777777777778 meter-second^-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/cdm/masked_cube.cml
+++ b/lib/iris/tests/results/cdm/masked_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="unknown">
+  <cube core-dtype="float32" dtype="float32" fill_value="1e-09" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -36,6 +36,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xf4816e76" dtype="float32" fill_value="1e-09" mask_checksum="0x54a64fdc" shape="(8, 20, 20)"/>
+    <data checksum="0xf4816e76" dtype="float32" mask_checksum="0x54a64fdc" shape="(8, 20, 20)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_all_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_all_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_last_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_last_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_middle_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_middle_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_zeroth_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/collapse_zeroth_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/slice.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/transposed.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/add/TestBroadcasting/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_all_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_all_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_last_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_last_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_middle_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_middle_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_zeroth_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_zeroth_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/slice.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/transposed.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_all_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_all_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_last_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_last_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_middle_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_middle_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_zeroth_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/collapse_zeroth_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/slice.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/transposed.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/subtract/TestBroadcasting/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -200,7 +200,6 @@ class TestCoordTrig(tests.IrisTest):
         self.assertXMLElement(cos_of_coord_radians, ('analysis', 'calculus', 'cos_simple_radians.xml'))
 
 
-@tests.skip_biggus
 class TestCalculusSimple3(tests.IrisTest):
 
     def setUp(self):
@@ -223,7 +222,6 @@ class TestCalculusSimple3(tests.IrisTest):
         self.assertCMLApproxData(t, ('analysis', 'calculus', 'handmade2_wrt_lat.cml'))
 
 
-@tests.skip_biggus
 class TestCalculusSimple2(tests.IrisTest):
 
     def setUp(self):
@@ -275,7 +273,6 @@ class TestCalculusSimple2(tests.IrisTest):
         self.assertCMLApproxData(t, ('analysis', 'calculus', 'delta_handmade_wrt_lat.cml'))
 
 
-@tests.skip_biggus
 class TestCalculusSimple1(tests.IrisTest):
 
     def setUp(self):
@@ -337,7 +334,6 @@ def build_cube(data, spherical=False):
     return cube
 
 
-@tests.skip_biggus
 class TestCalculusWKnownSolutions(tests.IrisTest):
 
     def get_coord_pts(self, cube):
@@ -623,7 +619,6 @@ class TestCurlInterface(tests.IrisTest):
         v.rename('northward_foobar2')
         self.assertRaises(ValueError, iris.analysis.calculus.spatial_vectors_with_phenom_name, u, v)
 
-    @tests.skip_biggus
     def test_rotated_pole(self):
         u = build_cube(np.empty((30, 20)), spherical='rotated')
         v = u.copy()

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1009,7 +1009,6 @@ class TestDataManagerIndexing(TestCube2d):
         self.assertRaises(IndexError, self.cube.__getitem__, ((0, 4, 5, 2), (3, 5, 5), 0, 0, 4) )
         self.assertRaises(IndexError, self.cube.__getitem__, (Ellipsis, Ellipsis, Ellipsis, Ellipsis, Ellipsis, Ellipsis) )
 
-    @tests.skip_biggus
     def test_fancy_indexing_bool_array(self):
         cube = self.cube
         cube.data = np.ma.masked_array(cube.data, mask=cube.data > 100000)
@@ -1149,19 +1148,16 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
 
         self.assertIsInstance(cube.data, np.ndarray)
 
-    @tests.skip_biggus
     def test_masked_field(self):
         # This pp field has some missing data values
         cube = iris.load_cube(tests.get_data_path(["PP", "mdi_handmade_small", "mdi_test_1000_0.pp"]))
         self.assertIsInstance(cube.data, ma.core.MaskedArray)
 
-    @tests.skip_biggus
     def test_missing_file(self):
         cube = self._load_3d_cube()
         self.assertIsInstance(cube.data, ma.core.MaskedArray)
         self.assertCML(cube, ('cdm', 'masked_cube.cml'))
 
-    @tests.skip_biggus
     def test_slicing(self):
         cube = self._load_3d_cube()
 
@@ -1186,7 +1182,7 @@ class TestMaskedData(tests.IrisTest, pp.PPTest):
         # extract the 2d field that has SOME missing values
         masked_slice = cube[0]
         masked_slice.data.fill_value = 123456
-        
+
         # test saving masked data
         reference_txt_path = tests.get_result_path(('cdm', 'masked_save_pp.txt'))
         with self.cube_save_test(reference_txt_path, reference_cubes=masked_slice) as temp_pp_path:

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -30,7 +30,6 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
-@tests.skip_biggus
 @tests.skip_data
 @tests.iristest_timing_decorator
 class TestBroadcasting(tests.IrisTest_nometa,

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -30,7 +30,6 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
-@tests.skip_biggus
 @tests.skip_data
 @tests.iristest_timing_decorator
 class TestBroadcasting(tests.IrisTest_nometa,

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -30,7 +30,6 @@ from iris.tests.unit.analysis.maths import \
     CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
 
 
-@tests.skip_biggus
 @tests.skip_data
 @tests.iristest_timing_decorator
 class TestBroadcasting(tests.IrisTest_nometa,

--- a/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
@@ -190,7 +190,6 @@ class Test___call____bad_src(tests.IrisTest):
             self.regridder(self.src_grid[::2, ::2])
 
 
-@tests.skip_biggus
 class Test__call__multidimensional(tests.IrisTest):
     def test_multidim(self):
         # Testing with >2D data to demonstrate correct operation over

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -69,7 +69,6 @@ class TestBoundsVertexDim(tests.IrisTest):
             'iris.fileformats.netcdf.NetCDFDataProxy.__getitem__',
             new=patched__getitem__)
 
-    @tests.skip_biggus
     def test_slowest_varying_vertex_dim(self):
         # Create the bounds cf variable.
         bounds = np.arange(24).reshape(4, 2, 3)


### PR DESCRIPTION
This removes some of the skippers that were put in place for the Iris-dask integration since they are no longer needed.

The cml has change for some due to core-dtype, dtype and fill value becoming cube attributes

Relevant Issue: #2398

There are still some outstanding tests that have skippers in them but they are a bit more complicated so I will deal with them in later PRs