### PR TITLE
Coord points and bounds inheritance.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1617,6 +1617,14 @@ class DimCoord(Coord):
 
     # The __ne__ operator from Coord implements the not __eq__ method.
 
+    # For Python 3, we must explicitly re-implement the '__hash__' method, as
+    # defining an '__eq__' has blocked its inheritance.  See ...
+    # https://docs.python.org/3.1/reference/datamodel.html#object.__hash__
+    # "If a class that overrides __eq__() needs to retain the
+    # implementation of __hash__() from a parent class, the interpreter
+    # must be told this explicitly".
+    __hash__ = Coord.__hash__
+
     def __getitem__(self, key):
         coord = super(DimCoord, self).__getitem__(key)
         coord.circular = self.circular and coord.shape == self.shape

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -768,8 +768,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
     # Must supply __hash__ as Python 3 does not enable it if __eq__ is defined.
     # NOTE: Violates "objects which compare equal must have the same hash".
-    # Currently needed, but not really correct and should be fixed.
-    # See #962 and #1772.
+    # We ought to remove this, as equality of two coords can *change*, so they
+    # really should not be hashable.
+    # However, current code needs it, e.g. so we can put them in sets.
+    # Fixing it will require changing those uses.  See #962 and #1772.
     def __hash__(self):
         return hash(id(self))
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3081,8 +3081,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             result = not result
         return result
 
-    # Must supply __hash__, Python 3 does not enable it if __eq__ is defined
-    # This is necessary for merging, but probably shouldn't be used otherwise.
+    # Must supply __hash__ as Python 3 does not enable it if __eq__ is defined.
+    # NOTE: Violates "objects which compare equal must have the same hash".
+    # Currently needed, but not really correct and should be fixed.
     # See #962 and #1772.
     def __hash__(self):
         return hash(id(self))

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3083,8 +3083,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     # Must supply __hash__ as Python 3 does not enable it if __eq__ is defined.
     # NOTE: Violates "objects which compare equal must have the same hash".
-    # Currently needed, but not really correct and should be fixed.
-    # See #962 and #1772.
+    # We ought to remove this, as equality of two cube can *change*, so they
+    # really should not be hashable.
+    # However, current code needs it, e.g. so we can put them in sets.
+    # Fixing it will require changing those uses.  See #962 and #1772.
     def __hash__(self):
         return hash(id(self))
 

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -326,10 +326,11 @@ class TestDimCoordCreation(tests.IrisTest):
                                      'monotonicity.*consistent.*all bounds'):
             iris.coords.DimCoord([1, 2, 3], bounds=[[1, 12], [2, 9], [3, 6]])
         # shapes of points and bounds
-        with self.assertRaisesRegexp(ValueError, 'shape of the bounds array'):
+        msg = 'Bounds shape must be compatible with points shape'
+        with self.assertRaisesRegexp(ValueError, msg):
             iris.coords.DimCoord([1, 2, 3], bounds=[0.5, 1.5, 2.5, 3.5])
         # another example of shapes of points and bounds
-        with self.assertRaisesRegexp(ValueError, 'shape of the bounds array'):
+        with self.assertRaisesRegexp(ValueError, msg):
             iris.coords.DimCoord([1, 2, 3], bounds=[[0.5, 1.5], [1.5, 2.5]])
 
         # numeric

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -84,8 +84,7 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
         bds_shape = list(self.bds_real.shape)
         bds_shape[0] += 1
         bds_wrong = np.zeros(bds_shape)
-        msg = ('The shape of the bounds array should be '
-               'points.shape \+ \(n_bounds,\)')
+        msg = 'Bounds shape must be compatible with points shape'
         with self.assertRaisesRegexp(ValueError, msg):
             DimCoord(self.pts_real, bounds=bds_wrong)
 
@@ -442,8 +441,7 @@ class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
     def test_fail_bad_shape(self):
         # Setting real points requires matching shape.
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
-        msg = ('The shape of the bounds array should be '
-               'points.shape \+ \(n_bounds,\)')
+        msg = 'Bounds shape must be compatible with points shape'
         with self.assertRaisesRegexp(ValueError, msg):
             coord.bounds = np.array([1.0, 2.0, 3.0])
 


### PR DESCRIPTION
This refactors the inheritance organisation of the `points` and `bounds` property code amongst Coord  / AuxCoord / DimCoord.

At present, `DimCoord` and `AuxCoord` both provide their own *independent* implementations of points+bounds getters+setters, but there is quite a lot of duplication in that code.
This refactor removes the code duplication, by ...
  * most of the relevant code is relocated by "pushing it up" from `AuxCoord` into `Coord`.
  * `AuxCoord` then becomes an almost trivial descendant of `Coord`, 
  * `DimCoord` is now a 'specialised' form that inherits + extends those implementations, adding realisation and DimCoord-specific validity testing.
  * the 'from_coord' routine has also been generalised in a similar way.

I think this structure makes more sense than the existing.
The knock-on effects are extremely minor : just that some error cases produce a slightly different message.
The recently-extended testing in `iris.tests.unit.coords` encourages me that nothing serious has been broken (!) 