### PR TITLE
Add cube co-realisation.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-08_co_realise_cubes.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-08_co_realise_cubes.txt
@@ -1,0 +1,3 @@
+* Added new function :func:`iris.co_realise_cubes` to compute multiple lazy
+  values in a single operation, avoiding repeated re-loading of data or
+  re-calculation of expressions.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -112,6 +112,7 @@ import iris._constraints
 from iris._deprecation import IrisDeprecation, warn_deprecated
 import iris.fileformats
 import iris.io
+from iris._lazy_data import co_realise_cubes
 
 
 try:
@@ -127,7 +128,7 @@ __version__ = '2.1.0dev0'
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',
            'save', 'Constraint', 'AttributeConstraint', 'sample_data_path',
            'site_configuration', 'Future', 'FUTURE',
-           'IrisDeprecation']
+           'IrisDeprecation', 'co_realise_cubes']
 
 
 Constraint = iris._constraints.Constraint

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -196,7 +196,7 @@ def co_realise_cubes(*cubes):
 
     Args:
 
-    * cubes : (list of `~iris.cube.Cube`)
+    * cubes (list of :class:`~iris.cube.Cube`):
         Arguments, each of which is a cube to be realised.
 
     For example::

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -158,3 +158,18 @@ def multidim_lazy_stack(stack):
         result = da.stack([multidim_lazy_stack(subarray)
                            for subarray in stack])
     return result
+
+
+def co_realise_cubes(cubes):
+    """
+    Fetch real data for multiple cubes at one time.
+
+    This fetches lazy content, equivalent to accessing each cube.data.
+    However, lazy calculations and data fetches can be shared between the
+    calculations, improving performance.
+
+    """
+    results = da.compute(list(cube.core_data() for cube in cubes))
+    for cube, result in zip(cubes, results):
+        cube.data = result
+    return cubes

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -1,0 +1,87 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Test function :func:`iris._lazy data.co_realise_cubes`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from mock import MagicMock
+import numpy as np
+
+from iris.cube import Cube
+from iris._lazy_data import as_lazy_data
+
+from iris._lazy_data import co_realise_cubes
+
+
+class ArrayAccessCounter(object):
+    def __init__(self, array):
+        self.dtype = array.dtype
+        self.shape = array.shape
+        self._array = array
+        self.access_count = 0
+
+    def __getitem__(self, keys):
+        self.access_count += 1
+        return self._array[keys]
+
+
+class Test_co_realise_cubes(tests.IrisTest):
+    def test_empty(self):
+        self.assertEqual(co_realise_cubes([]), [])
+
+    def test_basic(self):
+        real_data = np.arange(3.)
+        cube = Cube(as_lazy_data(real_data))
+        self.assertTrue(cube.has_lazy_data())
+        result, = co_realise_cubes([cube])
+        self.assertEqual(result, cube)
+        self.assertFalse(cube.has_lazy_data())
+        self.assertArrayAllClose(cube.core_data(), real_data)
+
+    def test_multi(self):
+        real_data = np.arange(3.)
+        cube = Cube(as_lazy_data(real_data))
+        self.assertTrue(cube.has_lazy_data())
+        cube_2 = cube + 1
+        cube_3 = cube + 2
+        cubes = [cube, cube_2, cube_3]
+        for cube in cubes:
+            self.assertTrue(cube.has_lazy_data())
+        results = co_realise_cubes(cubes)
+        self.assertEqual(results, cubes)
+        for cube in cubes:
+            self.assertFalse(cube.has_lazy_data())
+
+    def test_combined_access(self):
+        wrapped_array = ArrayAccessCounter(np.arange(3.))
+        lazy_array = as_lazy_data(wrapped_array)
+        derived_a = lazy_array + 1
+        derived_b = lazy_array + 2
+        cube_a = Cube(derived_a)
+        cube_b = Cube(derived_b)
+        co_realise_cubes([cube_a, cube_b])
+        # Though used twice, the source data should only get fetched once.
+        self.assertEqual(wrapped_array.access_count, 1)
+
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
User code often forms multiple stats, where data may be very large.
= several small, lazy, calculated results derived from same large, lazy data 
Calculation scans the data, each time you realise one.
This can + should be done in parallel with `da.compute(*dask_stats_arrays)`.
You then need to assign those results back into Iris `cube.data` elements.

I can't find a neat Python idiom for this, so we can provide a simple utility routine.

Note: I'm proposing to put this in package `iris` itself, as I don't rate the alternatives :
  * `iris._lazy_data` is private
  * `iris.utils`, on inspection, I think is for "handy things you might just have written yourself"
     *whereas* : this code uses knowledge of internals.
