### PR TITLE
Pin Dask to >=0.17.1

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -10,4 +10,4 @@ numpy
 scipy
 # pyke (not pip installable)  #conda: pyke
 cf_units
-dask>=0.15.0
+dask>=0.17.1


### PR DESCRIPTION
Until Dask 0.17.1 there was a bug where computing scalar arrays could result in errors (dask/dask#2823). We had a workaround (https://github.com/SciTools/iris/pull/2878) which we took out after a fixed version of Dask was released. We should have also updated the minimum version of Dask at that point.