### PR TITLE
Save and load bools as bytes with valid_range (0, 1) in netCDF format

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-14_save_bools_as_bytes.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-14_save_bools_as_bytes.txt
@@ -1,0 +1,2 @@
+* It is now possible to save boolean data to netCDF format. The data are saved with a data type of 'byte', and a 'valid_range' attribute with value (0, 1).
+* NetCDF variables with data type 'byte', and a 'valid_range' attribute with value (0, 1) or 'valid_min' and 'valid_max' attributes with values 0 and 1 respectively, are interpreted as boolean values on load.

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1624,9 +1624,9 @@ fc_extras
         attr_units = get_attr_units(cf_coord_var, attributes)
 
         def cf_var_as_array(cf_var):
-            dtype = iris.fileformats.netcdf._get_actual_dtype(cf_var)
             fill_value = getattr(cf_var.cf_data, '_FillValue',
-                                 netCDF4.default_fillvals[dtype.str[1:]])
+                                 netCDF4.default_fillvals[cf_var.dtype.str[1:]])
+            dtype = iris.fileformats.netcdf._get_actual_dtype(cf_var)
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1624,9 +1624,13 @@ fc_extras
         attr_units = get_attr_units(cf_coord_var, attributes)
 
         def cf_var_as_array(cf_var):
-            fill_value = getattr(cf_var.cf_data, '_FillValue',
-                                 netCDF4.default_fillvals[cf_var.dtype.str[1:]])
             dtype = iris.fileformats.netcdf._get_actual_dtype(cf_var)
+            fill_value = getattr(
+                cf_var.cf_data,
+                '_FillValue',
+                netCDF4.default_fillvals.get(
+                    dtype.str[1:],
+                    np.ma.masked_array([], dtype=dtype).fill_value))
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1413,9 +1413,10 @@ class Saver(object):
         """
         if coord.has_bounds():
             # Get the values in a form which is valid for the file format.
-            bounds, valid_range = self._ensure_valid_dtype(coord.bounds,
-                                              'the bounds of coordinate',
-                                              coord)
+            bounds, valid_range = self._ensure_valid_dtype(
+                coord.bounds,
+                'the bounds of coordinate',
+                coord)
             n_bounds = bounds.shape[-1]
 
             if n_bounds == 2:
@@ -1626,8 +1627,9 @@ class Saver(object):
                 cf_name = cf_dimensions[0]
 
             # Get the values in a form which is valid for the file format.
-            points, valid_range = self._ensure_valid_dtype(coord.points, 'coordinate',
-                                              coord)
+            points, valid_range = self._ensure_valid_dtype(coord.points,
+                                                           'coordinate',
+                                                           coord)
 
             # Create the CF-netCDF variable.
             cf_var = self._dataset.createVariable(

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1387,6 +1387,9 @@ class Saver(object):
                                  self._dataset.file_format)
                 raise ValueError(msg)
             values = values.astype(np.int32)
+        # NetCDF does not support booleans, so save them as bytes.
+        if values.dtype == np.dtype('bool'):
+            values = values.astype(np.byte)
         return values
 
     def _create_cf_bounds(self, coord, cf_var, cf_name):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -493,13 +493,13 @@ def _set_attributes(attributes, key, value):
 
 def _get_actual_dtype(cf_var):
     # Check if we should interpret this data as boolean.
-    if (cf_var.dtype == np.byte and
+    if (cf_var.dtype == np.dtype('byte') and
             getattr(cf_var, 'scale_factor', 1) == 1 and
             getattr(cf_var, 'add_offset', 0) == 0 and
             (tuple(getattr(cf_var, 'valid_range', ())) == (0, 1) or
              getattr(cf_var, 'valid_min', None) == 0 and
              getattr(cf_var, 'valid_max', None) == 1)):
-        return np.bool
+        return np.dtype('bool')
     else:
         # Figure out what the eventual data type will be after any scale/offset
         # transforms.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1389,9 +1389,9 @@ class Saver(object):
             values = values.astype(np.int32)
         # NetCDF does not support booleans, so save them as bytes.
         valid_range = None
-        if values.dtype == np.dtype('bool'):
-            values = values.astype('byte')
-            valid_range = np.array([0, 1], 'byte')
+        if values.dtype == np.bool:
+            values = values.astype(np.byte)
+            valid_range = np.array([0, 1], np.byte)
         return values, valid_range
 
     def _create_cf_bounds(self, coord, cf_var, cf_name):

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -35,7 +35,7 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
-from iris.coords import CellMethod
+from iris.coords import AuxCoord, CellMethod
 from iris.cube import Cube, CubeList
 from iris.fileformats.netcdf import CF_CONVENTIONS_VERSION
 from iris.fileformats.netcdf import Saver
@@ -427,6 +427,26 @@ class TestScalarCube(tests.IrisTest):
             iris.save(cube, fout)
             scalar_cube = iris.load_cube(fout)
             self.assertEqual(scalar_cube.name(), 'scalar_cube')
+
+
+class TestBooleanData(tests.IrisTest):
+    def test_boolean_data_save_load(self):
+        coord = AuxCoord([False, True], long_name='bool_coord')
+        cube = Cube([True, False], long_name='bool_cube',
+                    aux_coords_and_dims=[(coord, 0)])
+        valid_range_attrs = {'valid_range', 'valid_min', 'valid_max'}
+        with self.temp_filename(suffix='.nc') as fout:
+            iris.save(cube, fout)
+            bool_cube = iris.load_cube(fout)
+            bool_coord = bool_cube.coord('bool_coord')
+            self.assertEqual(bool_cube.dtype, np.dtype('bool'))
+            self.assertArrayEqual(bool_cube.data, [True, False])
+            self.assertEqual(bool_coord.dtype, np.dtype('bool'))
+            self.assertArrayEqual(bool_coord.points, [False, True])
+            self.assertEqual(set(bool_cube.attributes) & valid_range_attrs,
+                             set())
+            self.assertEqual(set(bool_coord.attributes) & valid_range_attrs,
+                             set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bools are not supported in netCDF, and attempting to save a cube with with boolean data raises and error. This PR causes them to be saved as bytes instead.