### PR TITLE
Move whatsnew entries to best location

### DIFF
--- a/docs/iris/src/whatsnew/2.0a0.rst
+++ b/docs/iris/src/whatsnew/2.0a0.rst
@@ -97,12 +97,6 @@ Incompatible Changes
 
 * The :meth:`~iris.cube.Cube.lazy_data` method no longer accepts any arguments.
 
-* Using :meth:`~iris.cube.Cube.convert_units` on a cube with unknown units will
-  result in a :data:`UnitConversionError` being raised.
-
-* Using :meth:`~iris.coords.Coord.convert_units` on a coordinate with unknown
-  units will result in a :data:`UnitConversionError` being raised.
-
 .. admonition:: Significant Changes in Calculated Results
 
   Due to the replacement of `Biggus`_ with `Dask`_, as described above, the results

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-24_convert-unknown-units.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-24_convert-unknown-units.txt
@@ -1,0 +1,5 @@
+* Using :meth:`~iris.cube.Cube.convert_units` on a cube with unknown units will
+  result in a :data:`UnitConversionError` being raised.
+
+* Using :meth:`~iris.coords.Coord.convert_units` on a coordinate with unknown
+  units will result in a :data:`UnitConversionError` being raised.


### PR DESCRIPTION
Raised in followup to #2700. In there, the whatsnew entry had been added directly to the compiled what's new rst document, meaning they had missed the whatsnew builder process, and were being recorded in the whatsnew for a release within which the changes they pointed to were not actually released (!). 

Rather than hold up #2700 any further, this PR removes them from the Iris v2.0a0 what's new document and adds them verbatim to a new whatsnew entry for the Iris v2.0 full release.