### PR TITLE
Sharedata

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -525,7 +525,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             # We do not perform a deepcopy when we supply new points so as to
             # not unncessarily copy the old points.
 
-            # Create a temp-coord to manage deep copying of a small array. 
+            # Create a temp-coord to manage deep copying of a small array.
             temp_coord = copy.copy(self)
             temp_coord.bounds = None
             # note: DataManager cannot be None or DataManager(None) for

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -521,14 +521,18 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             raise ValueError('If bounds are specified, points must also be '
                              'specified')
 
-        new_coord = copy.deepcopy(self)
         if points is not None:
+            # We do not perform a deepcopy when we supply new points so as to
+            # not unncessarily copy the old points.
+            new_coord = copy.copy(self)
+            new_coord.attributes = copy.deepcopy(self.attributes)
+            new_coord.coord_system = copy.deepcopy(self.coord_system)
             new_coord._points_dm = None
             new_coord.points = points
-            # Regardless of whether bounds are provided as an argument, new
-            # points will result in new bounds, discarding those copied from
-            # self.
+            # new points will result in new bounds.
             new_coord.bounds = bounds
+        else:
+            new_coord = copy.deepcopy(self)
 
         return new_coord
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -524,9 +524,15 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if points is not None:
             # We do not perform a deepcopy when we supply new points so as to
             # not unncessarily copy the old points.
-            new_coord = copy.copy(self)
-            new_coord.attributes = copy.deepcopy(self.attributes)
-            new_coord.coord_system = copy.deepcopy(self.coord_system)
+
+            # Create a temp-coord to manage deep copying of a small array. 
+            temp_coord = copy.copy(self)
+            temp_coord.bounds = None
+            # note: DataManager cannot be None or DataManager(None) for
+            # a deepcopy operation.
+            temp_coord._points_dm = DataManager(np.array((1,)))
+            new_coord = copy.deepcopy(temp_coord)
+            del(temp_coord)
             new_coord._points_dm = None
             new_coord.points = points
             # new points will result in new bounds.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -25,6 +25,7 @@ import iris.tests as tests
 
 from itertools import permutations
 
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
@@ -1897,7 +1898,7 @@ class Test_share_data(tests.IrisTest):
 
 class Test___getitem__no_share_data(tests.IrisTest):
     def test_lazy_array(self):
-        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube = Cube(da.from_array(np.arange(6).reshape(2, 3), chunks=6))
         cube2 = cube[1:]
         self.assertTrue(cube2.has_lazy_data())
         cube.data
@@ -1911,7 +1912,7 @@ class Test___getitem__no_share_data(tests.IrisTest):
 
 class Test___getitem__share_data(tests.IrisTest):
     def test_lazy_array(self):
-        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube = Cube(da.from_array(np.arange(6).reshape(2, 3), chunks=6))
         cube.share_data = True
         cube2 = cube[1:]
         self.assertFalse(cube.has_lazy_data())

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1883,13 +1883,13 @@ class Test_remove_metadata(tests.IrisTest):
 
 
 class Test_share_data(tests.IrisTest):
-    def setter_lazy_data(self):
-        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+    def test_setter_lazy_data(self):
+        cube = Cube(da.from_array(np.arange(6).reshape(2, 3), chunks=6))
         cube.share_data = True
         self.assertFalse(cube.has_lazy_data())
         self.assertTrue(cube._share_data)
 
-    def setter_realised_data(self):
+    def test_setter_realised_data(self):
         cube = Cube(np.arange(6).reshape(2, 3))
         cube.share_data = True
         self.assertFalse(cube.has_lazy_data())

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -66,6 +66,10 @@ class Test___init___data(tests.IrisTest):
         self.assertEqual(type(cube.data), np.ndarray)
         self.assertArrayEqual(cube.data, data)
 
+    def test_default_share_data(self):
+        cube = Cube(np.arange(1))
+        self.assertFalse(cube.share_data)
+
 
 class Test_extract(tests.IrisTest):
     def test_scalar_cube_exists(self):
@@ -1875,6 +1879,50 @@ class Test_remove_metadata(tests.IrisTest):
         self.cube.remove_cell_measure(self.cube.cell_measure('area'))
         self.assertEqual(self.cube._cell_measures_and_dims,
                          [[self.b_cell_measure, (0, 1)]])
+
+
+class Test_share_data(tests.IrisTest):
+    def setter_lazy_data(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube.share_data = True
+        self.assertFalse(cube.has_lazy_data())
+        self.assertTrue(cube._share_data)
+
+    def setter_realised_data(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube.share_data = True
+        self.assertFalse(cube.has_lazy_data())
+        self.assertTrue(cube._share_data)
+
+
+class Test___getitem__no_share_data(tests.IrisTest):
+    def test_lazy_array(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube2 = cube[1:]
+        self.assertTrue(cube2.has_lazy_data())
+        cube.data
+        self.assertTrue(cube2.has_lazy_data())
+
+    def test_ndarray(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube2 = cube[1:]
+        self.assertIsNot(cube.data.base, cube2.data.base)
+
+
+class Test___getitem__share_data(tests.IrisTest):
+    def test_lazy_array(self):
+        cube = Cube(biggus.NumpyArrayAdapter(np.arange(6).reshape(2, 3)))
+        cube.share_data = True
+        cube2 = cube[1:]
+        self.assertFalse(cube.has_lazy_data())
+        self.assertFalse(cube2.has_lazy_data())
+        self.assertIs(cube.data.base, cube2.data.base)
+
+    def test_ndarray(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        cube.share_data = True
+        cube2 = cube[1:]
+        self.assertIs(cube.data.base, cube2.data.base)
 
 
 class Test__getitem_CellMeasure(tests.IrisTest):


### PR DESCRIPTION
regarding #2681 I think that 'share_data' is part of the public API in 1.13 and should be preserved

this PR reimplements #2549 with respect to master, a fairly simple exercise

I think this should be included in iris 2.0