### PR TITLE
Remove fill_value from cube cml

### DIFF
--- a/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
+++ b/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -523,7 +523,7 @@
     <cellMethods/>
     <data checksum="0x9554cc14" dtype="float32" shape="(6, 10, 83, 83)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1046,7 +1046,7 @@
     <cellMethods/>
     <data checksum="0xd9d57b21" dtype="float32" shape="(6, 10, 83, 83)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="surface_altitude" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/air_temperature_1.cml
+++ b/lib/iris/tests/results/FF/air_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/air_temperature_2.cml
+++ b/lib/iris/tests/results/FF/air_temperature_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/soil_temperature_1.cml
+++ b/lib/iris/tests/results/FF/soil_temperature_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="soil_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="soil_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s08i225"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/FF/surface_altitude_1.cml
+++ b/lib/iris/tests/results/FF/surface_altitude_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="surface_altitude" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/abs.cml
+++ b/lib/iris/tests/results/analysis/abs.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition.cml
+++ b/lib/iris/tests/results/analysis/addition.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_coord_x.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_coord_y.cml
+++ b/lib/iris/tests/results/analysis/addition_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/addition_different_std_name.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_in_place.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_in_place_coord.cml
+++ b/lib/iris/tests/results/analysis/addition_in_place_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/addition_scalar.cml
+++ b/lib/iris/tests/results/analysis/addition_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" long_name="squared temperature" units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" long_name="squared temperature" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="object" dtype="object" fill_value="-1e+30" units="kelvin^2">
+  <cube core-dtype="object" dtype="object" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_original.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" long_name="squared temperature" units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" long_name="squared temperature" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="object" dtype="object" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="object" dtype="object" units="unknown">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc_original.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/areaweights_original.cml
+++ b/lib/iris/tests/results/analysis/areaweights_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/division.cml
+++ b/lib/iris/tests/results/analysis/division.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="1">
+  <cube core-dtype="float32" dtype="float32" units="1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_array.cml
+++ b/lib/iris/tests/results/analysis/division_by_array.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="kelvin">
+  <cube core-dtype="float32" dtype="float32" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_latitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="57.2957795130823 kelvin-radian^-1">
+  <cube core-dtype="float32" dtype="float32" units="57.2957795130823 kelvin-radian^-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_longitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="57.2957795130823 kelvin-radian^-1">
+  <cube core-dtype="float32" dtype="float32" units="57.2957795130823 kelvin-radian^-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_singular_coord.cml
+++ b/lib/iris/tests/results/analysis/division_by_singular_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="kelvin">
+  <cube core-dtype="float64" dtype="float64" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_scalar.cml
+++ b/lib/iris/tests/results/analysis/division_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="kelvin">
+  <cube core-dtype="float32" dtype="float32" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="kelvin^4">
+  <cube core-dtype="float64" dtype="float64" units="kelvin^4">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/gmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/hmean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2dslice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_2slices.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_bounded_mid_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/interpolation/nearest_neighbour_extract_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/log.cml
+++ b/lib/iris/tests/results/analysis/log.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="ln(re 1 kelvin)">
+  <cube core-dtype="float32" dtype="float32" units="ln(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log10.cml
+++ b/lib/iris/tests/results/analysis/log10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="lg(re 1 kelvin)">
+  <cube core-dtype="float32" dtype="float32" units="lg(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log2.cml
+++ b/lib/iris/tests/results/analysis/log2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="lb(re 1 kelvin)">
+  <cube core-dtype="float32" dtype="float32" units="lb(re 1 kelvin)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/maths_original.cml
+++ b/lib/iris/tests/results/analysis/maths_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/max_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/mean_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/median_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/min_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/multiply.cml
+++ b/lib/iris/tests/results/analysis/multiply.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/multiply_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/multiply_different_std_name.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="kelvin^2">
+  <cube core-dtype="float32" dtype="float32" units="kelvin^2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/original.cml
+++ b/lib/iris/tests/results/analysis/original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_common.cml
+++ b/lib/iris/tests/results/analysis/original_common.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/original_hmean.cml
+++ b/lib/iris/tests/results/analysis/original_hmean.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_both_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_both_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_grid.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_grid.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_src.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_src.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_circular_srcmissingmask.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_circular_srcmissingmask.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/linear_non_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/linear_non_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_both_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_both_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_grid.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_grid.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_src.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_src.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_circular_srcmissingmask.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_circular_srcmissingmask.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/regrid/nearest_non_circular.cml
+++ b/lib/iris/tests/results/analysis/regrid/nearest_non_circular.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/rms_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sqrt.cml
+++ b/lib/iris/tests/results/analysis/sqrt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="kelvin">
+  <cube core-dtype="float32" dtype="float32" units="kelvin">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/std_dev_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/subtract.cml
+++ b/lib/iris/tests/results/analysis/subtract.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_array.cml
+++ b/lib/iris/tests/results/analysis/subtract_array.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_x.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_coord_y.cml
+++ b/lib/iris/tests/results/analysis/subtract_coord_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1.00000001505e+30" units="K">
+  <cube core-dtype="float64" dtype="float64" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/subtract_scalar.cml
+++ b/lib/iris/tests/results/analysis/subtract_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="K">
+  <cube core-dtype="float32" dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/sum_latitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/sum_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/weighted_mean_original.cml
+++ b/lib/iris/tests/results/analysis/weighted_mean_original.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_eq_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
+++ b/lib/iris/tests/results/cdm/extract/lat_gt_10_and_lon_ge_10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cdm/masked_cube.cml
+++ b/lib/iris/tests/results/cdm/masked_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e-09" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <attributes>
       <attribute name="STASH" value="m01s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/concatenate/concat_2y2d.cml
