### PR TITLE
Use any latest Python 3 version in Travis matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3
 sudo: false
 
 env:


### PR DESCRIPTION
In response to #2774,
let's just see what unpinning the minor version will do ...
