### PR TITLE
Move fill-value handling into DataManager.

### DIFF
--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -37,7 +37,7 @@ class DataManager(object):
 
     """
 
-    def __init__(self, data, realised_dtype=None):
+    def __init__(self, data, fill_value=None, realised_dtype=None):
         """
         Create a data manager for the specified data.
 
@@ -49,6 +49,11 @@ class DataManager(object):
             managed.
 
         Kwargs:
+
+        * fill_value:
+            The intended fill-value of :class:`~iris._data_manager.DataManager`
+            masked data. Note that, the fill-value is cast relative to the
+            dtype of the :class:`~iris._data_manager.DataManager`.
 
         * realised_dtype:
             The intended dtype of the specified lazy data, which must be
@@ -62,6 +67,9 @@ class DataManager(object):
 
         self._realised_dtype = None
         self._realised_dtype_setter(realised_dtype)
+
+        # Must be set after the realised dtype.
+        self.fill_value = fill_value
 
         # Enforce the manager contract.
         self._assert_axioms()
@@ -114,9 +122,11 @@ class DataManager(object):
         if isinstance(other, type(self)):
             result = False
             same_lazy = self.has_lazy_data() == other.has_lazy_data()
+            same_fill_value = self.fill_value == other.fill_value
             same_realised_dtype = self._realised_dtype == other._realised_dtype
             same_dtype = self.dtype == other.dtype
-            if same_lazy and same_realised_dtype and same_dtype:
+            if same_lazy and same_fill_value and same_realised_dtype \
+                    and same_dtype:
                 result = array_equal(self.core_data(), other.core_data())
 
         return result
@@ -149,14 +159,18 @@ class DataManager(object):
         Returns an string representation of the instance.
 
         """
-        fmt = '{cls}({data!r}{dtype})'
+        fmt = '{cls}({data!r}{fill_value}{dtype})'
+        fill_value = ''
         dtype = ''
+
+        if self.fill_value is not None:
+            fill_value = ', fill_value={!r}'.format(self.fill_value)
 
         if self._realised_dtype is not None:
             dtype = ', realised_dtype={!r}'.format(self._realised_dtype)
 
         result = fmt.format(data=self.core_data(), cls=type(self).__name__,
-                            dtype=dtype)
+                            fill_value=fill_value, dtype=dtype)
 
         return result
 
@@ -185,7 +199,15 @@ class DataManager(object):
                 'real data and realised {!r}.')
         assert state, emsg.format(self._realised_dtype)
 
-    def _deepcopy(self, memo, data=None, realised_dtype='none'):
+        state = not (self.has_lazy_data() and
+                     self._lazy_array.dtype.kind != 'f' and
+                     self._realised_dtype is not None)
+        emsg = ('Unexpected lazy data dtype with realised dtype, got '
+                'lazy data {!r} and realised {!r}.')
+        assert state, emsg.format(self._lazy_array.dtype, self._realised_dtype)
+
+    def _deepcopy(self, memo, data=None, fill_value='none',
+                  realised_dtype='none'):
         """
         Perform a deepcopy of the :class:`~iris._data_manager.DataManager`
         instance.
@@ -200,6 +222,9 @@ class DataManager(object):
         * data:
             Replacement data to substitute the currently managed
             data with.
+
+        * fill_value:
+            Replacement fill-value.
 
         * realised_dtype:
             Replacement for the intended dtype of the realised lazy data.
@@ -222,11 +247,16 @@ class DataManager(object):
                 # If the replacement data is valid, then use it but
                 # without copying it.
 
+            if isinstance(fill_value, six.string_types) and \
+                    fill_value == 'none':
+                fill_value = self.fill_value
+
             if isinstance(realised_dtype, six.string_types) and \
                     realised_dtype == 'none':
                 realised_dtype = self._realised_dtype
 
-            result = DataManager(data, realised_dtype=realised_dtype)
+            result = DataManager(data, fill_value=fill_value,
+                                 realised_dtype=realised_dtype)
         except ValueError as error:
             emsg = 'Cannot copy {!r} - {}'
             raise ValueError(emsg.format(type(self).__name__, error))
@@ -254,6 +284,10 @@ class DataManager(object):
                     emsg = ('Cannot set realised dtype, no lazy data '
                             'is available.')
                     raise ValueError(emsg)
