### PR TITLE
Provide info on pp-field indices in the file for structured um loads.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Apr-12_fast_load_file_indices.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Apr-12_fast_load_file_indices.txt
@@ -1,0 +1,8 @@
+* The :class:`iris.fileformats.um.FieldCollation` objects, which are passed
+  into load callbacks when using
+  :func:`iris.fileformats.um.structured_um_loading`, now
+  have the additional properties :
+  :data:`iris.fileformats.um.FieldCollation.data_filepath` and
+  :data:`iris.fileformats.um.FieldCollation.data_field_indices`.
+  These provide the file locations of the original data fields, which are
+  otherwise lost in the structured loading process.

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -831,7 +831,7 @@ def _pp_attribute_names(header_defn):
     special_headers = list('_' + name for name in _SPECIAL_HEADERS)
     extra_data = list(EXTRA_DATA.values())
     special_attributes = ['_raw_header', 'raw_lbtim', 'raw_lbpack',
-                          'boundary_packing']
+                          'boundary_packing', '_index_in_structured_load_file']
     return normal_headers + special_headers + extra_data + special_attributes
 
 
@@ -864,6 +864,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         self.raw_lbtim = None
         self.raw_lbpack = None
         self.boundary_packing = None
+        self._index_in_structured_load_file = None
         if header is not None:
             self.raw_lbtim = header[self.HEADER_DICT['lbtim'][0]]
             self.raw_lbpack = header[self.HEADER_DICT['lbpack'][0]]

--- a/lib/iris/fileformats/um/__init__.py
+++ b/lib/iris/fileformats/um/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,7 +27,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Publish the FF-replacement features here, and include documentation.
 from ._ff_replacement import um_to_pp, load_cubes, load_cubes_32bit_ieee
-from ._fast_load import structured_um_loading
-from ._fast_load_structured_fields import FieldCollation
+from ._fast_load import structured_um_loading, FieldCollation
 __all__ = ['um_to_pp', 'load_cubes', 'load_cubes_32bit_ieee',
            'structured_um_loading', 'FieldCollation']

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -294,7 +294,7 @@ def group_structured_fields(field_iterator,
        :func:`iris.fileformats.pp_load_rules._convert_time_coords`).
 
     Returns:
-        A generator of BasicFieldCollation objects, each of which contains a
+        A generator of 'collation_class' objects, each of which contains a
         single collated group from the input fields.
 
     .. note::

--- a/lib/iris/tests/unit/fileformats/um/fast_load/test_FieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load/test_FieldCollation.py
@@ -34,7 +34,6 @@ import iris.tests as tests
 import numpy as np
 
 import iris
-from iris.fileformats.um import structured_um_loading
 
 from iris.tests.integration.fast_load.test_fast_load import Mixin_FieldTest
 

--- a/lib/iris/tests/unit/fileformats/um/fast_load/test_FieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load/test_FieldCollation.py
@@ -1,0 +1,83 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the class
+:class:`iris.fileformats.um._fast_load.FieldCollation`.
+
+This only tests the additional functionality for recording file locations of
+PPFields that make loaded cubes.
+The original class is the baseclass of this, now renamed 'BasicFieldCollation'.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.fileformats.um import structured_um_loading
+
+from iris.tests.integration.fast_load.test_fast_load import Mixin_FieldTest
+
+
+class TestFastCallbackLocationInfo(Mixin_FieldTest, tests.IrisTest):
+    do_fast_loads = True
+
+    def setUp(self):
+        # Call parent setup.
+        super(TestFastCallbackLocationInfo, self).setUp()
+
+        # Create a basic load test case.
+        self.callback_collations = []
+        self.callback_filepaths = []
+
+        def fast_load_callback(cube, collation, filename):
+            self.callback_collations.append(collation)
+            self.callback_filepaths.append(filename)
+
+        flds = self.fields(c_t='11112222', c_h='11221122', phn='01010101')
+        self.test_filepath = self.save_fieldcubes(flds)
+        iris.load(self.test_filepath, callback=fast_load_callback)
+
+    def test_callback_collations_filepaths(self):
+        self.assertEqual(len(self.callback_collations), 2)
+        self.assertEqual(self.callback_collations[0].data_filepath,
+                         self.test_filepath)
+        self.assertEqual(self.callback_collations[1].data_filepath,
+                         self.test_filepath)
+
+    def test_callback_collations_field_indices(self):
+        self.assertEqual(
+            self.callback_collations[0].data_field_indices.dtype, np.int64)
+        self.assertArrayEqual(
+            self.callback_collations[0].data_field_indices,
+            [[1, 3], [5, 7]])
+
+        self.assertEqual(
+            self.callback_collations[1].data_field_indices.dtype, np.int64)
+        self.assertArrayEqual(
+            self.callback_collations[1].data_field_indices,
+            [[0, 2], [4, 6]])
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_BasicFieldCollation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_BasicFieldCollation.py
@@ -31,7 +31,8 @@ from iris._lazy_data import as_lazy_data
 from cftime import datetime
 import numpy as np
 
-from iris.fileformats.um._fast_load_structured_fields import FieldCollation
+from iris.fileformats.um._fast_load_structured_fields \
+    import BasicFieldCollation as FieldCollation
 import iris.fileformats.pp
 
 

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -71,9 +71,7 @@ class Test__grouping(tests.IrisTest):
 
     def _group_result(self, fields):
         # Run the testee, but returning just the groups (not FieldCollations).
-        with mock.patch('iris.fileformats.um._fast_load_structured_fields.'
-                        'FieldCollation', new=lambda args: args):
-            result = list(group_structured_fields(fields))
+        result = list(group_structured_fields(fields, collation_class=tuple))
         return result
 
     def _test_fields(self, item):


### PR DESCRIPTION
This intends to address problems discussed in [this comment](https://github.com/SciTools/iris/pull/2640#issuecomment-313665559) and follow-ons.

Implementation notes :
  * The information is attached to the 'field' arg in the load callback, i.e. in this case a FieldCollation.
  * The caller should be able to use this to annotate the multidimensional collated cubes as required :  I believe this is what the users's existing code does (using normal load to annotate each raw cube with an extra  "pseudolevel ordering" coordinate).
  * the old 'FieldCollation' class is now renamed 'BasicFieldCollation' : the new, public 'FieldCollation' is a derived class which adds the location-in-input-file info.  This preserves the original, cleaner concept.

Todo:
  * [x] user to confirm suitablility
  * [x] needs a whatsnew
 