### PR TITLE
Fix masked time bounds

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1543,7 +1543,10 @@ fc_extras
             bounds_data = cf_bounds_var[:]
             # Gracefully fill bounds masked array.
             if ma.isMaskedArray(bounds_data):
-                bounds_data = ma.filled(bounds_data)
+                if not ma.isMaskedArray(points_data):
+                    bounds_data = ma.filled(bounds_data, fill_value=0.)
+                else:
+                    bounds_data = ma.filled(bounds_data)
                 msg = 'Gracefully filling {!r} dimension coordinate masked bounds'
                 warnings.warn(msg.format(str(cf_coord_var.cf_name)))
             # Handle transposed bounds where the vertex dimension is not


### PR DESCRIPTION
In the problem that this PR is attempting to solve, a NetCDF file had a time coordinate whose points were unmasked, but its bounds were masked.  The coordinate could not be constructed because the masked bounds were being filled with the fill_value (9x10^36) which could not be interpreted as a date. 

This potential fix checks that if the bounds array for a coordinate is masked, the points array is also masked, otherwise the bounds array is filled with zeros instead of the cube fill value.  I consider this acceptable because I can't think of any reasonable situation in which a bounds array would be masked when the points array isn't.

This does not assign reasonable values to the bounds array, it just makes it able to be constructed in a case like the one in question so that the silly coordinate can at least be inspected and adjusted.

I am still not sure whether this is the best way to fix this, and would appreciate some opinions please.