### PR TITLE
Remove `LazyArray` class from coords

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1685,10 +1685,7 @@ class ProtoCube(object):
         # the CoordDefn used by scalar_defns: `coord.points.dtype` and
         # `type(coord)`.
         def key_func(coord):
-            # Try to avoid evaluating LazyArray instances.
-            points_dtype = coord._points.dtype
-            if points_dtype is None:
-                points_dtype = coord.points.dtype
+            points_dtype = coord.points.dtype
             return (not np.issubdtype(points_dtype, np.number),
                     not isinstance(coord, iris.coords.DimCoord),
                     hint_dict.get(coord.name(), len(hint_dict) + 1),

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -25,121 +25,12 @@ import six
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 import warnings
-import zlib
 
-import cf_units
 import numpy as np
 
-from iris._deprecation import warn_deprecated
 from iris._cube_coord_common import CFVariableMixin
 import iris.coords
 import iris.util
-
-
-class _LazyArray(object):
-    """
-    Represents a simplified NumPy array which is only computed on demand.
-
-    It provides the :meth:`view()` and :meth:`reshape()` methods so it
-    can be used in place of a standard NumPy array under some
-    circumstances.
-
-    The first use of either of these methods causes the array to be
-    computed and cached for any subsequent access.
-
-    """
-    def __init__(self, shape, func, dtype=None):
-        """
-        Args:
-
-        * shape (tuple):
-            The shape of the array which will be created.
-        * func:
-            The function which will be called to supply the real array.
-
-        Kwargs:
-
-        * dtype (np.dtype):
-            The numpy dtype of the array which will be created.
-            Defaults to None to signify the dtype is unknown.
-
-        """
-        self.shape = tuple(shape)
-        self._func = func
-        self.dtype = dtype
-        self._array = None
-
-    def __repr__(self):
-        return '<LazyArray(shape={}, dtype={!r})>'.format(self.shape,
-                                                          self.dtype)
-
-    def _cached_array(self):
-        if self._array is None:
-            self._array = np.asarray(self._func())
-            del self._func
-        return self._array
-
-    def reshape(self, *args, **kwargs):
-        """
-        Returns a view of this array with the given shape.
-
-        See :meth:`numpy.ndarray.reshape()` for argument details.
-
-        """
-        return self._cached_array().reshape(*args, **kwargs)
-
-    def to_xml_attr(self):
-        """
-        Returns a string describing this array, suitable for use in CML.
-
-        """
-        crc = zlib.crc32(np.array(self._cached_array(), order='C'))
-        crc &= 0xffffffff
-        return 'LazyArray(shape={}, checksum=0x{:08x})'.format(self.shape, crc)
-
-    def view(self, *args, **kwargs):
-        """
-        Returns a view of this array.
-
-        See :meth:`numpy.ndarray.view()` for argument details.
-
-        """
-        return self._cached_array().view(*args, **kwargs)
-
-
-class LazyArray(_LazyArray):
-    """
-    Represents a simplified NumPy array which is only computed on demand.
-
-    It provides the :meth:`view()` and :meth:`reshape()` methods so it
-    can be used in place of a standard NumPy array under some
-    circumstances.
-
-    The first use of either of these methods causes the array to be
-    computed and cached for any subsequent access.
-
-    .. deprecated:: 1.9
-
-    """
-    def __init__(self, shape, func, dtype=None):
-        """
-        Args:
-
-        * shape (tuple):
-            The shape of the array which will be created.
-        * func:
-            The function which will be called to supply the real array.
-
-        Kwargs:
-
-        * dtype (np.dtype):
-            The numpy dtype of the array which will be created.
-            Defaults to None to signify the dtype is unknown.
-
-        """
-        warn_deprecated('LazyArray is deprecated and will be removed '
-                        'in a future release.', stacklevel=2)
-        super(LazyArray, self).__init__(shape, func, dtype)
 
 
 class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
@@ -507,8 +398,7 @@ class HybridHeightFactory(AuxCoordFactory):
                 'orography': self.orography}
 
     def _derive(self, delta, sigma, orography):
-        temp = delta + sigma * orography
-        return temp
+        return delta + sigma * orography
 
     def make_coord(self, coord_dims_func):
         """
@@ -525,25 +415,18 @@ class HybridHeightFactory(AuxCoordFactory):
         """
         # Which dimensions are relevant?
         derived_dims = self.derived_dims(coord_dims_func)
