### PR TITLE
Add a welcome message for first merge

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,8 @@
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+    Congratulations on having your first pull request merged!
+    The Iris community are stoked that you've contributed and we all look forward to
+    your future work :smile: :tada: :fireworks:


### PR DESCRIPTION
Uses https://github.com/apps/welcome to give a friendly message on merged PRs for first-time contributors.

I don't have confidence in the multi-line string and emojis... I'd probably want to test this out on a fresh repo somewhere before enabling.