### PR TITLE
Added a stale configuration: https://probot.github.io/apps/stale/.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,26 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 140
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 21
+
+# Issues with these labels will never be considered stale
+exemptLabels: []
+
+# Label to use when marking an issue as stale
+staleLabel: "Status: Stalled"
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue/PR has been automatically marked as "stalled" because it has not had
+  any recent activity. In order to keep the Iris issue tracker relevant and accessible
+  this issue/PR will be closed if no further activity occurs.
+  We really appreciate your contributions, but we also acknowledge that it is not
+  always possible to afford every single issue the attention we would like, or
+  that it deserves.
+  
+  Thank you for your understanding.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+


### PR DESCRIPTION
https://probot.github.io/apps/stale/ is a service that automatically closes issues/PRs after a configurable number of days of inactivity.

It is somewhat controversial to put this forward, but essentially my *personal* stance is: if an issue is untouched for >20 weeks it is probably not the biggest issue that the Iris development community should be focussing on (that is not to say that individuals can't chose to focus on whatever they like, it is just not representative of the focus of the Iris community as a whole).

I've picked these numbers out of the blue, and am completely up for a reasoned justification for their change. I'm certain the message itself could be significantly improved - let's focus on the wording if we decide to actually go with this.

cc: @SciTools/iris-devs - would be great to get some visual feedback in the form of 👍 / 👎 on this description. The votes will be taken into consideration by the steering council when it makes the final call.