### PR TITLE
Restart doctests and example tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
   - TEST_TARGET=default
   - TEST_TARGET=default TEST_MINIMAL=true
   - TEST_TARGET=coding
+  - TEST_TARGET=example
+  - TEST_TARGET=doctest
 
 git:
   depth: 10000

--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -176,8 +176,8 @@ For example, to mask values that lie beyond the range of the original data:
    >>> scheme = iris.analysis.Linear(extrapolation_mode='mask')
    >>> new_column = column.interpolate(sample_points, scheme)
    >>> print(new_column.coord('altitude').points)
-   [           nan   494.44451904   588.88891602   683.33325195   777.77783203
-      872.222229     966.66674805  1061.11108398  1155.55541992            nan]
+   [-- 494.44451904296875 588.888916015625 683.333251953125 777.77783203125
+    872.2222290039062 966.666748046875 1061.111083984375 1155.555419921875 --]
 
 
 .. _caching_an_interpolator:

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -197,7 +197,14 @@ class Future(threading.local):
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
                           self.netcdf_no_unlimited, self.clip_latitudes)
 
+    deprecated_options = {}
+
     def __setattr__(self, name, value):
+        if name in self.deprecated_options:
+            reason = self.deprecated_options[name]
+            msg = ("the 'Future' object property {!r} is now deprecated. "
+                   "Please remove code which uses this.  {}")
+            warn_deprecated(msg.format(name, reason))
         if name not in self.__dict__:
             msg = "'Future' object has no attribute {!r}".format(name)
             raise AttributeError(msg)


### PR DESCRIPTION
Now that we are approaching the end of dask we need to restart doctests and extests on Travis, not least to ensure we haven't broken all of the docs on the dask branch!

Fixes #2460 