### PR TITLE
Ensure declared dtype of data proxy objects matches returned dtype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
   depth: 10000
 
 install:
-  - export IRIS_TEST_DATA_REF="942e6344d6e6d00c85d824dadd49b5d6f57f4b4a"
+  - export IRIS_TEST_DATA_REF="1632baf808dc65cdcce59f7e160b4e5d4a32c262"
   - export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//")
 
   # Install miniconda

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -134,6 +134,10 @@ def as_concrete_data(data, **kwargs):
     return data
 
 
+def nan_array_type(dtype):
+    return np.dtype('f8') if dtype.kind in 'biu' else dtype
+
+
 def array_masked_to_nans(array):
     """
     Convert a masked array to a NumPy `ndarray` filled with NaN values. Input
@@ -163,10 +167,8 @@ def array_masked_to_nans(array):
     else:
         if ma.is_masked(array):
             mask = array.mask
-            if array.dtype.kind in 'biu':
-                result = array.data.astype(np.dtype('f8'))
-            else:
-                result = array.data.copy()
+            new_dtype = nan_array_type(array.data.dtype)
+            result = array.data.astype(new_dtype)
             result[mask] = np.nan
         else:
             result = array.data

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -139,7 +139,7 @@ class GribWrapper(object):
     def __init__(self, grib_message, grib_fh=None):
         """Store the grib message and compute our extra keys."""
         self.grib_message = grib_message
-        self.data_dtype = np.zeros(0).dtype
+        self.realised_dtype = np.zeros(0).dtype
 
         if self.edition != 1:
             emsg = 'GRIB edition {} is not supported by {!r}.'
@@ -178,7 +178,7 @@ class GribWrapper(object):
             # The byte offset requires to be reset back to the first byte
             # of this message. The file pointer offset is always at the end
             # of the current message due to the grib-api reading the message.
-            proxy = GribDataProxy(shape, self.data_dtype, grib_fh.name,
+            proxy = GribDataProxy(shape, self.realised_dtype, grib_fh.name,
                                   offset - message_length)
             self._data = as_lazy_data(proxy)
         else:

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -139,6 +139,7 @@ class GribWrapper(object):
     def __init__(self, grib_message, grib_fh=None):
         """Store the grib message and compute our extra keys."""
         self.grib_message = grib_message
+        self.data_dtype = np.zeros(0).dtype
 
         if self.edition != 1:
             emsg = 'GRIB edition {} is not supported by {!r}.'
@@ -177,7 +178,7 @@ class GribWrapper(object):
             # The byte offset requires to be reset back to the first byte
             # of this message. The file pointer offset is always at the end
             # of the current message due to the grib-api reading the message.
-            proxy = GribDataProxy(shape, np.zeros(0).dtype, grib_fh.name,
+            proxy = GribDataProxy(shape, self.data_dtype, grib_fh.name,
                                   offset - message_length)
             self._data = as_lazy_data(proxy)
         else:

--- a/lib/iris/fileformats/grib/message.py
+++ b/lib/iris/fileformats/grib/message.py
@@ -120,6 +120,10 @@ class GribMessage(object):
         # Default for fill value is None.
         return None
 
+    @property
+    def data_dtype(self):
+        return np.dtype('f8')
+
     def core_data(self):
         return self.data
 

--- a/lib/iris/fileformats/grib/message.py
+++ b/lib/iris/fileformats/grib/message.py
@@ -164,7 +164,7 @@ class GribMessage(object):
                 shape = (grid_section['numberOfDataPoints'],)
             else:
                 shape = (grid_section['Nj'], grid_section['Ni'])
-            proxy = _DataProxy(shape, np.dtype('f8'), np.nan,
+            proxy = _DataProxy(shape, self.data_dtype, np.nan,
                                self._recreate_raw)
             data = as_lazy_data(proxy)
         else:

--- a/lib/iris/fileformats/grib/message.py
+++ b/lib/iris/fileformats/grib/message.py
@@ -121,7 +121,7 @@ class GribMessage(object):
         return None
 
     @property
-    def data_dtype(self):
+    def realised_dtype(self):
         return np.dtype('f8')
 
     def core_data(self):
@@ -164,7 +164,7 @@ class GribMessage(object):
                 shape = (grid_section['numberOfDataPoints'],)
             else:
                 shape = (grid_section['Nj'], grid_section['Ni'])
-            proxy = _DataProxy(shape, self.data_dtype, np.nan,
+            proxy = _DataProxy(shape, self.realised_dtype, np.nan,
                                self._recreate_raw)
             data = as_lazy_data(proxy)
         else:

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -397,8 +397,8 @@ class NetCDFDataProxy(object):
             dataset.close()
         if ma.isMaskedArray(var):
             if self.dtype.kind in 'biu':
-                msg = "NetCDF variable '{}' has masked data, which is not " \
-                      "supported for declared dtype '{}'."
+                msg = "NetCDF variable {!r} has masked data, which is not " \
+                      "supported for declared dtype {!r}."
                 raise TypeError(
                     msg.format(self.variable_name, self.dtype.name))
             var = array_masked_to_nans(var)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -402,7 +402,7 @@ class NetCDFDataProxy(object):
                 raise TypeError(
                     msg.format(self.variable_name, self.dtype.name))
             var = array_masked_to_nans(var)
-        return var
+        return var.astype(self.dtype, copy=False)
 
     def __repr__(self):
         fmt = '<{self.__class__.__name__} shape={self.shape}' \

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -402,7 +402,7 @@ class NetCDFDataProxy(object):
                 raise TypeError(
                     msg.format(self.variable_name, self.dtype.name))
             var = array_masked_to_nans(var)
-        return var.astype(self.dtype, copy=False)
+        return np.asanyarray(var, dtype=self.dtype)
 
     def __repr__(self):
         fmt = '<{self.__class__.__name__} shape={self.shape}' \

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -57,7 +57,7 @@ import iris.fileformats._pyke_rules
 import iris.io
 import iris.util
 from iris._lazy_data import (array_masked_to_nans, as_lazy_data,
-                             convert_nans_array)
+                             convert_nans_array, nan_array_type)
 
 # Show Pyke inference engine statistics.
 DEBUG = False
@@ -378,7 +378,7 @@ class NetCDFDataProxy(object):
 
     def __init__(self, shape, dtype, path, variable_name, fill_value):
         self.shape = shape
-        self.dtype = dtype
+        self.dtype = nan_array_type(dtype)
         self.path = path
         self.variable_name = variable_name
         self.fill_value = fill_value

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -862,7 +862,8 @@ class PPDataProxy(object):
 
     @property
     def dtype(self):
-        return self.src_dtype.newbyteorder('=')
+        return np.dtype('f8') if self.src_dtype.kind == 'i' \
+                 else self.src_dtype.newbyteorder('=')
 
     @property
     def fill_value(self):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -882,7 +882,8 @@ class PPDataProxy(object):
                                                self.boundary_packing,
                                                self.shape, self.src_dtype,
                                                self.mdi, self.mask)
-        return data.__getitem__(keys)
+        return data.__getitem__(keys).astype(self.dtype, copy=False)
+
 
     def __repr__(self):
         fmt = '<{self.__class__.__name__} shape={self.shape}' \

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1081,7 +1081,7 @@ def _pp_attribute_names(header_defn):
     special_headers = list('_' + name for name in _SPECIAL_HEADERS)
     extra_data = list(EXTRA_DATA.values())
     special_attributes = ['_raw_header', 'raw_lbtim', 'raw_lbpack',
-                          'boundary_packing', '_data_dtype']
+                          'boundary_packing', '_realised_dtype']
     return normal_headers + special_headers + extra_data + special_attributes
 
 
@@ -1114,7 +1114,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         self.raw_lbtim = None
         self.raw_lbpack = None
         self.boundary_packing = None
-        self._data_dtype = None
+        self._realised_dtype = None
         if header is not None:
             self.raw_lbtim = header[self.HEADER_DICT['lbtim'][0]]
             self.raw_lbpack = header[self.HEADER_DICT['lbpack'][0]]
@@ -1285,12 +1285,12 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
 
         """
         # Cache the real data on first use
