### PR TITLE
Update regular coord checking

### DIFF
--- a/lib/iris/tests/unit/util/test__coord_regular.py
+++ b/lib/iris/tests/unit/util/test__coord_regular.py
@@ -1,0 +1,116 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test elements of :mod:`iris.util` that deal with checking coord regularity.
+Specifically, this module tests the following functions:
+
+  * :func:`iris.util.is_regular`,
+  * :func:`iris.util.regular_step`, and
+  * :func:`iris.util.points_step`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import inspect
+
+import numpy as np
+
+from iris.coords import AuxCoord, DimCoord
+from iris.exceptions import CoordinateNotRegularError, CoordinateMultiDimError
+from iris.util import is_regular, regular_step, points_step
+
+
+class Test_is_regular(tests.IrisTest):
+    def test_coord_with_regular_step(self):
+        coord = DimCoord(np.arange(5))
+        result = is_regular(coord)
+        self.assertTrue(result)
+
+    def test_coord_with_irregular_step(self):
+        # Check that a `CoordinateNotRegularError` is captured.
+        coord = AuxCoord(np.array([2, 5, 1, 4]))
+        result = is_regular(coord)
+        self.assertFalse(result)
+
+    def test_scalar_coord(self):
+        # Check that a `ValueError` is captured.
+        coord = DimCoord(5)
+        result = is_regular(coord)
+        self.assertFalse(result)
+
+    def test_coord_with_string_points(self):
+        # Check that a `TypeError` is captured.
+        coord = AuxCoord(['a', 'b', 'c'])
+        result = is_regular(coord)
+        self.assertFalse(result)
+
+
+class Test_regular_step(tests.IrisTest):
+    def test_basic(self):
+        dtype = np.float64
+        points = np.arange(5, dtype=dtype)
+        coord = DimCoord(points)
+        expected = np.mean(np.diff(points))
+        result = regular_step(coord)
+        self.assertArrayEqual(expected, result)
+        self.assertEqual(result.dtype, dtype)
+
+    def test_2d_coord(self):
+        coord = AuxCoord(np.arange(8).reshape(2, 4))
+        exp_emsg = 'Expected 1D coord'
+        with self.assertRaisesRegexp(CoordinateMultiDimError, exp_emsg):
+            regular_step(coord)
+
+    def test_scalar_coord(self):
+        coord = DimCoord(5)
+        exp_emsg = 'non-scalar coord'
+        with self.assertRaisesRegexp(ValueError, exp_emsg):
+            regular_step(coord)
+
+    def test_coord_with_irregular_step(self):
+        name = 'latitude'
+        coord = AuxCoord(np.array([2, 5, 1, 4]), standard_name=name)
+        exp_emsg = '{} is not regular'.format(name)
+        with self.assertRaisesRegexp(CoordinateNotRegularError, exp_emsg):
+            regular_step(coord)
+
+
+class Test_points_step(tests.IrisTest):
+    def test_regular_points(self):
+        regular_points = np.arange(5)
+        exp_avdiff = np.mean(np.diff(regular_points))
+        result_avdiff, result = points_step(regular_points)
+        self.assertArrayEqual(exp_avdiff, result_avdiff)
+        self.assertTrue(result)
+
+    def test_irregular_points(self):
+        irregular_points = np.array([2, 5, 1, 4])
+        exp_avdiff = np.mean(np.diff(irregular_points))
+        result_avdiff, result = points_step(irregular_points)
+        self.assertArrayEqual(exp_avdiff, result_avdiff)
+        self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/util/test__coord_regular.py
+++ b/lib/iris/tests/unit/util/test__coord_regular.py
@@ -73,7 +73,7 @@ class Test_regular_step(tests.IrisTest):
         coord = DimCoord(points)
         expected = np.mean(np.diff(points))
         result = regular_step(coord)
-        self.assertArrayEqual(expected, result)
+        self.assertEqual(expected, result)
         self.assertEqual(result.dtype, dtype)
 
     def test_2d_coord(self):
@@ -101,14 +101,14 @@ class Test_points_step(tests.IrisTest):
         regular_points = np.arange(5)
         exp_avdiff = np.mean(np.diff(regular_points))
         result_avdiff, result = points_step(regular_points)
-        self.assertArrayEqual(exp_avdiff, result_avdiff)
+        self.assertEqual(exp_avdiff, result_avdiff)
         self.assertTrue(result)
 
     def test_irregular_points(self):
         irregular_points = np.array([2, 5, 1, 4])
         exp_avdiff = np.mean(np.diff(irregular_points))
         result_avdiff, result = points_step(irregular_points)
-        self.assertArrayEqual(exp_avdiff, result_avdiff)
+        self.assertEqual(exp_avdiff, result_avdiff)
         self.assertFalse(result)
 
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1379,13 +1379,20 @@ def regular_step(coord):
     if coord.shape[0] < 2:
         raise ValueError("Expected a non-scalar coord")
 
-    diffs = coord.points[1:] - coord.points[:-1]
-    avdiff = np.mean(diffs)
-    if not np.allclose(diffs, avdiff, rtol=0.001):
-        # TODO: This value is set for test_analysis to pass...
+    avdiff, regular = points_step(coord.points)
+    if not regular:
         msg = "Coord %s is not regular" % coord.name()
         raise iris.exceptions.CoordinateNotRegularError(msg)
     return avdiff.astype(coord.points.dtype)
+
+
+def points_step(points):
+    """Determine whether a set of points has a regular step."""
+    diffs = np.diff(points)
+    avdiff = np.mean(diffs)
+    # TODO: This value for `rtol` is set for test_analysis to pass...
+    regular = np.allclose(diffs, avdiff, rtol=0.001)
+    return avdiff, regular
 
 
 def unify_time_units(cubes):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1387,7 +1387,7 @@ def regular_step(coord):
 
 
 def points_step(points):
-    """Determine whether a set of points has a regular step."""
+    """Determine whether a NumPy array has a regular step."""
     diffs = np.diff(points)
     avdiff = np.mean(diffs)
     # TODO: This value for `rtol` is set for test_analysis to pass...


### PR DESCRIPTION
The existing checks for whether a coord is regular in `iris.util` quite reasonably only works on coords. However in #2527 I need to check whether just a set of _points_ is regular, which the existing functionality could not achieve.

To deal with this I have added a new function, `iris.util.points_step`, which checks whether there is a regular step between a set of points (a NumPy array). This function represents the part of `iris.util.regular_step` that dealt with checking the incoming coord's points. I've also added tests for the `iris.util` functions `is_regular`, `regular_step`, and `points_step`.

Note: #2527 now depends on this PR.