### PR TITLE
Change behaviour of 'error' level

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -224,7 +224,7 @@ class Future(threading.local):
     def __setattr__(self, name, value):
         if name in self.deprecated_options:
             level = self.deprecated_options[name]
-            if level == 'error':
+            if level == 'error' and not value:
                 emsg = ("setting the 'Future' property {prop!r} has been "
                         "deprecated to be removed in a future release, and "
                         "deprecated {prop!r} behaviour has been removed. "

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -57,15 +57,16 @@ class Test___setattr__(tests.IrisTest):
 
     def test_netcdf_no_unlimited(self):
         future = Future()
-        exp_emsg = "'Future' property 'netcdf_promote' is deprecated"
+        exp_emsg = "'Future' property 'netcdf_no_unlimited' is deprecated"
         with self.assertWarnsRegexp(exp_emsg):
-            future.netcdf_promote = True
+            future.netcdf_no_unlimited = True
 
     def test_invalid_netcdf_no_unlimited(self):
         future = Future()
-        exp_emsg = "'Future' property 'netcdf_promote' has been deprecated"
+        exp_emsg = \
+            "'Future' property 'netcdf_no_unlimited' has been deprecated"
         with self.assertRaisesRegexp(AttributeError, exp_emsg):
-            future.netcdf_promote = False
+            future.netcdf_no_unlimited = False
 
     def test_cell_datetime_objects(self):
         future = Future()

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -43,13 +43,17 @@ class Test___setattr__(tests.IrisTest):
         with self.assertRaises(AttributeError):
             future.numberwang = 7
 
-    def test_invalid_netcdf_promote_attributes(self):
+    def test_netcdf_promote(self):
         future = Future()
-        states = [True, False]
-        exp_emsg = "deprecated 'netcdf_promote' behaviour has been removed"
-        for state in states:
-            with self.assertRaisesRegexp(AttributeError, exp_emsg):
-                future.netcdf_promote = state
+        exp_emsg = "'Future' property 'netcdf_promote' is deprecated"
+        with self.assertWarnsRegexp(exp_emsg):
+            future.netcdf_promote = True
+
+    def test_invalid_netcdf_promote(self):
+        future = Future()
+        exp_emsg = "'Future' property 'netcdf_promote' has been deprecated"
+        with self.assertRaisesRegexp(AttributeError, exp_emsg):
+            future.netcdf_promote = False
 
     def test_invalid_netcdf_no_unlimited_attributes(self):
         future = Future()

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -55,14 +55,17 @@ class Test___setattr__(tests.IrisTest):
         with self.assertRaisesRegexp(AttributeError, exp_emsg):
             future.netcdf_promote = False
 
-    def test_invalid_netcdf_no_unlimited_attributes(self):
+    def test_netcdf_no_unlimited(self):
         future = Future()
-        states = [True, False]
-        exp_emsg =\
-            "deprecated 'netcdf_no_unlimited' behaviour has been removed"
-        for state in states:
-            with self.assertRaisesRegexp(AttributeError, exp_emsg):
-                future.netcdf_no_unlimited = state
+        exp_emsg = "'Future' property 'netcdf_promote' is deprecated"
+        with self.assertWarnsRegexp(exp_emsg):
+            future.netcdf_promote = True
+
+    def test_invalid_netcdf_no_unlimited(self):
+        future = Future()
+        exp_emsg = "'Future' property 'netcdf_promote' has been deprecated"
+        with self.assertRaisesRegexp(AttributeError, exp_emsg):
+            future.netcdf_promote = False
 
     def test_cell_datetime_objects(self):
         future = Future()


### PR DESCRIPTION
Changed the behaviour of the 'error' level for `iris.FUTURE` options so that if a user sets them to `True` a warning is raised rather than an error.

(As an aside, I'm only able to test this behaviour because we currently have an option which is at 'error' level.)