### PR TITLE
Remove some cube.fill_value usages

### DIFF
--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -205,12 +205,10 @@ class TestAnalysisBasic(tests.IrisTest):
         file = tests.get_data_path(('PP', 'aPProt1', 'rotatedMHtimecube.pp'))
         cubes = iris.load(file)
         self.cube = cubes[0]
-        self.cube_fill_val = self.cube.fill_value
         self.assertCML(self.cube, ('analysis', 'original.cml'))
 
     def _common(self, name, aggregate, original_name='original_common.cml', *args, **kwargs):
         self.cube.data = self.cube.data.astype(np.float64)
-        self.cube.fill_value = self.cube_fill_val
 
         self.assertCML(self.cube, ('analysis', original_name))
 
@@ -236,7 +234,6 @@ class TestAnalysisBasic(tests.IrisTest):
     def test_hmean(self):
         # harmonic mean requires data > 0
         self.cube.data *= self.cube.data
-        self.cube.fill_value = self.cube_fill_val
         self._common('hmean', iris.analysis.HMEAN, 'original_hmean.cml', rtol=1e-05)
 
     def test_gmean(self):

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -360,11 +360,7 @@ class TestBasicMaths(tests.IrisTest):
 class TestDivideAndMultiply(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
-        # We require to preserve the cube fill_value
-        # across the cube data setter operation.
-        fill_value = self.cube.fill_value
         self.cube.data = self.cube.data - 260
-        self.cube.fill_value = fill_value
 
     def test_divide(self):
         a = self.cube
@@ -498,17 +494,11 @@ class TestDivideAndMultiply(tests.IrisTest):
 class TestExponentiate(tests.IrisTest):
     def setUp(self):
         self.cube = iris.tests.stock.global_pp()
-        # We require to preserve the cube fill_value
-        # across the cube data setter operation.
-        self.fill_value = self.cube.fill_value
         self.cube.data = self.cube.data - 260
-        self.cube.fill_value = self.fill_value
 
     def test_exponentiate(self):
         a = self.cube
         a.data = a.data.astype(np.float64)
-        # We require to preserve the cube fill_value after setting the data.
-        a.fill_value = self.fill_value
         e = pow(a, 4)
         self.assertCMLApproxData(e, ('analysis', 'exponentiate.cml'))
 
@@ -516,8 +506,6 @@ class TestExponentiate(tests.IrisTest):
         # Make sure we have something which we can take the root of.
         a = self.cube
         a.data = abs(a.data)
-        # We require to preserve the cube fill_value after setting the data.
-        a.fill_value = self.fill_value
         a.units **= 2
 
         e = a ** 0.5


### PR DESCRIPTION
Some of the parts of the tests that try to set the cube.fill_value which no longer exists