-
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['delta'],
-                                nd_points_by_key['sigma'],
-                                nd_points_by_key['orography'])
-        shape = self._shape(nd_points_by_key)
-        dtype = self._dtype(nd_points_by_key)
-        points = _LazyArray(shape, calc_points, dtype)
+        points = self._derive(nd_points_by_key['delta'],
+                              nd_points_by_key['sigma'],
+                              nd_points_by_key['orography'])
 
         bounds = None
         if ((self.delta and self.delta.nbounds) or
                 (self.sigma and self.sigma.nbounds)):
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
 
@@ -566,9 +449,7 @@ class HybridHeightFactory(AuxCoordFactory):
                     orography = orography_pts.reshape(
                         orography_pts_shape.append(1))
                 return self._derive(delta, sigma, orography)
-            b_shape = self._shape(nd_values_by_key)
-            b_dtype = self._dtype(nd_values_by_key)
-            bounds = _LazyArray(b_shape, calc_bounds, b_dtype)
+            bounds = calc_bounds()
 
         hybrid_height = iris.coords.AuxCoord(points,
                                              standard_name=self.standard_name,
@@ -707,8 +588,7 @@ class HybridPressureFactory(AuxCoordFactory):
                 'surface_air_pressure': self.surface_air_pressure}
 
     def _derive(self, delta, sigma, surface_air_pressure):
-        temp = delta + sigma * surface_air_pressure
-        return temp
+        return delta + sigma * surface_air_pressure
 
     def make_coord(self, coord_dims_func):
         """
@@ -725,25 +605,18 @@ class HybridPressureFactory(AuxCoordFactory):
         """
         # Which dimensions are relevant?
         derived_dims = self.derived_dims(coord_dims_func)
-
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['delta'],
-                                nd_points_by_key['sigma'],
-                                nd_points_by_key['surface_air_pressure'])
-        shape = self._shape(nd_points_by_key)
-        dtype = self._dtype(nd_points_by_key)
-        points = _LazyArray(shape, calc_points, dtype)
+        points = self._derive(nd_points_by_key['delta'],
+                              nd_points_by_key['sigma'],
+                              nd_points_by_key['surface_air_pressure'])
 
         bounds = None
         if ((self.delta and self.delta.nbounds) or
                 (self.sigma and self.sigma.nbounds)):
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
 
@@ -767,9 +640,7 @@ class HybridPressureFactory(AuxCoordFactory):
                     surface_air_pressure = surface_air_pressure_pts.reshape(
                         surface_air_pressure_pts_shape.append(1))
                 return self._derive(delta, sigma, surface_air_pressure)
-            b_shape = self._shape(nd_values_by_key)
-            b_dtype = self._dtype(nd_values_by_key)
-            bounds = _LazyArray(b_shape, calc_bounds, b_dtype)
+            bounds = calc_bounds()
 
         hybrid_pressure = iris.coords.AuxCoord(
             points, standard_name=self.standard_name, long_name=self.long_name,
@@ -914,7 +785,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
                     depth_c=self.depth_c, nsigma=self.nsigma, zlev=self.zlev)
 
     def _derive(self, sigma, eta, depth, depth_c,
-                nsigma, zlev, shape, nsigma_slice):
+                zlev, shape, nsigma_slice):
         # Perform the ocean sigma over z coordinate nsigma slice.
         if eta.ndim:
             eta = eta[nsigma_slice]
@@ -945,10 +816,9 @@ class OceanSigmaZFactory(AuxCoordFactory):
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
         points_shape = self._shape(nd_points_by_key)
-        points_dtype = self._dtype(nd_points_by_key, shape=(), nsigma_slice=())
 
         # Calculate the nsigma slice.
         nsigma_slice = [slice(None)] * len(derived_dims)
