### PR TITLE
Allow missing_value as a user set attribute

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -33,7 +33,7 @@ class LimitedAttributeDict(dict):
                        'calendar', 'leap_month', 'leap_year', 'month_lengths',
                        'coordinates', 'grid_mapping', 'climatology',
                        'cell_methods', 'formula_terms', 'compress',
-                       'missing_value', 'add_offset', 'scale_factor',
+                       'add_offset', 'scale_factor',
                        '_FillValue')
 
     def __init__(self, *args, **kwargs):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -90,7 +90,7 @@ _CF_ATTRS = ['add_offset', 'ancillary_variables', 'axis', 'bounds', 'calendar',
 
 # CF attributes that should not be global.
 _CF_DATA_ATTRS = ['flag_masks', 'flag_meanings', 'flag_values',
-                  'instance_dimension', 'sample_dimension',
+                  'instance_dimension', 'missing_value', 'sample_dimension',
                   'standard_error_multiplier']
 
 # CF attributes that should only be global.

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -711,6 +711,7 @@ class TestNetCDFSave(tests.IrisTest):
                  'flag_masks': 'a',
                  'flag_meanings': 'b',
                  'flag_values': 'c',
+                 'missing_value': 1.e20,
                  'STASH': iris.fileformats.pp.STASH(1, 2, 3)}
         for k, v in six.iteritems(avars):
             self.cube.attributes[k] = v


### PR DESCRIPTION
This allows the user to set missing_value as an attribute on a
cube while ensuring that it is saved as local attribute in the
netcdf file.

Fixes #1588

Signed-off-by: Klaus Zimmermann <klaus.zimmermann@smhi.se>