+                if self._lazy_array.dtype.kind != 'f':
+                    emsg = ('Cannot set realised dtype for lazy data '
+                            'with {!r}.')
+                    raise ValueError(emsg.format(self._lazy_array.dtype))
                 if realised_dtype.kind not in 'biu':
                     emsg = ('Can only cast lazy data to an integer or boolean '
                             'dtype, got {!r}.')
@@ -262,23 +296,6 @@ class DataManager(object):
 
                 # Check the manager contract, as the managed dtype has changed.
                 self._assert_axioms()
-
-    def core_data(self):
-        """
-        If real data is being managed, then return the :class:`~numpy.ndarray`
-        or :class:`numpy.ma.core.MaskedArray`. Otherwise, return the lazy
-        :class:`~dask.array.core.Array`.
-
-        Returns:
-            The real or lazy data.
-
-        """
-        if self.has_lazy_data():
-            result = self._lazy_array
-        else:
-            result = self._real_array
-
-        return result
 
     @property
     def data(self):
@@ -308,8 +325,12 @@ class DataManager(object):
                         'before trying again.')
                 raise MemoryError(emsg.format(self.shape, self.dtype))
 
-            # Check the manager contract, as the managed data has changed.
-            self._assert_axioms()
+        if ma.isMaskedArray(self._real_array):
+            # Align the numpy fill-value with the data manager fill-value.
+            self._real_array.fill_value = self.fill_value
+
+        # Check the manager contract, as the managed data has changed.
+        self._assert_axioms()
 
         return self._real_array
 
@@ -365,6 +386,14 @@ class DataManager(object):
         # Always reset the realised dtype, as the managed data has changed.
         self._realised_dtype = None
 
+        # Reset the fill-value appropriately.
+        if ma.isMaskedArray(data):
+            # Align the data manager fill-value with the numpy fill-value.
+            self.fill_value = data.fill_value
+        else:
+            # Clear the data manager fill-value.
+            self.fill_value = None
+
         # Check the manager contract, as the managed data has changed.
         self._assert_axioms()
 
@@ -382,6 +411,26 @@ class DataManager(object):
         return result
 
     @property
+    def fill_value(self):
+        return self._fill_value
+
+    @fill_value.setter
+    def fill_value(self, fill_value):
+        if fill_value is not None:
+            # Convert the given value to the dtype of the data manager.
+            fill_value = np.asarray([fill_value])[0]
+            target_dtype = self.dtype
+            if fill_value.dtype.kind == 'f' and target_dtype.kind in 'biu':
+                # Perform rounding when converting floats to ints.
+                fill_value = np.rint(fill_value)
+            try:
+                [fill_value] = np.asarray([fill_value], dtype=target_dtype)
+            except OverflowError:
+                emsg = 'Fill value of {!r} invalid for {!r}.'
+                raise ValueError(emsg.format(fill_value, self.dtype))
+        self._fill_value = fill_value
+
+    @property
     def ndim(self):
         """
         The number of dimensions covered by the data being managed.
@@ -397,7 +446,7 @@ class DataManager(object):
         """
         return self.core_data().shape
 
-    def copy(self, data=None, realised_dtype='none'):
+    def copy(self, data=None, fill_value='none', realised_dtype='none'):
         """
         Returns a deep copy of this :class:`~iris._data_manager.DataManager`
         instance.
@@ -406,6 +455,9 @@ class DataManager(object):
 
         * data:
             Replace the data of the copy with this data.
+
+        * fill_value:
+            Replacement fill-value.
 
         * realised_dtype:
             Replace the intended dtype of the lazy data
@@ -416,7 +468,25 @@ class DataManager(object):
 
         """
         memo = {}
-        return self._deepcopy(memo, data=data, realised_dtype=realised_dtype)
+        return self._deepcopy(memo, data=data, fill_value=fill_value,
+                              realised_dtype=realised_dtype)
+
+    def core_data(self):
+        """
+        If real data is being managed, then return the :class:`~numpy.ndarray`
+        or :class:`numpy.ma.core.MaskedArray`. Otherwise, return the lazy
+        :class:`~dask.array.core.Array`.
+
+        Returns:
+            The real or lazy data.
+
+        """
+        if self.has_lazy_data():
+            result = self._lazy_array
+        else:
+            result = self._real_array
+
+        return result
 
     def has_lazy_data(self):
         """
@@ -449,7 +519,7 @@ class DataManager(object):
 
         return result
 
-    def replace(self, data, realised_dtype=None):
+    def replace(self, data, fill_value=None, realised_dtype=None):
         """
         Perform an in-place replacement of the managed data.
 
