### PR TITLE
Fix rules test for _make_cube

### DIFF
--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -18,18 +18,20 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
 
-from iris.fileformats.rules import _make_cube
-import iris.fileformats.rules
+import warnings
+
+from iris.fileformats.rules import ConversionMetadata, _make_cube
 from iris.tests import mock
+import numpy as np
 
 
 class Test(tests.IrisTest):
-    @tests.skip_biggus
     def test_invalid_units(self):
         # Mock converter() function that returns an invalid
         # units string amongst the collection of other elements.
@@ -42,13 +44,15 @@ class Test(tests.IrisTest):
         cell_methods = None
         dim_coords_and_dims = None
         aux_coords_and_dims = None
-        metadata = iris.fileformats.rules.ConversionMetadata(
-            factories, references, standard_name, long_name, units, attributes,
-            cell_methods, dim_coords_and_dims, aux_coords_and_dims)
+        metadata = ConversionMetadata(factories, references,
+                                      standard_name, long_name, units,
+                                      attributes, cell_methods,
+                                      dim_coords_and_dims, aux_coords_and_dims)
         converter = mock.Mock(return_value=metadata)
 
-        field = mock.Mock()
-        with mock.patch('warnings.warn') as warn:
+        field = mock.Mock(core_data=lambda: np.arange(3.), bmdi=9999.)
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always")
             cube, factories, references = _make_cube(field, converter)
 
         # Check attributes dictionary is correctly populated.
@@ -57,9 +61,9 @@ class Test(tests.IrisTest):
         self.assertEqual(cube.attributes, expected_attributes)
 
         # Check warning was raised.
-        self.assertEqual(warn.call_count, 1)
-        warning_msg = warn.call_args[0][0]
-        self.assertIn('invalid units', warning_msg)
+        self.assertEqual(len(warn), 1)
+        exp_emsg = 'invalid units {!r}'.format(units)
+        six.assertRegex(self, str(warn[0].message), exp_emsg)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -18,7 +18,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -26,9 +25,11 @@ import iris.tests as tests
 
 import warnings
 
-from iris.fileformats.rules import ConversionMetadata, _make_cube
+from iris.fileformats.rules import ConversionMetadata
 from iris.tests import mock
 import numpy as np
+
+from iris.fileformats.rules import _make_cube
 
 
 class Test(tests.IrisTest):
@@ -63,7 +64,7 @@ class Test(tests.IrisTest):
         # Check warning was raised.
         self.assertEqual(len(warn), 1)
         exp_emsg = 'invalid units {!r}'.format(units)
-        six.assertRegex(self, str(warn[0].message), exp_emsg)
+        self.assertRegexpMatches(str(warn[0]), exp_emsg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove another biggus skipper, this time on a test that was causing a segfault. It appears the segfault was being caused when creating the cube with `core_data` described by an empty mock object.

I've also removed some needless mockism from the wider test that was being used to capture a raised warning. I've replaced the mockism with the warning capture and check code used widely elsewhere within Iris tests.

Part-fixes #2398. 