+++ b/lib/iris/tests/results/concatenate/concat_2y2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1234.0" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/concatenate/concat_masked_2y2d_int16.cml
+++ b/lib/iris/tests/results/concatenate/concat_masked_2y2d_int16.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int16" dtype="int16" fill_value="-37" units="unknown">
+  <cube core-dtype="int16" dtype="int16" units="unknown">
     <coords>
       <coord datadims="[1]">
         <dimCoord bounds="[[-0.5, 0.5],

--- a/lib/iris/tests/results/constrained_load/all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -102,7 +102,7 @@
     </cellMethods>
     <data checksum="0x0f9c7d63" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -154,7 +154,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/all_ml_10_22_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -53,7 +53,7 @@
     </cellMethods>
     <data checksum="0x152ab762" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -106,7 +106,7 @@
     </cellMethods>
     <data checksum="0x38f24240" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -160,7 +160,7 @@
     </cellMethods>
     <data checksum="0x777b79f0" dtype="float32" shape="(2, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/attribute_constraint.cml
+++ b/lib/iris/tests/results/constrained_load/attribute_constraint.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="my_attribute" value="foobar"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_and_theta_level_gt_30_le_3_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_10_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_all_10_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -191,7 +191,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -242,7 +242,7 @@
     </cellMethods>
     <data checksum="0x0f9c7d63" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -294,7 +294,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_10_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_and_theta_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_gt_30_le_3_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_30_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_lat_gt_30_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_load_match.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_match.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/constrained_load/theta_load_strict.cml
+++ b/lib/iris/tests/results/constrained_load/theta_load_strict.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pickling/cubelist.cml
+++ b/lib/iris/tests/results/cube_io/pickling/cubelist.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -516,7 +516,7 @@
     <cellMethods/>
     <data checksum="0x7a31dc88" dtype="float32" shape="(6, 70, 100, 100)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="surface_altitude" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="surface_altitude" units="m">
     <attributes>
       <attribute name="STASH" value="m01s00i033"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pickling/single_cube.cml
+++ b/lib/iris/tests/results/cube_io/pickling/single_cube.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pickling/theta.cml
+++ b/lib/iris/tests/results/cube_io/pickling/theta.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_io/pp/load/global.cml
+++ b/lib/iris/tests/results/cube_io/pp/load/global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
+++ b/lib/iris/tests/results/cube_slice/real_data_dual_tuple_indexing3.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
+++ b/lib/iris/tests/results/cube_slice/real_empty_data_indexing.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure_at_sea_level" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure_at_sea_level" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadFF/simple_callback.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="processing" value="fast-ff"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple_callback.cml
+++ b/lib/iris/tests/results/experimental/fieldsfile/TestStructuredLoadPP/simple_callback.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i407"/>
       <attribute name="processing" value="fast-pp"/>

