### PR TITLE
Change FUTURE flag netcdf_promote behaviour

### DIFF
--- a/docs/iris/example_code/General/SOI_filtering.py
+++ b/docs/iris/example_code/General/SOI_filtering.py
@@ -52,10 +52,6 @@ def low_pass_weights(window, cutoff):
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load the monthly-valued Southern Oscillation Index (SOI) time-series.
     fname = iris.sample_data_path('SOI_Darwin.nc')
     soi = iris.load_cube(fname)

--- a/docs/iris/example_code/General/anomaly_log_colouring.py
+++ b/docs/iris/example_code/General/anomaly_log_colouring.py
@@ -36,10 +36,6 @@ import matplotlib.colors as mcols
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load a sample air temperatures sequence.
     file_path = iris.sample_data_path('E1_north_america.nc')
     temperatures = iris.load_cube(file_path)

--- a/docs/iris/example_code/General/cross_section.py
+++ b/docs/iris/example_code/General/cross_section.py
@@ -15,10 +15,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load some test data.
     fname = iris.sample_data_path('hybrid_height.nc')
     theta = iris.load_cube(fname, 'air_potential_temperature')

--- a/docs/iris/example_code/General/custom_aggregation.py
+++ b/docs/iris/example_code/General/custom_aggregation.py
@@ -65,10 +65,6 @@ def count_spells(data, threshold, axis, spell_length):
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load the whole time-sequence as a single cube.
     file_path = iris.sample_data_path('E1_north_america.nc')
     cube = iris.load_cube(file_path)

--- a/docs/iris/example_code/General/inset_plot.py
+++ b/docs/iris/example_code/General/inset_plot.py
@@ -17,9 +17,7 @@ import iris.plot as iplt
 
 
 def main():
-    # Load the data
-    with iris.FUTURE.context(netcdf_promote=True):
-        cube1 = iris.load_cube(iris.sample_data_path('ostia_monthly.nc'))
+    cube1 = iris.load_cube(iris.sample_data_path('ostia_monthly.nc'))
     # Slice into cube to retrieve data for the inset map showing the
     # data region
     region = cube1[-1, :, :]

--- a/docs/iris/example_code/General/orca_projection.py
+++ b/docs/iris/example_code/General/orca_projection.py
@@ -22,10 +22,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load data
     filepath = iris.sample_data_path('orca2_votemper.nc')
     cube = iris.load_cube(filepath)

--- a/docs/iris/example_code/General/polynomial_fit.py
+++ b/docs/iris/example_code/General/polynomial_fit.py
@@ -16,10 +16,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load some test data.
     fname = iris.sample_data_path('A1B_north_america.nc')
     cube = iris.load_cube(fname)

--- a/docs/iris/example_code/General/projections_and_annotations.py
+++ b/docs/iris/example_code/General/projections_and_annotations.py
@@ -106,10 +106,6 @@ def make_plot(projection_name, projection_crs):
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Demonstrate with two different display projections.
     make_plot('Equidistant Cylindrical', ccrs.PlateCarree())
     make_plot('North Polar Stereographic', ccrs.NorthPolarStereo())

--- a/docs/iris/example_code/General/rotated_pole_mapping.py
+++ b/docs/iris/example_code/General/rotated_pole_mapping.py
@@ -21,10 +21,6 @@ import iris.analysis.cartography
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load some test data.
     fname = iris.sample_data_path('rotated_pole.nc')
     air_pressure = iris.load_cube(fname)

--- a/docs/iris/example_code/Meteorology/COP_1d_plot.py
+++ b/docs/iris/example_code/Meteorology/COP_1d_plot.py
@@ -36,10 +36,6 @@ import iris.analysis.cartography
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load data into three Cubes, one for each set of NetCDF files.
     e1 = iris.load_cube(iris.sample_data_path('E1_north_america.nc'))
 

--- a/docs/iris/example_code/Meteorology/TEC.py
+++ b/docs/iris/example_code/Meteorology/TEC.py
@@ -20,10 +20,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load the "total electron content" cube.
     filename = iris.sample_data_path('space_weather.nc')
     cube = iris.load_cube(filename, 'total electron content')

