### PR TITLE
Remove obsolete reference from Userguide.

### DIFF
--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -66,9 +66,7 @@ but with the data representing their difference:
 
     Notice that the coordinates "time" and "forecast_period" have been removed 
     from the resultant cube; 
-    this is because these coordinates differed between the two input cubes. 
-    For more control on whether or not coordinates should be automatically 
-    ignored :func:`iris.analysis.maths.subtract` can be used instead.
+    this is because these coordinates differed between the two input cubes.
 
 
 .. _cube-maths_anomaly:


### PR DESCRIPTION
See reference here : https://github.com/SciTools/iris/pull/1911#issuecomment-215032215

The `iris.analysis.maths.add() / subtract()` routines used to have a keyword `ignore=True`, but this has been deprecated and non-functional since (allegedly) v0.8 (!)
The keyword is finally removed in v2.0 anyway.

This is what the Userguide reference is referring to, so I just removed it.