--- a/lib/iris/tests/results/file_load/theta_levels.cml
+++ b/lib/iris/tests/results/file_load/theta_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -51,7 +51,7 @@
     </cellMethods>
     <data checksum="0x17763b08" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -102,7 +102,7 @@
     </cellMethods>
     <data checksum="0xc185be42" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -153,7 +153,7 @@
     </cellMethods>
     <data checksum="0xe65750bc" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -204,7 +204,7 @@
     </cellMethods>
     <data checksum="0x816283f9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -255,7 +255,7 @@
     </cellMethods>
     <data checksum="0x56b85efa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -306,7 +306,7 @@
     </cellMethods>
     <data checksum="0xe96a203f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -357,7 +357,7 @@
     </cellMethods>
     <data checksum="0xce07f637" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -408,7 +408,7 @@
     </cellMethods>
     <data checksum="0x1cfc905c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -459,7 +459,7 @@
     </cellMethods>
     <data checksum="0xe239fdec" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -510,7 +510,7 @@
     </cellMethods>
     <data checksum="0x45a44f1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -561,7 +561,7 @@
     </cellMethods>
     <data checksum="0xb12f6572" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -612,7 +612,7 @@
     </cellMethods>
     <data checksum="0x0e3c5965" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -663,7 +663,7 @@
     </cellMethods>
     <data checksum="0x6347d5bd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -714,7 +714,7 @@
     </cellMethods>
     <data checksum="0x77273f7e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -765,7 +765,7 @@
     </cellMethods>
     <data checksum="0x4bd3a5eb" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -816,7 +816,7 @@
     </cellMethods>
     <data checksum="0x129ae43d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -867,7 +867,7 @@
     </cellMethods>
     <data checksum="0x10f0c12e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -918,7 +918,7 @@
     </cellMethods>
     <data checksum="0x2bb76c16" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -969,7 +969,7 @@
     </cellMethods>
     <data checksum="0xf5b26d1a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1020,7 +1020,7 @@
     </cellMethods>
     <data checksum="0x9b8c7031" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1071,7 +1071,7 @@
     </cellMethods>
     <data checksum="0xc310cc9a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1122,7 +1122,7 @@
     </cellMethods>
     <data checksum="0xb41fa10f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1173,7 +1173,7 @@
     </cellMethods>
     <data checksum="0xefab27e4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1224,7 +1224,7 @@
     </cellMethods>
     <data checksum="0x946cabe8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1275,7 +1275,7 @@
     </cellMethods>
     <data checksum="0x5998cbc6" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1326,7 +1326,7 @@
     </cellMethods>
     <data checksum="0xb0a6552e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1377,7 +1377,7 @@
     </cellMethods>
     <data checksum="0xab0a810b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1428,7 +1428,7 @@
     </cellMethods>
     <data checksum="0x9ab0fdd8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1479,7 +1479,7 @@
     </cellMethods>
     <data checksum="0x34f06e6a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1530,7 +1530,7 @@
     </cellMethods>
     <data checksum="0x47c31d91" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1581,7 +1581,7 @@
     </cellMethods>
     <data checksum="0x8569fd3f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1632,7 +1632,7 @@
     </cellMethods>
     <data checksum="0x3ace76f3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1683,7 +1683,7 @@
     </cellMethods>
     <data checksum="0xbc11c8a9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1734,7 +1734,7 @@
     </cellMethods>
     <data checksum="0xbf693c7d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1785,7 +1785,7 @@
     </cellMethods>
     <data checksum="0xc100ff09" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1836,7 +1836,7 @@
     </cellMethods>
     <data checksum="0x43595449" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1887,7 +1887,7 @@
     </cellMethods>
     <data checksum="0x377b59d4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/u_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/u_wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x127b39e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0x088c4545" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0xc896dcd3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0x3df23f98" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xa97d11dd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x24173b24" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0x16761c14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0xf6f56e25" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x57a3823b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0xc43c2a0b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x08bf7abd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x5870c1e0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x7cac5103" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0xcd2d62b1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x4e1b7ef5" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x104081c2" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0x392ef79f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xdf6dbef7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x871b4ee8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x3cee95b4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x76208cc7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xa0f56a0a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0xc5654966" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xde1441e7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xf70c5634" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xe2d29281" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0xcfe34b4d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0x4cb07673" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0x47c8d38a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x6c15a2c3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb922530c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0x5020a5d1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0xe308ebfa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x50f626b0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x19624929" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x4c54b2ff" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/v_wind_levels.cml
