### PR TITLE
Correct STASH regular expression

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -25,7 +25,7 @@ imagehash
 requests
 
 # Optional iris dependencies
-ecmwf_grib
+python-ecmwf_grib
 esmpy>=7.0
 gdal
 libmo_unpack

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -305,7 +305,8 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         if not isinstance(msi, six.string_types):
             raise TypeError('Expected STASH code MSI string, got %r' % (msi,))
 
-        msi_match = re.match('^\s*m(.*)s(.*)i(.*)\s*$', msi, re.IGNORECASE)
+        msi_match = re.match('^\s*m(\d{2})s(\d{2})i(\d{3})\s*$', msi,
+                             re.IGNORECASE)
 
         if msi_match is None:
             raise ValueError('Expected STASH code MSI string "mXXsXXiXXX", '

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -305,8 +305,7 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         if not isinstance(msi, six.string_types):
             raise TypeError('Expected STASH code MSI string, got %r' % (msi,))
 
-        msi_match = re.match('^\s*m(\d{2})s(\d{2})i(\d{3})\s*$', msi,
-                             re.IGNORECASE)
+        msi_match = re.match('^\s*m(.*)s(.*)i(.*)\s*$', msi, re.IGNORECASE)
 
         if msi_match is None:
             raise ValueError('Expected STASH code MSI string "mXXsXXiXXX", '

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -305,7 +305,7 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         if not isinstance(msi, six.string_types):
             raise TypeError('Expected STASH code MSI string, got %r' % (msi,))
 
-        msi_match = re.match('^\s*m(\d{2})s(\d{2})i(\d{3})\s*$', msi,
+        msi_match = re.match('^\s*m(\d{2}|\?{2})s(\d{2})i(\d{3})\s*$', msi,
                              re.IGNORECASE)
 
         if msi_match is None:

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -305,8 +305,9 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         if not isinstance(msi, six.string_types):
             raise TypeError('Expected STASH code MSI string, got %r' % (msi,))
 
-        msi_match = re.match('^\s*m(\d{2}|\?{2})s(\d{2})i(\d{3})\s*$', msi,
-                             re.IGNORECASE)
+        msi_match = re.match(
+            '^\s*m(\d{2}|\?{2})s(\d{2}|\?{2})i(\d{3}|\?{3})\s*$', msi,
+            re.IGNORECASE)
 
         if msi_match is None:
             raise ValueError('Expected STASH code MSI string "mXXsXXiXXX", '

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -64,8 +64,10 @@ class TestPPStash(tests.IrisTest):
 
     def test_illegal_stash_str_range(self):
         self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm00s02i003')
+        self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm??s02i003')
         self.assertNotEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm01s02i003')
         self.assertEqual('m00s02i003', iris.fileformats.pp.STASH(0, 2, 3))
+        self.assertEqual('m??s02i003', iris.fileformats.pp.STASH(0, 2, 3))
         self.assertNotEqual('m01s02i003', iris.fileformats.pp.STASH(0, 2, 3))
 
     def test_illegal_stash_stash_range(self):

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -76,74 +76,36 @@ class TestPPStash(tests.IrisTest):
         self.assertEqual(iris.fileformats.pp.STASH(100, 2, 3), iris.fileformats.pp.STASH(999, 2, 3))
 
     def test_illegal_stash_format(self):
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'abc')
-        with self.assertRaises(ValueError):
-            self.assertEqual('abc', iris.fileformats.pp.STASH(1, 2, 3))
+        test_values = (
+            ('abc', (1, 2, 3)),
+            ('mlotstmin', (1, 2, 3)),
+            ('m1s2i3', (1, 2, 3)),
+            ('m1s2i3', (2, 3, 4)),
+            ('m01s2i3', (1, 2, 3)),
+            ('m01s2i3', (2, 3, 4)),
+            ('m01s02i3', (1, 2, 3)),
+            ('m01s02i3', (2, 3, 4)),
+            ('m01s02003', (1, 2, 3)),
+            ('m100s02i003', (100, 2, 3)),
+            ('m01s02i0000000003', (1, 2, 3)),
+            ('m01s02i0000000003', (2, 3, 4)),
+            )
 
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'mlotstmin')
-        with self.assertRaises(ValueError):
-            self.assertEqual('mlotstmin', iris.fileformats.pp.STASH(1, 2, 3))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02003')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m01s02003', iris.fileformats.pp.STASH(1, 2, 3))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(100, 2, 3), 'm100s02i003')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m100s02i003', iris.fileformats.pp.STASH(100, 2, 3))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i0000000003')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m01s02i0000000003', iris.fileformats.pp.STASH(1, 2, 3))
-        with self.assertRaises(ValueError):
-            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i0000000003')
-        with self.assertRaises(ValueError):
-            self.assertNotEqual('m01s02i0000000003', iris.fileformats.pp.STASH(2, 3, 4))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i3')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m01s02i3', iris.fileformats.pp.STASH(1, 2, 3))
-        with self.assertRaises(ValueError):
-            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i3')
-        with self.assertRaises(ValueError):
-            self.assertNotEqual('m01s02i3', iris.fileformats.pp.STASH(2, 3, 4))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s2i3')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m01s2i3', iris.fileformats.pp.STASH(1, 2, 3))
-        with self.assertRaises(ValueError):
-            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s2i3')
-        with self.assertRaises(ValueError):
-            self.assertNotEqual('m01s2i3', iris.fileformats.pp.STASH(2, 3, 4))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm1s2i3')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m1s2i3', iris.fileformats.pp.STASH(1, 2, 3))
-        with self.assertRaises(ValueError):
-            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm1s2i3')
-        with self.assertRaises(ValueError):
-            self.assertNotEqual('m1s2i3', iris.fileformats.pp.STASH(2, 3, 4))
+        for (test_value, reference) in test_values:
+            msg = 'Expected STASH code .* {!r}'.format(test_value)
+            with self.assertRaisesRegexp(ValueError, msg):
+                test_value == iris.fileformats.pp.STASH(*reference)
 
     def test_illegal_stash_type(self):
