### PR TITLE
Maintain lazy bounds in Aux Factory derivation

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -187,7 +187,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         # Transpose to be consistent with the Cube.
         sorted_pairs = sorted(enumerate(dims), key=lambda pair: pair[1])
         transpose_order = [pair[0] for pair in sorted_pairs] + [len(dims)]
-        bounds = coord.bounds
+        bounds = coord.core_bounds()
         if dims:
             bounds = bounds.transpose(transpose_order)
 


### PR DESCRIPTION
If you print a cube with a bounded derived coordinate it realises the lazy bounds of the coordinates from which the derived coordinate is derived: :scream: 

```python
>>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))
>>> aux_coord = cube.coord('sigma')
>>> print aux_coord.has_lazy_points()
True
>>> print aux_coord.has_lazy_bounds()
True

>>> print cube

>>> print aux_coord.has_lazy_points()
True
>>> print aux_coord.has_lazy_bounds()
False
```

More accurately, printing a cube with a derived (bounded) coordinate triggers the deferred construction of the derived coordinate. If this derived coordinate is bounded then an oversight in the code that calculates the derived coordinate from the dependency coordinates, such as `sigma` in the example above, would cause the bounds to be accessed directly and so realise the bounds.