### PR TITLE
Bump travis python version 3.5 to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3.6
 sudo: false
 
 env:


### PR DESCRIPTION
Use Python 3.6 for the Python 3 Travis tests due to[ issues using python 3.5](https://github.com/SciTools/iris/pull/2769#issuecomment-335147830).