### PR TITLE
Lazy bounds test

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -170,7 +170,8 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 dependency_dims[key] = coord_dims_func(coord)
         return dependency_dims
 
-    def _nd_bounds(self, coord, dims, ndim):
+    @staticmethod
+    def _nd_bounds(coord, dims, ndim):
         """
         Returns the coord's bounds in Cube-orientation and
         broadcastable to N dimensions.

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -187,7 +187,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         # Transpose to be consistent with the Cube.
         sorted_pairs = sorted(enumerate(dims), key=lambda pair: pair[1])
         transpose_order = [pair[0] for pair in sorted_pairs] + [len(dims)]
-        bounds = coord.bounds
+        bounds = coord.core_bounds()
         if dims:
             bounds = bounds.transpose(transpose_order)
 

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -255,16 +255,6 @@ class TestAuxCoordCreation(tests.IrisTest):
                   ", standard_name='air_temperature', units=Unit('kelvin'))"
                   )
         self.assertEqual(result, str(a))
-
-    @tests.skip_data
-    def test_lazy_bounds(self):
-        # Make sure that bounds arrays loaded as lazy do not get realised
-        # when the cube is printed.
-        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
-                                                   'small_theta_colpex.nc']))
-        self.assertTrue(cube.coord('sigma').has_lazy_bounds())
-        printed_cube = str(cube)
-        self.assertTrue(cube.coord('sigma').has_lazy_bounds())
         
     def test_string_coord_equality(self):
         b = iris.coords.AuxCoord(['Jan', 'Feb', 'March'], units='no_unit')

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -256,6 +256,7 @@ class TestAuxCoordCreation(tests.IrisTest):
                   )
         self.assertEqual(result, str(a))
 
+    @tests.skip_data
     def test_lazy_bounds(self):
         # Make sure that bounds arrays loaded as lazy do not get realised
         # when the cube is printed.

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -255,6 +255,13 @@ class TestAuxCoordCreation(tests.IrisTest):
                   ", standard_name='air_temperature', units=Unit('kelvin'))"
                   )
         self.assertEqual(result, str(a))
+
+    def test_lazy_bounds(self):
+        # Make sure that bounds arrays loaded as lazy do not get realised
+        # by the loading process.
+        cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))
+        cube
+        self.assertTrue(cube.coord('sigma').has_lazy_bounds())
         
     def test_string_coord_equality(self):
         b = iris.coords.AuxCoord(['Jan', 'Feb', 'March'], units='no_unit')

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -258,9 +258,11 @@ class TestAuxCoordCreation(tests.IrisTest):
 
     def test_lazy_bounds(self):
         # Make sure that bounds arrays loaded as lazy do not get realised
-        # by the loading process.
-        cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))
-        cube
+        # when the cube is printed.
+        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
+                                                   'small_theta_colpex.nc']))
+        self.assertTrue(cube.coord('sigma').has_lazy_bounds())
+        printed_cube = str(cube)
         self.assertTrue(cube.coord('sigma').has_lazy_bounds())
         
     def test_string_coord_equality(self):

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -34,7 +34,7 @@ from iris.aux_factory import AuxCoordFactory
 
 
 class Test__nd_points(tests.IrisTest):
-    def test_numpy_scalar_cooord(self):
+    def test_numpy_scalar_coord(self):
         points = np.arange(1)
         coord = iris.coords.AuxCoord(points)
         result = AuxCoordFactory._nd_points(coord, (), 2)
@@ -79,6 +79,59 @@ class Test__nd_points(tests.IrisTest):
         expected = raw_points.T[np.newaxis, np.newaxis, ..., np.newaxis]
         self.assertArrayEqual(result, expected)
 
+
+
+class Test__nd_bounds(tests.IrisTest):
+    def test_numpy_scalar_coord(self):
+        bounds = np.arange(2).reshape(1, 2)
+        coord = iris.coords.AuxCoord(np.arange(1), bounds=bounds)
+        result = AuxCoordFactory._nd_bounds(coord, (), 2)
+        expected = bounds[np.newaxis]
+        self.assertArrayEqual(result, expected)
+
+    def test_numpy_simple(self):
+        points = np.arange(12).reshape(4, 3)
+        bounds = np.arange(24).reshape(4, 3, 2)
+        coord = iris.coords.AuxCoord(points, bounds=bounds)
+        result = AuxCoordFactory._nd_bounds(coord, (0, 1), 2)
+        expected = bounds
+        self.assertArrayEqual(result, expected)
+
+    def test_numpy_complex(self):
+        points = np.arange(12).reshape(4, 3)
+        bounds = np.arange(24).reshape(4, 3, 2)
+        coord = iris.coords.AuxCoord(points, bounds=bounds)
+        result = AuxCoordFactory._nd_bounds(coord, (3, 2), 5)
+        expected = bounds.T[np.newaxis, np.newaxis, ..., np.newaxis]
+        self.assertArrayEqual(result, expected)
+
+    def test_lazy_simple(self):
+        raw_points = np.arange(12).reshape(4, 3)
+        points = as_lazy_data(raw_points, 1)
+        raw_bounds = np.arange(24).reshape(4, 3, 2)
+        bounds = as_lazy_data(raw_bounds, 1)
+        coord = iris.coords.AuxCoord(points, bounds=bounds)
+        self.assertTrue(is_lazy_data(coord.core_bounds()))
+        result = AuxCoordFactory._nd_bounds(coord, (0, 1), 2)
+        # Check we haven't triggered the loading of the coordinate values.
+        self.assertTrue(is_lazy_data(coord.core_bounds()))
+        self.assertTrue(is_lazy_data(result))
+        expected = raw_bounds
+        self.assertArrayEqual(result, expected)
+
+    def test_lazy_complex(self):
+        raw_points = np.arange(12).reshape(4, 3)
+        points = as_lazy_data(raw_points, 1)
+        raw_bounds = np.arange(24).reshape(4, 3, 2)
+        bounds = as_lazy_data(raw_bounds, 1)
+        coord = iris.coords.AuxCoord(points, bounds=bounds)
+        self.assertTrue(is_lazy_data(coord.core_bounds()))
+        result = AuxCoordFactory._nd_bounds(coord, (3, 2), 5)
+        # Check we haven't triggered the loading of the coordinate values.
+        self.assertTrue(is_lazy_data(coord.core_bounds()))
+        self.assertTrue(is_lazy_data(result))
+        expected = raw_bounds.T[np.newaxis, np.newaxis, ..., np.newaxis]
+        self.assertArrayEqual(result, expected)
 
 @tests.skip_data
 class Test_lazy_aux_coords(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -80,5 +80,27 @@ class Test__nd_points(tests.IrisTest):
         self.assertArrayEqual(result, expected)
 
 
+@tests.skip_data
+class Test_lazy_aux_coords(tests.IrisTest):
+    def test_lazy_coord_loading(self):
+        # Test that points and bounds arrays stay lazy upon cube loading
+        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
+                                                   'small_theta_colpex.nc']))
+        for coord in cube.aux_coords:
+            self.assertTrue(coord.has_lazy_points())
+            if coord.has_bounds():
+                self.assertTrue(coord.has_lazy_bounds())
+
+    def test_lazy_coord_printing(self):
+        # Test that points and bounds arrays stay lazy upon cube printing
+        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
+                                                   'small_theta_colpex.nc']))
+        printed_cube = str(cube)
+        for coord in cube.aux_coords:
+            self.assertTrue(coord.has_lazy_points())
+            if coord.has_bounds():
+                self.assertTrue(coord.has_lazy_bounds())
+
+
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -82,21 +82,22 @@ class Test__nd_points(tests.IrisTest):
 
 @tests.skip_data
 class Test_lazy_aux_coords(tests.IrisTest):
+    def setUp(self):
+        self.cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
+                                                   'small_theta_colpex.nc']))
+
     def test_lazy_coord_loading(self):
         # Test that points and bounds arrays stay lazy upon cube loading
-        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
-                                                   'small_theta_colpex.nc']))
-        for coord in cube.aux_coords:
+        for coord in self.cube.aux_coords and self.cube.derived_coords:
             self.assertTrue(coord.has_lazy_points())
             if coord.has_bounds():
                 self.assertTrue(coord.has_lazy_bounds())
 
     def test_lazy_coord_printing(self):
         # Test that points and bounds arrays stay lazy upon cube printing
-        cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
-                                                   'small_theta_colpex.nc']))
+        cube = self.cube
         printed_cube = str(cube)
-        for coord in cube.aux_coords:
+        for coord in cube.aux_coords and cube.derived_coords:
             self.assertTrue(coord.has_lazy_points())
             if coord.has_bounds():
                 self.assertTrue(coord.has_lazy_bounds())

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -83,8 +83,9 @@ class Test__nd_points(tests.IrisTest):
 @tests.skip_data
 class Test_lazy_aux_coords(tests.IrisTest):
     def setUp(self):
-        self.cube = iris.load_cube(tests.get_data_path(['NetCDF', 'testing',
-                                                   'small_theta_colpex.nc']))
+        self.cube = iris.load_cube(tests.get_data_path
+                                   (['NetCDF', 'testing',
+                                     'small_theta_colpex.nc']))
 
     def test_lazy_coord_loading(self):
         # Test that points and bounds arrays stay lazy upon cube loading


### PR DESCRIPTION
This is a new PR to replace https://github.com/SciTools/iris/pull/2588.  This entails the one-line change which fixes the realization of derived coord lazy bounds upon printing the cube, along with a test to ensure its effectiveness.