### PR TITLE
Set the documentation build to use viridis as the default colormap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,10 @@ script:
   # affect any downstream functionality but causes the build to fail
   # spuriously. The echo-backtick workaround gets around this error,
   # which should be investigated further in the future.
-  - if [[ $TEST_TARGET == 'doctest' ]]; then
+  - >
+    if [[ $TEST_TARGET == 'doctest' ]]; then
       cd $INSTALL_DIR/docs/iris;
+      echo 'image.cmap: viridis' > matplotlibrc;
       echo `make clean html`;
       make doctest;
     fi

--- a/docs/iris/src/_templates/index.html
+++ b/docs/iris/src/_templates/index.html
@@ -29,7 +29,7 @@ $(document).ready(function() {
     // Only use first 5 images
     for (var i = 0; i < 5; i++) {
         var img = images[i];
-		$ss.append('<a href="'+img[2]+'"><img src="'+img[1]+'" class="slideshowImage"/></a>');
+		$ss.append('<a href="'+img[2]+'" style="background-color: white;" ><img src="'+img[1]+'" class="slideshowImage"/></a>');
     }
 
     $ss.cycle({


### PR DESCRIPTION
This is necessary because we still have mpl 1, not 2.

In addition, I was finding that the image scroller on the homepage was showing a black background for unusually shaped images. I fixed this by setting the background to white - it would be awesome to have a thorough refresh of the docs' styling, but I didn't get around to doing that yet.