### PR TITLE
test_pearsonr: use compatible cubes for testing compatible cubes

### DIFF
--- a/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
+++ b/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
@@ -61,7 +61,7 @@ class Test(tests.IrisTest):
 
     def test_compatible_cubes(self):
         r = stats.pearsonr(self.cube_a, self.cube_b,
-                            ['latitude', 'longitude'])
+                           ['latitude', 'longitude'])
         self.assertArrayAlmostEqual(r.data, [0.81114936,
                                              0.81690538,
                                              0.79833135,
@@ -83,8 +83,8 @@ class Test(tests.IrisTest):
 
     def test_compatible_cubes_weighted(self):
         r = stats.pearsonr(self.cube_a, self.cube_b,
-                            ['latitude', 'longitude'],
-                            self.weights)
+                           ['latitude', 'longitude'],
+                           self.weights)
         self.assertArrayAlmostEqual(r.data, [0.79106045,
                                              0.79989169,
                                              0.78826918,

--- a/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
+++ b/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -39,6 +39,7 @@ class Test(tests.IrisTest):
             ('NetCDF', 'global', 'xyt', 'SMALL_total_column_co2.nc')))
         self.cube_a = cube_temp[0:6]
         self.cube_b = cube_temp[20:26]
+        self.cube_b.replace_coord(self.cube_a.coord('time').copy())
         cube_temp = self.cube_a.copy()
         cube_temp.coord('latitude').guess_bounds()
         cube_temp.coord('longitude').guess_bounds()
@@ -59,15 +60,14 @@ class Test(tests.IrisTest):
                            'longitude')
 
     def test_compatible_cubes(self):
-        with self.assertRaises(ValueError):
-            r = stats.pearsonr(self.cube_a, self.cube_b,
-                               ['latitude', 'longitude'])
-            self.assertArrayAlmostEqual(r.data, [0.81114936,
-                                                 0.81690538,
-                                                 0.79833135,
-                                                 0.81118674,
-                                                 0.79745386,
-                                                 0.81278484])
+        r = stats.pearsonr(self.cube_a, self.cube_b,
+                            ['latitude', 'longitude'])
+        self.assertArrayAlmostEqual(r.data, [0.81114936,
+                                             0.81690538,
+                                             0.79833135,
+                                             0.81118674,
+                                             0.79745386,
+                                             0.81278484])
 
     def test_broadcast_cubes(self):
         r1 = stats.pearsonr(self.cube_a, self.cube_b[0, :, :],
@@ -82,16 +82,15 @@ class Test(tests.IrisTest):
         self.assertArrayEqual(r2.data, np.array(r_by_slice))
 
     def test_compatible_cubes_weighted(self):
-        with self.assertRaises(ValueError):
-            r = stats.pearsonr(self.cube_a, self.cube_b,
-                               ['latitude', 'longitude'],
-                               self.weights)
-            self.assertArrayAlmostEqual(r.data, [0.79106045,
-                                                 0.79989169,
-                                                 0.78826918,
-                                                 0.79925855,
-                                                 0.79011544,
-                                                 0.80115837])
+        r = stats.pearsonr(self.cube_a, self.cube_b,
+                            ['latitude', 'longitude'],
+                            self.weights)
+        self.assertArrayAlmostEqual(r.data, [0.79106045,
+                                             0.79989169,
+                                             0.78826918,
+                                             0.79925855,
+                                             0.79011544,
+                                             0.80115837])
 
     def test_broadcast_cubes_weighted(self):
         r = stats.pearsonr(self.cube_a, self.cube_b[0, :, :],


### PR DESCRIPTION
The setup for `test_pearsonr` creates two cubes by taking different slices out of a larger cube, and therefore have different time coordinates.  This means that, since #2498, the cubes cannot be multiplied together and therefore cannot be correlated.  This was reflected in changes to two of the tests at #2498, where they were changed to expect a `ValueError`.

Since the original intention of these tests was to check the correct numbers come out of the calculation, I have modified the setup so that the time coordinates match, and reverted the above mentioned changes to the two "compatible cubes" tests.