### PR TITLE
avoid runtime overflow

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1018,7 +1018,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             bounds = [lower, upper]
             # Create points for the new collapsed coordinate.
             points_dtype = self.points.dtype
-            points = [(lower + upper) * 0.5]
+            points = [(float(lower) + float(upper)) * 0.5]
 
             # Create the new collapsed coordinate.
             coord = self.copy(points=np.array(points, dtype=points_dtype),

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -323,6 +323,12 @@ class Test_collapsed(tests.IrisTest):
                                           [7, 8, 10, 11]]))
         with self.assertRaises(ValueError):
             coord.collapsed()
+
+    def test_collapsed_overflow(self):
+        coord = DimCoord(points=np.array([1493892000, 1493895600, 1493899200],
+                                         dtype=np.int32))
+        result = coord.collapsed()
+        self.assertEqual(result.points, 1493895600)
 
 
 class Test_is_compatible(tests.IrisTest):


### PR DESCRIPTION
There is currently the potential for a `RuntimeWarning: overflow encountered in int_scalars` which is missed during collapsed calculations, which can trip up unwary users of limited data types, such as int32 for very large numbers (e.g. seconds since 1970)

This PR pushes the casting, which already occurs, into the individual values, to limit the chance of overflow.  

The chance is still there, it is the responsibility of data creators to use appropriate data types.  this is a point fix which will help some users 