### PR TITLE
Reduced the number of processes used by default when testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,10 +117,10 @@ install:
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=8;
+      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=3;
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
-      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=8;
+      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=3;
     fi
 
   # Capture install-dir: As a test command must be last for get Travis to check

--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -127,7 +127,9 @@ class TestRunner():
         if self.stop:
             print('Stopping tests after the first error or failure')
         if self.num_processors is None:
-            self.num_processors = multiprocessing.cpu_count() - 1
+            # Choose a magic number that works reasonably well for the default
+            # number of processes.
+            self.num_processors = (multiprocessing.cpu_count() + 1) // 4 + 1
         else:
             self.num_processors = int(self.num_processors)
 


### PR DESCRIPTION
Given we are far more parallelised now in iris (thanks to our new-found dask abilities) we don't need to use as many processes in parallel when testing. I didn't do any particularly sophisticated analysis of the "sweet spot", but leave that as an exercise for the interested reader...

In summary: we don't need to flood the machine with processes, and anything is better than what we currently do...


On Travis (where the numbers are extremely erratic), using 8 processes appears to take a similar amount of time to using 3. On my laptop (4 core), using 1 process takes about the same amount of time as 3.