### PR TITLE
Fix doctest failing due to change in 'netcdf_promote' future behaviour

### DIFF
--- a/docs/iris/src/userguide/regridding_plots/interpolate_column.py
+++ b/docs/iris/src/userguide/regridding_plots/interpolate_column.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 fname = iris.sample_data_path('hybrid_height.nc')
-column = iris.load_cube(fname)[:, 0, 0]
+column = iris.load_cube(fname, 'air_potential_temperature')[:, 0, 0]
 
 alt_coord = column.coord('altitude')
 


### PR DESCRIPTION
Closes https://github.com/SciTools/iris/issues/2880

The new behaviour causes the reference surface to be loaded as a separate cube, so the `load_cube()` call fails.