### PR TITLE
Integrate DataManager with Coord, DimCoord, and AuxCoord

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1685,7 +1685,7 @@ class ProtoCube(object):
         # the CoordDefn used by scalar_defns: `coord.points.dtype` and
         # `type(coord)`.
         def key_func(coord):
-            points_dtype = coord._points.dtype
+            points_dtype = coord.dtype
             return (not np.issubdtype(points_dtype, np.number),
                     not isinstance(coord, iris.coords.DimCoord),
                     hint_dict.get(coord.name(), len(hint_dict) + 1),

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -215,7 +215,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         # Transpose to be consistent with the Cube.
         sorted_pairs = sorted(enumerate(dims), key=lambda pair: pair[1])
         transpose_order = [pair[0] for pair in sorted_pairs]
-        points = coord._points
+        points = coord.core_points()
         if dims and transpose_order != list(range(len(dims))):
             points = points.transpose(transpose_order)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1066,9 +1066,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 else self.core_points()
             lower, upper = item.min(), item.max()
             bounds_dtype = item.dtype
-            bounds = np.empty((2,), 'object')
-            bounds[0] = lower
-            bounds[1] = upper
+            # Ensure 2D shape of new bounds.
+            bounds = np.empty((1, 2), 'object')
+            bounds[0, 0] = lower
+            bounds[0, 1] = upper
             # Create points for the new collapsed coordinate.
             points_dtype = self.dtype
             points = (lower + upper) * 0.5

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1746,10 +1746,10 @@ class AuxCoord(Coord):
             (n_bounds, )``.
 
         """
+        bounds = None
         if self._bounds_dm is not None:
-            return self._bounds_dm.data.view()
-        else:
-            return None
+            bounds = self._bounds_dm.data
+        return bounds
 
     @bounds.setter
     def bounds(self, bounds):
@@ -1758,7 +1758,7 @@ class AuxCoord(Coord):
             if not is_lazy_data(bounds):
                 bounds = self._sanitise_array(bounds, 2)
             # NB. Use _points to avoid triggering any lazy array.
-            if self._points_dm.shape != bounds.shape[:-1]:
+            if self.shape != bounds.shape[:-1]:
                 raise ValueError("Bounds shape must be compatible with points "
                                  "shape.")
             if self._bounds_dm is None:

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1728,7 +1728,7 @@ class AuxCoord(Coord):
         if bounds is None:
             self._bounds_dm = None
         else:
-            if not self.has_lazy_bounds():
+            if not is_lazy_data(bounds):
                 bounds = self._sanitise_array(bounds, 2)
             if self.shape != bounds.shape[:-1]:
                 raise ValueError("Bounds shape must be compatible with points "

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1653,18 +1653,22 @@ class DimCoord(Coord):
             # Ensure we have a realised array of new bounds values.
             bounds = as_concrete_data(bounds, result_dtype=self.dtype)
             bounds = np.asarray(bounds)
+            shape_2d = (self.shape[0], bounds.shape[0])
             if bounds.ndim == 1:
-                bounds = bounds.reshape(self.shape[0], bounds.shape[0])
+                bounds = bounds.reshape(shape_2d)
             # Checks for appropriate values for the new bounds.
             self._new_bounds_requirements(bounds)
 
             # Ensure the array is read-only.
             bounds.flags.writeable = False
-            if self._bounds_dm is None:
+            if self._bounds_dm is None or bounds.shape == shape_2d:
+                # Construct a new bounds DataManager iff:
+                #  * there wasn't a bounds DataManager before, or
+                #  * we've increased the dimensionality of the new bounds.
                 self._bounds_dm = DataManager(bounds,
                                               realised_dtype=bounds.dtype)
             else:
-                self._bounds_dm.replace(bounds)
+                self._bounds_dm.data = bounds
 
     def is_monotonic(self):
         return True

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -904,7 +904,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
     @property
     def points_dtype(self):
         """
-        Abstract property which returns the Numpy data type of the Coordinate.
+        The NumPy data type of the coord's points.
 
         """
         return self._points_dm.dtype
@@ -912,7 +912,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
     @property
     def bounds_dtype(self):
         """
-        Abstract property which returns the Numpy data type of the Coordinate.
+        The NumPy data type of the coord's bounds. Will be `None` if the coord
+        does not have bounds.
 
         """
         result = None

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -902,9 +902,9 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         return compatible
 
     @property
-    def points_dtype(self):
+    def dtype(self):
         """
-        The NumPy data type of the coord's points.
+        The NumPy data type of the coord, as specified by it's points.
 
         """
         return self._points_dm.dtype
@@ -1101,7 +1101,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             bounds_dtype = item.dtype
             bounds = [lower, upper]
             # Create points for the new collapsed coordinate.
-            points_dtype = self.points.dtype
+            points_dtype = self.dtype
             points = [(lower + upper) * 0.5]
 
             # Create the new collapsed coordinate.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -44,7 +44,7 @@ import iris.time
 import iris.util
 
 from iris._cube_coord_common import CFVariableMixin
-from iris.util import is_regular
+from iris.util import points_step
 
 
 class CoordDefn(collections.namedtuple('CoordDefn',
@@ -1446,7 +1446,11 @@ class DimCoord(Coord):
             bounds values will be defined. Defaults to False.
 
         """
-        points = (zeroth + step) + step * np.arange(count, dtype=np.float64)
+        points = (zeroth + step) + step * np.arange(count, dtype=np.float32)
+        _, regular = points_step(points)
+        if not regular:
+            points = (zeroth + step) + step * np.arange(count,
+                                                        dtype=np.float64)
         points.flags.writeable = False
 
         if with_bounds:

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -23,15 +23,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import skip
-
 import iris
 from iris.analysis import MEAN
 from iris._lazy_data import is_lazy_data
 
 
 class Test_aggregated_by(tests.IrisTest):
-    @skip("Deferred loading of coordinates is temporarily removed.")
     @tests.skip_data
     def test_agg_by_aux_coord(self):
         problem_test_file = tests.get_data_path(('NetCDF', 'testing',
@@ -48,7 +45,7 @@ class Test_aggregated_by(tests.IrisTest):
         # triggered the load of the coordinate's data.
         forecast_period_coord = cube.coord('forecast_period')
 
-        self.assertTrue(is_lazy_data(forecast_period_coord._points))
+        self.assertTrue(is_lazy_data(forecast_period_coord.core_points()))
 
         # Now confirm we can aggregate along this coord.
         res_cube = cube.aggregated_by('forecast_period', MEAN)

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -579,26 +579,41 @@ class TestGetterSetter(tests.IrisTest):
 
 class TestGuessBounds(tests.IrisTest):
     def test_guess_bounds(self):
-        coord = iris.coords.DimCoord(np.array([0, 10, 20, 30]), long_name="foo", units="1")
+        coord = iris.coords.DimCoord(np.array([0, 10, 20, 30]),
+                                     long_name="foo", units="1")
         coord.guess_bounds()
-        self.assertArrayEqual(coord.bounds, np.array([[-5, 5], [5, 15], [15, 25], [25, 35]]))
-        
+        self.assertArrayEqual(coord.bounds,
+                              np.array([[-5, 5], [5, 15], [15, 25], [25, 35]]))
+
         coord.bounds = None
         coord.guess_bounds(0.25)
-        self.assertArrayEqual(coord.bounds, np.array([[-5, 5], [5, 15], [15, 25], [25, 35]]) + 2.5)
-        
+        self.assertArrayEqual(coord.bounds,
+                              np.array([[-5, 5],
+                                        [5, 15],
+                                        [15, 25],
+                                        [25, 35]]) + 2.5)
+
         coord.bounds = None
         coord.guess_bounds(0.75)
-        self.assertArrayEqual(coord.bounds, np.array([[-5, 5], [5, 15], [15, 25], [25, 35]]) - 2.5)
+        self.assertArrayEqual(coord.bounds,
+                              np.array([[-5, 5],
+                                        [5, 15],
+                                        [15, 25],
+                                        [25, 35]]) - 2.5)
 
         points = coord.points.copy()
         points[2] = 25
         coord.points = points
         coord.bounds = None
         coord.guess_bounds()
-        self.assertArrayEqual(coord.bounds, np.array([[-5., 5.], [5., 17.5], [17.5, 27.5], [27.5, 32.5]]))
-        
+        self.assertArrayEqual(coord.bounds,
+                              np.array([[-5., 5.],
+                                        [5., 17.5],
+                                        [17.5, 27.5],
+                                        [27.5, 32.5]]))
+
         # if the points are not monotonic, then guess_bounds should fail
+        points = coord.points.copy()
         points[2] = 32
         coord = iris.coords.AuxCoord.from_coord(coord)
         coord.points = points

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -33,6 +33,7 @@ import iris.aux_factory
 import iris.coord_systems
 import iris.coords
 import iris.exceptions
+from iris._data_manager import DataManager
 import iris.tests.stock
 
 
@@ -538,41 +539,43 @@ class TestGetterSetter(tests.IrisTest):
     def test_get_set_points_and_bounds(self):
         cube = iris.tests.stock.realistic_4d()
         coord = cube.coord("grid_latitude")
-        
+
         # get bounds
         bounds = coord.bounds
         self.assertEqual(bounds.shape, (100, 2))
-        
+
         self.assertEqual(bounds.shape[-1], coord.nbounds)
-        
+
         # set bounds
         coord.bounds = bounds + 1
-        
+
         np.testing.assert_array_equal(coord.bounds, bounds + 1)
 
         # set bounds - different length to existing points
         with self.assertRaises(ValueError):
             coord.bounds = bounds[::2, :]
-        
+
         # set points/bounds to None
         with self.assertRaises(ValueError):
             coord.points = None
         coord.bounds = None
-        
-        # set bounds from non-numpy pair
-        coord._points = None  # reset the undelying shape of the coordinate
+
+        # set bounds from non-numpy pair.
+        # First reset the underlying shape of the coordinate.
+        coord._points_dm = DataManager(1)
         coord.points = 1
         coord.bounds = [123, 456]
         self.assertEqual(coord.shape, (1, ))
         self.assertEqual(coord.bounds.shape, (1, 2))
-        
+
         # set bounds from non-numpy pairs
-        coord._points = None # reset the undelying shape of the coordinate
-        coord.points = list(range(3))
+        # First reset the underlying shape of the coord's points and bounds.
+        coord._points_dm = DataManager(np.arange(3))
+        coord.bounds = None
         coord.bounds = [[123, 456], [234, 567], [345, 678]]
         self.assertEqual(coord.shape, (3, ))
         self.assertEqual(coord.bounds.shape, (3, 2))
-        
+
 
 class TestGuessBounds(tests.IrisTest):
     def test_guess_bounds(self):

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -27,7 +27,6 @@ import six
 # importing anything else
 import iris.tests as tests
 
-from unittest import skip
 import warnings
 
 import numpy as np
@@ -144,7 +143,6 @@ class TestRealistic4d(tests.GraphicsTest):
             with self.assertRaises(UserWarning):
                 factory = HybridHeightFactory(orography=sigma)
 
-    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_bounded_orography(self):
         # Start with everything normal
         orog = self.cube.coord('surface_altitude')
@@ -158,10 +156,9 @@ class TestRealistic4d(tests.GraphicsTest):
         self.assertIsInstance(altitude.bounds, np.ndarray)
 
         # Make sure altitude.bounds now raises an error.
-        altitude = self.cube.coord('altitude')
         exp_emsg = 'operands could not be broadcast together'
         with self.assertRaisesRegexp(ValueError, exp_emsg):
-            altitude.bounds
+            self.cube.coord('altitude')
 
 
 @tests.skip_data
@@ -225,7 +222,6 @@ class TestHybridPressure(tests.IrisTest):
                 factory = HybridPressureFactory(
                     sigma=sigma, surface_air_pressure=sigma)
 
-    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_bounded_surface_pressure(self):
         # Start with everything normal
         surface_pressure = self.cube.coord('surface_air_pressure')
@@ -239,10 +235,9 @@ class TestHybridPressure(tests.IrisTest):
         self.assertIsInstance(pressure.bounds, np.ndarray)
 
         # Make sure pressure.bounds now raises an error.
-        pressure = self.cube.coord('air_pressure')
         exp_emsg = 'operands could not be broadcast together'
         with self.assertRaisesRegexp(ValueError, exp_emsg):
-            pressure.bounds
+            self.cube.coord('air_pressure')
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -32,7 +32,6 @@ import os.path
 import shutil
 import stat
 import tempfile
-from unittest import skip
 
 import netCDF4 as nc
 import numpy as np
@@ -107,14 +106,12 @@ class TestNetCDFLoad(tests.IrisTest):
             self.assertCML(cube, ('netcdf',
                                   'netcdf_global_xyzt_gems_iter_%d.cml' % i))
 
-    @skip("Deferred loading of coordinates is temporarily removed.")
     def test_load_rotated_xy_land(self):
         # Test loading single xy rotated pole CF-netCDF file.
         cube = iris.load_cube(tests.get_data_path(
             ('NetCDF', 'rotated', 'xy', 'rotPole_landAreaFraction.nc')))
         # Make sure the AuxCoords have lazy data.
-        self.assertTrue(is_lazy_data(cube.coord('latitude')._points))
-
+        self.assertTrue(is_lazy_data(cube.coord('latitude').core_points()))
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xy_land.cml'))
 
     def test_load_rotated_xyt_precipitation(self):

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -59,10 +59,10 @@ class Test__nd_points(tests.IrisTest):
         raw_points = np.arange(12).reshape(4, 3)
         points = as_lazy_data(raw_points, 1)
         coord = iris.coords.AuxCoord(points)
-        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord.core_points()))
         result = AuxCoordFactory._nd_points(coord, (0, 1), 2)
         # Check we haven't triggered the loading of the coordinate values.
-        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord.core_points()))
         self.assertTrue(is_lazy_data(result))
         expected = raw_points
         self.assertArrayEqual(result, expected)
