### PR TITLE
Get cell method interval from t2 - t1 no lbtim.ia when loading pp

### DIFF
--- a/lib/iris/etc/pp_save_rules.txt
+++ b/lib/iris/etc/pp_save_rules.txt
@@ -79,7 +79,6 @@ IF
     scalar_coord(cm, 'forecast_period') is None
     scalar_coord(cm, 'forecast_reference_time') is None
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 0
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').points[0])
     pp.t2 = netcdftime.datetime(0, 0, 0)
@@ -91,7 +90,6 @@ IF
     not scalar_coord(cm, 'time').has_bounds()
     scalar_coord(cm, 'forecast_period') is not None
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 1
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').points[0])
     pp.t2 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').points[0] - scalar_coord(cm, 'forecast_period').points[0])
@@ -127,59 +125,6 @@ THEN
     pp.t2 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0,1])
     pp.lbft = scalar_coord(cm, 'time').units.convert(scalar_coord(cm, 'time').bounds[0, 1], 'hours since epoch') - scalar_coord(cm, 'forecast_reference_time').units.convert(scalar_coord(cm, 'forecast_reference_time').points[0], 'hours since epoch')
 
-IF
-    # XXX Note the repetition of the previous rule's constraints
-    # This can be addressed through REQUIRES/PROVIDES extensions
-    scalar_coord(cm, 'time') is not None
-    scalar_coord(cm, 'time').has_bounds()
-    scalar_coord(cm, 'clim_season') is None
-    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
-    scalar_cell_method(cm, 'mean', 'time') is not None
-    scalar_cell_method(cm, 'mean', 'time').intervals != ()
-    scalar_cell_method(cm, 'mean', 'time').intervals[0].endswith('hour')
-THEN
-    pp.lbtim.ia = int(scalar_cell_method(cm, 'mean', 'time').intervals[0][:-5])
-
-IF
-    # XXX Note the repetition of the previous rule's constraints
-    scalar_coord(cm, 'time') is not None
-    scalar_coord(cm, 'time').has_bounds()
-    scalar_coord(cm, 'clim_season') is None
-    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
-    scalar_cell_method(cm, 'mean', 'time') is None or scalar_cell_method(cm, 'mean', 'time').intervals == () or not scalar_cell_method(cm, 'mean', 'time').intervals[0].endswith('hour')
-THEN
-    pp.lbtim.ia = 0
-
-IF
-    # If the cell methods contain a minimum then overwrite lbtim.ia with this
-    # interval
-    scalar_coord(cm, 'time') is not None
-    scalar_coord(cm, 'time').has_bounds()
-    scalar_coord(cm, 'clim_season') is None
-    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
-    scalar_cell_method(cm, 'minimum', 'time') is not None
-    scalar_cell_method(cm, 'minimum', 'time').intervals != ()
-    scalar_cell_method(cm, 'minimum', 'time').intervals[0].endswith('hour')
-THEN
-    # set lbtim.ia with the integer part of the cell method's interval
-    # e.g. if interval is '24 hour' then lbtim.ia becomes 24
-    pp.lbtim.ia = int(scalar_cell_method(cm, 'minimum', 'time').intervals[0][:-5])
-
-IF
-    # If the cell methods contain a maximum then overwrite lbtim.ia with this
-    # interval
-    scalar_coord(cm, 'time') is not None
-    scalar_coord(cm, 'time').has_bounds()
-    scalar_coord(cm, 'clim_season') is None
-    scalar_coord(cm, 'forecast_period') is not None or scalar_coord(cm, 'forecast_reference_time') is not None
-    scalar_cell_method(cm, 'maximum', 'time') is not None
-    scalar_cell_method(cm, 'maximum', 'time').intervals != ()
-    scalar_cell_method(cm, 'maximum', 'time').intervals[0].endswith('hour')
-THEN
-    # set lbtim.ia with the integer part of the cell method's interval
-    # e.g. if interval is '1 hour' then lbtim.ia becomes 1
-    pp.lbtim.ia = int(scalar_cell_method(cm, 'maximum', 'time').intervals[0][:-5])
-
 #climatiological time mean - single year
 IF
     scalar_coord(cm, 'time') is not None
@@ -190,7 +135,6 @@ IF
     scalar_coord(cm, 'clim_season') is not None
     'clim_season' in cm.cell_methods[-1].coord_names
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 2
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0, 0])
     pp.t2 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0, 1])
@@ -208,7 +152,6 @@ IF
     'clim_season' in cm.cell_methods[-1].coord_names
     scalar_coord(cm, 'clim_season').points[0] == 'djf'
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 3
 
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0,0])
@@ -233,7 +176,6 @@ IF
     'clim_season' in cm.cell_methods[-1].coord_names
     scalar_coord(cm, 'clim_season').points[0] == 'mam'
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 3
 
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0,0])
@@ -258,7 +200,6 @@ IF
     'clim_season' in cm.cell_methods[-1].coord_names
     scalar_coord(cm, 'clim_season').points[0] == 'jja'
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 3
 
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0,0])
@@ -283,7 +224,6 @@ IF
     'clim_season' in cm.cell_methods[-1].coord_names
     scalar_coord(cm, 'clim_season').points[0] == 'son'
 THEN
-    pp.lbtim.ia = 0
     pp.lbtim.ib = 3
 
     pp.t1 = scalar_coord(cm, 'time').units.num2date(scalar_coord(cm, 'time').bounds[0,0])

--- a/lib/iris/fileformats/pp_rules.py
+++ b/lib/iris/fileformats/pp_rules.py
@@ -971,10 +971,10 @@ def _all_other_rules(f):
         zone_method = 'mean'
 
     if time_method is not None:
-        if f.lbtim.ia != 0:
-            intervals = '{} hour'.format(f.lbtim.ia)
-        else:
-            intervals = None
+        time_unit = f.time_unit('hours')
+        t1_num = time_unit.date2num(f.t1)
+        t2_num = time_unit.date2num(f.t2)
+        intervals = '{} hour'.format(t2_num - t1_num)
 
         if f.lbtim.ib == 2:
             # Aggregation over a period of time.


### PR DESCRIPTION
Before now, when loading a pp file/fieldsfile, we have used the lbtim.ia value to set the interval of the cell method. This is incorrect.

 :open_mouth: 

From the f03 documentation:
> for time aggregated fields IA is the time interval in hours between the individual fields from which the mean was computed

We had thought "time interval" referred to the period over which time-processing is being done but that is not the case! "time interval" refers to the sampling frequency aka how frequently the data is being sampled to generate the mean/accumulation/etc.

### Example
Say the UM is outputting a pressure field every hour. Some of these fields are aggregated so that the maximum over 12 hours is calculated and the resultant field is output as part of a fieldsfile/pp file. In this resultant file the field would have the values:
`lbtim.ia = 1` <- because the maximum was calculated from hourly data
`t2-t1 = 12 hours` <- because the maximum was taken over a 12 hour time interval
Previously this example file would have been loaded in as 
```
     Cell methods:
          mean: time (1 hour)
```
But it should be:
```
     Cell methods:
          mean: time (12 hour)
```

### This PR
The cell_method time interval should be calculated from the difference between T1 and T2 so this PR adds that.

N.B.  In this PR I have removed all saving to lbtim.ia as we don't encode that information in the cube so we can't save it out correctly.
