### PR TITLE
Unify getitem code between Cube, Coord and CellMeasures.

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -340,7 +340,8 @@ def load_cube(uris, constraint=None, callback=None):
     if len(constraints) != 1:
         raise ValueError('only a single constraint is allowed')
 
-    cubes = _load_collection(uris, constraints, callback).merged().cubes()
+    cubes = _load_collection(uris, constraints, callback)
+    cubes = cubes.merged().cubes()
 
     try:
         cube = cubes.merge_cube()

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1685,7 +1685,7 @@ class ProtoCube(object):
         # the CoordDefn used by scalar_defns: `coord.points.dtype` and
         # `type(coord)`.
         def key_func(coord):
-            points_dtype = coord.points.dtype
+            points_dtype = coord._points.dtype
             return (not np.issubdtype(points_dtype, np.number),
                     not isinstance(coord, iris.coords.DimCoord),
                     hint_dict.get(coord.name(), len(hint_dict) + 1),

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -195,7 +195,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         nd_shape = [1] * ndim + [coord.nbounds]
         for dim, size in zip(dims, coord.shape):
             nd_shape[dim] = size
-        bounds.shape = tuple(nd_shape)
+        bounds = bounds.reshape(nd_shape)
         return bounds
 
     @staticmethod
@@ -297,7 +297,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
                     # we just add an extra 1.
                     shape.append(1)
                 nd_values = np.array(nd_values)
-                nd_values.shape = shape
+                nd_values = nd_values.reshape(shape)
             else:
                 # If no coord, treat value as zero.
                 # Use a float16 to provide `shape` attribute and avoid

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -893,8 +893,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         """
         nbounds = 0
-        if self.bounds is not None:
-            nbounds = self.bounds.shape[-1]
+        if self._bounds is not None:
+            nbounds = self._bounds.shape[-1]
         return nbounds
 
     def has_bounds(self):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -448,7 +448,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         self.points = points
         self.bounds = bounds
 
-    def __getitem__(self, key):
+    def __getitem__(self, keys):
         """
         Returns a new Coord whose values are obtained by conventional array
         indexing.
@@ -460,34 +460,19 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             indexing.
 
         """
-        # Turn the key(s) into a full slice spec - i.e. one entry for
-        # each dimension of the coord.
-        full_slice = iris.util._build_full_slice_given_keys(key, self.ndim)
-
         # Fetch the points and bounds.
         points = self._points
         bounds = self._bounds
 
-        def is_full_slice(s):
-            return isinstance(s, slice) and s == slice(None, None)
+        # Index both points and bounds with the keys.
+        _, points = iris.util._slice_data_with_keys(
+            points, keys, self.ndim)
+        if bounds is not None:
+            _, bounds = iris.util._slice_data_with_keys(
+                bounds, keys, self.ndim + 1)
 
-        if not all(is_full_slice(s) for s in full_slice):
-            # Make indexing on the cube column based by using the
-            # column_slices_generator (potentially requires slicing the
-            # data multiple times).
-            _, slice_gen = iris.util.column_slices_generator(full_slice,
-                                                             self.ndim)
-            for keys in slice_gen:
-                if points is not None:
-                    points = points[keys]
-                    if points.shape and min(points.shape) == 0:
-                        raise IndexError('Cannot index with zero length '
-                                         'slice.')
-                if bounds is not None:
-                    bounds = bounds[keys + (Ellipsis, )]
-
-        # Copy data after indexing to avoid making coords that are
-        # views on other coords. This will not realise lazy data.
+        # Copy data after indexing, to avoid making coords that are
+        # views on other coords.  This will not realise lazy data.
         points = points.copy()
         if bounds is not None:
             bounds = bounds.copy()
@@ -1496,7 +1481,7 @@ class DimCoord(Coord):
     @property
     def points(self):
         """The local points values as a read-only NumPy array."""
-        points = self._points.view()
+        points = self._points
         return points
 
     @points.setter
@@ -1530,7 +1515,7 @@ class DimCoord(Coord):
         """
         bounds = None
         if self._bounds is not None:
-            bounds = self._bounds.view()
+            bounds = self._bounds
         return bounds
 
     @bounds.setter
@@ -1600,9 +1585,6 @@ class AuxCoord(Coord):
         # Ensure the array has enough dimensions.
         # NB. Returns the *same object* if result.ndim >= ndmin
         result = np.array(result, ndmin=ndmin, copy=False)
-        # We don't need to copy the data, but we do need to have our
-        # own view so we can control the shape, etc.
-        result = result.view()
         return result
 
     @property
@@ -1614,7 +1596,7 @@ class AuxCoord(Coord):
             # NOTE: we probably don't have full support for masked aux-coords.
             # We certainly *don't* handle a _FillValue attribute (and possibly
             # the loader will throw one away ?)
-        return self._points.view()
+        return self._points
 
     @points.setter
     def points(self, points):
@@ -1656,7 +1638,7 @@ class AuxCoord(Coord):
                 # We certainly *don't* handle a _FillValue attribute (and
                 # possibly the loader will throw one away ?)
                 self._bounds = bounds
-            bounds = bounds.view()
+            bounds = bounds
         else:
             bounds = None
 
@@ -1797,37 +1779,22 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
                              "not {}".format(measure))
         self._measure = measure
 
