### PR TITLE
Remove FutureWarning from use of np.issubdtype(obj, np.str)

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -1159,7 +1159,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             raise ValueError('Cannot partially collapse a coordinate (%s).'
                              % self.name())
 
-        if np.issubdtype(self.dtype, np.str):
+        if np.issubdtype(self.dtype, np.str_):
             # Collapse the coordinate by serializing the points and
             # bounds as strings.
             def serialize(x):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3556,7 +3556,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             new_bounds = iris.util.rolling_window(coord_.points, window)
 
-            if np.issubdtype(new_bounds.dtype, np.str):
+            if np.issubdtype(new_bounds.dtype, np.str_):
                 # Handle case where the AuxCoord contains string. The points
                 # are the serialized form of the points contributing to each
                 # window and the bounds are the first and last points in the

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1412,7 +1412,7 @@ fc_extras
             attributes['invalid_units'] = attr_units
             attr_units = cf_units._UNKNOWN_UNIT_STRING
 
-        if np.issubdtype(cf_var.dtype, np.str):
+        if np.issubdtype(cf_var.dtype, np.str_):
             attr_units = cf_units._NO_UNIT_STRING
 
         # Get any assoicated calendar for a time reference coordinate.

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -73,7 +73,7 @@ reference_terms = dict(atmosphere_sigma_coordinate=['ps'],
 
 # NetCDF returns a different type for strings depending on Python version.
 def _is_str_dtype(var):
-    return ((six.PY2 and np.issubdtype(var.dtype, np.str)) or
+    return ((six.PY2 and np.issubdtype(var.dtype, np.str_)) or
             (six.PY3 and np.issubdtype(var.dtype, np.bytes_)))
 
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1570,7 +1570,7 @@ class Saver(object):
         cf_dimensions = [dimension_names[dim] for dim in
                          cube.coord_dims(coord)]
 
-        if np.issubdtype(coord.points.dtype, np.str):
+        if np.issubdtype(coord.points.dtype, np.str_):
             string_dimension_depth = coord.points.dtype.itemsize
             if coord.points.dtype.kind == 'U':
                 string_dimension_depth //= 4


### PR DESCRIPTION
As of np >= 1.14 ```np.issubdtype(np.str, np.str)``` raises a warning:

```
FutureWarning: Conversion of the second argument of issubdtype from `str` to `str` is deprecated. In future, it will be treated as `np.str_ == np.dtype(str).type`.
```

Instead, we should be doing ```np.issubdtype(np.str, np.str_)```.

This is backwards compatible and works on python 2 & 3:

```
(iris-dev-py3) pelson@~/dev/scitools/iris> python -c "import numpy as np; print(np.__version__); np.issubdtype(np.str, np.str)"
1.14.0
-c:1: FutureWarning: Conversion of the second argument of issubdtype from `str` to `str` is deprecated. In future, it will be treated as `np.str_ == np.dtype(str).type`.
(iris-dev-py3) pelson@~/dev/scitools/iris> python -c "import numpy as np; print(np.__version__); np.issubdtype(np.str, np.str_)"
1.14.0
```

```
(iris-dev-py3) pelson@~/dev/scitools/iris> source deactivate
pelson@~/dev/scitools/iris> python -c "import numpy as np; print(np.__version__); np.issubdtype(np.str, np.str_)"
1.11.3
pelson@~/dev/scitools/iris> python -c "import numpy as np; print(np.__version__); np.issubdtype(np.str, np.str)"
1.11.3
```