### PR TITLE
Ensure cube.transpose functionality

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2782,10 +2782,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         if new_order is None:
-            # Passing NumPy arrays as new_order works in NumPy but not in dask.
-            # Dask docs specify a list, so ensure a list is used.
-            new_order = list(np.arange(self.ndim)[::-1])
-        elif len(new_order) != self.ndim:
+            new_order = np.arange(self.ndim)[::-1]
+
+        # `new_order` must be an iterable for checking with `self.ndim`.
+        # Dask transpose only supports lists, so ensure `new_order` is
+        # always a list.
+        new_order = list(new_order)
+
+        if len(new_order) != self.ndim:
             raise ValueError('Incorrect number of dimensions.')
 
         # Transpose the data payload.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1926,6 +1926,5 @@ class Test_transpose(tests.IrisTest):
             self.cube.transpose([1])
 
 
-
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1880,20 +1880,51 @@ class TestCellMeasures(tests.IrisTest):
 
 
 class Test_transpose(tests.IrisTest):
+    def setUp(self):
+        self.data = np.arange(24).reshape(3, 2, 4)
+        self.cube = Cube(self.data)
+        self.lazy_cube = Cube(as_lazy_data(self.data))
+
     def test_lazy_data(self):
-        data = np.arange(12).reshape(3, 4)
-        cube = Cube(as_lazy_data(data))
+        cube = self.lazy_cube
         cube.transpose()
         self.assertTrue(cube.has_lazy_data())
-        self.assertArrayEqual(data.T, cube.data)
+        self.assertArrayEqual(self.data.T, cube.data)
 
-    def test_not_lazy_data(self):
-        data = np.arange(12).reshape(3, 4)
-        cube = Cube(data)
-        cube.transpose()
-        self.assertFalse(cube.has_lazy_data())
-        self.assertIs(data.base, cube.data.base)
-        self.assertArrayEqual(data.T, cube.data)
+    def test_real_data(self):
+        self.cube.transpose()
+        self.assertFalse(self.cube.has_lazy_data())
+        self.assertIs(self.data.base, self.cube.data.base)
+        self.assertArrayEqual(self.data.T, self.cube.data)
+
+    def test_real_data__new_order(self):
+        new_order = [2, 0, 1]
+        self.cube.transpose(new_order)
+        self.assertFalse(self.cube.has_lazy_data())
+        self.assertIs(self.data.base, self.cube.data.base)
+        self.assertArrayEqual(self.data.transpose(new_order), self.cube.data)
+
+    def test_lazy_data__new_order(self):
+        new_order = [2, 0, 1]
+        cube = self.lazy_cube
+        cube.transpose(new_order)
+        self.assertTrue(cube.has_lazy_data())
+        self.assertArrayEqual(self.data.transpose(new_order), cube.data)
+
+    def test_lazy_data__transpose_order_ndarray(self):
+        # Check that a transpose order supplied as an array does not trip up
+        # a dask transpose operation.
+        new_order = np.array([2, 0, 1])
+        cube = self.lazy_cube
+        cube.transpose(new_order)
+        self.assertTrue(cube.has_lazy_data())
+        self.assertArrayEqual(self.data.transpose(new_order), cube.data)
+
+    def test_bad_transpose_order(self):
+        exp_emsg = 'Incorrect number of dimensions'
+        with self.assertRaisesRegexp(ValueError, exp_emsg):
+            self.cube.transpose([1])
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In some cases (notably when calling `cube.slices` with slice dims specified in a different order to their order on the cube), `cube.transpose` could be called with a NumPy array specifying the `new_order` kwarg. This is not supported by `dask.array.transpose`.

This PR ensures that `new_order` is **always** a list, which the previous checks did not ensure, and adds tests for this behaviour.

Fixes #2579 and required for #2460/#2576 to proceed.