### PR TITLE
Restore readonly DimCoords

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1610,17 +1610,17 @@ class DimCoord(Coord):
         """
         new_coord = copy.deepcopy(super(DimCoord, self), memo)
         # Ensure points and bounds arrays are read-only.
-        new_coord._points_dm.core_data().flags.writeable = False
+        new_coord._points_dm.data.flags.writeable = False
         if new_coord._bounds_dm is not None:
-            new_coord._bounds_dm.core_data().flags.writeable = False
+            new_coord._bounds_dm.data.flags.writeable = False
         return new_coord
 
     def copy(self, points=None, bounds=None):
         new_coord = super(DimCoord, self).copy(points=points, bounds=bounds)
         # Make the arrays read-only.
-        new_coord._points_dm.core_data().flags.writeable = False
+        new_coord._points_dm.data.flags.writeable = False
         if bounds is not None:
-            new_coord._bounds_dm.core_data().flags.writeable = False
+            new_coord._bounds_dm.data.flags.writeable = False
         return new_coord
 
     def __eq__(self, other):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -666,7 +666,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         or a dask array.
 
         """
-        return self._points_dm.core_data()
+        result = self._points_dm.core_data()
+        if not is_lazy_data(result):
+            result = result.view()
+        return result
 
     def core_bounds(self):
         """
@@ -677,6 +680,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         result = None
         if self.has_bounds():
             result = self._bounds_dm.core_data()
+            if not is_lazy_data(result):
+                result = result.view()
         return result
 
     def has_lazy_points(self):
@@ -1758,16 +1763,6 @@ class DimCoord(Coord):
             bounds.flags.writeable = False
 
     bounds = property(Coord._bounds_getter, _bounds_setter)
-
-    def core_points(self):
-        result = super(DimCoord, self).core_points()
-        return result.view()
-
-    def core_bounds(self):
-        result = super(DimCoord, self).core_bounds()
-        if result is not None:
-            result = result.view()
-        return result
 
     def is_monotonic(self):
         return True

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1604,7 +1604,6 @@ class DimCoord(Coord):
 
         """
         new_coord = copy.deepcopy(super(DimCoord, self), memo)
-
         # Ensure points and bounds arrays are read-only.
         new_coord._points_dm.core_data().flags.writeable = False
         if new_coord._bounds_dm is not None:
