### PR TITLE
Dask data manager propagate

### DIFF
--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -77,7 +77,7 @@ class DataManager(object):
         if ma.isMaskedArray(data) and \
                 isinstance(fill_value, six.string_types) and \
                 fill_value == 'none':
-            self._propogate_masked_data_fill_value()
+            self._propagate_masked_data_fill_value()
         else:
             if isinstance(fill_value, six.string_types) and \
                     fill_value == 'none':
@@ -277,7 +277,7 @@ class DataManager(object):
 
         return result
 
-    def _propogate_masked_data_fill_value(self):
+    def _propagate_masked_data_fill_value(self):
         """
         Align the data manager fill-value with the real masked array
         fill-value.
@@ -292,7 +292,7 @@ class DataManager(object):
                 # represent this by clearing the data manager fill-value.
                 self.fill_value = None
             else:
-                # Propogate the masked array fill-value to the data manager.
+                # Propagate the masked array fill-value to the data manager.
                 self.fill_value = data.fill_value
 
     def _realised_dtype_setter(self, realised_dtype):
@@ -421,7 +421,7 @@ class DataManager(object):
         # Reset the fill-value appropriately.
         if ma.isMaskedArray(data):
             # Align the data manager fill-value with the numpy fill-value.
-            self._propogate_masked_data_fill_value()
+            self._propagate_masked_data_fill_value()
         else:
             # Clear the data manager fill-value.
             self.fill_value = None

--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -294,10 +294,6 @@ class DataManager(object):
             else:
                 # Propogate the masked array fill-value to the data manager.
                 self.fill_value = data.fill_value
-                # Catch the case where numpy has a fill-value (default, or
-                # otherwise) that is invalid for the underlying dtype.
-                if self.fill_value != data.fill_value:
-                    self.fill_value = None
 
     def _realised_dtype_setter(self, realised_dtype):
         """

--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -73,16 +73,14 @@ class DataManager(object):
         # Set the lazy data realised dtype, if appropriate.
         self._realised_dtype_setter(realised_dtype)
 
+        default_fill_value = (isinstance(fill_value, six.string_types) and
+                              fill_value == 'none')
+
         # Set the fill-value, must be set after the realised dtype.
-        if ma.isMaskedArray(data) and \
-                isinstance(fill_value, six.string_types) and \
-                fill_value == 'none':
+        if ma.isMaskedArray(data) and default_fill_value:
             self._propagate_masked_data_fill_value()
         else:
-            if isinstance(fill_value, six.string_types) and \
-                    fill_value == 'none':
-                fill_value = None
-            self.fill_value = fill_value
+            self.fill_value = None if default_fill_value else fill_value
 
         # Enforce the manager contract.
         self._assert_axioms()
@@ -419,12 +417,13 @@ class DataManager(object):
         self._realised_dtype = None
 
         # Reset the fill-value appropriately.
-        if ma.isMaskedArray(data):
-            # Align the data manager fill-value with the numpy fill-value.
-            self._propagate_masked_data_fill_value()
-        else:
-            # Clear the data manager fill-value.
-            self.fill_value = None
+        if init_done:
+            if ma.isMaskedArray(data):
+                # Align the data manager fill-value with the numpy fill-value.
+                self._propagate_masked_data_fill_value()
+            else:
+                # Clear the data manager fill-value.
+                self.fill_value = None
 
         # Check the manager contract, as the managed data has changed.
         self._assert_axioms()

--- a/lib/iris/_data_manager.py
+++ b/lib/iris/_data_manager.py
@@ -37,7 +37,7 @@ class DataManager(object):
 
     """
 
-    def __init__(self, data, fill_value=None, realised_dtype=None):
+    def __init__(self, data, fill_value='none', realised_dtype=None):
         """
         Create a data manager for the specified data.
 
@@ -74,9 +74,14 @@ class DataManager(object):
         self._realised_dtype_setter(realised_dtype)
 
         # Set the fill-value, must be set after the realised dtype.
-        if ma.isMaskedArray(data) and fill_value is None:
+        if ma.isMaskedArray(data) and \
+                isinstance(fill_value, six.string_types) and \
+                fill_value == 'none':
             self._propogate_masked_data_fill_value()
         else:
+            if isinstance(fill_value, six.string_types) and \
+                    fill_value == 'none':
+                fill_value = None
             self.fill_value = fill_value
 
         # Enforce the manager contract.

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="temperature" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/single_missing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="temperature" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
         <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
+++ b/lib/iris/tests/results/analysis/last_quartile_foo_3d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="thingness" units="1">
+  <cube core-dtype="float64" dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="4a0cb9d8" points="[90, 0, -90]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="int64"/>

--- a/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
+++ b/lib/iris/tests/results/analysis/proportion_foo_2d_masked.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" long_name="thingness" units="1">
+  <cube core-dtype="float64" dtype="float64" long_name="thingness" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_subset_masked_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="source" value="Iris test case"/>
     </attributes>

--- a/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
+++ b/lib/iris/tests/results/experimental/analysis/interpolate/LinearInterpolator/orthogonal_cube_with_factory.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="999999.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_temperature" units="K">
     <coords>
       <coord datadims="[1, 2]">
         <auxCoord id="9041e969" points="[[-660.0, -610.0, -560.0, -510.0, -460.0, -410.0],

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -566,8 +566,16 @@ class Test_data__getter(tests.IrisTest):
         self.assertArrayEqual(result, self.real_array)
 
     def test_with_real_mask_array__default_fill_value(self):
-        self.mask_array.fill_value = 1234
+        fill_value = 1234
+        self.mask_array.fill_value = fill_value
         dm = DataManager(self.mask_array)
