### PR TITLE
Populate cube.fill_value thru cube.data setter.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1705,8 +1705,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def data(self, data):
         # Assign the new data to the data manager.
         self._data_manager.data = data
-        # Clear the cube fill-value.
-        self._fill_value = None
+        if ma.isMaskedArray(data):
+            # Set the cube fill-value.
+            self.fill_value = data.fill_value
+        else:
+            # Clear the cube fill-value.
+            self.fill_value = None
 
     def has_lazy_data(self):
         return self._data_manager.has_lazy_data()

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" long_name="temperature" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" long_name="temperature" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" long_name="thingness" units="1">
+  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[90, 0, -90]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int64"/>

--- a/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" long_name="thingness" units="1">
+  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" standard_name="air_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" standard_name="air_temperature" units="K">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord id="9041e969" points="[[-660.0, -610.0, -560.0, -510.0, -460.0, -410.0],

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -20,7 +20,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -41,7 +41,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -66,7 +66,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -89,7 +89,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -112,7 +112,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -131,7 +131,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -150,7 +150,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -170,7 +170,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -190,7 +190,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -213,7 +213,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -232,7 +232,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -252,7 +252,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -272,7 +272,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -295,7 +295,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -320,7 +320,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_maximum" units="1" var_name="cube_maximum">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_maximum" units="1" var_name="cube_maximum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -333,7 +333,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mean" units="1" var_name="cube_mean">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mean" units="1" var_name="cube_mean">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -346,7 +346,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_median" units="1" var_name="cube_median">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_median" units="1" var_name="cube_median">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -359,7 +359,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -372,7 +372,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_minimum" units="1" var_name="cube_minimum">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_minimum" units="1" var_name="cube_minimum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -385,7 +385,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -404,7 +404,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -424,7 +424,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -447,7 +447,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_mode" units="1" var_name="cube_mode">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mode" units="1" var_name="cube_mode">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -460,7 +460,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_point" units="1" var_name="cube_point">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_point" units="1" var_name="cube_point">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -473,7 +473,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -486,7 +486,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_sum" units="1" var_name="cube_sum">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_sum" units="1" var_name="cube_sum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -499,7 +499,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" long_name="cube_variance" units="1" var_name="cube_variance">
+  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_variance" units="1" var_name="cube_variance">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1323,12 +1323,19 @@ class Test_fill_value(tests.IrisTest):
         cube.fill_value = fill_value
         self.assertEqual(cube.fill_value, fill_value)
 
-    def test_cube_data_setter_with_none(self):
+    def test_cube_data_setter_with_ndarray(self):
         fill_value = 123
         cube = Cube(np.array(0), fill_value=fill_value)
         self.assertEqual(cube.fill_value, fill_value)
         cube.data = np.array(1)
-        self.assertEqual(cube.fill_value, None)
+        self.assertIsNone(cube.fill_value)
+
+    def test_cube_data_setter_with_masked_array(self):
+        fill_value = 123
+        cube = Cube(np.array(0))
+        self.assertIsNone(cube.fill_value)
+        cube.data = ma.masked_array(1, fill_value=fill_value)
+        self.assertEqual(cube.fill_value, fill_value)
 
     def test_fill_value_bool(self):
         fill_value = np.bool_(True)
@@ -1675,6 +1682,21 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         subcube = cube[3:]
         self.assertEqual(subcube.dtype, dtype)
         self.assertArrayAllClose(subcube.fill_value, fill_value)
+
+    def test_data_getter__masked_with_fill_value(self):
+        fill_value = 1234
+        cube = self._sample_cube(masked=True,
+                                 cube_fill_value=fill_value)
+        self.assertEqual(cube.fill_value, fill_value)
+        data = cube.data
+        self.assertEqual(data.fill_value, fill_value)
+
+    def test_data_getter__masked_with_fill_value_default(self):
+        cube = self._sample_cube(masked=True)
+        self.assertIsNone(cube.fill_value)
+        data = cube.data
+        np_fill_value = ma.masked_array(0, dtype=cube.dtype).fill_value
+        self.assertEqual(data.fill_value, np_fill_value)
 
 
 class TestSubset(tests.IrisTest):


### PR DESCRIPTION
This PR is a follow-on action from #2492 and detailed in #2516 and allows the `cube.fill_value` to be set from the `fill_value` of concrete masked data being passed to `cube.data` setter.

All of the CML changes are due to either tests directly setting `cube.data` with a masked array, or tests that use testing stock cubes that set `cube.data` directly with a masked array ... thus populating the `cube.fill_value` and thus bleeding thru to the CML. This is the behaviour that we want to see.

If data passed to the `cube.data` setter is not masked data, then the `cube.fill_value` will be clear, as before.

This PR also neatly completes the circle with `fill_value` and masked arrays wrt the cube, in that the `cube.data` getter will set the `fill_value` of any masked array returned to the user with the `cube.fill_value`, and now this PR allows the `fill_value` of a masked array to set the `cube.fill_value` through the `cube.data` setter.