### PR TITLE
Check DimCoord poins and bounds before setting

### DIFF
--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -316,7 +316,7 @@ class TestDimCoordCreation(tests.IrisTest):
         
     def test_dim_coord_restrictions(self):
         # 1d
-        with self.assertRaisesRegexp(ValueError, 'must be 1-dim'):
+        with self.assertRaisesRegexp(ValueError, 'must be scalar or 1-dim'):
             iris.coords.DimCoord([[1, 2, 3], [4, 5, 6]])
         # monotonic
         with self.assertRaisesRegexp(ValueError, 'must be strictly monotonic'):
@@ -326,7 +326,7 @@ class TestDimCoordCreation(tests.IrisTest):
                                      'monotonicity.*consistent.*all bounds'):
             iris.coords.DimCoord([1, 2, 3], bounds=[[1, 12], [2, 9], [3, 6]])
         # shapes of points and bounds
-        msg = 'Bounds shape must be compatible with points shape'
+        msg = 'The shape of the bounds array should be'
         with self.assertRaisesRegexp(ValueError, msg):
             iris.coords.DimCoord([1, 2, 3], bounds=[0.5, 1.5, 2.5, 3.5])
         # another example of shapes of points and bounds

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -84,7 +84,7 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
         bds_shape = list(self.bds_real.shape)
         bds_shape[0] += 1
         bds_wrong = np.zeros(bds_shape)
-        msg = 'Bounds shape must be compatible with points shape'
+        msg = 'The shape of the bounds array should be'
         with self.assertRaisesRegexp(ValueError, msg):
             DimCoord(self.pts_real, bounds=bds_wrong)
 
@@ -405,7 +405,7 @@ class Test_points__setter(tests.IrisTest, DimCoordTestMixin):
         self.assertArrayEqual(coord.points, points)
 
     def test_fail_not_monotonic(self):
-        # Setting real points requires matching shape.
+        # Setting real points requires that they are monotonic.
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
         msg = 'strictly monotonic'
         with self.assertRaisesRegexp(ValueError, msg):
@@ -451,13 +451,13 @@ class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
     def test_fail_bad_shape(self):
         # Setting real points requires matching shape.
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
-        msg = 'Bounds shape must be compatible with points shape'
+        msg = 'The shape of the bounds array should be'
         with self.assertRaisesRegexp(ValueError, msg):
             coord.bounds = np.array([1.0, 2.0, 3.0])
         self.assertArrayEqual(coord.bounds, self.bds_real)
 
     def test_fail_not_monotonic(self):
-        # Setting real points requires matching shape.
+        # Setting real bounds requires that they are monotonic.
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
         msg = 'strictly monotonic'
         with self.assertRaisesRegexp(ValueError, msg):

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -397,10 +397,20 @@ class Test_points__setter(tests.IrisTest, DimCoordTestMixin):
 
     def test_fail_bad_shape(self):
         # Setting real points requires matching shape.
-        coord = DimCoord([1.0, 2.0])
+        points = [1.0, 2.0]
+        coord = DimCoord(points)
         msg = 'Require data with shape \(2,\), got \(3,\)'
         with self.assertRaisesRegexp(ValueError, msg):
             coord.points = np.array([1.0, 2.0, 3.0])
+        self.assertArrayEqual(coord.points, points)
+
+    def test_fail_not_monotonic(self):
+        # Setting real points requires matching shape.
+        coord = DimCoord(self.pts_real, bounds=self.bds_real)
+        msg = 'strictly monotonic'
+        with self.assertRaisesRegexp(ValueError, msg):
+            coord.points = np.array([3.0, 1.0, 2.0])
+        self.assertArrayEqual(coord.points, self.pts_real)
 
     def test_set_lazy(self):
         # Setting new lazy points realises them.
@@ -444,6 +454,15 @@ class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
         msg = 'Bounds shape must be compatible with points shape'
         with self.assertRaisesRegexp(ValueError, msg):
             coord.bounds = np.array([1.0, 2.0, 3.0])
+        self.assertArrayEqual(coord.bounds, self.bds_real)
+
+    def test_fail_not_monotonic(self):
+        # Setting real points requires matching shape.
+        coord = DimCoord(self.pts_real, bounds=self.bds_real)
+        msg = 'strictly monotonic'
+        with self.assertRaisesRegexp(ValueError, msg):
+            coord.bounds = np.array([[3.0, 2.0], [1.0, 0.0], [2.0, 1.0]])
+        self.assertArrayEqual(coord.bounds, self.bds_real)
 
     def test_set_lazy(self):
         # Setting new lazy bounds realises them.


### PR DESCRIPTION
Setting DimCoord points/bounds to an array that doesn't meet the requirements raises an exception, but the points/bounds array is still set on the coordinate. This PR stops that happening by doing the requirements checks _before_ modifying the coord with the new array.

I've modified the functions `_new_points_requirements()` and `_new_bounds_requirements()` so that they check the slightly more lenient requirements of the array which is passed in, rather than those of the actual array assigned, i.e, the points value passed can be a scalar, and the bounds value can be 1D if there is only a single point.