@@ -957,27 +827,20 @@ class OceanSigmaZFactory(AuxCoordFactory):
         nsigma_slice[index] = slice(0, int(nd_points_by_key['nsigma']))
         nsigma_slice = tuple(nsigma_slice)
 
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['sigma'],
-                                nd_points_by_key['eta'],
-                                nd_points_by_key['depth'],
-                                nd_points_by_key['depth_c'],
-                                nd_points_by_key['nsigma'],
-                                nd_points_by_key['zlev'],
-                                points_shape,
-                                nsigma_slice)
-
-        points = _LazyArray(points_shape, calc_points, points_dtype)
+        points = self._derive(nd_points_by_key['sigma'],
+                              nd_points_by_key['eta'],
+                              nd_points_by_key['depth'],
+                              nd_points_by_key['depth_c'],
+                              nd_points_by_key['zlev'],
+                              points_shape,
+                              nsigma_slice)
 
         bounds = None
         if self.zlev.nbounds or (self.sigma and self.sigma.nbounds):
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
             bounds_shape = self._shape(nd_values_by_key)
-            bounds_dtype = self._dtype(nd_values_by_key, shape=(),
-                                       nsigma_slice=())
             nsigma_slice_bounds = nsigma_slice + (slice(None),)
 
             # Define the function here to obtain a closure.
@@ -1004,12 +867,10 @@ class OceanSigmaZFactory(AuxCoordFactory):
                                     nd_values_by_key['eta'],
                                     nd_values_by_key['depth'],
                                     nd_values_by_key['depth_c'],
-                                    nd_values_by_key['nsigma'],
                                     nd_values_by_key['zlev'],
                                     bounds_shape,
                                     nsigma_slice_bounds)
-
-            bounds = _LazyArray(bounds_shape, calc_bounds, bounds_dtype)
+            bounds = calc_bounds()
 
         coord = iris.coords.AuxCoord(points,
                                      standard_name=self.standard_name,
@@ -1122,8 +983,7 @@ class OceanSigmaFactory(AuxCoordFactory):
         return dict(sigma=self.sigma, eta=self.eta, depth=self.depth)
 
     def _derive(self, sigma, eta, depth):
-        result = eta + sigma * (depth + eta)
-        return result
+        return eta + sigma * (depth + eta)
 
     def make_coord(self, coord_dims_func):
         """
@@ -1140,24 +1000,17 @@ class OceanSigmaFactory(AuxCoordFactory):
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-        points_shape = self._shape(nd_points_by_key)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['sigma'],
-                                nd_points_by_key['eta'],
-                                nd_points_by_key['depth'])
-
-        points = _LazyArray(points_shape, calc_points)
+        points = self._derive(nd_points_by_key['sigma'],
+                              nd_points_by_key['eta'],
+                              nd_points_by_key['depth'])
 
         bounds = None
         if self.sigma and self.sigma.nbounds:
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
-            bounds_shape = self._shape(nd_values_by_key)
 
             # Define the function here to obtain a closure.
             def calc_bounds():
@@ -1181,10 +1034,9 @@ class OceanSigmaFactory(AuxCoordFactory):
                         nd_values_by_key[key] = bounds
                 return self._derive(nd_values_by_key['sigma'],
                                     nd_values_by_key['eta'],
-                                    nd_values_by_key['depth'],
-                                    bounds_shape)
+                                    nd_values_by_key['depth'])
 
-            bounds = _LazyArray(bounds_shape, calc_bounds)
+            bounds = calc_bounds()
 
         coord = iris.coords.AuxCoord(points,
                                      standard_name=self.standard_name,
@@ -1317,8 +1169,7 @@ class OceanSg1Factory(AuxCoordFactory):
 
     def _derive(self, s, c, eta, depth, depth_c):
         S = depth_c * s + (depth - depth_c) * c
-        result = S + eta * (1 + S / depth)
-        return result
+        return S + eta * (1 + S / depth)
 
     def make_coord(self, coord_dims_func):
         """
@@ -1335,26 +1186,19 @@ class OceanSg1Factory(AuxCoordFactory):
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-        points_shape = self._shape(nd_points_by_key)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['s'],
-                                nd_points_by_key['c'],
-                                nd_points_by_key['eta'],
-                                nd_points_by_key['depth'],
-                                nd_points_by_key['depth_c'])
-
-        points = _LazyArray(points_shape, calc_points)
+        points = self._derive(nd_points_by_key['s'],
+                              nd_points_by_key['c'],
+                              nd_points_by_key['eta'],
+                              nd_points_by_key['depth'],
+                              nd_points_by_key['depth_c'])
 
         bounds = None
         if self.s.nbounds or (self.c and self.c.nbounds):
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
-            bounds_shape = self._shape(nd_values_by_key)
 
             # Define the function here to obtain a closure.
             def calc_bounds():
