### PR TITLE
CML changes for cf_units v1.2.0

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2018-Jan-11_short-unit-strings.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2018-Jan-11_short-unit-strings.txt
@@ -1,0 +1,2 @@
+* The cf_units dependency version has been updated to v1.2.0, which prints shorter unit strings.
+  For example, the unit ``meter-second^-1`` is now printed as ``m.s-1``.

--- a/lib/iris/tests/results/analysis/apply_ifunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="squared temperature" units="kelvin^2">
+  <cube dtype="float32" long_name="squared temperature" units="K2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ifunc_frompyfunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="object" units="kelvin^2">
+  <cube dtype="object" units="K2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/apply_ufunc.cml
+++ b/lib/iris/tests/results/analysis/apply_ufunc.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="squared temperature" units="kelvin^2">
+  <cube dtype="float32" long_name="squared temperature" units="K2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/calculus/curl_contrived_cartesian2.cml
+++ b/lib/iris/tests/results/analysis/calculus/curl_contrived_cartesian2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" long_name="u curl of wind" units="0.277777777777778 hertz">
+  <cube dtype="float64" long_name="u curl of wind" units="0.277777777777778 Hz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,
@@ -31,7 +31,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(10, 25, 49)" state="loaded"/>
   </cube>
-  <cube dtype="float64" long_name="v curl of wind" units="0.277777777777778 hertz">
+  <cube dtype="float64" long_name="v curl of wind" units="0.277777777777778 Hz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,
@@ -62,7 +62,7 @@
     <cellMethods/>
     <data dtype="float64" shape="(10, 25, 49)" state="loaded"/>
   </cube>
-  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 hertz">
+  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 Hz">
     <coords>
       <coord datadims="[2]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived1.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
+  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 s-1.rad-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="620d7656" points="[-87.0, -81.0, -75.0, -69.0, -63.0, -57.0, -51.0,

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived2.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 second^-1-radian^-1">
+  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 s-1.rad-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="620d7656" points="[-88.7143, -86.1429, -83.5714, -81.0, -78.4286,

--- a/lib/iris/tests/results/analysis/calculus/grad_contrived_non_spherical1.cml
+++ b/lib/iris/tests/results/analysis/calculus/grad_contrived_non_spherical1.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 hertz">
+  <cube dtype="float64" long_name="w curl of wind" units="0.277777777777778 Hz">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="a2e1fbc2" points="[3.105, 5.315, 7.525, 9.735, 11.945, 14.155,

--- a/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 m.s-1.rad-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-87.75, -83.25, -78.75, -74.25, -69.75, -65.25,

--- a/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade2_wrt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 m.s-1.rad-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -85.5, -81.0, -76.5, -72.0, -67.5, -63.0,

--- a/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_simple_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 m.s-1">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="61a1c174" long_name="x" points="[0.5, 1.5, 2.5, 3.5]" shape="(4,)" units="Unit('count')" value_type="float32"/>

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lat.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_latitude" units="15.9154943091895 m.s-1.rad-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_lon.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 meter-second^-1-radian^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_longitude" units="15.9154943091895 m.s-1.rad-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_x.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 meter-second^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_x" units="0.277777777777778 m.s-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-90.0, -45.0, 0.0, 45.0, 90.0]" shape="(5,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
+++ b/lib/iris/tests/results/analysis/calculus/handmade_wrt_y.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_y" units="0.277777777777778 meter-second^-1">
+  <cube dtype="float32" long_name="derivative_of_x_wind_wrt_y" units="0.277777777777778 m.s-1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="77a50eb5" points="[-67.5, -22.5, 22.5, 67.5]" shape="(4,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">

--- a/lib/iris/tests/results/analysis/division_by_array.cml
+++ b/lib/iris/tests/results/analysis/division_by_array.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin">
+  <cube dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_latitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="57.2957795130823 kelvin-radian^-1">
+  <cube dtype="float32" units="57.2957795130823 K.rad-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_longitude.cml
+++ b/lib/iris/tests/results/analysis/division_by_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="57.2957795130823 kelvin-radian^-1">
+  <cube dtype="float32" units="57.2957795130823 K.rad-1">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_by_singular_coord.cml
+++ b/lib/iris/tests/results/analysis/division_by_singular_coord.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" units="kelvin">
+  <cube dtype="float64" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/division_scalar.cml
+++ b/lib/iris/tests/results/analysis/division_scalar.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin">
+  <cube dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/exponentiate.cml
+++ b/lib/iris/tests/results/analysis/exponentiate.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" units="kelvin^4">
+  <cube dtype="float64" units="K4">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log.cml
+++ b/lib/iris/tests/results/analysis/log.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="ln(re 1 kelvin)">
+  <cube dtype="float32" units="ln(re 1 K)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log10.cml
+++ b/lib/iris/tests/results/analysis/log10.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="lg(re 1 kelvin)">
+  <cube dtype="float32" units="lg(re 1 K)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/log2.cml
+++ b/lib/iris/tests/results/analysis/log2.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="lb(re 1 kelvin)">
+  <cube dtype="float32" units="lb(re 1 K)">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/multiply.cml
+++ b/lib/iris/tests/results/analysis/multiply.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/multiply_different_std_name.cml
+++ b/lib/iris/tests/results/analysis/multiply_different_std_name.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/sqrt.cml
+++ b/lib/iris/tests/results/analysis/sqrt.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin">
+  <cube dtype="float32" units="K">
     <coords>
       <coord>
         <dimCoord bounds="[[-28083.0, 6477.0]]" id="1d45e087" points="[6477]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>

--- a/lib/iris/tests/results/analysis/variance_latitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="m-2.kg2.s-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-4-kilogram^4-second^-8">
+  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="m-4.kg4.s-8">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
+++ b/lib/iris/tests/results/analysis/variance_latitude_longitude_1call.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="meter^-2-kilogram^2-second^-4">
+  <cube dtype="float64" standard_name="air_pressure_at_sea_level" units="m-2.kg2.s-4">
     <attributes>
       <attribute name="STASH" value="m01s16i222"/>
       <attribute name="source" value="Data from Met Office Unified Model"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_all_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_all_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_last_dims.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_last_dims.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_middle_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_middle_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_zeroth_dim.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/collapse_zeroth_dim.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/slice.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/slice.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>

--- a/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/transposed.cml
+++ b/lib/iris/tests/results/unit/analysis/maths/multiply/TestBroadcasting/transposed.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="kelvin^2">
+  <cube dtype="float32" units="K2">
     <coords>
       <coord>
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>


### PR DESCRIPTION
The recent v1.2.0 release of `cf_units` has altered how `cf_units` prints unit strings. This has caused a number of CML test failures in Iris, which are addressed here.

Fixes #2935. 