### PR TITLE
Test imagehash 'old_hex_to_hash' function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ install:
   - export OVERRIDE_TEST_DATA_REPOSITORY=$(pwd)/iris-test-data/test_data
 
 # show config in action
-  - python -c "import iris.config; print iris.config.TEST_DATA_DIR"
+  - python -c "import iris.config; print(iris.config.TEST_DATA_DIR)"
 
   # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
 # i.e. There should be no DownloadWarning reports in the log.
   - python -c 'import cartopy; cartopy.io.shapereader.natural_earth()'
 
-# iris test data
+# download iris test data
   - >
     if [[ "$TEST_MINIMAL" != true ]]; then
       wget --quiet -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip;
@@ -97,16 +97,15 @@ install:
       mv "iris-test-data-${IRIS_TEST_DATA_SUFFIX}" iris-test-data;
     fi
 
-# set config paths
-  - >
-    SITE_CFG=lib/iris/etc/site.cfg;
-    echo "[Resources]" > $SITE_CFG;
-    echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> $SITE_CFG;
-    echo "doc_dir = $(pwd)/docs/iris" >> $SITE_CFG;
-    echo "[System]" >> $SITE_CFG;
-    echo "udunits2_path = $PREFIX/lib/libudunits2.so" >> $SITE_CFG;
+# install iris itself
 
   - python setup.py --quiet install
+
+# set test data path
+  - export OVERRIDE_TEST_DATA_REPOSITORY=$(pwd)/iris-test-data/test_data
+
+# show config in action
+  - python -c "import iris.config; print iris.config.TEST_DATA_DIR"
 
   # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -818,7 +818,7 @@ class IrisTest_nometa(unittest.TestCase):
             else:
                 uris = repo[unique_id]
                 # Create the expected perceptual image hashes from the uris.
-                to_hash = imagehash.hex_to_hash
+                to_hash = imagehash.old_hex_to_hash
                 expected = [to_hash(os.path.splitext(os.path.basename(uri))[0],
                                     hash_size=_HASH_SIZE)
                             for uri in uris]

--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -140,7 +140,7 @@ def diff_viewer(repo, key, repo_fname, phash, status,
 
 def _calculate_hit(uris, phash, action):
     # Create the expected perceptual image hashes from the uris.
-    to_hash = imagehash.hex_to_hash
+    to_hash = imagehash.old_hex_to_hash
     expected = [to_hash(os.path.splitext(os.path.basename(uri))[0],
                         hash_size=iris.tests._HASH_SIZE)
                 for uri in uris]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,5 @@ mock
 nose
 pep8
 filelock
-imagehash
+imagehash<4
 requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,5 @@ mock
 nose
 pep8
 filelock
-imagehash<4
+imagehash
 requests


### PR DESCRIPTION
**DO NOT MERGE**
Like #2973 this is just fishing for information.
( We can't simply apply the 'old' hash function to everything, because then we can't add any new hashes.
So, we will need to either convert all existing hash keys, or use old+new methods selectively somehow. )