@@ -1380,10 +1224,8 @@ class OceanSg1Factory(AuxCoordFactory):
                                     nd_values_by_key['c'],
                                     nd_values_by_key['eta'],
                                     nd_values_by_key['depth'],
-                                    nd_values_by_key['depth_c'],
-                                    bounds_shape)
-
-            bounds = _LazyArray(bounds_shape, calc_bounds)
+                                    nd_values_by_key['depth_c'])
+            bounds = calc_bounds()
 
         coord = iris.coords.AuxCoord(points,
                                      standard_name=self.standard_name,
@@ -1514,8 +1356,7 @@ class OceanSFactory(AuxCoordFactory):
     def _derive(self, s, eta, depth, a, b, depth_c):
         c = ((1 - b) * np.sinh(a * s) / np.sinh(a) + b *
              (np.tanh(a * (s + 0.5)) / (2 * np.tanh(0.5 * a)) - 0.5))
-        result = eta * (1 + s) + depth_c * s + (depth - depth_c) * c
-        return result
+        return eta * (1 + s) + depth_c * s + (depth - depth_c) * c
 
     def make_coord(self, coord_dims_func):
         """
@@ -1532,27 +1373,20 @@ class OceanSFactory(AuxCoordFactory):
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-        points_shape = self._shape(nd_points_by_key)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['s'],
-                                nd_points_by_key['eta'],
-                                nd_points_by_key['depth'],
-                                nd_points_by_key['a'],
-                                nd_points_by_key['b'],
-                                nd_points_by_key['depth_c'])
-
-        points = _LazyArray(points_shape, calc_points)
+        points = self._derive(nd_points_by_key['s'],
+                              nd_points_by_key['eta'],
+                              nd_points_by_key['depth'],
+                              nd_points_by_key['a'],
+                              nd_points_by_key['b'],
+                              nd_points_by_key['depth_c'])
 
         bounds = None
         if self.s.nbounds:
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
-            bounds_shape = self._shape(nd_values_by_key)
 
             # Define the function here to obtain a closure.
             def calc_bounds():
@@ -1579,10 +1413,8 @@ class OceanSFactory(AuxCoordFactory):
                                     nd_values_by_key['depth'],
                                     nd_values_by_key['a'],
                                     nd_values_by_key['b'],
-                                    nd_values_by_key['depth_c'],
-                                    bounds_shape)
-
-            bounds = _LazyArray(bounds_shape, calc_bounds)
+                                    nd_values_by_key['depth_c'])
+            bounds = calc_bounds()
 
         coord = iris.coords.AuxCoord(points,
                                      standard_name=self.standard_name,
@@ -1716,8 +1548,7 @@ class OceanSg2Factory(AuxCoordFactory):
 
     def _derive(self, s, c, eta, depth, depth_c):
         S = (depth_c * s + depth * c) / (depth_c + depth)
-        result = eta + (eta + depth) * S
-        return result
+        return eta + (eta + depth) * S
 
     def make_coord(self, coord_dims_func):
         """
@@ -1734,23 +1565,17 @@ class OceanSg2Factory(AuxCoordFactory):
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
 
-        # Build a "lazy" points array.
+        # Build the points array.
         nd_points_by_key = self._remap(dependency_dims, derived_dims)
-        points_shape = self._shape(nd_points_by_key)
-
-        # Define the function here to obtain a closure.
-        def calc_points():
-            return self._derive(nd_points_by_key['s'],
-                                nd_points_by_key['c'],
-                                nd_points_by_key['eta'],
-                                nd_points_by_key['depth'],
-                                nd_points_by_key['depth_c'])
-
-        points = _LazyArray(points_shape, calc_points)
+        points = self._derive(nd_points_by_key['s'],
+                              nd_points_by_key['c'],
+                              nd_points_by_key['eta'],
+                              nd_points_by_key['depth'],
+                              nd_points_by_key['depth_c'])
 
         bounds = None
         if self.s.nbounds or (self.c and self.c.nbounds):
-            # Build a "lazy" bounds array.
+            # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
             bounds_shape = self._shape(nd_values_by_key)
@@ -1779,10 +1604,8 @@ class OceanSg2Factory(AuxCoordFactory):
                                     nd_values_by_key['c'],
                                     nd_values_by_key['eta'],
                                     nd_values_by_key['depth'],
-                                    nd_values_by_key['depth_c'],
-                                    bounds_shape)
-
-            bounds = _LazyArray(bounds_shape, calc_bounds)
+                                    nd_values_by_key['depth_c'])
+            bounds = calc_bounds()
 
         coord = iris.coords.AuxCoord(points,
                                      standard_name=self.standard_name,

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1578,7 +1578,6 @@ class OceanSg2Factory(AuxCoordFactory):
             # Build the bounds array.
             nd_values_by_key = self._remap_with_bounds(dependency_dims,
                                                        derived_dims)
-            bounds_shape = self._shape(nd_values_by_key)
 
             # Define the function here to obtain a closure.
             def calc_bounds():

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -30,7 +30,6 @@ import numpy as np
 
 from iris._cube_coord_common import CFVariableMixin
 import iris.coords
-import iris.util
 
 
 class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1648,7 +1648,7 @@ fc_extras
             # dimension names.
             if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
                 # Resolving the data to a numpy array (i.e. *not* masked) for
-                # compatibility with array creators (i.e. LazyArray or Dask)
+                # compatibility with array creators (i.e. dask)
                 bounds_data = np.asarray(bounds_data)
                 bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
                                                   cf_coord_var)

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -23,12 +23,15 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import skip
+
 import iris
 from iris.analysis import MEAN
 from iris._lazy_data import is_lazy_data
 
 
 class Test_aggregated_by(tests.IrisTest):
