### PR TITLE
Lazy masked fill_value retrieval for NC save 

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -126,6 +126,34 @@ def as_concrete_data(data):
     return data
 
 
+def lazy_masked_fill_value(data):
+    """
+    Return the fill value of a lazy masked array.
+
+    Args:
+
+    * data:
+        A dask array, NumPy `ndarray` or masked array
+
+    Returns:
+        The fill value of `data` if `data` represents a masked array, or None.
+
+    """
+    # If lazy, get the smallest slice of the data from which we can retrieve
+    # the fill_value.
+    if is_lazy_data(data):
+        inds = tuple([0] * (data.ndim-1))
+        smallest_slice = data[inds][:0]
+        data = as_concrete_data(smallest_slice)
+
+    # Now get the fill value.
+    fill_value = None
+    if ma.isMaskedArray(data):
+        fill_value = data.fill_value
+
+    return fill_value
+
+
 def multidim_lazy_stack(stack):
     """
     Recursively build a multidimensional stacked dask array.

--- a/lib/iris/tests/unit/lazy_data/test_lazy_masked_fill_value.py
+++ b/lib/iris/tests/unit/lazy_data/test_lazy_masked_fill_value.py
@@ -1,0 +1,86 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Test the function :func:`iris._lazy data.lazy_masked_fill_value`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import dask.array as da
+import numpy as np
+import numpy.ma as ma
+
+from iris._lazy_data import lazy_masked_fill_value, _MAX_CHUNK_SIZE
+
+
+class Test_as_lazy_data(tests.IrisTest):
+    def setUp(self):
+        shape = (2, 3, 4)
+        data = np.arange(24).reshape(shape)
+        mask = np.zeros(shape)
+        mask[data % 5 == 1] = 1
+        self.fill_value = 9999
+        self.m = ma.masked_array(data, mask=mask, fill_value=self.fill_value)
+        self.dm = da.from_array(self.m, asarray=False,
+                                chunks=_MAX_CHUNK_SIZE)
+
+    def test_lazy_masked_ND(self):
+        fill_value = lazy_masked_fill_value(self.dm)
+        self.assertEqual(fill_value, self.fill_value)
+
+    def test_lazy_masked_0D(self):
+        data = self.dm[0, 0, :1]
+        fill_value = lazy_masked_fill_value(data)
+        self.assertEqual(fill_value, self.fill_value)
+
+    def test_lazy_masked_1D(self):
+        data = self.dm[0, 0, :]
+        fill_value = lazy_masked_fill_value(data)
+        self.assertEqual(fill_value, self.fill_value)
+
+    def test_lazy_masked_2D(self):
+        data = self.dm[0, :]
+        fill_value = lazy_masked_fill_value(data)
+        self.assertEqual(fill_value, self.fill_value)
+
+    def test_real_masked(self):
+        fill_value = lazy_masked_fill_value(self.m)
+        self.assertEqual(fill_value, self.fill_value)
+
+    def test_lazy_unmasked(self):
+        data = da.from_array(self.m.filled(),
+                             chunks=_MAX_CHUNK_SIZE)
+        fill_value = lazy_masked_fill_value(data)
+        self.assertIsNone(fill_value)
+
+    def test_real_unmasked(self):
+        data = self.m.filled()
+        fill_value = lazy_masked_fill_value(data)
+        self.assertIsNone(fill_value)
+
+    def test_data_not_realised(self):
+        # Check that only the zero-element slice is realised.
+        data = self.dm[0, :]
+        lazy_masked_fill_value(data)
+        self.assertIsInstance(data, da.core.Array)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Enables lazy masked `fill_value` retrieval for NetCDF save.

Dask exposes no mechanism for retrieving the fill value of a lazy masked array (indeed, arguably this is currently not a soluble problem). This PR proposes a workaround for this problem, exposes the workaround as a function in `iris._lazy_data` and integrates the function into the NetCDF saver.

Specifically, the workaround realises the smallest possible slice of the lazy masked data array that, when realised, contains the required fill value. Turns out the smallest possible slice is actually an empty slice:
```python
>>> m = np.ma.masked_array([0, 1, 2], mask=[1, 0, 1], fill_value=9999)
>>> dm = da.from_array(m, chunks=(3,), asarray=False)
>>> dm[:0].compute().fill_value
9999
```

Fixes #2703. 