### PR TITLE
Fix Travis doctests error handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ sudo: false
 
 env:
   matrix:
-    - TEST_TARGET=default
-    - TEST_TARGET=default TEST_MINIMAL=true
     - TEST_TARGET=coding
+    - TEST_TARGET=default TEST_MINIMAL=true
+    - TEST_TARGET=default
     - TEST_TARGET=example
     - TEST_TARGET=doctest
 
@@ -116,15 +116,19 @@ script:
   - if [[ $TEST_TARGET == 'example' ]]; then
       python -m iris.tests.runner --example-tests --print-failed-images --num-processors=8;
     fi
+
+  # Capture install-dir: As a test command must be last for get Travis to check
+  # the RC, so it's best to start each operation with an absolute cd.
+  - INSTALL_DIR=$(pwd)
+
   # "make html" produces an error when run on Travis that does not
   # affect any downstream functionality but causes the build to fail
   # spuriously. The echo-backtick workaround gets around this error,
   # which should be investigated further in the future.
   - if [[ $TEST_TARGET == 'doctest' ]]; then
-      cd docs/iris;
+      cd $INSTALL_DIR/docs/iris;
       echo `make clean html`;
       make doctest;
-      cd ../../;
     fi
 
   # Split the organisation out of the slug. See https://stackoverflow.com/a/5257398/741316 for description.
@@ -142,10 +146,10 @@ script:
   # An extra call to check "whatsnew" contributions are valid, because the
   # Iris test for it needs a *developer* install to be able to find the docs.
   - if [[ $TEST_TARGET == 'doctest' ]]; then
-      cd docs/iris/src/whatsnew;
+      cd $INSTALL_DIR/docs/iris/src/whatsnew;
       python aggregate_directory.py --checkonly;
-      cd ../../../../;
     fi
   - if [[ $TEST_TARGET == 'coding' ]]; then
+      cd $INSTALL_DIR;
       python setup.py test --coding-tests;
     fi


### PR DESCRIPTION
It seems that some time ago we stopped Travis reporting various test errors, 
 - it happened at #2610 
 - see [this comment](https://github.com/SciTools/iris/pull/2610/files#r145707816) and [this one](https://github.com/SciTools/iris/pull/2610/files#r145707951)

The problem is that the various test operations occur in groups of commands joined by ";" and Travis only checks the final RC value.  So by wrapping a test in cd-in and -out commands 
( e.g. `"cd my/inner/dir; test; cd ../../.."` )
we have masked any errors that the test raises !

So, this fixes that.

At present we are failing on both a doctest and the whatsnew-aggregation check.
Those need fixing separately.
So ***it will make sense to merge this with the "doctest" check failing***

**P.S.**
I also changed the order of the test matrix, so it runs "TEST_TARGET=coding" first.
I think it makes sense to get the earliest possible warning of pep8/header failures, which is after all what this target was added for.  Also to run "minimal" before "full" for the same reason.
This is particularly desirable since we restricted the number of cpus so that Travis is no longer starting all the targets at once.