### PR TITLE
Reverse 2878

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -65,15 +65,6 @@ def _limited_shape(shape):
     return tuple(shape)
 
 
-def _getall(a):
-    res = a[()]
-    if isinstance(res, ma.core.MaskedConstant):
-        res = ma.masked_array(res.data, mask=res.mask)
-    return res
-
-_getall_delayed = dask.delayed(_getall)
-
-
 def as_lazy_data(data, chunks=None, asarray=False):
     """
     Convert the input array `data` to a dask array.
@@ -104,15 +95,10 @@ def as_lazy_data(data, chunks=None, asarray=False):
         # but reduce it if larger than a default maximum size.
         chunks = _limited_shape(data.shape)
 
+    if isinstance(data, ma.core.MaskedConstant):
+        data = ma.masked_array(data.data, mask=data.mask)
     if not is_lazy_data(data):
-        if data.shape == ():
-            # Workaround for https://github.com/dask/dask/issues/2823. Make
-            # sure scalar dask arrays return numpy objects.
-            dtype = data.dtype
-            data = _getall_delayed(data)
-            data = da.from_delayed(data, (), dtype)
-        else:
-            data = da.from_array(data, chunks=chunks, asarray=asarray)
+        data = da.from_array(data, chunks=chunks, asarray=asarray)
     return data
 
 

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -124,7 +124,10 @@ def as_concrete_data(data):
         # In some cases dask may return a scalar numpy.int/numpy.float object
         # rather than a numpy.ndarray object.
         # Recorded in https://github.com/dask/dask/issues/2111.
+        dtype = data.dtype
         data = np.asanyarray(data.compute())
+        if isinstance(data, ma.core.MaskedConstant):
+            data = ma.masked_array(data.data, dtype=dtype, mask=data.mask)
 
     return data
 

--- a/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
@@ -23,9 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import unittest
-
-import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
@@ -92,17 +89,6 @@ class Test_as_concrete_data(tests.IrisTest):
         result = as_concrete_data(lazy_array)
         self.assertFalse(is_lazy_data(result))
         self.assertMaskedArrayEqual(result, a)
-
-    def test_dask_scalar_proxy_pass_through(self):
-        # This test will fail when using a version of Dask with
-        # https://github.com/dask/dask/issues/2823 fixed. At that point the
-        # changes introduced in https://github.com/SciTools/iris/pull/2878 can
-        # be reversed.
-        a = np.array(5)
-        proxy = MyProxy(a)
-        d = da.from_array(proxy, 1, asarray=False)
-        result = d.compute()
-        self.assertEqual(proxy, result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A workaround for https://github.com/dask/dask/issues/2823 was added in https://github.com/SciTools/iris/pull/2878. The dask issue is fixed in the latest release, so this PR reverts the changes.

N.B. There is a test which will fail on master now that the Dask issue is fixed, so this needs resolving ASAP.