### PR TITLE
Ignore missing formula terms when constructing aux factories

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1676,7 +1676,8 @@ class ProtoCube(object):
             dependencies = factory.dependencies
             for key in sorted(dependencies):
                 coord = dependencies[key]
-                dependency_defns.append((key, coord._as_defn()))
+                if coord is not None:
+                    dependency_defns.append((key, coord._as_defn()))
             factory_defn = _FactoryDefn(type(factory), dependency_defns)
             factory_defns.append(factory_defn)
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -359,6 +359,14 @@ class Test_register__CoordSig_general(_MergeTest, tests.IrisTest):
         self.cube1.add_aux_factory(mock.MagicMock(spec=HybridPressureFactory))
         self.check_fail("cube.aux_factories", "differ")
 
+    def test_factory_defns_one_missing_term(self):
+        self.cube1.add_aux_factory(mock.MagicMock(spec=HybridPressureFactory))
+        no_delta_factory = mock.MagicMock(spec=HybridPressureFactory)
+        no_delta_factory.delta = None
+        self.cube2.add_aux_factory(no_delta_factory)
+
+        self.check_fail("cube.aux_factories", "differ")
+
     def test_noise(self):
         cube2 = self.cube2
 


### PR DESCRIPTION
The CF conventions state that certain `formula_terms` terms may be omitted and assumed to be zero (http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#dimensionless-v-coord). This logic is implemented in the various `AuxCoordFactory` sub-classes in Iris, but when constructing factories from data loaded from a netCDF file an error is raised if a term is missing. This PR allows factories to be constructed with missing terms.

The change has the perhaps undesirable side effect that if a formula term refers to a variable which doesn't exist, or one which has been ignored because it wasn't valid, the factory will still be constructed with that coordinate omitted. Previously this would result in an error caused by a dependency coordinate not being present in an `AuxCoordFactory` when merging (see https://github.com/SciTools/iris/blob/master/lib/iris/_merge.py#L1679). But it looks like this was unintentional; the `AuxCoordFactory` class are written in a way which allows missing coordinates.