+++ b/lib/iris/tests/results/file_load/v_wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x50e427ed" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0xa4593dbf" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0x00ff91f2" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0xa03492c0" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xc61368b3" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x9a20e5c6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0xfbcb2a96" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0x31c19cd4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x6b0cc25a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0x31d04486" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0x7e2cc5b6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x26741d4b" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x2c2d97dd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x6a294180" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0x92eb6ab4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x39456c40" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x4963cfd6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0xe81e8be7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xfb9b0ed6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x2057f49e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x9bb6020a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x05970b5d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xb013389c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0x208fa829" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xe2582bbd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xb964b7d7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xc8a5b95e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0x4bd4eae9" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0xe0549b09" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0xf6e3546d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x5525ab2a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb48c5eb1" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0xcfb28f0d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0x4290df26" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x82c0d953" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x49202448" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x04b1c44c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/file_load/wind_levels.cml
+++ b/lib/iris/tests/results/file_load/wind_levels.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -52,7 +52,7 @@
     </cellMethods>
     <data checksum="0x127b39e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -104,7 +104,7 @@
     </cellMethods>
     <data checksum="0x088c4545" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -156,7 +156,7 @@
     </cellMethods>
     <data checksum="0xc896dcd3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -208,7 +208,7 @@
     </cellMethods>
     <data checksum="0x3df23f98" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -260,7 +260,7 @@
     </cellMethods>
     <data checksum="0xa97d11dd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -312,7 +312,7 @@
     </cellMethods>
     <data checksum="0x24173b24" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -364,7 +364,7 @@
     </cellMethods>
     <data checksum="0x16761c14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -416,7 +416,7 @@
     </cellMethods>
     <data checksum="0xf6f56e25" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -468,7 +468,7 @@
     </cellMethods>
     <data checksum="0x57a3823b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -520,7 +520,7 @@
     </cellMethods>
     <data checksum="0xd841777e" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -572,7 +572,7 @@
     </cellMethods>
     <data checksum="0xc43c2a0b" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -624,7 +624,7 @@
     </cellMethods>
     <data checksum="0x08bf7abd" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -676,7 +676,7 @@
     </cellMethods>
     <data checksum="0x5870c1e0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -728,7 +728,7 @@
     </cellMethods>
     <data checksum="0x7cac5103" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -780,7 +780,7 @@
     </cellMethods>
     <data checksum="0xcd2d62b1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -832,7 +832,7 @@
     </cellMethods>
     <data checksum="0x4e1b7ef5" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -884,7 +884,7 @@
     </cellMethods>
     <data checksum="0x104081c2" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -936,7 +936,7 @@
     </cellMethods>
     <data checksum="0x392ef79f" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -988,7 +988,7 @@
     </cellMethods>
     <data checksum="0xdf6dbef7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1040,7 +1040,7 @@
     </cellMethods>
     <data checksum="0x871b4ee8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1092,7 +1092,7 @@
     </cellMethods>
     <data checksum="0x3cee95b4" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1144,7 +1144,7 @@
     </cellMethods>
     <data checksum="0x76208cc7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1196,7 +1196,7 @@
     </cellMethods>
     <data checksum="0xa0f56a0a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1248,7 +1248,7 @@
     </cellMethods>
     <data checksum="0xc5654966" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1300,7 +1300,7 @@
     </cellMethods>
     <data checksum="0xde1441e7" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1352,7 +1352,7 @@
     </cellMethods>
     <data checksum="0xf70c5634" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1404,7 +1404,7 @@
     </cellMethods>
     <data checksum="0xe2d29281" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1456,7 +1456,7 @@
     </cellMethods>
     <data checksum="0xcfe34b4d" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1508,7 +1508,7 @@
     </cellMethods>
     <data checksum="0x4cb07673" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1560,7 +1560,7 @@
     </cellMethods>
     <data checksum="0x47c8d38a" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1612,7 +1612,7 @@
     </cellMethods>
     <data checksum="0x6c15a2c3" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1664,7 +1664,7 @@
     </cellMethods>
     <data checksum="0xb922530c" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1716,7 +1716,7 @@
     </cellMethods>
     <data checksum="0x5020a5d1" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1768,7 +1768,7 @@
     </cellMethods>
     <data checksum="0xe308ebfa" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1820,7 +1820,7 @@
     </cellMethods>
     <data checksum="0x50f626b0" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1872,7 +1872,7 @@
     </cellMethods>
     <data checksum="0x19624929" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1924,7 +1924,7 @@
     </cellMethods>
     <data checksum="0x4c54b2ff" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -1976,7 +1976,7 @@
     </cellMethods>
     <data checksum="0x4cd24d81" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2028,7 +2028,7 @@
     </cellMethods>
     <data checksum="0x50e427ed" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2080,7 +2080,7 @@
     </cellMethods>
     <data checksum="0xa4593dbf" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2132,7 +2132,7 @@
     </cellMethods>
     <data checksum="0x00ff91f2" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2184,7 +2184,7 @@
     </cellMethods>
     <data checksum="0xa03492c0" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2236,7 +2236,7 @@
     </cellMethods>
     <data checksum="0xc61368b3" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2288,7 +2288,7 @@
     </cellMethods>
     <data checksum="0x9a20e5c6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2340,7 +2340,7 @@
     </cellMethods>
     <data checksum="0xfbcb2a96" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2392,7 +2392,7 @@
     </cellMethods>
     <data checksum="0x31c19cd4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2444,7 +2444,7 @@
     </cellMethods>
     <data checksum="0x6b0cc25a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2496,7 +2496,7 @@
     </cellMethods>
     <data checksum="0x31d04486" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2548,7 +2548,7 @@
     </cellMethods>
     <data checksum="0x7e2cc5b6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2600,7 +2600,7 @@
     </cellMethods>
     <data checksum="0x26741d4b" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2652,7 +2652,7 @@
     </cellMethods>
     <data checksum="0x2c2d97dd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2704,7 +2704,7 @@
     </cellMethods>
     <data checksum="0x6a294180" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2756,7 +2756,7 @@
     </cellMethods>
     <data checksum="0x92eb6ab4" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2808,7 +2808,7 @@
     </cellMethods>
     <data checksum="0x39456c40" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2860,7 +2860,7 @@
     </cellMethods>
     <data checksum="0x4963cfd6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2912,7 +2912,7 @@
     </cellMethods>
     <data checksum="0xe81e8be7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -2964,7 +2964,7 @@
     </cellMethods>
     <data checksum="0xfb9b0ed6" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3016,7 +3016,7 @@
     </cellMethods>
     <data checksum="0x2057f49e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3068,7 +3068,7 @@
     </cellMethods>
     <data checksum="0x9bb6020a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3120,7 +3120,7 @@
     </cellMethods>
     <data checksum="0x05970b5d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3172,7 +3172,7 @@
     </cellMethods>
     <data checksum="0xb013389c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3224,7 +3224,7 @@
     </cellMethods>
     <data checksum="0x208fa829" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3276,7 +3276,7 @@
     </cellMethods>
     <data checksum="0xe2582bbd" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3328,7 +3328,7 @@
     </cellMethods>
     <data checksum="0xb964b7d7" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3380,7 +3380,7 @@
     </cellMethods>
     <data checksum="0xc8a5b95e" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3432,7 +3432,7 @@
     </cellMethods>
     <data checksum="0x4bd4eae9" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3484,7 +3484,7 @@
     </cellMethods>
     <data checksum="0xe0549b09" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3536,7 +3536,7 @@
     </cellMethods>
     <data checksum="0xf6e3546d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3588,7 +3588,7 @@
     </cellMethods>
     <data checksum="0x5525ab2a" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3640,7 +3640,7 @@
     </cellMethods>
     <data checksum="0xb48c5eb1" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3692,7 +3692,7 @@
     </cellMethods>
     <data checksum="0xcfb28f0d" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3744,7 +3744,7 @@
     </cellMethods>
     <data checksum="0x4290df26" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3796,7 +3796,7 @@
     </cellMethods>
     <data checksum="0x82c0d953" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3848,7 +3848,7 @@
     </cellMethods>
     <data checksum="0x49202448" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -3900,7 +3900,7 @@
     </cellMethods>
     <data checksum="0x04b1c44c" dtype="float32" shape="(144, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/dec.cml
