### PR TITLE
Deprecate cell_datetime_objects in iris.Future

### DIFF
--- a/docs/iris/example_code/Meteorology/COP_1d_plot.py
+++ b/docs/iris/example_code/Meteorology/COP_1d_plot.py
@@ -86,7 +86,6 @@ def main():
     # Constrain the period 1860-1999 and extract the observed data from a1b
     constraint = iris.Constraint(time=lambda
                                  cell: 1860 <= cell.point.year <= 1999)
-    with iris.FUTURE.context(cell_datetime_objects=True):
         observed = a1b_mean.extract(constraint)
         # Assert that this data set is the same as the e1 scenario:
         # they share data up to the 1999 cut off.

--- a/docs/iris/example_code/Meteorology/COP_1d_plot.py
+++ b/docs/iris/example_code/Meteorology/COP_1d_plot.py
@@ -86,11 +86,11 @@ def main():
     # Constrain the period 1860-1999 and extract the observed data from a1b
     constraint = iris.Constraint(time=lambda
                                  cell: 1860 <= cell.point.year <= 1999)
-        observed = a1b_mean.extract(constraint)
-        # Assert that this data set is the same as the e1 scenario:
-        # they share data up to the 1999 cut off.
-        assert np.all(np.isclose(observed.data,
-                                 e1_mean.extract(constraint).data))
+    observed = a1b_mean.extract(constraint)
+    # Assert that this data set is the same as the e1 scenario:
+    # they share data up to the 1999 cut off.
+    assert np.all(np.isclose(observed.data,
+                             e1_mean.extract(constraint).data))
 
     # Plot the observed data
     qplt.plot(observed, label='observed', color='black', lw=1.5)

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -198,6 +198,7 @@ to represent the climatological seasons and the season year respectively::
 
 .. testsetup:: aggregation
 
+    import datetime
     import iris
 
     filename = iris.sample_data_path('ostia_monthly.nc')
@@ -301,7 +302,8 @@ do not cover a three month period (note: judged here as > 3*28 days):
 
 .. doctest:: aggregation
 
-    >>> spans_three_months = lambda t: (t.bound[1] - t.bound[0]) > 3*28*24.0
+    >>> tdelta_3mth = datetime.timedelta(hours=3*28*24.0)
+    >>> spans_three_months = lambda t: (t.bound[1] - t.bound[0]) > tdelta_3mth
     >>> three_months_bound = iris.Constraint(time=spans_three_months)
     >>> full_season_means = annual_seasonal_mean.extract(three_months_bound)
     >>> full_season_means

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -255,8 +255,7 @@ for ease of calendar-based testing.
     DimCoord([2009-11-19 10:00:00, 2009-11-19 11:00:00, 2009-11-19 12:00:00], standard_name='time', calendar='gregorian')
     >>> # Define a function which accepts a datetime as its argument (this is simplified in later examples).
     >>> hour_11 = iris.Constraint(time=lambda cell: cell.point.hour == 11)
-    ...     cube_11 = cube_all.extract(hour_11)
-    ... 
+    >>> cube_11 = cube_all.extract(hour_11)
     >>> print('Selected times :\n' + str(cube_11.coord('time')))
     Selected times :
     DimCoord([2009-11-19 11:00:00], standard_name='time', calendar='gregorian')
@@ -281,9 +280,9 @@ time selections when loading or extracting data.
 The previous constraint example can now be written as:
 
    >>> the_11th_hour = iris.Constraint(time=iris.time.PartialDateTime(hour=11))
-   ...     print(iris.load_cube(
-   ...         iris.sample_data_path('uk_hires.pp'),
-   ...         'air_potential_temperature' & the_11th_hour).coord('time'))
+   >>> print(iris.load_cube(
+   ...	iris.sample_data_path('uk_hires.pp'),
+   ...	'air_potential_temperature' & the_11th_hour).coord('time'))
    DimCoord([2009-11-19 11:00:00], standard_name='time', calendar='gregorian')
 
 A more complex example might be when there exists a time sequence representing the first day of every week
