### PR TITLE
Fix a few more tests

### DIFF
--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -32,8 +32,6 @@ from iris.fileformats.netcdf import _load_cube
 from iris.tests import mock
 
 
-# XXX: TODO
-@tests.skip_biggus
 class TestFillValue(tests.IrisTest):
     def setUp(self):
         name = 'iris.fileformats.netcdf._assert_case_specific_facts'
@@ -46,64 +44,69 @@ class TestFillValue(tests.IrisTest):
         self.filename = 'DUMMY'
 
     def _make_cf_var(self, dtype):
-        variable = mock.Mock(spec=netCDF4.Variable, dtype=dtype)
+        variable = mock.Mock(spec=netCDF4.Variable,
+                             dtype=dtype)
         cf_var = mock.MagicMock(spec=iris.fileformats.cf.CFVariable,
-                                cf_data=variable, cf_name='DUMMY_VAR',
-                                cf_group=mock.Mock(), dtype=dtype,
-                                shape=mock.MagicMock())
+                                cf_data=variable,
+                                cf_name='DUMMY_VAR',
+                                cf_group=mock.Mock(),
+                                dtype=dtype,
+                                shape=(1,))
         return cf_var
 
     def _test(self, cf_var, expected_fill_value):
         cube = _load_cube(self.engine, self.cf, cf_var, self.filename)
-        self.assertEqual(cube._my_data.fill_value, expected_fill_value)
+        self.assertEqual(cube.fill_value, expected_fill_value)
 
     def test_from_attribute_dtype_f4(self):
         # A _FillValue attribute on the netCDF variable should end up as
         # the fill_value for the cube.
         dtype = np.dtype('f4')
+        fill_value = 9999.
         cf_var = self._make_cf_var(dtype)
-        cf_var.cf_data._FillValue = mock.sentinel.FILL_VALUE
-        self._test(cf_var, mock.sentinel.FILL_VALUE)
+        cf_var.cf_data._FillValue = fill_value
+        self._test(cf_var, fill_value)
 
     def test_from_default_dtype_f4(self):
         # Without an explicit _FillValue attribute on the netCDF
-        # variable, the fill value should be selected from the default
-        # netCDF fill values.
+        # variable, the fill value should be set to `None`.
         dtype = np.dtype('f4')
         cf_var = self._make_cf_var(dtype)
-        self._test(cf_var, netCDF4.default_fillvals['f4'])
+        self._test(cf_var, None)
 
     def test_from_attribute_dtype_i4(self):
         # A _FillValue attribute on the netCDF variable should end up as
         # the fill_value for the cube.
         dtype = np.dtype('i4')
+        fill_value = 9999
         cf_var = self._make_cf_var(dtype)
-        cf_var.cf_data._FillValue = mock.sentinel.FILL_VALUE
-        self._test(cf_var, mock.sentinel.FILL_VALUE)
+        cf_var.cf_data._FillValue = fill_value
+        self._test(cf_var, fill_value)
 
     def test_from_default_dtype_i4(self):
         # Without an explicit _FillValue attribute on the netCDF
-        # variable, the fill value should be selected from the default
-        # netCDF fill values.
+        # variable, the fill value should be set to `None`.
         dtype = np.dtype('i4')
         cf_var = self._make_cf_var(dtype)
-        self._test(cf_var, netCDF4.default_fillvals['i4'])
+        self._test(cf_var, None)
 
     def test_from_attribute_with_scale_offset(self):
         # The _FillValue attribute still takes priority even when an
         # offset/scale transformation takes place on the data.
         dtype = np.dtype('i2')
+        fill_value = 999
         cf_var = self._make_cf_var(dtype)
         cf_var.scale_factor = np.float64(1.5)
-        cf_var.cf_data._FillValue = mock.sentinel.FILL_VALUE
-        self._test(cf_var, mock.sentinel.FILL_VALUE)
+        cf_var.cf_data._FillValue = fill_value
+        self._test(cf_var, fill_value)
 
     def test_from_default_with_scale_offset(self):
-        # The fill value should be related to the *non-scaled* dtype.
+        # Without an explicit _FillValue attribute on the netCDF
+        # variable, the fill value should be set to `None`.
         dtype = np.dtype('i2')
         cf_var = self._make_cf_var(dtype)
         cf_var.scale_factor = np.float64(1.5)
-        self._test(cf_var, netCDF4.default_fillvals['i2'])
+        self._test(cf_var, None)
 
 
 class TestCoordAttributes(tests.IrisTest):
@@ -186,8 +189,6 @@ class TestCoordAttributes(tests.IrisTest):
             self.assertEqual(set(attributes.items()), set(expect))
 
 
-# XXX: TODO
-@tests.skip_biggus
 class TestCubeAttributes(tests.IrisTest):
     def setUp(self):
         this = 'iris.fileformats.netcdf._assert_case_specific_facts'
@@ -208,11 +209,11 @@ class TestCubeAttributes(tests.IrisTest):
         cf_attrs_unused = mock.Mock(return_value=attrs)
         cf_var = mock.MagicMock(spec=iris.fileformats.cf.CFVariable,
                                 dtype=np.dtype('i4'),
-                                cf_data=mock.Mock(),
+                                cf_data=mock.Mock(_FillValue=None),
                                 cf_name='DUMMY_VAR',
                                 cf_group=mock.Mock(),
                                 cf_attrs_unused=cf_attrs_unused,
-                                shape=mock.MagicMock())
+                                shape=(1,))
         return cf_var
 
     def test_flag_pass_thru(self):


### PR DESCRIPTION
Unskipped some more tests that were previously reliant on biggus.

Specifically, this means removing excessive mockism of some NetCDF tests and updated them to reflect changes to `cube` / `DataManager` API.

Fixes part of #2398