### PR TITLE
Dask merge concat fill value

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -416,7 +416,6 @@ class _CubeSignature(object):
             - scalar coords
             - attributes
             - dtype
-            - fill_value
 
         Args:
 
@@ -464,14 +463,6 @@ class _CubeSignature(object):
         if self.data_type != other.data_type:
             msgs.append(msg_template.format('Data types', '',
                                             self.data_type, other.data_type))
-
-        # Check fill value.
-        if self.fill_value != other.fill_value:
-            # Allow fill-value promotion if either fill-value is None.
-            if self.fill_value is not None and other.fill_value is not None:
-                msgs.append(msg_template.format('Fill values', '',
-                                                self.fill_value,
-                                                other.fill_value))
 
         # Check _cell_measures_and_dims
         if self.cell_measures_and_dims != other.cell_measures_and_dims:
@@ -727,10 +718,14 @@ class _ProtoCube(object):
 
         # Check for compatible coordinate signatures.
         if match:
-            if self._cube_signature.fill_value is None and \
-                    cube_signature.fill_value is not None:
-                # Perform proto-cube fill-value promotion.
-                self._cube_signature.fill_value = cube_signature.fill_value
+            fill_value = self._cube_signature.fill_value
+            # Determine whether the fill value requires to be
+            # demoted to the default value.
+            if fill_value is not None:
+                if cube_signature.fill_value is None or \
+                        cube_signature.fill_value != fill_value:
+                    # Demote the fill value to the default.
+                    self._cube_signature.fill_value = None
             coord_signature = _CoordSignature(cube_signature)
             candidate_axis = self._coord_signature.candidate_axis(
                 coord_signature)

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -722,8 +722,7 @@ class _ProtoCube(object):
             # Determine whether the fill value requires to be
             # demoted to the default value.
             if fill_value is not None:
-                if cube_signature.fill_value is None or \
-                        cube_signature.fill_value != fill_value:
+                if cube_signature.fill_value != fill_value:
                     # Demote the fill value to the default.
                     self._cube_signature.fill_value = None
             coord_signature = _CoordSignature(cube_signature)

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1287,8 +1287,7 @@ class ProtoCube(object):
             # Determine whether the fill value requires to be demoted
             # to the default value.
             if cube_signature.fill_value is not None:
-                if other.fill_value is None or \
-                        cube_signature.fill_value != other.fill_value:
+                if cube_signature.fill_value != other.fill_value:
                     # Demote the fill value to the default.
                     signature = self._build_signature(self._source,
                                                       default_fill_value=True)

--- a/lib/iris/tests/results/concatenate/concat_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" units="unknown">
+  <cube core-dtype="float32" dtype="float32" fill_value="1234.0" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2x2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1234.0" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2y2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1234.0" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -244,6 +244,45 @@ class TestDataMergeCombos(tests.IrisTest):
             self.assertEqual(result.dtype, self.dtype)
             self._check_fill_value(result, fill0, fill1)
 
+    def test_fill_value_invariant_to_order__same_non_None(self):
+        fill_value = 1234
+        cubes = [self._make_cube(i, mask=True,
+                                 fill_value=fill_value) for i in range(3)]
+        for combo in itertools.permutations(cubes):
+            result = iris.cube.CubeList(combo).merge_cube()
+            self.assertEqual(result.fill_value, fill_value)
+            self.assertEqual(result.data.fill_value, fill_value)
+
+    def test_fill_value_invariant_to_order__all_None(self):
+        cubes = [self._make_cube(i, mask=True,
+                                 fill_value=None) for i in range(3)]
+        for combo in itertools.permutations(cubes):
+            result = iris.cube.CubeList(combo).merge_cube()
+            self.assertIsNone(result.fill_value)
+            np_fill_value = ma.masked_array(0, dtype=result.dtype).fill_value
+            self.assertEqual(result.data.fill_value, np_fill_value)
+
+    def test_fill_value_invariant_to_order__different_non_None(self):
+        cubes = [self._make_cube(0, mask=True, fill_value=1234)]
+        cubes.append(self._make_cube(1, mask=True, fill_value=2341))
+        cubes.append(self._make_cube(2, mask=True, fill_value=3412))
+        cubes.append(self._make_cube(3, mask=True, fill_value=4123))
+        for combo in itertools.permutations(cubes):
+            result = iris.cube.CubeList(combo).merge_cube()
+            self.assertIsNone(result.fill_value)
+            np_fill_value = ma.masked_array(0, dtype=result.dtype).fill_value
+            self.assertEqual(result.data.fill_value, np_fill_value)
+
+    def test_fill_value_invariant_to_order__mixed(self):
+        cubes = [self._make_cube(0, mask=True, fill_value=None)]
+        cubes.append(self._make_cube(1, mask=True, fill_value=1234))
+        cubes.append(self._make_cube(2, mask=True, fill_value=4321))
+        for combo in itertools.permutations(cubes):
+            result = iris.cube.CubeList(combo).merge_cube()
+            self.assertIsNone(result.fill_value)
+            np_fill_value = ma.masked_array(0, dtype=result.dtype).fill_value
+            self.assertEqual(result.data.fill_value, np_fill_value)
+
 
 @tests.skip_data
 class TestDataMerge(tests.IrisTest):

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -153,18 +153,19 @@ class TestDataMergeCombos(tests.IrisTest):
         return result
 
     def _check_fill_value(self, result, fill0, fill1):
