### PR TITLE
test for bug in aggregator

### DIFF
--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -348,9 +348,10 @@ class Test_aggregated_by(tests.IrisTest):
                                               name='month')
         agg_cube = self.time_cube.aggregated_by('month', MEAN)
         coord_categorisation.add_month(agg_cube, 'time', name='month_name')
-        self.assertEquals(agg_cube.coord('month_name').points[0], 'Jan')
-        self.assertEquals(agg_cube.coord('month_name').points[4], 'May')
-        self.assertEquals(agg_cube.coord('month_name').points[8], 'Sep')
+        month_order = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
+                       'Sep', 'Oct', 'Nov', 'Dec']
+        for i, month in enumerate(month_order):
+            self.assertEquals(agg_cube.coord('month_name').points[i], month)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -339,19 +339,23 @@ class Test_aggregated_by(tests.IrisTest):
                                                     (latitude, 1),
                                                     (longitude, 2)])
 
-    def test_month_name(self):
-        # This will test the ability of the aggregator to correctly calculate
-        # the order of months in the new coordinate array.
-        # The month names should appear in chronological order from January
-        # through to December.
+    def test_date_aggregator(self):
+        # Test the ability of the aggregator to correctly calculate
+        # the new points array of an aggregated time coordinate.
         coord_categorisation.add_month_number(self.time_cube, 'time',
                                               name='month')
         agg_cube = self.time_cube.aggregated_by('month', MEAN)
-        coord_categorisation.add_month(agg_cube, 'time', name='month_name')
-        month_order = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
-                       'Sep', 'Oct', 'Nov', 'Dec']
-        for i, month in enumerate(month_order):
-            self.assertEquals(agg_cube.coord('month_name').points[i], month)
+        # Get a list of point values for the aggregated month coordinate (this
+        # should be 1 to 12):
+        month_numbers = agg_cube.coord('month').points
+        # Get a list of point values in number format for the month on the
+        # aggregated time coordinate (this should also be 1 to 12):
+        months = [agg_cube.coord('time').units.num2date(point).month
+                  for point in agg_cube.coord('time').points]
+        # Check that the months are the same for the aggregated time
+        # coordinate and the aggregated month coordinate:
+        for month_number, month in zip(month_numbers, months):
+            self.assertEquals(month_number, month)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -321,15 +321,19 @@ class Test_lazy_aggregate(tests.IrisTest):
 
 class Test_aggregated_by(tests.IrisTest):
     def setUp(self):
+        # This sets up a cube with a time coordinate containing two years and
+        # two months.
+        # This will test the ability of the aggregator to correctly calculate
+        # the order of months in the new coordinate array.
         latitude = DimCoord(np.linspace(-90, 90, 4),
                             standard_name='latitude',
                             units='degrees')
         longitude = DimCoord(np.linspace(45, 360, 8),
                              standard_name='longitude',
                              units='degrees')
-        time_unit = unit.Unit('hours since epoch',
+        time_unit = unit.Unit('days since epoch',
                               calendar=unit.CALENDAR_360_DAY)
-        time = DimCoord(np.linspace(104040, 122040, 26),
+        time = DimCoord(np.linspace(0, 750, 26),
                         standard_name='time',
                         units=time_unit)
         self.time_cube = Cube(np.zeros((26, 4, 8), np.float32),
@@ -343,7 +347,8 @@ class Test_aggregated_by(tests.IrisTest):
         agg_cube = self.time_cube.aggregated_by('month', MEAN)
         coord_categorisation.add_month(agg_cube, 'time', name='month_name')
         self.assertEquals(agg_cube.coord('month_name').points[0], 'Jan')
-        self.assertEquals(agg_cube.coord('month_name').points[2], 'Mar')
+        self.assertEquals(agg_cube.coord('month_name').points[4], 'May')
+        self.assertEquals(agg_cube.coord('month_name').points[8], 'Sep')
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -323,15 +323,13 @@ class Test_aggregated_by(tests.IrisTest):
     def setUp(self):
         # This sets up a cube with a time coordinate containing two years and
         # two months.
-        # This will test the ability of the aggregator to correctly calculate
-        # the order of months in the new coordinate array.
         latitude = DimCoord(np.linspace(-90, 90, 4),
                             standard_name='latitude',
                             units='degrees')
         longitude = DimCoord(np.linspace(45, 360, 8),
                              standard_name='longitude',
                              units='degrees')
-        time_unit = unit.Unit('days since epoch',
+        time_unit = unit.Unit('days since 1970-01-01 00:00:00',
                               calendar=unit.CALENDAR_360_DAY)
         time = DimCoord(np.linspace(0, 750, 26),
                         standard_name='time',
@@ -342,6 +340,10 @@ class Test_aggregated_by(tests.IrisTest):
                                                     (longitude, 2)])
 
     def test_month_name(self):
+        # This will test the ability of the aggregator to correctly calculate
+        # the order of months in the new coordinate array.
+        # The month names should appear in chronological order from January
+        # through to December.
         coord_categorisation.add_month_number(self.time_cube, 'time',
                                               name='month')
         agg_cube = self.time_cube.aggregated_by('month', MEAN)

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -23,6 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+import cf_units as unit
 import numpy as np
 import numpy.ma as ma
 
@@ -326,9 +327,11 @@ class Test_aggregated_by(tests.IrisTest):
         longitude = DimCoord(np.linspace(45, 360, 8),
                              standard_name='longitude',
                              units='degrees')
+        time_unit = unit.Unit('hours since epoch',
+                              calendar=unit.CALENDAR_360_DAY)
         time = DimCoord(np.linspace(104040, 122040, 26),
                         standard_name='time',
-                        units='hours since 1970-01-01 00:00:00')
+                        units=time_unit)
         self.time_cube = Cube(np.zeros((26, 4, 8), np.float32),
                                dim_coords_and_dims=[(time, 0),
                                                     (latitude, 1),
@@ -337,7 +340,7 @@ class Test_aggregated_by(tests.IrisTest):
     def test_month_name(self):
         coord_categorisation.add_month_number(self.time_cube, 'time',
                                               name='month')
-        agg_cube = self.time_cube.aggregated_by('time', MEAN)
+        agg_cube = self.time_cube.aggregated_by('month', MEAN)
         coord_categorisation.add_month(agg_cube, 'time', name='month_name')
         self.assertEquals(agg_cube.coord('month_name').points[0], 'Jan')
         self.assertEquals(agg_cube.coord('month_name').points[2], 'Mar')


### PR DESCRIPTION
The method that iris currently uses to aggregate by months assumes that there will always be whole years to aggregate over, so when you try to aggregate by month over, for example, two years and two months, the aggregation becomes confused.  

When extra months are added, the groups over which to aggregate become uneven, and this affects the calculation which determines the order of the months.  Consequently, if you add month names to the new coordinate array, they are are returned in the wrong order (like this for the example described above):

['Jan' 'Feb' 'Sep' 'Oct' 'Nov' 'Dec' 'Jan' 'Feb' 'Mar' 'Apr' 'May' 'Jun']

This problem requires a new approach to the way we aggregate over months rather than the addition of a quick bug fix.