### PR TITLE
Fix pickle test

### DIFF
--- a/lib/iris/tests/results/cube_io/pickling/theta.cml
+++ b/lib/iris/tests/results/cube_io/pickling/theta.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -121,7 +121,6 @@ class StandardReportWithExclusions(pep8.StandardReport):
         '*/iris/tests/test_iterate.py',
         '*/iris/tests/test_load.py',
         '*/iris/tests/test_merge.py',
-        '*/iris/tests/test_pickling.py',
         '*/iris/tests/test_pp_cf.py',
         '*/iris/tests/test_pp_module.py',
         '*/iris/tests/test_pp_stash.py',

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -22,7 +22,8 @@ Test pickling of Iris objects.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-# import iris tests first so that some things can be initialised before importing anything else
+# Import iris tests first so that some things can be initialised
+# before importing anything else.
 import iris.tests as tests
 
 import six.moves.cPickle as pickle
@@ -36,7 +37,10 @@ import iris
 
 class TestPickle(tests.IrisTest):
     def pickle_then_unpickle(self, obj):
-        """Returns a generator of ("cpickle protocol number", object) tuples."""
+        """
+        Returns a generator of ("cpickle protocol number", object) tuples.
+
+        """
         for protocol in range(1 + pickle.HIGHEST_PROTOCOL):
             bio = io.BytesIO()
             pickle.dump(obj, bio, protocol)
@@ -48,19 +52,22 @@ class TestPickle(tests.IrisTest):
             yield protocol, reconstructed_obj
 
     def assertCubeData(self, cube1, cube2):
-        np.testing.assert_array_equal(cube1.data, cube2.data)
+        self.assertArrayEqual(cube1.data, cube2.data)
 
-    @tests.skip_biggus
     @tests.skip_data
     def test_cube_pickle(self):
-        cube = iris.load_cube(tests.get_data_path(('PP', 'globClim1', 'theta.pp')))
+        cube = iris.load_cube(tests.get_data_path(('PP',
+                                                   'globClim1',
+                                                   'theta.pp')))
         self.assertTrue(cube.has_lazy_data())
-        self.assertCML(cube, ('cube_io', 'pickling', 'theta.cml'), checksum=False)
+        self.assertCML(cube, ('cube_io', 'pickling', 'theta.cml'),
+                       checksum=False)
 
-        for _, recon_cube in self.pickle_then_unpickle(cube):
+        for p, recon_cube in self.pickle_then_unpickle(cube):
             self.assertTrue(recon_cube.has_lazy_data())
-            self.assertCML(recon_cube, ('cube_io', 'pickling', 'theta.cml'), checksum=False)
-            self.assertCubeData(cube, recon_cube)
+            self.assertCML(recon_cube, ('cube_io', 'pickling', 'theta.cml'),
+                           checksum=False)
+            self.assertCubeData(cube.copy(), recon_cube)
 
     @tests.skip_data
     def test_cube_with_coord_points(self):
@@ -76,23 +83,28 @@ class TestPickle(tests.IrisTest):
 
     @tests.skip_data
     def test_cubelist_pickle(self):
-        cubelist = iris.load(tests.get_data_path(('PP', 'COLPEX', 'theta_and_orog_subset.pp')))
+        cubelist = iris.load(tests.get_data_path(('PP', 'COLPEX',
+                                                  'theta_and_orog_subset.pp')))
         single_cube = cubelist[0]
 
         self.assertCML(cubelist, ('cube_io', 'pickling', 'cubelist.cml'))
         self.assertCML(single_cube, ('cube_io', 'pickling', 'single_cube.cml'))
 
         for _, reconstructed_cubelist in self.pickle_then_unpickle(cubelist):
-            self.assertCML(reconstructed_cubelist, ('cube_io', 'pickling', 'cubelist.cml'))
-            self.assertCML(reconstructed_cubelist[0], ('cube_io', 'pickling', 'single_cube.cml'))
+            self.assertCML(reconstructed_cubelist, ('cube_io', 'pickling',
+                                                    'cubelist.cml'))
+            self.assertCML(reconstructed_cubelist[0], ('cube_io', 'pickling',
+                                                       'single_cube.cml'))
 
-            for cube_orig, cube_reconstruct in zip(cubelist, reconstructed_cubelist):
+            for cube_orig, cube_reconstruct in zip(cubelist,
+                                                   reconstructed_cubelist):
                 self.assertArrayEqual(cube_orig.data, cube_reconstruct.data)
                 self.assertEqual(cube_orig, cube_reconstruct)
 
     def test_picking_equality_misc(self):
         items_to_test = [
-                        cf_units.Unit("hours since 2007-01-15 12:06:00", calendar=cf_units.CALENDAR_STANDARD),
+                        cf_units.Unit("hours since 2007-01-15 12:06:00",
+                                      calendar=cf_units.CALENDAR_STANDARD),
                         cf_units.as_unit('1'),
                         cf_units.as_unit('meters'),
                         cf_units.as_unit('no-unit'),
@@ -100,11 +112,11 @@ class TestPickle(tests.IrisTest):
                         ]
 
         for orig_item in items_to_test:
-            for protocol, reconstructed_item in self.pickle_then_unpickle(orig_item):
-                fail_msg = ('Items are different after pickling at protocol %s.'
-                           '\nOrig item: %r\nNew item: %r' % (protocol, orig_item, reconstructed_item)
-                            )
-                self.assertEqual(orig_item, reconstructed_item, fail_msg)
+            for protocol, reconst_item in self.pickle_then_unpickle(orig_item):
+                fail_msg = ('Items are different after pickling '
+                            'at protocol {}.\nOrig item: {!r}\nNew item: {!r}')
+                fail_msg = fail_msg.format(protocol, orig_item, reconst_item)
+                self.assertEqual(orig_item, reconst_item, fail_msg)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -30,9 +30,9 @@ import six.moves.cPickle as pickle
 import io
 
 import cf_units
-import numpy as np
 
 import iris
+from iris._lazy_data import as_concrete_data
 
 
 class TestPickle(tests.IrisTest):
@@ -51,8 +51,16 @@ class TestPickle(tests.IrisTest):
 
             yield protocol, reconstructed_obj
 
+    @staticmethod
+    def _real_data(cube):
+        # Get the concrete data of the cube for performing data values
+        # comparison checks.
+        return as_concrete_data(cube.core_data(),
+                                nans_replacement=cube.fill_value,
+                                result_dtype=cube.dtype)
+
     def assertCubeData(self, cube1, cube2):
-        self.assertArrayEqual(cube1.data, cube2.data)
+        self.assertArrayEqual(self._real_data(cube1), self._real_data(cube2))
 
     @tests.skip_data
     def test_cube_pickle(self):
@@ -67,7 +75,7 @@ class TestPickle(tests.IrisTest):
             self.assertTrue(recon_cube.has_lazy_data())
             self.assertCML(recon_cube, ('cube_io', 'pickling', 'theta.cml'),
                            checksum=False)
-            self.assertCubeData(cube.copy(), recon_cube)
+            self.assertCubeData(cube, recon_cube)
 
     @tests.skip_data
     def test_cube_with_coord_points(self):


### PR DESCRIPTION
Fix a cube pickling roundtrip test that was not preserving lazy data and causing a spurious test failure. Bonus: test module now pep8 compliant!

Fixes part of #2398 