-        with self.assertRaises(TypeError):
-            self.assertEqual(iris.fileformats.pp.STASH.from_msi(102003), 'm01s02i003')
+        test_values = (
+            (102003, 'm01s02i003'),
+            (['m01s02i003'], 'm01s02i003'),
+            )
 
-        with self.assertRaises(TypeError):
-            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi(102003))
-
-        with self.assertRaises(TypeError):
-            self.assertEqual(iris.fileformats.pp.STASH.from_msi(['m01s02i003']), 'm01s02i003')
-
-        with self.assertRaises(TypeError):
-            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi(['m01s02i003']))
+        for (test_value, reference) in test_values:
+            msg = 'Expected STASH code .* {!r}'.format(test_value)
+            with self.assertRaisesRegexp(TypeError, msg):
+                iris.fileformats.pp.STASH.from_msi(test_value) == reference
 
     def test_stash_lbuser(self):
         stash = iris.fileformats.pp.STASH(2, 32, 456)

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -110,6 +110,11 @@ class TestPPStash(tests.IrisTest):
             self.assertEqual('abc', iris.fileformats.pp.STASH(1, 2, 3))
 
         with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'mlotstmin')
+        with self.assertRaises(ValueError):
+            self.assertEqual('mlotstmin', iris.fileformats.pp.STASH(1, 2, 3))
+
+        with self.assertRaises(ValueError):
             self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02003')
         with self.assertRaises(ValueError):
             self.assertEqual('m01s02003', iris.fileformats.pp.STASH(1, 2, 3))

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -58,45 +58,11 @@ class TestPPStash(tests.IrisTest):
         self.assertNotEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm02s03i004')
         self.assertNotEqual('m02s03i004', iris.fileformats.pp.STASH(1, 2, 3))
 
-    def test_irregular_stash_str(self):
-        self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i0000000003')
-        self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i3')
-        self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s2i3')
-        self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm1s2i3')
-
-        self.assertEqual('m01s02i0000000003', iris.fileformats.pp.STASH(1, 2, 3))
-        self.assertEqual('m01s02i3', iris.fileformats.pp.STASH(1, 2, 3))
-        self.assertEqual('m01s2i3', iris.fileformats.pp.STASH(1, 2, 3))
-        self.assertEqual('m1s2i3', iris.fileformats.pp.STASH(1, 2, 3))
-
-        self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i0000000003')
-        self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i3')
-        self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s2i3')
-        self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm1s2i3')
-
-        self.assertNotEqual('m01s02i0000000003', iris.fileformats.pp.STASH(2, 3, 4))
-        self.assertNotEqual('m01s02i3', iris.fileformats.pp.STASH(2, 3, 4))
-        self.assertNotEqual('m01s2i3', iris.fileformats.pp.STASH(2, 3, 4))
-        self.assertNotEqual('m1s2i3', iris.fileformats.pp.STASH(2, 3, 4))
-
-        self.assertEqual(iris.fileformats.pp.STASH.from_msi('M01s02i003'), 'm01s02i003')
-        self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi('M01s02i003'))
-
     def test_illegal_stash_str_range(self):
-        self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm??s02i003')
-        self.assertNotEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm01s02i003')
-        self.assertEqual('m??s02i003', iris.fileformats.pp.STASH(0, 2, 3))
-        self.assertNotEqual('m01s02i003', iris.fileformats.pp.STASH(0, 2, 3))
-
-        self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm??s02i003')
         self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm00s02i003')
-        self.assertEqual('m??s02i003', iris.fileformats.pp.STASH(0, 2, 3))
+        self.assertNotEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm01s02i003')
         self.assertEqual('m00s02i003', iris.fileformats.pp.STASH(0, 2, 3))
