### PR TITLE
Fixes for GRIB unit tests

### DIFF
--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -181,7 +181,7 @@ class GribWrapper(object):
                                   offset - message_length)
             self._data = as_lazy_data(proxy)
         else:
-            values_array = _message_values(grib_message, shape)
+            self._data = _message_values(grib_message, shape)
 
     def _confirm_in_scope(self):
         """Ensure we have a grib flavour that we choose to support."""

--- a/lib/iris/fileformats/grib/__init__.py
+++ b/lib/iris/fileformats/grib/__init__.py
@@ -181,7 +181,7 @@ class GribWrapper(object):
                                   offset - message_length)
             self._data = as_lazy_data(proxy)
         else:
-            self._data = _message_values(grib_message, shape)
+            self.data = _message_values(grib_message, shape)
 
     def _confirm_in_scope(self):
         """Ensure we have a grib flavour that we choose to support."""

--- a/lib/iris/tests/test_grib_load_translations.py
+++ b/lib/iris/tests/test_grib_load_translations.py
@@ -369,7 +369,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         grib.edition = 1
         return grib
 
-    @tests.skip_dask_mask
     def test_grib1_unknownparam(self):
         grib = self.mock_grib()
         grib.table2Version = 0
@@ -379,7 +378,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
-    @tests.skip_dask_mask
     def test_grib1_unknown_local_param(self):
         grib = self.mock_grib()
         grib.table2Version = 128
@@ -389,7 +387,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, 'UNKNOWN LOCAL PARAM 999.128')
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
-    @tests.skip_dask_mask
     def test_grib1_unknown_standard_param(self):
         grib = self.mock_grib()
         grib.table2Version = 1
@@ -408,7 +405,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit(units_str))
 
-    @tests.skip_dask_mask
     def test_grib1_known_standard_params(self):
         # at present, there are just a very few of these
         self.known_grib1(11, 'air_temperature', 'kelvin')

--- a/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
@@ -91,46 +91,21 @@ class Test_data__masked(tests.IrisTest):
         self.assertEqual(result.shape, self.shape)
         self.assertArrayEqual(result, expected)
 
-    @tests.skip_dask_mask
-    def test_bitmap_present_int_data(self):
+    def test_bitmap_present(self):
         # Test the behaviour where bitmap and codedValues shapes
-        # are not equal, and codedValues is integer data.
-        data_type = np.int64
+        # are not equal.
         input_values = np.arange(5)
-        output_values = np.array([-1, -1, 0, 1, -1, -1, -1, 2, -1, 3, -1, 4],
-                                 dtype=data_type)
+        output_values = np.array([-1, -1, 0, 1, -1, -1, -1, 2, -1, 3, -1, 4])
         message = _make_test_message({3: self._section_3,
                                       6: {'bitMapIndicator': 0,
                                           'bitmap': self.bitmap},
                                       7: {'codedValues': input_values}})
-        result = as_concrete_data(message.data, nans_replacement=ma.masked,
-                                  result_dtype=data_type)
-        expected = ma.masked_array(output_values,
-                                   np.logical_not(self.bitmap))
-        expected = expected.reshape(self.shape)
-        self.assertMaskedArrayEqual(result, expected)
-        self.assertEqual(result.dtype, data_type)
-
-    @tests.skip_dask_mask
-    def test_bitmap_present_float_data(self):
-        # Test the behaviour where bitmap and codedValues shapes
-        # are not equal, and codedValues is float data.
-        data_type = np.float32
-        input_values = np.arange(5, dtype=np.float32) + 5
-        output_values = np.array([-1, -1, 5, 6, -1, -1, -1, 7, -1, 8, -1, 9],
-                                 dtype=data_type)
-        message = _make_test_message({3: self._section_3,
-                                      6: {'bitMapIndicator': 0,
-                                          'bitmap': self.bitmap},
-                                      7: {'codedValues': input_values}})
-        result = as_concrete_data(message.data, nans_replacement=ma.masked,
-                                  result_dtype=data_type)
+        result = as_concrete_data(message.data)
         expected = ma.masked_array(output_values,
                                    np.logical_not(self.bitmap))
         expected = expected.reshape(self.shape)
         self.assertMaskedArrayEqual(result, expected)
 
-    @tests.skip_dask_mask
     def test_bitmap__shapes_mismatch(self):
         # Test the behaviour where bitmap and codedValues shapes do not match.
         # Too many or too few unmasked values in codedValues will cause this.
@@ -140,9 +115,8 @@ class Test_data__masked(tests.IrisTest):
                                           'bitmap': self.bitmap},
                                       7: {'codedValues': values}})
         with self.assertRaisesRegexp(TranslationError, 'do not match'):
-            as_concrete_data(message.data, nans_replacement=ma.masked)
+            as_concrete_data(message.data)
 
-    @tests.skip_dask_mask
     def test_bitmap__invalid_indicator(self):
         values = np.arange(12)
         message = _make_test_message({3: self._section_3,
@@ -150,7 +124,7 @@ class Test_data__masked(tests.IrisTest):
                                           'bitmap': None},
                                       7: {'codedValues': values}})
         with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
-            as_concrete_data(message.data, nans_replacement=ma.masked)
+            as_concrete_data(message.data)
 
 
 class Test_data__unsupported(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test__DataProxy.py
@@ -33,24 +33,23 @@ from iris.exceptions import TranslationError
 from iris.fileformats.grib.message import _DataProxy
 
 
-@tests.skip_dask_mask
 class Test__bitmap(tests.IrisTest):
     def test_no_bitmap(self):
         section_6 = {'bitMapIndicator': 255, 'bitmap': None}
-        data_proxy = _DataProxy(0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0)
         result = data_proxy._bitmap(section_6)
         self.assertIsNone(result)
 
     def test_bitmap_present(self):
         bitmap = randint(2, size=(12))
         section_6 = {'bitMapIndicator': 0, 'bitmap': bitmap}
-        data_proxy = _DataProxy(0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0)
         result = data_proxy._bitmap(section_6)
         self.assertArrayEqual(bitmap, result)
 
     def test_bitmap__invalid_indicator(self):
         section_6 = {'bitMapIndicator': 100, 'bitmap': None}
-        data_proxy = _DataProxy(0, 0, 0, 0)
+        data_proxy = _DataProxy(0, 0, 0)
         with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
             data_proxy._bitmap(section_6)
 


### PR DESCRIPTION
Closes #2710
Closes #2709 

Relatively straightforward:
- Fixed the bug where the data array of a `GribWrapper` wasn't being assigned to, and unskipped relevant tests
- Removed uses of `nans_replacement` in other unit tests.
- Removed a duplicate unit test which only differed on the dtype of the data. It was testing the "realised dtype" and "nans_replacement" code.