### PR TITLE
Run Travis tests in serial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,10 @@ install:
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
+      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=1;
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
-      python -m iris.tests.runner --example-tests --print-failed-images;
+      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=1;
     fi
   # "make html" produces an error when run on Travis that does not
   # affect any downstream functionality but causes the build to fail


### PR DESCRIPTION
Fix to get the tests passing while we investigate why there are now so many time-outs.