### PR TITLE
Remove the last bits of biggus

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -97,8 +97,11 @@ def as_concrete_data(data, **kwargs):
 
     """
     if is_lazy_data(data):
-        # Realise dask array.
-        data = data.compute()
+        # Realise dask array, ensuring the data result is always a NumPy array.
+        # In some cases dask may return a scalar numpy.int/numpy.float object
+        # rather than a numpy.ndarray object.
+        # Recorded in https://github.com/dask/dask/issues/2111.
+        data = np.asanyarray(data.compute())
         # Convert any missing data as requested.
         data = convert_nans_array(data, **kwargs)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -33,7 +33,6 @@ import warnings
 from xml.dom.minidom import Document
 import zlib
 
-import biggus
 import dask.array as da
 import numpy as np
 import numpy.ma as ma

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -663,9 +663,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             This object defines the shape of the cube and the phenomenon
             value in each cell.
 
-            It can be a biggus array, a numpy array, a numpy array
-            subclass (such as :class:`numpy.ma.MaskedArray`), or an
-            *array_like* as described in :func:`numpy.asarray`.
+            ``data`` can be a dask array, a NumPy array, a NumPy array
+            subclass (such as :class:`numpy.ma.MaskedArray`), or
+            array_like (as described in :func:`numpy.asarray`).
 
             See :attr:`Cube.data<iris.cube.Cube.data>`.
 

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -30,8 +30,8 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
-from iris.coords import DimCoord
 from iris._lazy_data import as_lazy_data
+from iris.coords import DimCoord
 
 
 class Test_lazy_maths(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -36,8 +36,8 @@ from iris._lazy_data import as_lazy_data
 
 class Test_lazy_maths(tests.IrisTest):
     def build_lazy_cube(self, points, dtype=np.float64, bounds=None, nx=10):
-        data = \
-            np.arange(len(points) * nx, dtype=dtype).reshape(len(points), nx)
+        data = np.arange(len(points) * nx, dtype=dtype) + 1  # Just avoid 0.
+        data = data.reshape(len(points), nx)
         data = as_lazy_data(data)
         cube = iris.cube.Cube(data, standard_name='air_temperature', units='K')
         lat = DimCoord(points, 'latitude', bounds=bounds)
@@ -100,13 +100,13 @@ class Test_lazy_maths(tests.IrisTest):
 
     def test_div_cubes__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        op = operator.div
+        op = operator.truediv
         self.cube_cube_math_op(c1, op)
 
     def test_div_scalar__float(self):
         c1 = self.build_lazy_cube([1, 2])
         scalar = 5
-        op = operator.div
+        op = operator.truediv
         self.cube_scalar_math_op(c1, scalar, op, commutative=False)
 
     def test_add_cubes__int(self):
@@ -144,13 +144,13 @@ class Test_lazy_maths(tests.IrisTest):
 
     def test_div_cubes__int(self):
         c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
-        op = operator.div
+        op = operator.truediv
         self.cube_cube_math_op(c1, op)
 
     def test_div_scalar__int(self):
         c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
         scalar = 5
-        op = operator.div
+        op = operator.truediv
         self.cube_scalar_math_op(c1, scalar, op, commutative=False)
 
 
@@ -196,11 +196,11 @@ class Test_lazy_maths__scalar_cube(tests.IrisTest):
         self.check_common(c3, c4, op)
 
     def test_div_scalar__int(self):
-        c3, c4, op = self.c3, 5, operator.div
+        c3, c4, op = self.c3, 5, operator.truediv
         self.check_common(c3, c4, op)
 
     def test_div_cubes__int(self):
-        c3, c4, op = self.c3, self.c4, operator.div
+        c3, c4, op = self.c3, self.c4, operator.truediv
         self.check_common(c3, c4, op)
 
     def test_add_scalar__float(self):
@@ -228,11 +228,11 @@ class Test_lazy_maths__scalar_cube(tests.IrisTest):
         self.check_common(c1, c2, op)
 
     def test_div_scalar__float(self):
-        c1, c2, op = self.c1, 5, operator.div
+        c1, c2, op = self.c1, 5, operator.truediv
         self.check_common(c1, c2, op)
 
     def test_div_cubes__float(self):
-        c1, c2, op = self.c1, self.c2, operator.div
+        c1, c2, op = self.c1, self.c2, operator.truediv
         self.check_common(c1, c2, op)
 
 

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -19,173 +19,247 @@
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import iris
+# import iris tests first so that some things can be initialised
+# before importing anything else.
 import iris.tests as tests
+
+import operator
+
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
-import biggus
-from biggus._init import _Elementwise
+
+import iris
+from iris.coords import DimCoord
+from iris._lazy_data import as_lazy_data
 
 
-@tests.skip_biggus
-class Test_Lazy_Maths(tests.IrisTest):
-    def build_lazy_cube(self, points, bounds=None, nx=10):
-        data = np.arange(len(points) * nx).reshape(len(points), nx)
-        data = biggus.NumpyArrayAdapter(data)
+class Test_lazy_maths(tests.IrisTest):
+    def build_lazy_cube(self, points, dtype=np.float64, bounds=None, nx=10):
+        data = \
+            np.arange(len(points) * nx, dtype=dtype).reshape(len(points), nx)
+        data = as_lazy_data(data)
         cube = iris.cube.Cube(data, standard_name='air_temperature', units='K')
-        lat = iris.coords.DimCoord(points, 'latitude', bounds=bounds)
-        lon = iris.coords.DimCoord(np.arange(nx), 'longitude')
+        lat = DimCoord(points, 'latitude', bounds=bounds)
+        lon = DimCoord(np.arange(nx), 'longitude')
         cube.add_dim_coord(lat, 0)
         cube.add_dim_coord(lon, 1)
         return cube
 
-    def assert_elementwise(self, cube, other, result, np_op):
-        self.assertIsInstance(result, _Elementwise)
-        self.assertEqual(result._numpy_op, np_op)
-        self.assertArrayAlmostEqual(result._array1, cube.lazy_data())
-        if other is not None:
-            self.assertArrayAlmostEqual(result._array2, other)
+    def check_common(self, base_cube, result):
+        self.assertTrue(base_cube.has_lazy_data())
+        self.assertTrue(result.has_lazy_data())
+        self.assertIsInstance(result.lazy_data(), da.core.Array)
 
-    def test_lazy_biggus_add_cubes(self):
+    def cube_cube_math_op(self, c1, math_op):
+        result = math_op(c1, c1)
+        self.check_common(c1, result)
+        expected = math_op(c1.data, c1.data)
+        self.assertArrayAlmostEqual(result.data, expected)
+
+    def cube_scalar_math_op(self, c1, scalar, math_op, commutative=True):
+        result = math_op(c1, scalar)
+        if commutative:
+            self.assertEqual(math_op(c1, scalar), math_op(scalar, c1))
+        self.check_common(c1, result)
+        expected = math_op(c1.data, scalar)
+        self.assertArrayAlmostEqual(result.data, expected)
+
+    def test_add_cubes__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 + c1
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, c1.lazy_data(), result, np.add)
+        op = operator.add
+        self.cube_cube_math_op(c1, op)
 
-    def test_lazy_biggus_add_scalar(self):
+    def test_add_scalar__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 + 5
-        self.assertEqual(c1 + 5, 5 + c1)
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, None, result, np.add)
+        scalar = 5
+        op = operator.add
+        self.cube_scalar_math_op(c1, scalar, op)
 
-    def test_lazy_biggus_mul_cubes(self):
+    def test_mul_cubes__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 * c1
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, c1.lazy_data(), result, np.multiply)
+        op = operator.mul
+        self.cube_cube_math_op(c1, op)
 
-    def test_lazy_biggus_mul_scalar(self):
+    def test_mul_scalar__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 * 5
-        self.assertEqual(c1 * 5, 5 * c1)
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, None, result, np.multiply)
+        scalar = 5
+        op = operator.mul
+        self.cube_scalar_math_op(c1, scalar, op)
 
-    def test_lazy_biggus_sub_cubes(self):
+    def test_sub_cubes__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 - c1
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, c1.lazy_data(), result, np.subtract)
+        op = operator.sub
+        self.cube_cube_math_op(c1, op)
 
-    def test_lazy_biggus_sub_scalar(self):
+    def test_sub_scalar__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 - 5
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, None, result, np.subtract)
+        scalar = 5
+        op = operator.sub
+        self.cube_scalar_math_op(c1, scalar, op, commutative=False)
 
-    def test_lazy_biggus_div_cubes(self):
+    def test_div_cubes__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 / c1
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, c1.lazy_data(), result, np.divide)
+        op = operator.div
+        self.cube_cube_math_op(c1, op)
 
-    def test_lazy_biggus_div_scalar(self):
+    def test_div_scalar__float(self):
         c1 = self.build_lazy_cube([1, 2])
-        cube = c1 / 5
-        result = cube.lazy_data()
-        self.assertTrue(cube.has_lazy_data())
-        self.assert_elementwise(c1, None, result, np.divide)
+        scalar = 5
+        op = operator.div
+        self.cube_scalar_math_op(c1, scalar, op, commutative=False)
+
+    def test_add_cubes__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        op = operator.add
+        self.cube_cube_math_op(c1, op)
+
+    def test_add_scalar__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        scalar = 5
+        op = operator.add
+        self.cube_scalar_math_op(c1, scalar, op)
+
+    def test_mul_cubes__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        op = operator.mul
+        self.cube_cube_math_op(c1, op)
+
+    def test_mul_scalar__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        scalar = 5
+        op = operator.mul
+        self.cube_scalar_math_op(c1, scalar, op)
+
+    def test_sub_cubes__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        op = operator.sub
+        self.cube_cube_math_op(c1, op)
+
+    def test_sub_scalar__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        scalar = 5
+        op = operator.sub
+        self.cube_scalar_math_op(c1, scalar, op, commutative=False)
+
+    def test_div_cubes__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        op = operator.div
+        self.cube_cube_math_op(c1, op)
+
+    def test_div_scalar__int(self):
+        c1 = self.build_lazy_cube([1, 2], dtype=np.int64)
+        scalar = 5
+        op = operator.div
+        self.cube_scalar_math_op(c1, scalar, op, commutative=False)
 
 
-@tests.skip_biggus
-class Test_Scalar_Cube_Lazy_Maths(tests.IrisTest):
-    def build_lazy_cube(self, value):
-        data = np.array(value)
-        data = biggus.NumpyArrayAdapter(data)
+class Test_lazy_maths__scalar_cube(tests.IrisTest):
+    def build_lazy_cube(self, value, dtype=np.float64):
+        data = as_lazy_data(np.array(value, dtype=dtype))
         return iris.cube.Cube(data, standard_name='air_temperature', units='K')
 
     def setUp(self):
         self.c1 = self.build_lazy_cube(3)
         self.c2 = self.build_lazy_cube(4)
+        self.c3 = self.build_lazy_cube(3, dtype=np.int64)
+        self.c4 = self.build_lazy_cube(4, dtype=np.int64)
 
-    def test_add_scalar(self):
-        cube = self.c1 + 5
+    def check_common(self, c1, c2, math_op):
+        cube = math_op(c1, c2)
         data = cube.data
         self.assertTrue(isinstance(data, np.ndarray))
         self.assertEqual(data.shape, ())
 
-    def test_add_cubes(self):
-        cube = self.c1 + self.c2
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_add_scalar__int(self):
+        c3, c4, op = self.c3, 5, operator.add
+        self.check_common(c3, c4, op)
 
-    def test_mul_scalar(self):
-        cube = self.c1 * 5
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_add_cubes__int(self):
+        c3, c4, op = self.c3, self.c4, operator.add
+        self.check_common(c3, c4, op)
 
-    def test_mul_cubes(self):
-        cube = self.c1 * self.c2
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_mul_scalar__int(self):
+        c3, c4, op = self.c3, 5, operator.mul
+        self.check_common(c3, c4, op)
 
-    def test_sub_scalar(self):
-        cube = self.c1 - 5
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_mul_cubes__int(self):
+        c3, c4, op = self.c3, self.c4, operator.mul
+        self.check_common(c3, c4, op)
 
-    def test_sub_cubes(self):
-        cube = self.c1 - self.c2
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_sub_scalar__int(self):
+        c3, c4, op = self.c3, 5, operator.sub
+        self.check_common(c3, c4, op)
 
-    def test_div_scalar(self):
-        cube = self.c1 / 5
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_sub_cubes__int(self):
+        c3, c4, op = self.c3, self.c4, operator.sub
+        self.check_common(c3, c4, op)
 
-    def test_div_cubes(self):
-        cube = self.c1 / self.c2
-        data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
-        self.assertEqual(data.shape, ())
+    def test_div_scalar__int(self):
+        c3, c4, op = self.c3, 5, operator.div
+        self.check_common(c3, c4, op)
+
+    def test_div_cubes__int(self):
+        c3, c4, op = self.c3, self.c4, operator.div
+        self.check_common(c3, c4, op)
+
+    def test_add_scalar__float(self):
+        c1, c2, op = self.c1, 5, operator.add
+        self.check_common(c1, c2, op)
+
+    def test_add_cubes__float(self):
+        c1, c2, op = self.c1, self.c2, operator.add
+        self.check_common(c1, c2, op)
+
+    def test_mul_scalar__float(self):
+        c1, c2, op = self.c1, 5, operator.mul
+        self.check_common(c1, c2, op)
+
+    def test_mul_cubes__float(self):
+        c1, c2, op = self.c1, self.c2, operator.mul
+        self.check_common(c1, c2, op)
+
+    def test_sub_scalar__float(self):
+        c1, c2, op = self.c1, 5, operator.sub
+        self.check_common(c1, c2, op)
+
+    def test_sub_cubes__float(self):
+        c1, c2, op = self.c1, self.c2, operator.sub
+        self.check_common(c1, c2, op)
+
+    def test_div_scalar__float(self):
+        c1, c2, op = self.c1, 5, operator.div
+        self.check_common(c1, c2, op)
+
+    def test_div_cubes__float(self):
+        c1, c2, op = self.c1, self.c2, operator.div
+        self.check_common(c1, c2, op)
 
 
-@tests.skip_biggus
-class Test_Masked_Lazy_Maths(tests.IrisTest):
-
-    def build_lazy_cube(self):
-        data = ma.array([[1., 1.], [1., 100000.]], mask=[[0, 0], [0, 1]])
-        data = biggus.NumpyArrayAdapter(data)
+class Test_lazy_maths__masked_data(tests.IrisTest):
+    def build_lazy_cube(self, dtype=np.float64):
+        data = ma.array([[1., 1.], [1., 100000.]],
+                        mask=[[0, 0], [0, 1]],
+                        dtype=dtype)
+        data = as_lazy_data(data)
         cube = iris.cube.Cube(data, standard_name='air_temperature', units='K')
-        lat = iris.coords.DimCoord([-10, 10], 'latitude')
-        lon = iris.coords.DimCoord([10, 20], 'longitude')
+        lat = DimCoord([-10, 10], 'latitude')
+        lon = DimCoord([10, 20], 'longitude')
         cube.add_dim_coord(lat, 0)
         cube.add_dim_coord(lon, 1)
         return cube
 
-    def test_subtract(self):
+    def test_subtract__float(self):
         cube_a = self.build_lazy_cube()
         cube_b = self.build_lazy_cube()
         cube_c = cube_a - cube_b
-        self.assertIsInstance(
-            cube_c.data,
-            ma.MaskedArray,
-            msg='known fail with biggus < 0.13.0, consider upgrading')
+        self.assertTrue(ma.isMaskedArray(cube_c.data))
+
+    def test_subtract__int(self):
+        cube_a = self.build_lazy_cube(dtype=np.int64)
+        cube_b = self.build_lazy_cube(dtype=np.int64)
+        cube_c = cube_a - cube_b
+        self.assertTrue(ma.isMaskedArray(cube_c.data))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove the final biggus imports (and usages) from the codebase*.

In essence, this means:

 * delete a couple of spurious (and unused!) biggus import statements,
 * sort out some test modules, and
 * tidy up the lazy data API where the tests very pleasingly showed up a couple of gaps in it.

Fixes #2443.
&nbsp;

\* Well, not _quite_: I explicitly **haven't** dealt with grib here - we'll [do](https://github.com/SciTools/iris/issues/2342) that [later](https://github.com/SciTools/iris/issues/2306).