### PR TITLE
What's New entry for Cube deprecations [ci skip]

### DIFF
--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
@@ -1,1 +1,1 @@
-* The deprecated keyword arguments ```coord``` and ```name``` have been removed from the class :class:`iris.cube.Cube`.
+* The deprecated keyword arguments ```coord``` and ```name``` have been removed from :class:`iris.cube.Cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
@@ -1,0 +1,1 @@
+* The deprecated keyword arguments ```coord``` and ```name``` have been removed from methods :method:`iris.cube.Cube.coord` and :method:`iris.cube.Cube.coords`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-kwargs.txt
@@ -1,1 +1,1 @@
-* The deprecated keyword arguments ```coord``` and ```name``` have been removed from methods :method:`iris.cube.Cube.coord` and :method:`iris.cube.Cube.coords`.
+* The deprecated keyword arguments ```coord``` and ```name``` have been removed from the class :class:`iris.cube.Cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
@@ -1,1 +1,1 @@
-* The deprecated methods ```iris.cube.Cube.add_history```, ```iris.cube.Cube.assert_valid``` and ```iris.cube.Cube.regridded``` have been removed from :mod:`iris.cube`.
+* The deprecated methods ```iris.cube.Cube.add_history```, ```iris.cube.Cube.assert_valid``` and ```iris.cube.Cube.regridded``` have been removed from the class :class:`iris.cube.Cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
@@ -1,1 +1,1 @@
-* The deprecated methods ```iris.cube.Cube.add_history```, ```iris.cube.Cube.assert_valid``` and ```iris.cube.Cube.regridded``` have been removed from the class :class:`iris.cube.Cube`.
+* The deprecated methods ```iris.cube.Cube.add_history```, ```iris.cube.Cube.assert_valid``` and ```iris.cube.Cube.regridded``` have been removed from :class:`iris.cube.Cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove-cube-methods.txt
@@ -1,0 +1,1 @@
+* The deprecated methods ```iris.cube.Cube.add_history```, ```iris.cube.Cube.assert_valid``` and ```iris.cube.Cube.regridded``` have been removed from :mod:`iris.cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove_regridded.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove_regridded.txt
@@ -1,1 +1,0 @@
-* The deprecated method ```iris.cube.Cube.regridded``` has been removed from the module :mod:`iris.cube`.

--- a/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove_regridded.txt
+++ b/docs/iris/src/whatsnew/contributions_v2.0.0/incompatiblechange_2017-Oct-19_remove_regridded.txt
@@ -1,0 +1,1 @@
+* The deprecated method ```iris.cube.Cube.regridded``` has been removed from the module :mod:`iris.cube`.


### PR DESCRIPTION
Covers #2695, in which only one deprecation was public API, I believe.