+        self.assertEqual(dm.fill_value, fill_value)
+        self.assertEqual(dm.data.fill_value, fill_value)
+
+    def test_with_real_mask_array__with_fill_value_None(self):
+        fill_value = 1234
+        self.mask_array.fill_value = fill_value
+        dm = DataManager(self.mask_array, fill_value=None)
         self.assertIsNone(dm.fill_value)
         np_fill_value = ma.array(0, dtype=dm.dtype).fill_value
         self.assertEqual(dm.data.fill_value, np_fill_value)
@@ -580,6 +588,14 @@ class Test_data__getter(tests.IrisTest):
 
     def test_with_lazy_mask_array__masked_default_fill_value(self):
         dm = DataManager(self.lazy_mask_array_masked,
+                         realised_dtype=self.realised_dtype)
+        self.assertIsNone(dm.fill_value)
+        np_fill_value = ma.array(0, dtype=dm.dtype).fill_value
+        self.assertEqual(dm.data.fill_value, np_fill_value)
+
+    def test_with_lazy_mask_array__masked_fill_value_None(self):
+        dm = DataManager(self.lazy_mask_array_masked,
+                         fill_value=None,
                          realised_dtype=self.realised_dtype)
         self.assertIsNone(dm.fill_value)
         np_fill_value = ma.array(0, dtype=dm.dtype).fill_value
@@ -839,7 +855,7 @@ class Test_data__setter(tests.IrisTest):
         self.assertIsNone(dm.fill_value)
         data = ma.array(1)
         dm.data = data
-        self.assertEqual(dm.fill_value, data.fill_value)
+        self.assertIsNone(dm.fill_value)
 
     def test_mask_array__with_fill_value(self):
         dm = DataManager(np.array(0))

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -471,7 +471,7 @@ class Test__deepcopy(tests.IrisTest):
             dm._deepcopy(self.memo, fill_value=1e+20)
 
 
-class Test__propogate_masked_data_fill_value(tests.IrisTest):
+class Test__propagate_masked_data_fill_value(tests.IrisTest):
     def setUp(self):
         self.real_array = np.array(0)
         self.mask_array = ma.array(0)
@@ -486,21 +486,21 @@ class Test__propogate_masked_data_fill_value(tests.IrisTest):
         dm = DataManager(self.real_array)
         dm.fill_value = 1234
         self.assertEqual(dm.fill_value, fill_value)
-        dm._propogate_masked_data_fill_value()
+        dm._propagate_masked_data_fill_value()
         self.assertEqual(dm.fill_value, fill_value)
 
     def test_clear_fill_value__with_np_default(self):
         fill_value = 1234
         self.dm.fill_value = fill_value
         self.assertEqual(self.dm.fill_value, fill_value)
-        self.dm._propogate_masked_data_fill_value()
+        self.dm._propagate_masked_data_fill_value()
         self.assertIsNone(self.dm.fill_value)
 
     def test_set_fill_value(self):
         fill_value = 1234
         self.assertIsNone(self.dm.fill_value)
         self.dm._real_array.fill_value = fill_value
-        self.dm._propogate_masked_data_fill_value()
+        self.dm._propagate_masked_data_fill_value()
         self.assertEqual(self.dm.fill_value, fill_value)
 
 

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -471,6 +471,39 @@ class Test__deepcopy(tests.IrisTest):
             dm._deepcopy(self.memo, fill_value=1e+20)
 
 
+class Test__propogate_masked_data_fill_value(tests.IrisTest):
+    def setUp(self):
+        self.real_array = np.array(0)
+        self.mask_array = ma.array(0)
+        np_fill_value = ma.array(0, dtype=self.mask_array.dtype).fill_value
+        assert np_fill_value == self.mask_array.fill_value
+        self.np_fill_value = np_fill_value
+        self.dm = DataManager(self.mask_array)
+        self.dm.fill_value = None
+
+    def test_nop__with_real_array(self):
+        fill_value = 1234
+        dm = DataManager(self.real_array)
+        dm.fill_value = 1234
+        self.assertEqual(dm.fill_value, fill_value)
+        dm._propogate_masked_data_fill_value()
+        self.assertEqual(dm.fill_value, fill_value)
+
+    def test_clear_fill_value__with_np_default(self):
+        fill_value = 1234
+        self.dm.fill_value = fill_value
+        self.assertEqual(self.dm.fill_value, fill_value)
+        self.dm._propogate_masked_data_fill_value()
+        self.assertIsNone(self.dm.fill_value)
+
+    def test_set_fill_value(self):
+        fill_value = 1234
+        self.assertIsNone(self.dm.fill_value)
+        self.dm._real_array.fill_value = fill_value
+        self.dm._propogate_masked_data_fill_value()
+        self.assertEqual(self.dm.fill_value, fill_value)
+
+
 class Test__realised_dtype_setter(tests.IrisTest):
     def setUp(self):
         self.real_array = np.array(0.0)


### PR DESCRIPTION
Ensures that when a masked array is passed to the `DataManager.__init__` or the `DataManager.data` setter, the masked array `fill_value` is correctly propagated to the `DataManager.fill_value`.

Note that, the default numpy `fill_value` for a `dtype` is never used to set the `DataManager.fill_value`, rather `None` is used instead. This ensures that when the `DataManager.data` getter is called and the realised result is a masked array, it is set with the default numpy `fill_value` for the `dtype` when the `DataManager.fill_value = None` (done automatically, when setting a masked array `fill_value` to `None`), otherwise the returned masked array is set to the non-`None` `cube.fill_value`.

Also addresses [comment](https://github.com/SciTools/iris/pull/2524#issuecomment-299241938).