### PR TITLE
Use matplotlib default settings for tests

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -77,6 +77,7 @@ import iris.util
 try:
     import matplotlib
     matplotlib.use('agg')
+    matplotlib.rcdefaults()
     import matplotlib.testing.compare as mcompare
     import matplotlib.pyplot as plt
 except ImportError:
@@ -874,7 +875,7 @@ class IrisTest_nometa(unittest.TestCase):
 # At present, that includes not using "python setup.py test"
 # The typically best way is like this :
 #    $ export IRIS_TEST_TIMINGS=1
-#    $ python -m unittest discover -s iris.tests 
+#    $ python -m unittest discover -s iris.tests
 # and commonly adding ...
 #    | grep "TIMING TEST" >iris_test_output.txt
 #


### PR DESCRIPTION
Recently when running the Iris tests locally, I have had a lot of errors of the form `AssertionError: Image comparison failed: Bad phash`.  It took me a while to realise that this was because I've set `image.cmap` and `axes.prop_cycle` in my `matplotlibrc` file, so the colours were wrong according to the plotting tests.

This very minor change forces the tests to use the matplotlib default settings, so the above issue doesn't come up.