### PR TITLE
Reduce exception message for loading missing files.

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -172,7 +172,7 @@ def expand_filespecs(file_specs):
                 msg += '\n    - "{}" matched {} file(s)'.format(pattern,
                                                                 len(expanded))
             else:
-                msg += '\n    * "{}" expanded to empty'.format(pattern)
+                msg += '\n    * "{}" didn\'t match any files'.format(pattern)
         raise IOError(msg)
 
     return [fname for fnames in all_expanded for fname in fnames]

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -169,11 +169,10 @@ def expand_filespecs(file_specs):
         msg = "One or more of the files specified did not exist:"
         for pattern, expanded in six.iteritems(glob_expanded):
             if expanded:
-                file_list = '\n       - {}'.format(', '.join(expanded))
+                msg += '\n  - "{}" matched {} file(s)'.format(pattern,
+                                                              len(expanded))
             else:
-                file_list = ''
-            msg += '\n    - "{}" matched {} file(s){}'.format(
-                    pattern, len(expanded), file_list)
+                msg += '\n  * "{}" expanded to empty'.format(pattern)
         raise IOError(msg)
 
     return [fname for fnames in all_expanded for fname in fnames]

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -169,10 +169,10 @@ def expand_filespecs(file_specs):
         msg = "One or more of the files specified did not exist:"
         for pattern, expanded in six.iteritems(glob_expanded):
             if expanded:
-                msg += '\n  - "{}" matched {} file(s)'.format(pattern,
-                                                              len(expanded))
+                msg += '\n    - "{}" matched {} file(s)'.format(pattern,
+                                                                len(expanded))
             else:
-                msg += '\n  * "{}" expanded to empty'.format(pattern)
+                msg += '\n    * "{}" expanded to empty'.format(pattern)
         raise IOError(msg)
 
     return [fname for fnames in all_expanded for fname in fnames]

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -80,7 +80,7 @@ class TestExpandFilespecs(tests.IrisTest):
         self.assertEqual(result, expected[::-1])
 
     def test_no_files_found(self):
-        msg = r'\/no_exist.txt\" matched 0 file\(s\)'
+        msg = r'\/no_exist.txt\" expanded to empty'
         with self.assertRaisesRegexp(IOError, msg):
             iio.expand_filespecs([os.path.join(self.tmpdir, 'no_exist.txt')])
 
@@ -91,9 +91,8 @@ class TestExpandFilespecs(tests.IrisTest):
                  os.path.join(self.tmpdir, '*')])
         expected = textwrap.dedent("""
             One or more of the files specified did not exist:
-                - "{0}/does_not_exist.txt" matched 0 file(s)
+                * "{0}/does_not_exist.txt" expanded to empty
                 - "{0}/*" matched 2 file(s)
-                   - {0}/a.foo, {0}/b.txt
             """).strip().format(self.tmpdir)
 
         self.assertStringEqual(str(err.exception), expected)

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -80,7 +80,7 @@ class TestExpandFilespecs(tests.IrisTest):
         self.assertEqual(result, expected[::-1])
 
     def test_no_files_found(self):
-        msg = r'\/no_exist.txt\" expanded to empty'
+        msg = r'\/no_exist.txt\" didn\'t match any files'
         with self.assertRaisesRegexp(IOError, msg):
             iio.expand_filespecs([os.path.join(self.tmpdir, 'no_exist.txt')])
 
@@ -91,7 +91,7 @@ class TestExpandFilespecs(tests.IrisTest):
                  os.path.join(self.tmpdir, '*')])
         expected = textwrap.dedent("""
             One or more of the files specified did not exist:
-                * "{0}/does_not_exist.txt" expanded to empty
+                * "{0}/does_not_exist.txt" didn\'t match any files
                 - "{0}/*" matched 2 file(s)
             """).strip().format(self.tmpdir)
 


### PR DESCRIPTION
See #2032.

I liked @pelson's suggestion of a tick and a cross at the start of each line, but comments on [this stackoverflow question](https://stackoverflow.com/questions/16676101) suggest doing this is terminal dependent (I couldn't get the suggestions to work under my ipython anyway).  So I went for a more basic - or * bullet point difference.