### PR TITLE
Handle MaskedConstant in cube maths

### DIFF
--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -205,8 +205,7 @@ class DataManager(object):
         assert state, emsg.format(self._realised_dtype)
 
         # Ensure validity of lazy data with realised dtype.
-        state = not (not self.has_lazy_data() and
-                     self._realised_dtype is not None)
+        state = self.has_lazy_data() or self._realised_dtype is None
         emsg = ('Unexpected real data with realised dtype, got '
                 'real data and realised {!r}.')
         assert state, emsg.format(self._realised_dtype)

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -49,6 +49,8 @@ def _output_dtype(op, left_dtype, right_dtype=None, in_place=False):
     operand_dtypes = [left_dtype, right_dtype] if right_dtype is not None \
                       else [left_dtype]
     if in_place:
+        # Always return the first dtype, even if the operation would fail due
+        # to failure to cast the result.
         return operand_dtypes[0]
     key = (op, tuple(operand_dtypes))
     result = _output_dtype_cache.get(key, None)

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -772,7 +772,7 @@ def _math_op_common(cube, operation_function, new_unit, new_dtype=None,
             and not new_cube.has_lazy_data() \
             and new_cube.data.shape == () \
             and ma.is_masked(new_cube.data):
-        new_cube.data = np.asanyarray(new_cube.data, dtype=new_dtype)
+        new_cube.data = ma.masked_array(0, 1, dtype=new_dtype)
 
     iris.analysis.clear_phenomenon_identity(new_cube)
     new_cube.units = new_unit

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -59,7 +59,7 @@ def _output_dtype(op, operand_dtypes, in_place):
 
 def _get_dtype(operand):
     """
-    Get the numpy dtype corresponsing to the numeric data in the object
+    Get the numpy dtype corresponding to the numeric data in the object
     provided.
 
     Args:

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -385,14 +385,12 @@ def _inplace_common_checks(cube, other, math_op):
     cast back to the integer data of `cube`.
 
     """
-    if cube.dtype.kind in 'iu':
-        other_kind = _get_dtype(other).kind
-        if other_kind not in 'iu':
-            # Cannot coerce math op between int `cube` and float `other`
-            # back to int.
+    other_dtype = _get_dtype(other)
+    if not np.can_cast(other_dtype, cube.dtype, 'same_kind'):
             aemsg = ('Cannot perform inplace {} between {!r} '
-                     'with integer data and {!r} with floating-point data.')
-            raise ArithmeticError(aemsg.format(math_op, cube, other))
+                     'with {} data and {!r} with {} data.')
+            raise ArithmeticError(
+                aemsg.format(math_op, cube, cube.dtype, other, other_dtype))
 
 
 def divide(cube, other, dim=None, in_place=False):

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -494,15 +494,6 @@ class TestDivideAndMultiply(tests.IrisTest):
         b = iris.analysis.maths.multiply(a, 5, in_place=False)
         self.assertIsNot(a, b)
 
