### PR TITLE
Update the documentation's copyright year... it's 2017.

### DIFF
--- a/docs/iris/src/_templates/layout.html
+++ b/docs/iris/src/_templates/layout.html
@@ -36,7 +36,7 @@
     <div class="footer">
     <p style="text-align: left; float: left; margin: 0px; padding: 0 0 0 5px;">Documentation licensed under the <a href="http://reference.data.gov.uk/id/open-government-licence" rel="license">Open Government Licence</a></p>
     {%- if show_copyright %}
-        &copy; <a href="{{ pathto('copyright') }}">British Crown Copyright</a> 2010 - 2014, Met Office
+        &copy; <a href="{{ pathto('copyright') }}">British Crown Copyright</a> {{ copyright_years }}, Met Office
     {%- endif %}
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -31,7 +31,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import datetime
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -46,8 +48,7 @@ sys.path.append(os.path.abspath(os.path.join('developers_guide')))
 
 # Temporary value for use by LaTeX and 'man' output.
 # Deleted at the end of the module.
-_authors = ('Byron Blay', 'Ed Campbell', 'Philip Elson', 'Richard Hattersley',
-            'Bill Little')
+_authors = ('Iris developers')
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
@@ -98,7 +99,8 @@ master_doc = 'contents'
 project = u'Iris'
 # define the copyright information for latex builds. Note, for html builds,
 # the copyright exists directly inside "_templates/layout.html"
-copyright = u'British Crown Copyright 2010 - 2015, Met Office'
+upper_copy_year = datetime.datetime.now().year
+copyright = u'British Crown Copyright 2010 - {}, Met Office'.format(upper_copy_year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,6 +187,8 @@ html_theme = 'sphinxdoc'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #html_theme_options = {}
+
+html_context = {'copyright_years': '2010 - {}'.format(upper_copy_year)}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = []


### PR DESCRIPTION
Tested to include the year when building.