-    def __getitem__(self, key):
+    def __getitem__(self, keys):
         """
         Returns a new CellMeasure whose values are obtained by
         conventional array indexing.
 
         """
-        # Turn the key(s) into a full slice spec - i.e. one entry for
-        # each dimension of the cell_measure.
-        full_slice = iris.util._build_full_slice_given_keys(key, self.ndim)
-
         # Get the data, all or part of which will become the new data.
         data = self._data_manager.core_data()
-        # Copy the data to avoid making the new measure a view on the old one.
+
+        # Index data with the keys.
+        # Note: does not copy data unless it has to.
+        _, data = iris.util._slice_data_with_keys(data, keys, self.ndim)
+
+        # Always copy data, to avoid making the new measure a view onto the old
+        # one.
         data = data.copy()
-
-        # If it's a "null" indexing operation (e.g. cell_measure[:, :]) then
-        # we can skip the indexing part.
-        def is_full_slice(s):
-            return isinstance(s, slice) and s == slice(None, None)
-
-        if not all(is_full_slice(s) for s in full_slice):
-            # Slice on each column, using `iris.util.column_slices_generator`
-            # (potentially slicing the data multiple times).
-            _, slice_gen = iris.util.column_slices_generator(full_slice,
-                                                             self.ndim)
-            for keys in slice_gen:
-                if data is not None:
-                    data = data[keys]
-                    if data.shape and min(data.shape) == 0:
-                        raise IndexError('Cannot index with zero length '
-                                         'slice.')
 
         # The result is a copy with replacement data.
         return self.copy(data=data)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -466,10 +466,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         # Index both points and bounds with the keys.
         _, points = iris.util._slice_data_with_keys(
-            points, keys, self.ndim)
+            points, keys)
         if bounds is not None:
             _, bounds = iris.util._slice_data_with_keys(
-                bounds, keys, self.ndim + 1)
+                bounds, keys)
 
         # Copy data after indexing, to avoid making coords that are
         # views on other coords.  This will not realise lazy data.
@@ -1481,8 +1481,7 @@ class DimCoord(Coord):
     @property
     def points(self):
         """The local points values as a read-only NumPy array."""
-        points = self._points
-        return points
+        return self._points
 
     @points.setter
     def points(self, points):
@@ -1790,7 +1789,7 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         # Index data with the keys.
         # Note: does not copy data unless it has to.
