### PR TITLE
Dtype concat fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="942e6344d6e6d00c85d824dadd49b5d6f57f4b4a"
+  - export IRIS_TEST_DATA_REF="1632baf808dc65cdcce59f7e160b4e5d4a32c262"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   # Install miniconda

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -711,5 +711,27 @@ class TestZonalMeanBounds(tests.IrisTest):
         self.assertTrue(cube.coord('longitude').has_bounds())
 
 
+@tests.skip_data
+class TestLoadPartialMask(tests.IrisTest):
+    def test_data(self):
+        # Ensure that fields merge correctly where one has a mask and one
+        # doesn't
+        filename = tests.get_data_path(['PP', 'simple_pp', 'partial_mask.pp'])
+
+        expected_data = np.ma.masked_array([[[0,  1],
+                                             [11, 12]],
+                                            [[99, 100],
+                                             [-1, -1]]],
+                                           [[[0, 0],
+                                             [0, 0]],
+                                            [[0, 0],
+                                             [1, 1]]],
+                                           dtype=np.int32)
+        cube = iris.load_cube(filename)
+
+        self.assertEqual(expected_data.dtype, cube.data.dtype)
+        self.assertMaskedArrayEqual(expected_data, cube.data, strict=False)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Demonstrates the issue with `PPDataProxy` specifying the 'wrong' dtype. The data is reinterpreted as integer and the nans, and hence the masked points, are lost.

Even if this test is adopted it should not be merged as-is, since the test_data sha will need to be changed (see https://github.com/SciTools/iris-test-data/pull/50).