### PR TITLE
Use the branch from dask PR#2301 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,12 @@ install:
       ln -s $(pwd)/iris-test-data-${IRIS_TEST_DATA_SUFFIX} iris-test-data;
     fi
 
+# Download + install dask from dask PR #2301
+  - wget https://github.com/jcrist/dask/archive/masked-array.zip;
+  - unzip masked-array.zip;
+  - cd dask-masked-array && python setup.py --quiet install;
+  - cd ..;
+
 # prepare iris build directory
   - python setup.py --with-unpack build_ext --include-dirs=${PREFIX}/include --library-dirs=${PREFIX}/lib
   - if [[ $TEST_TARGET -ne 'coding' ]]; then


### PR DESCRIPTION
NOTE: this targets the new iris branch `dask_mask_array`

This adds instructions in the travis set up to get dask from the branch in the [Dask PR](https://github.com/dask/dask/pull/2301) that adds masked array support.

