### PR TITLE
convert_units: raise exception when unit is unknown

### DIFF
--- a/docs/iris/src/whatsnew/2.0a0.rst
+++ b/docs/iris/src/whatsnew/2.0a0.rst
@@ -97,9 +97,11 @@ Incompatible Changes
 
 * The :meth:`~iris.cube.Cube.lazy_data` method no longer accepts any arguments.
 
-* Attempting to use the :meth:`iris.cube.Cube.convert_units` method on a cube
-  where the existing unit is unknown will raise a :data:`UnitConversionError`
-  exception.
+* Using :meth:`~iris.cube.Cube.convert_units` on a cube with unknown units will
+  result in a :data:`UnitConversionError` being raised.
+
+* Using :meth:`~iris.coords.Coord.convert_units` on a coordinate with unknown
+  units will result in a :data:`UnitConversionError` being raised.
 
 .. admonition:: Significant Changes in Calculated Results
 

--- a/docs/iris/src/whatsnew/2.0a0.rst
+++ b/docs/iris/src/whatsnew/2.0a0.rst
@@ -91,15 +91,15 @@ Bugs Fixed
   :class:`~iris.cube.Cube` with :data:`integer` or :data:`boolean` data with
   a :data:`float` result will raise an :data:`ArithmeticError` exception.
 
-* Attempting to use the :meth:`iris.cube.Cube.convert_units` method on a cube
-  where the existing unit is unknown will raise a :data:`UnitConversionError`
-  exception.
-
 
 Incompatible Changes
 ====================
 
 * The :meth:`~iris.cube.Cube.lazy_data` method no longer accepts any arguments.
+
+* Attempting to use the :meth:`iris.cube.Cube.convert_units` method on a cube
+  where the existing unit is unknown will raise a :data:`UnitConversionError`
+  exception.
 
 .. admonition:: Significant Changes in Calculated Results
 

--- a/docs/iris/src/whatsnew/2.0a0.rst
+++ b/docs/iris/src/whatsnew/2.0a0.rst
@@ -91,6 +91,10 @@ Bugs Fixed
   :class:`~iris.cube.Cube` with :data:`integer` or :data:`boolean` data with
   a :data:`float` result will raise an :data:`ArithmeticError` exception.
 
+* Attempting to use the :meth:`iris.cube.Cube.convert_units` method on a cube
+  where the existing unit is unknown will raise a :data:`UnitConversionError`
+  exception.
+
 
 Incompatible Changes
 ====================

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -895,10 +895,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         """
         # If the coord has units convert the values in points (and bounds if
         # present).
-        if not self.units.is_unknown():
-            self.points = self.units.convert(self.points, unit)
-            if self.has_bounds():
-                self.bounds = self.units.convert(self.bounds, unit)
+        if self.units.is_unknown():
+            raise iris.exceptions.UnitConversionError(
+                'Cannot convert from unknown units. '
+                'The "coord.units" attribute may be set directly.')
+        self.points = self.units.convert(self.points, unit)
+        if self.has_bounds():
+            self.bounds = self.units.convert(self.bounds, unit)
         self.units = unit
 
     def cells(self):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -880,8 +880,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         """
         # If the cube has units convert the data.
-        if not self.units.is_unknown():
-            self.data = self.units.convert(self.data, unit)
+        if self.units.is_unknown():
+            raise iris.exceptions.UnitConversionError(
+                'cannot convert from unknown units to {!s}, '
+                'set the "units" attribute instead'.format(unit))
+        self.data = self.units.convert(self.data, unit)
         self.units = unit
 
     def add_cell_method(self, cell_method):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -882,8 +882,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # If the cube has units convert the data.
         if self.units.is_unknown():
             raise iris.exceptions.UnitConversionError(
-                'cannot convert from unknown units to {!s}, '
-                'set the "units" attribute instead'.format(unit))
+                'Cannot convert from unknown units. '
+                'The "cube.units" attribute may be set directly.')
         self.data = self.units.convert(self.data, unit)
         self.units = unit
 

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -151,4 +151,9 @@ class DuplicateDataError(MergeError):
 
 
 class LazyAggregatorError(Exception):
+    pass
+
+
+class UnitConversionError(IrisError):
+    """Raised when Iris is unable to convert a unit."""
     pass

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -30,6 +30,7 @@ import numpy as np
 import iris
 from iris.coords import DimCoord, AuxCoord, Coord
 from iris.tests import mock
+from iris.exceptions import UnitConversionError
 
 
 Pair = collections.namedtuple('Pair', 'points bounds')
@@ -353,6 +354,14 @@ class Test_is_compatible(tests.IrisTest):
         self.other_coord.attributes['array_test'] = np.array([1.0, 2, 777.7])
         self.assertFalse(self.test_coord.is_compatible(self.other_coord))
 
+
+class Test_convert_units(tests.IrisTest):
+    def test_convert_unknown_units(self):
+        coord = iris.coords.AuxCoord(1, units='unknown')
+        emsg = ('Cannot convert from unknown units. '
+                'The "coord.units" attribute may be set directly.')
+        with self.assertRaisesRegexp(UnitConversionError, emsg):
+            coord.convert_units('degrees')
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2008,7 +2008,9 @@ class Test_transpose(tests.IrisTest):
 class Test_convert_units(tests.IrisTest):
     def test_convert_unknown_units(self):
         cube = iris.cube.Cube(1)
-        with self.assertRaises(UnitConversionError):
+        emsg = ('Cannot convert from unknown units. '
+                'The "cube.units" attribute may be set directly.')
+        with self.assertRaisesRegexp(UnitConversionError, emsg):
             cube.convert_units('mm day-1')
 
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -37,7 +37,8 @@ from iris.analysis import WeightedAggregator, Aggregator
 from iris.analysis import MEAN
 from iris.cube import Cube
 from iris.coords import AuxCoord, DimCoord, CellMeasure
-from iris.exceptions import CoordinateNotFoundError, CellMeasureNotFoundError
+from iris.exceptions import (CoordinateNotFoundError, CellMeasureNotFoundError,
+                             UnitConversionError)
 from iris.tests import mock
 import iris.tests.stock as stock
 from iris._lazy_data import as_lazy_data
@@ -2002,6 +2003,13 @@ class Test_transpose(tests.IrisTest):
         exp_emsg = 'Incorrect number of dimensions'
         with self.assertRaisesRegexp(ValueError, exp_emsg):
             self.cube.transpose([1])
+
+
+class Test_convert_units(tests.IrisTest):
+    def test_convert_unknown_units(self):
+        cube = iris.cube.Cube(1)
+        with self.assertRaises(UnitConversionError):
+            cube.convert_units('mm day-1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix for #1977.  If the units on a cube are unknown, the `convert_units` method should raise an exception.  I consider the current behaviour of just setting the units to be a bug.  If a user has not realised the metadata in the data file is incomplete, then the cube could end up with spurious data values.

A couple of things I'm not sure of:

1. I couldn't figure out if the class definitions in `iris.exceptions` were in any particular order, so just put the new one at the end.

1. Did I put the whatsnew in the right place?