-    def test_type_error(self):
-        with self.assertRaises(TypeError):
-            iris.analysis.maths.multiply('not a cube', 2)
-        with self.assertRaises(TypeError):
-            iris.analysis.maths.multiply(self.cube, 'not a cube')
-        with self.assertRaises(TypeError):
-            iris.analysis.maths.multiply(self.cube, 'not a cube',
-                                         in_place=True)
-
 
 @tests.skip_data
 class TestExponentiate(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -23,6 +23,7 @@ import six
 from abc import ABCMeta, abstractproperty
 
 import numpy as np
+from numpy import ma
 
 from iris.analysis import MEAN
 from iris.cube import Cube
@@ -135,8 +136,8 @@ class CubeArithmeticMaskingTestMixin(six.with_metaclass(ABCMeta, object)):
 
     def _test_partial_mask(self, in_place):
         # Helper method for masked data tests.
-        dat_a = np.ma.array([2., 2., 2., 2.], mask=[1, 0, 1, 0])
-        dat_b = np.ma.array([2., 2., 2., 2.], mask=[1, 1, 0, 0])
+        dat_a = ma.array([2., 2., 2., 2.], mask=[1, 0, 1, 0])
+        dat_b = ma.array([2., 2., 2., 2.], mask=[1, 1, 0, 0])
 
         cube_a = Cube(dat_a)
         cube_b = Cube(dat_b)
@@ -168,10 +169,10 @@ class CubeArithmeticMaskedConstantTestMixin(
         # Cube in_place arithmetic operation.
         dtype = np.int64
         fill_value = 12345
-        dat = np.ma.masked_array(0, 1, dtype)
+        dat = ma.masked_array(0, 1, dtype)
         cube = Cube(dat, fill_value=fill_value)
         res = self.cube_func(cube, 5, in_place=True)
-        self.assertMaskedArrayEqual(np.ma.masked_array(0, 1), res.data)
+        self.assertMaskedArrayEqual(ma.masked_array(0, 1), res.data)
         self.assertEqual(dtype, res.dtype)
         # self.assertEqual(fill_value, res.fill_value)
         self.assertIs(res, cube)
@@ -180,10 +181,10 @@ class CubeArithmeticMaskedConstantTestMixin(
         # Cube in_place arithmetic operation.
         dtype = np.int64
         fill_value = 12345
-        dat = np.ma.masked_array(0, 1, dtype)
+        dat = ma.masked_array(0, 1, dtype)
         cube = Cube(dat, fill_value=fill_value)
         res = self.cube_func(cube, 5, in_place=False)
-        self.assertMaskedArrayEqual(np.ma.masked_array(0, 1), res.data)
+        self.assertMaskedArrayEqual(ma.masked_array(0, 1), res.data)
         self.assertEqual(dtype, res.dtype)
         # self.assertEqual(fill_value, res.fill_value)
         self.assertIsNot(res, cube)

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -168,23 +168,19 @@ class CubeArithmeticMaskedConstantTestMixin(
     def test_masked_constant_in_place(self):
         # Cube in_place arithmetic operation.
         dtype = np.int64
-        fill_value = 12345
         dat = ma.masked_array(0, 1, dtype)
-        cube = Cube(dat, fill_value=fill_value)
+        cube = Cube(dat)
         res = self.cube_func(cube, 5, in_place=True)
         self.assertMaskedArrayEqual(ma.masked_array(0, 1), res.data)
         self.assertEqual(dtype, res.dtype)
-        # self.assertEqual(fill_value, res.fill_value)
         self.assertIs(res, cube)
 
     def test_masked_constant_not_in_place(self):
         # Cube in_place arithmetic operation.
         dtype = np.int64
-        fill_value = 12345
         dat = ma.masked_array(0, 1, dtype)
-        cube = Cube(dat, fill_value=fill_value)
+        cube = Cube(dat)
         res = self.cube_func(cube, 5, in_place=False)
         self.assertMaskedArrayEqual(ma.masked_array(0, 1), res.data)
         self.assertEqual(dtype, res.dtype)
-        # self.assertEqual(fill_value, res.fill_value)
         self.assertIsNot(res, cube)

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -159,3 +159,31 @@ class CubeArithmeticMaskingTestMixin(six.with_metaclass(ABCMeta, object)):
 
         self.assertMaskedArrayEqual(com, res.data)
         self.assertIsNot(res, orig_cube)
+
+
+class CubeArithmeticMaskedConstantTestMixin(
+        six.with_metaclass(ABCMeta, object)):
+
+    def test_masked_constant_in_place(self):
+        # Cube in_place arithmetic operation.
+        dtype = np.int64
+        fill_value = 12345
+        dat = np.ma.masked_array(0, 1, dtype)
+        cube = Cube(dat, fill_value=fill_value)
+        res = self.cube_func(cube, 5, in_place=True)
+        self.assertMaskedArrayEqual(np.ma.masked_array(0, 1), res.data)
+        self.assertEqual(dtype, res.dtype)
+        # self.assertEqual(fill_value, res.fill_value)
+        self.assertIs(res, cube)
+
+    def test_masked_constant_not_in_place(self):
+        # Cube in_place arithmetic operation.
+        dtype = np.int64
+        fill_value = 12345
+        dat = np.ma.masked_array(0, 1, dtype)
+        cube = Cube(dat, fill_value=fill_value)
+        res = self.cube_func(cube, 5, in_place=False)
+        self.assertMaskedArrayEqual(np.ma.masked_array(0, 1), res.data)
+        self.assertEqual(dtype, res.dtype)
+        # self.assertEqual(fill_value, res.fill_value)
+        self.assertIsNot(res, cube)

--- a/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
@@ -1,0 +1,99 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the function :func:`iris.analysis.maths._inplace_common_checks`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+from numpy import ma
+
+from iris.analysis.maths import _get_dtype
+from iris.cube import Cube
+from iris.coords import DimCoord, AuxCoord
+
+
+class Test(tests.IrisTest):
+    def _check_call(self, obj, expected_dtype):
+        result = _get_dtype(obj)
+        self.assertEqual(expected_dtype, result)
+
+    def test_int8(self):
+        n = -128
+        self._check_call(n, np.int8)
+
+    def test_int16(self):
+        n = -129
+        self._check_call(n, np.int16)
+
+    def test_uint8(self):
+        n = 255
+        self._check_call(n, np.uint8)
+
+    def test_uint16(self):
+        n = 256
+        self._check_call(n, np.uint16)
+
+    def test_float16(self):
+        n = 60000.0
+        self._check_call(n, np.float16)
+
+    def test_float32(self):
+        n = 65000.0
+        self._check_call(n, np.float32)
+
+    def test_scalar_demote(self):
+        n = np.int64(10)
+        self._check_call(n, np.uint8)
+
+    def test_array(self):
+        a = np.array([1, 2, 3], dtype=np.int16)
+        self._check_call(a, np.int16)
+
+    def test_scalar_array(self):
+        a = np.array(1, dtype=np.int32)
+        self._check_call(a, np.int32)
+
+    def test_masked_array(self):
+        m = ma.masked_array([1, 2, 3], [1, 0, 1], dtype=np.float16)
+        self._check_call(m, np.float16)
+
+    def test_masked_constant(self):
+        m = ma.masked
+        self._check_call(m, m.dtype)
+
+    def test_cube(self):
+        data = np.array([1, 2, 3], dtype=np.float32)
+        cube = Cube(data)
+        self._check_call(cube, np.float32)
+
+    def test_aux_coord(self):
+        points = np.array([1, 2, 3], dtype=np.int64)
+        aux_coord = AuxCoord(points)
+        self._check_call(aux_coord, np.int64)
+
+    def test_dim_coord(self):
+        points = np.array([1, 2, 3], dtype=np.float16)
+        dim_coord = DimCoord(points)
+        self._check_call(dim_coord, np.float16)

--- a/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the function :func:`iris.analysis.maths._inplace_common_checks`.
+Unit tests for the function :func:`iris.analysis.maths._get_dtype`.
 
 """
 

--- a/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
@@ -63,6 +63,10 @@ class Test(tests.IrisTest):
         n = 65000.0
         self._check_call(n, np.float32)
 
+    def test_float64(self):
+        n = 1e40
+        self._check_call(n, np.float64)
+
     def test_scalar_demote(self):
         n = np.int64(10)
         self._check_call(n, np.uint8)
@@ -72,28 +76,33 @@ class Test(tests.IrisTest):
         self._check_call(a, np.int16)
 
     def test_scalar_array(self):
-        a = np.array(1, dtype=np.int32)
-        self._check_call(a, np.int32)
+        dtype = np.int32
+        a = np.array(1, dtype=dtype)
+        self._check_call(a, dtype)
 
     def test_masked_array(self):
-        m = ma.masked_array([1, 2, 3], [1, 0, 1], dtype=np.float16)
-        self._check_call(m, np.float16)
+        dtype = np.float16
+        m = ma.masked_array([1, 2, 3], [1, 0, 1], dtype=dtype)
+        self._check_call(m, dtype)
 
     def test_masked_constant(self):
         m = ma.masked
         self._check_call(m, m.dtype)
 
     def test_cube(self):
-        data = np.array([1, 2, 3], dtype=np.float32)
+        dtype = np.float32
+        data = np.array([1, 2, 3], dtype=dtype)
         cube = Cube(data)
-        self._check_call(cube, np.float32)
+        self._check_call(cube, dtype)
 
     def test_aux_coord(self):
-        points = np.array([1, 2, 3], dtype=np.int64)
+        dtype = np.int64
+        points = np.array([1, 2, 3], dtype=dtype)
         aux_coord = AuxCoord(points)
-        self._check_call(aux_coord, np.int64)
+        self._check_call(aux_coord, dtype)
 
     def test_dim_coord(self):
-        points = np.array([1, 2, 3], dtype=np.float16)
+        dtype = np.float16
+        points = np.array([1, 2, 3], dtype=dtype)
         dim_coord = DimCoord(points)
-        self._check_call(dim_coord, np.float16)
+        self._check_call(dim_coord, dtype)

--- a/lib/iris/tests/unit/analysis/maths/test__inplace_common_checks.py
+++ b/lib/iris/tests/unit/analysis/maths/test__inplace_common_checks.py
@@ -124,9 +124,8 @@ class Test(tests.IrisTest):
         self.assertIsNone(result)
 
     def test_uint_cube_int_cube(self):
-        result = _inplace_common_checks(self.uint_cube, self.int_cube,
-                                        self.op)
-        self.assertIsNone(result)
+        with self.assertRaisesRegexp(ArithmeticError, self.emsg):
+            _inplace_common_checks(self.uint_cube, self.int_cube, self.op)
 
     def test_int_cube__scalar_float(self):
         with self.assertRaisesRegexp(ArithmeticError, self.emsg):
@@ -145,8 +144,8 @@ class Test(tests.IrisTest):
             _inplace_common_checks(self.uint_cube, self.scalar_float, self.op)
 
     def test_uint_cube__int_array(self):
-        result = _inplace_common_checks(self.uint_cube, self.int_cube, self.op)
-        self.assertIsNone(result)
+        with self.assertRaisesRegexp(ArithmeticError, self.emsg):
+            _inplace_common_checks(self.uint_cube, self.int_cube, self.op)
 
     def test_uint_cube__float_array(self):
         with self.assertRaisesRegexp(ArithmeticError, self.emsg):

--- a/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
@@ -1,0 +1,182 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the function :func:`iris.analysis.maths._inplace_common_checks`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from itertools import product
+import operator
+
+import numpy as np
+
+from iris.analysis.maths import _output_dtype
+
+
+class Test(tests.IrisTest):
+    def setUp(self):
+        # Operators which result in a value of the same dtype as their
+        # arguments when the arguments' dtypes are the same.
+        self.same_result_ops = [operator.add,
+                                operator.sub,
+                                operator.mul,
+                                operator.pow,
+                                operator.div,
+                                np.add,
+                                np.subtract,
+                                np.multiply,
+                                np.power,
+                                np.divide]
+
+        self.unary_same_result_ops = [np.abs]
+
+        # Operators which always result in a float.
+        self.float_ops = [operator.truediv,
+                          np.true_divide]
+
+        self.unary_float_ops = [np.log,
+                                np.log2,
+                                np.log10,
+                                np.exp]
+
+        self.all_binary_ops = self.same_result_ops + self.float_ops
+        self.all_unary_ops = self.unary_same_result_ops + self.unary_float_ops
+
+        self.dtypes = [np.dtype('i2'), np.dtype('i4'), np.dtype('i8'),
+                       np.dtype('f2'), np.dtype('f4'), np.dtype('f8')]
+
+    def _binary_error_message(self, op, left_dtype, right_dtype,
+                              expected_dtype, result_dtype, in_place=False):
+        msg = "Output for {op.__class__.__name__} {op.__name__!r} and " \
+              "arguments ({lhs!r}, {rhs!r}, in_place={in_place}) " \
+              "was {res!r}. Expected {exp!r}."
+        return msg.format(op=op, lhs=left_dtype, rhs=right_dtype,
+                          exp=expected_dtype, res=result_dtype,
+                          in_place=in_place)
+
+    def _unary_error_message(self, op, dtype, expected_dtype, result_dtype,
+                             in_place=False):
+        msg = "Output for {op.__class__.__name__} {op.__name__!r} and " \
+              "arguments ({arg!r}, in_place={in_place}) was {res!r}. " \
+              "Expected {exp!r}."
+        return msg.format(op=op, arg=dtype,
+                          exp=expected_dtype, res=result_dtype,
+                          in_place=in_place)
+
+    def test_same_result(self):
+        # Check that the result dtype is the same as the input dtypes for
+        # relevant operators.
+        for dtype in self.dtypes:
+            for op in self.same_result_ops:
+                result_dtype = _output_dtype(op, dtype, dtype)
+                self.assertEqual(dtype, result_dtype)
+            for op in self.unary_same_result_ops:
+                result_dtype = _output_dtype(op, dtype)
+                self.assertEqual(dtype, result_dtype)
+
+    def test_binary_float(self):
+        # Check that the result dtype is a float for relevant operators.
+        # Perform checks for a selection of cases.
+        cases = [(np.dtype('i2'), np.dtype('i2'), np.dtype('f8')),
+                 (np.dtype('i2'), np.dtype('i4'), np.dtype('f8')),
+                 (np.dtype('i4'), np.dtype('i4'), np.dtype('f8')),
+                 (np.dtype('i2'), np.dtype('f2'), np.dtype('f4')),
+                 (np.dtype('i2'), np.dtype('f4'), np.dtype('f4')),
+                 (np.dtype('i8'), np.dtype('f2'), np.dtype('f8')),
+                 (np.dtype('f2'), np.dtype('f2'), np.dtype('f2')),
+                 (np.dtype('f4'), np.dtype('f4'), np.dtype('f4')),
+                 (np.dtype('f2'), np.dtype('f4'), np.dtype('f4'))]
+        for ldtype, rdtype, expected_dtype in cases:
+            for op in self.float_ops:
+                result_dtype = _output_dtype(op, ldtype, rdtype)
+                self.assertEqual(expected_dtype, result_dtype,
+                                 self._binary_error_message(op, ldtype, rdtype,
+                                                            expected_dtype,
+                                                            result_dtype))
+
+    def test_unary_float(self):
+        cases = [(np.dtype('i2'), np.dtype('f4')),
+                 (np.dtype('i4'), np.dtype('f8')),
+                 (np.dtype('i8'), np.dtype('f8')),
+                 (np.dtype('f2'), np.dtype('f2')),
+                 (np.dtype('f4'), np.dtype('f4')),
+                 (np.dtype('f8'), np.dtype('f8'))]
+        for dtype, expected_dtype in cases:
+            for op in self.unary_float_ops:
+                result_dtype = _output_dtype(op, dtype)
+                self.assertEqual(expected_dtype, result_dtype,
+                                 self._unary_error_message(op, dtype,
+                                                           expected_dtype,
+                                                           result_dtype))
+
+    def test_binary_float_argument(self):
+        # Check that when one argument is a float dtype, a float dtype results
+        # Unary operators are covered by other tests.
+        dtypes = [np.dtype('i2'), np.dtype('i4'), np.dtype('i8'),
+                  np.dtype('f2'), np.dtype('f4'), np.dtype('f8')]
+        expected_dtypes = [np.dtype('f4'), np.dtype('f8'), np.dtype('f8'),
+                           np.dtype('f2'), np.dtype('f4'), np.dtype('f8')]
+        for op in self.all_binary_ops:
+            for dtype, expected_dtype in zip(dtypes, expected_dtypes):
+                result_dtype = _output_dtype(op, dtype, np.dtype('f2'))
+                self.assertEqual(expected_dtype, result_dtype,
+                                 self._binary_error_message(op, dtype,
+                                                            np.dtype('f2'),
+                                                            expected_dtype,
+                                                            result_dtype))
+
+    def test_in_place(self):
+        # Check that when the in_place argument is True, the result is always
+        # the same as first operand.
+        for ldtype, rdtype in product(self.dtypes, self.dtypes):
+            for op in self.all_binary_ops:
+                result_dtype = _output_dtype(op, ldtype, rdtype, in_place=True)
+                self.assertEqual(result_dtype, ldtype,
+                                 self._binary_error_message(op, ldtype, rdtype,
+                                                            ldtype,
+                                                            result_dtype,
+                                                            in_place=True))
+
+        for dtype in self.dtypes:
+            for op in self.all_unary_ops:
+                result_dtype = _output_dtype(op, dtype, in_place=True)
+                self.assertEqual(result_dtype, dtype,
+                                 self._unary_error_message(op, dtype, dtype,
+                                                           result_dtype,
+                                                           in_place=True))
+
+    def test_commuative(self):
+        # Check that the operation is commutative if in_place is not specified.
+        for dtype1, dtype2 in product(self.dtypes, self.dtypes):
+            for op in self.all_binary_ops:
+                result_dtype1 = _output_dtype(op, dtype1, dtype2)
+                result_dtype2 = _output_dtype(op, dtype2, dtype1)
+                self.assertEqual(
+                    result_dtype1,
+                    result_dtype2,
+                    "_output_dtype is not commutative with arguments "
+                    "{!r} and {!r}: {!r} != {!r}".format(dtype1,
+                                                         dtype2,
+                                                         result_dtype1,
+                                                         result_dtype2))

--- a/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
@@ -42,12 +42,17 @@ class Test(tests.IrisTest):
                                 operator.sub,
                                 operator.mul,
                                 operator.pow,
-                                operator.div,
+                                operator.floordiv,
                                 np.add,
                                 np.subtract,
                                 np.multiply,
                                 np.power,
                                 np.divide]
+        try:
+            self.same_result_ops.append(operator.div)
+        except AttributeError:
+            # operator.div doesn't exist in Python 3
+            pass
 
         self.unary_same_result_ops = [np.abs]
 

--- a/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__output_dtype.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the function :func:`iris.analysis.maths._inplace_common_checks`.
+Unit tests for the function :func:`iris.analysis.maths._output_dtype`.
 
 """
 
@@ -157,7 +157,6 @@ class Test(tests.IrisTest):
                                                             ldtype,
                                                             result_dtype,
                                                             in_place=True))
-
         for dtype in self.dtypes:
             for op in self.all_unary_ops:
                 result_dtype = _output_dtype(op, dtype, in_place=True)

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -27,7 +27,8 @@ import operator
 
 from iris.analysis.maths import add
 from iris.tests.unit.analysis.maths import \
-    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
+    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin, \
+    CubeArithmeticMaskedConstantTestMixin
 
 
 @tests.skip_data
@@ -53,6 +54,17 @@ class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
     def cube_func(self):
         return add
 
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(tests.IrisTest_nometa,
+                         CubeArithmeticMaskedConstantTestMixin):
+    @property
+    def data_op(self):
+        return operator.add
+
+    @property
+    def cube_func(self):
+        return add
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -27,7 +27,8 @@ import operator
 
 from iris.analysis.maths import multiply
 from iris.tests.unit.analysis.maths import \
-    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
+    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin, \
+    CubeArithmeticMaskedConstantTestMixin
 
 
 @tests.skip_data
@@ -45,6 +46,18 @@ class TestBroadcasting(tests.IrisTest_nometa,
 
 @tests.iristest_timing_decorator
 class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+    @property
+    def data_op(self):
+        return operator.mul
+
+    @property
+    def cube_func(self):
+        return multiply
+
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(tests.IrisTest_nometa,
+                         CubeArithmeticMaskedConstantTestMixin):
     @property
     def data_op(self):
         return operator.mul

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -27,7 +27,8 @@ import operator
 
 from iris.analysis.maths import subtract
 from iris.tests.unit.analysis.maths import \
-    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin
+    CubeArithmeticBroadcastingTestMixin, CubeArithmeticMaskingTestMixin, \
+    CubeArithmeticMaskedConstantTestMixin
 
 
 @tests.skip_data
@@ -45,6 +46,18 @@ class TestBroadcasting(tests.IrisTest_nometa,
 
 @tests.iristest_timing_decorator
 class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+    @property
+    def data_op(self):
+        return operator.sub
+
+    @property
+    def cube_func(self):
+        return subtract
+
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(tests.IrisTest_nometa,
+                         CubeArithmeticMaskedConstantTestMixin):
     @property
     def data_op(self):
         return operator.sub


### PR DESCRIPTION
Numpy operations which result in a scalar masked array return an instance of `np.ma.core.MaskedConstant` that always has a dtype of `np.float64`. This means that in cube arithmetic the dtype information can be lost.

This PR is an attempt to rectify that. The idea is to run the operation on dummy arrays with the input dtypes and use the dtype of the result to fix up the dtype of the cube in the scalar masked array case.

This approach doesn't work for arbitrary functions (i.e. instances of `iris.analysis.maths.IFunc`), because (1) the dtype can depend on kwargs, and (2) the function may fail if the arguments don't meet particular requirements (e.g. shape), and it's not possible to determine these requirements for arbitrary functions. It might be worth handling the limited case where the IFunc wraps a Numpy ufunc, as this may cover the majority of use cases.