@@ -316,7 +315,7 @@ functionality with PartialDateTime:
 
     >>> st_swithuns_daterange = iris.Constraint(
     ...     time=lambda cell: PartialDateTime(month=7, day=15) < cell < PartialDateTime(month=8, day=25))
-    ...   within_st_swithuns = long_ts.extract(st_swithuns_daterange)
+    >>> within_st_swithuns = long_ts.extract(st_swithuns_daterange)
     ... 
     >>> print(within_st_swithuns.coord('time'))
     DimCoord([2007-07-16 00:00:00, 2007-07-23 00:00:00, 2007-07-30 00:00:00,

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -244,11 +244,9 @@ However, when constraining by time we usually want to test calendar-related
 aspects such as hours of the day or months of the year, so Iris
 provides special features to facilitate this:
 
-Firstly, Iris can be configured so that when it evaluates Constraint
-expressions, it will convert time-coordinate values (points and bounds) from
-numbers into :class:`~datetime.datetime`-like objects for ease of calendar-based
-testing.  This feature is not backwards compatible so for now it must be
-explicitly enabled by setting the "cell_datetime_objects" option in :class:`iris.Future`:
+Firstly, when Iris evaluates Constraint expressions, it will convert time-coordinate 
+values (points and bounds) from numbers into :class:`~datetime.datetime`-like objects
+for ease of calendar-based testing.:
 
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cube_all = iris.load_cube(filename, 'air_potential_temperature')
@@ -257,7 +255,6 @@ explicitly enabled by setting the "cell_datetime_objects" option in :class:`iris
     DimCoord([2009-11-19 10:00:00, 2009-11-19 11:00:00, 2009-11-19 12:00:00], standard_name='time', calendar='gregorian')
     >>> # Define a function which accepts a datetime as its argument (this is simplified in later examples).
     >>> hour_11 = iris.Constraint(time=lambda cell: cell.point.hour == 11)
-    >>> with iris.FUTURE.context(cell_datetime_objects=True):
     ...     cube_11 = cube_all.extract(hour_11)
     ... 
     >>> print('Selected times :\n' + str(cube_11.coord('time')))
@@ -284,7 +281,6 @@ time selections when loading or extracting data.
 The previous constraint example can now be written as:
 
    >>> the_11th_hour = iris.Constraint(time=iris.time.PartialDateTime(hour=11))
-   >>> with iris.FUTURE.context(cell_datetime_objects=True):
    ...     print(iris.load_cube(
    ...         iris.sample_data_path('uk_hires.pp'),
    ...         'air_potential_temperature' & the_11th_hour).coord('time'))
@@ -320,7 +316,6 @@ functionality with PartialDateTime:
 
     >>> st_swithuns_daterange = iris.Constraint(
     ...     time=lambda cell: PartialDateTime(month=7, day=15) < cell < PartialDateTime(month=8, day=25))
-    >>> with iris.FUTURE.context(cell_datetime_objects=True):
     ...   within_st_swithuns = long_ts.extract(st_swithuns_daterange)
     ... 
     >>> print(within_st_swithuns.coord('time'))

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -246,7 +246,7 @@ provides special features to facilitate this:
 
 Firstly, when Iris evaluates Constraint expressions, it will convert time-coordinate 
 values (points and bounds) from numbers into :class:`~datetime.datetime`-like objects
-for ease of calendar-based testing.:
+for ease of calendar-based testing.
 
     >>> filename = iris.sample_data_path('uk_hires.pp')
     >>> cube_all = iris.load_cube(filename, 'air_potential_temperature')

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -281,8 +281,8 @@ The previous constraint example can now be written as:
 
    >>> the_11th_hour = iris.Constraint(time=iris.time.PartialDateTime(hour=11))
    >>> print(iris.load_cube(
-   ...	iris.sample_data_path('uk_hires.pp'),
-   ...	'air_potential_temperature' & the_11th_hour).coord('time'))
+   ...     iris.sample_data_path('uk_hires.pp'),
+   ...	   'air_potential_temperature' & the_11th_hour).coord('time'))
    DimCoord([2009-11-19 11:00:00], standard_name='time', calendar='gregorian')
 
 A more complex example might be when there exists a time sequence representing the first day of every week

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-23_cell-datetime-objs.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-23_cell-datetime-objs.txt
@@ -1,0 +1,9 @@
+:class:`iris.coords.Cell` objects in time coordinates now contain datetime objects by default and not numbers.
+For example::
+    >>> cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
+    >>> print(cube.coord('time').cell(0).point)
+        1998-12-01 00:00:00
+
+This change particularly impacts constraining datasets on time. All time constraints
+must now be constructed with datetime objects or :class:`~iris.time.PartialDateTime` objects.
+See userguide section 2.2.1 for more details on producing time constraints.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -143,7 +143,7 @@ AttributeConstraint = iris._constraints.AttributeConstraint
 class Future(threading.local):
     """Run-time configuration controller."""
 
-    def __init__(self, cell_datetime_objects=False, netcdf_promote=False,
+    def __init__(self, cell_datetime_objects=True, netcdf_promote=False,
                  netcdf_no_unlimited=False, clip_latitudes=False):
         """
         A container for run-time options controls.
@@ -151,7 +151,7 @@ class Future(threading.local):
         To adjust the values simply update the relevant attribute from
         within your code. For example::
 
-            iris.FUTURE.cell_datetime_objects = True
+            iris.FUTURE.cell_datetime_objects = False
 
         If Iris code is executed with multiple threads, note the values of
         these options are thread-specific.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -197,14 +197,18 @@ class Future(threading.local):
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
                           self.netcdf_no_unlimited, self.clip_latitudes)
 
-    deprecated_options = {'cell_datetime_objects'}
+    deprecated_options = {'cell_datetime_objects': 'warning'}
 
     def __setattr__(self, name, value):
         if name in self.deprecated_options:
-            reason = self.deprecated_options[name]
-            msg = ("the 'Future' object property {!r} is now deprecated. "
-                   "Please remove code which uses this.  {}")
-            warn_deprecated(msg.format(name, reason))
+            level = self.deprecated_options[name]
+            if level == 'error':
+                pass
+            else:
+                msg = ("setting the 'Future' property {!r} is deprecated "
+                       "and will be removed in a future release. "
+                       "Please remove code that sets this property.")
+                warn_deprecated(msg.format(name))
         if name not in self.__dict__:
             msg = "'Future' object has no attribute {!r}".format(name)
             raise AttributeError(msg)
@@ -221,15 +225,8 @@ class Future(threading.local):
         statement, the previous state is restored.
 
         For example::
-
-            with iris.FUTURE.context():
-                iris.FUTURE.cell_datetime_objects = False
-                # ... code which expects integers
-
-        Or more concisely::
-
             with iris.FUTURE.context(cell_datetime_objects=False):
-                # ... code which expects integers
+                # ... code that expects numbers and not datetimes
 
         """
         # Save the current context

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -224,12 +224,12 @@ class Future(threading.local):
 
             with iris.FUTURE.context():
                 iris.FUTURE.cell_datetime_objects = False
-                # ... code which expects time objects
+                # ... code which expects integers
 
         Or more concisely::
 
             with iris.FUTURE.context(cell_datetime_objects=False):
-                # ... code which expects time objects
+                # ... code which expects integers
 
         """
         # Save the current context

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -197,7 +197,7 @@ class Future(threading.local):
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
                           self.netcdf_no_unlimited, self.clip_latitudes)
 
-    deprecated_options = {}
+    deprecated_options = {'cell_datetime_objects'}
 
     def __setattr__(self, name, value):
         if name in self.deprecated_options:
@@ -223,12 +223,12 @@ class Future(threading.local):
         For example::
 
             with iris.FUTURE.context():
-                iris.FUTURE.cell_datetime_objects = True
+                iris.FUTURE.cell_datetime_objects = False
                 # ... code which expects time objects
 
         Or more concisely::
 
-            with iris.FUTURE.context(cell_datetime_objects=True):
+            with iris.FUTURE.context(cell_datetime_objects=False):
                 # ... code which expects time objects
 
         """

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1109,7 +1109,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 point = self.units.num2date(point)
                 if bound is not None:
                     bound = self.units.num2date(bound)
-               
+
         else:
             warn_deprecated("the 'Future' object property "
                             "cell_datetime_objects is now deprecated. Please "

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1110,7 +1110,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 if bound is not None:
                     bound = self.units.num2date(bound)
                     
-        else
+        else:
             warn_deprecated("the 'Future' object property "
                             "cell_datetime_objects is now deprecated. Please "
                             "remove code which uses this. cell_datetime_objects")

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1115,7 +1115,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                     "behaviour. "
                     "Please update your code to support using cells as "
                     "datetime objects."
-                    "See the userguide, §2.2.1 for examples of this.")
+                    "See the userguide section 2.2.1 for examples of this.")
             warn_deprecated(wmsg)
 
         return Cell(point, bound)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1109,11 +1109,12 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 point = self.units.num2date(point)
                 if bound is not None:
                     bound = self.units.num2date(bound)
-                    
+               
         else:
             warn_deprecated("the 'Future' object property "
                             "cell_datetime_objects is now deprecated. Please "
-                            "remove code which uses this. cell_datetime_objects")
+                            "remove code which uses this. "
+                            "cell_datetime_objects")
 
         return Cell(point, bound)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -37,6 +37,7 @@ import numpy as np
 import numpy.ma as ma
 
 from iris._data_manager import DataManager
+from iris._deprecation import warn_deprecated
 from iris._lazy_data import as_concrete_data, is_lazy_data, multidim_lazy_stack
 import iris.aux_factory
 import iris.exceptions
@@ -1109,12 +1110,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 point = self.units.num2date(point)
                 if bound is not None:
                     bound = self.units.num2date(bound)
-
         else:
-            warn_deprecated("the 'Future' object property "
-                            "cell_datetime_objects is now deprecated. Please "
-                            "remove code which uses this. "
-                            "cell_datetime_objects")
+            wmsg = ("disabling cells as datetime objects is deprecated "
+                    "behaviour. "
+                    "Please update your code to support using cells as "
+                    "datetime objects."
+                    "See the userguide, §2.2.1 for examples of this.")
+            warn_deprecated(wmsg)
 
         return Cell(point, bound)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1109,6 +1109,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 point = self.units.num2date(point)
                 if bound is not None:
                     bound = self.units.num2date(bound)
+                    
+        else
+            warn_deprecated("the 'Future' object property "
+                            "cell_datetime_objects is now deprecated. Please "
+                            "remove code which uses this. cell_datetime_objects")
 
         return Cell(point, bound)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1950,9 +1950,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                         unit = ' {!s}'.format(coord.units)
 
                     # Format cell depending on type of point and whether it
-                    # has a bound
-                    with iris.FUTURE.context(cell_datetime_objects=False):
-                        coord_cell = coord.cell(0)
+                    # has a bound.
+                    coord_cell = coord.cell(0)
                     if isinstance(coord_cell.point, six.string_types):
                         # Indent string type coordinates
                         coord_cell_split = [iris.util.clip_string(str(item))
@@ -1962,20 +1961,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             pad=' ', width=indent + len(coord.name()) + 2)
                         coord_cell_str = line_sep.join(coord_cell_split) + unit
                     else:
-                        # Human readable times
-                        if coord.units.is_time_reference():
-                            coord_cell_cpoint = coord.units.num2date(
-                                coord_cell.point)
-                            if coord_cell.bound is not None:
-                                coord_cell_cbound = coord.units.num2date(
-                                    coord_cell.bound)
-                        else:
-                            coord_cell_cpoint = coord_cell.point
-                            coord_cell_cbound = coord_cell.bound
+                        coord_cell_cpoint = coord_cell.point
+                        coord_cell_cbound = coord_cell.bound
 
                         coord_cell_str = '{!s}{}'.format(coord_cell_cpoint,
                                                          unit)
-                        if coord_cell.bound is not None:
+                        if coord_cell_cbound is not None:
                             bound = '({})'.format(', '.join(str(val) for
                                                   val in coord_cell_cbound))
                             coord_cell_str += ', bound={}{}'.format(bound,

--- a/lib/iris/tests/integration/test_PartialDateTime.py
+++ b/lib/iris/tests/integration/test_PartialDateTime.py
@@ -34,7 +34,6 @@ class Test(tests.IrisTest):
         # The `netcdf4` Python module introduced new calendar classes by v1.2.7
         # This test is primarily of this interface, so the
         # final test assertion is simple.
-        with iris.FUTURE.context(cell_datetime_objects=True):
             filename = tests.get_data_path(('PP', 'structured', 'small.pp'))
             cube = iris.load_cube(filename)
             pdt = PartialDateTime(year=1992, month=10, day=1, hour=2)

--- a/lib/iris/tests/integration/test_PartialDateTime.py
+++ b/lib/iris/tests/integration/test_PartialDateTime.py
@@ -34,12 +34,12 @@ class Test(tests.IrisTest):
         # The `netcdf4` Python module introduced new calendar classes by v1.2.7
         # This test is primarily of this interface, so the
         # final test assertion is simple.
-            filename = tests.get_data_path(('PP', 'structured', 'small.pp'))
-            cube = iris.load_cube(filename)
-            pdt = PartialDateTime(year=1992, month=10, day=1, hour=2)
-            time_constraint = iris.Constraint(time=lambda cell: cell < pdt)
-            sub_cube = cube.extract(time_constraint)
-            self.assertEqual(sub_cube.coord('time').points.shape, (1,))
+        filename = tests.get_data_path(('PP', 'structured', 'small.pp'))
+        cube = iris.load_cube(filename)
+        pdt = PartialDateTime(year=1992, month=10, day=1, hour=2)
+        time_constraint = iris.Constraint(time=lambda cell: cell < pdt)
+        sub_cube = cube.extract(time_constraint)
+        self.assertEqual(sub_cube.coord('time').points.shape, (1,))
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -26,6 +26,8 @@ import six
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
+import datetime
+
 import iris
 import iris.tests.stock as stock
 
@@ -58,16 +60,19 @@ class TestSimple(tests.IrisTest):
         sub_list = self.slices.extract(constraint)
         self.assertEqual(len(sub_list), 2 * 6)
 
-        constraint = iris.Constraint(model_level_number=lambda c: ( c > 30 ) | (c <= 3))
+        constraint = iris.Constraint(
+            model_level_number=lambda c: (c > 30) | (c <= 3))
         sub_list = self.slices.extract(constraint)
         self.assertEqual(len(sub_list), 43 * 6)
 
-        constraint = iris.Constraint(coord_values={'model_level_number': lambda c: c > 1000})
+        constraint = iris.Constraint(
+            coord_values={'model_level_number': lambda c: c > 1000})
         sub_list = self.slices.extract(constraint)
         self.assertEqual(len(sub_list), 0)
 
         constraint = (iris.Constraint(model_level_number=10) &
-                      iris.Constraint(time=347922.))
+                      iris.Constraint(
+                          time=datetime.datetime(2009, 9, 9, 18, 0)))
         sub_list = self.slices.extract(constraint)
         self.assertEqual(len(sub_list), 1)
 

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -27,6 +27,7 @@ import six
 import iris.tests as tests
 
 from collections import Iterable
+import datetime
 import itertools
 import numpy as np
 import numpy.ma as ma
@@ -290,12 +291,12 @@ class TestDataMerge(tests.IrisTest):
         data_path = tests.get_data_path(
             ('PP', 'COLPEX', 'theta_and_orog_subset.pp'))
         phenom_constraint = iris.Constraint('air_potential_temperature')
-        time_value_1 = 347921.33333332836627960205
-        time_value_2 = 347921.83333333209156990051
-        time_constraint1 = iris.Constraint(time=time_value_1)
-        time_constraint2 = iris.Constraint(time=time_value_2)
+        datetime_1 = datetime.datetime(2009, 9, 9, 17, 20)
+        datetime_2 = datetime.datetime(2009, 9, 9, 17, 50)
+        time_constraint1 = iris.Constraint(time=datetime_1)
+        time_constraint2 = iris.Constraint(time=datetime_2)
         time_constraint_1_and_2 = iris.Constraint(
-            time=lambda c: c in (time_value_1, time_value_2))
+            time=lambda c: c in (datetime_1, datetime_2))
         cube1 = iris.load_cube(data_path, phenom_constraint & time_constraint1)
         cube2 = iris.load_cube(data_path, phenom_constraint & time_constraint2)
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -241,15 +241,6 @@ class Test_cell(tests.IrisTest):
                                             mock.sentinel.upper]]))
         return coord
 
-    def test_time_as_number(self):
-        # Make sure Coord.cell() normally returns the values straight
-        # out of the Coord's points/bounds arrays.
-        coord = self._mock_coord()
-        cell = Coord.cell(coord, 0)
-        self.assertIs(cell.point, mock.sentinel.time)
-        self.assertEqual(cell.bound,
-                         (mock.sentinel.lower, mock.sentinel.upper))
-
     def test_time_as_object(self):
         # Ensure Coord.cell() converts the point/bound values to
         # "datetime" objects.

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -251,16 +251,14 @@ class Test_cell(tests.IrisTest):
                          (mock.sentinel.lower, mock.sentinel.upper))
 
     def test_time_as_object(self):
-        # When iris.FUTURE.cell_datetime_objects is True, ensure
-        # Coord.cell() converts the point/bound values to "datetime"
-        # objects.
+        # Ensure Coord.cell() converts the point/bound values to
+        # "datetime" objects.
         coord = self._mock_coord()
         coord.units.num2date = mock.Mock(
             side_effect=[mock.sentinel.datetime,
                          (mock.sentinel.datetime_lower,
                           mock.sentinel.datetime_upper)])
-        with mock.patch('iris.FUTURE', cell_datetime_objects=True):
-            cell = Coord.cell(coord, 0)
+        cell = Coord.cell(coord, 0)
         self.assertIs(cell.point, mock.sentinel.datetime)
         self.assertEqual(cell.bound,
                          (mock.sentinel.datetime_lower,

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -397,14 +397,21 @@ class Test_collapsed__warning(tests.IrisTest):
 
 
 class Test_summary(tests.IrisTest):
+    def setUp(self):
+        self.cube = Cube(0)
+
     def test_cell_datetime_objects(self):
         # Check the scalar coordinate summary still works even when
         # iris.FUTURE.cell_datetime_objects is True.
-        cube = Cube(0)
-        cube.add_aux_coord(AuxCoord(42, units='hours since epoch'))
-        with FUTURE.context(cell_datetime_objects=True):
-            summary = cube.summary()
+        self.cube.add_aux_coord(AuxCoord(42, units='hours since epoch'))
+        summary = self.cube.summary()
         self.assertIn('1970-01-02 18:00:00', summary)
+
+    def test_scalar_str_coord(self):
+        str_value = 'foo'
+        self.cube.add_aux_coord(AuxCoord(str_value))
+        summary = self.cube.summary()
+        self.assertIn(str_value, summary)
 
 
 class Test_is_compatible(tests.IrisTest):


### PR DESCRIPTION
This is my attempt at making all the alterations regarding the :`iris.Future` option `cell_datetime_objects`. This Pull Request Closes #2831 .