### PR TITLE
Refactor assertGivesWarning into separate methods

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -551,7 +551,7 @@ class IrisTest_nometa(unittest.TestCase):
                         if expr.search(message))
 
     @contextlib.contextmanager
-    def assertGivesWarning(self, expected_regexp=''):
+    def assertWarnsRegexp(self, expected_regexp=''):
         # Check that a warning is raised matching a given expression.
         with self._recordWarningMatches(expected_regexp) as matches:
             yield
@@ -562,7 +562,7 @@ class IrisTest_nometa(unittest.TestCase):
 
 
     @contextlib.contextmanager
-    def assertDoesNotGiveWarning(self, expected_regexp=''):
+    def assertNoWarningsRegexp(self, expected_regexp=''):
         # Check that no warning matching the given expression is raised.
         with self._recordWarningMatches(expected_regexp) as matches:
             yield

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -410,7 +410,7 @@ class Test_write_fill_value(tests.IrisTest):
         # Test that a warning is raised if the data contains the fill value.
         cube = self._make_cube('>f4')
         fill_value = 1
-        with self.assertGivesWarning(
+        with self.assertWarnsRegexp(
                 'contains unmasked data points equal to the fill-value'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
@@ -420,7 +420,7 @@ class Test_write_fill_value(tests.IrisTest):
         # when it is of a byte type.
         cube = self._make_cube('>i1')
         fill_value = 1
-        with self.assertGivesWarning(
+        with self.assertWarnsRegexp(
                 'contains unmasked data points equal to the fill-value'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
@@ -430,7 +430,7 @@ class Test_write_fill_value(tests.IrisTest):
         # value if no fill_value argument is supplied.
         cube = self._make_cube('>f4')
         cube.data[0, 0] = nc.default_fillvals['f4']
-        with self.assertGivesWarning(
+        with self.assertWarnsRegexp(
                 'contains unmasked data points equal to the fill-value'):
             with self._netCDF_var(cube):
                 pass
@@ -440,7 +440,7 @@ class Test_write_fill_value(tests.IrisTest):
         # value if no fill_value argument is supplied when the data is of a
         # byte type.
         cube = self._make_cube('>i1')
-        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
+        with self.assertNoWarningsRegexp(r'\(fill\|mask\)'):
             with self._netCDF_var(cube):
                 pass
 
@@ -449,7 +449,7 @@ class Test_write_fill_value(tests.IrisTest):
         # a masked point.
         fill_value = 1
         cube = self._make_cube('>f4', masked_value=fill_value)
-        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
+        with self.assertNoWarningsRegexp(r'\(fill\|mask\)'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
 
@@ -457,7 +457,7 @@ class Test_write_fill_value(tests.IrisTest):
         # Test that a warning is raised when saving masked byte data with no
         # fill value supplied.
         cube = self._make_cube('>i1', masked_value=1)
-        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
+        with self.assertNoWarningsRegexp(r'\(fill\|mask\)'):
             with self._netCDF_var(cube):
                 pass
 
@@ -466,7 +466,7 @@ class Test_write_fill_value(tests.IrisTest):
         # fill value supplied if the the data does not contain the fill_value.
         fill_value = 100
         cube = self._make_cube('>i1', masked_value=2)
-        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
+        with self.assertNoWarningsRegexp(r'\(fill\|mask\)'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -440,7 +440,7 @@ class Test_write_fill_value(tests.IrisTest):
         # value if no fill_value argument is supplied when the data is of a
         # byte type.
         cube = self._make_cube('>i1')
-        with self.assertGivesWarning(r'\(fill\|mask\)', expect_warning=False):
+        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
             with self._netCDF_var(cube):
                 pass
 
@@ -449,7 +449,7 @@ class Test_write_fill_value(tests.IrisTest):
         # a masked point.
         fill_value = 1
         cube = self._make_cube('>f4', masked_value=fill_value)
-        with self.assertGivesWarning(r'\(fill\|mask\)', expect_warning=False):
+        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
 
@@ -457,7 +457,7 @@ class Test_write_fill_value(tests.IrisTest):
         # Test that a warning is raised when saving masked byte data with no
         # fill value supplied.
         cube = self._make_cube('>i1', masked_value=1)
-        with self.assertGivesWarning(r'\(fill\|mask\)', expect_warning=False):
+        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
             with self._netCDF_var(cube):
                 pass
 
@@ -466,7 +466,7 @@ class Test_write_fill_value(tests.IrisTest):
         # fill value supplied if the the data does not contain the fill_value.
         fill_value = 100
         cube = self._make_cube('>i1', masked_value=2)
-        with self.assertGivesWarning(r'\(fill\|mask\)', expect_warning=False):
+        with self.assertDoesNotGiveWarning(r'\(fill\|mask\)'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
 

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -146,7 +146,7 @@ class Test_save(tests.IrisTest):
         # Set underlying data value at masked point to BMDI value.
         field.data.data[1] = field.bmdi
         self.assertArrayAllClose(field.data.data[1], field.bmdi)
-        with self.assertGivesWarning(r'\(mask\|fill\)', expect_warning=False):
+        with self.assertDoesNotGiveWarning(r'\(mask\|fill\)'):
             with self.temp_filename('.pp') as temp_filename:
                 with open(temp_filename, 'wb') as pp_file:
                     field.save(pp_file)

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -108,7 +108,7 @@ class Test_save(tests.IrisTest):
         data_64 = np.linspace(0, 1, num=10, endpoint=False).reshape(2, 5)
         checksum_32 = field_checksum(data_64.astype('>f4'))
         msg = 'Downcasting array precision from float64 to float32 for save.'
-        with self.assertGivesWarning(msg):
+        with self.assertWarnsRegexp(msg):
             checksum_64 = field_checksum(data_64.astype('>f8'))
         self.assertEqual(checksum_32, checksum_64)
 
@@ -119,7 +119,7 @@ class Test_save(tests.IrisTest):
         # Make float32 data, as float64 default produces an extra warning.
         field.data = np.ma.masked_array([1., field.bmdi, 3.], dtype=np.float32)
         msg = 'PPField data contains unmasked points'
-        with self.assertGivesWarning(msg):
+        with self.assertWarnsRegexp(msg):
             with self.temp_filename('.pp') as temp_filename:
                 with open(temp_filename, 'wb') as pp_file:
                     field.save(pp_file)
@@ -131,7 +131,7 @@ class Test_save(tests.IrisTest):
         # Make float32 data, as float64 default produces an extra warning.
         field.data = np.array([1., field.bmdi, 3.], dtype=np.float32)
         msg = 'PPField data contains unmasked points'
-        with self.assertGivesWarning(msg):
+        with self.assertWarnsRegexp(msg):
             with self.temp_filename('.pp') as temp_filename:
                 with open(temp_filename, 'wb') as pp_file:
                     field.save(pp_file)
@@ -146,7 +146,7 @@ class Test_save(tests.IrisTest):
         # Set underlying data value at masked point to BMDI value.
         field.data.data[1] = field.bmdi
         self.assertArrayAllClose(field.data.data[1], field.bmdi)
-        with self.assertDoesNotGiveWarning(r'\(mask\|fill\)'):
+        with self.assertNoWarningsRegexp(r'\(mask\|fill\)'):
             with self.temp_filename('.pp') as temp_filename:
                 with open(temp_filename, 'wb') as pp_file:
                     field.save(pp_file)

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -40,7 +40,7 @@ class Test___setattr__(tests.IrisTest):
         future = Future()
         new_value = not future.clip_latitudes
         msg = "'Future' property 'clip_latitudes' is deprecated"
-        with self.assertGivesWarning(msg):
+        with self.assertWarnsRegexp(msg):
             future.clip_latitudes = new_value
         self.assertEqual(future.clip_latitudes, new_value)
 


### PR DESCRIPTION
It's confusing that `assertGivesWarning` can be used to assert that no warning is raised. I've refactored the code into separate methods.