### PR TITLE
Corrected use of deprecated numpy behaviour. Necessary for numpy 1.12

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -239,7 +239,7 @@ class GribWrapper(object):
             # The byte offset requires to be reset back to the first byte
             # of this message. The file pointer offset is always at the end 
             # of the current message due to the grib-api reading the message.
-            proxy = GribDataProxy(shape, np.zeros(0).dtype, np.nan,
+            proxy = GribDataProxy(shape, np.array([0.]).dtype, np.nan,
                                   grib_fh.name,
                                   offset - message_length,
                                   auto_regularise)


### PR DESCRIPTION
proposed replacement for #2468

targeting master for the 1.13 release