### PR TITLE
Remove deprecated cube methods assert_valid and add_history

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2118,15 +2118,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return summary
 
-    def assert_valid(self):
-        """
-        Does nothing and returns None.
-
-        .. deprecated:: 0.8
-
-        """
-        warn_deprecated('Cube.assert_valid() has been deprecated.')
-
     def __str__(self):
         # six has a decorator for this bit, but it doesn't do errors='replace'.
         if six.PY3:
@@ -3154,29 +3145,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     __pow__ = iris.analysis.maths.exponentiate
     # END OPERATOR OVERLOADS
-
-    def add_history(self, string):
-        """
-        Add the given string to the cube's history.
-        If the history coordinate does not exist, then one will be created.
-
-        .. deprecated:: 1.6
-            Add/modify history metadata within
-            :attr:`~iris.cube.Cube.attributes` as needed.
-
-        """
-        warn_deprecated("Cube.add_history() has been deprecated - "
-                        "please modify/create cube.attributes['history'] "
-                        "as needed.")
-
-        timestamp = datetime.datetime.now().strftime("%d/%m/%y %H:%M:%S")
-        string = '%s Iris: %s' % (timestamp, string)
-
-        try:
-            history = self.attributes['history']
-            self.attributes['history'] = '%s\n%s' % (history, string)
-        except KeyError:
-            self.attributes['history'] = string
 
     # START ANALYSIS ROUTINES
 

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -99,7 +99,6 @@ class TestUnmappable(tests.GraphicsTest):
             0)
         cube.standard_name = 'air_temperature'
         cube.units = 'K'
-        cube.assert_valid()
         self.cube = cube
 
     def test_simple(self):

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -668,11 +668,9 @@ class TestTimeTripleMerging(tests.IrisTest):
                                    ])
         cube = cubes.merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging2.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
         cube = iris.cube.CubeList(cubes[:-1]).merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging3.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
     def test_simple3(self):
         cubes = iris.cube.CubeList([
@@ -685,11 +683,9 @@ class TestTimeTripleMerging(tests.IrisTest):
                                    ])
         cube = cubes.merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging4.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
         cube = iris.cube.CubeList(cubes[:-1]).merge()[0]
         self.assertCML(cube, ('merge', 'time_triple_merging5.cml'), checksum=False)
-        self.assertIsNone(cube.assert_valid())
 
 
 class TestCubeMergeTheoretical(tests.IrisTest):


### PR DESCRIPTION
Fixes #2650 
Fixes #2651 

Is it easier to have lump all the deprecation remvals in one PR or split them out??