### PR TITLE
plotting NZ rotated pole extents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="942e6344d6e6d00c85d824dadd49b5d6f57f4b4a"
+  - export IRIS_TEST_DATA_REF="7c0e32c8812b464e467a9555bdc25dc1e0c5be0c"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   # Install miniconda

--- a/docs/iris/src/whatsnew/contributions_1.13/newfeature_2017-May-10_NZ_dateline.txt
+++ b/docs/iris/src/whatsnew/contributions_1.13/newfeature_2017-May-10_NZ_dateline.txt
@@ -1,0 +1,1 @@
+* A new capability has been added which recognises where rotated pole limited area datasets are using a 0<=lambda<360 extent and provides a useful base projection to enable them to display with a reasonable extent.

--- a/lib/iris/tests/integration/plot/test_nzdateline.py
+++ b/lib/iris/tests/integration/plot/test_nzdateline.py
@@ -1,0 +1,52 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test set up of limited area map extents which bridge the date line.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import iris
+# Run tests in no graphics mode if matplotlib is not available.
+if tests.MPL_AVAILABLE:
+    import matplotlib.pyplot as plt
+    from iris.plot import contour, contourf, pcolormesh, pcolor,\
+        points, scatter
+
+
+@tests.skip_plot
+@tests.skip_data
+class TestExtent(tests.IrisTest):
+    def test_dateline(self):
+        dpath = tests.get_data_path(['PP', 'nzgust.pp'])
+        cube = iris.load_cube(dpath)
+        pcolormesh(cube)
+        # Ensure that the limited area expected for NZ is set.
+        # This is set in longitudes with the datum set to the
+        # International Date Line.
+        self.assertTrue(-10 < plt.gca().get_xlim()[0] < -5 and
+                        5 < plt.gca().get_xlim()[1] < 10)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
this is a work around for a long standing bug related to New Zealand model output and Cartopy extents

Cartopy defines the extent of a RotatedPole as -180 <= lambda < 180 and this is immutable

New Zealand modellers use a rotated pole CRS with an extent from 0 <= lambda < 360 with the area of interest around 180

The result is a map with a small strip of data on each side and a massive missing section in the middle

This work around in the shared plotting code identifies this condition and requests an adapted projection space from Cartopy to ensure a sensible map extent is set