### PR TITLE
Remove tests loading PP via um.load_cubes, which is not correct usage.

### DIFF
--- a/lib/iris/tests/integration/um/test_fieldsfile.py
+++ b/lib/iris/tests/integration/um/test_fieldsfile.py
@@ -52,21 +52,5 @@ class TestStructuredLoadFF(tests.IrisTest):
         self.assertCML(cube)
 
 
-@tests.skip_data
-class TestStructuredLoadPP(tests.IrisTest):
-    def setUp(self):
-        self.fname = tests.get_data_path(('PP', 'structured', 'small.pp'))
-
-    def test_simple(self):
-        [cube] = load(self.fname, None)
-        self.assertCML(cube)
-
-    def test_simple_callback(self):
-        def callback(cube, field, filename):
-            cube.attributes['processing'] = 'fast-pp'
-        [cube] = load(self.fname, callback=callback)
-        self.assertCML(cube)
-
-
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Closes #2822 , and relates to some other current issues ...
 * #2818 documentation of iris.fileformats.um.load_cubes is seriously misleading
 * #2816 some test classes, including this one are not running under Travis

(neither of which are fixed here, or yet) 