### PR TITLE
added Note to documentation about iris.load

### DIFF
--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -130,6 +130,11 @@ star wildcards can be used::
     cubes = iris.load(filename)
 
 
+.. note::
+
+     The cubes returned will not necessarily be in the same order as the 
+     order of the filenames.
+
 Constrained loading
 -----------------------
 Given a large dataset, it is possible to restrict or constrain the load 


### PR DESCRIPTION
When loading multiple files with a single call to iris.load, the cubes returned are not in the same order as the input list of filenames.
I could find nothing in the documentation to explain this, hence this PR which simply adds 2 lines to the documentation.