@@ -1683,8 +1682,8 @@ class DimCoord(Coord):
 
     def _points_setter(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
-        # Ensure it is an actual array, and also make our own distinct view
-        # so that we can make it read-only.
+        # Ensure it is an actual array, and also make our own copy so that we
+        # can make it read-only.
         points = as_concrete_data(points)
         points = np.array(points)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1679,7 +1679,7 @@ class DimCoord(Coord):
 
     def _points_setter(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
-        copy = is_lazy_data(points)
+        copy = not is_lazy_data(points)
         points = as_concrete_data(points)
         # Ensure it is an actual array, and also make our own distinct view
         # so that we can make it read-only.
@@ -1741,7 +1741,7 @@ class DimCoord(Coord):
     def _bounds_setter(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.
-            copy = is_lazy_data(bounds)
+            copy = not is_lazy_data(bounds)
             bounds = as_concrete_data(bounds)
             bounds = np.array(bounds, copy=copy)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -572,7 +572,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
     def _points_getter(self):
         """The coordinate points values as a NumPy array."""
-        return self._points_dm.data
+        return self._points_dm.data.view()
 
     def _points_setter(self, points):
         # Set the points to a new array - as long as it's the same shape.
@@ -601,7 +601,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         """
         bounds = None
         if self.has_bounds():
-            bounds = self._bounds_dm.data
+            bounds = self._bounds_dm.data.view()
         return bounds
 
     def _bounds_setter(self, bounds):
@@ -1677,9 +1677,6 @@ class DimCoord(Coord):
         if points.size > 1 and not iris.util.monotonic(points, strict=True):
             raise ValueError('The points array must be strictly monotonic.')
 
-    def _points_getter(self):
-        return super(DimCoord, self)._points_getter().view()
-
     def _points_setter(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
         # Ensure it is an actual array, and also make our own copy so that we
@@ -1701,7 +1698,7 @@ class DimCoord(Coord):
             # Make the array read-only.
             points.flags.writeable = False
 
-    points = property(_points_getter, _points_setter)
+    points = property(Coord._points_getter, _points_setter)
 
     def _new_bounds_requirements(self, bounds):
         """
@@ -1740,12 +1737,6 @@ class DimCoord(Coord):
                     raise ValueError('The direction of monotonicity must be '
                                      'consistent across all bounds')
 
-    def _bounds_getter(self):
-        result = super(DimCoord, self)._bounds_getter()
-        if result is not None:
-            result = result.view()
-        return result
-
     def _bounds_setter(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.
@@ -1766,7 +1757,7 @@ class DimCoord(Coord):
             # Ensure the array is read-only.
             bounds.flags.writeable = False
 
-    bounds = property(_bounds_getter, _bounds_setter)
+    bounds = property(Coord._bounds_getter, _bounds_setter)
 
     def core_points(self):
         result = super(DimCoord, self).core_points()

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1677,6 +1677,9 @@ class DimCoord(Coord):
         if points.size > 1 and not iris.util.monotonic(points, strict=True):
             raise ValueError('The points array must be strictly monotonic.')
 
+    def _points_getter(self):
+        return super(DimCoord, self)._points_getter().view()
+
     def _points_setter(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
         copy = not is_lazy_data(points)
@@ -1699,7 +1702,7 @@ class DimCoord(Coord):
             # Make the array read-only.
             points.flags.writeable = False
 
-    points = property(Coord._points_getter, _points_setter)
+    points = property(_points_getter, _points_setter)
 
     def _new_bounds_requirements(self, bounds):
         """
@@ -1738,6 +1741,9 @@ class DimCoord(Coord):
                     raise ValueError('The direction of monotonicity must be '
                                      'consistent across all bounds')
 
+    def _bounds_getter(self):
+        return super(DimCoord, self)._bounds_getter().view()
+
     def _bounds_setter(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.
@@ -1759,7 +1765,7 @@ class DimCoord(Coord):
             # Ensure the array is read-only.
             bounds.flags.writeable = False
 
-    bounds = property(Coord._bounds_getter, _bounds_setter)
+    bounds = property(_bounds_getter, _bounds_setter)
 
     def is_monotonic(self):
         return True

--- a/lib/iris/tests/unit/coords/__init__.py
+++ b/lib/iris/tests/unit/coords/__init__.py
@@ -55,14 +55,12 @@ def is_real_data(array):
 
 def arrays_share_data(a1, a2):
     # Check whether 2 real arrays with the same content view the same data.
-    # Notes:
-    # *  !! destructive !!
-    # *  requires that array contents are initially identical
-    # *  forces a1 to be writeable and modifies it
-    assert np.all(a1 == a2)
-    a1.flags.writeable = True
-    a1 += np.array(1.0, dtype=a1.dtype)
-    return np.all(a1 == a2)
+    # For an ndarray x, x.base will either be None (if x owns its data) or a
+    # reference to the array which owns its data (if x is a view).
+    return a1 is a2 or \
+           a1.base is a2 or \
+           a2.base is a1 or \
+           a1.base is a2.base and a1.base is not None
 
 
 def lazyness_string(data):

--- a/lib/iris/tests/unit/coords/test_AuxCoord.py
+++ b/lib/iris/tests/unit/coords/test_AuxCoord.py
@@ -62,6 +62,10 @@ class Test__init__(tests.IrisTest, AuxCoordTestMixin):
                     self.assertArraysShareData(
                         pts, self.pts_real,
                         'Points are not the same data as the provided array.')
+                    self.assertIsNot(
+                        pts, self.pts_real,
+                        'Points array is the same instance as the provided '
+                        'array.')
                 else:
                     # the original points were cast to a test dtype.
                     check_pts = self.pts_real.astype(coord.dtype)
@@ -81,6 +85,10 @@ class Test__init__(tests.IrisTest, AuxCoordTestMixin):
                     self.assertArraysShareData(
                         bds, self.bds_real,
                         'Bounds are not the same data as the provided array.')
+                    self.assertIsNot(
+                        pts, self.pts_real,
+                        'Bounds array is the same instance as the provided '
+                        'array.')
                 else:
                     # the original bounds were cast to a test dtype.
                     check_bds = self.bds_real.astype(coord.bounds_dtype)
@@ -123,7 +131,7 @@ class Test_core_points(tests.IrisTest, AuxCoordTestMixin):
         coord = AuxCoord(self.pts_lazy)
         real_points = coord.points
         result = coord.core_points()
-        self.assertIs(result, real_points)
+        self.assertEqualRealArraysAndDtypes(result, real_points)
 
 
 class Test_core_bounds(tests.IrisTest, AuxCoordTestMixin):
@@ -152,7 +160,7 @@ class Test_core_bounds(tests.IrisTest, AuxCoordTestMixin):
         coord = AuxCoord(self.pts_real, bounds=self.bds_lazy)
         real_bounds = coord.bounds
         result = coord.core_bounds()
-        self.assertIs(result, real_bounds)
+        self.assertEqualRealArraysAndDtypes(result, real_bounds)
 
 
 class Test_lazy_points(tests.IrisTest, AuxCoordTestMixin):

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -56,29 +56,23 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
             pts = coord.core_points()
             bds = coord.core_bounds()
             # Check properties of points.
-            if (points_type_name == 'real' and
-                    coord.dtype == self.pts_real.dtype):
-                # Points array should be identical to the reference one.
-                self.assertArraysShareData(
-                    pts, self.pts_real,
-                    'Points are not the same data as the provided array.')
-            else:
-                # the original points array was cast to a test dtype.
-                check_pts = self.pts_real.astype(coord.dtype)
-                self.assertEqualRealArraysAndDtypes(pts, check_pts)
+            # Points array should not be identical to the reference one.
+            self.assertArraysDoNotShareData(
+                 pts, self.pts_real,
+               'Points are the same data as the provided array.')
+            # the original points array was cast to a test dtype.
+            check_pts = self.pts_real.astype(coord.dtype)
+            self.assertEqualRealArraysAndDtypes(pts, check_pts)
 
             # Check properties of bounds.
             if bounds_type_name != 'no':
-                if (bounds_type_name == 'real' and
-                        coord.bounds_dtype == self.bds_real.dtype):
-                    # Bounds array should be the reference data.
-                    self.assertArraysShareData(
-                        bds, self.bds_real,
-                        'Bounds are not the same data as the provided array.')
-                else:
-                    # the original bounds array was cast to a test dtype.
-                    check_bds = self.bds_real.astype(coord.bounds_dtype)
-                    self.assertEqualRealArraysAndDtypes(bds, check_bds)
+                # Bounds array should not be the reference data.
+                self.assertArraysDoNotShareData(
+                     bds, self.bds_real,
+                    'Bounds are the same data as the provided array.')
+                # the original bounds array was cast to a test dtype.
+                check_bds = self.bds_real.astype(coord.bounds_dtype)
+                self.assertEqualRealArraysAndDtypes(bds, check_bds)
 
     def test_fail_bounds_shape_mismatch(self):
         bds_shape = list(self.bds_real.shape)
@@ -113,9 +107,9 @@ class Test_core_points(tests.IrisTest, DimCoordTestMixin):
         data = self.pts_real
         coord = DimCoord(data)
         result = coord.core_points()
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, self.pts_real,
-            'core_points() are not the same data as the internal array.')
+            'core_points() are the same data as the internal array.')
 
     def test_lazy_points(self):
         lazy_data = self.pts_lazy
@@ -137,9 +131,9 @@ class Test_core_bounds(tests.IrisTest, DimCoordTestMixin):
     def test_real_bounds(self):
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
         result = coord.core_bounds()
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, self.bds_real,
-            'core_bounds() are not the same data as the internal array.')
+            'core_bounds() are the same data as the internal array.')
 
     def test_lazy_bounds(self):
         coord = DimCoord(self.pts_real, bounds=self.bds_lazy)
@@ -383,12 +377,12 @@ class Test_points__getter(tests.IrisTest, DimCoordTestMixin):
         self.setupTestArrays()
 
     def test_real_points(self):
-        # Getting real points does not change or copy them.
+        # Getting real points returns a copy
         coord = DimCoord(self.pts_real)
         result = coord.core_points()
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, self.pts_real,
-            'Points are not the same array as the provided data.')
+            'Points are the same array as the provided data.')
 
 
 class Test_points__setter(tests.IrisTest, DimCoordTestMixin):
@@ -396,14 +390,14 @@ class Test_points__setter(tests.IrisTest, DimCoordTestMixin):
         self.setupTestArrays()
 
     def test_set_real(self):
-        # Setting points does not copy, but makes a readonly view.
+        # Setting points copies the data
         coord = DimCoord(self.pts_real)
         new_pts = self.pts_real + 102.3
         coord.points = new_pts
         result = coord.core_points()
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, new_pts,
-            'Points are not the same data as the assigned array.')
+            'Points are the same data as the assigned array.')
 
     def test_fail_bad_shape(self):
         # Setting real points requires matching shape.
@@ -446,9 +440,9 @@ class Test_bounds__getter(tests.IrisTest, DimCoordTestMixin):
         # Getting real bounds does not change or copy them.
         coord = DimCoord(self.pts_real, bounds=self.bds_real)
         result = coord.bounds
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, self.bds_real,
-            'Points are not the same array as the provided data.')
+            'Bounds are the same array as the provided data.')
 
 
 class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
@@ -461,9 +455,9 @@ class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
         new_bounds = self.bds_real + 102.3
         coord.bounds = new_bounds
         result = coord.core_bounds()
-        self.assertArraysShareData(
+        self.assertArraysDoNotShareData(
             result, new_bounds,
-            'Bounds are not the same data as the assigned array.')
+            'Bounds are the same data as the assigned array.')
 
     def test_fail_bad_shape(self):
         # Setting real points requires matching shape.

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -87,16 +87,6 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
         with self.assertRaisesRegexp(ValueError, msg):
             DimCoord([1, 2, 0, 3])
 
-    def test_copy_arrays(self):
-        # points and bounds arrays are copied
-        pts = np.array([2, 4, 6])
-        bnds = np.array([[1, 3], [3, 5], [5, 7]])
-        coord = DimCoord(pts, bounds=bnds)
-        pts[1] = 8
-        bnds[1, 1] = 10
-        self.assertEqual(coord.points[1], 4)
-        self.assertEqual(coord.bounds[1, 1], 5)
-
 
 class Test_core_points(tests.IrisTest, DimCoordTestMixin):
     # Test for DimCoord.core_points() with various types of points and bounds.

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -93,6 +93,16 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
         with self.assertRaisesRegexp(ValueError, msg):
             DimCoord([1, 2, 0, 3])
 
+    def test_copy_arrays(self):
+        # points and bounds arrays are copied
+        pts = np.array([2, 4, 6])
+        bnds = np.array([[1, 3], [3, 5], [5, 7]])
+        coord = DimCoord(pts, bounds=bnds)
+        pts[1] = 8
+        bnds[1, 1] = 10
+        self.assertEqual(coord.points[1], 4)
+        self.assertEqual(coord.bounds[1, 1], 5)
+
 
 class Test_core_points(tests.IrisTest, DimCoordTestMixin):
     # Test for DimCoord.core_points() with various types of points and bounds.
@@ -420,6 +430,13 @@ class Test_points__setter(tests.IrisTest, DimCoordTestMixin):
         result = coord.core_points()
         self.assertEqualRealArraysAndDtypes(result, new_pts.compute())
 
+    def test_copy_array(self):
+        # Assigning points creates a copy
+        pts = np.array([1, 2, 3])
+        coord = DimCoord(pts)
+        pts[1] = 5
+        self.assertEqual(coord.points[1], 2)
+
 
 class Test_bounds__getter(tests.IrisTest, DimCoordTestMixin):
     def setUp(self):
@@ -471,6 +488,14 @@ class Test_bounds__setter(tests.IrisTest, DimCoordTestMixin):
         coord.bounds = new_bounds
         result = coord.core_bounds()
         self.assertEqualRealArraysAndDtypes(result, new_bounds.compute())
+
+    def test_copy_array(self):
+        # Assigning bounds creates a copy
+        pts = np.array([2, 4, 6])
+        bnds = np.array([[1, 3], [3, 5], [5, 7]])
+        coord = DimCoord(pts, bounds=bnds)
+        bnds[1, 1] = 10
+        self.assertEqual(coord.bounds[1, 1], 5)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/coords/test_DimCoord.py
+++ b/lib/iris/tests/unit/coords/test_DimCoord.py
@@ -59,7 +59,7 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
             # Points array should not be identical to the reference one.
             self.assertArraysDoNotShareData(
                  pts, self.pts_real,
-               'Points are the same data as the provided array.')
+                 'Points are the same data as the provided array.')
             # the original points array was cast to a test dtype.
             check_pts = self.pts_real.astype(coord.dtype)
             self.assertEqualRealArraysAndDtypes(pts, check_pts)
@@ -69,7 +69,7 @@ class Test__init__(tests.IrisTest, DimCoordTestMixin):
                 # Bounds array should not be the reference data.
                 self.assertArraysDoNotShareData(
                      bds, self.bds_real,
-                    'Bounds are the same data as the provided array.')
+                     'Bounds are the same data as the provided array.')
                 # the original bounds array was cast to a test dtype.
                 check_bds = self.bds_real.astype(coord.bounds_dtype)
                 self.assertEqualRealArraysAndDtypes(bds, check_bds)


### PR DESCRIPTION
Historically it's always been the case that the points and bounds arrays of a DimCoord haven't been modifiable from outside the class. Recently this has slipped.

There are two changes in this PR. ~One I consider an obvious bug: when converting the argument to the points/bounds setter to a numpy array, a flag is created which determines whether to make a copy. Currently this flag is set if the input is lazy, but this is the wrong way around. If the input argument is already a numpy array, the points will be modifiable via the original array passed in. Conversely, if a lazy array is passed in then we can safely use the array returned by `as_concrete_data` as the actual points array, since there's no way a user could have a reference to it.~ Edit: I've realised that even if the input array is lazy we need to copy the result of `as_concrete_data`, since it could simply be a dask wrapper around a NumPy array to which the user has access.

The other change might be considered more controversial. Although the points array returned by the points/bounds array is read-only, it is not a view. This means it's possible for a user to change metadata like dtype and shape. I've changed it so that the getter always returns a view.