### PR TITLE
remove site.cfg exclude from manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ recursive-include lib/iris/tests/results *.cml *.cdl *.txt *.xml *.json
 recursive-include lib/iris/etc *
 include lib/iris/fileformats/_pyke_rules/*.k?b
 include lib/iris/tests/stock*.npz
-exclude lib/iris/etc/site.cfg
 
 include requirements/*.txt
 


### PR DESCRIPTION
Iris tests that require test data are currently being skipped in the travis-ci on `master`.

The root cause "appears" to be #2938 on the `2.0.x` branch, which was merged back into `master`. It had an explicit `exclude lib/iris/ext/site.cfg` in the `MANIFEST.in`.

This PR reverts that exclusion in the manifest.