+++ b/lib/iris/tests/results/merge/dec.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -140,7 +140,7 @@
     </cellMethods>
     <data checksum="0x7b0108a9" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="specific_humidity" units="kg kg-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="specific_humidity" units="kg kg-1">
     <attributes>
       <attribute name="STASH" value="m01s00i010"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -280,7 +280,7 @@
     </cellMethods>
     <data checksum="0x28056617" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="x_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="x_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i002"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -421,7 +421,7 @@
     </cellMethods>
     <data checksum="0xe099eee0" dtype="float32" shape="(38, 145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="y_wind" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="y_wind" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s00i003"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/theta.cml
+++ b/lib/iris/tests/results/merge/theta.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/merge/theta_two_times.cml
+++ b/lib/iris/tests/results/merge/theta_two_times.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -20,7 +20,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -41,7 +41,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -66,7 +66,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -89,7 +89,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -112,7 +112,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -131,7 +131,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -150,7 +150,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -170,7 +170,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -190,7 +190,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -213,7 +213,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -232,7 +232,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -252,7 +252,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -272,7 +272,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -295,7 +295,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -320,7 +320,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_maximum" units="1" var_name="cube_maximum">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_maximum" units="1" var_name="cube_maximum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -333,7 +333,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mean" units="1" var_name="cube_mean">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mean" units="1" var_name="cube_mean">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -346,7 +346,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_median" units="1" var_name="cube_median">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_median" units="1" var_name="cube_median">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -359,7 +359,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -372,7 +372,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_minimum" units="1" var_name="cube_minimum">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_minimum" units="1" var_name="cube_minimum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -385,7 +385,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -404,7 +404,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -424,7 +424,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -447,7 +447,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_mode" units="1" var_name="cube_mode">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_mode" units="1" var_name="cube_mode">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -460,7 +460,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_point" units="1" var_name="cube_point">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_point" units="1" var_name="cube_point">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -473,7 +473,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -486,7 +486,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_sum" units="1" var_name="cube_sum">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_sum" units="1" var_name="cube_sum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -499,7 +499,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube core-dtype="int32" dtype="int32" fill_value="-2147483647" long_name="cube_variance" units="1" var_name="cube_variance">
+  <cube core-dtype="int32" dtype="int32" long_name="cube_variance" units="1" var_name="cube_variance">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_index_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_mix_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_slice_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_deferred_tuple_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_hires.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+20" long_name="Zonal Surface Wind Speed" standard_name="eastward_wind" units="m s-1" var_name="uas">
+  <cube core-dtype="float32" dtype="float32" long_name="Zonal Surface Wind Speed" standard_name="eastward_wind" units="m s-1" var_name="uas">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="cmor_version" value="0.96"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyt_total.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
+  <cube core-dtype="float64" dtype="float64" long_name="Total column Carbon Dioxide" units="kg m**-2" var_name="tcco2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="Thu Feb 11 10:56:57 2010: ncks total_column_co2.nc -o SMALL_total_column_co2.nc -d time,,30

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube core-dtype="float64" dtype="float64" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>
@@ -26,7 +26,7 @@
     <cellMethods/>
     <data checksum="0x65252ed2" dtype="float64" shape="(1, 60, 181, 360)"/>
   </cube>
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube core-dtype="float64" dtype="float64" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
+  <cube core-dtype="float64" dtype="float64" long_name="Carbon Dioxide" units="kg kg**-1" var_name="co2">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-32767.0" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
+  <cube core-dtype="float64" dtype="float64" long_name="Logarithm of surface pressure" units="no_unit" var_name="lnsp">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="history" value="2009-08-25 13:46:31 GMT by mars2netcdf-0.92"/>

