### PR TITLE
Critical Testing Instability | Dask Version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,3 @@ GNU Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
 along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-


### PR DESCRIPTION
The first commit on this branch removes white space from the README.md: a no change change

this cascades a chain of CI testing failure ERRORs, of the form:

```
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/Iris-2.0a0-py2.7-linux-x86_64.egg/iris/cube.py", line 2130, in __getitem__
    cube_data, keys)
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/Iris-2.0a0-py2.7-linux-x86_64.egg/iris/util.py", line 690, in _slice_data_with_keys
    data = data[this_slice]
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/dask/array/core.py", line 1222, in __getitem__
    index2 = normalize_index(index, self.shape)
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/dask/array/slicing.py", line 762, in normalize_index
    raise IndexError("Too many indices for array")
IndexError: Too many indices for array
```

This does has not appeared on the last run of master testing, which was last run ~28 days prior to this run

This previous run was using dask 0.15.2
https://travis-ci.org/SciTools/iris/jobs/270360216#L1266

This run is using dask 0.15.3
I can reproduce this failure locally using dask 0.15.3

It is not clear to me that this minor version change is the trigger for the failure mode, it is just a potential clue

This is a blocker for incoming Pull Requests, and hence I consider it a significant and time critical issue