@@ -71,10 +71,10 @@ class Test__nd_points(tests.IrisTest):
         raw_points = np.arange(12).reshape(4, 3)
         points = as_lazy_data(raw_points, 1)
         coord = iris.coords.AuxCoord(points)
-        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord.core_points()))
         result = AuxCoordFactory._nd_points(coord, (3, 2), 5)
         # Check we haven't triggered the loading of the coordinate values.
-        self.assertTrue(is_lazy_data(coord._points))
+        self.assertTrue(is_lazy_data(coord.core_points()))
         self.assertTrue(is_lazy_data(result))
         expected = raw_points.T[np.newaxis, np.newaxis, ..., np.newaxis]
         self.assertArrayEqual(result, expected)


### PR DESCRIPTION
This starts the process of integrating the `DataManager` with coord classes. Specifically, this adds the `DataManager` to the abstract coord class `iris.coords.Coord`. This is done as the initial step to fully integrating the `DataManager` with `DimCoord` and `AuxCoord`.

Still a work in progress:

 * I haven't touched `Coord.__getitem__` as there is still outstanding work in this area in #2519.
 * I've only done a light touch on `Coord.copy` as the copy code will need to be thought about in the context of `DimCoord` and `AuxCoord`.
 * I haven't even looked at the tests (and it is likely that many will now fail). I think the tests will be easier to deal with at the same time as tackling `DimCoord` and `AuxCoord`.