--- a/lib/iris/tests/results/netcdf/netcdf_lcc.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_lcc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="1e+20" long_name="Daily Mean Near-Surface Air Temperature" standard_name="air_temperature" units="Celsius" var_name="tas">
+  <cube core-dtype="float64" dtype="float64" long_name="Daily Mean Near-Surface Air Temperature" standard_name="air_temperature" units="Celsius" var_name="tas">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>

--- a/lib/iris/tests/results/netcdf/netcdf_rotated_xy_land.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_rotated_xy_land.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+30" long_name="land area fraction of grid cell" standard_name="land_area_fraction" units="1" var_name="sftls">
+  <cube core-dtype="float32" dtype="float32" long_name="land area fraction of grid cell" standard_name="land_area_fraction" units="1" var_name="sftls">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="conventionsURL" value="http://www.cgd.ucar.edu/cms/eaton/cf-metadata/index.html"/>

--- a/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_rotated_xyt_precipitation.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+30" long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
+  <cube core-dtype="float32" dtype="float32" long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
     <attributes>
       <attribute name="Conventions" value="CF-1.0"/>
       <attribute name="NCO" value="4.1.0"/>

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K" var_name="air_potential_temperature">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K" var_name="air_potential_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m01s00i004"/>

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_ndim_auxiliary.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="1e+30" long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
+  <cube core-dtype="float32" dtype="float32" long_name="Precipitation" standard_name="precipitation_flux" units="kg m-2 s-1" var_name="pr">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="NCO" value="4.1.0"/>

