### PR TITLE
Fix iris-test-data skips in Travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ install:
   - export OVERRIDE_TEST_DATA_REPOSITORY=$(pwd)/iris-test-data/test_data
 
 # show config in action
-  - python -c "import iris.config; print iris.config.TEST_DATA_DIR"
+  - python -c "import iris.config; print(iris.config.TEST_DATA_DIR)"
 
   # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
 # i.e. There should be no DownloadWarning reports in the log.
   - python -c 'import cartopy; cartopy.io.shapereader.natural_earth()'
 
-# iris test data
+# download iris test data
   - >
     if [[ "$TEST_MINIMAL" != true ]]; then
       wget --quiet -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip;
@@ -97,16 +97,15 @@ install:
       mv "iris-test-data-${IRIS_TEST_DATA_SUFFIX}" iris-test-data;
     fi
 
-# set config paths
-  - >
-    SITE_CFG=lib/iris/etc/site.cfg;
-    echo "[Resources]" > $SITE_CFG;
-    echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> $SITE_CFG;
-    echo "doc_dir = $(pwd)/docs/iris" >> $SITE_CFG;
-    echo "[System]" >> $SITE_CFG;
-    echo "udunits2_path = $PREFIX/lib/libudunits2.so" >> $SITE_CFG;
+# install iris itself
 
   - python setup.py --quiet install
+
+# set test data path
+  - export OVERRIDE_TEST_DATA_REPOSITORY=$(pwd)/iris-test-data/test_data
+
+# show config in action
+  - python -c "import iris.config; print iris.config.TEST_DATA_DIR"
 
   # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.


### PR DESCRIPTION
It turns out that all tests using iris-test-data have been skipping for a while
 -- as in all the visible log messages "SKIP: Tests(s) require external data."
 -- e.g. : https://travis-ci.org/SciTools/iris/jobs/341527576#L3747

This is in fact since https://github.com/SciTools/iris/commit/8a327b4f0faf4d150b72508262eaa6b5a31690f8, 

However, I'm bafflled as to why 
  * it seem not to be the Iris code changes at that point
  * it isn't the newer version of setuptools

The existing code in `.travis.yml` seems definitely wrong, because it creates `site.cfg` in the local directory, which is not the iris installation.
I'm currently at a loss to explain how `iris.config` previously managed to find the test data ??

**Anyway,**
~proposed here is to put the 'site.cfg' into the installation, which should fix it.~
Make test data available via `OVERRIDE_TEST_DATA_REPOSITORY` environment variable. 

**NOTE:**
This won't fix all the existing test failures,  due to the failure of `iris.tests.check_graphic`.
In fact, there will be a whole lot more of them ...