### PR TITLE
ENH: Shared data between cube slices

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -541,17 +541,22 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             raise ValueError('If bounds are specified, points must also be '
                              'specified')
 
-        new_coord = copy.deepcopy(self)
         if points is not None:
+            # We do not perform a deepcopy when we supply new points so as to
+            # not unncessarily copy the old points.
+            new_coord = copy.copy(self)
+            new_coord.attributes = copy.deepcopy(self.attributes)
+            new_coord.coord_system = copy.deepcopy(self.coord_system)
+
             # Explicitly not using the points property as we don't want the
             # shape the new points to be constrained by the shape of
             # self.points
             new_coord._points = None
             new_coord.points = points
-            # Regardless of whether bounds are provided as an argument, new
-            # points will result in new bounds, discarding those copied from
-            # self.
+            # new points will result in new bounds.
             new_coord.bounds = bounds
+        else:
+            new_coord = copy.deepcopy(self)
 
         return new_coord
 
@@ -1521,7 +1526,7 @@ class DimCoord(Coord):
 
     @points.setter
     def points(self, points):
-        points = np.array(points, ndmin=1)
+        points = np.array(points, ndmin=1, copy=False)
         # If points are already defined for this coordinate,
         if hasattr(self, '_points') and self._points is not None:
             # Check that setting these points wouldn't change self.shape
@@ -1557,7 +1562,7 @@ class DimCoord(Coord):
     def bounds(self, bounds):
         if bounds is not None:
             # Ensure the bounds are a compatible shape.
-            bounds = np.array(bounds, ndmin=2)
+            bounds = np.array(bounds, ndmin=2, copy=False)
             if self.shape != bounds.shape[:-1]:
                 raise ValueError(
                     "The shape of the bounds array should be "

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1526,7 +1526,7 @@ class DimCoord(Coord):
 
     @points.setter
     def points(self, points):
-        points = np.array(points, ndmin=1, copy=False)
+        points = np.array(points, ndmin=1)
         # If points are already defined for this coordinate,
         if hasattr(self, '_points') and self._points is not None:
             # Check that setting these points wouldn't change self.shape
@@ -1562,7 +1562,7 @@ class DimCoord(Coord):
     def bounds(self, bounds):
         if bounds is not None:
             # Ensure the bounds are a compatible shape.
-            bounds = np.array(bounds, ndmin=2, copy=False)
+            bounds = np.array(bounds, ndmin=2)
             if self.shape != bounds.shape[:-1]:
                 raise ValueError(
                     "The shape of the bounds array should be "

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -774,7 +774,20 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         # When True indexing may result in a view onto the original data array,
         # to avoid unnecessary copying.
-        self.share_data = False
+        self._share_data = False
+
+    @property
+    def share_data(self):
+        """Share cube data when slicing/indexing cube if True."""
+        return self._share_data
+
+    @share_data.setter
+    def share_data(self, value):
+        # Realise the data if is hasn't already been as sharing lazy data is
+        # not right now possible or a usecase understood.
+        if self.has_lazy_data():
+            self.data
+        self._share_data = bool(value)
 
     @property
     def metadata(self):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -786,7 +786,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Realise the data if is hasn't already been as sharing lazy data is
         # not right now possible or a usecase understood.
         if self.has_lazy_data():
-            self.data
+            _ = self.data
         self._share_data = bool(value)
 
     @property

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -65,6 +65,10 @@ class Test___init___data(tests.IrisTest):
         self.assertEqual(type(cube.data), np.ndarray)
         self.assertArrayEqual(cube.data, data)
 
+    def test_default_share_data(self):
+        cube = Cube(np.arange(1))
+        self.assertFalse(cube.share_data)
+
 
 class Test_extract(tests.IrisTest):
     def test_scalar_cube_exists(self):
@@ -1405,6 +1409,50 @@ class Test_remove_metadata(tests.IrisTest):
         self.cube.remove_cell_measure(self.cube.cell_measure('area'))
         self.assertEqual(self.cube._cell_measures_and_dims,
                          [[self.b_cell_measure, (0, 1)]])
+
+
+class Test_share_data(tests.IrisTest):
+    def setter_lazy_data(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube.share_data = True
+        self.assertFalse(cube.has_lazy_data())
+        self.assertTrue(cube._share_data)
+
+    def setter_realised_data(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube.share_data = True
+        self.assertFalse(cube.has_lazy_data())
+        self.assertTrue(cube._share_data)
+
+
+class Test___getitem__no_share_data(tests.IrisTest):
+    def test_lazy_array(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube2 = cube[1:]
+        self.assertTrue(cube2.has_lazy_data())
+        cube.data
+        self.assertTrue(cube2.has_lazy_data())
+
+    def test_ndarray(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube2 = cube[1:]
+        self.assertIsNot(cube.data.base, cube2.data.base)
+
+
+class Test___getitem__share_data(tests.IrisTest):
+    def test_lazy_array(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube.share_data = True
+        cube2 = cube[1:]
+        self.assertFalse(cube.has_lazy_data())
+        self.assertFalse(cube2.has_lazy_data())
+        self.assertIs(cube.data.base, cube2.data.base)
+
+    def test_ndarray(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube.share_data = True
+        cube2 = cube[1:]
+        self.assertIs(cube.data.base, cube2.data.base)
 
 
 class Test__getitem_CellMeasure(tests.IrisTest):


### PR DESCRIPTION
- When indexing a cube when the data is reaslised (not lazy), a view of the original array is returned where possible (subject to the rules when slicing in numpy).
- When indexing a cube when the data is not reaslised (lazy), realising the data on one will still not realise the data on the other.
- Optimisation of coord copy when replacing the points is to shallow copy the points and bounds before replacing them to avoid unnecessary copies.
- Existing behaviour is that slicing coordinates returns views of the original points and bounds (where possible).  This was likely chosen behaviour on the basis that DimCoords at least is not writeable.  This is not the same however for Auxiliary coordinates and likely raises the likely case for this being a bug (i.e. one can modify AuxCoord object points and bounds).
- DimCoord slicing will now return views of its data like AuxCoords.  DimCoords will continue to realise data unlike AuxCoords due to the validation necessary for being monotonically increasing.

I have put up the changes here to demonstrate the UI (tests will follow an agreement in principle of the changes).

Demonstrate the UI of this PR:
```Python
>>> cube = iris.cube.Cube([1, 2, 3, 4])
>>> cube2 = cube[::-1]
>>> cube2.data 
>>> cube2.data.base is None
True
>>> cube.share_data = True
>>> cube2 = cube[::-1]
>>> cube2.data.base is None
False
>>> cube2.data.base is cube.data
True
```

Replaces #2261, #1992 
These changes are shown to be readily applicable when switching to dask too [link](https://github.com/cpelley/iris/pull/37)

**NOT FOR MERGING**