-        fill_value = self._expected_fill_value(fill0, fill1)
-        if fill_value is None:
-            fill_value = ma.masked_array(0, dtype=result.dtype).fill_value
+        expected_fill_value = self._expected_fill_value(fill0, fill1)
+        if expected_fill_value is None:
             self.assertIsNone(result.fill_value)
             data = result.data
             if ma.isMaskedArray(data):
-                self.assertEqual(data.fill_value, fill_value)
+                np_fill_value = ma.masked_array(0,
+                                                dtype=result.dtype).fill_value
+                self.assertEqual(data.fill_value, np_fill_value)
         else:
-            self.assertEqual(result.fill_value, fill_value)
+            self.assertEqual(result.fill_value, expected_fill_value)
             data = result.data
             if ma.isMaskedArray(data):
-                self.assertEqual(data.fill_value, fill_value)
+                self.assertEqual(data.fill_value, expected_fill_value)
 
     def setUp(self):
         self.dtype = np.dtype('int32')
@@ -201,9 +202,9 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(0, 1), (0, 1), (0, 1)]
-            fill_value = self._expected_fill_value(fill0, fill1)
+            expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
-                                       fill_value=fill_value)
+                                       fill_value=expected_fill_value)
             self.assertMaskedArrayEqual(result.data, expected)
             self.assertEqual(result.dtype, self.dtype)
             self._check_fill_value(result, fill0, fill1)
@@ -219,9 +220,9 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(1, 1), (0, 1), (0, 1)]
-            fill_value = self._expected_fill_value(fill0, fill1)
+            expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
-                                       fill_value=fill_value)
+                                       fill_value=expected_fill_value)
             self.assertMaskedArrayEqual(result.data, expected)
             self.assertEqual(result.dtype, self.dtype)
             self._check_fill_value(result, fill0, fill1)
@@ -237,9 +238,9 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(0, 0), (0, 1), (0, 1)]
-            fill_value = self._expected_fill_value(fill0, fill1)
+            expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
-                                       fill_value=fill_value)
+                                       fill_value=expected_fill_value)
             self.assertMaskedArrayEqual(result.data, expected)
             self.assertEqual(result.dtype, self.dtype)
             self._check_fill_value(result, fill0, fill1)

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -146,14 +146,14 @@ class TestDataMergeCombos(tests.IrisTest):
         return cube
 
     @staticmethod
-    def _expected_fill(fill0, fill1):
+    def _expected_fill_value(fill0, fill1):
         result = None
         if fill0 == fill1:
             result = fill0
         return result
 
     def _check_fill_value(self, result, fill0, fill1):
-        fill_value = self._expected_fill(fill0, fill1)
+        fill_value = self._expected_fill_value(fill0, fill1)
         if fill_value is None:
             fill_value = ma.masked_array(0, dtype=result.dtype).fill_value
             self.assertIsNone(result.fill_value)
@@ -201,7 +201,7 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(0, 1), (0, 1), (0, 1)]
-            fill_value = self._expected_fill(fill0, fill1)
+            fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=fill_value)
             self.assertMaskedArrayEqual(result.data, expected)
@@ -219,7 +219,7 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(1, 1), (0, 1), (0, 1)]
-            fill_value = self._expected_fill(fill0, fill1)
+            fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=fill_value)
             self.assertMaskedArrayEqual(result.data, expected)
@@ -237,7 +237,7 @@ class TestDataMergeCombos(tests.IrisTest):
                                          fill_value=fill1))
             result = cubes.merge_cube()
             mask = [(0, 0), (0, 1), (0, 1)]
-            fill_value = self._expected_fill(fill0, fill1)
+            fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=fill_value)
             self.assertMaskedArrayEqual(result.data, expected)


### PR DESCRIPTION
This PR refines the approach taken with handling the `cube.fill_value` by merge and concatenate.

This PR extends the expected behaviour of `numpy` with regards to how it manages the `fill_value` when combining masked arrays and/or ndarrays to cubes (it is valid for a cube to have a `fill_value` even though it has a ndarray payload).

In summary, when combining cubes via merge or concatenate, the resultant cube will have:
* a `fill_value` that is non-`None` **iff** all cubes have the same non-`None` `fill_value`
* a `fill_value` that is `None`, if:
   * at least one cube has a `fill_value` of `None`, or
   * the candidate cube and the proto-cube have a different `fill_value`

This simply means that, 
* if the `cube.fill_value` is set to a non-`None` value, and the cube has a masked payload, then the masked array returned by `cube.data` will have a `fill_value` that matches the `cube.fill_value`.
* if the `cube.fill_value` is set to `None`, and the cube has a masked payload, then the masked array returned by `cube.data` will have the default `fill_value` generated by `numpy` for that specific `dtype`.