-        if self.data_dtype.kind == 'i' and self.bmdi == -1e30:
+        if self.realised_dtype.kind == 'i' and self.bmdi == -1e30:
             self.bmdi = -9999
         if is_lazy_data(self._data):
             self._data = as_concrete_data(self._data,
                                           nans_replacement=ma.masked,
-                                          result_dtype=self.data_dtype)
+                                          result_dtype=self.realised_dtype)
         return self._data
 
     @data.setter
@@ -1301,14 +1301,14 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         return self._data
 
     @property
-    def data_dtype(self):
+    def realised_dtype(self):
         return self._data.dtype \
-            if self._data_dtype is None \
-            else self._data_dtype
+            if self._realised_dtype is None \
+            else self._realised_dtype
 
-    @data_dtype.setter
-    def data_dtype(self, value):
-        self._data_dtype = value
+    @realised_dtype.setter
+    def realised_dtype(self, value):
+        self._realised_dtype = value
 
     @property
     def calendar(self):
@@ -1896,7 +1896,7 @@ def _create_field_data(field, data_shape, land_mask):
                             field.raw_lbpack,
                             field.boundary_packing,
                             field.bmdi, land_mask)
-        field.data_dtype = dtype.newbyteorder('=')
+        field.realised_dtype = dtype.newbyteorder('=')
         block_shape = data_shape if 0 not in data_shape else (1, 1)
         field.data = as_lazy_data(proxy, chunks=block_shape)
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -882,8 +882,8 @@ class PPDataProxy(object):
                                                self.boundary_packing,
                                                self.shape, self.src_dtype,
                                                self.mdi, self.mask)
