### PR TITLE
Fix bug with aux coords with scalefactor/add_offset

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -1624,7 +1624,7 @@ fc_extras
         attr_units = get_attr_units(cf_coord_var, attributes)
 
         def cf_var_as_array(cf_var):
-            dtype = cf_var.dtype
+            dtype = iris.fileformats.netcdf.get_actual_dtype(cf_var)
             fill_value = getattr(cf_var.cf_data, '_FillValue',
                                  netCDF4.default_fillvals[dtype.str[1:]])
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1624,7 +1624,7 @@ fc_extras
         attr_units = get_attr_units(cf_coord_var, attributes)
 
         def cf_var_as_array(cf_var):
-            dtype = iris.fileformats.netcdf.get_actual_dtype(cf_var)
+            dtype = iris.fileformats.netcdf._get_actual_dtype(cf_var)
             fill_value = getattr(cf_var.cf_data, '_FillValue',
                                  netCDF4.default_fillvals[dtype.str[1:]])
             proxy = iris.fileformats.netcdf.NetCDFDataProxy(

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -490,7 +490,7 @@ def _set_attributes(attributes, key, value):
         attributes[str(key)] = value
 
 
-def get_actual_dtype(cf_var):
+def _get_actual_dtype(cf_var):
     # Figure out what the eventual data type will be after any scale/offset
     # transforms.
     dummy_data = np.zeros(1, dtype=cf_var.dtype)
@@ -503,7 +503,7 @@ def get_actual_dtype(cf_var):
 
 def _load_cube(engine, cf, cf_var, filename):
     """Create the cube associated with the CF-netCDF data variable."""
-    dtype = get_actual_dtype(cf_var)
+    dtype = _get_actual_dtype(cf_var)
 
     # Create cube with deferred data, but no metadata
     fill_value = getattr(cf_var.cf_data, '_FillValue',

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -490,8 +490,7 @@ def _set_attributes(attributes, key, value):
         attributes[str(key)] = value
 
 
-def _load_cube(engine, cf, cf_var, filename):
-    """Create the cube associated with the CF-netCDF data variable."""
+def get_actual_dtype(cf_var):
     # Figure out what the eventual data type will be after any scale/offset
     # transforms.
     dummy_data = np.zeros(1, dtype=cf_var.dtype)
@@ -499,12 +498,18 @@ def _load_cube(engine, cf, cf_var, filename):
         dummy_data = cf_var.scale_factor * dummy_data
     if hasattr(cf_var, 'add_offset'):
         dummy_data = cf_var.add_offset + dummy_data
+    return dummy_data.dtype
+
+
+def _load_cube(engine, cf, cf_var, filename):
+    """Create the cube associated with the CF-netCDF data variable."""
+    dtype = get_actual_dtype(cf_var)
 
     # Create cube with deferred data, but no metadata
     fill_value = getattr(cf_var.cf_data, '_FillValue',
                          netCDF4.default_fillvals[cf_var.dtype.str[1:]])
-    proxy = NetCDFDataProxy(cf_var.shape, dummy_data.dtype,
-                            filename, cf_var.cf_name, fill_value)
+    proxy = NetCDFDataProxy(cf_var.shape, dtype, filename, cf_var.cf_name,
+                            fill_value)
     data = as_lazy_data(proxy)
     cube = iris.cube.Cube(data)
 

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -30,6 +30,7 @@ import iris.tests as tests
 import numpy as np
 
 from iris.coords import AuxCoord
+from iris.fileformats.cf import CFVariable
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_auxiliary_coordinate
 from iris.tests import mock
@@ -40,15 +41,15 @@ class TestBoundsVertexDim(tests.IrisTest):
         # Create coordinate cf variables and pyke engine.
         points = np.arange(6).reshape(2, 3)
         self.cf_coord_var = mock.Mock(
+            spec=CFVariable,
             dimensions=('foo', 'bar'),
             cf_name='wibble',
+            cf_data=mock.Mock(),
             standard_name=None,
             long_name='wibble',
             units='m',
             shape=points.shape,
             dtype=points.dtype,
-            scale_factor=1,
-            add_offset=0,
             __getitem__=lambda self, key: points[key])
 
         self.engine = mock.Mock(
@@ -75,12 +76,12 @@ class TestBoundsVertexDim(tests.IrisTest):
         # Create the bounds cf variable.
         bounds = np.arange(24).reshape(4, 2, 3)
         self.cf_bounds_var = mock.Mock(
+            spec=CFVariable,
             dimensions=('nv', 'foo', 'bar'),
             cf_name='wibble_bnds',
+            cf_data=mock.Mock(),
             shape=bounds.shape,
             dtype=bounds.dtype,
-            scale_factor=1,
-            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         # Expected bounds on the resulting coordinate should be rolled so that
@@ -116,12 +117,12 @@ class TestBoundsVertexDim(tests.IrisTest):
     def test_fastest_varying_vertex_dim(self):
         bounds = np.arange(24).reshape(2, 3, 4)
         self.cf_bounds_var = mock.Mock(
+            spec=CFVariable,
             dimensions=('foo', 'bar', 'nv'),
             cf_name='wibble_bnds',
+            cf_data=mock.Mock(),
             shape=bounds.shape,
             dtype=bounds.dtype,
-            scale_factor=1,
-            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         expected_coord = AuxCoord(
@@ -155,12 +156,12 @@ class TestBoundsVertexDim(tests.IrisTest):
         # this should still work because the vertex dim is the fastest varying.
         bounds = np.arange(24).reshape(2, 3, 4)
         self.cf_bounds_var = mock.Mock(
+            spec=CFVariable,
             dimensions=('x', 'y', 'nv'),
             cf_name='wibble_bnds',
+            cf_data=mock.Mock(),
             shape=bounds.shape,
             dtype=bounds.dtype,
-            scale_factor=1,
-            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         expected_coord = AuxCoord(
@@ -187,6 +188,66 @@ class TestBoundsVertexDim(tests.IrisTest):
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
             self.assertEqual(self.engine.provides['coordinates'],
                              expected_list)
+
+
+class TestDtype(tests.IrisTest):
+    def setUp(self):
+        # Create coordinate cf variables and pyke engine.
+        points = np.arange(6).reshape(2, 3)
+        self.cf_coord_var = mock.Mock(
+            spec=CFVariable,
+            dimensions=('foo', 'bar'),
+            cf_name='wibble',
+            cf_data=mock.Mock(),
+            standard_name=None,
+            long_name='wibble',
+            units='m',
+            shape=points.shape,
+            dtype=points.dtype,
+            __getitem__=lambda self, key: points[key])
+
+        self.engine = mock.Mock(
+            cube=mock.Mock(),
+            cf_var=mock.Mock(dimensions=('foo', 'bar')),
+            filename='DUMMY',
+            provides=dict(coordinates=[]))
+
+        def patched__getitem__(proxy_self, keys):
+            if proxy_self.variable_name == self.cf_coord_var.cf_name:
+                return self.cf_coord_var[keys]
+            raise RuntimeError()
+
+        self.deferred_load_patch = mock.patch(
+            'iris.fileformats.netcdf.NetCDFDataProxy.__getitem__',
+            new=patched__getitem__)
+
+    def test_scale_factor_add_offset_int(self):
+        self.cf_coord_var.scale_factor = 3
+        self.cf_coord_var.add_offset = 5
+
+        with self.deferred_load_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+        coord, _ = self.engine.provides['coordinates'][0]
+        self.assertEqual(coord.dtype.kind, 'i')
+
+    def test_scale_factor_float(self):
+        self.cf_coord_var.scale_factor = 3.
+
+        with self.deferred_load_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+        coord, _ = self.engine.provides['coordinates'][0]
+        self.assertEqual(coord.dtype.kind, 'f')
+
+    def test_add_offset_float(self):
+        self.cf_coord_var.add_offset = 5.
+
+        with self.deferred_load_patch:
+            build_auxiliary_coordinate(self.engine, self.cf_coord_var)
+
+        coord, _ = self.engine.provides['coordinates'][0]
+        self.assertEqual(coord.dtype.kind, 'f')
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -47,6 +47,8 @@ class TestBoundsVertexDim(tests.IrisTest):
             units='m',
             shape=points.shape,
             dtype=points.dtype,
+            scale_factor=1,
+            add_offset=0,
             __getitem__=lambda self, key: points[key])
 
         self.engine = mock.Mock(
@@ -77,6 +79,8 @@ class TestBoundsVertexDim(tests.IrisTest):
             cf_name='wibble_bnds',
             shape=bounds.shape,
             dtype=bounds.dtype,
+            scale_factor=1,
+            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         # Expected bounds on the resulting coordinate should be rolled so that
@@ -116,6 +120,8 @@ class TestBoundsVertexDim(tests.IrisTest):
             cf_name='wibble_bnds',
             shape=bounds.shape,
             dtype=bounds.dtype,
+            scale_factor=1,
+            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         expected_coord = AuxCoord(
@@ -153,6 +159,8 @@ class TestBoundsVertexDim(tests.IrisTest):
             cf_name='wibble_bnds',
             shape=bounds.shape,
             dtype=bounds.dtype,
+            scale_factor=1,
+            add_offset=0,
             __getitem__=lambda self, key: bounds[key])
 
         expected_coord = AuxCoord(


### PR DESCRIPTION
The date type of a variable in a netCDF file is not necessarily the same as the dtype of the array returned by netCDF4, if a scale_factor and/or add_offset are applied. If the data is lazily loaded, we need to figure out what the actual dtype will be. This was already handled for cube data, but not for auxiliary coordinate data, which can now also be lazy. It doesn't apply to dimension coordinates which don't have lazy data.