--- a/docs/iris/example_code/Meteorology/hovmoller.py
+++ b/docs/iris/example_code/Meteorology/hovmoller.py
@@ -17,10 +17,6 @@ import iris.quickplot as qplt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # load a single cube of surface temperature between +/- 5 latitude
     fname = iris.sample_data_path('ostia_monthly.nc')
     cube = iris.load_cube(fname,

--- a/docs/iris/example_code/Oceanography/atlantic_profiles.py
+++ b/docs/iris/example_code/Oceanography/atlantic_profiles.py
@@ -22,10 +22,6 @@ import matplotlib.pyplot as plt
 
 
 def main():
-    # Enable a future option, to ensure that the netcdf load works the same way
-    # as in future Iris versions.
-    iris.FUTURE.netcdf_promote = True
-
     # Load the gridded temperature and salinity data.
     fname = iris.sample_data_path('atlantic_profiles.nc')
     cubes = iris.load(fname)

--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -123,8 +123,7 @@ For instance, the :class:`iris.analysis.Linear` scheme requires 1D numeric,
 monotonic, coordinates. Supposing we have a single column cube such as
 the one defined below:
 
-    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'),
-                              'air_potential_temperature')
+    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'), 'air_potential_temperature')
     >>> column = cube[:, 0, 0]
     >>> print(column.summary(shorten=True))
     air_potential_temperature / (K)     (model_level_number: 15)

--- a/docs/iris/src/userguide/interpolation_and_regridding.rst
+++ b/docs/iris/src/userguide/interpolation_and_regridding.rst
@@ -123,7 +123,9 @@ For instance, the :class:`iris.analysis.Linear` scheme requires 1D numeric,
 monotonic, coordinates. Supposing we have a single column cube such as
 the one defined below:
 
-    >>> column = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))[:, 0, 0]
+    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'),
+                              'air_potential_temperature')
+    >>> column = cube[:, 0, 0]
     >>> print(column.summary(shorten=True))
     air_potential_temperature / (K)     (model_level_number: 15)
 

--- a/docs/iris/src/userguide/real_and_lazy_data.rst
+++ b/docs/iris/src/userguide/real_and_lazy_data.rst
@@ -186,8 +186,7 @@ coordinates' lazy points and bounds:
 
 .. doctest::
 
-    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'),
-                              'air_potential_temperature')
+    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'), 'air_potential_temperature')
 
     >>> dim_coord = cube.coord('model_level_number')
     >>> print(dim_coord.has_lazy_points())

--- a/docs/iris/src/userguide/real_and_lazy_data.rst
+++ b/docs/iris/src/userguide/real_and_lazy_data.rst
@@ -186,7 +186,8 @@ coordinates' lazy points and bounds:
 
 .. doctest::
 
-    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'))
+    >>> cube = iris.load_cube(iris.sample_data_path('hybrid_height.nc'),
+                              'air_potential_temperature')
 
     >>> dim_coord = cube.coord('model_level_number')
     >>> print(dim_coord.has_lazy_points())

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-24_netcdf-promote.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-24_netcdf-promote.txt
@@ -1,0 +1,5 @@
+* Deprecated FUTURE flag :attr:`iris.Future.netcdf_promote`.
+
+* Removed deprecated behaviour that does not automatically promote NetCDF variables to cubes.
+  This change means that NetCDF variables that define reference surfaces for dimensionless vertical coordinates
+  will always be promoted and loaded as independent cubes.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -172,9 +172,15 @@ class Future(threading.local):
 
         For more details, see :ref:`using-time-constraints`.
 
-        The option `netcdf_promote` controls whether the netCDF loader
-        will expose variables which define reference surfaces for
-        dimensionless vertical coordinates as independent Cubes.
+        .. deprecated:: 2.0.0
+
+            The option `netcdf_promote` is deprecated and will be removed in a
+            future release and the deprecated code paths this option used to
+            toggle have been removed.
+
+            The option `netcdf_promote` controlled whether the netCDF loader
+            exposed variables that defined reference surfaces for
+            dimensionless vertical coordinates as independent Cubes.
 
         The option `netcdf_no_unlimited`, when True, changes the
         behaviour of the netCDF saver, such that no dimensions are set to

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -143,7 +143,7 @@ AttributeConstraint = iris._constraints.AttributeConstraint
 class Future(threading.local):
     """Run-time configuration controller."""
 
