### PR TITLE
nearest_neighbour_index bugfixes

### DIFF
--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -42,14 +42,16 @@ class Test_nearest_neighbour_index__ascending(tests.IrisTest):
         self.coord = DimCoord(points, circular=False,
                               units='degrees')
 
-    def _test_nearest_neighbour_index(self, target, bounds=None,
+    def _test_nearest_neighbour_index(self, target, bounds=None, ext_pnts=None,
                                       circular=False):
         _bounds = [[-20, 10], [10, 100], [100, 260], [260, 340]]
-        ext_pnts = [-70, -10, 110, 275, 370]
+        _ext_pnts = [-70, -10, 110, 275, 370]
         if bounds is True:
             self.coord.bounds = _bounds
         else:
             self.coord.bounds = bounds
+        if ext_pnts is None:
+            ext_pnts = _ext_pnts
         self.coord.circular = circular
         results = [self.coord.nearest_neighbour_index(ind) for ind in ext_pnts]
         self.assertEqual(results, target)
@@ -79,6 +81,23 @@ class Test_nearest_neighbour_index__ascending(tests.IrisTest):
         _bounds = [[-20, 10], [80, 170], [180, 190], [240, 340]]
         target = [0, 0, 1, 3, 3]
         self._test_nearest_neighbour_index(target, bounds=_bounds)
+
+    def test_bounded_disjointed_float_points(self):
+        _bounds = [[-20, 15], [20, 100], [100, 260], [260, 340]]
+        _ext_pnts = [17., 17.2, 17.8, 18.2]
+        target = [0, 0, 1, 1]
+        self._test_nearest_neighbour_index(target, bounds=_bounds,
+                                           ext_pnts=_ext_pnts)
+
+    def test_bounded_outside_float_points(self):
+        _bounds = [[-10, 45], [45, 135], [135, 225], [225, 280]]
+        _ext_pnts = [-11.7, 281.7]
+        target = [0, 3]
+        self._test_nearest_neighbour_index(target, bounds=_bounds,
+                                           ext_pnts=_ext_pnts)
+
+    def test_bounded_disjointed(self):
+        _bounds = [[-20, 10], [80, 170], [180, 190], [240, 340]]
 
     def test_scalar(self):
         self.coord = DimCoord([0], circular=False, units='degrees')

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -135,7 +135,7 @@ class Test_nearest_neighbour_index__descending(tests.IrisTest):
         self._test_nearest_neighbour_index(target, bounds=True)
 
     def test_bounded_circular(self):
-        target = [0, 3, 1, 0, 3]
+        target = [0, 3, 1, 0, 2]
         self._test_nearest_neighbour_index(target, bounds=True, circular=True)
 
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -77,19 +77,20 @@ class Test_nearest_neighbour_index__ascending(tests.IrisTest):
         target = [0, 0, 1, 2, 3]
         self._test_nearest_neighbour_index(target, bounds=_bounds)
 
-    def test_bounded_disjointed(self):
-        _bounds = [[-20, 10], [80, 170], [180, 190], [240, 340]]
-        target = [0, 0, 1, 3, 3]
-        self._test_nearest_neighbour_index(target, bounds=_bounds)
+    def test_bounded_disjointed_circular(self):
+        _bounds = [[-5, 10], [80, 170], [180, 190], [240, 340]]
+        target = [3, 0, 1, 3, 0]
+        self._test_nearest_neighbour_index(target, bounds=_bounds,
+                                           circular=True)
 
-    def test_bounded_disjointed_float_points(self):
+    def test_bounded_disjointed_float_point(self):
         _bounds = [[-20, 15], [20, 100], [100, 260], [260, 340]]
         _ext_pnts = [17., 17.2, 17.8, 18.2]
         target = [0, 0, 1, 1]
         self._test_nearest_neighbour_index(target, bounds=_bounds,
                                            ext_pnts=_ext_pnts)
 
-    def test_bounded_outside_float_points(self):
+    def test_bounded_outside_float_point(self):
         _bounds = [[-10, 45], [45, 135], [135, 225], [225, 280]]
         _ext_pnts = [-11.7, 281.7]
         target = [0, 3]


### PR DESCRIPTION
Closes https://github.com/SciTools/iris/issues/2969

There are a couple of bugs in `Coord.nearest_neighbour_index()`, demonstrated by the tests in the first two commits.

1) If the bounds of the coordinate have an integer dtype and the point argument is a float, the wrong index can be returned due to casting a float to an int.
2) Wrapping is not handled if the coordinate is circular and has bounds.

To be honest, I think wrapping should really be taken into account whether or not the coordinate is circular, as long as the unit has a modulus, but I haven't made that change here.