### PR TITLE
np.percentile method as an alternative to scipy.mstats

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1041,7 +1041,6 @@ def _percentile(data, axis, percent, **kwargs):
     if shape:
         data = data.reshape([np.prod(shape), data.shape[-1]])
     # Perform the percentile calculation.
-    print('PERCENTILE METHOD ', percentile_method)
     if percentile_method == 'fast':
         msg = 'Cannot use fast np.percentile method with masked array.'
         if ma.isMaskedArray(data):

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1027,7 +1027,7 @@ def _percentile(data, axis, percent, **kwargs):
     dimension of the resulting percentile data payload.
 
     Kwargs:
-    
+
     * percentile_method (string) :
         Switch to opt between the scipy.stats.mstats.mquantiles method for
         calculating percentiles, and the much faster np.percentiles method.

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1026,18 +1026,36 @@ def _percentile(data, axis, percent, **kwargs):
     If a new additive dimension is formed, then it will always be the last
     dimension of the resulting percentile data payload.
 
+    Kwargs:
+    
+    * percentile_method (string) :
+        Switch to opt between the scipy.stats.mstats.mquantiles method for
+        calculating percentiles, and the much faster np.percentiles method.
+
     """
+    percentile_method = kwargs.get('percentile_method', None)
     # Ensure that the target axis is the last dimension.
     data = np.rollaxis(data, axis, start=data.ndim)
-    quantiles = np.array(percent) / 100.
     shape = data.shape[:-1]
     # Flatten any leading dimensions.
     if shape:
         data = data.reshape([np.prod(shape), data.shape[-1]])
     # Perform the percentile calculation.
-    result = scipy.stats.mstats.mquantiles(data, quantiles, axis=-1, **kwargs)
+    print('PERCENTILE METHOD ', percentile_method)
+    if percentile_method == 'fast':
+        msg = 'Cannot use fast np.percentile method with masked array.'
+        if ma.isMaskedArray(data):
+            raise TypeError(msg)
+        result = np.percentile(data, percent, axis=-1)
+    else:
+        quantiles = np.array(percent) / 100.
+        result = scipy.stats.mstats.mquantiles(data, quantiles, axis=-1,
+                                               **kwargs)
     if not ma.isMaskedArray(data) and not ma.is_masked(result):
         result = np.asarray(result)
+        if percentile_method == 'fast':
+            result = result.T
+
     # Ensure to unflatten any leading dimensions.
     if shape:
         if not isinstance(percent, collections.Iterable):

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -365,11 +365,52 @@ class TestAggregators(tests.IrisTest):
                        ('analysis', 'third_quartile_foo_1d.cml'),
                        checksum=False)
 
+    def test_fast_percentile_1d(self):
+        cube = tests.stock.simple_1d()
+
+        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
+                                        percent=25, percentile_method='fast')
+        np.testing.assert_array_almost_equal(first_quartile.data,
+                                             np.array([2.5], dtype=np.float32))
+        self.assertCML(first_quartile, ('analysis',
+                                        'first_quartile_foo_1d.cml'),
+                       checksum=False)
+
+        third_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
+                                        percent=75)
+        np.testing.assert_array_almost_equal(third_quartile.data,
+                                             np.array([7.5],
+                                             dtype=np.float32))
+        self.assertCML(third_quartile,
+                       ('analysis', 'third_quartile_foo_1d.cml'),
+                       checksum=False)
+
     def test_percentile_2d(self):
         cube = tests.stock.simple_2d()
 
         first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
                                         percent=25)
+        np.testing.assert_array_almost_equal(first_quartile.data,
+                                             np.array([0.75, 4.75, 8.75],
+                                             dtype=np.float32))
+        self.assertCML(first_quartile, ('analysis',
+                                        'first_quartile_foo_2d.cml'),
+                       checksum=False)
+
+        first_quartile = cube.collapsed(('foo', 'bar'),
+                                        iris.analysis.PERCENTILE, percent=25)
+        np.testing.assert_array_almost_equal(first_quartile.data,
+                                             np.array([2.75],
+                                             dtype=np.float32))
+        self.assertCML(first_quartile, ('analysis',
+                                        'first_quartile_foo_bar_2d.cml'),
+                       checksum=False)
+
+    def test_fast_percentile_2d(self):
+        cube = tests.stock.simple_2d()
+
+        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
+                                        percent=25, percentile_method='fast')
         np.testing.assert_array_almost_equal(first_quartile.data,
                                              np.array([0.75, 4.75, 8.75],
                                              dtype=np.float32))
@@ -396,10 +437,31 @@ class TestAggregators(tests.IrisTest):
                                                        [14., 15., 16., 17.]],
                                              dtype=np.float32))
 
+    def test_fast_percentile_3d(self):
+        array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+
+        last_quartile = iris.analysis._percentile(array_3d, 0, 50,
+                                                  percentile_method='fast')
+        np.testing.assert_array_almost_equal(last_quartile,
+                                             np.array([[6., 7., 8., 9.],
+                                                       [10., 11., 12., 13.],
+                                                       [14., 15., 16., 17.]],
+                                             dtype=np.float32))
+
     def test_percentile_3d_axis_one(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
 
         last_quartile = iris.analysis._percentile(array_3d, 1, 50)
+        np.testing.assert_array_almost_equal(last_quartile,
+                                             np.array([[4., 5., 6., 7.],
+                                                       [16., 17., 18., 19.]],
+                                             dtype=np.float32))
+
+    def test_fast_percentile_3d_axis_one(self):
+        array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+
+        last_quartile = iris.analysis._percentile(array_3d, 1, 50,
+                                                  percentile_method='fast')
         np.testing.assert_array_almost_equal(last_quartile,
                                              np.array([[4., 5., 6., 7.],
                                                        [16., 17., 18., 19.]],
@@ -428,11 +490,35 @@ class TestAggregators(tests.IrisTest):
                                        'last_quartile_foo_3d_masked.cml'),
                        checksum=False)
 
+    def test_fast_percentile_3d_masked(self):
+        cube = tests.stock.simple_3d_mask()
+        msg = 'Cannot use fast np.percentile method with masked array.'
+
+        with self.assertRaisesRegexp(TypeError, msg):
+            cube.collapsed('wibble',
+                           iris.analysis.PERCENTILE, percent=75,
+                           percentile_method='fast')
+
     def test_percentile_3d_notmasked(self):
         cube = tests.stock.simple_3d()
 
         last_quartile = cube.collapsed('wibble',
                                        iris.analysis.PERCENTILE, percent=75)
+        np.testing.assert_array_almost_equal(last_quartile.data,
+                                             np.array([[9., 10., 11., 12.],
+                                                       [13., 14., 15., 16.],
+                                                       [17., 18., 19., 20.]],
+                                             dtype=np.float32))
+        self.assertCML(last_quartile, ('analysis',
+                                       'last_quartile_foo_3d_notmasked.cml'),
+                       checksum=False)
+
+    def test_fast_percentile_3d_notmasked(self):
+        cube = tests.stock.simple_3d()
+
+        last_quartile = cube.collapsed('wibble',
+                                       iris.analysis.PERCENTILE, percent=75,
+                                       percentile_method='fast')
         np.testing.assert_array_almost_equal(last_quartile.data,
                                              np.array([[9., 10., 11., 12.],
                                                        [13., 14., 15., 16.],

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -345,150 +345,142 @@ class TestAggregator_mdtol_keyword(tests.IrisTest):
 
 
 class TestAggregators(tests.IrisTest):
-    def test_percentile_1d(self):
+
+    def _check_coord_properties(self, cube, collapse_coord, unit, points):
+        if not isinstance(collapse_coord, list):
+            collapse_coord = [collapse_coord]
+        name = 'percentile_over_' + '_'.join(collapse_coord)
+        self.assertTrue(cube.coord(name))
+        self.assertEqual(cube.coord(name).units, unit)
+        self.assertEqual(cube.coord(name).points, points)
+        
+    def _check_collapsed_percentile(self, cube, percents, collapse_coord,
+                                    expected_result, coord_check=False,
+                                    **kwargs):
+
+        expected_result = np.array(expected_result, dtype=np.float32)
+        result = cube.collapsed(collapse_coord, iris.analysis.PERCENTILE,
+                                percent=percents, **kwargs)
+        np.testing.assert_array_almost_equal(result.data, expected_result)
+        if coord_check:
+            self._check_coord_properties(result, collapse_coord, 1, [percents])
+
+    def _check_percentile(self, data, axis, percents, expected_result,
+                          coord_check=False, **kwargs):
+
+        result = iris.analysis._percentile(data, axis, percents, **kwargs)
+
+        np.testing.assert_array_almost_equal(result, expected_result)
+
+    def test_percentile_invalid_percentile_method(self):
         cube = tests.stock.simple_1d()
+        msg = 'Unknown percentile_method'
 
-        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=25)
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([2.5], dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_1d.cml'),
-                       checksum=False)
+        with self.assertRaisesRegexp(ValueError, msg):
+            cube.collapsed('foo', iris.analysis.PERCENTILE, percent=50,
+                           percentile_method='invalid_method')
 
-        third_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=75)
-        np.testing.assert_array_almost_equal(third_quartile.data,
-                                             np.array([7.5],
-                                             dtype=np.float32))
-        self.assertCML(third_quartile,
-                       ('analysis', 'third_quartile_foo_1d.cml'),
-                       checksum=False)
-
-    def test_fast_percentile_1d(self):
+    def test_percentile_1d_25_percent(self):
         cube = tests.stock.simple_1d()
+        self._check_collapsed_percentile(
+            cube, 25, 'foo', 2.5, coord_check=True)
 
-        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=25, percentile_method='fast')
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([2.5], dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_1d.cml'),
-                       checksum=False)
+    def test_percentile_1d_75_percent(self):
+        cube = tests.stock.simple_1d()
+        self._check_collapsed_percentile(
+            cube, 75, 'foo', 7.5, coord_check=True)
 
-        third_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=75)
-        np.testing.assert_array_almost_equal(third_quartile.data,
-                                             np.array([7.5],
-                                             dtype=np.float32))
-        self.assertCML(third_quartile,
-                       ('analysis', 'third_quartile_foo_1d.cml'),
-                       checksum=False)
+    def test_fast_percentile_1d_25_percent(self):
+        cube = tests.stock.simple_1d()
+        self._check_collapsed_percentile(
+            cube, 25, 'foo', 2.5, percentile_method='numpy_percentile',
+            coord_check=True)
 
-    def test_percentile_2d(self):
+    def test_fast_percentile_1d_75_percent(self):
+        cube = tests.stock.simple_1d()
+        self._check_collapsed_percentile(
+            cube, 75, 'foo', 7.5, percentile_method='numpy_percentile',
+            coord_check=True)
+
+    def test_percentile_2d_single_coord(self):
         cube = tests.stock.simple_2d()
+        self._check_collapsed_percentile(
+            cube, 25, 'foo', [0.75, 4.75, 8.75], coord_check=True)
 
-        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=25)
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([0.75, 4.75, 8.75],
-                                             dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_2d.cml'),
-                       checksum=False)
-
-        first_quartile = cube.collapsed(('foo', 'bar'),
-                                        iris.analysis.PERCENTILE, percent=25)
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([2.75],
-                                             dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_bar_2d.cml'),
-                       checksum=False)
-
-    def test_fast_percentile_2d(self):
+    def test_percentile_2d_two_coords(self):
         cube = tests.stock.simple_2d()
+        self._check_collapsed_percentile(
+            cube, 25, ['foo', 'bar'], [2.75], coord_check=True)
 
-        first_quartile = cube.collapsed('foo', iris.analysis.PERCENTILE,
-                                        percent=25, percentile_method='fast')
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([0.75, 4.75, 8.75],
-                                             dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_2d.cml'),
-                       checksum=False)
+    def test_fast_percentile_2d_single_coord(self):
+        cube = tests.stock.simple_2d()
+        self._check_collapsed_percentile(cube, 25, 'foo', [0.75, 4.75, 8.75],
+            percentile_method='numpy_percentile', coord_check=True)
 
-        first_quartile = cube.collapsed(('foo', 'bar'),
-                                        iris.analysis.PERCENTILE, percent=25)
-        np.testing.assert_array_almost_equal(first_quartile.data,
-                                             np.array([2.75],
-                                             dtype=np.float32))
-        self.assertCML(first_quartile, ('analysis',
-                                        'first_quartile_foo_bar_2d.cml'),
-                       checksum=False)
+    def test_fast_percentile_2d_two_coords(self):
+        cube = tests.stock.simple_2d()
+        self._check_collapsed_percentile(cube, 25, ['foo', 'bar'], [2.75],
+            percentile_method='numpy_percentile', coord_check=True)
 
     def test_percentile_3d(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
-
-        last_quartile = iris.analysis._percentile(array_3d, 0, 50)
-        np.testing.assert_array_almost_equal(last_quartile,
-                                             np.array([[6., 7., 8., 9.],
-                                                       [10., 11., 12., 13.],
-                                                       [14., 15., 16., 17.]],
-                                             dtype=np.float32))
+        expected_result =  np.array([[6., 7., 8., 9.],
+                                     [10., 11., 12., 13.],
+                                     [14., 15., 16., 17.]],
+                                    dtype=np.float32)
+        self._check_percentile(array_3d, 0, 50, expected_result)
 
     def test_fast_percentile_3d(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
-
-        last_quartile = iris.analysis._percentile(array_3d, 0, 50,
-                                                  percentile_method='fast')
-        np.testing.assert_array_almost_equal(last_quartile,
-                                             np.array([[6., 7., 8., 9.],
-                                                       [10., 11., 12., 13.],
-                                                       [14., 15., 16., 17.]],
-                                             dtype=np.float32))
+        expected_result =  np.array([[6., 7., 8., 9.],
+                                     [10., 11., 12., 13.],
+                                     [14., 15., 16., 17.]],
+                                    dtype=np.float32)
+        self._check_percentile(array_3d, 0, 50, expected_result,
+                               percentile_method='numpy_percentile')
 
     def test_percentile_3d_axis_one(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+        expected_result = np.array([[4., 5., 6., 7.],
+                                    [16., 17., 18., 19.]],
+                                   dtype=np.float32)
 
-        last_quartile = iris.analysis._percentile(array_3d, 1, 50)
-        np.testing.assert_array_almost_equal(last_quartile,
-                                             np.array([[4., 5., 6., 7.],
-                                                       [16., 17., 18., 19.]],
-                                             dtype=np.float32))
+        self._check_percentile(array_3d, 1, 50, expected_result)
 
     def test_fast_percentile_3d_axis_one(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+        expected_result = np.array([[4., 5., 6., 7.],
+                                    [16., 17., 18., 19.]],
+                                   dtype=np.float32)
 
-        last_quartile = iris.analysis._percentile(array_3d, 1, 50,
-                                                  percentile_method='fast')
-        np.testing.assert_array_almost_equal(last_quartile,
-                                             np.array([[4., 5., 6., 7.],
-                                                       [16., 17., 18., 19.]],
-                                             dtype=np.float32))
+        self._check_percentile(array_3d, 1, 50, expected_result,
+                               percentile_method='numpy_percentile')
 
     def test_percentile_3d_axis_two(self):
         array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+        expected_result = np.array([[1.5, 5.5, 9.5],
+                                    [13.5, 17.5, 21.5]],
+                                   dtype=np.float32)
 
-        last_quartile = iris.analysis._percentile(array_3d, 2, 50)
-        np.testing.assert_array_almost_equal(last_quartile,
-                                             np.array([[1.5, 5.5, 9.5],
-                                                       [13.5, 17.5, 21.5]],
-                                             dtype=np.float32))
+        self._check_percentile(array_3d, 2, 50, expected_result)
+
+    def test_fast_percentile_3d_axis_two(self):
+        array_3d = np.arange(24, dtype=np.int32).reshape((2, 3, 4))
+        expected_result = np.array([[1.5, 5.5, 9.5],
+                                    [13.5, 17.5, 21.5]],
+                                   dtype=np.float32)
+
+        self._check_percentile(array_3d, 2, 50, expected_result,
+                               percentile_method='numpy_percentile')
 
     def test_percentile_3d_masked(self):
         cube = tests.stock.simple_3d_mask()
-
-        last_quartile = cube.collapsed('wibble',
-                                       iris.analysis.PERCENTILE, percent=75)
-        np.testing.assert_array_almost_equal(last_quartile.data,
-                                             np.array([[12., 13., 14., 15.],
-                                                       [16., 17., 18., 19.],
-                                                       [20., 18., 19., 20.]],
-                                             dtype=np.float32))
-        self.assertCML(last_quartile, ('analysis',
-                                       'last_quartile_foo_3d_masked.cml'),
-                       checksum=False)
+        expected_result = [[12., 13., 14., 15.],
+                           [16., 17., 18., 19.],
+                           [20., 18., 19., 20.]]
+        
+        self._check_collapsed_percentile(
+            cube, 75, 'wibble', expected_result, coord_check=True)
 
     def test_fast_percentile_3d_masked(self):
         cube = tests.stock.simple_3d_mask()
@@ -497,36 +489,26 @@ class TestAggregators(tests.IrisTest):
         with self.assertRaisesRegexp(TypeError, msg):
             cube.collapsed('wibble',
                            iris.analysis.PERCENTILE, percent=75,
-                           percentile_method='fast')
+                           percentile_method='numpy_percentile')
 
     def test_percentile_3d_notmasked(self):
         cube = tests.stock.simple_3d()
+        expected_result = [[9., 10., 11., 12.],
+                           [13., 14., 15., 16.],
+                           [17., 18., 19., 20.]]
 
-        last_quartile = cube.collapsed('wibble',
-                                       iris.analysis.PERCENTILE, percent=75)
-        np.testing.assert_array_almost_equal(last_quartile.data,
-                                             np.array([[9., 10., 11., 12.],
-                                                       [13., 14., 15., 16.],
-                                                       [17., 18., 19., 20.]],
-                                             dtype=np.float32))
-        self.assertCML(last_quartile, ('analysis',
-                                       'last_quartile_foo_3d_notmasked.cml'),
-                       checksum=False)
+        self._check_collapsed_percentile(
+            cube, 75, 'wibble', expected_result, coord_check=True)
 
     def test_fast_percentile_3d_notmasked(self):
         cube = tests.stock.simple_3d()
+        expected_result = [[9., 10., 11., 12.],
+                           [13., 14., 15., 16.],
+                           [17., 18., 19., 20.]]
 
-        last_quartile = cube.collapsed('wibble',
-                                       iris.analysis.PERCENTILE, percent=75,
-                                       percentile_method='fast')
-        np.testing.assert_array_almost_equal(last_quartile.data,
-                                             np.array([[9., 10., 11., 12.],
-                                                       [13., 14., 15., 16.],
-                                                       [17., 18., 19., 20.]],
-                                             dtype=np.float32))
-        self.assertCML(last_quartile, ('analysis',
-                                       'last_quartile_foo_3d_notmasked.cml'),
-                       checksum=False)
+        self._check_collapsed_percentile(
+            cube, 75, 'wibble', expected_result, coord_check=True,
+            percentile_method='numpy_percentile')
 
     def test_proportion(self):
         cube = tests.stock.simple_1d()


### PR DESCRIPTION
Introduction of a numpy.percentile method to the percentile aggregator for the purposes of providing a fast alternative (approx 50 times faster).

* Accessed with kwarg percentile_method="fast" passed to cube.collapsed method.
* Existing unit tests duplicated with call to fast method, where masked data will result in an error.
* Ran test cases and found fractional differences of order 1E-16 between two methods.
* scipy.stats.mstats.mquantiles method remains important for dealing with masked data.

- [x] added unit tests.