-
-        self.assertEqual(iris.fileformats.pp.STASH(100, 2, 3), 'm??s02i003')
-        self.assertEqual(iris.fileformats.pp.STASH(100, 2, 3), 'm100s02i003')
-        self.assertEqual('m??s02i003', iris.fileformats.pp.STASH(100, 2, 3))
-        self.assertEqual('m100s02i003', iris.fileformats.pp.STASH(100, 2, 3))
+        self.assertNotEqual('m01s02i003', iris.fileformats.pp.STASH(0, 2, 3))
 
     def test_illegal_stash_stash_range(self):
         self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), iris.fileformats.pp.STASH(0, 2, 3))
@@ -118,6 +84,52 @@ class TestPPStash(tests.IrisTest):
             self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02003')
         with self.assertRaises(ValueError):
             self.assertEqual('m01s02003', iris.fileformats.pp.STASH(1, 2, 3))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(100, 2, 3), 'm100s02i003')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m100s02i003', iris.fileformats.pp.STASH(100, 2, 3))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i0000000003')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m01s02i0000000003', iris.fileformats.pp.STASH(1, 2, 3))
+        with self.assertRaises(ValueError):
+            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i0000000003')
+        with self.assertRaises(ValueError):
+            self.assertNotEqual('m01s02i0000000003', iris.fileformats.pp.STASH(2, 3, 4))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s02i3')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m01s02i3', iris.fileformats.pp.STASH(1, 2, 3))
+        with self.assertRaises(ValueError):
+            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s02i3')
+        with self.assertRaises(ValueError):
+            self.assertNotEqual('m01s02i3', iris.fileformats.pp.STASH(2, 3, 4))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm01s2i3')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m01s2i3', iris.fileformats.pp.STASH(1, 2, 3))
+        with self.assertRaises(ValueError):
+            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm01s2i3')
+        with self.assertRaises(ValueError):
+            self.assertNotEqual('m01s2i3', iris.fileformats.pp.STASH(2, 3, 4))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm1s2i3')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m1s2i3', iris.fileformats.pp.STASH(1, 2, 3))
+        with self.assertRaises(ValueError):
+            self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm1s2i3')
+        with self.assertRaises(ValueError):
+            self.assertNotEqual('m1s2i3', iris.fileformats.pp.STASH(2, 3, 4))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(iris.fileformats.pp.STASH.from_msi('M01s02i003'), 'm01s02i003')
+        with self.assertRaises(ValueError):
+            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi('M01s02i003'))
 
     def test_illegal_stash_type(self):
         with self.assertRaises(TypeError):

--- a/lib/iris/tests/test_pp_stash.py
+++ b/lib/iris/tests/test_pp_stash.py
@@ -58,6 +58,10 @@ class TestPPStash(tests.IrisTest):
         self.assertNotEqual(iris.fileformats.pp.STASH(1, 2, 3), 'm02s03i004')
         self.assertNotEqual('m02s03i004', iris.fileformats.pp.STASH(1, 2, 3))
 
+    def test_irregular_stash_str(self):
+        self.assertEqual(iris.fileformats.pp.STASH.from_msi('M01s02i003'), 'm01s02i003')
+        self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi('M01s02i003'))
+
     def test_illegal_stash_str_range(self):
         self.assertEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm00s02i003')
         self.assertNotEqual(iris.fileformats.pp.STASH(0, 2, 3), 'm01s02i003')
@@ -125,11 +129,6 @@ class TestPPStash(tests.IrisTest):
             self.assertNotEqual(iris.fileformats.pp.STASH(2, 3, 4), 'm1s2i3')
         with self.assertRaises(ValueError):
             self.assertNotEqual('m1s2i3', iris.fileformats.pp.STASH(2, 3, 4))
-
-        with self.assertRaises(ValueError):
-            self.assertEqual(iris.fileformats.pp.STASH.from_msi('M01s02i003'), 'm01s02i003')
-        with self.assertRaises(ValueError):
-            self.assertEqual('m01s02i003', iris.fileformats.pp.STASH.from_msi('M01s02i003'))
 
     def test_illegal_stash_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Attempts to fix #2624.

However, some of the `test_pp_cf.py` tests fail because the test files (located [here](https://github.com/SciTools/iris-test-data/tree/master/test_data/PP/cf_processing)) now have invalid STASH codes; `002000000000.44.101.131200.1920.09.01.00.00.b.pp` and `008000000000.44.101.000128.1890.09.01.00.00.b.pp` have a STASH code of `44101` (`ValueError: Expected STASH code MSI string "mXXsXXiXXX", got u'm??s44i101'`) and `st0fc942.b.pp` and `st0fc699.b.pp` have a STASH code of `0` (`ValueError: Expected STASH code MSI string "mXXsXXiXXX", got u'm02s00i???'`)

Would it be possible for someone to help? What should I do now?