--- a/lib/iris/tests/results/netcdf/netcdf_stereo.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_stereo.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
+  <cube core-dtype="float32" dtype="float32" long_name="toa_brightness_temperature" standard_name="toa_brightness_temperature" units="K" var_name="data">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-9999.0" long_name="Mean temperature" units="degrees_celsius" var_name="tmean">
+  <cube core-dtype="float32" dtype="float32" long_name="Mean temperature" units="degrees_celsius" var_name="tmean">
     <attributes>
       <attribute name="Conventions" value="CF-1.6"/>
       <attribute name="Note" value="This dataset is for test purposes only"/>

--- a/lib/iris/tests/results/pp_rules/global.cml
+++ b/lib/iris/tests/results/pp_rules/global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="9999.0" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
+++ b/lib/iris/tests/results/pp_rules/lbproc_mean_max_min.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -37,7 +37,7 @@
     <cellMethods/>
     <data checksum="0x80e93a14" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -78,7 +78,7 @@
     </cellMethods>
     <data checksum="0x85641c30" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -119,7 +119,7 @@
     </cellMethods>
     <data checksum="0x03d5c2e9" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -160,7 +160,7 @@
     </cellMethods>
     <data checksum="0xac9bd3e8" dtype="float32" shape="(145, 192)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/lbtim_2.cml
+++ b/lib/iris/tests/results/pp_rules/lbtim_2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/ocean_depth.cml
+++ b/lib/iris/tests/results/pp_rules/ocean_depth.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
+++ b/lib/iris/tests/results/pp_rules/ocean_depth_bounded.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/pp_rules/rotated_uk.cml
+++ b/lib/iris/tests/results/pp_rules/rotated_uk.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="wind_speed_of_gust" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="wind_speed_of_gust" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s03i463"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_0d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
+++ b/lib/iris/tests/results/regrid/airpress_on_theta_3d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_pressure" units="Pa">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_pressure" units="Pa">
     <attributes>
       <attribute name="STASH" value="m01s00i408"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_0d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_1d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_2d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
