### PR TITLE
Bumps the version for 2.1dev + v2.0x what's new tweaks

### DIFF
--- a/docs/iris/src/whatsnew/2.0.rst
+++ b/docs/iris/src/whatsnew/2.0.rst
@@ -192,6 +192,18 @@ Incompatible Changes
 * If the `packing` argument to `iris.save` is a dictionary, an error is raised
   if it contains any keys other than 'dtype', 'scale_factor' and 'add_offset'.
 
+* The deprecated :mod:`iris.fileformats.grib` was removed. All Iris GRIB
+  functionality is now delivered through :mod:`iris-grib`.
+
+* In Iris v1 it was possible to configure Iris to log at import time through
+  :attr:`iris.config.LOGGING`. This capability has been removed in iris v2.
+
+* When coordinates have no well defined plot axis, iris.plot and iris.quickplot
+  routines now use the order of the cube's dimensions to determine the
+  coordinates to plot as the x and y axis of a plot. 
+
+* The cf_units dependency version has been updated to v1.2.0, which prints shorter
+  unit strings.
 
 
 Deprecation removals

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-27_grib_removed.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-27_grib_removed.txt
@@ -1,1 +1,0 @@
-* The deprecated :mod:`iris.fileformats.grib` was removed. All Iris GRIB functionality is now delivered through :mod:`iris-grib`.

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-27_logging_removed.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-27_logging_removed.txt
@@ -1,1 +1,0 @@
-* In Iris v1 it was possible to configure Iris to log at import time through :attr:`iris.config.LOGGING`. This capability has been removed in iris v2.

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-30_axis_order_plotting.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2017-Oct-30_axis_order_plotting.txt
@@ -1,1 +1,0 @@
-* When coordinates have no well defined plot axis, iris.plot and iris.quickplot routines now use the order of the cube's dimensions to determine the coordinates to plot as the x and y axis of a plot. 

--- a/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2018-Jan-11_short-unit-strings.txt
+++ b/docs/iris/src/whatsnew/contributions_2.0/incompatiblechange_2018-Jan-11_short-unit-strings.txt
@@ -1,2 +1,0 @@
-* The cf_units dependency version has been updated to v1.2.0, which prints shorter unit strings.
-  For example, the unit ``meter-second^-1`` is now printed as ``m.s-1``.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -121,7 +121,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '2.1.0dev1'
+__version__ = '2.1.0dev0'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -121,7 +121,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '2.0.0rc1'
+__version__ = '2.1.0dev1'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',


### PR DESCRIPTION
Here are the doc changes I made directly to the v2.0.x branch. If we want to change them in any way, we would need a PR to the upstream/v2.0.x branch (happy to do that, or the reviewer can do it directly).
