### PR TITLE
Rename iris_sample_data to correct package name (iris-sample-data)

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -478,7 +478,7 @@ def sample_data_path(*path_to_join):
     if iris_sample_data is not None:
         target = os.path.join(iris_sample_data.path, target)
     else:
-        raise ImportError("Please install the 'iris_sample_data' package to "
+        raise ImportError("Please install the 'iris-sample-data' package to "
                           "access sample data.")
     if not glob.glob(target):
         raise ValueError('Sample data file(s) at {!r} not found.\n'


### PR DESCRIPTION
I got the 
```     
raise ImportError("Please install the 'iris_sample_data' package to "
                          "access sample data.")
```

Then did `conda install -c conda-forge iris_sample_data` to get:
```
PackageNotFoundError: Packages missing in current channels:
            
  - iris_sample_data
```

Renamed iris_sample_data to the correct package name of iris-sample-data