+++ b/lib/iris/tests/results/regrid/theta_on_airpress_3d.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/system/supported_filetype_.pp.cml
+++ b/lib/iris/tests/results/system/supported_filetype_.pp.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="wind_speed" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="wind_speed" units="m s-1">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[9.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/trajectory/constant_latitude.cml
+++ b/lib/iris/tests/results/trajectory/constant_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/single_point.cml
+++ b/lib/iris/tests/results/trajectory/single_point.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="9.96920996839e+36" long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
+  <cube core-dtype="float64" dtype="float64" long_name="Temperature" standard_name="sea_water_potential_temperature" units="degC" var_name="votemper">
     <attributes>
       <attribute name="Conventions" value="CF-1.1"/>
       <attribute name="DOMAIN_DIM_N001" value="x"/>

--- a/lib/iris/tests/results/trajectory/zigzag.cml
+++ b/lib/iris/tests/results/trajectory/zigzag.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float64" dtype="float64" fill_value="-1073741824.0" standard_name="air_potential_temperature" units="K">
+  <cube core-dtype="float64" dtype="float64" standard_name="air_potential_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s00i004"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/uri_callback/pp_global.cml
+++ b/lib/iris/tests/results/uri_callback/pp_global.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="filename" value="global.pp"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/001000000000.00.000.000000.1860.01.01.00.00.f.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_surface_height_above_geoid" units="m" var_name="sea_surface_height_above_geoid">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_surface_height_above_geoid" units="m" var_name="sea_surface_height_above_geoid">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
     </attributes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
+  <cube core-dtype="float32" dtype="float32" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/ocean_xsect.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC" var_name="sea_water_potential_temperature">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_water_potential_temperature" units="degC" var_name="sea_water_potential_temperature">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
+  <cube core-dtype="float32" dtype="float32" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="1" var_name="unknown">
+  <cube core-dtype="float32" dtype="float32" units="1" var_name="unknown">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s00i???"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st30211.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="northward_ocean_heat_transport" units="PW" var_name="northward_ocean_heat_transport">
+  <cube core-dtype="float32" dtype="float32" standard_name="northward_ocean_heat_transport" units="PW" var_name="northward_ocean_heat_transport">
     <attributes>
       <attribute name="Conventions" value="CF-1.5"/>
       <attribute name="STASH" value="m02s30i211"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.000128.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.004224.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.03.236.008320.1990.12.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/000003000000.16.202.000128.1860.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/001000000000.00.000.000000.1860.01.01.00.00.f.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/001000000000.00.000.000000.1860.01.01.00.00.f.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_surface_height_above_geoid" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_surface_height_above_geoid" units="m">
     <coords>
       <coord>
         <dimCoord bounds="[[-86400.0, 0.0]]" id="1d45e087" points="[-43200.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/002000000000.44.101.131200.1920.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/008000000000.44.101.000128.1890.09.01.00.00.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <attributes>
       <attribute name="STASH" value="m??s44i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/12187.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1">
+  <cube core-dtype="float32" dtype="float32" long_name="change_over_time_in_upward_air_velocity_due_to_advection" units="m s-1">
     <attributes>
       <attribute name="STASH" value="m01s12i187"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/HadCM2_ts_SAT_ann_18602100.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="Celsius">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="Celsius">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_level_lat_orig.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_press_orig.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_lon_lat_several.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_n10r13xy.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="source" value="Data from Met Office Unified Model"/>
     </attributes>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_time_press.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="geopotential_height" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/aaxzc_tseries.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abcza_pa19591997_daily_29.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -63,7 +63,7 @@
     </cellMethods>
     <data checksum="0x82b10a0a" dtype="float32" shape="(360, 73, 96)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s03i236"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>
@@ -126,7 +126,7 @@
     </cellMethods>
     <data checksum="0xd9f6eff7" dtype="float32" shape="(360, 73, 96)"/>
   </cube>
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="precipitation_flux" units="kg m-2 s-1">
+  <cube core-dtype="float32" dtype="float32" standard_name="precipitation_flux" units="kg m-2 s-1">
     <attributes>
       <attribute name="STASH" value="m01s05i216"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/abxpa_press_lat.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1.07374e+09" standard_name="geopotential_height" units="m">
+  <cube core-dtype="float32" dtype="float32" standard_name="geopotential_height" units="m">
     <attributes>
       <attribute name="STASH" value="m01s16i202"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/model.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="air_temperature" units="K">
+  <cube core-dtype="float32" dtype="float32" standard_name="air_temperature" units="K">
     <attributes>
       <attribute name="STASH" value="m01s16i203"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/ocean_xsect.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="sea_water_potential_temperature" units="degC">
+  <cube core-dtype="float32" dtype="float32" standard_name="sea_water_potential_temperature" units="degC">
     <attributes>
       <attribute name="STASH" value="m02s00i101"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc699.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st0fc942.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" units="unknown">
+  <cube core-dtype="float32" dtype="float32" units="unknown">
     <attributes>
       <attribute name="STASH" value="m02s00i???"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_pp/st30211.b.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube core-dtype="float32" dtype="float32" fill_value="-1e+30" standard_name="northward_ocean_heat_transport" units="PW">
+  <cube core-dtype="float32" dtype="float32" standard_name="northward_ocean_heat_transport" units="PW">
     <attributes>
       <attribute name="STASH" value="m02s30i211"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>


### PR DESCRIPTION
Now that `fill_value` isn't a cube attribute, nor is it a part of the xml we need to remove the fill_value from the cml

See the change in the recently merged PR: https://github.com/SciTools/iris/pull/2699/files#diff-d1f30240d0d146f09f58577e718ba6a6L2824