-    def __init__(self, cell_datetime_objects=True, netcdf_promote=False,
+    def __init__(self, cell_datetime_objects=True, netcdf_promote=True,
                  netcdf_no_unlimited=False, clip_latitudes=False):
         """
         A container for run-time options controls.
@@ -197,13 +197,18 @@ class Future(threading.local):
         return msg.format(self.cell_datetime_objects, self.netcdf_promote,
                           self.netcdf_no_unlimited, self.clip_latitudes)
 
-    deprecated_options = {'cell_datetime_objects': 'warning'}
+    deprecated_options = {'cell_datetime_objects': 'warning',
+                          'netcdf_promote': 'error'}
 
     def __setattr__(self, name, value):
         if name in self.deprecated_options:
             level = self.deprecated_options[name]
             if level == 'error':
-                pass
+                emsg = ("deprecated {prop!r} behaviour has been removed and "
+                        "setting the 'Future' property {prop!r} has been "
+                        "deprecated to be removed in a future release. "
+                        "PLease remove code that sets this property.")
+                raise AttributeError(emsg.format(prop=name))
             else:
                 msg = ("setting the 'Future' property {!r} is deprecated "
                        "and will be removed in a future release. "

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -204,10 +204,10 @@ class Future(threading.local):
         if name in self.deprecated_options:
             level = self.deprecated_options[name]
             if level == 'error':
-                emsg = ("deprecated {prop!r} behaviour has been removed and "
-                        "setting the 'Future' property {prop!r} has been "
-                        "deprecated to be removed in a future release. "
-                        "PLease remove code that sets this property.")
+                emsg = ("setting the 'Future' property {prop!r} has been "
+                        "deprecated to be removed in a future release, and "
+                        "deprecated {prop!r} behaviour has been removed. "
+                        "Please remove code that sets this property.")
                 raise AttributeError(emsg.format(prop=name))
             else:
                 msg = ("setting the 'Future' property {!r} is deprecated "

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1008,9 +1008,14 @@ class CFReader(object):
             for variable_type in self._variable_types:
                 # Prevent grid mapping variables being mis-identified as
                 # CF coordinate variables.
-                ignore = None if issubclass(variable_type, CFGridMappingVariable) else coordinate_names
-                match = variable_type.identify(self._dataset.variables, ignore=ignore,
-                                               target=cf_variable.cf_name, warn=False)
+                if issubclass(variable_type, CFGridMappingVariable):
+                    ignore = None
+                else:
+                    ignore = coordinate_names
+                match = variable_type.identify(self._dataset.variables,
+                                               ignore=ignore,
+                                               target=cf_variable.cf_name,
+                                               warn=False)
                 # Sanity check dimensionality coverage.
                 for cf_name, cf_var in six.iteritems(match):
                     if cf_var.spans(cf_variable):
@@ -1030,7 +1035,8 @@ class CFReader(object):
             # Build CF data variable relationships.
             if isinstance(cf_variable, CFDataVariable):
                 # Add global netCDF attributes.
-                cf_group.global_attributes.update(self.cf_group.global_attributes)
+                cf_group.global_attributes.update(
+                    self.cf_group.global_attributes)
                 # Add appropriate "dimensioned" CF coordinate variables.
                 cf_group.update({cf_name: self.cf_group[cf_name] for cf_name
                                     in cf_variable.dimensions if cf_name in
@@ -1043,7 +1049,8 @@ class CFReader(object):
                 # Add appropriate formula terms.
                 for cf_var in six.itervalues(self.cf_group.formula_terms):
                     for cf_root in cf_var.cf_terms_by_root:
-                        if cf_root in cf_group and cf_var.cf_name not in cf_group:
+                        if (cf_root in cf_group and
+                                cf_var.cf_name not in cf_group):
                             # Sanity check dimensionality.
                             if cf_var.spans(cf_variable):
                                 cf_group[cf_var.cf_name] = cf_var

--- a/lib/iris/tests/integration/test_cube.py
+++ b/lib/iris/tests/integration/test_cube.py
@@ -34,7 +34,7 @@ class Test_aggregated_by(tests.IrisTest):
     def test_agg_by_aux_coord(self):
         problem_test_file = tests.get_data_path(('NetCDF', 'testing',
                                                 'small_theta_colpex.nc'))
-        cube = iris.load_cube(problem_test_file)
+        cube = iris.load_cube(problem_test_file, 'air_potential_temperature')
 
         # Test aggregating by aux coord, notably the `forecast_period` aux
         # coord on `cube`, whose `_points` attribute is a lazy array.

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -74,9 +74,10 @@ class TestHybridPressure(tests.IrisTest):
         with self.temp_filename(suffix='.nc') as filename, \
                 self.temp_filename(suffix='.nc') as other_filename:
             iris.save(self.cube, filename)
-            cube = iris.load_cube(filename)
+            cube = iris.load_cube(filename, 'air_potential_temperature')
             iris.save(cube, other_filename)
-            other_cube = iris.load_cube(other_filename)
+            other_cube = iris.load_cube(other_filename,
+                                        'air_potential_temperature')
             self.assertEqual(cube, other_cube)
 
 
@@ -120,7 +121,7 @@ class TestSaveMultipleAuxFactories(tests.IrisTest):
         sa.points = sa.points * 10
         with self.temp_filename('.nc') as fname:
             iris.save([hh1, hh2], fname)
-            cubes = iris.load(fname)
+            cubes = iris.load(fname, 'air_temperature')
             cubes = sorted(cubes, key=lambda cube: cube.attributes['cube'])
             self.assertCML(cubes)
 
@@ -203,7 +204,7 @@ class TestLazySave(tests.IrisTest):
     def test_lazy_preserved_save(self):
         fpath = tests.get_data_path(('NetCDF', 'label_and_climate',
                                      'small_FC_167_mon_19601101.nc'))
-        acube = iris.load_cube(fpath)
+        acube = iris.load_cube(fpath, 'air_temperature')
         self.assertTrue(acube.has_lazy_data())
         with self.temp_filename('.nc') as nc_path:
             with Saver(nc_path, 'NETCDF4') as saver:

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -74,7 +74,7 @@ class SystemInitialTest(tests.IrisTest):
         filetypes = ('.nc', '.pp')
         if tests.GRIB_AVAILABLE:
             filetypes += ('.grib2',)
-        with iris.FUTURE.context(netcdf_no_unlimited=True, netcdf_promote=True):
+        with iris.FUTURE.context(netcdf_no_unlimited=True):
             for filetype in filetypes:
                 saved_tmpfile = iris.util.create_temp_filename(suffix=filetype)
                 iris.save(cm, saved_tmpfile)

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -254,7 +254,7 @@ class TestLoad(tests.IrisTest):
     def test_attributes_populated(self):
         filename = tests.get_data_path(
             ('NetCDF', 'label_and_climate', 'small_FC_167_mon_19601101.nc'))
-        cube = iris.load_cube(filename)
+        cube = iris.load_cube(filename, 'air_temperature')
         self.assertEqual(
             sorted(cube.coord('longitude').attributes.items()), 
             [('data_type', 'float'), 

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -564,9 +564,10 @@ class TestNetCDFSave(tests.IrisTest):
         # Test saving a CF-netCDF file which contains a hybrid height
         # (i.e. dimensionless vertical) coordinate.
         # Read PP input file.
+        names = ['air_potential_temperature', 'surface_altitude']
         file_in = tests.get_data_path(
             ('PP', 'COLPEX', 'small_colpex_theta_p_alt.pp'))
-        cube = iris.load_cube(file_in, 'air_potential_temperature')
+        cube = iris.load_cube(file_in, names[0])
 
         # Write Cube to netCDF file.
         with self.temp_filename(suffix='.nc') as file_out:
@@ -577,10 +578,12 @@ class TestNetCDFSave(tests.IrisTest):
                            ('netcdf', 'netcdf_save_hybrid_height.cdl'))
 
             # Read netCDF file.
-            cube = iris.load_cube(file_out)
+            cubes = iris.load(file_out)
+            cubes_names = [c.name() for c in cubes]
+            self.assertEqual(cubes_names, names)
 
             # Check the PP read, netCDF write, netCDF read mechanism.
-            self.assertCML(cube,
+            self.assertCML(cubes.extract(names[0])[0],
                            ('netcdf', 'netcdf_save_load_hybrid_height.cml'))
 
     @tests.skip_data

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -348,7 +348,7 @@ class TestAttributePositive(tests.GraphicsTest):
     def test_2d_positive_up(self):
         path = tests.get_data_path(('NetCDF', 'testing',
                                     'small_theta_colpex.nc'))
-        cube = iris.load_cube(path)[0, :, 42, :]
+        cube = iris.load_cube(path, 'air_potential_temperature')[0, :, 42, :]
         qplt.pcolormesh(cube)
         self.check_graphic()
 

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -154,9 +154,9 @@ class Test__nd_bounds(tests.IrisTest):
 @tests.skip_data
 class Test_lazy_aux_coords(tests.IrisTest):
     def setUp(self):
-        self.cube = iris.load_cube(tests.get_data_path
-                                   (['NetCDF', 'testing',
-                                     'small_theta_colpex.nc']))
+        path = tests.get_data_path(['NetCDF', 'testing',
+                                    'small_theta_colpex.nc'])
+        self.cube = iris.load_cube(path, 'air_potential_temperature')
 
     def _check_lazy(self):
         coords = self.cube.aux_coords + self.cube.derived_coords

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -249,9 +249,8 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
                 self.assertIs(aux_coord_group[name_bnds].cf_data,
                               getattr(self, name_bnds))
 
-    def test_future_promote_reference(self):
-        with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
-                iris.FUTURE.context(netcdf_promote=True):
+    def test_promote_reference(self):
+        with mock.patch('netCDF4.Dataset', return_value=self.dataset):
             cf_group = CFReader('dummy').cf_group
             self.assertEqual(len(cf_group), len(self.variables))
             # Check the number of data variables.
@@ -270,44 +269,31 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
 
     def test_formula_terms_ignore(self):
         self.orography.dimensions = ['lat', 'wibble']
-        for state in [False, True]:
-            with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
-                    iris.FUTURE.context(netcdf_promote=state), \
-                    mock.patch('warnings.warn') as warn:
-                cf_group = CFReader('dummy').cf_group
-                if state:
-                    group = cf_group.promoted
-                    self.assertEqual(list(group.keys()), ['orography'])
-                    self.assertIs(group['orography'].cf_data, self.orography)
-                    self.assertEqual(warn.call_count, 1)
-                else:
-                    self.assertEqual(len(cf_group.promoted), 0)
-                    self.assertEqual(warn.call_count, 2)
+        with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
+                mock.patch('warnings.warn') as warn:
+            cf_group = CFReader('dummy').cf_group
+            group = cf_group.promoted
+            self.assertEqual(list(group.keys()), ['orography'])
+            self.assertIs(group['orography'].cf_data, self.orography)
+            self.assertEqual(warn.call_count, 1)
 
     def test_auxiliary_ignore(self):
         self.x.dimensions = ['lat', 'wibble']
-        for state in [False, True]:
-            with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
-                    iris.FUTURE.context(netcdf_promote=state), \
-                    mock.patch('warnings.warn') as warn:
-                cf_group = CFReader('dummy').cf_group
-                if state:
-                    promoted = ['x', 'orography']
-                    group = cf_group.promoted
-                    self.assertEqual(set(group.keys()), set(promoted))
-                    for name in promoted:
-                        self.assertIs(group[name].cf_data, getattr(self, name))
-                    self.assertEqual(warn.call_count, 1)
-                else:
-                    self.assertEqual(len(cf_group.promoted), 0)
-                    self.assertEqual(warn.call_count, 2)
+        with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
+                mock.patch('warnings.warn') as warn:
+            cf_group = CFReader('dummy').cf_group
+            promoted = ['x', 'orography']
+            group = cf_group.promoted
+            self.assertEqual(set(group.keys()), set(promoted))
+            for name in promoted:
+                self.assertIs(group[name].cf_data, getattr(self, name))
+            self.assertEqual(warn.call_count, 1)
 
     def test_promoted_auxiliary_ignore(self):
         self.wibble = netcdf_variable('wibble', 'lat wibble', np.float)
         self.variables['wibble'] = self.wibble
         self.orography.coordinates = 'wibble'
         with mock.patch('netCDF4.Dataset', return_value=self.dataset), \
-                iris.FUTURE.context(netcdf_promote=True), \
                 mock.patch('warnings.warn') as warn:
             cf_group = CFReader('dummy').cf_group.promoted
             promoted = ['wibble', 'orography']

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -47,6 +47,14 @@ class Test___setattr__(tests.IrisTest):
         with self.assertRaises(AttributeError):
             future.numberwang = 7
 
+    def test_invalid_netcdf_promote_attributes(self):
+        future = Future()
+        states = [True, False]
+        exp_emsg = ''
+        for state in states:
+            with self.assertRaisesRegexp(AttributeError, exp_emsg):
+                future.netcdf_promote = state
+
     def test_cell_datetime_objects(self):
         future = Future()
         new_value = not future.cell_datetime_objects


### PR DESCRIPTION
With Iris v2.0, "the future has arrived". This PR swaps the behaviour of the FUTURE flag `netcdf_promote` so that the future behaviour is on by default. As the old behaviour is deprecated I've also removed the old behaviour, and `Future` will now raise an error if a user tries to set the `netcdf_promote` flag (to either `True` or `False`). Tests and docs are updated and I've added a whatsnew entry as well.

Fixes #2845.  