### PR TITLE
Remove deprecated rule logging config options

### DIFF
--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -47,20 +47,6 @@ defined by :mod:`ConfigParser`.
 
     The [optional] name of the logger to notify when first imported.
 
-.. py:data:: iris.config.RULE_LOG_DIR
-
-    The [optional] full path to the rule logging directory used by
-    :func:`iris.fileformats.pp.load()` and
-    :func:`iris.fileformats.pp.save()`.
-
-    .. deprecated:: 1.10
-
-.. py:data:: iris.config.RULE_LOG_IGNORE
-
-    The [optional] list of users to ignore when logging rules.
-
-    .. deprecated:: 1.10
-
 ----------
 """
 
@@ -147,13 +133,6 @@ PALETTE_PATH = get_dir_option(_RESOURCE_SECTION, 'palette_path',
 #################
 # Logging options
 _LOGGING_SECTION = 'Logging'
-
-
-RULE_LOG_DIR = get_dir_option(_LOGGING_SECTION, 'rule_dir')
-
-
-RULE_LOG_IGNORE = get_option(_LOGGING_SECTION, 'rule_ignore')
-
 
 IMPORT_LOGGER = get_option(_LOGGING_SECTION, 'import_logger')
 


### PR DESCRIPTION
Removes rule logging config items. This has an impact on `fileformats/rules.py`, from which I've removed all rule logging functionality.

Fixes #2655