### PR TITLE
Fix for dtype.kind

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -337,7 +337,7 @@ class _CubeSignature(object):
         kwargs = self.defn._asdict()
         if kwargs['dtype'] is None and not cube.has_lazy_data() and \
                 isinstance(cube.data, ma.masked_array) and \
-                cube.data.dtype.kind == 'i':
+                cube.data.dtype.kind in 'biu':
             kwargs['dtype'] = self.data_type
             self.defn = iris.cube.CubeMetadata(**kwargs)
 

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -134,7 +134,7 @@ def array_masked_to_nans(array):
     else:
         if ma.is_masked(array):
             mask = array.mask
-            if array.dtype.kind == 'i':
+            if array.dtype.kind in 'biu':
                 result = array.data.astype(np.dtype('f8'))
             else:
                 result = array.data.copy()

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1640,8 +1640,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     emsg = 'Cube does not have lazy data, cannot set dtype.'
                     raise ValueError(emsg)
                 if dtype.kind not in 'biu':
-                    emsg = ('Can only cast lazy data to integral dtype, '
-                            'got {!r}.')
+                    emsg = ('Can only cast lazy data to integral or bool '
+                            'dtype, got {!r}.')
                     raise ValueError(emsg.format(dtype))
                 self._fill_value = None
                 self._dtype = dtype

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1639,7 +1639,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 if not self.has_lazy_data():
                     emsg = 'Cube does not have lazy data, cannot set dtype.'
                     raise ValueError(emsg)
-                if dtype.kind != 'i':
+                if dtype.kind not in 'biu':
                     emsg = ('Can only cast lazy data to integral dtype, '
                             'got {!r}.')
                     raise ValueError(emsg.format(dtype))
@@ -1658,7 +1658,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # Convert the given value to the dtype of the cube.
             fill_value = np.asarray([fill_value])[0]
             target_dtype = self.dtype
-            if fill_value.dtype.kind == 'f' and target_dtype.kind == 'i':
+            if fill_value.dtype.kind == 'f' and target_dtype.kind in 'biu':
                 # Perform rounding when converting floats to ints.
                 fill_value = np.rint(fill_value)
             try:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1640,7 +1640,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     emsg = 'Cube does not have lazy data, cannot set dtype.'
                     raise ValueError(emsg)
                 if dtype.kind not in 'biu':
-                    emsg = ('Can only cast lazy data to integral or bool '
+                    emsg = ('Can only cast lazy data to an integer or boolean '
                             'dtype, got {!r}.')
                     raise ValueError(emsg.format(dtype))
                 self._fill_value = None

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1252,7 +1252,7 @@ class Test_fill_value(tests.IrisTest):
         self.assertEqual(cube.fill_value, None)
 
     def test_fill_value_bool(self):
-        fill_value = np.array([1], dtype=np.dtype('bool'))[0]
+        fill_value = np.bool_(True)
         for dtype in self.dtypes:
             data = np.array([0], dtype=dtype)
             cube = Cube(data, fill_value=fill_value)
@@ -1261,7 +1261,7 @@ class Test_fill_value(tests.IrisTest):
             self.assertEqual(cube.fill_value.dtype, dtype)
 
     def test_fill_value_int(self):
-        fill_value = np.array([123], dtype=np.dtype('int'))[0]
+        fill_value = np.int_(123)
         for dtype in self.dtypes:
             data = np.array([0], dtype=dtype)
             cube = Cube(data, fill_value=fill_value)
@@ -1270,7 +1270,7 @@ class Test_fill_value(tests.IrisTest):
             self.assertEqual(cube.fill_value.dtype, dtype)
 
     def test_fill_value_float(self):
-        fill_value = np.array([123.4], dtype=np.dtype('float'))[0]
+        fill_value = np.float_(123.4)
         for dtype in self.dtypes:
             data = np.array([0], dtype=dtype)
             cube = Cube(data, fill_value=fill_value)
@@ -1281,7 +1281,7 @@ class Test_fill_value(tests.IrisTest):
             self.assertEqual(cube.fill_value.dtype, dtype)
 
     def test_fill_value_uint(self):
-        fill_value = np.array([123], dtype=np.dtype('uint'))[0]
+        fill_value = np.uint(123)
         for dtype in self.dtypes:
             data = np.array([0], dtype=dtype)
             cube = Cube(data, fill_value=fill_value)
@@ -1290,7 +1290,7 @@ class Test_fill_value(tests.IrisTest):
             self.assertEqual(cube.fill_value.dtype, dtype)
 
     def test_fill_value_overflow(self):
-        fill_value = np.array([1e+20], dtype=np.dtype('float'))[0]
+        fill_value = np.float_(1e+20)
         data = np.array([0], dtype=np.int)
         emsg = 'Fill value of .* invalid for cube dtype'
         with self.assertRaisesRegexp(ValueError, emsg):
@@ -1372,12 +1372,7 @@ class Test_dtype(tests.IrisTest):
             data = ma.array([0, 1], dtype=dtype)
             data[0] = ma.masked
             cube = Cube(as_lazy_data(data))
-            if dtype == np.dtype('float'):
-                self.assertEqual(cube.dtype, dtype)
-            else:
-                # For dask, integral masked data is converted to float
-                # to support the replacement of masks with NaNs.
-                self.assertEqual(cube.dtype, np.dtype('float'))
+            self.assertEqual(cube.dtype, np.dtype('float'))
             # Check that accessing the dtype does not trigger loading
             # of the data.
             self.assertTrue(cube.has_lazy_data())

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1411,7 +1411,7 @@ class Test_dtype(tests.IrisTest):
     def test_lazy_data_with_dtype_non_integral(self):
         for dtype in self.dtypes:
             data = np.array([0, 1], dtype=dtype)
-            emsg = 'Can only cast lazy data to integral dtype'
+            emsg = 'Can only cast lazy data to integral or bool dtype'
             with self.assertRaisesRegexp(ValueError, emsg):
                 Cube(as_lazy_data(data), dtype=np.complex)
 
@@ -1521,7 +1521,7 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         cube = self._sample_cube(dtype=np.float32, lazy=True,
                                  cube_fill_value=23.7)
         self.assertArrayAllClose(cube.fill_value, 23.7)
-        msg = "Can only cast lazy data to integral dtype"
+        msg = "Can only cast lazy data to integral or bool dtype"
         with self.assertRaisesRegexp(ValueError, msg):
             cube.dtype = np.float64
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1406,7 +1406,7 @@ class Test_dtype(tests.IrisTest):
     def test_lazy_data_with_dtype_non_integral(self):
         for dtype in self.dtypes:
             data = np.array([0, 1], dtype=dtype)
-            emsg = 'Can only cast lazy data to integral or bool dtype'
+            emsg = 'Can only cast lazy data to an integer or boolean dtype'
             with self.assertRaisesRegexp(ValueError, emsg):
                 Cube(as_lazy_data(data), dtype=np.complex)
 
@@ -1516,7 +1516,7 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         cube = self._sample_cube(dtype=np.float32, lazy=True,
                                  cube_fill_value=23.7)
         self.assertArrayAllClose(cube.fill_value, 23.7)
-        msg = "Can only cast lazy data to integral or bool dtype"
+        msg = "Can only cast lazy data to an integer or boolean dtype"
         with self.assertRaisesRegexp(ValueError, msg):
             cube.dtype = np.float64
 


### PR DESCRIPTION
Fix to support `dtype.kind` to also check for `uint` and `bool` cases (as well as `int`).

