### PR TITLE
avoid pypi namespace clash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ def extract_version():
 
 
 setup(
-    name='Iris',
+    name='iris-scitools',
     version=extract_version(),
     url='http://scitools.org.uk/iris/',
     author='UK Met Office',

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,13 @@ setup(
     version=extract_version(),
     url='http://scitools.org.uk/iris/',
     author='UK Met Office',
-
+    license='LGPLv3',
+    platforms='any',
+    description='Data interoperability library',
+    long_description=('Data interoperability library for meteorological and \n'
+                      'oceanographic data formats, providing \n'
+                      'data analysis and visualisation capabilities.'),
+    author_email='https://groups.google.com/forum/#!forum/scitools-iris',
     packages=find_package_tree('lib/iris', 'iris'),
     package_dir={'': 'lib'},
     package_data={


### PR DESCRIPTION
an update to the setup to change the 'name' of the package to `iris-scitools` to enable registry in pypi

we were exploring this years ago and have just been reminded of the request #606 

uploading v1.12 won't work, as it clashes with the already registered `Iris`, but we can be ready for the next release