-        _, data = iris.util._slice_data_with_keys(data, keys, self.ndim)
+        _, data = iris.util._slice_data_with_keys(data, keys)
 
         # Always copy data, to avoid making the new measure a view onto the old
         # one.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2152,14 +2152,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         # turn the keys into a full slice spec (all dims)
-        full_slice = iris.util._build_full_slice_given_keys(keys,
-                                                            len(self.shape))
-
-        # make indexing on the cube column based by using the
-        # column_slices_generator (potentially requires slicing the data
-        # multiple times)
-        dimension_mapping, slice_gen = iris.util.column_slices_generator(
-            full_slice, len(self.shape))
+        full_slice = iris.util._build_full_slice_given_keys(keys, self.ndim)
 
         def new_coord_dims(coord_):
             return [dimension_mapping[d]
@@ -2171,23 +2164,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     for d in self.cell_measure_dims(cm_)
                     if dimension_mapping[d] is not None]
 
-        try:
-            first_slice = next(slice_gen)
-        except StopIteration:
-            first_slice = None
-
+        # Fetch the data as a generic array-like object.
         cube_data = self._data_manager.core_data()
 
-        if first_slice is not None:
-            data = cube_data[first_slice]
-        else:
-            data = copy.deepcopy(cube_data)
+        # Index with the keys, using orthogonal slicing.
+        dimension_mapping, data = iris.util._slice_data_with_keys(
+            cube_data, keys, self.ndim)
 
-        for other_slice in slice_gen:
-            data = data[other_slice]
-
-        # We don't want a view of the data, so take a copy of it if it's
-        # not already our own.
+        # We don't want a view of the data, so take a copy of it.
         data = copy.deepcopy(data)
 
         # We can turn a masked array into a normal array if it's full.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2169,7 +2169,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         # Index with the keys, using orthogonal slicing.
         dimension_mapping, data = iris.util._slice_data_with_keys(
-            cube_data, keys, self.ndim)
+            cube_data, keys)
 
         # We don't want a view of the data, so take a copy of it.
         data = copy.deepcopy(data)

--- a/lib/iris/tests/unit/util/test__slice_data_with_keys.py
+++ b/lib/iris/tests/unit/util/test__slice_data_with_keys.py
@@ -34,6 +34,7 @@ import iris.tests as tests
 import numpy as np
 
 from iris.util import _slice_data_with_keys
+from iris._lazy_data import as_lazy_data, as_concrete_data
 
 
 class DummyArray(object):
@@ -251,6 +252,158 @@ class Test_dimensions_mapping(MixinIndexingTest, tests.IrisTest):
         # Cutting out the middle dim.
         self.check((3, 4, 2), Index[:, 2],
                    expect_map={None: None, 0: 0, 1: None, 2: 1})
