### PR TITLE
BUG: Stratify tgt lev broadcasting

### DIFF
--- a/lib/iris/experimental/stratify.py
+++ b/lib/iris/experimental/stratify.py
@@ -140,7 +140,7 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
 
     # The dimensions of cube and src_data must be broadcastable.
     try:
-        cube_data, src_data = np.broadcast_arrays(cube.data, src_data)
+        np.broadcast_arrays(cube.data, src_data)
     except ValueError:
         emsg = ('Cannot broadcast the cube and src_levels with '
                 'shapes {} and {}.')
@@ -152,12 +152,12 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
         # The dimensions of tgt_levels must be broadcastable to cube
         # in everything but the interpolation axis - otherwise raise
         # an exception.
-        dim_delta = cube_data.ndim - tgt_levels.ndim
+        dim_delta = cube.data.ndim - tgt_levels.ndim
         # The axis is relative to the cube. Calculate the axis of
         # interplation relative to the tgt_levels.
         tgt_axis = axis - dim_delta
         # Calculate the cube shape without the axis of interpolation.
-        data_shape = list(cube_data.shape)
+        data_shape = list(cube.data.shape)
         data_shape.pop(axis)
         # Calculate the tgt_levels shape without the axis of interpolation.
         target_shape = list(tgt_levels.shape)
@@ -168,9 +168,9 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
         except ValueError:
             emsg = ('Cannot broadcast the cube and tgt_levels with '
                     'shapes {} and {}, whilst ignoring axis of interpolation.')
-            raise ValueError(emsg.format(cube_data.shape, tgt_levels.shape))
+            raise ValueError(emsg.format(cube.data.shape, tgt_levels.shape))
         # Calculate the dimensions over the cube that the tgt_levels span.
-        tgt_aux_dims = list(range(cube_data.ndim))[dim_delta:]
+        tgt_aux_dims = list(range(cube.data.ndim))[dim_delta:]
 
     if interpolator is None:
         # Use the default stratify interpolator.
@@ -178,7 +178,7 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
                                interpolation='linear', extrapolation='nan')
 
     # Now perform the interpolation.
-    new_data = interpolator(tgt_levels, src_data, cube_data, axis=axis)
+    new_data = interpolator(tgt_levels, src_data, cube.data, axis=axis)
 
     # Create a result cube with the correct shape and metadata.
     result = Cube(new_data, **cube.copy().metadata._asdict())

--- a/lib/iris/experimental/stratify.py
+++ b/lib/iris/experimental/stratify.py
@@ -138,38 +138,10 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
     else:
         src_data = src_levels.data
 
-    # The dimensions of cube and src_data must be broadcastable.
-    try:
-        np.broadcast_arrays(cube.data, src_data)
-    except ValueError:
-        emsg = ('Cannot broadcast the cube and src_levels with '
-                'shapes {} and {}.')
-        raise ValueError(emsg.format(cube.shape, src_data.shape))
-
     tgt_levels = np.asarray(tgt_levels)
     tgt_aux_dims = axis
     if tgt_levels.ndim != 1:
-        # The dimensions of tgt_levels must be broadcastable to cube
-        # in everything but the interpolation axis - otherwise raise
-        # an exception.
         dim_delta = cube.data.ndim - tgt_levels.ndim
-        # The axis is relative to the cube. Calculate the axis of
-        # interplation relative to the tgt_levels.
-        tgt_axis = axis - dim_delta
-        # Calculate the cube shape without the axis of interpolation.
-        data_shape = list(cube.data.shape)
-        data_shape.pop(axis)
-        # Calculate the tgt_levels shape without the axis of interpolation.
-        target_shape = list(tgt_levels.shape)
-        target_shape.pop(tgt_axis)
-        # Now ensure that the shapes are broadcastable.
-        try:
-            np.broadcast_arrays(np.empty(data_shape), np.empty(target_shape))
-        except ValueError:
-            emsg = ('Cannot broadcast the cube and tgt_levels with '
-                    'shapes {} and {}, whilst ignoring axis of interpolation.')
-            raise ValueError(emsg.format(cube.data.shape, tgt_levels.shape))
-        # Calculate the dimensions over the cube that the tgt_levels span.
         tgt_aux_dims = list(range(cube.data.ndim))[dim_delta:]
 
     if interpolator is None:

--- a/lib/iris/tests/unit/experimental/stratify/test_relevel.py
+++ b/lib/iris/tests/unit/experimental/stratify/test_relevel.py
@@ -55,18 +55,6 @@ class Test(tests.IrisTest):
         self.coord = self.src_levels.coord('wibble')
         self.axes = (self.coord, self.coord.name(), None, 0)
 
-    def test_broadcast_fail_src_levels(self):
-        emsg = 'Cannot broadcast the cube and src_levels'
-        data = np.arange(60).reshape(3, 4, 5)
-        with self.assertRaisesRegexp(ValueError, emsg):
-            relevel(self.cube, AuxCoord(data), [1, 2, 3])
-
-    def test_broadcast_fail_tgt_levels(self):
-        emsg = 'Cannot broadcast the cube and tgt_levels'
-        data = np.arange(60).reshape(3, 4, 5)
-        with self.assertRaisesRegexp(ValueError, emsg):
-            relevel(self.cube, self.coord, data)
-
     def test_standard_input(self):
         for axis in self.axes:
             result = relevel(self.cube,


### PR DESCRIPTION
Currently src_data is being broadcasted using cube.data however, tgt_levels is not.  This means that python-stratify will raise an exception in the case of broadcasting:

```Python
...
  File "stratify/_vinterp.pyx", line 508, in stratify._vinterp.interpolate (stratify/_vinterp.c:6426)
    interp = _Interpolation(z_target, z_src, fz_src, rising=rising, axis=axis,
  File "stratify/_vinterp.pyx", line 566, in stratify._vinterp._Interpolation.__init__ (stratify/_vinterp.c:7436)
    raise ValueError(emsg.format(z_target.ndim, z_src.ndim))
ValueError: z_target and z_src must have the same number of dimensions, got 3 != 4.
```
~**NOT FOR MERGING**:
Await merge of https://github.com/SciTools-incubator/python-stratify/pull/15 followed by a tag release of pyhon-stratify.  Tests will not pass until then.~