### PR TITLE
Prevent sliced coords sharing data with their parent coord.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -464,38 +464,40 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         # each dimension of the coord.
         full_slice = iris.util._build_full_slice_given_keys(key, self.ndim)
 
-        # If it's a "null" indexing operation (e.g. coord[:, :]) then
-        # we can preserve deferred loading by avoiding promoting _points
-        # and _bounds to full ndarray instances.
+        # Fetch the points and bounds.
+        points = self._points
+        bounds = self._bounds
+
+        # Track whether we need to copy data after any indexing operation.
+        # NOTE: when we get rid of LazyArray-s, we can remove this bit.
+        points_copied = False
+        bounds_copied = False
+
+        # If it's a "null" indexing operation (e.g. coord[:, :]) then we can
+        # avoid all the indexing.  This is desirable if we have LazyArray-s,
+        # as they must be fetched first (you can't index them).
         def is_full_slice(s):
             return isinstance(s, slice) and s == slice(None, None)
-        if all(is_full_slice(s) for s in full_slice):
-            points = self._points
-            bounds = self._bounds
-            # Take copies, to avoid making coords that are views on other ones.
-            if not isinstance(points, iris.aux_factory._LazyArray):
-                points = points.copy()
+        null_operation = all(is_full_slice(s) for s in full_slice)
+
+        if null_operation:
+            # If we have Lazy Arrays, don't copy but just allow the new coord
+            # to share the same LazyArray object.
+            if isinstance(points, iris.aux_factory._LazyArray):
+                points_copied = True
             if bounds is not None:
-                if not isinstance(bounds, iris.aux_factory._LazyArray):
-                    bounds = bounds.copy()
+                if isinstance(bounds, iris.aux_factory._LazyArray):
+                    bounds_copied = True
         else:
-            points = self._points
             if isinstance(points, iris.aux_factory._LazyArray):
                 # This triggers the LazyArray to compute its values
                 # (if it hasn't already), which will also trigger any
                 # deferred loading of its dependencies.
                 points = points.view()
-            else:
-                # Take a copy to avoid making coords that are views on other
-                # coords.  This will not realise lazy data.
-                points = points.copy()
-            bounds = self._bounds
+                points_copied = True
             if isinstance(bounds, iris.aux_factory._LazyArray):
                 bounds = bounds.view()
-            elif bounds is not None:
-                # Take a copy to avoid making coords that are views on other
-                # coords.  This will not realise lazy data.
-                bounds = bounds.copy()
+                bounds_copied = True
 
             # Make indexing on the cube column based by using the
             # column_slices_generator (potentially requires slicing the
@@ -511,6 +513,14 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 if bounds is not None:
                     bounds = bounds[keys + (Ellipsis, )]
 
+        # Copy data after indexing, if needed, to avoid making coords that are
+        # views on other coords.  This will not realise lazy data.
+        if not points_copied:
+            points = points.copy()
+        if bounds is not None and not bounds_copied:
+            bounds = bounds.copy()
+
+        # The new coordinate is a copy of the old one with replaced content.
         new_coord = self.copy(points=points, bounds=bounds)
         return new_coord
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -472,6 +472,12 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if all(is_full_slice(s) for s in full_slice):
             points = self._points
             bounds = self._bounds
+            # Take copies, to avoid making coords that are views on other ones.
+            if not isinstance(points, iris.aux_factory._LazyArray):
+                points = points.copy()
+            if bounds is not None:
+                if not isinstance(bounds, iris.aux_factory._LazyArray):
+                    bounds = bounds.copy()
         else:
             points = self._points
             if isinstance(points, iris.aux_factory._LazyArray):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -479,9 +479,17 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 # (if it hasn't already), which will also trigger any
                 # deferred loading of its dependencies.
                 points = points.view()
+            else:
+                # Take a copy to avoid making coords that are views on other
+                # coords.  This will not realise lazy data.
+                points = points.copy()
             bounds = self._bounds
             if isinstance(bounds, iris.aux_factory._LazyArray):
                 bounds = bounds.view()
+            elif bounds is not None:
+                # Take a copy to avoid making coords that are views on other
+                # coords.  This will not realise lazy data.
+                bounds = bounds.copy()
 
             # Make indexing on the cube column based by using the
             # column_slices_generator (potentially requires slicing the

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -88,22 +88,6 @@ class TestLazy(tests.IrisTest):
         self.assertEqual(self.coord.shape, (3, 4))
         self._check_lazy(self.coord)
 