-        return data.__getitem__(keys).astype(self.dtype, copy=False)
-
+        data = data.__getitem__(keys)
+        return np.asanyarray(data, dtype=self.dtype)
 
     def __repr__(self):
         fmt = '<{self.__class__.__name__} shape={self.shape}' \
@@ -1081,7 +1081,7 @@ def _pp_attribute_names(header_defn):
     special_headers = list('_' + name for name in _SPECIAL_HEADERS)
     extra_data = list(EXTRA_DATA.values())
     special_attributes = ['_raw_header', 'raw_lbtim', 'raw_lbpack',
-                          'boundary_packing']
+                          'boundary_packing', '_data_dtype']
     return normal_headers + special_headers + extra_data + special_attributes
 
 
@@ -1114,6 +1114,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         self.raw_lbtim = None
         self.raw_lbpack = None
         self.boundary_packing = None
+        self._data_dtype = None
         if header is not None:
             self.raw_lbtim = header[self.HEADER_DICT['lbtim'][0]]
             self.raw_lbpack = header[self.HEADER_DICT['lbpack'][0]]
@@ -1284,11 +1285,12 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
 
         """
         # Cache the real data on first use
-        if self._data.dtype.kind == 'i' and self.bmdi == -1e30:
+        if self.data_dtype.kind == 'i' and self.bmdi == -1e30:
             self.bmdi = -9999
         if is_lazy_data(self._data):
             self._data = as_concrete_data(self._data,
-                                          nans_replacement=ma.masked)
+                                          nans_replacement=ma.masked,
+                                          result_dtype=self.data_dtype)
         return self._data
 
     @data.setter
@@ -1297,6 +1299,16 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
 
     def core_data(self):
         return self._data
+
+    @property
+    def data_dtype(self):
+        return self._data.dtype \
+            if self._data_dtype is None \
+            else self._data_dtype
+
+    @data_dtype.setter
+    def data_dtype(self, value):
+        self._data_dtype = value
 
     @property
     def calendar(self):
@@ -1884,6 +1896,7 @@ def _create_field_data(field, data_shape, land_mask):
                             field.raw_lbpack,
                             field.boundary_packing,
                             field.bmdi, land_mask)
+        field.data_dtype = dtype.newbyteorder('=')
         block_shape = data_shape if 0 not in data_shape else (1, 1)
         field.data = as_lazy_data(proxy, chunks=block_shape)
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -906,7 +906,7 @@ def _make_cube(field, converter):
                           cell_methods=metadata.cell_methods,
                           dim_coords_and_dims=metadata.dim_coords_and_dims,
                           aux_coords_and_dims=metadata.aux_coords_and_dims,
-                          fill_value=field.bmdi, dtype=field.data_dtype)
+                          fill_value=field.bmdi, dtype=field.realised_dtype)
     
 
     # Temporary code to deal with invalid standard names in the

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -906,7 +906,7 @@ def _make_cube(field, converter):
                           cell_methods=metadata.cell_methods,
                           dim_coords_and_dims=metadata.dim_coords_and_dims,
                           aux_coords_and_dims=metadata.aux_coords_and_dims,
-                          fill_value=field.bmdi, dtype=field.core_data().dtype)
+                          fill_value=field.bmdi, dtype=field.data_dtype)
     
 
     # Temporary code to deal with invalid standard names in the

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -99,8 +99,9 @@ class FieldCollation(object):
         return self.data
 
     @property
-    def data_dtype(self):
-        return np.result_type(*[field.data_dtype for field in self._fields])
+    def realised_dtype(self):
+        return np.result_type(*[field.realised_dtype
+                                for field in self._fields])
 
     @property
     def data_proxy(self):

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -99,6 +99,10 @@ class FieldCollation(object):
         return self.data
 
     @property
+    def data_dtype(self):
+        return np.result_type(*[field.data_dtype for field in self._fields])
+
+    @property
     def data_proxy(self):
         return self.data
 

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -715,7 +715,7 @@ class TestZonalMeanBounds(tests.IrisTest):
 class TestLoadPartialMask(tests.IrisTest):
     def test_data(self):
         # Ensure that fields merge correctly where one has a mask and one
-        # doesn't
+        # doesn't.
         filename = tests.get_data_path(['PP', 'simple_pp', 'partial_mask.pp'])
 
         expected_data = np.ma.masked_array([[[0,  1],

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -711,5 +711,27 @@ class TestZonalMeanBounds(tests.IrisTest):
         self.assertTrue(cube.coord('longitude').has_bounds())
 
 
+@tests.skip_data
+class TestLoadPartialMask(tests.IrisTest):
+    def test_data(self):
+        # Ensure that fields merge correctly where one has a mask and one
+        # doesn't
+        filename = tests.get_data_path(['PP', 'simple_pp', 'partial_mask.pp'])
+
+        expected_data = np.ma.masked_array([[[0,  1],
+                                             [11, 12]],
+                                            [[99, 100],
+                                             [-1, -1]]],
+                                           [[[0, 0],
+                                             [0, 0]],
+                                            [[0, 0],
+                                             [1, 1]]],
+                                           dtype=np.int32)
+        cube = iris.load_cube(filename)
+
+        self.assertEqual(expected_data.dtype, cube.data.dtype)
+        self.assertMaskedArrayEqual(expected_data, cube.data, strict=False)
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
+++ b/lib/iris/tests/results/integration/netcdf/TestSaveMultipleAuxFactories/hybrid_height_cubes.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int64" dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature">
+  <cube core-dtype="float64" dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="cube" value="hh1"/>
@@ -64,7 +64,7 @@
     <cellMethods/>
     <data checksum="0x2acdccca" dtype="int64" shape="(3, 4, 5, 6)"/>
   </cube>
-  <cube core-dtype="int64" dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature_0">
+  <cube core-dtype="float64" dtype="int64" standard_name="air_temperature" units="K" var_name="air_temperature_0">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="cube" value="hh2"/>

--- a/lib/iris/tests/results/netcdf/int64_data_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_data_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
+  <cube core-dtype="float64" dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/netcdf_monotonic.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_monotonic.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind1">
+  <cube core-dtype="float64" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind1">
     <attributes>
       <attribute name="test" value="weak-monotonic time coordinate"/>
     </attributes>
@@ -18,7 +18,7 @@
     <cellMethods/>
     <data checksum="0xd4e7a32f" dtype="int32" shape="(3, 3, 3)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind2">
+  <cube core-dtype="float64" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind2">
     <attributes>
       <attribute name="test" value="masked monotonic time coordinate"/>
     </attributes>
@@ -36,7 +36,7 @@
     <cellMethods/>
     <data checksum="0xd4e7a32f" dtype="int32" shape="(3, 3, 3)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind3">
+  <cube core-dtype="float64" dtype="int32" standard_name="eastward_wind" units="m s-1" var_name="wind3">
     <attributes>
       <attribute name="test" value="masked non-monotonic time coordinate"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/netcdf_units_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_units_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" standard_name="air_temperature" units="kelvin" var_name="cube_0">
+  <cube core-dtype="float64" dtype="int32" standard_name="air_temperature" units="kelvin" var_name="cube_0">
     <coords>
       <coord>
         <dimCoord id="f1596e20" points="[100]" shape="(1,)" standard_name="height" units="Unit('meters')" value_type="int32" var_name="height"/>

--- a/lib/iris/tests/results/netcdf/netcdf_units_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_units_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" standard_name="air_temperature" units="unknown" var_name="cube_1">
+  <cube core-dtype="float64" dtype="int32" standard_name="air_temperature" units="unknown" var_name="cube_1">
     <attributes>
       <attribute name="invalid_units" value="kevin"/>
     </attributes>

--- a/lib/iris/tests/results/netcdf/uint32_data_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_data_netcdf3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
+  <cube core-dtype="float64" dtype="int32" standard_name="surface_temperature" units="K" var_name="temp">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>


### PR DESCRIPTION
If a Dask array is created from an array-like with a `dtype` attribute which is different from the dtype of an array returned by its `__getitem__`, this can cause problems, notably with `concatenate` and `stack`.

This PR ensures that the dtype attribute of `NetCDFDataProxy` and `PPDataProxy` objects can be promoted to from the actual dtype of the arrays returned by `__getitem__`, or that an error is raised if not. In practice this means that if the attribute is of kind int, uint or byte, and during a `__getitem__` call masked data is discovered (which would be convered to NaNs with a dtype of f8), an error is raised.

I've made changes so that when constructing a `NetCDFDataProxy`, the actual expected dtype of the arrays returned by `__getitem__` should be passed in. For `PPDataProxy`, the dtype property is derived from the one passed in. I'm not particularly happy about this difference, but it's hard to avoid.

When a `NetCDFDataProxy` is constructed for use in a `Cube`, the dtype  passed in is that of the nan array which would be returned if the variable contained masked data. The actual dtype of the data is stored by the cube's dtype. In other cases (i.e coordinates and cell measures), the dtype passed in is the dtype of the NetCDF variable itself. This shouldn't cause problems; masked data is not supported in coordinates, and integer data is not supported in cell measures.

`PPDataProxy` objects are only ever used for cube data, so no dtype information is lost as it is stored in `Cube.dtype`.