+
+
+class TestResults(tests.IrisTest):
+    # Integration-style test, exercising (mostly) the same cases as above,
+    # but checking actual results, for both real and lazy array inputs.
+
+    def check(self, real_data, keys, expect_result, expect_map):
+        real_data = np.array(real_data)
+        lazy_data = as_lazy_data(real_data, real_data.shape)
+        real_dim_map, real_result = _slice_data_with_keys(real_data, keys)
+        lazy_dim_map, lazy_result = _slice_data_with_keys(lazy_data, keys)
+        lazy_result = as_concrete_data(lazy_result)
+        self.assertArrayEqual(real_result, expect_result)
+        self.assertArrayEqual(lazy_result, expect_result)
+        self.assertEqual(real_dim_map, expect_map)
+        self.assertEqual(lazy_dim_map, expect_map)
+
+    def test_1d_int(self):
+        self.check([1, 2, 3, 4], Index[2],
+                   [3],
+                   {None: None, 0: None})
+
+    def test_1d_all(self):
+        self.check([1, 2, 3], Index[:],
+                   [1, 2, 3],
+                   {None: None, 0: 0})
+
+    def test_1d_tuple(self):
+        self.check([1, 2, 3], Index[(2, 0, 1, 0), ],
+                   [3, 1, 2, 1],
+                   {None: None, 0: 0})
+
+    def test_fail_1d_2keys(self):
+        msg = 'More slices .* than dimensions'
+        with self.assertRaisesRegexp(IndexError, msg):
+            self.check([1, 2, 3], Index[1, 2], None, None)
+
+    def test_fail_empty_slice(self):
+        msg = 'Cannot index with zero length slice'
+        with self.assertRaisesRegexp(IndexError, msg):
+            self.check([1, 2, 3], Index[1:1], None, None)
+
+    def test_2d_tuple(self):
+        self.check([[11, 12], [21, 22], [31, 32]],
+                   Index[(2, 0, 1), ],
+                   [[31, 32], [11, 12], [21, 22]],
+                   {None: None, 0: 0, 1: 1})
+
+    def test_2d_two_tuples(self):
+        # Could be treated as fancy indexing, but must not be !
+        # Two separate 2-D indexing operations.
+        self.check([[11, 12, 13], [21, 22, 23], [31, 32, 33]],
+                   Index[(2, 0), (0, 1, 0, 1)],
+                   [[31, 32, 31, 32], [11, 12, 11, 12]],
+                   {None: None, 0: 0, 1: 1})
+
+    def test_2d_tuple_and_value(self):
+        # The two keys are applied in separate operations, and in the reverse
+        # order (?) :  The second op is then slicing a 1-D array, not 2-D.
+        self.check([[11, 12, 13, 14], [21, 22, 23, 24], [31, 32, 33, 34]],
+                   Index[(2, 0, 1), 3],
+                   [34, 14, 24],
+                   {None: None, 0: 0, 1: None})
+
+    def test_2d_single_int(self):
+        self.check([[11, 12, 13], [21, 22, 23], [31, 32, 33]],
+                   Index[1],
+                   [21, 22, 23],
+                   {None: None, 0: None, 1: 0})
+
+    def test_2d_int_slice(self):
+        self.check([[11, 12, 13], [21, 22, 23], [31, 32, 33]],
+                   Index[2, 1:3],
+                   [32, 33],
+                   {None: None, 0: None, 1: 0})
+
+    def test_3d_1int(self):
+        self.check([[[111, 112, 113], [121, 122, 123]],
+                    [[211, 212, 213], [221, 222, 223]],
+                    [[311, 312, 313], [321, 322, 323]]],
+                   Index[1],
+                   [[211, 212, 213], [221, 222, 223]],
+                   {None: None, 0: None, 1: 0, 2: 1})
+
+    def test_3d_2int(self):
+        self.check([[[111, 112, 113], [121, 122, 123], [131, 132, 133]],
+                    [[211, 212, 213], [221, 222, 223], [231, 232, 233]]],
+                   Index[1, 2],
+                   [231, 232, 233],
+                   {None: None, 0: None, 1: None, 2: 0})
+
+    def test_3d_tuple_and_value(self):
+        # The two keys are applied in separate operations, and in the reverse
+        # order (?) : The second op is slicing a 2-D array, not 3-D.
+        self.check([[[111, 112, 113, 114], [121, 122, 123, 124]],
+                    [[211, 212, 213, 214], [221, 222, 223, 224]],
+                    [[311, 312, 313, 314], [321, 322, 323, 324]]],
+                   Index[(2, 0, 1), 1],
+                   [[321, 322, 323, 324],
+                    [121, 122, 123, 124],
+                    [221, 222, 223, 224]],
+                   {None: None, 0: 0, 1: None, 2: 1})
+
+    def test_3d_ellipsis_last(self):
+        self.check([[[111, 112, 113], [121, 122, 123]],
+                    [[211, 212, 213], [221, 222, 223]],
+                    [[311, 312, 313], [321, 322, 323]]],
+                   Index[2, ...],
+                   [[311, 312, 313], [321, 322, 323]],
+                   {None: None, 0: None, 1: 0, 2: 1})
+
+    def test_3d_ellipsis_first_1int(self):
+        self.check([[[111, 112, 113, 114], [121, 122, 123, 124]],
+                    [[211, 212, 213, 214], [221, 222, 223, 224]],
+                    [[311, 312, 313, 314], [321, 322, 323, 324]]],
+                   Index[..., 2],
+                   [[113, 123],
+                    [213, 223],
+                    [313, 323]],
+                   {None: None, 0: 0, 1: 1, 2: None})
+
+    def test_3d_ellipsis_mid_1int(self):
+        self.check([[[111, 112, 113], [121, 122, 123]],
+                    [[211, 212, 213], [221, 222, 223]],
+                    [[311, 312, 313], [321, 322, 323]]],
+                   Index[..., 1, ...],
+                   [[121, 122, 123],
+                    [221, 222, 223],
+                    [321, 322, 323]],
+                   {None: None, 0: 0, 1: None, 2: 1})
+
+    def test_3d_ellipsis_first_2int(self):
+        self.check([[[111, 112, 113], [121, 122, 123]],
+                    [[211, 212, 213], [221, 222, 223]],
+                    [[311, 312, 313], [321, 322, 323]]],
+                   Index[..., 1, 2],
+                   [123, 223, 323],
+                   {None: None, 0: 0, 1: None, 2: None})
+
+    def test_3d_multiple_tuples(self):
+        # Where there are TWO or more tuple keys, this could be misinterpreted
+        # as 'fancy' indexing :  It should resolve into multiple calls.
+        self.check([[[111, 112, 113, 114], [121, 122, 123, 124]],
+                    [[211, 212, 213, 214], [221, 222, 223, 224]],
+                    [[311, 312, 313, 314], [321, 322, 323, 324]]],
+                   Index[(1, 2, 1), :, (2, 2, 3)],
+                   [[[213, 213, 214], [223, 223, 224]],
+                    [[313, 313, 314], [323, 323, 324]],
+                    [[213, 213, 214], [223, 223, 224]]],
+                   {None: None, 0: 0, 1: 1, 2: 2})
+        # NOTE: there seem to be an extra initial [:, :, :].
+        # That's just what it does at present.
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/util/test__slice_data_with_keys.py
+++ b/lib/iris/tests/unit/util/test__slice_data_with_keys.py
@@ -1,0 +1,257 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.util._slice_data_with_keys`.
+
+Note: much of the functionality really belongs to the other routines,
+:func:`iris.util._build_full_slice_given_keys`, and
+:func:`column_slices_generator`.
+However, it is relatively simple to test multiple aspects of all three here
+in combination.
+
+"""
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+from iris.util import _slice_data_with_keys
+
+
+class DummyArray(object):
+    # A dummy array-like that records the keys of indexing calls.
+    def __init__(self, shape, _indexing_record_list=None):
+        self.shape = shape
+        self.ndim = len(shape)
+        if _indexing_record_list is None:
+            _indexing_record_list = []
+        self._getitem_call_keys = _indexing_record_list
+
+    def __getitem__(self, keys):
+        # Add the indexing keys to the call list.
+        self._getitem_call_keys.append(keys)
+        # Return a new object with the correct derived shape, and record its
+        # indexing operations in the same key list as this.
+        shape_array = np.zeros(self.shape)
+        shape_array = shape_array.__getitem__(keys)
+        new_shape = shape_array.shape
+        return DummyArray(new_shape,
+                          _indexing_record_list=self._getitem_call_keys)
+
+
+class Indexer(object):
+    # An object to make __getitem__ arglists from indexing operations.
+    def __getitem__(self, keys):
+        return keys
+
+
+# An Indexer object for generating indexing keys in a nice visible way.
+Index = Indexer()
+
+
+class MixinIndexingTest(object):
+    def check(self, shape, keys, expect_call_keys=None, expect_map=None):
+        data = DummyArray(shape)
+        dim_map, _ = _slice_data_with_keys(data, keys)
+        if expect_call_keys is not None:
+            calls_got = data._getitem_call_keys
+            # Check that the indexing keys applied were the expected ones.
+            equal = len(calls_got) == len(expect_call_keys)
+            for act_call, expect_call in zip(calls_got, expect_call_keys):
+                equal &= len(act_call) == len(expect_call)
+                # A problem here is that in each call, some keys may be
+                # *arrays*, and arrays can't be compared in the "normal"
+                # way.  So we must use np.all for comparison :-(
+                for act_key, expect_key in zip(act_call, expect_call):
+                    equal &= (np.asanyarray(act_key).dtype ==
+                              np.asanyarray(expect_key).dtype and
+                              np.all(act_key == expect_key))
+            errmsg = 'Different key lists:\n{!s}\n!=\n{!s}\n'
+
+            def showkeys(keys_list):
+                msg = '[\n  '
+                msg += '\n  '.join(str(x) for x in keys_list)
+                msg += '\n]'
+                return msg
+
+            self.assertTrue(equal, errmsg.format(showkeys(calls_got),
+                                                 showkeys(expect_call_keys)))
+        if expect_map is not None:
+            self.assertEqual(dim_map, expect_map)
+
+
+class Test_indexing(MixinIndexingTest, tests.IrisTest):
+    # Check the indexing operations performed for various requested keys.
+
+    def test_0d_nokeys(self):
+        # Performs *no* underlying indexing operation.
+        self.check((), Index[()],
+                   [])
+
+    def test_1d_int(self):
+        self.check((4,), Index[2],
+                   [(2,)])
+
+    def test_1d_float(self):
+        # Number types are not cast.
+        self.check((4,), Index[3.1],
+                   [(3.1,)])
+
+    def test_1d_all(self):
+        self.check((3,), Index[:],
+                   [(slice(None),)])
+
+    def test_1d_tuple(self):
+        # The call makes tuples into 1-D arrays, and a trailing Ellipsis is
+        # added (for the 1-D case only).
+        self.check((3,), Index[(2, 0, 1), ],
+                   [(np.array([2, 0, 1]), Ellipsis)])
+
+    def test_fail_1d_2keys(self):
+        msg = 'More slices .* than dimensions'
+        with self.assertRaisesRegexp(IndexError, msg):
+            self.check((3,), Index[1, 2])
+
+    def test_fail_empty_slice(self):
+        msg = 'Cannot index with zero length slice'
+        with self.assertRaisesRegexp(IndexError, msg):
+            self.check((3,), Index[1:1])
+
+    def test_2d_tuple(self):
+        # Like the above, but there is an extra no-op at the start and no
+        # trailing Ellipsis is generated.
+        self.check((3, 2), Index[(2, 0, 1), ],
+                   [(slice(None), slice(None)),
+                    (np.array([2, 0, 1]), slice(None))])
+
+    def test_2d_two_tuples(self):
+        # Could be treated as fancy indexing, but must not be !
+        # Two separate 2-D indexing operations.
+        self.check((3, 2), Index[(2, 0, 1, 1), (0, 1, 0, 1)],
+                   [(np.array([2, 0, 1, 1]), slice(None)),
+                    (slice(None), np.array([0, 1, 0, 1]))])
+
+    def test_2d_tuple_and_value(self):
+        # The two keys are applied in separate operations, and in the reverse
+        # order (?) :  The second op is then slicing a 1-D array, not 2-D.
+        self.check((3, 5), Index[(2, 0, 1), 3],
+                   [(slice(None), 3),
+                    (np.array([2, 0, 1]), Ellipsis)])
+
+    def test_2d_single_int(self):
+        self.check((3, 4), Index[2],
+                   [(2, slice(None))])
+
+    def test_2d_multiple_int(self):
+        self.check((3, 4), Index[2, 1:3],
+                   [(2, slice(1, 3))])
+
+    def test_3d_1int(self):
+        self.check((3, 4, 5), Index[2],
+                   [(2, slice(None), slice(None))])
+
+    def test_3d_2int(self):
+        self.check((3, 4, 5), Index[2, 3],
+                   [(2, 3, slice(None))])
+
+    def test_3d_tuple_and_value(self):
+        # The two keys are applied in separate operations, and in the reverse
+        # order (?) : The second op is slicing a 2-D array, not 3-D.
+        self.check((3, 5, 7), Index[(2, 0, 1), 4],
+                   [(slice(None), 4, slice(None)),
+                    (np.array([2, 0, 1]), slice(None))])
+
+    def test_3d_ellipsis_last(self):
+        self.check((3, 4, 5), Index[2, ...],
+                   [(2, slice(None), slice(None))])
+
+    def test_3d_ellipsis_first_1int(self):
+        self.check((3, 4, 5), Index[..., 2],
+                   [(slice(None), slice(None), 2)])
+
+    def test_3d_ellipsis_first_2int(self):
+        self.check((3, 4, 5), Index[..., 2, 3],
+                   [(slice(None), 2, 3)])
+
+    def test_3d_multiple_tuples(self):
+        # Where there are TWO or more tuple keys, this could be misinterpreted
+        # as 'fancy' indexing :  It should resolve into multiple calls.
+        self.check((3, 4, 5), Index[(1, 2, 1), :, (2, 2, 3)],
+                   [(slice(None), slice(None), slice(None)),
+                    (np.array([1, 2, 1]), slice(None), slice(None)),
+                    (slice(None), slice(None), np.array([2, 2, 3])),
+                    ])
+        # NOTE: there seem to be an extra initial [:, :, :].
+        # That's just what it does at present.
+
+
+class Test_dimensions_mapping(MixinIndexingTest, tests.IrisTest):
+    # Check the dimensions map returned for various requested keys.
+
+    def test_1d_nochange(self):
+        self.check((3,), Index[1:2],
+                   expect_map={None: None, 0: 0})
+
+    def test_1d_1int_losedim0(self):
+        self.check((3,), Index[1],
+                   expect_map={None: None, 0: None})
+
+    def test_1d_tuple_nochange(self):
+        # A selection index leaves the dimension intact.
+        self.check((3,), Index[(1, 0, 1, 2), ],
+                   expect_map={None: None, 0: 0})
+
+    def test_1d_1tuple_nochange(self):
+        # A selection index with only one value in it *still* leaves the
+        # dimension intact.
+        self.check((3,), Index[(2,), ],
+                   expect_map={None: None, 0: 0})
+
+    def test_1d_slice_nochange(self):
+        # A slice leaves the dimension intact.
+        self.check((3,), Index[1:7],
+                   expect_map={None: None, 0: 0})
+
+    def test_2d_nochange(self):
+        self.check((3, 4), Index[:, :],
+                   expect_map={None: None, 0: 0, 1: 1})
+
+    def test_2d_losedim0(self):
+        self.check((3, 4), Index[1, :],
+                   expect_map={None: None, 0: None, 1: 0})
+
+    def test_2d_losedim1(self):
+        self.check((3, 4), Index[1:4, 2],
+                   expect_map={None: None, 0: 0, 1: None})
+
+    def test_2d_loseboth(self):
+        # Two indices give scalar result.
+        self.check((3, 4), Index[1, 2],
+                   expect_map={None: None, 0: None, 1: None})
+
+    def test_3d_losedim1(self):
+        # Cutting out the middle dim.
+        self.check((3, 4, 2), Index[:, 2],
+                   expect_map={None: None, 0: 0, 1: None, 2: 1})
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -698,8 +698,15 @@ def _build_full_slice_given_keys(keys, ndim):
 
 def _slice_data_with_keys(data, keys):
     """
+    Index an array-like object as "data[keys]", with orthogonal indexing.
 
-    Index an array-like object with orthogonal keys.
+    Args:
+
+    * data (array-like):
+        array to index.
+
+    * keys (list):
+        list of indexes, as received from a __getitem__ call.
 
     This enforces an orthogonal interpretation of indexing, which means that
     both 'real' (numpy) arrays and other array-likes index in the same way,
@@ -707,8 +714,9 @@ def _slice_data_with_keys(data, keys):
 
     Returns (dim_map, data_region), where :
 
-    *  dim_map (dict) :
-        A dimension map, as for :func:`column_slices_generator`.
+    * dim_map (dict) :
+        A dimension map, as returned by :func:`column_slices_generator`.
+        i.e. "dim_map[old_dim_index]" --> "new_dim_index" or None.
 
     * data_region (array-like) :
         The sub-array.

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -696,22 +696,39 @@ def _build_full_slice_given_keys(keys, ndim):
     return full_slice
 
 
-def _slice_data_with_keys(data, keys, n_parent_dims):
-    # Combine _build_full_slice_given_keys and column_slices_generator to index
-    # any array-like object with arbitrary keys using an orthogonal indexing
-    # interpretation.
-    # This means that both numpy and lazy data will index in the same way.
-    # Return a dimension map, and the indexed data.
-    #
-    # NOTE: by using slicing on only one index at a time, this also generally
-    # avoids copying the data, except when a key contains a list of indices.
-    full_slice = _build_full_slice_given_keys(keys, n_parent_dims)
+def _slice_data_with_keys(data, keys):
+    """
 
-    dims_mapping, slices_iter = column_slices_generator(full_slice,
-                                                        n_parent_dims)
+    Index an array-like object with orthogonal keys.
+
+    This enforces an orthogonal interpretation of indexing, which means that
+    both 'real' (numpy) arrays and other array-likes index in the same way,
+    instead of numpy arrays doing 'fancy indexing'.
+
+    Returns (dim_map, data_region), where :
+
+    *  dim_map (dict) :
+        A dimension map, as for :func:`column_slices_generator`.
+
+    * data_region (array-like) :
+        The sub-array.
+
+    .. Note::
+
+        Avoids copying the data, where possible.
+
+    """
+    # Combines the use of _build_full_slice_given_keys and
+    # column_slices_generator.
+    # By slicing on only one index at a time, this also mostly avoids copying
+    # the data, except some cases when a key contains a list of indices.
+    n_dims = len(data.shape)
+    full_slice = _build_full_slice_given_keys(keys, n_dims)
+    dims_mapping, slices_iter = column_slices_generator(full_slice, n_dims)
     for this_slice in slices_iter:
         data = data[this_slice]
         if data.ndim > 0 and min(data.shape) < 1:
+            # Disallow slicings where a dimension has no points, like "[5:5]".
             raise IndexError('Cannot index with zero length slice.')
 
     return dims_mapping, data


### PR DESCRIPTION
This is a useful preliminary to replacing lazy/real array data with DataManager in Coords code.

It reduces the indexing code in those 3 areas to suspiciously similar usages, with the bulk of the common code in a new private utility routine `iris.utils._slice_data_with_keys` :  I think that code can usefully go inside `DataManager.__getitem__` in future.

In future, in addition to rebasing all these 3 areas onto DataManager, I would also move the coord points and bounds accessors into `Coord` as generic methods, and make DimCoord extend the generic calls with its extra checks and tweaks.  The new similarities of handling make this attractive, but it is better left undone because (a) it makes this PR simpler and (b) it will be simpler when the underlying data objects are all DataManager-s.

This PR also contains a strictly temporary hack to remove the special-casing of LazyArray data within AuxCoords, by wrapping them as dask arrays instead (`WrappedLazyArray` class and `_wrap_lazy` function in coords.py).  
This should be replaced by the result of https://github.com/SciTools/iris/pull/2518 when that is ready.
