### PR TITLE
Remove a few more biggus skippers

### DIFF
--- a/lib/iris/tests/results/abf/load.cml
+++ b/lib/iris/tests/results/abf/load.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="leaf_area_index" units="%">
+  <cube core-dtype="uint8" dtype="uint8" standard_name="leaf_area_index" units="%">
     <attributes>
       <attribute name="source" value="Boston University"/>
     </attributes>
@@ -34,6 +34,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0xbf5ea7c7" dtype="uint8" fill_value="255" mask_checksum="0x90665a57" shape="(2160, 4320)"/>
+    <data checksum="0xbf5ea7c7" dtype="uint8" mask_checksum="0x90665a57" shape="(2160, 4320)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/unit/fileformats/grib/load_cubes/load_cubes/reduced_raw.cml
+++ b/lib/iris/tests/results/unit/fileformats/grib/load_cubes/load_cubes/reduced_raw.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential" units="m2 s-2">
+  <cube core-dtype="float64" dtype="float64" standard_name="geopotential" units="m2 s-2">
     <attributes>
       <attribute name="centre" value="European Centre for Medium Range Weather Forecasts"/>
     </attributes>

--- a/lib/iris/tests/test_abf.py
+++ b/lib/iris/tests/test_abf.py
@@ -28,7 +28,6 @@ import iris
 import iris.fileformats.abf
 
 
-@tests.skip_biggus
 @tests.skip_data
 class TestAbfLoad(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -205,9 +205,6 @@ class TestPPField_GlobalTemperature(IrisPPTest):
 
 @tests.skip_data
 class TestPackedPP(IrisPPTest):
-    # skip this tests, there are differences in behaviour of
-    # the mock patch of mo_pack across python and mock versions
-    @tests.skip_biggus
     def test_wgdos(self):
         filepath = tests.get_data_path(('PP', 'wgdos_packed',
                                         'nae.20100104-06_0001.pp'))

--- a/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
+++ b/lib/iris/tests/unit/fileformats/grib/test_load_cubes.py
@@ -52,7 +52,6 @@ class Test(tests.IrisTest):
 @tests.skip_data
 class Test_load_cubes(tests.IrisTest):
 
-    @tests.skip_biggus
     def test_reduced_raw(self):
         # Loading a GRIB message defined on a reduced grid without
         # interpolating to a regular grid.

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -67,7 +67,6 @@ class TestPPField(PPField):
 
 
 class Test_save(tests.IrisTest):
-    @tests.skip_biggus
     def test_float64(self):
         # Tests down-casting of >f8 data to >f4.
 


### PR DESCRIPTION
These tests had biggus skippers in place but the tests were largely passing. The tests that weren't passing needed updated CML to reflect changes elsewhere in Iris code, primarily to `DataManager`.