### PR TITLE
Fix for changed API of cartopy.crs.Stereographic

### DIFF
--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -719,7 +719,7 @@ class Stereographic(CoordSystem):
         return ccrs.Stereographic(
             self.central_lat, self.central_lon,
             self.false_easting, self.false_northing,
-            self.true_scale_lat, globe)
+            self.true_scale_lat, globe=globe)
 
     def as_cartopy_projection(self):
         return self.as_cartopy_crs()


### PR DESCRIPTION
Fixes currently broken tests in `iris.tests.test_co……ordsystem` :
  * Test_Stereographic_as_cartopy_crs.test_as_cartopy_crs
  * Test_Stereographic_as_cartopy_projection.test_as_cartopy_projection

Cartopy 0.16 has a breaking change to the API in terms of argument ordering.
( They added a new `scale_factor` arg in front of the last `globe` arg instead of after it )
Passing `globe` as a kwarg fixes it.
