### PR TITLE
Document replacement of "iris.fileformats.ff" and "iris.experimental.fieldsfile".

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-18_remove-exp-ff.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-18_remove-exp-ff.txt
@@ -1,1 +1,8 @@
 * Removed deprecated module ```iris.experimental.fieldsfile```.
+  Note that there is no direct replacment for
+  ```:meth:iris.experimental.fieldsfile.load```, which specifically performed
+  fast loading from _either_ PP or FF files.
+  Instead, please enable `:meth:iris.fileformats.um.structured_um_loading` and
+  within that context call `:meth:iris.load`, or the format-specific
+  `:meth:iris.fileformats.pp.load_cubes` or
+  `:meth:iris.fileformats.um.load_cubes`.

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-18_remove-ff.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-18_remove-ff.txt
@@ -1,1 +1,2 @@
 * Removed deprecated module ```iris.fileformats.ff```.
+  Please use facilities in `:mod:iris.fileformats.um` instead.

--- a/lib/iris/fileformats/um/__init__.py
+++ b/lib/iris/fileformats/um/__init__.py
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Provides iris loading support for UM file types, FieldsFile and PP.
+Provides iris loading support for UM Fieldsfile-like file types, and PP.
+
+At present, the only UM file types supported are true FieldsFiles and LBCs.
+Other types of UM file may fail to load correctly (or at all).
 
 """
 

--- a/lib/iris/fileformats/um/_ff_replacement.py
+++ b/lib/iris/fileformats/um/_ff_replacement.py
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
 """
-Support for UM file types.
+Support for UM "fieldsfile-like" files.
 
-At present, only FieldsFiles and LBCs are supported.
+At present, the only UM file types supported are true FieldsFiles and LBCs.
 Other types of UM file may fail to load correctly (or at all).
 
 """
@@ -32,7 +32,7 @@ from iris.fileformats.pp import _load_cubes_variable_loader
 
 def um_to_pp(filename, read_data=False, word_depth=None):
     """
-    Extract the individual PPFields from within a UM file.
+    Extract individual PPFields from within a UM Fieldsfile-like file.
 
     Returns an iterator over the fields contained within the FieldsFile,
     returned as :class:`iris.fileformats.pp.PPField` instances.
@@ -71,7 +71,7 @@ def um_to_pp(filename, read_data=False, word_depth=None):
 def load_cubes(filenames, callback, constraints=None,
                _loader_kwargs=None):
     """
-    Loads cubes from a list of UM files filenames.
+    Loads cubes from filenames of UM fieldsfile-like files.
 
     Args:
 
@@ -96,7 +96,8 @@ def load_cubes(filenames, callback, constraints=None,
 
 def load_cubes_32bit_ieee(filenames, callback, constraints=None):
     """
-    Loads cubes from a list of 32bit ieee converted UM files filenames.
+    Loads cubes from filenames of 32bit ieee converted UM fieldsfile-like
+    files.
 
     .. seealso::
 


### PR DESCRIPTION
Closes #2818.
