### PR TITLE
Corrected use of deprecated numpy behaviour. Necessary for numpy 1.12.

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -239,7 +239,7 @@ class GribWrapper(object):
             # The byte offset requires to be reset back to the first byte
             # of this message. The file pointer offset is always at the end 
             # of the current message due to the grib-api reading the message.
-            proxy = GribDataProxy(shape, np.zeros(.0).dtype, np.nan,
+            proxy = GribDataProxy(shape, np.array([0.]).dtype, np.nan,
                                   grib_fh.name,
                                   offset - message_length,
                                   auto_regularise)


### PR DESCRIPTION
The behaviour we are depending on is deprecated (and removed) in newer numpy versions...

```
$ python -c "import numpy as np; print(np.__version__); np.zeros(0.).dtype"
1.7.1

$ python -c "import numpy as np; print(np.__version__); np.zeros(0.)"
1.12.1
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'float' object cannot be interpreted as an index
```

We will also want to fix this in iris_grib.