### PR TITLE
Nc simple chunks

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -110,14 +110,10 @@ def as_lazy_data(data, chunks=None, asarray=False):
         The input array converted to a dask array.
 
     """
-    if chunks is not None:
-        requested_shape = chunks
-        chunks = requested_shape
-    else:
-        # Default to the shape of the wrapped array-like.
-        requested_shape = data.shape
-        # reduce if larger than a default maximum size.
-        chunks = _limited_shape(requested_shape)
+    if chunks is None:
+        # Default to the shape of the wrapped array-like,
+        # but reduce it if larger than a default maximum size.
+        chunks = _limited_shape(data.shape)
 
     if isinstance(data, ma.core.MaskedConstant):
         data = ma.masked_array(data.data, mask=data.mask)

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -23,8 +23,6 @@ To avoid replicating implementation-dependent test and conversion code.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import atexit
-
 import dask
 import dask.array as da
 import dask.context

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -80,8 +80,8 @@ def _limited_shape(shape):
     shape = list(shape)
     i_reduce = 0
     while np.prod(shape) > _MAX_CHUNK_SIZE:
-        factor = np.ceil(np.prod(shape) / float(_MAX_CHUNK_SIZE))
-        new_dim = int(np.floor(shape[i_reduce] / factor))
+        factor = np.ceil(np.prod(shape) / _MAX_CHUNK_SIZE)
+        new_dim = int(shape[i_reduce] / factor)
         if new_dim < 1:
             new_dim = 1
         shape[i_reduce] = new_dim

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -73,13 +73,17 @@ _MAX_CHUNK_SIZE = 8 * 1024 * 1024 * 2
 
 
 def _limited_shape(shape):
+    # Reduce a shape to less than a default overall number-of-points, reducing
+    # earlier dimensions preferentially.
+    # Note: this is only a heuristic, assuming that earlier dimensions are
+    # 'outer' storage dimensions -- not *always* true, even for NetCDF data.
+    shape = list(shape)
     i_reduce = 0
     while np.prod(shape) > _MAX_CHUNK_SIZE:
         factor = np.ceil(np.prod(shape) / float(_MAX_CHUNK_SIZE))
         new_dim = int(np.floor(shape[i_reduce] / factor))
         if new_dim < 1:
             new_dim = 1
-        shape = list(shape)
         shape[i_reduce] = new_dim
         i_reduce += 1
     return tuple(shape)

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1221,7 +1221,7 @@ class ProtoCube(object):
                 if is_lazy_data(data):
                     all_have_data = False
                 else:
-                    data = as_lazy_data(data, chunks=data.shape)
+                    data = as_lazy_data(data)
                 stack[nd_index] = data
                 # Determine the largest dtype.
                 if dtype is None:

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1630,7 +1630,7 @@ fc_extras
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)
-            return as_lazy_data(proxy, chunks=proxy.shape)
+            return as_lazy_data(proxy)
 
         # Get any coordinate point data.
         if isinstance(cf_coord_var, cf.CFLabelVariable):
@@ -1701,7 +1701,7 @@ fc_extras
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(
                 cf_var.shape, dtype, engine.filename,
                 cf_var.cf_name, fill_value)
-            return as_lazy_data(proxy, chunks=proxy.shape)
+            return as_lazy_data(proxy)
 
         data = cf_var_as_array(cf_cm_attr)
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -489,7 +489,6 @@ def _set_attributes(attributes, key, value):
     else:
         attributes[str(key)] = value
 
-DEFAULT_MAX_POINTS = 10e6
 
 def _load_cube(engine, cf, cf_var, filename):
     """Create the cube associated with the CF-netCDF data variable."""
@@ -506,21 +505,7 @@ def _load_cube(engine, cf, cf_var, filename):
                          netCDF4.default_fillvals[cf_var.dtype.str[1:]])
     proxy = NetCDFDataProxy(cf_var.shape, dummy_data.dtype,
                             filename, cf_var.cf_name, fill_value)
-    def reduced_chunks(shape):
-        global DEFAULT_MAX_POINTS
-        i_reduce = 0
-        while np.prod(shape) > DEFAULT_MAX_POINTS:
-            factor = np.ceil(np.prod(shape) / float(DEFAULT_MAX_POINTS))
-            new_dim = int(np.floor(shape[i_reduce] / factor))
-            if new_dim < 1:
-                new_dim = 1
-            shape = list(shape)
-            shape[i_reduce] = new_dim
-            i_reduce += 1
-        return tuple(shape)
-
-    reduced_shape = reduced_chunks(cf_var.shape)
-    data = as_lazy_data(proxy, chunks=reduced_shape)
+    data = as_lazy_data(proxy)
     cube = iris.cube.Cube(data)
 
     # Reset the pyke inference engine.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -489,6 +489,7 @@ def _set_attributes(attributes, key, value):
     else:
         attributes[str(key)] = value
 
+DEFAULT_MAX_POINTS = 10e6
 
 def _load_cube(engine, cf, cf_var, filename):
     """Create the cube associated with the CF-netCDF data variable."""
@@ -505,7 +506,21 @@ def _load_cube(engine, cf, cf_var, filename):
                          netCDF4.default_fillvals[cf_var.dtype.str[1:]])
     proxy = NetCDFDataProxy(cf_var.shape, dummy_data.dtype,
                             filename, cf_var.cf_name, fill_value)
-    data = as_lazy_data(proxy, chunks=cf_var.shape)
+    def reduced_chunks(shape):
+        global DEFAULT_MAX_POINTS
+        i_reduce = 0
+        while np.prod(shape) > DEFAULT_MAX_POINTS:
+            factor = np.ceil(np.prod(shape) / float(DEFAULT_MAX_POINTS))
+            new_dim = int(np.floor(shape[i_reduce] / factor))
+            if new_dim < 1:
+                new_dim = 1
+            shape = list(shape)
+            shape[i_reduce] = new_dim
+            i_reduce += 1
+        return tuple(shape)
+
+    reduced_shape = reduced_chunks(cf_var.shape)
+    data = as_lazy_data(proxy, chunks=reduced_shape)
     cube = iris.cube.Cube(data)
 
     # Reset the pyke inference engine.

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -89,8 +89,7 @@ class FieldCollation(object):
             stack = np.empty(self.vector_dims_shape, 'object')
             for nd_index, field in zip(np.ndindex(self.vector_dims_shape),
                                        self.fields):
-                stack[nd_index] = as_lazy_data(field._data,
-                                               chunks=field._data.shape)
+                stack[nd_index] = as_lazy_data(field._data)
             self._data_cache = multidim_lazy_stack(stack)
         return self._data_cache
 


### PR DESCRIPTION
This is a simple solution, supposed to address the problems in #2840

As the change is general in 'as_lazy_data' it can in principle apply elsewhere,
but in practice no single data fields ever get that big, so it only kicks in for large NetCDF variables.

~**Do not merge** until we can confirm that it definitely solves the known problem in  #2840 .~
#2839 tests the fix -- looking good.