### PR TITLE
Get working with iris-grib-with-eccodes; Python 3 included.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
       conda install --quiet --file minimal-conda-requirements.txt;
     else
       if [[ "$TRAVIS_PYTHON_VERSION" == 3* ]]; then
-        sed -e '/ecmwf_grib/d' -e '/esmpy/d' -e 's/#.\+$//' conda-requirements.txt | xargs conda install --quiet;
+        sed -e '/esmpy/d' -e 's/#.\+$//' conda-requirements.txt | xargs conda install --quiet;
       else
         conda install --quiet --file conda-requirements.txt;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,6 @@ install:
       fi
     fi
 
-  # JUST FOR NOW : Install latest version of iris-grib.
-  # TODO : remove when this release is available on conda-forge.
-  - if [[ "$TEST_MINIMAL" != true ]]; then
-        pip install git+https://github.com/SciTools/iris-grib.git@v0.11.0 ;
-    fi
-
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 
   # Output debug info

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ install:
       fi
     fi
 
+  # JUST FOR NOW : Install latest version of iris-grib.
+  # TODO : remove when this release is available on conda-forge.
+  - if [[ "$TEST_MINIMAL" != true ]]; then
+        pip install git+https://github.com/SciTools/iris-grib.git@v0.11.0 ;
+    fi
+
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 
   # Output debug info

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -35,4 +35,4 @@ python-stratify
 pyugrid
 
 # Iris extensions (i.e. key tools that depend on Iris)
-iris_grib
+iris_grib>=0.12

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -25,7 +25,6 @@ imagehash
 requests
 
 # Optional iris dependencies
-python-ecmwf_grib
 esmpy>=7.0
 gdal
 libmo_unpack
@@ -36,4 +35,4 @@ python-stratify
 pyugrid
 
 # Iris extensions (i.e. key tools that depend on Iris)
-# iris_grib
+iris_grib

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -35,4 +35,4 @@ python-stratify
 pyugrid
 
 # Iris extensions (i.e. key tools that depend on Iris)
-iris_grib>=0.12
+# iris_grib>=0.12

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -330,7 +330,7 @@ def save(source, target, saver=None, **kwargs):
         * netCDF - the Unidata network Common Data Format:
             * see :func:`iris.fileformats.netcdf.save`
         * GRIB2 - the WMO GRIdded Binary data format:
-            * see :func:`iris.fileformats.grib.save_grib2`.
+            * see :func:`iris_grib.save_grib2`.
         * PP - the Met Office UM Post Processing Format:
             * see :func:`iris.fileformats.pp.save`
 

--- a/lib/iris/tests/integration/format_interop/test_name_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_name_grib.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/format_interop/test_name_grib.py
+++ b/lib/iris/tests/integration/format_interop/test_name_grib.py
@@ -72,21 +72,19 @@ class TestNameToGRIB(tests.IrisTest):
     def test_name2_field(self):
         filepath = tests.get_data_path(('NAME', 'NAMEII_field.txt'))
         name_cubes = iris.load(filepath)
-        # Check gribapi version, because we currently have a known load/save
-        # problem with gribapi 1v14 (at least).
-        gribapi_ver = gribapi.grib_get_api_version()
-        gribapi_fully_supported_version = \
-            (StrictVersion(gribapi.grib_get_api_version()) <
-             StrictVersion('1.13'))
+
+        # There is a known load/save problem with numerous
+        # gribapi/eccodes versions and
+        # zero only data, where min == max.
+        # This may be a problem with data scaling.
         for i, name_cube in enumerate(name_cubes):
-            if not gribapi_fully_supported_version:
-                data = name_cube.data
-                if np.min(data) == np.max(data):
-                    msg = ('NAMEII cube #{}, "{}" has empty data : '
-                           'SKIPPING test for this cube, as save/load will '
-                           'not currently work with gribabi > 1v12.')
-                    warnings.warn(msg.format(i, name_cube.name()))
-                    continue
+            data = name_cube.data
+            if np.min(data) == np.max(data):
+                msg = ('NAMEII cube #{}, "{}" has empty data : '
+                       'SKIPPING test for this cube, as save/load will '
+                       'not currently work.')
+                warnings.warn(msg.format(i, name_cube.name()))
+                continue
 
             with self.temp_filename('.grib2') as temp_filename:
                 iris.save(name_cube, temp_filename)

--- a/lib/iris/tests/integration/test_grib_load.py
+++ b/lib/iris/tests/integration/test_grib_load.py
@@ -22,7 +22,7 @@ style tests have been split out of there.
 
 The remainder of the old 'tests/test_grib_load.py' is now renamed as
 'tests/test_grib_load_translations.py'.  Those tests are implementation-
-specific, and target the module 'iris.fileformats.grib'.
+specific, and target the module 'iris_grib'.
 
 """
 from __future__ import (absolute_import, division, print_function)

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -34,6 +34,7 @@ import iris.coords
 
 if tests.GRIB_AVAILABLE:
     import gribapi
+    from iris_grib._load_convert import _MDI as MDI
 
 
 @tests.skip_data
@@ -50,10 +51,10 @@ class TestLoadSave(tests.TestGribMessage):
             iris.save(cubes, temp_file_path)
             expect_diffs = {'totalLength': (4837, 4832),
                             'productionStatusOfProcessedData': (0, 255),
-                            'scaleFactorOfRadiusOfSphericalEarth': (4294967295,
+                            'scaleFactorOfRadiusOfSphericalEarth': (MDI,
                                                                     0),
                             'shapeOfTheEarth': (0, 1),
-                            'scaledValueOfRadiusOfSphericalEarth': (4294967295,
+                            'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                     6367470),
                             'typeOfGeneratingProcess': (0, 255),
                             'generatingProcessIdentifier': (128, 255),
@@ -70,10 +71,10 @@ class TestLoadSave(tests.TestGribMessage):
             iris.save(cubes, temp_file_path)
             expect_diffs = {'totalLength': (648196, 648191),
                             'productionStatusOfProcessedData': (0, 255),
-                            'scaleFactorOfRadiusOfSphericalEarth': (4294967295,
+                            'scaleFactorOfRadiusOfSphericalEarth': (MDI,
                                                                     0),
                             'shapeOfTheEarth': (0, 1),
-                            'scaledValueOfRadiusOfSphericalEarth': (4294967295,
+                            'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                     6367470),
                             'longitudeOfLastGridPoint': (392109982, 32106370),
                             'latitudeOfLastGridPoint': (19419996, 19419285),
@@ -91,10 +92,10 @@ class TestLoadSave(tests.TestGribMessage):
         cubes = iris.load(source_grib)
         expect_diffs = {'totalLength': (21232, 21227),
                         'productionStatusOfProcessedData': (0, 255),
-                        'scaleFactorOfRadiusOfSphericalEarth': (4294967295,
+                        'scaleFactorOfRadiusOfSphericalEarth': (MDI,
                                                                 0),
                         'shapeOfTheEarth': (0, 1),
-                        'scaledValueOfRadiusOfSphericalEarth': (4294967295,
+                        'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                 6367470),
                         'longitudeOfLastGridPoint': (356249908, 356249809),
                         'latitudeOfLastGridPoint': (-89999938, -89999944),

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for :mod:`iris.fileformats.grib._save_rules`."""
+"""Integration tests for :mod:`iris_grib._save_rules`."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa


### PR DESCRIPTION
This won't work until a new iris-grib>=0.12 is available on conda-forge
I'm assuming that will have masked dask support AND eccodes

There are changes here specific to the eccodes transition, ported across from #2607