### PR TITLE
Planning to cut 2.0.0rc1 today.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Iris
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.51860.svg)](https://dx.doi.org/10.5281/zenodo.51860)
 [![Documentation for master branch ](https://img.shields.io/badge/docs-master-blue.svg)](https://scitools-docs.github.io/iris/master/index.html)
 
-(C) British Crown Copyright 2010 - 2017, Met Office
+(C) British Crown Copyright 2010 - 2018, Met Office
 
 Iris is a powerful, easy to use, community-driven Python library for
 analysing and visualising meteorological and oceanographic data sets.
@@ -53,7 +53,7 @@ There is also a documentation build for the latest code in the main GitHub repos
 Copyright and licence
 ---------------------
 
-(C) British Crown Copyright 2010 - 2017, Met Office
+(C) British Crown Copyright 2010 - 2018, Met Office
 
 This file is part of Iris.
 

--- a/docs/iris/src/whatsnew/2.0.rst
+++ b/docs/iris/src/whatsnew/2.0.rst
@@ -2,7 +2,7 @@ What's New in Iris 2.0.0
 ************************
 
 :Release: 2.0.0rc1
-:Date: 2017-10-30
+:Date: 2018-01-11
 
 
 This document explains the new/changed features of Iris in version 2.0.0

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -121,7 +121,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '2.1.0.dev0'
+__version__ = '2.0.0rc1'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',


### PR DESCRIPTION
Heads-up: It is time to cut the release candidate (OK - I accept. It is *past* time 😉 )

There have been 1 or 2 tweaks that have gone into master that there is no reason not to bring into 2.0, so I'm planning to update the upstream/v2.0.x to point to master once this is merged. I will then simply tag (on github) the release candidate, and ensure the documentation is available on the scitools page.

My own todo list:
- [ ] merge this PR
- [ ] push master to v2.0.x
- [ ] tag v2.0.0rc1
- [ ] push the v2.0.0rc1 docs to scitools.org.uk under http://scitools.org.uk/iris/docs/v2.0 (do not update latest just yet)
- [ ] announce the release candidate on the mailing list
- [ ] have a beer for finally tagging a release
- [ ] document all of the things that were needed for the release
- [ ] upload it to pypi
- [ ] close all the milestone stuff
- [ ] make sure @bjlittle can help me get the rc tested with our MO userbase
- [ ] update master version number to 2.1.0.dev0 (or put up a PR for versioneer)
- [ ] update upstream/v2.0.x to 2.0.1.dev0