@@ -462,12 +532,16 @@ class DataManager(object):
 
         Kwargs:
 
+        * fill_value:
+            Replacement for the :class:`~iris._data_manager.DataManager`
+            fill-value.
+
         * realised_dtype:
             The intended dtype of the specified lazy data.
 
         .. note::
             Data replacement alone will clear the intended dtype
-            of the realised lazy data.
+            of the realised lazy data, and the fill-value.
 
         """
         # Snapshot the currently managed data.
@@ -476,6 +550,7 @@ class DataManager(object):
         self.data = data
         try:
             self._realised_dtype_setter(realised_dtype)
+            self.fill_value = fill_value
         except ValueError as error:
             # Backout the data replacement, and reinstate the cached
             # original managed data.

--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -105,7 +105,8 @@ class DataManager(object):
         lazy payload to determine the equality result.
 
         Comparison is strict with regards to lazy or real managed payload,
-        the realised_dtype, the dtype of the payload and the payload content.
+        the realised_dtype, the dtype of the payload, the fill-value and the
+        payload content.
 
         Args:
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1193,6 +1193,12 @@ def _proportion(array, function, axis, **kwargs):
     else:
         total_non_masked = array.shape[axis]
 
+    # Sanitise the result of this operation thru ma.asarray to ensure that
+    # the dtype of the fill-value and the dtype of the array are aligned.
+    # Otherwise, it is possible for numpy to return a masked array that has
+    # a dtype for its data that is different to the dtype of the fill-value,
+    # which can cause issues outside this function.
+    # Reference - tests/unit/analyis/test_PROPORTION.py Test_masked.test_ma
     numerator = _count(array, function, axis=axis, **kwargs)
     result = ma.asarray(numerator / total_non_masked)
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1193,7 +1193,10 @@ def _proportion(array, function, axis, **kwargs):
     else:
         total_non_masked = array.shape[axis]
 
-    return _count(array, function, axis=axis, **kwargs) / total_non_masked
+    numerator = _count(array, function, axis=axis, **kwargs)
+    result = ma.asarray(numerator / total_non_masked)
+
+    return result
 
 
 def _rms(array, axis, **kwargs):

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -211,8 +211,8 @@ class TestLazySave(tests.IrisTest):
         self.assertTrue(acube.has_lazy_data())
 
     def test_lazy_mask_preserve_fill_value(self):
-        cube = iris.cube.Cube(np.ma.array([0, 1], mask=[False, True],
-                                          fill_value=-1))
+        data = ma.array([0, 1], mask=[False, True])
+        cube = iris.cube.Cube(data, fill_value=-1)
         with self.temp_filename(suffix='.nc') as filename, \
                 self.temp_filename(suffix='.nc') as other_filename:
             iris.save(cube, filename, unlimited_dimensions=[])

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -67,7 +67,7 @@ class Test___eq__(tests.IrisTest):
     def setUp(self):
         self.shape = (2, 3, 4)
         self.size = np.prod(self.shape)
-        self.real_array = np.arange(self.size).reshape(self.shape)
+        self.real_array = np.arange(self.size, dtype=float).reshape(self.shape)
 
     def test_real_with_real(self):
         dm1 = DataManager(self.real_array)
@@ -79,9 +79,20 @@ class Test___eq__(tests.IrisTest):
         dm2 = DataManager(np.ones(self.shape))
         self.assertFalse(dm1 == dm2)
 
+    def test_real_with_real__fill_value(self):
+        fill_value = 1234
+        dm1 = DataManager(self.real_array, fill_value=fill_value)
+        dm2 = DataManager(self.real_array, fill_value=fill_value)
+        self.assertEqual(dm1, dm2)
+
+    def test_real_with_real__fill_value_failure(self):
+        dm1 = DataManager(self.real_array, fill_value=1234)
+        dm2 = DataManager(self.real_array, fill_value=4321)
+        self.assertFalse(dm1 == dm2)
+
     def test_real_with_real__dtype_failure(self):
         dm1 = DataManager(self.real_array)
-        dm2 = DataManager(self.real_array * 1.0)
+        dm2 = DataManager(self.real_array.astype(int))
         self.assertFalse(dm1 == dm2)
 
     def test_real_with_lazy_failure(self):
@@ -100,9 +111,24 @@ class Test___eq__(tests.IrisTest):
         dm2 = DataManager(as_lazy_data(self.real_array) * 10)
         self.assertFalse(dm1 == dm2)
 
+    def test_lazy_with_lazy__fill_value(self):
+        fill_value = 1234
+        dm1 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=fill_value)
+        dm2 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=fill_value)
+        self.assertEqual(dm1, dm2)
+
+    def test_lazy_with_lazy__fill_value_failure(self):
+        dm1 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=1234)
+        dm2 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=4321)
+        self.assertFalse(dm1 == dm2)
+
     def test_lazy_with_lazy__dtype_failure(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
-        dm2 = DataManager(as_lazy_data(self.real_array) * 1.0)
+        dm2 = DataManager(as_lazy_data(self.real_array).astype(int))
         self.assertFalse(dm1 == dm2)
 
     def test_lazy_with_lazy__realised_dtype(self):
@@ -129,7 +155,7 @@ class Test___ne__(tests.IrisTest):
     def setUp(self):
         self.shape = (2, 3, 4)
         self.size = np.prod(self.shape)
-        self.real_array = np.arange(self.size).reshape(self.shape)
+        self.real_array = np.arange(self.size, dtype=float).reshape(self.shape)
 
     def test_real_with_real(self):
         dm1 = DataManager(self.real_array)
@@ -141,9 +167,20 @@ class Test___ne__(tests.IrisTest):
         dm2 = DataManager(self.real_array.copy())
         self.assertFalse(dm1 != dm2)
 
+    def test_real_with_real__fill_value(self):
+        dm1 = DataManager(self.real_array, fill_value=1234)
+        dm2 = DataManager(self.real_array, fill_value=4321)
+        self.assertNotEqual(dm1, dm2)
+
+    def test_real_with_real__fill_value_failure(self):
+        fill_value = 1234
+        dm1 = DataManager(self.real_array, fill_value=fill_value)
+        dm2 = DataManager(self.real_array, fill_value=fill_value)
+        self.assertFalse(dm1 != dm2)
+
     def test_real_with_real__dtype(self):
         dm1 = DataManager(self.real_array)
-        dm2 = DataManager(self.real_array * 1.0)
+        dm2 = DataManager(self.real_array.astype(int))
         self.assertNotEqual(dm1, dm2)
 
     def test_real_with_lazy(self):
@@ -162,9 +199,24 @@ class Test___ne__(tests.IrisTest):
         dm2 = DataManager(as_lazy_data(self.real_array))
         self.assertFalse(dm1 != dm2)
 
+    def test_lazy_with_lazy__fill_value(self):
+        dm1 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=1234)
+        dm2 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=4321)
+        self.assertNotEqual(dm1, dm2)
+
+    def test_lazy_with_lazy__fill_value_failure(self):
+        fill_value = 1234
+        dm1 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=fill_value)
+        dm2 = DataManager(as_lazy_data(self.real_array),
+                          fill_value=fill_value)
+        self.assertFalse(dm1 != dm2)
+
     def test_lazy_with_lazy__dtype(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
-        dm2 = DataManager(as_lazy_data(self.real_array) * 1.0)
+        dm2 = DataManager(as_lazy_data(self.real_array).astype(int))
         self.assertNotEqual(dm1, dm2)
 
     def test_lazy_with_lazy__realised_dtype(self):
@@ -190,7 +242,8 @@ class Test___ne__(tests.IrisTest):
 class Test___repr__(tests.IrisTest):
     def setUp(self):
         self.real_array = np.array(123)
-        self.lazy_array = as_lazy_data(self.real_array)
+        masked_array = ma.array([0, 1], mask=[0, 1])
+        self.lazy_array = as_lazy_data(masked_array)
         self.name = DataManager.__name__
 
     def test_real(self):
@@ -199,10 +252,26 @@ class Test___repr__(tests.IrisTest):
         expected = '{}({!r})'.format(self.name, self.real_array)
         self.assertEqual(result, expected)
 
+    def test_real__fill_value(self):
+        fill_value = 1234
+        dm = DataManager(self.real_array, fill_value=fill_value)
+        result = repr(dm)
+        fmt = '{}({!r}, fill_value={!r})'
+        expected = fmt.format(self.name, self.real_array, fill_value)
+        self.assertEqual(result, expected)
+
     def test_lazy(self):
         dm = DataManager(self.lazy_array)
         result = repr(dm)
         expected = '{}({!r})'.format(self.name, self.lazy_array)
+        self.assertEqual(result, expected)
+
+    def test_lazy__fill_value(self):
+        fill_value = 1234.0
+        dm = DataManager(self.lazy_array, fill_value=fill_value)
+        result = repr(dm)
+        fmt = '{}({!r}, fill_value={!r})'
+        expected = fmt.format(self.name, self.lazy_array, fill_value)
         self.assertEqual(result, expected)
 
     def test_lazy__realised_dtype(self):
@@ -211,6 +280,16 @@ class Test___repr__(tests.IrisTest):
         result = repr(dm)
         fmt = '{}({!r}, realised_dtype={!r})'
         expected = fmt.format(self.name, self.lazy_array, dtype)
+        self.assertEqual(result, expected)
+
+    def test_lazy__fill_value_realised_dtype(self):
+        fill_value = 1234
+        dtype = np.dtype('int16')
+        dm = DataManager(self.lazy_array, fill_value=fill_value,
+                         realised_dtype=dtype)
+        result = repr(dm)
+        fmt = '{}({!r}, fill_value={!r}, realised_dtype={!r})'
+        expected = fmt.format(self.name, self.lazy_array, fill_value, dtype)
         self.assertEqual(result, expected)
 
 
@@ -245,12 +324,22 @@ class Test__assert_axioms(tests.IrisTest):
         with self.assertRaisesRegexp(AssertionError, emsg):
             self.dm._assert_axioms()
 
+    def test_non_float_lazy_array_with_realised_dtype(self):
+        self.dm._real_array = None
+        self.dm._lazy_array = self.lazy_array
+        self.dm._realised_dtype = np.dtype('int')
+        emsg = ("Unexpected lazy data dtype with realised dtype, got "
+                "lazy data dtype\('int64'\) and realised "
+                "dtype\('int64'\)")
+        with self.assertRaisesRegexp(AssertionError, emsg):
+            self.dm._assert_axioms()
+
 
 class Test__deepcopy(tests.IrisTest):
     def setUp(self):
         self.shape = (2, 3, 4)
         self.size = np.prod(self.shape)
-        self.real_array = np.arange(self.size).reshape(self.shape)
+        self.real_array = np.arange(self.size, dtype=float).reshape(self.shape)
         self.memo = dict()
 
     def test_real(self):
@@ -301,6 +390,12 @@ class Test__deepcopy(tests.IrisTest):
         with self.assertRaisesRegexp(ValueError, emsg):
             dm._deepcopy(self.memo, realised_dtype=np.dtype('int16'))
 
+    def test_lazy_with_realised_dtype__lazy_dtype_failure(self):
+        dm = DataManager(as_lazy_data(self.real_array).astype(int))
+        emsg = 'Cannot copy'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            dm._deepcopy(self.memo, realised_dtype=np.dtype('int16'))
+
     def test_lazy_with_realised_dtype_failure(self):
         dm = DataManager(as_lazy_data(self.real_array))
         emsg = 'Cannot copy'
@@ -341,10 +436,44 @@ class Test__deepcopy(tests.IrisTest):
         with self.assertRaisesRegexp(ValueError, emsg):
             dm._deepcopy(self.memo, data=as_lazy_data(np.array(0)))
 
+    def test__default_fill_value(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        result = dm._deepcopy(self.memo)
+        self.assertIsNone(result.fill_value)
+
+    def test__default_with_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        result = dm._deepcopy(self.memo)
+        self.assertEqual(result.fill_value, fill_value)
+
+    def test__clear_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        result = dm._deepcopy(self.memo, fill_value=None)
+        self.assertIsNone(result.fill_value)
+
+    def test__set_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        result = dm._deepcopy(self.memo, fill_value=fill_value)
+        self.assertEqual(result.fill_value, fill_value)
+
+    def test__set_fill_value_failure(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        emsg = 'Cannot copy'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            dm._deepcopy(self.memo, fill_value=1e+20)
+
 
 class Test__realised_dtype_setter(tests.IrisTest):
     def setUp(self):
-        self.real_array = np.array(0)
+        self.real_array = np.array(0.0)
         self.lazy_array = as_lazy_data(self.real_array)
         self.dm = DataManager(self.lazy_array)
 
@@ -367,6 +496,11 @@ class Test__realised_dtype_setter(tests.IrisTest):
         self.dm._realised_dtype_setter(self.dm.dtype)
         self.assertIsNone(self.dm._realised_dtype)
 
+    def test_lazy_with_same_dtype(self):
+        self.assertIsNone(self.dm._realised_dtype)
+        self.dm._realised_dtype_setter(self.dm.dtype)
+        self.assertIsNone(self.dm._realised_dtype)
+
     def test_real_array_failure(self):
         self.dm._lazy_array = None
         self.dm._real_array = self.real_array
@@ -377,9 +511,9 @@ class Test__realised_dtype_setter(tests.IrisTest):
 
     def test_invalid_realised_dtype(self):
         emsg = ("Can only cast lazy data to an integer or boolean "
-                "dtype, got dtype\('float64'\)")
+                "dtype, got dtype\('float32'\)")
         with self.assertRaisesRegexp(ValueError, emsg):
-            self.dm._realised_dtype_setter(np.dtype('float64'))
+            self.dm._realised_dtype_setter(np.dtype('float32'))
 
     def test_lazy_with_realised_dtype(self):
         dtypes = (np.dtype('bool'), np.dtype('int16'), np.dtype('uint16'))
@@ -388,6 +522,13 @@ class Test__realised_dtype_setter(tests.IrisTest):
             self.dm._realised_dtype_setter(dtype)
             self.assertEqual(self.dm._realised_dtype, dtype)
 
+    def test_lazy_with_realised_dtype__lazy_dtype_failure(self):
+        self.dm._lazy_array = self.lazy_array.astype(np.dtype('int64'))
+        emsg = ("Cannot set realised dtype for lazy data "
+                "with dtype\('int64'\)")
+        with self.assertRaisesRegexp(ValueError, emsg):
+            self.dm._realised_dtype_setter(np.dtype('int16'))
+
     def test_lazy_replace_with_none(self):
         self.assertIsNone(self.dm._realised_dtype)
         dtype = np.dtype('int16')
@@ -395,18 +536,6 @@ class Test__realised_dtype_setter(tests.IrisTest):
         self.assertEqual(self.dm._realised_dtype, dtype)
         self.dm._realised_dtype_setter(None)
         self.assertIsNone(self.dm._realised_dtype)
-
-
-class Test_core_data(tests.IrisTest):
-    def test_real_array(self):
-        real_array = np.array(0)
-        dm = DataManager(real_array)
-        self.assertIs(dm.core_data(), real_array)
-
-    def test_lazy_array(self):
-        lazy_array = as_lazy_data(np.array(0))
-        dm = DataManager(lazy_array)
-        self.assertIs(dm.core_data(), lazy_array)
 
 
 class Test_data__getter(tests.IrisTest):
@@ -435,6 +564,34 @@ class Test_data__getter(tests.IrisTest):
         result = dm.data
         self.assertFalse(dm.has_lazy_data())
         self.assertArrayEqual(result, self.real_array)
+
+    def test_with_real_mask_array__default_fill_value(self):
+        self.mask_array.fill_value = 1234
+        dm = DataManager(self.mask_array)
+        self.assertIsNone(dm.fill_value)
+        np_fill_value = ma.array(0, dtype=dm.dtype).fill_value
+        self.assertEqual(dm.data.fill_value, np_fill_value)
+
+    def test_with_real_mask_array__with_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(self.mask_array, fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        self.assertEqual(dm.data.fill_value, fill_value)
+
+    def test_with_lazy_mask_array__masked_default_fill_value(self):
+        dm = DataManager(self.lazy_mask_array_masked,
+                         realised_dtype=self.realised_dtype)
+        self.assertIsNone(dm.fill_value)
+        np_fill_value = ma.array(0, dtype=dm.dtype).fill_value
+        self.assertEqual(dm.data.fill_value, np_fill_value)
+
+    def test_with_lazy_mask_array__masked_with_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(self.lazy_mask_array_masked,
+                         fill_value=fill_value,
+                         realised_dtype=self.realised_dtype)
+        self.assertEqual(dm.fill_value, fill_value)
+        self.assertEqual(dm.data.fill_value, fill_value)
 
     def test_with_lazy_mask_array__not_masked(self):
         dm = DataManager(self.lazy_mask_array,
@@ -662,24 +819,119 @@ class Test_data__setter(tests.IrisTest):
         self.assertNotIsInstance(dm.data, ma.core.MaskedConstant)
         self.assertMaskedArrayEqual(dm.data, masked_data)
 
+    def test_real_array__fill_value_clearance(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        dm.data = np.array(1)
+        self.assertIsNone(dm.fill_value)
+
+    def test_lazy_array__fill_value_clearance(self):
+        fill_value = 1234
+        dm = DataManager(as_lazy_data(np.array(0)),
+                         fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        dm.data = as_lazy_data(np.array(1))
+        self.assertIsNone(dm.fill_value)
+
+    def test_mask_array__default_fill_value(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        data = ma.array(1)
+        dm.data = data
+        self.assertEqual(dm.fill_value, data.fill_value)
+
+    def test_mask_array__with_fill_value(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        fill_value = 1234
+        data = ma.array(1, fill_value=fill_value)
+        dm.data = data
+        self.assertEqual(dm.fill_value, fill_value)
+
 
 class Test_dtype(tests.IrisTest):
     def setUp(self):
-        self.real_array = np.array(0, dtype=np.dtype('float64'))
-        self.lazy_array = as_lazy_data(np.array(0, dtype=np.dtype('int64')))
+        self.real_array = np.array(0, dtype=np.dtype('int64'))
+        self.lazy_array = as_lazy_data(np.array(0, dtype=np.dtype('float64')))
 
     def test_real_array(self):
         dm = DataManager(self.real_array)
-        self.assertEqual(dm.dtype, np.dtype('float64'))
+        self.assertEqual(dm.dtype, np.dtype('int64'))
 
     def test_lazy_array(self):
         dm = DataManager(self.lazy_array)
-        self.assertEqual(dm.dtype, np.dtype('int64'))
+        self.assertEqual(dm.dtype, np.dtype('float64'))
 
     def test_lazy_array_realised_dtype(self):
         dm = DataManager(self.lazy_array, realised_dtype=np.dtype('bool'))
         self.assertEqual(dm.dtype, np.dtype('bool'))
-        self.assertEqual(dm._lazy_array.dtype, np.dtype('int64'))
+        self.assertEqual(dm._lazy_array.dtype, np.dtype('float64'))
+
+
+class Test_fill_value(tests.IrisTest):
+    def setUp(self):
+        self.dtypes = (np.dtype('int'), np.dtype('uint'),
+                       np.dtype('bool'), np.dtype('float'))
+
+    def test___init___default(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+
+    def test___init___with_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+
+    def test_fill_value_bool(self):
+        fill_value = np.bool_(True)
+        for dtype in self.dtypes:
+            data = np.array([0], dtype=dtype)
+            dm = DataManager(data)
+            dm.fill_value = fill_value
+            [expected] = np.asarray([fill_value], dtype=dtype)
+            self.assertEqual(dm.fill_value, expected)
+            self.assertEqual(dm.fill_value.dtype, dtype)
+
+    def test_fill_value_int(self):
+        fill_value = np.int(1234)
+        for dtype in self.dtypes:
+            data = np.array([0], dtype=dtype)
+            dm = DataManager(data)
+            dm.fill_value = fill_value
+            [expected] = np.asarray([fill_value], dtype=dtype)
+            self.assertEqual(dm.fill_value, expected)
+            self.assertEqual(dm.fill_value.dtype, dtype)
+
+    def test_fill_value_float(self):
+        fill_value = np.float(123.4)
+        for dtype in self.dtypes:
+            data = np.array([0], dtype=dtype)
+            dm = DataManager(data)
+            dm.fill_value = fill_value
+            if dtype.kind in 'biu':
+                fill_value = np.rint(fill_value)
+            [expected] = np.asarray([fill_value], dtype=dtype)
+            self.assertEqual(dm.fill_value, expected)
+            self.assertEqual(dm.fill_value.dtype, dtype)
+
+    def test_fill_value_uint(self):
+        fill_value = np.uint(1234)
+        for dtype in self.dtypes:
+            data = np.array([0], dtype=dtype)
+            dm = DataManager(data)
+            dm.fill_value = fill_value
+            [expected] = np.array([fill_value], dtype=dtype)
+            self.assertEqual(dm.fill_value, expected)
+            self.assertEqual(dm.fill_value.dtype, dtype)
+
+    def test_fill_value_overflow(self):
+        fill_value = np.float(1e+20)
+        data = np.array([0], dtype=np.int32)
+        dm = DataManager(data)
+        emsg = 'Fill value of .* invalid for dtype'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            dm.fill_value = fill_value
 
 
 class Test_ndim(tests.IrisTest):
@@ -721,32 +973,54 @@ class Test_shape(tests.IrisTest):
 
 
 class Test_copy(tests.IrisTest):
-    def test_without_realised_dtype(self):
+    def setUp(self):
+        self.method = 'iris._data_manager.DataManager._deepcopy'
+        self.data = mock.sentinel.data
+        self.return_value = mock.sentinel.return_value
+        self.memo = {}
+
+    def test(self):
         dm = DataManager(np.array(0))
-        method = 'iris._data_manager.DataManager._deepcopy'
-        data = mock.sentinel.data
-        return_value = mock.sentinel.return_value
-        memo = {}
-        kwargs = dict(data=data, realised_dtype='none')
-        with mock.patch(method) as mocker:
-            mocker.return_value = return_value
-            result = dm.copy(data=data)
-            mocker.assert_called_once_with(memo, **kwargs)
-        self.assertIs(result, return_value)
+        kwargs = dict(data=self.data, fill_value='none', realised_dtype='none')
+        with mock.patch(self.method) as mocker:
+            mocker.return_value = self.return_value
+            result = dm.copy(data=self.data)
+            mocker.assert_called_once_with(self.memo, **kwargs)
+        self.assertIs(result, self.return_value)
+
+    def test_with_fill_value(self):
+        dm = DataManager(np.array(0))
+        fill_value = mock.sentinel.fill_value
+        kwargs = dict(data=self.data, fill_value=fill_value,
+                      realised_dtype='none')
+        with mock.patch(self.method) as mocker:
+            mocker.return_value = self.return_value
+            result = dm.copy(data=self.data, fill_value=fill_value)
+            mocker.assert_called_once_with(self.memo, **kwargs)
+        self.assertIs(result, self.return_value)
 
     def test_with_realised_dtype(self):
         dm = DataManager(np.array(0))
-        method = 'iris._data_manager.DataManager._deepcopy'
-        data = mock.sentinel.data
         realised_dtype = mock.sentinel.realised_dtype
-        return_value = mock.sentinel.return_value
-        memo = {}
-        kwargs = dict(data=data, realised_dtype=realised_dtype)
-        with mock.patch(method) as mocker:
-            mocker.return_value = return_value
-            result = dm.copy(data=data, realised_dtype=realised_dtype)
-            mocker.assert_called_once_with(memo, **kwargs)
-        self.assertIs(result, return_value)
+        kwargs = dict(data=self.data, fill_value='none',
+                      realised_dtype=realised_dtype)
+        with mock.patch(self.method) as mocker:
+            mocker.return_value = self.return_value
+            result = dm.copy(data=self.data, realised_dtype=realised_dtype)
+            mocker.assert_called_once_with(self.memo, **kwargs)
+        self.assertIs(result, self.return_value)
+
+
+class Test_core_data(tests.IrisTest):
+    def test_real_array(self):
+        real_array = np.array(0)
+        dm = DataManager(real_array)
+        self.assertIs(dm.core_data(), real_array)
+
+    def test_lazy_array(self):
+        lazy_array = as_lazy_data(np.array(0))
+        dm = DataManager(lazy_array)
+        self.assertIs(dm.core_data(), lazy_array)
 
 
 class Test_has_lazy_data(tests.IrisTest):
@@ -905,6 +1179,35 @@ class Test_replace(tests.IrisTest):
             dm.replace(np.array([999]),
                        realised_dtype=np.dtype('float32'))
         self.assertArrayEqual(dm.data, data)
+
+    def test__clear_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        dm.replace(np.array(1))
+        self.assertIsNone(dm.fill_value)
+
+    def test__clear_fill_value_masked(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+        data = ma.masked_array(1, fill_value=4321)
+        dm.replace(data)
+        self.assertIsNone(dm.fill_value)
+
+    def test__set_fill_value(self):
+        fill_value = 1234
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        dm.replace(np.array(0), fill_value=fill_value)
+        self.assertEqual(dm.fill_value, fill_value)
+
+    def test__set_fill_value_failure(self):
+        dm = DataManager(np.array(0))
+        self.assertIsNone(dm.fill_value)
+        emsg = 'Fill value of .* invalid for dtype'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            dm.replace(np.array(1), fill_value=1e+20)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Push the handling of `fill_value` down into the `DataManager`, as this is a generic capability that should be handled by the `DataManager` and not by the owning container.