+    @skip("Deferred loading of coordinates is temporarily removed.")
     @tests.skip_data
     def test_agg_by_aux_coord(self):
         problem_test_file = tests.get_data_path(('NetCDF', 'testing',

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -39,56 +39,6 @@ import iris.tests.stock
 logger = logging.getLogger('tests')
 
 
-class TestLazy(tests.IrisTest):
-    def setUp(self):
-        # Start with a coord with LazyArray points.
-        shape = (3, 4)
-        dtype = np.int64
-        point_func = lambda: np.arange(12, dtype=dtype).reshape(shape)
-        points = iris.aux_factory._LazyArray(shape, point_func, dtype)
-        self.coord = iris.coords.AuxCoord(points=points)
-
-    def _check_lazy(self, coord):
-        self.assertIsInstance(self.coord._points, iris.aux_factory._LazyArray)
-        self.assertIsNone(self.coord._points._array)
-
-    def test_nop(self):
-        self._check_lazy(self.coord)
-
-    def _check_both_lazy(self, new_coord):
-        # Make sure both coords have an "empty" LazyArray.
-        self._check_lazy(self.coord)
-        self._check_lazy(new_coord)
-
-    def test_lazy_slice1(self):
-        self._check_both_lazy(self.coord[:])
-
-    def test_lazy_slice2(self):
-        self._check_both_lazy(self.coord[:, :])
-
-    def test_lazy_slice3(self):
-        self._check_both_lazy(self.coord[...])
-
-    def _check_concrete(self, new_coord):
-        # Taking a genuine subset slice should trigger the evaluation
-        # of the original LazyArray, and result in a normal ndarray for
-        # the new coord.
-        self.assertIsInstance(self.coord._points, iris.aux_factory._LazyArray)
-        self.assertIsInstance(self.coord._points._array, np.ndarray)
-        self.assertIsInstance(new_coord._points, np.ndarray)
-
-    def test_concrete_slice1(self):
-        self._check_concrete(self.coord[0])
-
-    def test_concrete_slice2(self):
-        self._check_concrete(self.coord[0, :])
-
-    def test_shape(self):
-        # Checking the shape shouldn't trigger a lazy load.
-        self.assertEqual(self.coord.shape, (3, 4))
-        self._check_lazy(self.coord)
-
-
 @tests.skip_data
 class TestCoordSlicing(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ import six
 # importing anything else
 import iris.tests as tests
 
+from unittest import skip
 import warnings
 
 import numpy as np
@@ -143,6 +144,7 @@ class TestRealistic4d(tests.GraphicsTest):
             with self.assertRaises(UserWarning):
                 factory = HybridHeightFactory(orography=sigma)
 
+    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_bounded_orography(self):
         # Start with everything normal
         orog = self.cube.coord('surface_altitude')
@@ -157,8 +159,9 @@ class TestRealistic4d(tests.GraphicsTest):
 
         # Make sure altitude.bounds now raises an error.
         altitude = self.cube.coord('altitude')
-        with self.assertRaises(ValueError):
-            bounds = altitude.bounds
+        exp_emsg = 'operands could not be broadcast together'
+        with self.assertRaisesRegexp(ValueError, exp_emsg):
+            altitude.bounds
 
 
 @tests.skip_data
@@ -222,6 +225,7 @@ class TestHybridPressure(tests.IrisTest):
                 factory = HybridPressureFactory(
                     sigma=sigma, surface_air_pressure=sigma)
 
+    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_bounded_surface_pressure(self):
         # Start with everything normal
         surface_pressure = self.cube.coord('surface_air_pressure')
@@ -236,8 +240,9 @@ class TestHybridPressure(tests.IrisTest):
 
         # Make sure pressure.bounds now raises an error.
         pressure = self.cube.coord('air_pressure')
-        with self.assertRaises(ValueError):
-            bounds = pressure.bounds
+        exp_emsg = 'operands could not be broadcast together'
+        with self.assertRaisesRegexp(ValueError, exp_emsg):
+            pressure.bounds
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -32,6 +32,7 @@ import os.path
 import shutil
 import stat
 import tempfile
+from unittest import skip
 
 import netCDF4 as nc
 import numpy as np
@@ -106,6 +107,7 @@ class TestNetCDFLoad(tests.IrisTest):
             self.assertCML(cube, ('netcdf',
                                   'netcdf_global_xyzt_gems_iter_%d.cml' % i))
 
+    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_load_rotated_xy_land(self):
         # Test loading single xy rotated pole CF-netCDF file.
         cube = iris.load_cube(tests.get_data_path(

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -63,9 +63,7 @@ class TestPickle(tests.IrisTest):
             self.assertCubeData(cube, recon_cube)
 
     @tests.skip_data
-    def test_cube_with_deferred_coord_points(self):
-        # Data with 2d lats and lons that when loaded results in points that
-        # are LazyArray objects.
+    def test_cube_with_coord_points(self):
         filename = tests.get_data_path(('NetCDF',
                                         'rotated',
                                         'xy',

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -29,7 +29,6 @@ import iris.tests as tests
 
 import numpy as np
 
-from iris.aux_factory import _LazyArray
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     reorder_bounds_data
 from iris.tests import mock
@@ -52,19 +51,6 @@ class Test(tests.IrisTest):
         cf_coord_var = mock.Mock(dimensions=('foo', 'bar'))
 
         res = reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
-        # Move zeroth dimension (nv) to the end.
-        expected = np.rollaxis(bounds_data, 0, bounds_data.ndim)
-        self.assertArrayEqual(res, expected)
-
-    def test_slowest_varying_lazy(self):
-        bounds_data = np.arange(24).reshape(4, 2, 3)
-        lazy_bounds_data = _LazyArray(bounds_data.shape, lambda: bounds_data,
-                                      bounds_data.dtype)
-        cf_bounds_var = mock.Mock(dimensions=('nv', 'foo', 'bar'))
-        cf_coord_var = mock.Mock(dimensions=('foo', 'bar'))
-
-        res = reorder_bounds_data(lazy_bounds_data, cf_bounds_var,
-                                  cf_coord_var)
         # Move zeroth dimension (nv) to the end.
         expected = np.rollaxis(bounds_data, 0, bounds_data.ndim)
         self.assertArrayEqual(res, expected)


### PR DESCRIPTION
In the past the coord `LazyArray` class was used to defer loading of all coords, but now it is only used to defer calculation of derived coordinates. However, there was still some `LazyArray` logic hanging around in the wider coords codebase, which was getting in the way of integrating the `DataManager` with coords. We have decided to remove the `LazyArray` class entirely to help this all along.

Note that doing this does not prevent derived coords from being calculated, but it does mean that the calculation is (currently) not deferred. When we come to [integrating derived coords with the `DataManager`](https://github.com/SciTools/iris/issues/2495) we can look to correcting this change, if by using dask deferral rather than by using the `LazyArray` class.