### PR TITLE
test_scalar_cube_load

### DIFF
--- a/docs/iris/src/whatsnew/2.0.rst
+++ b/docs/iris/src/whatsnew/2.0.rst
@@ -129,6 +129,11 @@ Bugs Fixed
 * The order in which files are passed to iris.load functions is now the order in
   which they are processed. (#2325)
 
+* Loading from netCDF files with :func:`iris.load` will load a cube for each scalar variable,
+  a variable that does not reference a netCDF dimension, unless that scalar variable is identified as
+  a CF scalar coordinate, referenced from another data variable via the 'coordinates' attribute.
+  Previously such data variables were ignored during load.
+
 
 Incompatible Changes
 ====================

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -487,8 +487,8 @@ class CFCoordinateVariable(CFVariable):
             # String variables can't be coordinates
             if _is_str_dtype(nc_var):
                 continue
-            # Restrict to one-dimensional with name as dimension OR zero-dimensional scalar
-            if not ((nc_var.ndim == 1 and nc_var_name in nc_var.dimensions) or (nc_var.ndim == 0)):
+            # Restrict to one-dimensional with name as dimension
+            if not (nc_var.ndim == 1 and nc_var_name in nc_var.dimensions):
                 continue
             # Restrict to monotonic?
             if monotonic:

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -420,5 +420,14 @@ class TestPackedData(tests.IrisTest):
         self._multi_test('multi_packed_multi_dtype.cdl', multi_dtype=True)
 
 
+class TestScalarCube(tests.IrisTest):
+    def test_scalar_cube_save_load(self):
+        cube = iris.cube.Cube(1, long_name='scalar_cube')
+        with self.temp_filename(suffix='.nc') as fout:
+            iris.save(cube, fout)
+            scalar_cube = iris.load_cube(fout)
+            self.assertEqual(scalar_cube.name(), 'scalar_cube')
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
new test to check that a scalar data variable in a netcdf file will be loaded into a cube

addressing long standing bug reports, including #1427
