### PR TITLE
Further docs refinement for v2.0.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -149,6 +149,23 @@ mo_pack (https://github.com/SciTools/mo_pack)
     A Python wrapper to libmo_unpack, giving WGDOS packing and unpacking.
 
 
+Generating conda requirements
+'''''''''''''''''''''''''''''
+
+Requirements for Iris are stored in the ``requirements`` directory in the root of the source repository.
+It is possible to generate a requirements file suitable for conda use with::
+
+    python requirements/gen_conda_requirements.py > conda_requirements.txt
+
+This may be installed with::
+
+    conda create -n my_iris_env --file conda_requirements.txt
+
+Alternatively, a full requirements file that includes all optional dependencies can be produced with::
+
+    python requirements/gen_conda_requirements.py --groups all > conda_requirements.txt
+
+
 Custom site configuration
 =========================
 The default site configuration values can be overridden by creating the file

--- a/INSTALL
+++ b/INSTALL
@@ -42,20 +42,11 @@ extract the iris source package, cd to the new directory, and enter::
 
 In-place build - an alternative for developers
 ==============================================
-We strongly encourage people to contribute to Iris and for this type of 
+We are very keen to encourage contributions to Iris. For this type of 
 development activity an in-place build can be useful. Once you've cloned 
-the Iris git repository you can perform an in-place build by entering::
+the Iris git repository you can perform an in-place build with::
 
-  python setup.py std_names
-  python setup.py build_ext --inplace
-
-Details of other setup.py options and commands can be found by entering::
-
-  python setup.py --help
-
-and::
-
-  python setup.py --help-commands
+  python setup.py develop
 
 
 Build and runtime requirements
@@ -73,40 +64,41 @@ If you are installing dependencies with a package manager on Linux,
 you may need to install the development packages (look for a "-dev" 
 postfix) in addition to the core packages.  
 
-python 2.7 or 3.4 (http://www.python.org/)
-    Iris requires Python 2.7 or Python 3.4.
 
-numpy 1.9 or later (http://numpy.scipy.org/)
+python 2.7 or 3.5+ (http://www.python.org/)
+    Iris requires Python 2.7 or Python 3.5+.
+
+numpy (http://numpy.scipy.org/)
     Python package for scientific computing including a powerful N-dimensional
     array object.
 
-scipy 0.10 or later (http://www.scipy.org/)
+scipy (http://www.scipy.org/)
     Python package for scientific computing.
 
-cartopy 0.11.0 or later (http://github.com/SciTools/cartopy/)
+cartopy v0.11.0 or later (http://github.com/SciTools/cartopy/)
     Python package which provides cartographic tools for python.
 
-dask 0.15.0 or later (https://dask.pydata.org/)
+dask v0.15.0 or later (https://dask.pydata.org/)
     Python package for parallel computing.
 
-PyKE 1.1.1 or later (http://pyke.sourceforge.net/)
+PyKE v1.1.1 or later (http://pyke.sourceforge.net/)
     Python knowledge-based inference engine.
 
-netcdf4-python 0.9.9 or later (http://netcdf4-python.googlecode.com/)
+netcdf4-python (http://netcdf4-python.googlecode.com/)
     Python interface to the netCDF version 4 C library.
     (It is strongly recommended to ensure your installation uses a
     thread-safe build of HDF5 to avoid segmentation faults when using
     lazy evaluation.)
 
-cf_units 1.0 or later (https://github.com/SciTools/cf_units)
-    CF data units handling, using udunits (q.v.).
+cf_units v1.0 or later (https://github.com/SciTools/cf_units)
+    CF data units handling, using udunits.
 
-udunits2 2.1.24 or later
-    (http://www.unidata.ucar.edu/downloads/udunits/index.jsp)
-    C library for units of physical quantities.
-
-setuptools 0.6c11 or later (http://pypi.python.org/pypi/setuptools/)
+setuptools v36.0 or later (http://pypi.python.org/pypi/setuptools/)
     Python package for installing/removing python packages.
+
+
+The full list of packages may be found in the repository at
+``requirements/core.txt``.
 
 
 Optional
@@ -116,88 +108,55 @@ additonal Iris functionality such as plotting and
 loading/saving GRIB. These packages are required for the full Iris test
 suite to run.
 
-gdal 1.9.1 or later (https://pypi.python.org/pypi/GDAL/)
+gdal (https://pypi.python.org/pypi/GDAL/)
     Python package for the Geospatial Data Abstraction Library (GDAL).
 
-graphviz 2.18 or later (http://www.graphviz.org/)
+graphviz (http://www.graphviz.org/)
     Graph visualisation software.
 
-iris-grib 0.11 or later
-    (https://github.com/scitools/iris-grib)
+iris-grib (https://github.com/scitools/iris-grib)
     Iris interface to ECMWF's GRIB API
 
-matplotlib 1.2.0 (http://matplotlib.sourceforge.net/)
+matplotlib (https://matplotlib.org)
     Python package for 2D plotting.  
 
-mock 1.0.1 (http://pypi.python.org/pypi/mock/)
+mock (http://pypi.python.org/pypi/mock/)
     Python mocking and patching package for testing. Note that this package
     is only required to support the Iris unit tests.
 
-nose 1.1.2 or later (https://nose.readthedocs.io/en/latest/)
+nose (https://nose.readthedocs.io/en/latest/)
     Python package for software testing. Iris is not compatible with nose2.
 
-pep8 1.4.6 (https://pypi.python.org/pypi/pep8)
+pep8 (https://pypi.python.org/pypi/pep8)
     Python package for software testing.
 
-pandas 0.11.0 or later (http://pandas.pydata.org)
+pandas (http://pandas.pydata.org)
     Python package providing high-performance, easy-to-use data structures and
     data analysis tools.
 
-PythonImagingLibrary 1.1.7 or later (http://effbot.org/zone/pil-index.htm)
+PythonImagingLibrary (http://effbot.org/zone/pil-index.htm)
     Python package for image processing.
 
-pyugrid 0.1.1 or later (https://github.com/pyugrid/pyugrid)
+pyugrid (https://github.com/pyugrid/pyugrid)
     A Python API to utilize data written using the unstructured grid
     UGRID conventions.
 
-shapely 1.2.14 (https://github.com/Toblerity/Shapely)
+shapely (https://github.com/Toblerity/Shapely)
     Python package for the manipulation and analysis of planar geometric
     objects.
 
-mo_pack 0.1.0dev0 (https://github.com/SciTools/mo_pack)
+mo_pack (https://github.com/SciTools/mo_pack)
     A Python wrapper to libmo_unpack, giving WGDOS packing and unpacking.
-
-* Those packages have been tested with a specific build.
-
-Packed PP
-=========
-The libmo_unpack library can be used by Iris for decoding/unpacking 
-PP files or Fields files that use an lbpack value of 1 or 4. This 
-library is open source, licensed under the 2-clause BSD licence. 
-It can be obtained from http://puma.nerc.ac.uk/trac/UM_TOOLS/wiki/unpack.
-
-Use of this library is not enabled by default. If this library is 
-available its use can be enabled by installing Iris with the following 
-command::
-
-  python setup.py --with-unpack install
-
-Note that if this library and/or its associated header files are installed 
-in a custom location then additional compiler arguments may need to be 
-passed in to ensure that the Python extension module linking against it 
-builds correctly::
-
-  python setup.py --with-unpack build_ext -I <custom include dir> \ 
-        -L <custom link-time libdir> -R <custom runtime libdir> install
 
 
 Custom site configuration
 =========================
 The default site configuration values can be overridden by creating the file
 ``iris/etc/site.cfg``. For example, the following snippet can be used to
-specify a non-standard location for your udunits library::
+specify a non-standard location for your dot executable::
 
   [System]
-  udunits2_path = /path/to/libudunits2.so
+  dot_path = /usr/bin/dot
 
 An example configuration file is available in ``iris/etc/site.cfg.template``.
 See :py:func:`iris.config` for further configuration options.
-
-
-Packaged distributions
-======================
-The Enthought Python Distribution (EPD)
-http://www.enthought.com/products/epd.php for Windows, OS X or
-Redhat provides some of the dependencies for Iris as does Python (x, y)
-https://python-xy.github.io/ which tends to be updated a
-bit more frequently.

--- a/docs/iris/src/_templates/index.html
+++ b/docs/iris/src/_templates/index.html
@@ -103,7 +103,7 @@ With Iris you can:
         <span class="linkdescr">extra information on specific technical issues</span></p>
     </li>
     <li>
-        <p class="biglink"><a class="biglink" href="whatsnew/2.0a0.html">What's new in Iris 2.0a0?</a><br/>
+        <p class="biglink"><a class="biglink" href="whatsnew/2.0.html">What's new in Iris 2.0?</a><br/>
         <span class="linkdescr">recent changes in Iris's capabilities</span></p>
     </li>
 	</ul>

--- a/docs/iris/src/whatsnew/index.rst
+++ b/docs/iris/src/whatsnew/index.rst
@@ -9,7 +9,7 @@ Iris versions.
 .. toctree::
    :maxdepth: 2
 
-   2.0a0.rst
+   2.0.rst
    1.13.rst
    1.12.rst
    1.11.rst


### PR DESCRIPTION
Including updating the install guide to:
 * avoid being over-prescriptive about dependency versions
 * mention setup.py develop
 * reference a sensible config item

Also fixes the link on the homepage to get to the correct what's new!