### PR TITLE
Stop testing with gdal.

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -3,7 +3,7 @@
 
 # esmpy regridding not available through pip.
 #conda: esmpy>=7.0  (only python=2)
-gdal
+#gdal : under review -- not tested at present
 mo_pack
 nc_time_axis
 pandas

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -6,3 +6,4 @@
 # first.
 
 iris_grib;python_version<"3"  #conda:
+gdal


### PR DESCRIPTION
Should be at least a temporary fix for the current test problems on master.
I moved it from the "all" to the "extensions" dependency-group (latter not used by Travis).

For the future, I would really like to **kick gdal out of our requirements altogether**...

It is ***only*** used by `iris.experimental.raster.export_geotiff`.
We have managed without in the internal SSS environments for some time,
if you "import iris.experimental.raster" in these, it simply fails.

Gdal seems to be a very large package of which we're only using a tiny part.
The dependencies [on conda-forge](https://github.com/conda-forge/libgdal-feedstock/blob/master/recipe/meta.yaml) are an immensely complicated + over-constrained lot.
No wonder it has caused trouble 
For instance, the latest problem is due to the move from 2.2.3_1 to 2.2.3_3 (that is, different build versions of libgdal 2.2.3) : We were ok with the build-1 version, but it has been removed from the channel.