### PR TITLE
coord system requirement added to regrid docstring

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3803,6 +3803,11 @@ calendar='gregorian')
             this cube will be converted to values on the new grid
             according to the given regridding scheme.
 
+        .. note::
+
+            Both the source and target cubes must have a CoordSystem, otherwise
+            this function is not applicable.
+
         """
         regridder = scheme.regridder(self, grid)
         return regridder(self)


### PR DESCRIPTION
If you want to use cube.regrid then both your source and target cubes have to have coordinate systems on them.  This is not explained in the docstring so I have added a note to point it out, because it was tripping some people up.