-    def _check_shared_data(self, coord):
-        # Updating the original coord's points should update the sliced
-        # coord's points too.
-        points = coord.points
-        new_points = coord[:].points
-        np.testing.assert_array_equal(points, new_points)
-        points[0, 0] = 999
-        self.assertEqual(points[0, 0], new_points[0, 0])
-
-    def test_concrete_shared_data(self):
-        coord = iris.coords.AuxCoord(np.arange(12).reshape((3, 4)))
-        self._check_shared_data(coord)
-
-    def test_lazy_shared_data(self):
-        self._check_shared_data(self.coord)
-
 
 @tests.skip_data
 class TestCoordSlicing(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -366,6 +366,15 @@ class Test_DimCoord_copy(tests.IrisTest):
 
         with self.assertRaisesRegexp(ValueError, msg):
             coord2.bounds[:] = 0
+
+
+class Test_AuxCoord__getitem__(tests.IrisTest):
+    def test_data_copy(self):
+        original_coord = AuxCoord([1., 2., 3.])
+        sub_coord = original_coord[:1]
+        original_values = sub_coord.points.copy()
+        original_coord.points[:] = -999.9
+        self.assertArrayEqual(sub_coord.points, original_values)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -370,18 +370,18 @@ class Test_DimCoord_copy(tests.IrisTest):
 
 class Test_AuxCoord__getitem__(tests.IrisTest):
     def test_partial_slice_data_copy(self):
-        original_coord = AuxCoord([1., 2., 3.])
-        sub_coord = original_coord[:1]
-        original_values = sub_coord.points.copy()
-        original_coord.points[:] = -999.9
-        self.assertArrayEqual(sub_coord.points, original_values)
+        parent_coord = AuxCoord([1., 2., 3.])
+        sub_coord = parent_coord[:1]
+        values_before_change = sub_coord.points.copy()
+        parent_coord.points[:] = -999.9
+        self.assertArrayEqual(sub_coord.points, values_before_change)
 
     def test_full_slice_data_copy(self):
-        original_coord = AuxCoord([1., 2., 3.])
-        sub_coord = original_coord[:]
-        original_values = sub_coord.points.copy()
-        original_coord.points[:] = -999.9
-        self.assertArrayEqual(sub_coord.points, original_values)
+        parent_coord = AuxCoord([1., 2., 3.])
+        sub_coord = parent_coord[:]
+        values_before_change = sub_coord.points.copy()
+        parent_coord.points[:] = -999.9
+        self.assertArrayEqual(sub_coord.points, values_before_change)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -369,9 +369,16 @@ class Test_DimCoord_copy(tests.IrisTest):
 
 
 class Test_AuxCoord__getitem__(tests.IrisTest):
-    def test_data_copy(self):
+    def test_partial_slice_data_copy(self):
         original_coord = AuxCoord([1., 2., 3.])
         sub_coord = original_coord[:1]
+        original_values = sub_coord.points.copy()
+        original_coord.points[:] = -999.9
+        self.assertArrayEqual(sub_coord.points, original_values)
+
+    def test_full_slice_data_copy(self):
+        original_coord = AuxCoord([1., 2., 3.])
+        sub_coord = original_coord[:]
         original_values = sub_coord.points.copy()
         original_coord.points[:] = -999.9
         self.assertArrayEqual(sub_coord.points, original_values)


### PR DESCRIPTION
While considering #2490 I noticed that a sliced Coord (an AuxCoord, at least) can be linked to the original.
This is exactly what we found when working on #2513, and fixed in [this line in that PR](https://github.com/SciTools/iris/pull/2513/files#r113925900)

I think this is a simple bug, as concluded for the CellMeasures.
Obviously though, a behaviour change in coords could be a bit more dangerous.
There were some very old tests that check the exact opposite behaviour (i.e. indexed coords share data with their originals), so I got rid of those.
Otherwise, it didn't break any existing tests ! :crossed_fingers: 

Note that this modified `Coord.__getitem__` code will simplify nicely when we get rid of `LazyArray`s.
Currently we must still support LazyArray-s for points and bounds data, as aux factories are still using them.