### PR TITLE
Stickler config

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,2 @@
+linters:
+    flake8:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[flake8]
+ignore = E402,\ # Due to conditional imports
+         E226   # Due to whitespace around operators (e.g. 2*x + 3)
+exclude = */iris/std_names.py,\
+          */iris/fileformats/cf.py,\
+          */iris/fileformats/dot.py,\
+          */iris/fileformats/pp_load_rules.py,\
+          */iris/fileformats/rules.py,\
+          */iris/fileformats/um_cf_map.py,\
+          */iris/fileformats/_pyke_rules/compiled_krb/*,\
+          */iris/io/__init__.py,\
+          */iris/io/format_picker.py,\
+          */iris/tests/__init__.py,\
+          */iris/tests/pp.py,\
+          */iris/tests/stock.py,\
+          */iris/tests/system_test.py,\
+          */iris/tests/test_analysis.py,\
+          */iris/tests/test_analysis_calculus.py,\
+          */iris/tests/test_basic_maths.py,\
+          */iris/tests/test_cartography.py,\
+          */iris/tests/test_cdm.py,\
+          */iris/tests/test_cell.py,\
+          */iris/tests/test_cf.py,\
+          */iris/tests/test_constraints.py,\
+          */iris/tests/test_coord_api.py,\
+          */iris/tests/test_coord_categorisation.py,\
+          */iris/tests/test_coordsystem.py,\
+          */iris/tests/test_cube_to_pp.py,\
+          */iris/tests/test_file_load.py,\
+          */iris/tests/test_file_save.py,\
+          */iris/tests/test_grib_save.py,\
+          */iris/tests/test_grib_save_rules.py,\
+          */iris/tests/test_hybrid.py,\
+          */iris/tests/test_intersect.py,\
+          */iris/tests/test_io_init.py,\
+          */iris/tests/test_iterate.py,\
+          */iris/tests/test_load.py,\
+          */iris/tests/test_merge.py,\
+          */iris/tests/test_pp_cf.py,\
+          */iris/tests/test_pp_module.py,\
+          */iris/tests/test_pp_stash.py,\
+          */iris/tests/test_pp_to_cube.py,\
+          */iris/tests/test_quickplot.py,\
+          */iris/tests/test_std_names.py,\
+          */iris/tests/test_unit.py,\
+          */iris/tests/test_uri_callback.py,\
+          */iris/tests/test_util.py
+


### PR DESCRIPTION
Adds stickler (not yet enabled on the repo) and a flake8 config, so that we can all run ```flake8 lib/iris``` and get a meaningful result (even if there *are* failures 😱).

Closes #2334 