### PR TITLE
Use six.assertRegex to avoid Python 3 test method deprecation.

### DIFF
--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ import warnings
 import iris.tests as tests
 
 import numpy as np
+import six
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     has_supported_mercator_parameters
@@ -79,7 +80,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegexpMatches(str(warns[0]), 'Scale factor')
+        six.assertRegex(self, str(warns[0]), 'Scale factor')
 
     def test_invalid_standard_parallel(self):
         # Iris does not yet support standard parallels other than zero for
@@ -101,7 +102,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegexpMatches(str(warns[0]), 'Standard parallel')
+        six.assertRegex(self, str(warns[0]), 'Standard parallel')
 
     def test_invalid_false_easting(self):
         # Iris does not yet support false eastings other than zero for
@@ -123,7 +124,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegexpMatches(str(warns[0]), 'False easting')
+        six.assertRegex(self, str(warns[0]), 'False easting')
 
     def test_invalid_false_northing(self):
         # Iris does not yet support false northings other than zero for
@@ -145,7 +146,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegexpMatches(str(warns[0]), 'False northing')
+        six.assertRegex(self, str(warns[0]), 'False northing')
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ import warnings
 import iris.tests as tests
 
 import numpy as np
+import six
 
 from iris.coord_systems import Stereographic
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
@@ -81,7 +82,7 @@ class TestHasSupportedStereographicParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegexpMatches(str(warns[0]), 'Scale factor')
+        six.assertRegex(self, str(warns[0]), 'Scale factor')
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -23,6 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+import six
 import warnings
 
 from iris.fileformats.rules import ConversionMetadata
@@ -51,10 +52,10 @@ class Test(tests.IrisTest):
                                       dim_coords_and_dims, aux_coords_and_dims)
         converter = mock.Mock(return_value=metadata)
 
-        test_data = np.arange(3.)
-        field = mock.Mock(core_data=lambda: test_data,
+        data = np.arange(3.)
+        field = mock.Mock(core_data=lambda: data,
                           bmdi=9999.,
-                          realised_dtype=test_data.dtype)
+                          realised_dtype=data.dtype)
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
             cube, factories, references = _make_cube(field, converter)
@@ -67,7 +68,7 @@ class Test(tests.IrisTest):
         # Check warning was raised.
         self.assertEqual(len(warn), 1)
         exp_emsg = 'invalid units {!r}'.format(units)
-        self.assertRegexpMatches(str(warn[0]), exp_emsg)
+        six.assertRegex(self, str(warn[0]), exp_emsg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In contrast to what I said [here](https://github.com/SciTools/iris/pull/2557#discussion_r117057815), there *is* a point to using six.assertRegex,
as otherwise assertRegexpMatches in Python 3 gives "DeprecationWarning: Please use assertRegex instead."