### PR TITLE
Fix for pandas.as_dataframe when cube data array is a view

### DIFF
--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -143,15 +143,18 @@ def _assert_shared(np_obj, pandas_obj):
     if base is None:
         base = pandas_obj.values
 
-    # Chase the stack of NumPy `base` references back to see if any of
-    # them are our original array.
-    while base is not None:
-        if base is np_obj:
-            return
-        # Take the next step up the stack of `base` references.
-        base = base.base
-    msg = 'Pandas {} does not share memory'.format(type(pandas_obj).__name__)
-    raise AssertionError(msg)
+    def _get_base(array):
+        # Chase the stack of NumPy `base` references back to the original array
+        while array.base is not None:
+            array = array.base
+        return array
+
+    base = _get_base(base)
+    np_base = _get_base(np_obj)
+    if base is not np_base:
+        msg = ('Pandas {} does not share memory'
+               .format(type(pandas_obj).__name__))
+        raise AssertionError(msg)
 
 
 def as_series(cube, copy=True):

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -299,6 +299,13 @@ class TestAsDataFrame(tests.IrisTest):
         with self.assertRaises(ValueError):
             data_frame = iris.pandas.as_data_frame(cube, copy=False)
 
+    def test_copy_false_with_cube_view(self):
+        data = np.array([[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]])
+        cube = Cube(data[:], long_name="foo")
+        data_frame = iris.pandas.as_data_frame(cube, copy=False)
+        data_frame[0][0] = 99
+        self.assertEqual(cube.data[0, 0], 99)
+
 
 @skip_pandas
 class TestSeriesAsCube(tests.IrisTest):


### PR DESCRIPTION
Trying to convert an iris cube to a pandas dataframe currently fails if the `copy=False` argument is used and the cube data is a view.  The data is correctly shared between the cube and the dataframe.  However, the check that the data is shared fails to account for the cube data being a view and throws an error.  First commit here demonstrates the failure (error is thrown when creating the dataframe), and the second is the fix.

I've not investigated why loading the data that triggered this error resulted in a cubelist where the individual cubes had a view for the data rather than the base array.  