### PR TITLE
Define default channels in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ install:
     echo 'Configure conda and create an environment';
     conda config --set always_yes yes --set changeps1 no;
     conda config --set show_channel_urls True;
-    conda config --add default_channels conda-forge;
     conda config --add default_channels anaconda;
+    conda config --add default_channels conda-forge;
     conda update --quiet conda;
     ENV_NAME='test-environment';
     conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION pip;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     echo 'Configure conda and create an environment';
     conda config --set always_yes yes --set changeps1 no;
     conda config --set show_channel_urls True;
-    conda config --add channels conda-forge;
+    conda config --add default_channels conda-forge;
     conda update --quiet conda;
     ENV_NAME='test-environment';
     conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION pip;

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
     conda config --set always_yes yes --set changeps1 no;
     conda config --set show_channel_urls True;
     conda config --add default_channels conda-forge;
+    conda config --add default_channels anaconda;
     conda update --quiet conda;
     ENV_NAME='test-environment';
     conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION pip;


### PR DESCRIPTION
💥 DON'T MERGE ME! 💥 

Currently the [Iris py3k tests are failing](https://travis-ci.org/SciTools/iris/jobs/330392249#L962). This may be due to a few dependencies (notably [boost](https://travis-ci.org/SciTools/iris/jobs/330392249#L628)) suddenly being pulled from `defaults` rather than `conda-forge`. 

This PR experiments with setting `default_channels` to `conda-forge` rather than adding `conda-forge` as a channel to try and prevent the conda env on Travis from being able to install from `defaults` at all. Let's see... ⏳ 