### PR TITLE
Slice order test with bugfix

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3940,6 +3940,17 @@ class _SliceIterator(collections.Iterator):
 
         if self._ordered:
             if any(self._mod_requested_dims != list(range(len(cube.shape)))):
+                # TODO: Correct the re-ordering here.
+                # Currently argsort determines the chronology of the requested
+                # order and then sorts it into that.  What we need is to relate
+                # the reduced-dimensionality order to the requested order and
+                # apply that instead.
+                # For example, if the requested order was [3, 0, 1], the cube
+                # gets sliced up and hence ends up with only 3 dimensions
+                # instead of 4, so the order then needs to become [2, 0, 1].
+                # TODO: How do I determine the reduced dimensionality ordering?
+                # Will this involve some sort of mapping of argsorted dims to
+                # new cube dims?
                 cube.transpose(self._mod_requested_dims)
 
         return cube


### PR DESCRIPTION
The problem that was occurring here was due to the difference in dimension indices before and after slicing.  For example, if I had a 4-dimensional cube and wanted to do cube.slices with the dim order as [3, 0, 1], upon slicing this order becomes [2, 0, 1].  This transition was not properly handled before; it had been attempted with the use of argsort(), but this was muddling things up and not sorting them properly.  

To fix the issue, I decided that after I had sliced the cube, I needed to remap the dimensions by converting them to their names and then back to their new indices to make sure that the order was correct.  To do this I have borrowed a piece of functionality that was used in cube.slices() which turns the dimension name into its index.  
