### PR TITLE
Fix imagehash hex_to_hash

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -820,7 +820,7 @@ class IrisTest_nometa(unittest.TestCase):
                 hexes = [os.path.splitext(os.path.basename(uri))[0]
                          for uri in uris]
                 # See https://github.com/JohannesBuchner/imagehash#changelog
-                # for details on imagehash release 4.0 old_hex_to_hash() fix.
+                # for details on imagehash release v4.0 old_hex_to_hash() fix.
                 hex_fix_available = hasattr(imagehash, 'old_hex_to_hash')
                 to_hash = imagehash.hex_to_hash
 
@@ -844,8 +844,8 @@ class IrisTest_nometa(unittest.TestCase):
                     matching, distances = _image_matcher(expected)
 
                     if not matching:
-                        # Retry, correcting old hex strings.
-                        # Note that, the "hash_size" kwarg is required.
+                        # Retry, correcting old hex strings. Note that,
+                        # the "hash_size" kwarg is required.
                         to_hash = imagehash.old_hex_to_hash
                         expected = [to_hash(uri_hex, hash_size=_HASH_SIZE)
                                     for uri_hex in hexes]

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -824,18 +824,24 @@ class IrisTest_nometa(unittest.TestCase):
                 hex_fix_available = hasattr(imagehash, 'old_hex_to_hash')
                 to_hash = imagehash.hex_to_hash
 
-                def _image_match(expected):
+                def _image_matcher(expected):
+                    """
+                    Returns whether at least one expected image is similar
+                    enough to the actual image, and the vector of hamming
+                    distances of each expected image from the actual image.
+
+                    """
                     # Calculate hamming distance vector for the result hash.
                     distances = [e - phash for e in expected]
                     result = np.all([d > _HAMMING_DISTANCE for d in distances])
-                    return not result
+                    return not result, distances
 
                 if hex_fix_available:
                     # Create expected perceptual image hashes from the uris.
                     # Note that, the "hash_size" kwarg is unavailable and old
                     # style hashes will not be corrected.
                     expected = [to_hash(uri_hex) for uri_hex in hexes]
-                    matching = _image_match(expected)
+                    matching, distances = _image_matcher(expected)
 
                     if not matching:
                         # Retry, correcting old hex strings.
@@ -843,14 +849,14 @@ class IrisTest_nometa(unittest.TestCase):
                         to_hash = imagehash.old_hex_to_hash
                         expected = [to_hash(uri_hex, hash_size=_HASH_SIZE)
                                     for uri_hex in hexes]
-                        matching = _image_match(expected)
+                        matching, distances = _image_matcher(expected)
                 else:
                     # Create expected perceptual image hashes from the uris.
                     # The version of imagehash will be prior to v4.0, so the
                     # "hash_size" kwarg is required.
                     expected = [to_hash(uri_hex, hash_size=_HASH_SIZE)
                                 for uri_hex in hexes]
-                    matching = _image_match(expected)
+                    matching, distances = _image_matcher(expected)
 
                 if not matching:
                     if dev_mode:

--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -139,25 +139,77 @@ def diff_viewer(repo, key, repo_fname, phash, status,
 
 
 def _calculate_hit(uris, phash, action):
-    # Create the expected perceptual image hashes from the uris.
+    hexes = [os.path.splitext(os.path.basename(uri))[0] for uri in uris]
+    # See https://github.com/JohannesBuchner/imagehash#changelog
+    # for details on imagehash release v4.0 old_hex_to_hash() fix.
+    hex_fix_available = hasattr(imagehash, 'old_hex_to_hash')
     to_hash = imagehash.hex_to_hash
-    expected = [to_hash(os.path.splitext(os.path.basename(uri))[0],
-                        hash_size=iris.tests._HASH_SIZE)
-                for uri in uris]
-    # Calculate the hamming distance vector for the result hash.
-    distances = [e - phash for e in expected]
+
+    if hex_fix_available:
+        # Note that, the "hash_size" kwarg is unavailable and old
+        # style hashes will not be corrected.
+        expected = [to_hash(uri_hex) for uri_hex in hexes]
+        # Calculate the hamming distance vector for the result hash.
+        dnew = [e - phash for e in expected]
+        # Retry, correcting old hex strings. Note that, the
+        # "hash_size" kwarg is required.
+        to_hash = imagehash.old_hex_to_hash
+        expected = [to_hash(uri_hex, hash_size=iris.tests._HASH_SIZE)
+                    for uri_hex in hexes]
+        # Calculate the hamming distance vector for the result hash.
+        dold = [e - phash for e in expected]
+    else:
+        # The version of imagehash will be prior to v4.0, so the
+        # "hash_size" kwarg is required.
+        expected = [to_hash(uri_hex, hash_size=iris.tests._HASH_SIZE)
+                    for uri_hex in hexes]
+        dold = [e - phash for e in expected]
+
+    dmsg = '{} (old={})' if hex_fix_available else '{}'
+
     if action == 'first':
         index = 0
+        if hex_fix_available:
+            distance = dmsg.format(dnew[index], dold[index])
+        else:
+            distance = dmsg.format(dold[index])
     elif action == 'last':
         index = -1
+        if hex_fix_available:
+            distance = dmsg.format(dnew[index], dold[index])
+        else:
+            distance = dmsg.format(dold[index])
     elif action == 'similar':
-        index = np.argmin(distances)
-    elif action == 'difference':
-        index = np.argmax(distances)
+        if hex_fix_available:
+            inew, iold = np.argmin(dnew), np.argmin(dold)
+            vnew, vold = dnew[inew], dold[iold]
+            if vnew <= vold:
+                index = inew
+                distance = '{} (old={})'.format(vnew, vold)
+            else:
+                index = iold
+                distance = '{} (new={})'.format(vold, vnew)
+        else:
+            index = np.argmin(dold)
+            distance = '{}'.format(dold[index])
+    elif action == 'different':
+        if hex_fix_available:
+            inew, iold = np.argmax(dnew), np.argmax(dold)
+            vnew, vold = dnew[inew], dold[iold]
+            if vnew >= vold:
+                index = inew
+                distance = '{} (old={})'.format(vnew, vold)
+            else:
+                index = iold
+                distance = '{} (new={})'.format(vold, vnew)
+        else:
+            index = np.argmax(dold)
+            distance = '{}'.format(dold[index])
     else:
         emsg = 'Unknown action: {!r}'
         raise ValueError(emsg.format(action))
-    return index, distances[index]
+
+    return index, distance
 
 
 def step_over_diffs(result_dir, action, display=True):

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -1,725 +1,726 @@
 {
     "example_tests.test_COP_1d_plot.TestCOP1DPlot.test_COP_1d_plot.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5dff1a996c06b47193eecc52275b936d58b6239ba94c133643897c6c2333f086.png"
-    ],
+    ], 
     "example_tests.test_COP_maps.TestCOPMaps.test_cop_maps.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57891cdba966a124897c568316997ea1a97e897ee1c6699d5681ad733c9296ac.png"
-    ],
+    ], 
     "example_tests.test_SOI_filtering.TestSOIFiltering.test_soi_filtering.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f23069d83de1e4e7ca0a595a9725b0f46cce499a97239a563dc594a4b725aa9.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5f23069d83de1e4e7ca0a595a9725b0f46cce499a97239a563dc594a4b725aa9.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5f21069d83de1e4e7ca0a595a9725b0f46ccec99a97239a563dc594a4b7252b9.png"
-    ],
+    ], 
     "example_tests.test_TEC.TestTEC.test_TEC.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/87a5866dd958594221765992e39a763c733609de5cc1837ed8419ccd27cfdc23.png",
+        "https://scitools.github.io/test-iris-imagehash/images/87a5866dd958594221765992e39a763c733609de5cc1837ed8419ccd27cfdc23.png", 
         "https://scitools.github.io/test-iris-imagehash/images/87a5866dd95879c221765992e39a7634733609de5cc18376d8498ccd27cfdc31.png"
-    ],
+    ], 
     "example_tests.test_anomaly_log_colouring.TestAnomalyLogColouring.test_anomaly_log_colouring.0": [
         "https://scitools.github.io/test-iris-imagehash/images/37222687a1c5f9c9c978d9788996b69492bb67677c64255e5acb89c9b1595a30.png"
-    ],
+    ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f33ba103f0bf0db38c93f4d38.png",
-        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f333e902f0bf0db38c93f4d38.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f33ba103f0bf0db38c93f4d38.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f333e902f0bf0db38c93f4d38.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f95106cad64b71c804ce29ecad2fec0da5bc662f333a102f0bf0db38c93f4d38.png"
-    ],
+    ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.1": [
         "https://scitools.github.io/test-iris-imagehash/images/6557a57e7681bb9f998cd8c5cdee7a0421ba1a918399e6dc724425e67a318538.png"
-    ],
+    ], 
     "example_tests.test_coriolis_plot.TestCoriolisPlot.test_coriolis_plot.0": [
         "https://scitools.github.io/test-iris-imagehash/images/e761a67b5996699aa77a99a611969e699661a3677c1983795ca4669e87195824.png"
-    ],
+    ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a98cdea946278b26f95aa0a17632255b4a297e72a58ffcd892b9428fdcd882.png"
-    ],
+    ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.1": [
         "https://scitools.github.io/test-iris-imagehash/images/57a984dfa9569c02964978c90ffe52b5a136237e72a9a15e78a55bac895dd881.png"
-    ],
+    ], 
     "example_tests.test_custom_aggregation.TestCustomAggregation.test_custom_aggregation.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f817681897e097e2d7ce1fca1e65e83090f0e3c56a981f858c33c87a55ef618.png"
-    ],
+    ], 
     "example_tests.test_custom_file_loading.TestCustomFileLoading.test_custom_file_loading.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f05d38f217a2c7d89ece182763b133ddc13f8d9c6cc644625b70cb3834db384.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5f05d38f217a2c7d89ece182763b133ddc13f8d9c6cc644625b70cb3834db384.png", 
         "https://scitools.github.io/test-iris-imagehash/images/df05d38f217a2c7d89e4e182763b133ddc11f8d946cce446a5b54cb3834db384.png"
-    ],
+    ], 
     "example_tests.test_deriving_phenomena.TestDerivingPhenomena.test_deriving_phenomena.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/9d999c6161964a679362629c236ed69b63968976de998366fc996e91096e7c81.png",
+        "https://scitools.github.io/test-iris-imagehash/images/9d999c6161964a679362629c236ed69b63968976de998366fc996e91096e7c81.png", 
         "https://scitools.github.io/test-iris-imagehash/images/9d899c7b61964a679362639c237ed68be1968b765e99816674816c990b6e7c91.png"
-    ],
+    ], 
     "example_tests.test_global_map.TestGlobalMap.test_global_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f999e62a166a17e0f7e7c911e6ad689d3809e113c9129666195d6b9c16ef681.png"
-    ],
+    ], 
     "example_tests.test_hovmoller.TestGlobalMap.test_hovmoller.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5d2d0c2d73d273c2a37df391a3d258c6a3c2a3767826097edc2d962d097b5883.png"
-    ],
+    ], 
     "example_tests.test_inset_plot.TestInsetPlot.test_inset_plot.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d7ff9649af0069a54da25b236faa29692d4912db93bad396a99489b4f324522a.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d7ff9649af0069a54da25b236faa29692d4912db93bad396a99489b4f324522a.png", 
         "https://scitools.github.io/test-iris-imagehash/images/97ff9649ad0069a54da25b236fa2296d2d4912db93bad396a994a9b4f324526a.png"
-    ],
+    ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.0": [
         "https://scitools.github.io/test-iris-imagehash/images/dddd8c87237226270da2d9da8d8e765323262f69732c86718de0d99c8dc973a4.png"
-    ],
+    ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.1": [
         "https://scitools.github.io/test-iris-imagehash/images/d57f9f1abf6234995ce01b9e0662d2818b0069e1839ccbad2997f3e1631d69e1.png"
-    ],
+    ], 
     "example_tests.test_lineplot_with_legend.TestLineplotWithLegend.test_lineplot_with_legend.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5797424aa6021d9669f8b165291ab965a9c233598f8052dfc3bf9ad6217f98e5.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5797424aa6021d9669f8b165291ab965a9c233598f8052dfc3bf9ad6217f98e5.png", 
         "https://scitools.github.io/test-iris-imagehash/images/57974228a6021d9669f8b167291ab965a9c233598f8052dfc3bf9ad6217f98e5.png"
-    ],
+    ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.0": [
         "https://scitools.github.io/test-iris-imagehash/images/df88ce582973257726cd7a898b4b0c72795ae39cde04877f48a124e167667362.png"
-    ],
+    ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.1": [
         "https://scitools.github.io/test-iris-imagehash/images/a765a665599a699aa7db18a643a6dc61996933677c9987595889649ce71878a6.png"
-    ],
+    ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.2": [
         "https://scitools.github.io/test-iris-imagehash/images/4f232673799cc94c87ed3287339ecc31a661a7cddc8ccd5e6693663203765826.png"
-    ],
+    ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.3": [
         "https://scitools.github.io/test-iris-imagehash/images/5f815ec121762536a79c93cc897b4c3361f3e1c5fc85164e38db7c9176ecd220.png"
-    ],
+    ], 
     "example_tests.test_polar_stereo.TestPolarStereo.test_polar_stereo.0": [
         "https://scitools.github.io/test-iris-imagehash/images/87168c5e49cbb691a3dd7929a37af63059c9835a76a3216edc848ee6897b5c81.png"
-    ],
+    ], 
     "example_tests.test_polynomial_fit.TestPolynomialFit.test_polynomial_fit.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d5ff52b94f26ac11a60493fe488262a9236db9c4c9d213563b6949ec6b3133f6.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d5ff52b94f26ac11a60493fe488262a9236db9c4c9d213563b6949ec6b3133f6.png", 
         "https://scitools.github.io/test-iris-imagehash/images/55ff52b94f26ac11a60493fe488262a9236db9c4c9d213563b6959e86b3933f6.png"
-    ],
+    ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1f298a1580c27336eb3d08d9e4c3ae563a60d931cd3d2728e7939ede4ad03.png",
-        "https://scitools.github.io/test-iris-imagehash/images/5fa3f298a1580c27336eb3d08d9e4c3aed61a60d931cd3d2728e7939e9e4ad03.png",
-        "https://scitools.github.io/test-iris-imagehash/images/5fa17298a1580c27336eb3d08d9e4c3aed63260d931cd3d273ce7939ecc5ad03.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5fa1f298a1580c27336eb3d08d9e4c3ae563a60d931cd3d2728e7939ede4ad03.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/5fa3f298a1580c27336eb3d08d9e4c3aed61a60d931cd3d2728e7939e9e4ad03.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/5fa17298a1580c27336eb3d08d9e4c3aed63260d931cd3d273ce7939ecc5ad03.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5fa17298a1580c27336eb3d08d9e4c3aed61a68d931c93d273ce7939ece4ad03.png"
-    ],
+    ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db2549976d9926c9b643982e8da149.png",
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c694e4ec28cf1b1b55abe63da25499d6c9926d9b643da26c9a149.png",
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db25499d6c9926d9b6439a26c9a149.png",
-        "https://scitools.github.io/test-iris-imagehash/images/c7a1d699391c694e4ec28cf1b1b55aae69da25499f6d9926db3263da2689a149.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db2549976d9926c9b643982e8da149.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c694e4ec28cf1b1b55abe63da25499d6c9926d9b643da26c9a149.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db25499d6c9926d9b6439a26c9a149.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/c7a1d699391c694e4ec28cf1b1b55aae69da25499f6d9926db3263da2689a149.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c7a1d699391c694e4ec28cf1b1b55aae61da2549976d9926db3663da2e89a149.png"
-    ],
+    ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa8867ae985c9b5837a7881235f7c2db90c817e7ca0837edea599e4817e7880.png"
-    ],
+    ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5da0e6e8c30799979df07181235b1a29996d696e7ca2a7d6dc919c9483de7e80.png"
-    ],
+    ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/5d78067ae38589851d7a7981235b1a099969cd7e5ca687f6de819e9ca75e7880.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5d78067ae38589851d7a7981235b1a099969cd7e5ca687f6de819e9ca75e7880.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5d78067ae385c9851d7a7981235b1a099969cd6e5ca687f6de81969cb75e7880.png"
-    ],
+    ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.3": [
         "https://scitools.github.io/test-iris-imagehash/images/5f814e0b217eb3d493c8c9396c21368e92cc9e39c333e1e4676e9c9f9c99561a.png"
-    ],
+    ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.0": [
         "https://scitools.github.io/test-iris-imagehash/images/3d9f24dfc960c9308734f3e9e34c6c4d717323b37c9421de18679c6783f25890.png"
-    ],
+    ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.1": [
         "https://scitools.github.io/test-iris-imagehash/images/3d9f24dfc960c9308734f3e9e34c6c4d717323337c9421de1c679c6783f25890.png"
-    ],
+    ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f81a95e837e56a1817e56a1a17e29547c81a95e7e81895e5e819b7a837e3485.png"
-    ],
+    ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.1": [
         "https://scitools.github.io/test-iris-imagehash/images/7d81837e837e7e81837e7c81a37ea55a7c01837e7c81837f5e8143a193fa34c0.png"
-    ],
+    ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.2": [
         "https://scitools.github.io/test-iris-imagehash/images/57a15e81a95ea17ea97e837e817e568156a17c815ea17c817681b15c6154cb7f.png"
-    ],
+    ], 
     "iris.tests.test_analysis.TestProject.test_cartopy_projection.0": [
         "https://scitools.github.io/test-iris-imagehash/images/79984a9383a62d3f6651b9e28362b85e06df74a17c2d64bd46bf4439f92083b6.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestBasic.test_contourf.0": [
         "https://scitools.github.io/test-iris-imagehash/images/175a963369b54987c99369cca1497938c38159b3679ba6737666d60c1c76a68d.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestBasic.test_pcolor.0": [
         "https://scitools.github.io/test-iris-imagehash/images/975a961369a549a7d99379cc2149696cc3b419b3679b26737e66c64c1c26a68d.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestBasic.test_unmappable.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a51672ad52295e0b79ed8ca384e9b143df3803276936477634d6b45c769658.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestBoundedCube.test_grid.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81897ea17e7681a17e5ea15e81895e5e81a17ea17e7e81a17e5e815e81a174.png",
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e5e81a17e5e815e81817e5e81a17ea17e5e81a17e5e815e81a17e.png"
-    ],
+        "https://scitools.github.io/test-iris-imagehash/images/5f81897ea17e7681a17e5ea15e81895e5e81a17ea17e7e81a17e5e815e81a174.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e5e81a17e5e815e81817e5e81a17ea17e5e81a17e5e815e81a17e.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/fa81857e857e7a81857e7a817a81857a7a81857e857e7a85857e7a817a81857a.png"
+    ], 
     "iris.tests.test_mapping.TestBoundedCube.test_pcolormesh.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f81a7aca17e49537143bc848d3c877a5e8178a5237e585a83dea6b4dca0274f.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_grid.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/fd01478d83feb85023ef13eb9c65ec04e49296d9d6cd736c66270d1229b2b991.png",
+        "https://scitools.github.io/test-iris-imagehash/images/fd01478d83feb85023ef13eb9c65ec04e49296d9d6cd736c66270d1229b2b991.png", 
         "https://scitools.github.io/test-iris-imagehash/images/fd01478f83feb85023ea136b9865ec84ec9296d9d6cd726c66270d7229b2b991.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_outline.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7c01a17e5e815e815e815e8181fe5e81a17ea17ea17ea17e5e81.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7c01a17e5e815e815e815e8181fe5e81a17ea17ea17ea17e5e81.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7e84a17e5e815e815ea15e81a15e5e81a15ea17ea15ea17e5e21.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_pcolormesh.0": [
         "https://scitools.github.io/test-iris-imagehash/images/fd81678d837eb81221fd13fb9c25ec04ec9296db96cd726423270d5309f2b991.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_scatter.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a0bc748956439b231b292cd624cfe25ef316b59c4c791b6369876c83d5598e.png",
+        "https://scitools.github.io/test-iris-imagehash/images/57a0bc748956439b231b292cd624cfe25ef316b59c4c791b6369876c83d5598e.png", 
         "https://scitools.github.io/test-iris-imagehash/images/57a0bc748956439b231ba92cd624cee25ef316b59c4c791b6379876483d5598e.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7d84e5d8837b1a275c8ce1f87ea1260e835fd931de8126ce2166da798b9d1983.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5781188ca9fec773653136079b4fd9d9568126c6a97c863389fe58c75603b91c.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.0": [
         "https://scitools.github.io/test-iris-imagehash/images/778139ed89dcc613217626cede8d993976a364cca95c961389f636c676498938.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.1": [
         "https://scitools.github.io/test-iris-imagehash/images/7d84e5d8837b1a275c8ce1f87ea1260e835fd931de8126ce2166da798b9d1983.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.2": [
         "https://scitools.github.io/test-iris-imagehash/images/5781188ca95ec7736531360793cfd9d9568126cea97cc63389fe58c75603b91c.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestLowLevel.test_simple.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5707294ca9a8d2332172368cf20dc973dee323cd250cde2389f6fc8c764b2d73.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestMappingSubRegion.test_simple.0": [
         "https://scitools.github.io/test-iris-imagehash/images/bd897c800b7e077e4976e1e1f681698307cb96e69c3cf81878343c1d0d9f06eb.png"
-    ],
+    ], 
     "iris.tests.test_mapping.TestUnmappable.test_simple.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f81b156837e5aa9b15e8dd4b9e66ea8197666b6234fb0574e819b11cc11d944.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/c17f43ff3e00a5b69740dc4a2728bca58bb67e538bedf6042993c64939268e13.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/e1ffa9ee5680876f1e80336c2fe0da81a3c26e1683683e114be6b69c6b61de16.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/df0746bc93e1b9892d78d222d9a69ee7e11925d91e4e4b26d23189d99c0c7636.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/f11fe960d6820f6e1fb873f80de05b9ea360cc972360641d8b60b69f6b609e96.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/f15f832a5ee0492a36e8b9ed8fa4f2b629dace4921681e17a9807e7c89835ef0.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/c17f83ff7e0019ae8ec0e538270ab6c38b78de044be27e0329a1be1da984fe56.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f11f43eb5c902de53690b9648fd2705a0b6bc20d2be4c697abc81e1fa9613e9c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f11f43eb5c902de53690b9648fd2705a0b6bc20d2be4c697abc81e1fa9613e9c.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f11703e85c982d60b69a9962cffa70ab0bede2942bc0961ba96c1e17e9e11e9e.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f43ee7e20a4f61640cc4a6f6bb8a583907b138bd9f31039939b5939a19b99.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c17f43ee7e20a4f61640cc4a6f6bb8a583907b138bd9f31039939b5939a19b99.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c17f43ee7e60a4f61640cc4a6f6bb8a503907b538bd9f31039939b5939a19b91.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17fb9ebfe0087eb0c0033b8efe0db8121427e1f8b6c3e114b66be9c0b61d616.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c17fb9ebfe0087eb0c0033b8efe0db8121427e1f8b6c3e114b66be9c0b61d616.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c17fb9e9fe8287eb0c0033b8efe09b8121427e1f8b6c3e114b66be9c0b61d616.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/df0746bc93e1b9892d78d222d9a69ee7e11925d91e4e4b26d23189d99c0c7636.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/e1ffad61fe00062b0cf8b6f90de01b99a36099971366711e1be6b1967b609996.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/c1ff833b7e000d3b66e8b9a98fe4f3932b929a5d21661a1789e05a7c99825af4.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f83fffe0919ee0440f9782f1ab3c28138db066be27b0629a1bb1d9984fa46.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c17f83fffe0919ee0440f9782f1ab3c28138db066be27b0629a1bb1d9984fa46.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c17f83fffe2919ee0400f9782f1ab3c28130db066be27b0629a1bb1d9984fb46.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ff13697e00196524f8b964c7d271422f4bd02d29e49a9729f81e1feb615e9c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c1ff13697e00196524f8b964c7d271422f4bd02d29e49a9729f81e1feb615e9c.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c19f13697e00b96524fa996247fa796b0f29f0942fe0921ba16c1e17eba11e9e.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed47129839e3896c469b52a385.png",
-        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed43129c39e3896e461b52a385.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed47129839e3896c469b52a385.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed43129c39e3896e461b52a385.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c55f832d3e991872466639e56fda93561db8e9ed47129839e3896c461b52b305.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7d053e99837a8d761989730ae3429c523cb7368dcc098f33ce43f9d8b470b366.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/75fef8e0cf07070f84d8796076e0b2c149761b1fb3ec495b8b69b20d1b70d990.png",
+        "https://scitools.github.io/test-iris-imagehash/images/75fef8e0cf07070f84d8796076e0b2c149761b1fb3ec495b8b69b20d1b70d990.png", 
         "https://scitools.github.io/test-iris-imagehash/images/75fef8e0cf07070f8cd8796076e0b2c149661b17b3ec595b8b69b20d1b70d990.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59e69d3246b8b7c56fc94933b324b6cd0918197923c1b697b7244949.png",
-        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59669d3246b8b7c56fc94933b326b6cd0918197b23c1b697b3244949.png",
+        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59e69d3246b8b7c56fc94933b324b6cd0918197923c1b697b7244949.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59669d3246b8b7c56fc94933b326b6cd0918197b23c1b697b3244949.png", 
         "https://scitools.github.io/test-iris-imagehash/images/a51f699b59e69d324638b7c56fcb4933b324b6cd0918197b23c1b697b3244949.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/25df98cddb2063b3c6e09d611e0638ce319ceb38cf6186611b867696bd98d879.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/dd5fc3b919991c52f66629e56dc8d31239a9eded43529c39a3894c461b52b305.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7d053e99837a8d761989730ae3429c523cb7368dcc098f33ce43f9d8b470b366.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f57ef8f08f87070f9b18697036e0b6d14b661b16a3ec6c5a0969b60d7b70d890.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f57ef8f08f87070f9b18697036e0b6d14b661b16a3ec6c5a0969b60d7b70d890.png", 
         "https://scitools.github.io/test-iris-imagehash/images/757ef8f08f87070f9b18697036e0b6c14b661b16a3ec6c5a0b69b60d7b72d890.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/b71f69eb59e69d32a638b7c44bc94933b326b6cc0998483f23c1b696b7244949.png"
-    ],
+    ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/359f9ccc596863b2c7608c611ce63cce3198eb38cf6186611bc67696bd98d879.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_down.0": [
         "https://scitools.github.io/test-iris-imagehash/images/e17f1f889e01e38306e0f1f83f20797e09a8595ea982597e89b0f3787398735c.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_up.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1ffa12b1e00bdf966e09e0b61fc929329fe727889827b1ceb005b1473b859d4.png",
+        "https://scitools.github.io/test-iris-imagehash/images/e1ffa12b1e00bdf966e09e0b61fc929329fe727889827b1ceb005b1473b859d4.png", 
         "https://scitools.github.io/test-iris-imagehash/images/e1ffa12b5e003df966e09e1b61fc929309fe727889827b1ceb105b1473b859d0.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_down.0": [
         "https://scitools.github.io/test-iris-imagehash/images/df29d665218729df09d85ca0e126580bdc58e7e67226835ada99e3e6237e5c19.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_up.0": [
         "https://scitools.github.io/test-iris-imagehash/images/77e836fec907c905a3f0c9c1817a76a8169a877e76a8875ed90771b4a158d9c1.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/f31fa5fa5ea8ad5a1ee8a1520be0a51703f23c1703f27c54230e564da9cd5e69.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_ty.0": [
         "https://scitools.github.io/test-iris-imagehash/images/d13f817a1e80a1e93f80d9a62da48b84a97a7e5ba1d2be5601db7e2d81edd486.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d17f81ff1e80a1ff1f00a95a2b407e00abe82b00a1fa7e00a1ff7e01a1ff56b7.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d17f81ff1e80a1ff1f00a95a2b407e00abe82b00a1fa7e00a1ff7e01a1ff56b7.png", 
         "https://scitools.github.io/test-iris-imagehash/images/d17f81ff1e00a1ff1f00a1fa2b407e00abe82b00a1fa7e00a1ff7e01a1ff56b7.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f6ac3332c17898d9395386ca3850ec7e3d87c9ac9e521274923d97273e3c6c9.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/d17fa1fe5e80a5565fa0a1520ba8bd000ba8ab5009ea7e01a1fe7e05a1fe5efd.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContour.test_zy.0": [
         "https://scitools.github.io/test-iris-imagehash/images/d1ff81ff5e80a93f1f80a91e2b407e00ab0a2b40a13e7e80a17f5ec1a17f56f5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa546b7166ab94aa15ebd48a95cf148a9f82607cbf05c9356b256967607564c.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_ty.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a507fca95ef201a952798287763906e9f0ad4d525bc67276c996b4d2a5461b.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_tz.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea9525e81a17ea97ea17e3f00a17e7e005ea103547ea1f9145ea1837f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/975a961c6dad6989c90958f283a729e5639999d373ccc6199e4a764ecc70a627.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa1a17e235a5e81a17ea152a17ea756897ea3565ca1a3565ca123575e81487f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestContourf.test_zy.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f81817e23505e81a17ea97ea17e2f50a17e6fd05e812350de8167f05e8152ff.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57ad8cfca952de4906cfe991a337320b210b23275a85a37f5c209ede8ddcdc60.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.1": [
         "https://scitools.github.io/test-iris-imagehash/images/7da1fc01a152837e03bd43af835eb09033f803fe5aad877ffc02b95e1c2e7c00.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.2": [
         "https://scitools.github.io/test-iris-imagehash/images/57ad8cfca952de4906cfe991a337320b210b23275a85a37f5c209ede8ddcdc60.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fe894f8a917a917267a5ea9835e7637272d87ccdc80037ed88d9c9089d27983.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5fe894f8a917a917267a5ea9835e7637272d87ccdc80037ed88d9c9089d27983.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5fe894f8a917a917267a5e89835e7627262f87ccdc80837ed88d9cb089d27983.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/dde08cf22307632dc3787987219e9c858368837ade29a77e78959cb8877658c3.png",
+        "https://scitools.github.io/test-iris-imagehash/images/dde08cf22307632dc3787987219e9c858368837ade29a77e78959cb8877658c3.png", 
         "https://scitools.github.io/test-iris-imagehash/images/dde08cf26387632dc378798721969c858368837ade28877e78959cbc877658c3.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a9dcdfa956232f26f958a0a37636255aca297a76a583fcd892a14283fcd882.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.1": [
         "https://scitools.github.io/test-iris-imagehash/images/7d81fc03835a83bc83fd43be837eb8c9a3f823fc7885835e7c831c278d4e5881.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.2": [
         "https://scitools.github.io/test-iris-imagehash/images/57a986f7a956de4906d949b483767663215a237e5aa5a37e7a031286a9ded881.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.3": [
         "https://scitools.github.io/test-iris-imagehash/images/57a9dcdfa956232f26f958a0a37636255aca297a76a583fcd892a14283fcd882.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.4": [
         "https://scitools.github.io/test-iris-imagehash/images/5daf2c7ef350c38f836ff1c1a1d0f8c13388033f5e0b835ed8871c270d7e58b0.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCS.test_missing_cs.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f837607a9dc89d8837a6912a7762367897dde335e8121ce7c855609837ec9b0.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f8156a983fead78a97c29a1a15ef802a94aa156f881837e5a9d72a803ff5aa1.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.1": [
         "https://scitools.github.io/test-iris-imagehash/images/7d70965ac30f69ad29fc4b85a13f78a109a7297778a0835ef202bcf0877fd242.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa1466d03eebc90a956a95aa15eb811217aa37efc81037e52a7d6840bff5aa1.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa9462be323bcd0addee907a15efc98a94b216e5ca0835edea156b4032f5a21.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa1466d036ebc90ad52a95aa15efc11217aa35e7ca1037e5686d6a40bff5e81.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa1466f03eebc90ad52a95aa15efc81a95a237e7ca1837e5e8556a4036e5a85.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/177ae693e3879c78e9a5690d5c6c69853cf2c660c618967aa393967a369263a5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png",
+        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png", 
         "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d51c1fe3c456aa5e2a341e16abd2a01e8ee9572d1ee954.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_tz.0": [
         "https://scitools.github.io/test-iris-imagehash/images/172ee9d1e9d116aee9d116aee9d11e2aa9d01e0a16aa1e2e162e7e4516aee955.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/977a9696298d69edc98d5978c38389a363a769987872964c96cc366c9c58765c.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/177ae185e985965ae985965ae985be5ae9859e601e5a1e68165a7e61165a6be1.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolor.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00bc4afe00f4427e15f4426b15.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00bc4afe00f4427e15f4426b15.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bb5d44a0bbdfe400bbdfe00b44afe00f44a7eb0f44a2bb5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8318f5ef829478398c97129c6e631.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_ty.0": [
         "https://scitools.github.io/test-iris-imagehash/images/b57a29a5c30dc30f69a5965a69a53cf08ed83cf0bed8e92d96c2c3073382d65a.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/957a3cf8690569a56ba5d702c30fd7078303c30f3ed07c7c69853c78b6da9652.png",
+        "https://scitools.github.io/test-iris-imagehash/images/957a3cf8690569a56ba5d702c30fd7078303c30f3ed07c7c69853c78b6da9652.png", 
         "https://scitools.github.io/test-iris-imagehash/images/957a1cf8690569a56ba5d702c30fd70f8307c30f3e507c7c69853c78b6da9652.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/3d5e384ccbc366b3a3a1c39961b3e379e349c76569b01a929c9e3c2c1c2e1cce.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57f81ef8a907a117a107a942a987a957a905a1175ea87cfea90756e81eaa5ef8.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zy.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5de85ce8a917a917a3172f00831f831fa915a3175ee05e7aa3177ce87ce87e40.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/177ae693e3879c78e9a5690d5c6c69853cf2c740c618967aa393967a369263a5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png",
+        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png", 
         "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d51c1fe3c456aa5e2a341e16abd2a01e8ee9573d1ee944.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_tz.0": [
         "https://scitools.github.io/test-iris-imagehash/images/172ee9d1e9d116aee9d116aee9d11e2aa9d01e0a16aa1e2e162e7e4516aee955.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/977a9696298d69adc98d5978c3a389a363a769987872964c96cc366c9c58765c.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/177ae185e985965ae985b65ae985be5ae9851e601e5a1e68165a7e61165a6be1.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormesh.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00b44afe00f442fe15f4426b15.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00b44afe00f442fe15f4426b15.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f54201bd0bb5f44a0bb5d44a0bbdfe400bbdfe00b44afe00f44afeb0f44a2bb5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8218f5eb8294783b8c97129c6e671.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8218f5eb8294783b8c97129c6e671.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8318f5eb829478398c97529c6e631.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_ty.0": [
         "https://scitools.github.io/test-iris-imagehash/images/b57a29a5c30dc30f6985965a69a53cf88ed83cf09ed8e92d96c2c30736c2d65a.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tz.0": [
         "https://scitools.github.io/test-iris-imagehash/images/957a3cf8690569a56ba5d602c30fd6478303c30f3ed07c7d69853c78b6da9652.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/3d5e384ccbc366b3e3a1c39961b3e371e349e76569b01a929c9e3c2c1c0e1cce.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57f81ef8a907a117a907bf42a907a957a905a1175ea87c7ea90756e81ea85ee8.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zy.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5de856e8a917a917a3173e00831f831f2915a3175ee05e7ba3177ce87ce85e60.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlot.test_t.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17fa9fa56a0a7c8cea09b232fc2488ea9187e39ab62fec52b89de163f005e58.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c17fa9fa56a0a7c8cea09b232fc2488ea9187e39ab62fec52b89de163f005e58.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f17fa9407ea0e700cea09b2325e248fea1fc60f981f2f4e52b8bd4363f007e5a.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlot.test_t_dates.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8b36d8d801eeb2b1074eaeb9490606fa18142ee8d3b114e32bf64.png",
-        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8936d85801eeb2b1034eaeb9490606fa39142ef8d3b114e32bf64.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8b36d8d801eeb2b1074eaeb9490606fa18142ee8d3b114e32bf64.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8936d85801eeb2b1034eaeb9490606fa39142ef8d3b114e32bf64.png", 
         "https://scitools.github.io/test-iris-imagehash/images/d5ff2b05548033218f001eeb2b1034eeeb9c907b6bf78146cebd39194e3abb64.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlot.test_x.0": [
         "https://scitools.github.io/test-iris-imagehash/images/f17fa9947ee1e35256a0891a1f39bc760bcaa6e9031c1e6c0b1f1e660b960ee9.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlot.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f1176964f660b1e1dcc1d38e27ac4e3a0b3e065e0b7e0e3f0b005e1e817f5e1d.png",
-        "https://scitools.github.io/test-iris-imagehash/images/f1176960f660b1e1dcc1d38e27ac4e3a0b3e065e0b3e0e3f0b005e1f817fde1d.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f1176964f660b1e1dcc1d38e27ac4e3a0b3e065e0b7e0e3f0b005e1e817f5e1d.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/f1176960f660b1e1dcc1d38e27ac4e3a0b3e065e0b3e0e3f0b005e1f817fde1d.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f117696cf6f0b1c99cd1d38e27ac4f720b2e26760b6e0e350f084eb6814f9e31.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlot.test_z.0": [
         "https://scitools.github.io/test-iris-imagehash/images/f15f832a5ee0492a36e8b9ed8fa4f2b629dace4921681e17a9807e7c89835ef0.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_non_cube_coordinate.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7e81a17e5e81a17e5e81a17e5e81a16e03547ea9a1567e81835e.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f8142af837ebd348376ad12a952a94289562c5e897a06bd52bf169efc894669.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa142edadc0ad12a15ebd10a15ebd90297ab7d6899b1683869d4eeb562546ad.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5fa142edadc0ad12a15ebd10a15ebd90297ab7d6899b1683869d4eeb562546ad.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5fa142edadc0ad12a15ebd10a15ebd90297ab756899b5683c69d4ecb562546ad.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/d11ff1a25ec0ad0c7e68ad860fe0ad7c0be6845e831e567f03af0efd811e1658.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d11ff1a25ec0ad0c7e68ad860fe0ad7c0be6845e831e567f03af0efd811e1658.png", 
         "https://scitools.github.io/test-iris-imagehash/images/d19ff1a05ec0ad0c7e68ad860fe0ad5c0be6845e831e567f03af0efd811e165a.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.3": [
         "https://scitools.github.io/test-iris-imagehash/images/f17ff16c7ea0a9547fa0a5d019b0b7d20bba964383df8e8303464e2f0b05562f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/55a9bcf0a15fadf00b4fa9565ee8a15f5fe816ee0bf0168f0b34064f0f100b0f.png",
-        "https://scitools.github.io/test-iris-imagehash/images/d757a5827929ad8079e9a9b016caa97d07ca865f0baa065f0ba80e7f0f805b7d.png",
+        "https://scitools.github.io/test-iris-imagehash/images/55a9bcf0a15fadf00b4fa9565ee8a15f5fe816ee0bf0168f0b34064f0f100b0f.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/d757a5827929ad8079e9a9b016caa97d07ca865f0baa065f0ba80e7f0f805b7d.png", 
         "https://scitools.github.io/test-iris-imagehash/images/d757a58279a9ad8279e9a9b016caa97c07ca865e0baa065f0ba80e7f0f805b7d.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/d75ff5c279e1ad8069e1ad8069e1ad5603aa865f078ec07f069e165e068e1e1f.png",
+        "https://scitools.github.io/test-iris-imagehash/images/d75ff5c279e1ad8069e1ad8069e1ad5603aa865f078ec07f069e165e068e1e1f.png", 
         "https://scitools.github.io/test-iris-imagehash/images/d75fb4d269e1a9a079e1e9f0162a965e07aa965e03a1865f0b82eb750f806b75.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_x.0": [
         "https://scitools.github.io/test-iris-imagehash/images/751dad905ae1b3061ca6499b37e9b5b64b3c256f0b9e1ee40f904668831f1e67.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f157e998f2e093130ceb8996736864f989905e6f231e866f0b9e066e0b9e5e68.png",
-        "https://scitools.github.io/test-iris-imagehash/images/f177e9d0f2e093930ceb8994736864f989905e6f231f862f0b1e066e0b9e5e68.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f157e998f2e093130ceb8996736864f989905e6f231e866f0b9e066e0b9e5e68.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/f177e9d0f2e093930ceb8994736864f989905e6f231f862f0b1e066e0b9e5e68.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f557e990f2e093130eeb8994736864f98990566f231f866f039e066f0b9e5e68.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a106fca956e982a978b9c1835fb1f40ba55a0f4bfa2c5aa70f46e3b41686b4.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.1": [
         "https://scitools.github.io/test-iris-imagehash/images/175a963369b54987c99369cca1497938c38159b3679ba6737666d60c1c76a68d.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f13f63eae6c0e9023d60b9590bd0b1b50bfc4a8f81bb2c5e215e46ff81174636.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f13f63eae6c0e9023d60b9590bd0b1b50bfc4a8f81bb2c5e215e46ff81174636.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f13f63eaeec0e9023d60b9590bd0b1b50bbc4a8f81bb0e5e215e46ff81174636.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.3": [
         "https://scitools.github.io/test-iris-imagehash/images/576a92232c3549a79b936cd8a9cd391cc3c15a7a639b6673cb32c60c9935a7a5.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6b44b0b49a9c303e38b3cd8634bbc3496b607a73c5cc3c95b6f4ba04323.png",
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9c303e38b3cd8634bbc34963607a73c5cc3c9db6f4ba04303.png",
+        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6b44b0b49a9c303e38b3cd8634bbc3496b607a73c5cc3c95b6f4ba04323.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9c303e38b3cd8634bbc34963607a73c5cc3c9db6f4ba04303.png", 
         "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f4490b49a9c30be38b3cd8634bbc3496360fa73c5c43cd9b6f4b804323.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/9716b631696949e2e9e179dc6149791a96b696331696a6c99e4686cc9cb139b3.png",
+        "https://scitools.github.io/test-iris-imagehash/images/9716b631696949e2e9e179dc6149791a96b696331696a6c99e4686cc9cb139b3.png", 
         "https://scitools.github.io/test-iris-imagehash/images/9786a6f1697849627978389e66cf361b86a686310e8766cdd969198e79787913.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/fd01fc0003fa23fd037e83ba03fa1bdd033e9336cc5c4c88dc0bb44b3eb77c03.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.1": [
         "https://scitools.github.io/test-iris-imagehash/images/57a9a956a94696c9295856b4a976766b215a76a6237de36d52a929167685a91e.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f117f4203e8031c13d803d5a0ff88b3d8b5a4c3e211e06bfa35e967d0d7d16bd.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f117f4203e8031c13d803d5a0ff88b3d8b5a4c3e211e06bfa35e967d0d7d16bd.png", 
         "https://scitools.github.io/test-iris-imagehash/images/f117f4203e8031c13d803d5a0ff88b3d8b5a4cbf211e06bfa34e967d0d7d16b9.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.3": [
         "https://scitools.github.io/test-iris-imagehash/images/7317a95c5ea8a1961eea69690bbce6342359765a21b4bc34036dd68b43579c8f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/77a9fca08957fce08952a95f7ee08b5f16a856a80b3e56bc0b1c037f0f000b5f.png",
+        "https://scitools.github.io/test-iris-imagehash/images/77a9fca08957fce08952a95f7ee08b5f16a856a80b3e56bc0b1c037f0f000b5f.png", 
         "https://scitools.github.io/test-iris-imagehash/images/75a9fca08957fce08952a95f7ee08b5f16a856a80b3e56be0b16037f0f000b5f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175ee9bc69a596ca69e196c269a1a552078ae857078af85d068adc5d968e5e5d.png",
+        "https://scitools.github.io/test-iris-imagehash/images/175ee9bc69a596ca69e196c269a1a552078ae857078af85d068adc5d968e5e5d.png", 
         "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a596ca69e196c269a1a552178ae957078af85d068adc5d968e5e5d.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.0": [
         "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.1": [
         "https://scitools.github.io/test-iris-imagehash/images/97a55c9a6978a3653496581ade6946870387a77c7970d9e17c835a8e863d26f4.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.0": [
         "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.1": [
         "https://scitools.github.io/test-iris-imagehash/images/97a55c9a6978a3653496581ade6946870387a77c7970d9e17c835a8e863d26f4.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_default.0": [
         "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f812971a17e928e097ee574a95f664da97472b5b642d94a5ee3a5147619186c.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.1": [
         "https://scitools.github.io/test-iris-imagehash/images/57a86929a156d60a69f5a55c6c29b88527afc396b358676bd9563801465a4f6f.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestPlotOtherCoordSystems.test_plot_tmerc.0": [
         "https://scitools.github.io/test-iris-imagehash/images/67cc99b399b3264d9999cc9aa66cd96464929331d99c666399b1cc98336bc9cc.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ffad6bfe2ba76944889b6325c25beeab1c3971cb629bc40b889b163b005b12.png",
-        "https://scitools.github.io/test-iris-imagehash/images/41ffad6bfebba76944889b6325825beeab1c3931cb629be40b889b163b005b12.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c1ffad6bfe2ba76944889b6325c25beeab1c3971cb629bc40b889b163b005b12.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/41ffad6bfebba76944889b6325825beeab1c3931cb629be40b889b163b005b12.png", 
         "https://scitools.github.io/test-iris-imagehash/images/415fbd61feaba74144809b6325ca59eea9bc31fdc1f299e70b8a99363b005b12.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t_dates.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c5ffab75fe8af76d04c01eeb2b1034e8eb1490606ba79146db8c1b005b36bb64.png",
-        "https://scitools.github.io/test-iris-imagehash/images/c5ff2b75feaaf77d04801eeb2b1034e8eb1490606ba79146fb8c19005b36bb64.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c5ffab75fe8af76d04c01eeb2b1034e8eb1490606ba79146db8c1b005b36bb64.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/c5ff2b75feaaf77d04801eeb2b1034e8eb1490606ba79146fb8c19005b36bb64.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c5ff2b41fe8af72904001eeb231034eaeb9c907a6bb79146dbae19105b36bb64.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ffad907e21a35246e8991b06b899664bc8b3e6039c1b6e0b1e1b661b961bef.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c1ffad907e21a35246e8991b06b899664bc8b3e6039c1b6e0b1e1b661b961bef.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c1ffbd907e21a35246e8991b06b899664bca33e4039c1b6e0b1e1b661b961bef.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1a360b805b96917e1a1c.png",
-        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1b360b805b16917e1a15.png",
+        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1a360b805b96917e1a1c.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1b360b805b16917e1a15.png", 
         "https://scitools.github.io/test-iris-imagehash/images/e5f76d6cfe00b1e9ccf193ce27ac1b760f0c13760b0e1b360b0c1bb6910f1b34.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_z.0": [
         "https://scitools.github.io/test-iris-imagehash/images/c1ff833b7e000d3b66e8b9a98fe4f3932b929a5d21661a1789e05a7c99825af4.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestSimple.test_bounds.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa9463fe303add0addcf901a14e5ea85ea9036f5ea1077ed007019607bef905.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestSimple.test_points.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa146ed436ebc90a956a95aa15ab8112b7aa35efc81037e5687d68403ff5e81.png"
-    ],
+    ], 
     "iris.tests.test_plot.TestSymbols.test_cloud_cover.0": [
         "https://scitools.github.io/test-iris-imagehash/images/975acc3069a5334f965acc3069a5334f965acc3069ad33cf9652cc3069ad33cf.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_alignment.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa9acf0a9544b0f836f5683a35a522fa70aa5d47ca0097a788279f6c97edc84.png",
+        "https://scitools.github.io/test-iris-imagehash/images/5fa9acf0a9544b0f836f5683a35a522fa70aa5d47ca0097a788279f6c97edc84.png", 
         "https://scitools.github.io/test-iris-imagehash/images/5fa9acf0a954cb0f836f5681a75a522fa70aa5d47ca0097a788279f6c97ed884.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c5bfa9565e80a5774cf893666689d97683fa3ba5c906b0a4611e5aa4b95f5a80.png",
+        "https://scitools.github.io/test-iris-imagehash/images/c5bfa9565e80a5774cf893666689d97683fa3ba5c906b0a4611e5aa4b95f5a80.png", 
         "https://scitools.github.io/test-iris-imagehash/images/c5bfa9565e80a5774ce893676689997683fa3ba5c916b0a4611e5aa4b95f5a80.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5f85d483a9722ffc03fdf940a1527227a112835e5aad837e5eb01eae857e5c81.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.0": [
         "https://scitools.github.io/test-iris-imagehash/images/7f81f411a95ea95aa15e49ea83fe5ea503bc03fd5aa1037efe02b402a55efc80.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5f85d483a9722ffc03fdf940a1527227a112835e5aad837e5eb01eae857e5c81.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.2": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa1f481a95aa34c03fd7991a37e5b67c9ea87fc7205035afca18625c95a7c80.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf_nameless.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa57483a95aa36c03fd7990a37e5b67c9ea87fc7201035bf4818621c95bfc80.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c559f273875976d926d30699a4b3a4.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_map.1": [
         "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c55972738f5976d926d30699a4b3a4.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolor.0": [
         "https://scitools.github.io/test-iris-imagehash/images/dd42bc7229a5639d835a5bb583df566239b1275c7ce00972fa80d6ea19727885.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolormesh.0": [
         "https://scitools.github.io/test-iris-imagehash/images/ddc2bc722925639d835a5bb583df566239b1275c7ce00972fa80d6ea19727885.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_non_cube_coordinate.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5f8156a1a15ea95a877ea97ea37e5e81a1fa837e5c81a37e58815ca1a35e58a0.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa156a9875aad58a97c29a1a15ef802a94aa17ef883037e5abd52ac07fe52a5.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.1": [
         "https://scitools.github.io/test-iris-imagehash/images/5fa146ed436ebc90a956a95aa15ab8112b7aa35efc81037e5687d68403ff5e81.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/51ffe1d1fe00a90c46e8a9860fe1a95c8be6995e011e52fe83a71bb6991e12fa.png",
+        "https://scitools.github.io/test-iris-imagehash/images/51ffe1d1fe00a90c46e8a9860fe1a95c8be6995e011e52fe83a71bb6991e12fa.png", 
         "https://scitools.github.io/test-iris-imagehash/images/51ffe1d1fe01a91c06e8a9860fe1a95c8be6995e011e52fe83a71bb6991e12da.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/41ffb16dfe29a9746ea8b9d60db8b346099a934683df9b8303465b2e1b04532e.png",
-        "https://scitools.github.io/test-iris-imagehash/images/417db16dfea9a9746eb8b9d60db8b346019a934683df9b87034e5b260b06532e.png",
+        "https://scitools.github.io/test-iris-imagehash/images/41ffb16dfe29a9746ea8b9d60db8b346099a934683df9b8303465b2e1b04532e.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/417db16dfea9a9746eb8b9d60db8b346019a934683df9b87034e5b260b06532e.png", 
         "https://scitools.github.io/test-iris-imagehash/images/417fb16dfea9a9746ea8b9d60db8b346099a934683df9b87034e5b260b04532e.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/55e9edf0af0fe9f0044da95656e8a95e1fa05b8e0bf65aae0b341b0e1b001b4f.png",
+        "https://scitools.github.io/test-iris-imagehash/images/55e9edf0af0fe9f0044da95656e8a95e1fa05b8e0bf65aae0b341b0e1b001b4f.png", 
         "https://scitools.github.io/test-iris-imagehash/images/875fa5927b29e99060e9e9b806caf97c8f8e135e03ae125e0ba41b7e1b805b7c.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175fb5e2ef21bda069a1b9c069f9994603ba9376078e917f160e1346168e1e1f.png",
+        "https://scitools.github.io/test-iris-imagehash/images/175fb5e2ef21bda069a1b9c069f9994603ba9376078e917f160e1346168e1e1f.png", 
         "https://scitools.github.io/test-iris-imagehash/images/155fb4e2e9a1a9a16da9b9e006fa9176078a965e0b869b5f0b8659751b807b75.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/65ffad907e21b34744a2198b26f9b1364b1c316e0b9e19e60b905b6e931f1b66.png",
+        "https://scitools.github.io/test-iris-imagehash/images/65ffad907e21b34744a2198b26f9b1364b1c316e0b9e19e60b905b6e931f1b66.png", 
         "https://scitools.github.io/test-iris-imagehash/images/65fdad90fe21b34744a2998b26f9b1364b1c316e0b9e19e60b905b6e831f1b66.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e5ffe9d1fe0093130ceb998466e87969a9901b66231e9b260b9e136e1b965b64.png",
+        "https://scitools.github.io/test-iris-imagehash/images/e5ffe9d1fe0093130ceb998466e87969a9901b66231e9b260b9e136e1b965b64.png", 
         "https://scitools.github.io/test-iris-imagehash/images/e5ffe9c1fe0093130ceb998466f87969a990196e231e9b26039e136e1b9e5b64.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/57a156f98f76ed02a95279a0a15a98c503df837c78a503be5a0bd31a277a3cac.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.1": [
         "https://scitools.github.io/test-iris-imagehash/images/a7a5a66d79585942897e589883de5c86799a23de5ca4a37cdc210ca7a35e7ca1.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f5ff676bee00a9616ce8b949079899b40b9c5baf81be195e015e1227991652b6.png",
+        "https://scitools.github.io/test-iris-imagehash/images/f5ff676bee00a9616ce8b949079899b40b9c5baf81be195e015e1227991652b6.png", 
         "https://scitools.github.io/test-iris-imagehash/images/75ff676bee01a9616ce8b949079891b48b9c5baf81ba195e015e1267991652b6.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.3": [
         "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c559f273875976d926d30699a4b3a4.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9438bc3cb3cd8436bbe34963607a63c5c438d9b6e5ba04323.png",
+        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9438bc3cb3cd8436bbe34963607a63c5c438d9b6e5ba04323.png", 
         "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9438bc3cb3cd8434bbe34963607a73c5c4b8d9b6e5b804323.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/9716a671696949e3e9e179dc6149791a96b692b3169693c59e4693c499b039b6.png",
+        "https://scitools.github.io/test-iris-imagehash/images/9716a671696949e3e9e179dc6149791a96b692b3169693c59e4693c499b039b6.png", 
         "https://scitools.github.io/test-iris-imagehash/images/9787a6716978496a79793c9e66cb361a86a696310e8773ced96c198679781932.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/fd81fc01836a03ba037f43b983fe58b60bfa03ff5885a37edc24dc04ec5a7881.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.1": [
         "https://scitools.github.io/test-iris-imagehash/images/57a946b9a956990696c979d903fe5eb5a136237e7a81a15e78a452ac837dd881.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1b7f461fe00b14104e8194a0ff89b7d8b1e5936213e13ee2356934e197e13bf.png",
-        "https://scitools.github.io/test-iris-imagehash/images/e1b7f460fe00b14104e8194a0ff89b7d8b1e5936213e13ee2316936f197e13bf.png",
+        "https://scitools.github.io/test-iris-imagehash/images/e1b7f461fe00b14104e8194a0ff89b7d8b1e5936213e13ee2356934e197e13bf.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/e1b7f460fe00b14104e8194a0ff89b7d8b1e5936213e13ee2316936f197e13bf.png", 
         "https://scitools.github.io/test-iris-imagehash/images/e1b7f460fe00b14104e8394a0ff89b7d8b1e5936213e13eea306936e197e13bf.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/459fad5d6e00a59646fb79690fb893642319336221feb9360b24d28f59d6988f.png",
+        "https://scitools.github.io/test-iris-imagehash/images/459fad5d6e00a59646fb79690fb893642319336221feb9360b24d28f59d6988f.png", 
         "https://scitools.github.io/test-iris-imagehash/images/459fad5d6e00a19646fb79690fb8b3642319336221feb9360b24d28f59d698ae.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/75a9fce1ab17b46101f8897776a8897f7e881e6e03be16ee0b161b1e1b000b5e.png",
+        "https://scitools.github.io/test-iris-imagehash/images/75a9fce1ab17b46101f8897776a8897f7e881e6e03be16ee0b161b1e1b000b5e.png", 
         "https://scitools.github.io/test-iris-imagehash/images/75a9fce1ab17b4e101d8897776a8997f7e881e2e03be16ee0b161b1e1b000b5e.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a196c269f9966269a1b172078ab97607fed9561e86d9549e8e5854.png",
+        "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a196c269f9966269a1b172078ab97607fed9561e86d9549e8e5854.png", 
         "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a196c269f9966269a1b152078ab97607fe99561e8ed9549e8e585c.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_not_reference_time_units.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/415f85e9fefb91e94600bb6f07009be7effa1966ab065b273b009b663b007a04.png",
-        "https://scitools.github.io/test-iris-imagehash/images/411d85e9fefb91e14600bb6707009be7effe1966ab06fb273b009b663f007a04.png",
-        "https://scitools.github.io/test-iris-imagehash/images/411f85e9fefb91e14600bb6f07009be7effe1966ab067b273b009b663b007a04.png",
+        "https://scitools.github.io/test-iris-imagehash/images/415f85e9fefb91e94600bb6f07009be7effa1966ab065b273b009b663b007a04.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/411d85e9fefb91e14600bb6707009be7effe1966ab06fb273b009b663f007a04.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/411f85e9fefb91e14600bb6f07009be7effe1966ab067b273b009b663b007a04.png", 
         "https://scitools.github.io/test-iris-imagehash/images/411f85e9fefb91e14600bb6707009be7effe1966ab06fb273b00bb263b007a04.png"
-    ],
+    ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_reference_time_units.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/417f8119feebeeff070054bb2b0014a0bb157ba6bb972b46dabf3b0419827b04.png",
-        "https://scitools.github.io/test-iris-imagehash/images/417f8119fefbeeff070054b92b0014a0bb557ba69b95ab46dabf3b0419827b04.png",
+        "https://scitools.github.io/test-iris-imagehash/images/417f8119feebeeff070054bb2b0014a0bb157ba6bb972b46dabf3b0419827b04.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/417f8119fefbeeff070054b92b0014a0bb557ba69b95ab46dabf3b0419827b04.png", 
         "https://scitools.github.io/test-iris-imagehash/images/417f8119fefbeeff070054bb2b0014a0bb14fbe69b952b46dabf3b0419827b04.png"
     ]
 }

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -1,726 +1,726 @@
 {
     "example_tests.test_COP_1d_plot.TestCOP1DPlot.test_COP_1d_plot.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5dff1a996c06b47193eecc52275b936d58b6239ba94c133643897c6c2333f086.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/baff589936602d8ec977334ae4dac9b61a6dc4d99532c86cc2913e36c4cc0f61.png"
     ], 
     "example_tests.test_COP_maps.TestCOPMaps.test_cop_maps.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57891cdba966a124897c568316997ea1a97e897ee1c6699d5681ad733c9296ac.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9138db95668524913e6ac168997e85957e917e876396b96a81b5ce3c496935.png"
     ], 
     "example_tests.test_SOI_filtering.TestSOIFiltering.test_soi_filtering.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f23069d83de1e4e7ca0a595a9725b0f46cce499a97239a563dc594a4b725aa9.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5f21069d83de1e4e7ca0a595a9725b0f46ccec99a97239a563dc594a4b7252b9.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac460b9c17b78723e05a5a9954edaf062332799954e9ca5c63b9a52d24e5a95.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8460b9c17b78723e05a5a9954edaf062333799954e9ca5c63b9a52d24e4a9d.png"
     ], 
     "example_tests.test_TEC.TestTEC.test_TEC.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/87a5866dd958594221765992e39a763c733609de5cc1837ed8419ccd27cfdc23.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/87a5866dd95879c221765992e39a7634733609de5cc18376d8498ccd27cfdc31.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9a42846e9a49c7596e3cce6c907b3a83c17e1b8239b3e4f33bc4.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9e43846e9a49c7596e2cce6c907b3a83c16e1b9231b3e4f33b8c.png"
     ], 
     "example_tests.test_anomaly_log_colouring.TestAnomalyLogColouring.test_anomaly_log_colouring.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/37222687a1c5f9c9c978d9788996b69492bb67677c64255e5acb89c9b1595a30.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png"
     ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f33ba103f0bf0db38c93f4d38.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f94106cad64b71c804ce29ecad2fec0da5b8662f333e902f0bf0db38c93f4d38.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f95106cad64b71c804ce29ecad2fec0da5bc662f333a102f0bf0db38c93f4d38.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc7c09f4d00fdb1c93fcb21c.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8a60536bd28e1320739437b5f437b0a53d66f4cc5c08f4d00fdb1c93fcb21c.png"
     ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/6557a57e7681bb9f998cd8c5cdee7a0421ba1a918399e6dc724425e67a318538.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6eaa57e6e81ddf999311ba3b3775e20845d5889c199673b4e22a4675e8ca11c.png"
     ], 
     "example_tests.test_coriolis_plot.TestCoriolisPlot.test_coriolis_plot.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e761a67b5996699aa77a99a611969e699661a3677c1983795ca4669e87195824.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e78665de9a699659e55e9965886979966986c5e63e98c19e3a256679e1981a24.png"
     ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a98cdea946278b26f95aa0a17632255b4a297e72a58ffcd892b9428fdcd882.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95317b9562e4d1649f5a05856e4ca4da52947e4ea5f13f1b499d42f13b1b41.png"
     ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a984dfa9569c02964978c90ffe52b5a136237e72a9a15e78a55bac895dd881.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9521fb956a394069921e93f07f4aad856cc47e4e95857a1ea5da3591ba1b81.png"
     ], 
     "example_tests.test_custom_aggregation.TestCustomAggregation.test_custom_aggregation.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f817681897e097e2d7ce1fca1e65e83090f0e3c56a981f858c33c87a55ef618.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe816e81917e907eb43e873f85677ac190f0703c6a95811f1ac33ce1a57a6f18.png"
     ], 
     "example_tests.test_custom_file_loading.TestCustomFileLoading.test_custom_file_loading.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f05d38f217a2c7d89ece182763b133ddc13f8d9c6cc644625b70cb3834db384.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/df05d38f217a2c7d89e4e182763b133ddc11f8d946cce446a5b54cb3834db384.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa0cbf1845e34be913787416edcc8bc3bc81f9b63332662a4ed30cdc1b2cd21.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fba0cbf1845e34be912787416edcc8bc3b881f9b62332762a5ad32cdc1b2cd21.png"
     ], 
     "example_tests.test_deriving_phenomena.TestDerivingPhenomena.test_deriving_phenomena.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/9d999c6161964a679362629c236ed69b63968976de998366fc996e91096e7c81.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/9d899c7b61964a679362639c237ed68be1968b765e99816674816c990b6e7c91.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/b9993986866952e6c9464639c4766bd9c669916e7b99c1663f99768990763e81.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/b99139de866952e6c946c639c47e6bd18769d16e7a9981662e813699d0763e89.png"
     ], 
     "example_tests.test_global_map.TestGlobalMap.test_global_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f999e62a166a17e0f7e7c911e6ad689d3809e113c9129666195d6b9c16ef681.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9979468566857ef07e3e8978566b91cb0179883c89946686a96b9d83766f81.png"
     ], 
     "example_tests.test_hovmoller.TestGlobalMap.test_hovmoller.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5d2d0c2d73d273c2a37df391a3d258c6a3c2a3767826097edc2d962d097b5883.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bab430b4ce4bce43c5becf89c54b1a63c543c56e1e64907e3bb469b490de1ac1.png"
     ], 
     "example_tests.test_inset_plot.TestInsetPlot.test_inset_plot.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d7ff9649af0069a54da25b236faa29692d4912db93bad396a99489b4f324522a.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/97ff9649ad0069a54da25b236fa2296d2d4912db93bad396a994a9b4f324526a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebff6992f50096a5b245dac4f6559496b49248dbc95dcb699529912dcf244a54.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9ff6992b50096a5b245dac4f64594b6b49248dbc95dcb699529952dcf244a56.png"
     ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/dddd8c87237226270da2d9da8d8e765323262f69732c86718de0d99c8dc973a4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bbbb31e1c44e64e4b0459b5bb1716ecac464f496ce34618eb1079b39b193ce25.png"
     ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/d57f9f1abf6234995ce01b9e0662d2818b0069e1839ccbad2997f3e1631d69e1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abfef958fd462c993a07d87960464b81d1009687c139d3b594e9cf87c6b89687.png"
     ], 
     "example_tests.test_lineplot_with_legend.TestLineplotWithLegend.test_lineplot_with_legend.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5797424aa6021d9669f8b165291ab965a9c233598f8052dfc3bf9ad6217f98e5.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/57974228a6021d9669f8b167291ab965a9c233598f8052dfc3bf9ad6217f98e5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae942526540b869961f8da694589da69543cc9af1014afbc3fd596b84fe19a7.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae942146540b869961f8de694589da69543cc9af1014afbc3fd596b84fe19a7.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/df88ce582973257726cd7a898b4b0c72795ae39cde04877f48a124e167667362.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fb11731a94cea4ee64b35e91d1d2304e9e5ac7397b20e1fe12852487e666ce46.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/a765a665599a699aa7db18a643a6dc61996933677c9987595889649ce71878a6.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e5a665a69a599659e5db1865c2653b869996cce63e99e19a1a912639e7181e65.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/4f232673799cc94c87ed3287339ecc31a661a7cddc8ccd5e6693663203765826.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f2c464ce9e399332e1b74ce1cc79338c6586e5b33b31b37a66c9664cc06e1a64.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f815ec121762536a79c93cc897b4c3361f3e1c5fc85164e38db7c9176ecd220.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa817a83846ea46ce539c93391de32cc86cf87a33fa168721cdb3e896e374b04.png"
     ], 
     "example_tests.test_polar_stereo.TestPolarStereo.test_polar_stereo.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/87168c5e49cbb691a3dd7929a37af63059c9835a76a3216edc848ee6897b5c81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e168317a92d36d89c5bb9e94c55e6f0c9a93c15a6ec584763b21716791de3a81.png"
     ], 
     "example_tests.test_polynomial_fit.TestPolynomialFit.test_polynomial_fit.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d5ff52b94f26ac11a60493fe488262a9236db9c4c9d213563b6949ec6b3133f6.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/55ff52b94f26ac11a60493fe488262a9236db9c4c9d213563b6959e86b3933f6.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abff4a9df26435886520c97f12414695c4b69d23934bc86adc969237d68ccc6f.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aaff4a9df26435886520c97f12414695c4b69d23934bc86adc969a17d69ccc6f.png"
     ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1f298a1580c27336eb3d08d9e4c3ae563a60d931cd3d2728e7939ede4ad03.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa3f298a1580c27336eb3d08d9e4c3aed61a60d931cd3d2728e7939e9e4ad03.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa17298a1580c27336eb3d08d9e4c3aed63260d931cd3d273ce7939ecc5ad03.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa17298a1580c27336eb3d08d9e4c3aed61a68d931c93d273ce7939ece4ad03.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854f19851a30e4cc76cd0bb179325ca7c665b0c938cb4b4e719e9cb727b5c0.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac54f19851a30e4cc76cd0bb179325cb78665b0c938cb4b4e719e9c9727b5c0.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb7c664b0c938cb4bce739e9c37a3b5c0.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb78665b1c938c94bce739e9c3727b5c0.png"
     ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db2549976d9926c9b643982e8da149.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c694e4ec28cf1b1b55abe63da25499d6c9926d9b643da26c9a149.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c7a196b9391c69464ec28cf1b3b55abe63db25499d6c9926d9b6439a26c9a149.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c7a1d699391c694e4ec28cf1b1b55aae69da25499f6d9926db3263da2689a149.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c7a1d699391c694e4ec28cf1b1b55aae61da2549976d9926db3663da2e89a149.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492e9b69964936dc21974b18592.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896727243318f8dad5a7dc65ba492b93699649b6dc25b64938592.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492b93699649b6dc25964938592.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75965ba492f9b69964db4cc65b64918592.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75865ba492e9b69964db6cc65b74918592.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa8867ae985c9b5837a7881235f7c2db90c817e7ca0837edea599e4817e7880.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa15615e97a193adc15e1e81c4fa3eb49d30817e3e05c17e7ba59927817e1e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5da0e6e8c30799979df07181235b1a29996d696e7ca2a7d6dc919c9483de7e80.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba056717c3e099e9b90f8e81c4da589499b696763e45e56b3b893929c17b7e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/5d78067ae38589851d7a7981235b1a099969cd7e5ca687f6de819e9ca75e7880.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5d78067ae385c9851d7a7981235b1a099969cd6e5ca687f6de81969cb75e7880.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba1e605ec7a191a1b85e9e81c4da58909996b37e3a65e16f7b817939e57a1e01.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba1e605ec7a193a1b85e9e81c4da58909996b3763a65e16f7b816939ed7a1e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f814e0b217eb3d493c8c9396c21368e92cc9e39c333e1e4676e9c9f9c99561a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8172d0847ecd2bc913939c36846c714933799cc3cc8727e67639f939996a58.png"
     ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/3d9f24dfc960c9308734f3e9e34c6c4d717323b37c9421de18679c6783f25890.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cd3e29847b18e639e6c14f1a09.png"
     ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/3d9f24dfc960c9308734f3e9e34c6c4d717323337c9421de1c679c6783f25890.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cc3e29847b38e639e6c14f1a09.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f81a95e837e56a1817e56a1a17e29547c81a95e7e81895e5e819b7a837e3485.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe81957ac17e6a85817e6a85857e942a3e81957a7e81917a7a81d95ec17e2ca1.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d81837e837e7e81837e7c81a37ea55a7c01837e7c81837f5e8143a193fa34c0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be81c17ec17e7e81c17e3e81c57ea55a3e80c17e3e81c1fe7a81c285c95f2c03.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a15e81a95ea17ea97e837e817e568156a17c815ea17c817681b15c6154cb7f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea857a81957a857e957ec17e817e6a816a853e817a853e816e818d3a862ad3fe.png"
     ], 
     "iris.tests.test_analysis.TestProject.test_cartopy_projection.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/79984a9383a62d3f6651b9e28362b85e06df74a17c2d64bd46bf4439f92083b6.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9e1952c9c165b4fc668a9d47c1461d7a60fb2e853eb426bd62fd229c9f04c16d.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_contourf.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/175a963369b54987c99369cca1497938c38159b3679ba6737666d60c1c76a68d.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_pcolor.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/975a961369a549a7d99379cc2149696cc3b419b3679b26737e66c64c1c26a68d.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a69c896a592e59bc99e3384929636c32d98cde6d964ce7e666332386465b1.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_unmappable.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a51672ad52295e0b79ed8ca384e9b143df3803276936477634d6b45c769658.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eaa5684eb54a947ad09eb731c521978dc2fb1cc0e4966ce26e2c6b2d3a6e691a.png"
     ], 
     "iris.tests.test_mapping.TestBoundedCube.test_grid.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81897ea17e7681a17e5ea15e81895e5e81a17ea17e7e81a17e5e815e81a174.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e5e81a17e5e815e81817e5e81a17ea17e5e81a17e5e815e81a17e.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/fa81857e857e7a81857e7a817a81857a7a81857e857e7a85857e7a817a81857a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81917e857e6e81857e7a857a81917a7a81857e857e7e81857e7a817a81852e.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81817e7a81857e857e7a81857e7a817a81857e.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81857a7a81857e857e7a85857e7a817a81857a.png"
     ], 
     "iris.tests.test_mapping.TestBoundedCube.test_pcolormesh.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a7aca17e49537143bc848d3c877a5e8178a5237e585a83dea6b4dca0274f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81e535857e92ca8ec23d21b13ce15e7a811ea5c47e1a5ac17b652d3b05e4f2.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_grid.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/fd01478d83feb85023ef13eb9c65ec04e49296d9d6cd736c66270d1229b2b991.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/fd01478f83feb85023ea136b9865ec84ec9296d9d6cd726c66270d7229b2b991.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf80e2b1c17f1d0ac4f7c8d739a637202749699b6bb3ce3666e4b048944d9d89.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf80e2f1c17f1d0ac457c8d619a637213749699b6bb34e3666e4b04e944d9d89.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_outline.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7c01a17e5e815e815e815e8181fe5e81a17ea17ea17ea17e5e81.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7e84a17e5e815e815ea15e81a15e5e81a15ea17ea15ea17e5e21.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e3e80857e7a817a817a817a81817f7a81857e857e857e857e7a81.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7e21857e7a817a817a857a81857a7a81857a857e857a857e7a84.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_pcolormesh.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/fd81678d837eb81221fd13fb9c25ec04ec9296db96cd726423270d5309f2b991.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf81e6b1c17e1d4884bfc8df39a43720374969db69b34e26c4e4b0ca904f9d89.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_scatter.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a0bc748956439b231b292cd624cfe25ef316b59c4c791b6369876c83d5598e.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/57a0bc748956439b231ba92cd624cee25ef316b59c4c791b6379876483d5598e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d894346b24f3477acf68ad39329ed8c696e136c1ab9a71.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d895346b2473477acf68ad39329ed8c69ee126c1ab9a71.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d84e5d8837b1a275c8ce1f87ea1260e835fd931de8126ce2166da798b9d1983.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5781188ca9fec773653136079b4fd9d9568126c6a97c863389fe58c75603b91c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea811831957fe3cea68c6ce0d9f29b9b6a816463953e61cc917f1ae36ac09d38.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/778139ed89dcc613217626cede8d993976a364cca95c961389f636c676498938.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee819cb7913b63c8846e64737bb1999c6ec52633953a69c8916f6c636e92911c.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d84e5d8837b1a275c8ce1f87ea1260e835fd931de8126ce2166da798b9d1983.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/5781188ca95ec7736531360793cfd9d9568126cea97cc63389fe58c75603b91c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea811831957ae3cea68c6ce0c9f39b9b6a816473953e63cc917f1ae36ac09d38.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_simple.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5707294ca9a8d2332172368cf20dc973dee323cd250cde2389f6fc8c764b2d73.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae0943295154bcc844e6c314fb093ce7bc7c4b3a4307bc4916f3f316ed2b4ce.png"
     ], 
     "iris.tests.test_mapping.TestMappingSubRegion.test_simple.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/bd897c800b7e077e4976e1e1f681698307cb96e69c3cf81878343c1d0d9f06eb.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bd913e01d07ee07e926e87876f8196c1e0d36967393c1f181e2c3cb8b0f960d7.png"
     ], 
     "iris.tests.test_mapping.TestUnmappable.test_simple.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f81b156837e5aa9b15e8dd4b9e66ea8197666b6234fb0574e819b11cc11d944.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe818d6ac17e5a958d7ab12b9d677615986e666dc4f20dea7281d98833889b22.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f43ff3e00a5b69740dc4a2728bca58bb67e538bedf6042993c64939268e13.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2ff7c00a56de9023b52e4143da5d16d7ecad1b76f2094c963929c6471c8.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1ffa9ee5680876f1e80336c2fe0da81a3c26e1683683e114be6b69c6b61de16.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff95776a01e1f67801cc36f4075b81c5437668c1167c88d2676d39d6867b68.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/df0746bc93e1b9892d78d222d9a69ee7e11925d91e4e4b26d23189d99c0c7636.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f11fe960d6820f6e1fb873f80de05b9ea360cc972360641d8b60b69f6b609e96.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ff897066b41f076f81dce1fb007da79c50633e9c40626b8d1066df9d6067969.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f15f832a5ee0492a36e8b9ed8fa4f2b629dace4921681e17a9807e7c89835ef0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f83ff7e0019ae8ec0e538270ab6c38b78de044be27e0329a1be1da984fe56.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7e0098757103a71ce4506dc3d11e7b20d2477ec094857db895217f6a.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f11f43eb5c902de53690b9648fd2705a0b6bc20d2be4c697abc81e1fa9613e9c.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f11703e85c982d60b69a9962cffa70ab0bede2942bc0961ba96c1e17e9e11e9e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ff8c2d73a09b4a76c099d26f14b0e5ad0d643b0d42763e9d51378f895867c39.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe8c0173a19b4066d599946f35f0ed5d0b74729d40369d8953678e897877879.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f43ee7e20a4f61640cc4a6f6bb8a583907b138bd9f31039939b5939a19b99.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c17f43ee7e60a4f61640cc4a6f6bb8a503907b538bd9f31039939b5939a19b91.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2777e04256f68023352f6d61da5c109dec8d19bcf089cc9d99a9c85d999.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2777e06256f68023352f6d61da5c009decad19bcf089cc9d99a9c85d989.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17fb9ebfe0087eb0c0033b8efe0db8121427e1f8b6c3e114b66be9c0b61d616.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c17fb9e9fe8287eb0c0033b8efe09b8121427e1f8b6c3e114b66be9c0b61d616.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe9dd77f00e1d73000cc1df707db8184427ef8d1367c88d2667d39d0866b68.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe9d977f41e1d73000cc1df707d98184427ef8d1367c88d2667d39d0866b68.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/df0746bc93e1b9892d78d222d9a69ee7e11925d91e4e4b26d23189d99c0c7636.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1ffad61fe00062b0cf8b6f90de01b99a36099971366711e1be6b1967b609996.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ffb5867f0060d4301f6d9fb007d899c50699e9c8668e78d8678d69de069969.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ff833b7e000d3b66e8b9a98fe4f3932b929a5d21661a1789e05a7c99825af4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17f83fffe0919ee0440f9782f1ab3c28138db066be27b0629a1bb1d9984fa46.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c17f83fffe2919ee0400f9782f1ab3c28130db066be27b0629a1bb1d9984fb46.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7f90987720029f1ef458cd43811cdb60d647de609485ddb899215f62.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7f94987720009f1ef458cd43810cdb60d647de609485ddb89921df62.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ff13697e00196524f8b964c7d271422f4bd02d29e49a9729f81e1feb615e9c.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c19f13697e00b96524fa996247fa796b0f29f0942fe0921ba16c1e17eba11e9e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc8967e0098a6241f9d26e34b8e42f4d20bb4942759e9941f78f8d7867a39.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83f9c8967e009da6245f9946e25f9ed6f0940f29f40749d8853678e8d7857879.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed47129839e3896c469b52a385.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c55f83293e991872466639e56fda93561db8e9ed43129c39e3896e461b52a385.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c55f832d3e991872466639e56fda93561db8e9ed47129839e3896c461b52b305.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d94ac5a1.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7c248399cc7917662d84ac5a1.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1b47c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d84acda0.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d053e99837a8d761989730ae3429c523cb7368dcc098f33ce43f9d8b470b366.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/75fef8e0cf07070f84d8796076e0b2c149761b1fb3ec495b8b69b20d1b70d990.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/75fef8e0cf07070f8cd8796076e0b2c149661b17b3ec595b8b69b20d1b70d990.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0211b9e066e074d83926ed8f8cd3792dad1964db0d80e9b09.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0311b9e066e074d839266d8e8cd379adad1964db0d80e9b09.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59e69d3246b8b7c56fc94933b324b6cd0918197923c1b697b7244949.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59669d3246b8b7c56fc94933b326b6cd0918197b23c1b697b3244949.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/a51f699b59e69d324638b7c56fcb4933b324b6cd0918197b23c1b697b3244949.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621deda3f69392cccd246db39018989ec4836de9ed249292.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a66b94c621deda3f69392cccd646db3901898dec4836de9cd249292.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621ceda3f6d392cccd246db3901898dec4836de9cd249292.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/25df98cddb2063b3c6e09d611e0638ce319ceb38cf6186611b867696bd98d879.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a4fb19b3db04c6cd6307b98678601c738c39d71cf3866186d8616e69bd191b9e.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/dd5fc3b919991c52f66629e56dc8d31239a9eded43529c39a3894c461b52b305.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bbfac39d9899384a6f6694a7b613cb489c95b7b7c24a399cc5913262d84acda0.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d053e99837a8d761989730ae3429c523cb7368dcc098f33ce43f9d8b470b366.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f57ef8f08f87070f9b18697036e0b6d14b661b16a3ec6c5a0969b60d7b70d890.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/757ef8f08f87070f9b18697036e0b6c14b661b16a3ec6c5a0b69b60d7b72d890.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af7e1f0ff1e1e0f0d918960e6c076d8bd266d868c537365a90966db0de0e1b09.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7e1f0ff1e1e0f0d918960e6c076d83d266d868c537365ad0966db0de4e1b09.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_coord.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/b71f69eb59e69d32a638b7c44bc94933b326b6cc0998483f23c1b696b7244949.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/edf896d79a67b94c651ced23d29392cccd646d33901912fcc4836d69ed249292.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_cube.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/359f9ccc596863b2c7608c611ce63cce3198eb38cf6186611bc67696bd98d879.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/acf939339a16c64de306318638673c738c19d71cf3866186d8636e69bd191b9e.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_down.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e17f1f889e01e38306e0f1f83f20797e09a8595ea982597e89b0f3787398735c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87fef8117980c7c160078f1ffc049e7e90159a7a95419a7e910dcf1ece19ce3a.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_up.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1ffa12b1e00bdf966e09e0b61fc929329fe727889827b1ceb005b1473b859d4.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e1ffa12b5e003df966e09e1b61fc929309fe727889827b1ceb105b1473b859d0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff85d47800bd9f660779d0863f49c9947f4e1e9141de38d700da28ce1d9a2b.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff85d47a00bc9f660779d8863f49c9907f4e1e9141de38d708da28ce1d9a0b.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_down.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/df29d665218729df09d85ca0e126580bdc58e7e67226835ada99e3e6237e5c19.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fb946ba684e194fb901b3a0587641ad03b1ae7674e64c15a5b99c767c47e3a98.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_up.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/77e836fec907c905a3f0c9c1817a76a8169a877e76a8875ed90771b4a158d9c1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee176c7f93e093a0c50f9383815e6e156859e17e6e15e17a9be08e2d851a9b83.png"
     ], 
     "iris.tests.test_plot.TestContour.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f31fa5fa5ea8ad5a1ee8a1520be0a51703f23c1703f27c54230e564da9cd5e69.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/cff8a55f7a15b55a7817854ad007a5e8c04f3ce8c04f3e2ac4706ab295b37a96.png"
     ], 
     "iris.tests.test_plot.TestContour.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d13f817a1e80a1e93f80d9a62da48b84a97a7e5ba1d2be5601db7e2d81edd486.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfc815e78018597fc019b65b425d121955e7eda854b7d6a80db7eb481b72b61.png"
     ], 
     "iris.tests.test_plot.TestContour.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d17f81ff1e80a1ff1f00a95a2b407e00abe82b00a1fa7e00a1ff7e01a1ff56b7.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d17f81ff1e00a1ff1f00a1fa2b407e00abe82b00a1fa7e00a1ff7e01a1ff56b7.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe81ff780185fff800955ad4027e00d517d400855f7e0085ff7e8085ff6aed.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe81ff780085fff800855fd4027e00d517d400855f7e0085ff7e8085ff6aed.png"
     ], 
     "iris.tests.test_plot.TestContour.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f6ac3332c17898d9395386ca3850ec7e3d87c9ac9e521274923d97273e3c6c9.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa56c3cc34e891b1c9a91c36c5a170e3c71b3e5993a784e492c49b4ecec76393.png"
     ], 
     "iris.tests.test_plot.TestContour.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d17fa1fe5e80a5565fa0a1520ba8bd000ba8ab5009ea7e01a1fe7e05a1fe5efd.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe857f7a01a56afa05854ad015bd00d015d50a90577e80857f7ea0857f7abf.png"
     ], 
     "iris.tests.test_plot.TestContour.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d1ff81ff5e80a93f1f80a91e2b407e00ab0a2b40a13e7e80a17f5ec1a17f56f5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bff81ff7a0195fcf8019578d4027e00d550d402857c7e0185fe7a8385fe6aaf.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa546b7166ab94aa15ebd48a95cf148a9f82607cbf05c9356b256967607564c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa562ed68569d52857abd12953a8f12951f64e0d30f3ac96a4d6a696ee06a32.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a507fca95ef201a952798287763906e9f0ad4d525bc67276c996b4d2a5461b.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eaa5e03f957a4f80954a9e41e16e9c60970fb5b24ada634e6e93692d4ba562d8.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea9525e81a17ea97ea17e3f00a17e7e005ea103547ea1f9145ea1837f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e954a7a81857e957e857efc00857e7e007a85c02a7e859f287a85c1fe.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/975a961c6dad6989c90958f283a729e5639999d373ccc6199e4a764ecc70a627.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a6938b6b5969193901a4fc1e594a7c69999cbce33639879526e72330e65e4.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1a17e235a5e81a17ea152a17ea756897ea3565ca1a3565ca123575e81487f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa85857ec45a7a81857e854a857ee56a917ec56a3a85c56a3a85c4ea7a8112fe.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81817e23505e81a17ea97ea17e2f50a17e6fd05e812350de8167f05e8152ff.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81817ec40a7a81857e957e857ef40a857ef60b7a81c40a7b81e60f7a814aff.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57ad8cfca952de4906cfe991a337320b210b23275a85a37f5c209ede8ddcdc60.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/7da1fc01a152837e03bd43af835eb09033f803fe5aad877ffc02b95e1c2e7c00.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be853f80854ac17ec0bdc2f5c17a0d09cc1fc07f5ab5e1fe3f409d7a38743e00.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/57ad8cfca952de4906cfe991a337320b210b23275a85a37f5c209ede8ddcdc60.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fe894f8a917a917267a5ea9835e7637272d87ccdc80037ed88d9c9089d27983.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fe894f8a917a917267a5e89835e7627262f87ccdc80837ed88d9cb089d27983.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a95c17a6eece4b4e1333b01c07e1bb13909914b9ec1.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a91c17a6ee464f4e1333b01c17e1bb1390d914b9ec1.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/dde08cf22307632dc3787987219e9c858368837ade29a77e78959cb8877658c3.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/dde08cf26387632dc378798721969c858368837ade28877e78959cbc877658c3.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb07314fc4e0c6b4c31e9ee1847939a1c116c15e7b94e57e1ea9391de16e1ac3.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb07314fc6e1c6b4c31e9ee1846939a1c116c15e7b14e17e1ea9393de16e1ac3.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a9dcdfa956232f26f958a0a37636255aca297a76a583fcd892a14283fcd882.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d81fc03835a83bc83fd43be837eb8c9a3f823fc7885835e7c831c278d4e5881.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be813fc0c15ac13dc1bfc27dc17e1d93c51fc43f1ea1c17a3ec138e4b1721a81.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a986f7a956de4906d949b483767663215a237e5aa5a37e7a031286a9ded881.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9561ef956a7b92609b922dc16e6ec6845ac47e5aa5c57e5ec04861957b1b81.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a9dcdfa956232f26f958a0a37636255aca297a76a583fcd892a14283fcd882.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/5daf2c7ef350c38f836ff1c1a1d0f8c13388033f5e0b835ed8871c270d7e58b0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/baf5347ecf0ac3f1c1f68f83850b1f83cc11c0fc7ad0c17a1be138e4b07e1a0d.png"
     ], 
     "iris.tests.test_plot.TestMissingCS.test_missing_cs.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f837607a9dc89d8837a6912a7762367897dde335e8121ce7c855609837ec9b0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac16ee0953b911bc15e9648e56ec4e691be7bcc7a8184733ea16a90c17e930d.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f8156a983fead78a97c29a1a15ef802a94aa156f881837e5a9d72a803ff5aa1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe816a95c17fb51e953e9485857a1f409552856a1f81c17e5ab94e15c0ff5a85.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/7d70965ac30f69ad29fc4b85a13f78a109a7297778a0835ef202bcf0877fd242.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be0e695ac3f096b5943fd2a185fc1e8590e594ee1e05c17a4f403d0fe1fe4b42.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1466d03eebc90a956a95aa15eb811217aa37efc81037e52a7d6840bff5aa1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b6c0773d09956a955a857a1d88845ec57e3f81c07e4ae56b21d0ff5a85.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa9462be323bcd0addee907a15efc98a94b216e5ca0835edea156b4032f5a21.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9562d4c7c43d0bb57b97e0857a3f1995d284763a05c17a7b856a2dc0f45a84.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1466d036ebc90ad52a95aa15efc11217aa35e7ca1037e5686d6a40bff5e81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b6c0763d09b54a955a857a3f88845ec57a3e85c07e6a616b25d0ff7a81.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1466f03eebc90ad52a95aa15efc81a95a237e7ca1837e5e8556a4036e5a85.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562f6c0773d09b54a955a857a3f81955ac47e3e85c17e7aa16a25c0765aa1.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/177ae693e3879c78e9a5690d5c6c69853cf2c660c618967aa393967a369263a5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4f63066318695ec5c9695e6c49c6a5.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d51c1fe3c456aa5e2a341e16abd2a01e8ee9572d1ee954.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eab478972a.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/172ee9d1e9d116aee9d116aee9d11e2aa9d01e0a16aa1e2e162e7e4516aee955.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/977a9696298d69edc98d5978c38389a363a769987872964c96cc366c9c58765c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95e696994b196b793b19a1ec3c191c5c6e596191e4e693269336c36391a6e3a.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/177ae185e985965ae985965ae985be5ae9859e601e5a1e68165a7e61165a6be1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a1695a97a17d5a97a17906785a7816685a7e86685ad687.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00bc4afe00f4427e15f4426b15.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bb5d44a0bbdfe400bbdfe00b44afe00f44a7eb0f44a2bb5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f003d527f002f427ea82f42d6a8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527e0d2f52d4ad.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8318f5ef829478398c97129c6e631.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1f94e2c119938e9463678c.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/b57a29a5c30dc30f69a5965a69a53cf08ed83cf0bed8e92d96c2c3073382d65a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a5695a96a53c0f711b3c0f7d1b97b46943c3e0cc416b5a.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/957a3cf8690569a56ba5d702c30fd7078303c30f3ed07c7c69853c78b6da9652.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/957a1cf8690569a56ba5d702c30fd70f8307c30f3e507c7c69853c78b6da9652.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a5eb40c3f0ebe0c1c0c3f07c0b3e3e96a13c1e6d5b694a.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e381f96a096a5d6a5eb40c3f0ebf0c1e0c3f07c0a3e3e96a13c1e6d5b694a.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/3d5e384ccbc366b3a3a1c39961b3e379e349c76569b01a929c9e3c2c1c2e1cce.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc585c39986cdc79ec792e3a6960d584939793c3438743873.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57f81ef8a907a117a107a942a987a957a905a1175ea87cfea90756e81eaa5ef8.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e885e0954295e195ea95a085e87a153e7f95e06a1778557a1f.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5de85ce8a917a917a3172f00831f831fa915a3175ee05e7aa3177ce87ce87e40.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba173a1795e895e8c5e8f400c1f8c1f895a8c5e87a077a5ec5e83e173e177e02.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/177ae693e3879c78e9a5690d5c6c69853cf2c740c618967aa393967a369263a5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4fe3026318695ec5c9695e6c49c6a5.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d11c1fe3c456aa5e2a341e16abd2e11eaee9513d1ee944.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/572ee3e0a9d11c1ea9d51c1fe3c456aa5e2a341e16abd2a01e8ee9573d1ee944.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eabc789722.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/172ee9d1e9d116aee9d116aee9d11e2aa9d01e0a16aa1e2e162e7e4516aee955.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/977a9696298d69adc98d5978c3a389a363a769987872964c96cc366c9c58765c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95e696994b196b593b19a1ec3c591c5c6e596191e4e693269336c36391a6e3a.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/177ae185e985965ae985b65ae985be5ae9851e601e5a1e68165a7e61165a6be1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a16d5a97a17d5a97a17806785a7816685a7e86685ad687.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f54203bd0bb5f44a0bbdfc420bbdfe400bbdfe00b44afe00f442fe15f4426b15.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f54201bd0bb5f44a0bb5d44a0bbdfe400bbdfe00b44afe00f44afeb0f44a2bb5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f002d527f002f427fa82f42d6a8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af4280bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527f0d2f52d4ad.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8218f5eb8294783b8c97129c6e671.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa829cfa151e63029c7de38338d7cce56b8318f5eb829478398c97529c6e631.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d84f17a1d94e2c11d938e9463678e.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1d94e2c11993ae9463678c.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_ty.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/b57a29a5c30dc30f6985965a69a53cf88ed83cf09ed8e92d96c2c30736c2d65a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a1695a96a53c1f711b3c0f791b97b46943c3e06c436b5a.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tz.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/957a3cf8690569a56ba5d602c30fd6478303c30f3ed07c7d69853c78b6da9652.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a56b40c3f06be2c1c0c3f07c0b3ebe96a13c1e6d5b694a.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/3d5e384ccbc366b3e3a1c39961b3e371e349e76569b01a929c9e3c2c1c0e1cce.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc785c39986cdc78ec792e7a6960d584939793c3438703873.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57f81ef8a907a117a907bf42a907a957a905a1175ea87c7ea90756e81ea85ee8.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e895e0fd4295e095ea95a085e87a153e7e95e06a1778157a17.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zy.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5de856e8a917a917a3173e00831f831f2915a3175ee05e7ba3177ce87ce85e60.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba176a1795e895e8c5e87c00c1f8c1f894a8c5e87a077adec5e83e173e177a06.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_t.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c17fa9fa56a0a7c8cea09b232fc2488ea9187e39ab62fec52b89de163f005e58.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f17fa9407ea0e700cea09b2325e248fea1fc60f981f2f4e52b8bd4363f007e5a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe955f6a05e5137305d9c4f443127195187e9cd5467fa3d4917b68fc007a1a.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe95027e05e7007305d9c4a447127f853f069f814f2fa7d4d12b6cfc007e5a.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_t_dates.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8b36d8d801eeb2b1074eaeb9490606fa18142ee8d3b114e32bf64.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d5ffab7554a8936d85801eeb2b1034eaeb9490606fa39142ef8d3b114e32bf64.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d5ff2b05548033218f001eeb2b1034eeeb9c907b6bf78146cebd39194e3abb64.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd5ae2a15cdb6b10178d7d4082e57d7290906f685814277b1dc88724cfd26.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd5ae2a15c9b6a10178d7d4082c57d7290906f6c58942f7b1dc88724cfd26.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd4a02a01cc84f10078d7d4082c77d73909ded6ef816273bd9c98725cdd26.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f17fa9947ee1e35256a0891a1f39bc760bcaa6e9031c1e6c0b1f1e660b960ee9.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe95297e87c74a6a059158f89c3d6ed0536597c0387836d0f87866d0697097.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f1176964f660b1e1dcc1d38e27ac4e3a0b3e065e0b7e0e3f0b005e1e817f5e1d.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f1176960f660b1e1dcc1d38e27ac4e3a0b3e065e0b3e0e3f0b005e1f817fde1d.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f117696cf6f0b1c99cd1d38e27ac4f720b2e26760b6e0e350f084eb6814f9e31.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896266f068d873b83cb71e435725cd07c607ad07e70fcd0007a7881fe7ab8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896066f068d873b83cb71e435725cd07c607ad07c70fcd0007af881fe7bb8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896366f0f8d93398bcb71e435f24ed074646ed07670acf010726d81f2798c.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_z.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f15f832a5ee0492a36e8b9ed8fa4f2b629dace4921681e17a9807e7c89835ef0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_non_cube_coordinate.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f81a17ea17e7e81a17e5e81a17e5e81a17e5e81a16e03547ea9a1567e81835e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7e81857e7a81857e7a81857e7a818576c02a7e95856a7e81c17a.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f8142af837ebd348376ad12a952a94289562c5e897a06bd52bf169efc894669.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe8142f5c17ebd2cc16eb548954a9542916a347a915e60bd4afd68793f916296.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa142edadc0ad12a15ebd10a15ebd90297ab7d6899b1683869d4eeb562546ad.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa142edadc0ad12a15ebd10a15ebd90297ab756899b5683c69d4ecb562546ad.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6b91d968c161b972d76aa462b5.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6a91d96ac163b972d36aa462b5.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/d11ff1a25ec0ad0c7e68ad860fe0ad7c0be6845e831e567f03af0efd811e1658.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d19ff1a05ec0ad0c7e68ad860fe0ad5c0be6845e831e567f03af0efd811e165a.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bf88f457a03b5307e16b561f007b53ed067217ac1786afec0f570bf8178681a.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bf98f057a03b5307e16b561f007b53ad067217ac1786afec0f570bf8178685a.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/f17ff16c7ea0a9547fa0a5d019b0b7d20bba964383df8e8303464e2f0b05562f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe8f367e05952afe05a50b980ded4bd05d69c2c1fb71c1c06272f4d0a06af4.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/55a9bcf0a15fadf00b4fa9565ee8a15f5fe816ee0bf0168f0b34064f0f100b0f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d757a5827929ad8079e9a9b016caa97d07ca865f0baa065f0ba80e7f0f805b7d.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d757a58279a9ad8279e9a9b016caa97c07ca865e0baa065f0ba80e7f0f805b7d.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aa953d0f85fab50fd0f2956a7a1785fafa176877d00f68f1d02c60f2f008d0f0.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebeaa5419e94b5019e97950d685395bee05361fad05560fad01570fef001dabe.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebeaa5419e95b5419e97950d6853953ee053617ad05560fad01570fef001dabe.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/d75ff5c279e1ad8069e1ad8069e1ad5603aa865f078ec07f069e165e068e1e1f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/d75fb4d269e1a9a079e1e9f0162a965e07aa965e03a1865f0b82eb750f806b75.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebfaaf439e87b5019687b5019687b56ac05561fae07103fe6079687a607178f8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebfa2d4b968795059e87970f6854697ae055697ac08561fad041d7aef001d6ae.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/751dad905ae1b3061ca6499b37e9b5b64b3c256f0b9e1ee40f904668831f1e67.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aeb8b5095a87cd60386592d9ec97ad6dd23ca4f6d0797827f0096216c1f878e6.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/f157e998f2e093130ceb8996736864f989905e6f231e866f0b9e066e0b9e5e68.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f177e9d0f2e093930ceb8994736864f989905e6f231f862f0b1e066e0b9e5e68.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f557e990f2e093130eeb8994736864f98990566f231f866f039e066f0b9e5e68.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fea97194f07c9c830d79169ce16269f91097af6c47861f6d0796076d0797a16.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fee970b4f07c9c930d79129ce16269f91097af6c4f861f4d0786076d0797a16.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/afea97094f07c9c870d79129ce16269f91096af6c4f861f6c07960f6d0797a16.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a106fca956e982a978b9c1835fb1f40ba55a0f4bfa2c5aa70f46e3b41686b4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea85603f956a9741951e9d83c1fa8d2fd0a55af0d25f345ae5f062c72d68612d.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/175a963369b54987c99369cca1497938c38159b3679ba6737666d60c1c76a68d.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f13f63eae6c0e9023d60b9590bd0b1b50bfc4a8f81bb2c5e215e46ff81174636.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f13f63eaeec0e9023d60b9590bd0b1b50bbc4a8f81bb0e5e215e46ff81174636.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffcc65767039740bc069d9ad00b8dadd03f52f181dd347a847a62ff81e8626c.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffcc65777039740bc069d9ad00b8dadd03d52f181dd707a847a62ff81e8626c.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/576a92232c3549a79b936cd8a9cd391cc3c15a7a639b6673cb32c60c9935a7a5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5649c434ac92e5d9c9361b95b39c38c3835a5ec6d966ced34c633099ace5a5.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6b44b0b49a9c303e38b3cd8634bbc3496b607a73c5cc3c95b6f4ba04323.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9c303e38b3cd8634bbc34963607a73c5cc3c9db6f4ba04303.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f4490b49a9c30be38b3cd8634bbc3496360fa73c5c43cd9b6f4b804323.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2dd2d09295c3c0c7d13c1bc6d23d2c696de0e53c3ac393daf6d205c2c4.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c3c0c7d13c1bc6d23d2c696ce0e53c3ac393dbf6d205c2c0.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2f92d09295c3d0c7d13c1bc6d23d2c696cf0e53c3ac2b3d9f6d201c2c4.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/9716b631696949e2e9e179dc6149791a96b696331696a6c99e4686cc9cb139b3.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/9786a6f1697849627978389e66cf361b86a686310e8766cdd969198e79787913.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9686d8c9696924797879e3b86929e58696d69cc6869659379626133398d9ccd.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e961658f961e92469e1e1c7966f36cd86165618c70e166b39b9698719e1e9ec8.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/fd01fc0003fa23fd037e83ba03fa1bdd033e9336cc5c4c88dc0bb44b3eb77c03.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf803f00c05fc4bfc07ec15dc05fd8bbc07cc96c333a32113bd02dd27ced3ec0.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a9a956a94696c9295856b4a976766b215a76a6237de36d52a929167685a91e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95956a95626993941a6a2d956e6ed6845a6e65c4bec7b64a9594686ea19578.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f117f4203e8031c13d803d5a0ff88b3d8b5a4c3e211e06bfa35e967d0d7d16bd.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/f117f4203e8031c13d803d5a0ff88b3d8b5a4cbf211e06bfa34e967d0d7d16b9.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a327c847860fdc57a69beb0be68bd.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a32fd847860fdc57269beb0be689d.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/7317a95c5ea8a1961eea69690bbce6342359765a21b4bc34036dd68b43579c8f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/cee8953a7a15856978579696d03d672cc49a6e5a842d3d2cc0b66bd1c2ea39f1.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/77a9fca08957fce08952a95f7ee08b5f16a856a80b3e56bc0b1c037f0f000b5f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/75a9fca08957fce08952a95f7ee08b5f16a856a80b3e56be0b16037f0f000b5f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a3dd038c0fef000d0fa.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a7dd068c0fef000d0fa.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175ee9bc69a596ca69e196c269a1a552078ae857078af85d068adc5d968e5e5d.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a596ca69e196c269a1a552178ae957078af85d068adc5d968e5e5d.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a973d96a56953968769439685a54ae05117eae0511fba60513bba69717aba.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96a56953968769439685a54ae85197eae0511fba60513bba69717aba.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/97a55c9a6978a3653496581ade6946870387a77c7970d9e17c835a8e863d26f4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/97a55c9a6978a3653496581ade6946870387a77c7970d9e17c835a8e863d26f4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_default.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/9f1ed91ce161e66161693609c9e139a749e3d993b29849d9969cf3668c36e634.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f812971a17e928e097ee574a95f664da97472b5b642d94a5ee3a5147619186c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81948e857e4971907ea72e95fa66b2952e4ead6d429b527ac7a5286e981836.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a86929a156d60a69f5a55c6c29b88527afc396b358676bd9563801465a4f6f.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea159694856a6b5096afa53a36941da1e4f5c369cd1ae6d69b6a1c80625af2f6.png"
     ], 
     "iris.tests.test_plot.TestPlotOtherCoordSystems.test_plot_tmerc.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/67cc99b399b3264d9999cc9aa66cd96464929331d99c666399b1cc98336bc9cc.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e63399cd99cd64b29999335965369b262649c98c9b3966c6998d3319ccd69333.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ffad6bfe2ba76944889b6325c25beeab1c3971cb629bc40b889b163b005b12.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/41ffad6bfebba76944889b6325825beeab1c3931cb629be40b889b163b005b12.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/415fbd61feaba74144809b6325ca59eea9bc31fdc1f299e70b8a99363b005b12.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffb5d67fd4e5962211d9c6a443da77d5389c8ed346d923d011d968dc00da48.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82ffb5d67fdde5962211d9c6a441da77d5389c8cd346d927d011d968dc00da48.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fabd867fd5e5822201d9c6a4539a77953d8cbf834f99e7d051996cdc00da48.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t_dates.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c5ffab75fe8af76d04c01eeb2b1034e8eb1490606ba79146db8c1b005b36bb64.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c5ff2b75feaaf77d04801eeb2b1034e8eb1490606ba79146fb8c19005b36bb64.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c5ff2b41fe8af72904001eeb231034eaeb9c907a6bb79146dbae19105b36bb64.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd5ae7f51efb6200378d7d4082c17d7280906d6e58962db31d800da6cdd26.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd4ae7f55efbe200178d7d4082c17d7280906d6e58962df319800da6cdd26.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd4827f51ef94200078d7c4082c57d739095ed6ed8962db759808da6cdd26.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ffad907e21a35246e8991b06b899664bc8b3e6039c1b6e0b1e1b661b961bef.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c1ffbd907e21a35246e8991b06b899664bca33e4039c1b6e0b1e1b661b961bef.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffb5097e84c54a621799d8601d9966d213cd67c039d876d078d866d869d8f7.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffbd097e84c54a621799d8601d9966d253cc27c039d876d078d866d869d8f7.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1a360b805b96917e1a1c.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e5ff6d60fe00b1e1ccd993ce27ac1b760f2c135e0b3e1b360b805b16917e1a15.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e5f76d6cfe00b1e9ccf193ce27ac1b760f0c13760b0e1b360b0c1bb6910f1b34.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07c586cd001da69897e5838.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07cd86cd001da68897e58a8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7efb6367f008d97338fc973e435d86ef030c86ed070d86cd030d86d89f0d82c.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_z.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c1ff833b7e000d3b66e8b9a98fe4f3932b929a5d21661a1789e05a7c99825af4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
     ], 
     "iris.tests.test_plot.TestSimple.test_bounds.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa9463fe303add0addcf901a14e5ea85ea9036f5ea1077ed007019607bef905.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9562fcc7c0b50bb53b9f8085727a157a95c0f67a85e07e0be08069e07d9fa0.png"
     ], 
     "iris.tests.test_plot.TestSimple.test_points.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa146ed436ebc90a956a95aa15ab8112b7aa35efc81037e5687d68403ff5e81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
     ], 
     "iris.tests.test_plot.TestSymbols.test_cloud_cover.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/975acc3069a5334f965acc3069a5334f965acc3069ad33cf9652cc3069ad33cf.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a330c96a5ccf2695a330c96a5ccf2695a330c96b5ccf3694a330c96b5ccf3.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_alignment.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa9acf0a9544b0f836f5683a35a522fa70aa5d47ca0097a788279f6c97edc84.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/5fa9acf0a954cb0f836f5681a75a522fa70aa5d47ca0097a788279f6c97ed884.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa95350f952ad2f0c1f66ac1c55a4af4e550a52b3e05905e1e419e6f937e3b21.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa95350f952ad3f0c1f66a81e55a4af4e550a52b3e05905e1e419e6f937e1b21.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/c5bfa9565e80a5774cf893666689d97683fa3ba5c906b0a4611e5aa4b95f5a80.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/c5bfa9565e80a5774ce893676689997683fa3ba5c916b0a4611e5aa4b95f5a80.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee321fc96666919b6ec15fdca593600d2586785a259dfa5a01.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee3217c9e66691996ec15fdca593680d2586785a259dfa5a01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f85d483a9722ffc03fdf940a1527227a112835e5aad837e5eb01eae857e5c81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/7f81f411a95ea95aa15e49ea83fe5ea503bc03fd5aa1037efe02b402a55efc80.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe812f88957a955a857a9257c17f7aa5c03dc0bf5a85c07e7f402d40a57a3f01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f85d483a9722ffc03fdf940a1527227a112835e5aad837e5eb01eae857e5c81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa1f481a95aa34c03fd7991a37e5b67c9ea87fc7205035afca18625c95a7c80.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa852f81955ac532c0bf9e89c57edae69357e13f4ea0c05a3f8561a4935a3e01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf_nameless.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa57483a95aa36c03fd7990a37e5b67c9ea87fc7201035bf4818621c95bfc80.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa52ec1955ac536c0bf9e09c57edae69357e13f4e80c0da2f81618493da3f01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_map.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c559f273875976d926d30699a4b3a4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_map.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c55972738f5976d926d30699a4b3a4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4ecef19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolor.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/dd42bc7229a5639d835a5bb583df566239b1275c7ce00972fa80d6ea19727885.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb423d4e94a5c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolormesh.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/ddc2bc722925639d835a5bb583df566239b1275c7ce00972fa80d6ea19727885.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb433d4e94a4c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_non_cube_coordinate.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5f8156a1a15ea95a877ea97ea37e5e81a1fa837e5c81a37e58815ca1a35e58a0.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa816a85857a955ae17e957ec57e7a81855fc17e3a81c57e1a813a85c57a1a05.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa156a9875aad58a97c29a1a15ef802a94aa17ef883037e5abd52ac07fe52a5.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa856a95e15ab51a953e9485857a1f409552857e1fc1c07e5abd4a35e07f4aa5.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/5fa146ed436ebc90a956a95aa15ab8112b7aa35efc81037e5687d68403ff5e81.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/51ffe1d1fe00a90c46e8a9860fe1a95c8be6995e011e52fe83a71bb6991e12fa.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/51ffe1d1fe01a91c06e8a9860fe1a95c8be6995e011e52fe83a71bb6991e12da.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8aff878b7f00953062179561f087953ad167997a80784a7fc1e5d86d9978485f.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8aff878b7f80953860179561f087953ad167997a80784a7fc1e5d86d9978485b.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/41ffb16dfe29a9746ea8b9d60db8b346099a934683df9b8303465b2e1b04532e.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/417db16dfea9a9746eb8b9d60db8b346019a934683df9b87034e5b260b06532e.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/417fb16dfea9a9746ea8b9d60db8b346099a934683df9b87034e5b260b04532e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82ff8db67f94952e76159d6bb01dcd629059c962c1fbd9c1c062da74d820ca74.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82be8db67f95952e761d9d6bb01dcd628059c962c1fbd9e1c072da64d060ca74.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe8db67f95952e76159d6bb01dcd629059c962c1fbd9e1c072da64d020ca74.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/55e9edf0af0fe9f0044da95656e8a95e1fa05b8e0bf65aae0b341b0e1b001b4f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/875fa5927b29e99060e9e9b806caf97c8f8e135e03ae125e0ba41b7e1b805b7c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aa97b70ff5f0970f20b2956a6a17957af805da71d06f5a75d02cd870d800d8f2.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1faa549de9497090697971d60539f3ef171c87ac075487ad025d87ed801da3e.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175fb5e2ef21bda069a1b9c069f9994603ba9376078e917f160e1346168e1e1f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/155fb4e2e9a1a9a16da9b9e006fa9176078a965e0b869b5f0b8659751b807b75.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e8faad47f784bd0596859d03969f9962c05dc96ee07189fe6870c862687178f8.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a8fa2d4797859585b6959d07605f896ee051697ad061d9fad0619aaed801deae.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_x.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/65ffad907e21b34744a2198b26f9b1364b1c316e0b9e19e60b905b6e931f1b66.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/65fdad90fe21b34744a2998b26f9b1364b1c316e0b9e19e60b905b6e831f1b66.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6ffb5097e84cde2224598d1649f8d6cd2388c76d0799867d009da76c9f8d866.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6bfb5097f84cde2224599d1649f8d6cd2388c76d0799867d009da76c1f8d866.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_y.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/e5ffe9d1fe0093130ceb998466e87969a9901b66231e9b260b9e136e1b965b64.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e5ffe9c1fe0093130ceb998466f87969a990196e231e9b26039e136e1b9e5b64.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ff978b7f00c9c830d7992166179e969509d866c478d964d079c876d869da26.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ff97837f00c9c830d79921661f9e9695099876c478d964c079c876d879da26.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a156f98f76ed02a95279a0a15a98c503df837c78a503be5a0bd31a277a3cac.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea856a9ff16eb740954a9e05855a19a3c0fbc13e1ea5c07d5ad0cb58e45e3c35.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/a7a5a66d79585942897e589883de5c86799a23de5ca4a37cdc210ca7a35e7ca1.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e5a565b69e1a9a42917e1a19c17b3a619e59c47b3a25c53e3b8430e5c57a3e85.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/f5ff676bee00a9616ce8b949079899b40b9c5baf81be195e015e1227991652b6.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/75ff676bee01a9616ce8b949079891b48b9c5baf81ba195e015e1267991652b6.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/afffe6d67700958636179d92e019992dd039daf5817d987a807a48e499684a6d.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aeffe6d67780958636179d92e019892dd139daf5815d987a807a48e699684a6d.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/577a86212c356ca783936cd9a9cd391cc3c559f273875976d926d30699a4b3a4.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9438bc3cb3cd8436bbe34963607a63c5c438d9b6e5ba04323.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/b5f4b6f44b0b49a9438bc3cb3cd8434bbe34963607a73c5c4b8d9b6e5b804323.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d67d2c696ce0653c3ac2b1d976da05c2c4.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d27d2c696ce0e53c3ad2b1d976da01c2c4.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/9716a671696949e3e9e179dc6149791a96b692b3169693c59e4693c499b039b6.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/9787a6716978496a79793c9e66cb361a86a696310e8773ced96c198679781932.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e968658e969692c797879e3b86929e58696d49cd6869c9a37962c923990d9c6d.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9e1658e961e92569e9e3c7966d36c586165698c70e1ce739b3698619e1e984c.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/fd81fc01836a03ba037f43b983fe58b60bfa03ff5885a37edc24dc04ec5a7881.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf813f80c156c05dc0fec29dc17f1a6dd05fc0ff1aa1c57e3b243b20375a1e81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.1": [
-        "https://scitools.github.io/test-iris-imagehash/images/57a946b9a956990696c979d903fe5eb5a136237e7a81a15e78a452ac837dd881.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95629d956a996069939e9bc07f7aad856cc47e5e81857a1e254a35c1be1b81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.2": [
-        "https://scitools.github.io/test-iris-imagehash/images/e1b7f461fe00b14104e8194a0ff89b7d8b1e5936213e13ee2356934e197e13bf.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e1b7f460fe00b14104e8194a0ff89b7d8b1e5936213e13ee2316936f197e13bf.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/e1b7f460fe00b14104e8394a0ff89b7d8b1e5936213e13eea306936e197e13bf.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f867f008d8220179852f01fd9bed1789a6c847cc877c46ac972987ec8fd.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179852f01fd9bed1789a6c847cc877c468c9f6987ec8fd.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179c52f01fd9bed1789a6c847cc877c560c976987ec8fd.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.3": [
-        "https://scitools.github.io/test-iris-imagehash/images/459fad5d6e00a59646fb79690fb893642319336221feb9360b24d28f59d6988f.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/459fad5d6e00a19646fb79690fb8b3642319336221feb9360b24d28f59d698ae.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600a56962df9e96f01dc926c498cc46847f9d6cd0244bf19a6b19f1.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600856962df9e96f01dcd26c498cc46847f9d6cd0244bf19a6b1975.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.4": [
-        "https://scitools.github.io/test-iris-imagehash/images/75a9fce1ab17b46101f8897776a8897f7e881e6e03be16ee0b161b1e1b000b5e.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/75a9fce1ab17b4e101d8897776a8997f7e881e2e03be16ee0b161b1e1b000b5e.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d86801f91ee6e1591fe7e117876c07d6877d068d878d800d07a.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d87801b91ee6e1599fe7e117874c07d6877d068d878d800d07a.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.5": [
-        "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a196c269f9966269a1b172078ab97607fed9561e86d9549e8e5854.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/175ea9b469a196c269f9966269a1b152078ab97607fe99561e8ed9549e8e585c.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ee0519d6ee07f9b6a78619b2a79711a2a.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ae0519d6ee07f996a78719b2a79711a3a.png"
     ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_not_reference_time_units.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/415f85e9fefb91e94600bb6f07009be7effa1966ab065b273b009b663b007a04.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/411d85e9fefb91e14600bb6707009be7effe1966ab06fb273b009b663f007a04.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/411f85e9fefb91e14600bb6f07009be7effe1966ab067b273b009b663b007a04.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/411f85e9fefb91e14600bb6707009be7effe1966ab06fb273b00bb263b007a04.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82faa1977fdf89976200ddf6e000d9e7f75f9866d560dae4dc00d966dc005e20.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82b8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00d966fc005e20.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200ddf6e000d9e7f77f9866d560dee4dc00d966dc005e20.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00dd64dc005e20.png"
     ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_reference_time_units.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/417f8119feebeeff070054bb2b0014a0bb157ba6bb972b46dabf3b0419827b04.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/417f8119fefbeeff070054b92b0014a0bb557ba69b95ab46dabf3b0419827b04.png", 
-        "https://scitools.github.io/test-iris-imagehash/images/417f8119fefbeeff070054bb2b0014a0bb14fbe69b952b46dabf3b0419827b04.png"
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fd777ffe0002addd4002805dda8de65dde9d4625bfddc209841de20.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002a9dd4002805ddaade65d9a9d5625bfddc209841de20.png", 
+        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002addd4002805dd28df67d9a9d4625bfddc209841de20.png"
     ]
 }

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -1,726 +1,726 @@
 {
     "example_tests.test_COP_1d_plot.TestCOP1DPlot.test_COP_1d_plot.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/baff589936602d8ec977334ae4dac9b61a6dc4d99532c86cc2913e36c4cc0f61.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/baff589936602d8ec977334ae4dac9b61a6dc4d99532c86cc2913e36c4cc0f61.png"
     ], 
     "example_tests.test_COP_maps.TestCOPMaps.test_cop_maps.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9138db95668524913e6ac168997e85957e917e876396b96a81b5ce3c496935.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea9138db95668524913e6ac168997e85957e917e876396b96a81b5ce3c496935.png"
     ], 
     "example_tests.test_SOI_filtering.TestSOIFiltering.test_soi_filtering.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac460b9c17b78723e05a5a9954edaf062332799954e9ca5c63b9a52d24e5a95.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8460b9c17b78723e05a5a9954edaf062333799954e9ca5c63b9a52d24e4a9d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fac460b9c17b78723e05a5a9954edaf062332799954e9ca5c63b9a52d24e5a95.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8460b9c17b78723e05a5a9954edaf062333799954e9ca5c63b9a52d24e4a9d.png"
     ], 
     "example_tests.test_TEC.TestTEC.test_TEC.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9a42846e9a49c7596e3cce6c907b3a83c17e1b8239b3e4f33bc4.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9e43846e9a49c7596e2cce6c907b3a83c16e1b9231b3e4f33b8c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9a42846e9a49c7596e3cce6c907b3a83c17e1b8239b3e4f33bc4.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e1a561b69b1a9e43846e9a49c7596e2cce6c907b3a83c16e1b9231b3e4f33b8c.png"
     ], 
     "example_tests.test_anomaly_log_colouring.TestAnomalyLogColouring.test_anomaly_log_colouring.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png"
     ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc7c09f4d00fdb1c93fcb21c.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9f8a60536bd28e1320739437b5f437b0a53d66f4cc5c08f4d00fdb1c93fcb21c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc7c09f4d00fdb1c93fcb21c.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/9f8a60536bd28e1320739437b5f437b0a53d66f4cc5c08f4d00fdb1c93fcb21c.png"
     ], 
     "example_tests.test_atlantic_profiles.TestAtlanticProfiles.test_atlantic_profiles.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6eaa57e6e81ddf999311ba3b3775e20845d5889c199673b4e22a4675e8ca11c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a6eaa57e6e81ddf999311ba3b3775e20845d5889c199673b4e22a4675e8ca11c.png"
     ], 
     "example_tests.test_coriolis_plot.TestCoriolisPlot.test_coriolis_plot.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e78665de9a699659e55e9965886979966986c5e63e98c19e3a256679e1981a24.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e78665de9a699659e55e9965886979966986c5e63e98c19e3a256679e1981a24.png"
     ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95317b9562e4d1649f5a05856e4ca4da52947e4ea5f13f1b499d42f13b1b41.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea95317b9562e4d1649f5a05856e4ca4da52947e4ea5f13f1b499d42f13b1b41.png"
     ], 
     "example_tests.test_cross_section.TestCrossSection.test_cross_section.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9521fb956a394069921e93f07f4aad856cc47e4e95857a1ea5da3591ba1b81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea9521fb956a394069921e93f07f4aad856cc47e4e95857a1ea5da3591ba1b81.png"
     ], 
     "example_tests.test_custom_aggregation.TestCustomAggregation.test_custom_aggregation.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe816e81917e907eb43e873f85677ac190f0703c6a95811f1ac33ce1a57a6f18.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe816e81917e907eb43e873f85677ac190f0703c6a95811f1ac33ce1a57a6f18.png"
     ], 
     "example_tests.test_custom_file_loading.TestCustomFileLoading.test_custom_file_loading.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa0cbf1845e34be913787416edcc8bc3bc81f9b63332662a4ed30cdc1b2cd21.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fba0cbf1845e34be912787416edcc8bc3b881f9b62332762a5ad32cdc1b2cd21.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/faa0cbf1845e34be913787416edcc8bc3bc81f9b63332662a4ed30cdc1b2cd21.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fba0cbf1845e34be912787416edcc8bc3b881f9b62332762a5ad32cdc1b2cd21.png"
     ], 
     "example_tests.test_deriving_phenomena.TestDerivingPhenomena.test_deriving_phenomena.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/b9993986866952e6c9464639c4766bd9c669916e7b99c1663f99768990763e81.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/b99139de866952e6c946c639c47e6bd18769d16e7a9981662e813699d0763e89.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/b9993986866952e6c9464639c4766bd9c669916e7b99c1663f99768990763e81.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/b99139de866952e6c946c639c47e6bd18769d16e7a9981662e813699d0763e89.png"
     ], 
     "example_tests.test_global_map.TestGlobalMap.test_global_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9979468566857ef07e3e8978566b91cb0179883c89946686a96b9d83766f81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa9979468566857ef07e3e8978566b91cb0179883c89946686a96b9d83766f81.png"
     ], 
     "example_tests.test_hovmoller.TestGlobalMap.test_hovmoller.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bab430b4ce4bce43c5becf89c54b1a63c543c56e1e64907e3bb469b490de1ac1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bab430b4ce4bce43c5becf89c54b1a63c543c56e1e64907e3bb469b490de1ac1.png"
     ], 
     "example_tests.test_inset_plot.TestInsetPlot.test_inset_plot.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebff6992f50096a5b245dac4f6559496b49248dbc95dcb699529912dcf244a54.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9ff6992b50096a5b245dac4f64594b6b49248dbc95dcb699529952dcf244a56.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ebff6992f50096a5b245dac4f6559496b49248dbc95dcb699529912dcf244a54.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9ff6992b50096a5b245dac4f64594b6b49248dbc95dcb699529952dcf244a56.png"
     ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bbbb31e1c44e64e4b0459b5bb1716ecac464f496ce34618eb1079b39b193ce25.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bbbb31e1c44e64e4b0459b5bb1716ecac464f496ce34618eb1079b39b193ce25.png"
     ], 
     "example_tests.test_lagged_ensemble.TestLaggedEnsemble.test_lagged_ensemble.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abfef958fd462c993a07d87960464b81d1009687c139d3b594e9cf87c6b89687.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abfef958fd462c993a07d87960464b81d1009687c139d3b594e9cf87c6b89687.png"
     ], 
     "example_tests.test_lineplot_with_legend.TestLineplotWithLegend.test_lineplot_with_legend.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae942526540b869961f8da694589da69543cc9af1014afbc3fd596b84fe19a7.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae942146540b869961f8de694589da69543cc9af1014afbc3fd596b84fe19a7.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eae942526540b869961f8da694589da69543cc9af1014afbc3fd596b84fe19a7.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eae942146540b869961f8de694589da69543cc9af1014afbc3fd596b84fe19a7.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fb11731a94cea4ee64b35e91d1d2304e9e5ac7397b20e1fe12852487e666ce46.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fb11731a94cea4ee64b35e91d1d2304e9e5ac7397b20e1fe12852487e666ce46.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e5a665a69a599659e5db1865c2653b869996cce63e99e19a1a912639e7181e65.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e5a665a69a599659e5db1865c2653b869996cce63e99e19a1a912639e7181e65.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f2c464ce9e399332e1b74ce1cc79338c6586e5b33b31b37a66c9664cc06e1a64.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/f2c464ce9e399332e1b74ce1cc79338c6586e5b33b31b37a66c9664cc06e1a64.png"
     ], 
     "example_tests.test_orca_projection.TestOrcaProjection.test_orca_projection.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa817a83846ea46ce539c93391de32cc86cf87a33fa168721cdb3e896e374b04.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa817a83846ea46ce539c93391de32cc86cf87a33fa168721cdb3e896e374b04.png"
     ], 
     "example_tests.test_polar_stereo.TestPolarStereo.test_polar_stereo.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e168317a92d36d89c5bb9e94c55e6f0c9a93c15a6ec584763b21716791de3a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e168317a92d36d89c5bb9e94c55e6f0c9a93c15a6ec584763b21716791de3a81.png"
     ], 
     "example_tests.test_polynomial_fit.TestPolynomialFit.test_polynomial_fit.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abff4a9df26435886520c97f12414695c4b69d23934bc86adc969237d68ccc6f.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aaff4a9df26435886520c97f12414695c4b69d23934bc86adc969a17d69ccc6f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abff4a9df26435886520c97f12414695c4b69d23934bc86adc969237d68ccc6f.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/aaff4a9df26435886520c97f12414695c4b69d23934bc86adc969a17d69ccc6f.png"
     ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854f19851a30e4cc76cd0bb179325ca7c665b0c938cb4b4e719e9cb727b5c0.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac54f19851a30e4cc76cd0bb179325cb78665b0c938cb4b4e719e9c9727b5c0.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb7c664b0c938cb4bce739e9c37a3b5c0.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb78665b1c938c94bce739e9c3727b5c0.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa854f19851a30e4cc76cd0bb179325ca7c665b0c938cb4b4e719e9cb727b5c0.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fac54f19851a30e4cc76cd0bb179325cb78665b0c938cb4b4e719e9c9727b5c0.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb7c664b0c938cb4bce739e9c37a3b5c0.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa854e19851a30e4cc76cd0bb179325cb78665b1c938c94bce739e9c3727b5c0.png"
     ], 
     "example_tests.test_projections_and_annotations.TestProjectionsAndAnnotations.test_projections_and_annotations.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492e9b69964936dc21974b18592.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896727243318f8dad5a7dc65ba492b93699649b6dc25b64938592.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492b93699649b6dc25964938592.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75965ba492f9b69964db4cc65b64918592.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75865ba492e9b69964db6cc65b74918592.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492e9b69964936dc21974b18592.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e385699d9c3896727243318f8dad5a7dc65ba492b93699649b6dc25b64938592.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e385699d9c3896627243318fcdad5a7dc6dba492b93699649b6dc25964938592.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75965ba492f9b69964db4cc65b64918592.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e3856b999c3896727243318f8dad5a75865ba492e9b69964db6cc65b74918592.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa15615e97a193adc15e1e81c4fa3eb49d30817e3e05c17e7ba59927817e1e01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa15615e97a193adc15e1e81c4fa3eb49d30817e3e05c17e7ba59927817e1e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba056717c3e099e9b90f8e81c4da589499b696763e45e56b3b893929c17b7e01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ba056717c3e099e9b90f8e81c4da589499b696763e45e56b3b893929c17b7e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba1e605ec7a191a1b85e9e81c4da58909996b37e3a65e16f7b817939e57a1e01.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba1e605ec7a193a1b85e9e81c4da58909996b3763a65e16f7b816939ed7a1e01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ba1e605ec7a191a1b85e9e81c4da58909996b37e3a65e16f7b817939e57a1e01.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ba1e605ec7a193a1b85e9e81c4da58909996b3763a65e16f7b816939ed7a1e01.png"
     ], 
     "example_tests.test_rotated_pole_mapping.TestRotatedPoleMapping.test_rotated_pole_mapping.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8172d0847ecd2bc913939c36846c714933799cc3cc8727e67639f939996a58.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8172d0847ecd2bc913939c36846c714933799cc3cc8727e67639f939996a58.png"
     ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cd3e29847b18e639e6c14f1a09.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cd3e29847b18e639e6c14f1a09.png"
     ], 
     "example_tests.test_wind_speed.TestWindSpeed.test_wind_speed.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cc3e29847b38e639e6c14f1a09.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bcf924fb9306930ce12ccf97c73236b28ecec4cc3e29847b38e639e6c14f1a09.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe81957ac17e6a85817e6a85857e942a3e81957a7e81917a7a81d95ec17e2ca1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe81957ac17e6a85817e6a85857e942a3e81957a7e81917a7a81d95ec17e2ca1.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be81c17ec17e7e81c17e3e81c57ea55a3e80c17e3e81c1fe7a81c285c95f2c03.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be81c17ec17e7e81c17e3e81c57ea55a3e80c17e3e81c1fe7a81c285c95f2c03.png"
     ], 
     "iris.tests.experimental.test_animate.IntegrationTest.test_cube_animation.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea857a81957a857e957ec17e817e6a816a853e817a853e816e818d3a862ad3fe.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea857a81957a857e957ec17e817e6a816a853e817a853e816e818d3a862ad3fe.png"
     ], 
     "iris.tests.test_analysis.TestProject.test_cartopy_projection.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/9e1952c9c165b4fc668a9d47c1461d7a60fb2e853eb426bd62fd229c9f04c16d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/9e1952c9c165b4fc668a9d47c1461d7a60fb2e853eb426bd62fd229c9f04c16d.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_contourf.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_pcolor.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a69c896a592e59bc99e3384929636c32d98cde6d964ce7e666332386465b1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e95a69c896a592e59bc99e3384929636c32d98cde6d964ce7e666332386465b1.png"
     ], 
     "iris.tests.test_mapping.TestBasic.test_unmappable.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eaa5684eb54a947ad09eb731c521978dc2fb1cc0e4966ce26e2c6b2d3a6e691a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eaa5684eb54a947ad09eb731c521978dc2fb1cc0e4966ce26e2c6b2d3a6e691a.png"
     ], 
     "iris.tests.test_mapping.TestBoundedCube.test_grid.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81917e857e6e81857e7a857a81917a7a81857e857e7e81857e7a817a81852e.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81817e7a81857e857e7a81857e7a817a81857e.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81857a7a81857e857e7a85857e7a817a81857a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81917e857e6e81857e7a857a81917a7a81857e857e7e81857e7a817a81852e.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81817e7a81857e857e7a81857e7a817a81857e.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a81857a7a81857e857e7a85857e7a817a81857a.png"
     ], 
     "iris.tests.test_mapping.TestBoundedCube.test_pcolormesh.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81e535857e92ca8ec23d21b13ce15e7a811ea5c47e1a5ac17b652d3b05e4f2.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81e535857e92ca8ec23d21b13ce15e7a811ea5c47e1a5ac17b652d3b05e4f2.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_grid.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf80e2b1c17f1d0ac4f7c8d739a637202749699b6bb3ce3666e4b048944d9d89.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf80e2f1c17f1d0ac457c8d619a637213749699b6bb34e3666e4b04e944d9d89.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bf80e2b1c17f1d0ac4f7c8d739a637202749699b6bb3ce3666e4b048944d9d89.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bf80e2f1c17f1d0ac457c8d619a637213749699b6bb34e3666e4b04e944d9d89.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_outline.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e3e80857e7a817a817a817a81817f7a81857e857e857e857e7a81.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7e21857e7a817a817a857a81857a7a81857a857e857a857e7a84.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e3e80857e7a817a817a817a81817f7a81857e857e857e857e7a81.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7e21857e7a817a817a857a81857a7a81857a857e857a857e7a84.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_pcolormesh.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf81e6b1c17e1d4884bfc8df39a43720374969db69b34e26c4e4b0ca904f9d89.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bf81e6b1c17e1d4884bfc8df39a43720374969db69b34e26c4e4b0ca904f9d89.png"
     ], 
     "iris.tests.test_mapping.TestLimitedAreaCube.test_scatter.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d894346b24f3477acf68ad39329ed8c696e136c1ab9a71.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d895346b2473477acf68ad39329ed8c69ee126c1ab9a71.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d894346b24f3477acf68ad39329ed8c696e136c1ab9a71.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d895346b2473477acf68ad39329ed8c69ee126c1ab9a71.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_keywords.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea811831957fe3cea68c6ce0d9f29b9b6a816463953e61cc917f1ae36ac09d38.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea811831957fe3cea68c6ce0d9f29b9b6a816463953e61cc917f1ae36ac09d38.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee819cb7913b63c8846e64737bb1999c6ec52633953a69c8916f6c636e92911c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ee819cb7913b63c8846e64737bb1999c6ec52633953a69c8916f6c636e92911c.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be21a71bc1de58e43a31871f7e856470c1fa9b8c7b81647384665b9ed1b998c1.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_params.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea811831957ae3cea68c6ce0c9f39b9b6a816473953e63cc917f1ae36ac09d38.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea811831957ae3cea68c6ce0c9f39b9b6a816473953e63cc917f1ae36ac09d38.png"
     ], 
     "iris.tests.test_mapping.TestLowLevel.test_simple.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eae0943295154bcc844e6c314fb093ce7bc7c4b3a4307bc4916f3f316ed2b4ce.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eae0943295154bcc844e6c314fb093ce7bc7c4b3a4307bc4916f3f316ed2b4ce.png"
     ], 
     "iris.tests.test_mapping.TestMappingSubRegion.test_simple.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bd913e01d07ee07e926e87876f8196c1e0d36967393c1f181e2c3cb8b0f960d7.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bd913e01d07ee07e926e87876f8196c1e0d36967393c1f181e2c3cb8b0f960d7.png"
     ], 
     "iris.tests.test_mapping.TestUnmappable.test_simple.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe818d6ac17e5a958d7ab12b9d677615986e666dc4f20dea7281d98833889b22.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe818d6ac17e5a958d7ab12b9d677615986e666dc4f20dea7281d98833889b22.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2ff7c00a56de9023b52e4143da5d16d7ecad1b76f2094c963929c6471c8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec2ff7c00a56de9023b52e4143da5d16d7ecad1b76f2094c963929c6471c8.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff95776a01e1f67801cc36f4075b81c5437668c1167c88d2676d39d6867b68.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ff95776a01e1f67801cc36f4075b81c5437668c1167c88d2676d39d6867b68.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ff897066b41f076f81dce1fb007da79c50633e9c40626b8d1066df9d6067969.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff897066b41f076f81dce1fb007da79c50633e9c40626b8d1066df9d6067969.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7e0098757103a71ce4506dc3d11e7b20d2477ec094857db895217f6a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec1ff7e0098757103a71ce4506dc3d11e7b20d2477ec094857db895217f6a.png"
     ], 
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ff8c2d73a09b4a76c099d26f14b0e5ad0d643b0d42763e9d51378f895867c39.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe8c0173a19b4066d599946f35f0ed5d0b74729d40369d8953678e897877879.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c2d73a09b4a76c099d26f14b0e5ad0d643b0d42763e9d51378f895867c39.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe8c0173a19b4066d599946f35f0ed5d0b74729d40369d8953678e897877879.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2777e04256f68023352f6d61da5c109dec8d19bcf089cc9d99a9c85d999.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec2777e06256f68023352f6d61da5c009decad19bcf089cc9d99a9c85d989.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec2777e04256f68023352f6d61da5c109dec8d19bcf089cc9d99a9c85d999.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec2777e06256f68023352f6d61da5c009decad19bcf089cc9d99a9c85d989.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe9dd77f00e1d73000cc1df707db8184427ef8d1367c88d2667d39d0866b68.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe9d977f41e1d73000cc1df707d98184427ef8d1367c88d2667d39d0866b68.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fe9dd77f00e1d73000cc1df707db8184427ef8d1367c88d2667d39d0866b68.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fe9d977f41e1d73000cc1df707d98184427ef8d1367c88d2667d39d0866b68.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ffb5867f0060d4301f6d9fb007d899c50699e9c8668e78d8678d69de069969.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ffb5867f0060d4301f6d9fb007d899c50699e9c8668e78d8678d69de069969.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7f90987720029f1ef458cd43811cdb60d647de609485ddb899215f62.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fec1ff7f94987720009f1ef458cd43810cdb60d647de609485ddb89921df62.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec1ff7f90987720029f1ef458cd43811cdb60d647de609485ddb899215f62.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fec1ff7f94987720009f1ef458cd43810cdb60d647de609485ddb89921df62.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc8967e0098a6241f9d26e34b8e42f4d20bb4942759e9941f78f8d7867a39.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83f9c8967e009da6245f9946e25f9ed6f0940f29f40749d8853678e8d7857879.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc8967e0098a6241f9d26e34b8e42f4d20bb4942759e9941f78f8d7867a39.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83f9c8967e009da6245f9946e25f9ed6f0940f29f40749d8853678e8d7857879.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d94ac5a1.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7c248399cc7917662d84ac5a1.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fac1b47c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d84acda0.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d94ac5a1.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7c248399cc7917662d84ac5a1.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3fac1b47c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d84acda0.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0211b9e066e074d83926ed8f8cd3792dad1964db0d80e9b09.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0311b9e066e074d839266d8e8cd379adad1964db0d80e9b09.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0211b9e066e074d83926ed8f8cd3792dad1964db0d80e9b09.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae7f1f07f3e0e0f0311b9e066e074d839266d8e8cd379adad1964db0d80e9b09.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621deda3f69392cccd246db39018989ec4836de9ed249292.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a66b94c621deda3f69392cccd646db3901898dec4836de9cd249292.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621ceda3f6d392cccd246db3901898dec4836de9cd249292.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621deda3f69392cccd246db39018989ec4836de9ed249292.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a5f896d99a66b94c621deda3f69392cccd646db3901898dec4836de9cd249292.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a5f896d99a67b94c621ceda3f6d392cccd246db3901898dec4836de9cd249292.png"
     ], 
     "iris.tests.test_plot.Test1dQuickplotScatter.test_cube_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a4fb19b3db04c6cd6307b98678601c738c39d71cf3866186d8616e69bd191b9e.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a4fb19b3db04c6cd6307b98678601c738c39d71cf3866186d8616e69bd191b9e.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bbfac39d9899384a6f6694a7b613cb489c95b7b7c24a399cc5913262d84acda0.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bbfac39d9899384a6f6694a7b613cb489c95b7b7c24a399cc5913262d84acda0.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_coord_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bea07c99c15eb16e9891ce50c742394a3ced6cb13390f1cc73c29f1b2d0ecd66.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_coord_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af7e1f0ff1e1e0f0d918960e6c076d8bd266d868c537365a90966db0de0e1b09.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae7e1f0ff1e1e0f0d918960e6c076d83d266d868c537365ad0966db0de4e1b09.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/af7e1f0ff1e1e0f0d918960e6c076d8bd266d868c537365a90966db0de0e1b09.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae7e1f0ff1e1e0f0d918960e6c076d83d266d868c537365ad0966db0de4e1b09.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_coord.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/edf896d79a67b94c651ced23d29392cccd646d33901912fcc4836d69ed249292.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/edf896d79a67b94c651ced23d29392cccd646d33901912fcc4836d69ed249292.png"
     ], 
     "iris.tests.test_plot.Test1dScatter.test_cube_cube.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/acf939339a16c64de306318638673c738c19d71cf3866186d8636e69bd191b9e.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/acf939339a16c64de306318638673c738c19d71cf3866186d8636e69bd191b9e.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_down.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87fef8117980c7c160078f1ffc049e7e90159a7a95419a7e910dcf1ece19ce3a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87fef8117980c7c160078f1ffc049e7e90159a7a95419a7e910dcf1ece19ce3a.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_up.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff85d47800bd9f660779d0863f49c9947f4e1e9141de38d700da28ce1d9a2b.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ff85d47a00bc9f660779d8863f49c9907f4e1e9141de38d708da28ce1d9a0b.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ff85d47800bd9f660779d0863f49c9947f4e1e9141de38d700da28ce1d9a2b.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ff85d47a00bc9f660779d8863f49c9907f4e1e9141de38d708da28ce1d9a0b.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_down.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fb946ba684e194fb901b3a0587641ad03b1ae7674e64c15a5b99c767c47e3a98.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fb946ba684e194fb901b3a0587641ad03b1ae7674e64c15a5b99c767c47e3a98.png"
     ], 
     "iris.tests.test_plot.TestAttributePositive.test_2d_positive_up.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee176c7f93e093a0c50f9383815e6e156859e17e6e15e17a9be08e2d851a9b83.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ee176c7f93e093a0c50f9383815e6e156859e17e6e15e17a9be08e2d851a9b83.png"
     ], 
     "iris.tests.test_plot.TestContour.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/cff8a55f7a15b55a7817854ad007a5e8c04f3ce8c04f3e2ac4706ab295b37a96.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/cff8a55f7a15b55a7817854ad007a5e8c04f3ce8c04f3e2ac4706ab295b37a96.png"
     ], 
     "iris.tests.test_plot.TestContour.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfc815e78018597fc019b65b425d121955e7eda854b7d6a80db7eb481b72b61.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfc815e78018597fc019b65b425d121955e7eda854b7d6a80db7eb481b72b61.png"
     ], 
     "iris.tests.test_plot.TestContour.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe81ff780185fff800955ad4027e00d517d400855f7e0085ff7e8085ff6aed.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe81ff780085fff800855fd4027e00d517d400855f7e0085ff7e8085ff6aed.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe81ff780185fff800955ad4027e00d517d400855f7e0085ff7e8085ff6aed.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe81ff780085fff800855fd4027e00d517d400855f7e0085ff7e8085ff6aed.png"
     ], 
     "iris.tests.test_plot.TestContour.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa56c3cc34e891b1c9a91c36c5a170e3c71b3e5993a784e492c49b4ecec76393.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa56c3cc34e891b1c9a91c36c5a170e3c71b3e5993a784e492c49b4ecec76393.png"
     ], 
     "iris.tests.test_plot.TestContour.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bfe857f7a01a56afa05854ad015bd00d015d50a90577e80857f7ea0857f7abf.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe857f7a01a56afa05854ad015bd00d015d50a90577e80857f7ea0857f7abf.png"
     ], 
     "iris.tests.test_plot.TestContour.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bff81ff7a0195fcf8019578d4027e00d550d402857c7e0185fe7a8385fe6aaf.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bff81ff7a0195fcf8019578d4027e00d550d402857c7e0185fe7a8385fe6aaf.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa562ed68569d52857abd12953a8f12951f64e0d30f3ac96a4d6a696ee06a32.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/faa562ed68569d52857abd12953a8f12951f64e0d30f3ac96a4d6a696ee06a32.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eaa5e03f957a4f80954a9e41e16e9c60970fb5b24ada634e6e93692d4ba562d8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eaa5e03f957a4f80954a9e41e16e9c60970fb5b24ada634e6e93692d4ba562d8.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e954a7a81857e957e857efc00857e7e007a85c02a7e859f287a85c1fe.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e954a7a81857e957e857efc00857e7e007a85c02a7e859f287a85c1fe.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a6938b6b5969193901a4fc1e594a7c69999cbce33639879526e72330e65e4.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e95a6938b6b5969193901a4fc1e594a7c69999cbce33639879526e72330e65e4.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa85857ec45a7a81857e854a857ee56a917ec56a3a85c56a3a85c4ea7a8112fe.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa85857ec45a7a81857e854a857ee56a917ec56a3a85c56a3a85c4ea7a8112fe.png"
     ], 
     "iris.tests.test_plot.TestContourf.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81817ec40a7a81857e957e857ef40a857ef60b7a81c40a7b81e60f7a814aff.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81817ec40a7a81857e957e857ef40a857ef60b7a81c40a7b81e60f7a814aff.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be853f80854ac17ec0bdc2f5c17a0d09cc1fc07f5ab5e1fe3f409d7a38743e00.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be853f80854ac17ec0bdc2f5c17a0d09cc1fc07f5ab5e1fe3f409d7a38743e00.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_bounds.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/eab5313f954a7b9260f39789c5ec4cd084d0c4e45aa1c5fe3a04797bb13b3b06.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a95c17a6eece4b4e1333b01c07e1bb13909914b9ec1.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a91c17a6ee464f4e1333b01c17e1bb1390d914b9ec1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a95c17a6eece4b4e1333b01c07e1bb13909914b9ec1.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa17291f95e895e8645e7a91c17a6ee464f4e1333b01c17e1bb1390d914b9ec1.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_orography.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb07314fc4e0c6b4c31e9ee1847939a1c116c15e7b94e57e1ea9391de16e1ac3.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb07314fc6e1c6b4c31e9ee1846939a1c116c15e7b14e17e1ea9393de16e1ac3.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bb07314fc4e0c6b4c31e9ee1847939a1c116c15e7b94e57e1ea9391de16e1ac3.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bb07314fc6e1c6b4c31e9ee1846939a1c116c15e7b14e17e1ea9393de16e1ac3.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be813fc0c15ac13dc1bfc27dc17e1d93c51fc43f1ea1c17a3ec138e4b1721a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be813fc0c15ac13dc1bfc27dc17e1d93c51fc43f1ea1c17a3ec138e4b1721a81.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea9561ef956a7b92609b922dc16e6ec6845ac47e5aa5c57e5ec04861957b1b81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea9561ef956a7b92609b922dc16e6ec6845ac47e5aa5c57e5ec04861957b1b81.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea953bfb956ac4f4649f1a05c56e6ca45a53945e6ea5c13f1b498542c13f1b41.png"
     ], 
     "iris.tests.test_plot.TestHybridHeight.test_points.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/baf5347ecf0ac3f1c1f68f83850b1f83cc11c0fc7ad0c17a1be138e4b07e1a0d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/baf5347ecf0ac3f1c1f68f83850b1f83cc11c0fc7ad0c17a1be138e4b07e1a0d.png"
     ], 
     "iris.tests.test_plot.TestMissingCS.test_missing_cs.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fac16ee0953b911bc15e9648e56ec4e691be7bcc7a8184733ea16a90c17e930d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fac16ee0953b911bc15e9648e56ec4e691be7bcc7a8184733ea16a90c17e930d.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe816a95c17fb51e953e9485857a1f409552856a1f81c17e5ab94e15c0ff5a85.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe816a95c17fb51e953e9485857a1f409552856a1f81c17e5ab94e15c0ff5a85.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_u.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/be0e695ac3f096b5943fd2a185fc1e8590e594ee1e05c17a4f403d0fe1fe4b42.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be0e695ac3f096b5943fd2a185fc1e8590e594ee1e05c17a4f403d0fe1fe4b42.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b6c0773d09956a955a857a1d88845ec57e3f81c07e4ae56b21d0ff5a85.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8562b6c0773d09956a955a857a1d88845ec57e3f81c07e4ae56b21d0ff5a85.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_no_v.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9562d4c7c43d0bb57b97e0857a3f1995d284763a05c17a7b856a2dc0f45a84.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa9562d4c7c43d0bb57b97e0857a3f1995d284763a05c17a7b856a2dc0f45a84.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b6c0763d09b54a955a857a3f88845ec57a3e85c07e6a616b25d0ff7a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8562b6c0763d09b54a955a857a3f88845ec57a3e85c07e6a616b25d0ff7a81.png"
     ], 
     "iris.tests.test_plot.TestMissingCoord.test_none.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562f6c0773d09b54a955a857a3f81955ac47e3e85c17e7aa16a25c0765aa1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8562f6c0773d09b54a955a857a3f81955ac47e3e85c17e7aa16a25c0765aa1.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4f63066318695ec5c9695e6c49c6a5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4f63066318695ec5c9695e6c49c6a5.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eab478972a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eab478972a.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95e696994b196b793b19a1ec3c191c5c6e596191e4e693269336c36391a6e3a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e95e696994b196b793b19a1ec3c191c5c6e596191e4e693269336c36391a6e3a.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a1695a97a17d5a97a17906785a7816685a7e86685ad687.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a1695a97a17d5a97a17906785a7816685a7e86685ad687.png"
     ], 
     "iris.tests.test_plot.TestPcolor.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f003d527f002f427ea82f42d6a8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527e0d2f52d4ad.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f003d527f002f427ea82f42d6a8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527e0d2f52d4ad.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1f94e2c119938e9463678c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1f94e2c119938e9463678c.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a5695a96a53c0f711b3c0f7d1b97b46943c3e0cc416b5a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a5695a96a53c0f711b3c0f7d1b97b46943c3e0cc416b5a.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a5eb40c3f0ebe0c1c0c3f07c0b3e3e96a13c1e6d5b694a.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e381f96a096a5d6a5eb40c3f0ebf0c1e0c3f07c0a3e3e96a13c1e6d5b694a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a5eb40c3f0ebe0c1c0c3f07c0b3e3e96a13c1e6d5b694a.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a95e381f96a096a5d6a5eb40c3f0ebf0c1e0c3f07c0a3e3e96a13c1e6d5b694a.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc585c39986cdc79ec792e3a6960d584939793c3438743873.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc585c39986cdc79ec792e3a6960d584939793c3438743873.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e885e0954295e195ea95a085e87a153e7f95e06a1778557a1f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e885e0954295e195ea95a085e87a153e7f95e06a1778557a1f.png"
     ], 
     "iris.tests.test_plot.TestPcolorNoBounds.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba173a1795e895e8c5e8f400c1f8c1f895a8c5e87a077a5ec5e83e173e177e02.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ba173a1795e895e8c5e8f400c1f8c1f895a8c5e87a077a5ec5e83e173e177e02.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4fe3026318695ec5c9695e6c49c6a5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85e67c9c7e1391e97a596b03a3696a13c4fe3026318695ec5c9695e6c49c6a5.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eabc789722.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea74c707958b3878958b38f8c7236a557a542c7868d54b877875978abc789722.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea74c707958b387895ab38f8c7236a557a542c7868d54b05787197eabc789722.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e874978b978b6875978b6875978b7854950b78506855787468747ea2687597aa.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95e696994b196b593b19a1ec3c591c5c6e596191e4e693269336c36391a6e3a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e95e696994b196b593b19a1ec3c591c5c6e596191e4e693269336c36391a6e3a.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a16d5a97a17d5a97a17806785a7816685a7e86685ad687.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a16d5a97a17d5a97a17806785a7816685a7e86685ad687.png"
     ], 
     "iris.tests.test_plot.TestPcolormesh.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f002d527f002f427fa82f42d6a8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/af4280bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527f0d2f52d4ad.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/af42c0bdd0ad2f52d0bd3f42d0bd7f02d0bd7f002d527f002f427fa82f42d6a8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/af4280bdd0ad2f52d0ad2b52d0bd7f02d0bd7f002d527f002f527f0d2f52d4ad.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d84f17a1d94e2c11d938e9463678e.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1d94e2c11993ae9463678c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d84f17a1d94e2c11d938e9463678e.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1594f3858a670c94e37b1cccb13e736a1d8cf17a1d94e2c11993ae9463678c.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_ty.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a1695a96a53c1f711b3c0f791b97b46943c3e06c436b5a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad5e94a5c3b0c3f096a1695a96a53c1f711b3c0f791b97b46943c3e06c436b5a.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_tz.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a56b40c3f06be2c1c0c3f07c0b3ebe96a13c1e6d5b694a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a95e3c1f96a096a5d6a56b40c3f06be2c1c0c3f07c0b3ebe96a13c1e6d5b694a.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc785c39986cdc78ec792e7a6960d584939793c3438703873.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc785c39986cdc78ec792e7a6960d584939793c3438703873.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e895e0fd4295e095ea95a085e87a153e7e95e06a1778157a17.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e895e0fd4295e095ea95a085e87a153e7e95e06a1778157a17.png"
     ], 
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zy.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ba176a1795e895e8c5e87c00c1f8c1f894a8c5e87a077adec5e83e173e177a06.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ba176a1795e895e8c5e87c00c1f8c1f894a8c5e87a077adec5e83e173e177a06.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_t.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83fe955f6a05e5137305d9c4f443127195187e9cd5467fa3d4917b68fc007a1a.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe95027e05e7007305d9c4a447127f853f069f814f2fa7d4d12b6cfc007e5a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83fe955f6a05e5137305d9c4f443127195187e9cd5467fa3d4917b68fc007a1a.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffe95027e05e7007305d9c4a447127f853f069f814f2fa7d4d12b6cfc007e5a.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_t_dates.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd5ae2a15cdb6b10178d7d4082e57d7290906f685814277b1dc88724cfd26.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd5ae2a15c9b6a10178d7d4082c57d7290906f6c58942f7b1dc88724cfd26.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/abffd4a02a01cc84f10078d7d4082c77d73909ded6ef816273bd9c98725cdd26.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abffd5ae2a15cdb6b10178d7d4082e57d7290906f685814277b1dc88724cfd26.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abffd5ae2a15c9b6a10178d7d4082c57d7290906f6c58942f7b1dc88724cfd26.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abffd4a02a01cc84f10078d7d4082c77d73909ded6ef816273bd9c98725cdd26.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_x.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe95297e87c74a6a059158f89c3d6ed0536597c0387836d0f87866d0697097.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffe95297e87c74a6a059158f89c3d6ed0536597c0387836d0f87866d0697097.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_y.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896266f068d873b83cb71e435725cd07c607ad07e70fcd0007a7881fe7ab8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896066f068d873b83cb71e435725cd07c607ad07c70fcd0007af881fe7bb8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe896366f0f8d93398bcb71e435f24ed074646ed07670acf010726d81f2798c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe896266f068d873b83cb71e435725cd07c607ad07e70fcd0007a7881fe7ab8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe896066f068d873b83cb71e435725cd07c607ad07c70fcd0007af881fe7bb8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe896366f0f8d93398bcb71e435f24ed074646ed07670acf010726d81f2798c.png"
     ], 
     "iris.tests.test_plot.TestPlot.test_z.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_non_cube_coordinate.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81857e857e7e81857e7a81857e7a81857e7a818576c02a7e95856a7e81c17a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7e81857e7a81857e7a81857e7a818576c02a7e95856a7e81c17a.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe8142f5c17ebd2cc16eb548954a9542916a347a915e60bd4afd68793f916296.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe8142f5c17ebd2cc16eb548954a9542916a347a915e60bd4afd68793f916296.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6b91d968c161b972d76aa462b5.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6a91d96ac163b972d36aa462b5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6b91d968c161b972d76aa462b5.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8542b7b503b548857abd08857abd09945eed6a91d96ac163b972d36aa462b5.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bf88f457a03b5307e16b561f007b53ed067217ac1786afec0f570bf8178681a.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8bf98f057a03b5307e16b561f007b53ad067217ac1786afec0f570bf8178685a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bf88f457a03b5307e16b561f007b53ed067217ac1786afec0f570bf8178681a.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bf98f057a03b5307e16b561f007b53ad067217ac1786afec0f570bf8178685a.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffe8f367e05952afe05a50b980ded4bd05d69c2c1fb71c1c06272f4d0a06af4.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffe8f367e05952afe05a50b980ded4bd05d69c2c1fb71c1c06272f4d0a06af4.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aa953d0f85fab50fd0f2956a7a1785fafa176877d00f68f1d02c60f2f008d0f0.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebeaa5419e94b5019e97950d685395bee05361fad05560fad01570fef001dabe.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebeaa5419e95b5419e97950d6853953ee053617ad05560fad01570fef001dabe.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/aa953d0f85fab50fd0f2956a7a1785fafa176877d00f68f1d02c60f2f008d0f0.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ebeaa5419e94b5019e97950d685395bee05361fad05560fad01570fef001dabe.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ebeaa5419e95b5419e97950d6853953ee053617ad05560fad01570fef001dabe.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_tx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebfaaf439e87b5019687b5019687b56ac05561fae07103fe6079687a607178f8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ebfa2d4b968795059e87970f6854697ae055697ac08561fad041d7aef001d6ae.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ebfaaf439e87b5019687b5019687b56ac05561fae07103fe6079687a607178f8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ebfa2d4b968795059e87970f6854697ae055697ac08561fad041d7aef001d6ae.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_x.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aeb8b5095a87cd60386592d9ec97ad6dd23ca4f6d0797827f0096216c1f878e6.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/aeb8b5095a87cd60386592d9ec97ad6dd23ca4f6d0797827f0096216c1f878e6.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_y.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fea97194f07c9c830d79169ce16269f91097af6c47861f6d0796076d0797a16.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fee970b4f07c9c930d79129ce16269f91097af6c4f861f4d0786076d0797a16.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/afea97094f07c9c870d79129ce16269f91096af6c4f861f6c07960f6d0797a16.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fea97194f07c9c830d79169ce16269f91097af6c47861f6d0796076d0797a16.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fee970b4f07c9c930d79129ce16269f91097af6c4f861f4d0786076d0797a16.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/afea97094f07c9c870d79129ce16269f91096af6c4f861f6c07960f6d0797a16.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea85603f956a9741951e9d83c1fa8d2fd0a55af0d25f345ae5f062c72d68612d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea85603f956a9741951e9d83c1fa8d2fd0a55af0d25f345ae5f062c72d68612d.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e85a69cc96ad92e193c9963385929e1cc3819acde6d965ce6e666b30386e65b1.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffcc65767039740bc069d9ad00b8dadd03f52f181dd347a847a62ff81e8626c.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8ffcc65777039740bc069d9ad00b8dadd03d52f181dd707a847a62ff81e8626c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffcc65767039740bc069d9ad00b8dadd03f52f181dd347a847a62ff81e8626c.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ffcc65777039740bc069d9ad00b8dadd03d52f181dd707a847a62ff81e8626c.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5649c434ac92e5d9c9361b95b39c38c3835a5ec6d966ced34c633099ace5a5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea5649c434ac92e5d9c9361b95b39c38c3835a5ec6d966ced34c633099ace5a5.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2dd2d09295c3c0c7d13c1bc6d23d2c696de0e53c3ac393daf6d205c2c4.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c3c0c7d13c1bc6d23d2c696ce0e53c3ac393dbf6d205c2c0.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2f92d09295c3d0c7d13c1bc6d23d2c696cf0e53c3ac2b3d9f6d201c2c4.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad2f6d2dd2d09295c3c0c7d13c1bc6d23d2c696de0e53c3ac393daf6d205c2c4.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c3c0c7d13c1bc6d23d2c696ce0e53c3ac393dbf6d205c2c0.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad2f6d2f92d09295c3d0c7d13c1bc6d23d2c696cf0e53c3ac2b3d9f6d201c2c4.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_yx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9686d8c9696924797879e3b86929e58696d69cc6869659379626133398d9ccd.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e961658f961e92469e1e1c7966f36cd86165618c70e166b39b9698719e1e9ec8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9686d8c9696924797879e3b86929e58696d69cc6869659379626133398d9ccd.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e961658f961e92469e1e1c7966f36cd86165618c70e166b39b9698719e1e9ec8.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf803f00c05fc4bfc07ec15dc05fd8bbc07cc96c333a32113bd02dd27ced3ec0.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bf803f00c05fc4bfc07ec15dc05fd8bbc07cc96c333a32113bd02dd27ced3ec0.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95956a95626993941a6a2d956e6ed6845a6e65c4bec7b64a9594686ea19578.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea95956a95626993941a6a2d956e6ed6845a6e65c4bec7b64a9594686ea19578.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a327c847860fdc57a69beb0be68bd.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a32fd847860fdc57269beb0be689d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a327c847860fdc57a69beb0be68bd.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8fe82f047c018c83bc01bc5af01fd1bcd15a32fd847860fdc57269beb0be689d.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/cee8953a7a15856978579696d03d672cc49a6e5a842d3d2cc0b66bd1c2ea39f1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/cee8953a7a15856978579696d03d672cc49a6e5a842d3d2cc0b66bd1c2ea39f1.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ee953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a3dd038c0fef000d0fa.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a7dd068c0fef000d0fa.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ee953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a3dd038c0fef000d0fa.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae953f0591ea3f07914a95fa7e07d1fa68156a15d07c6a7dd068c0fef000d0fa.png"
     ], 
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_zx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a973d96a56953968769439685a54ae05117eae0511fba60513bba69717aba.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96a56953968769439685a54ae85197eae0511fba60513bba69717aba.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e87a973d96a56953968769439685a54ae05117eae0511fba60513bba69717aba.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e87a952d96a56953968769439685a54ae85197eae0511fba60513bba69717aba.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coord_names.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_coords.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9a53a59961ec5a62c691a587b9662e1c0e1e53e9e0e9b873ec15a7161bc642f.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_default.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/f9789b388786678686966c9093879ce592c79bc94d19929b6939cf66316c672c.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa81948e857e4971907ea72e95fa66b2952e4ead6d429b527ac7a5286e981836.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81948e857e4971907ea72e95fa66b2952e4ead6d429b527ac7a5286e981836.png"
     ], 
     "iris.tests.test_plot.TestPlotDimAndAuxCoordsKwarg.test_yx_order.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea159694856a6b5096afa53a36941da1e4f5c369cd1ae6d69b6a1c80625af2f6.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea159694856a6b5096afa53a36941da1e4f5c369cd1ae6d69b6a1c80625af2f6.png"
     ], 
     "iris.tests.test_plot.TestPlotOtherCoordSystems.test_plot_tmerc.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e63399cd99cd64b29999335965369b262649c98c9b3966c6998d3319ccd69333.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e63399cd99cd64b29999335965369b262649c98c9b3966c6998d3319ccd69333.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffb5d67fd4e5962211d9c6a443da77d5389c8ed346d923d011d968dc00da48.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82ffb5d67fdde5962211d9c6a441da77d5389c8cd346d927d011d968dc00da48.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fabd867fd5e5822201d9c6a4539a77953d8cbf834f99e7d051996cdc00da48.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffb5d67fd4e5962211d9c6a443da77d5389c8ed346d923d011d968dc00da48.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82ffb5d67fdde5962211d9c6a441da77d5389c8cd346d927d011d968dc00da48.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82fabd867fd5e5822201d9c6a4539a77953d8cbf834f99e7d051996cdc00da48.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_t_dates.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd5ae7f51efb6200378d7d4082c17d7280906d6e58962db31d800da6cdd26.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd4ae7f55efbe200178d7d4082c17d7280906d6e58962df319800da6cdd26.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3ffd4827f51ef94200078d7c4082c57d739095ed6ed8962db759808da6cdd26.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3ffd5ae7f51efb6200378d7d4082c17d7280906d6e58962db31d800da6cdd26.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3ffd4ae7f55efbe200178d7d4082c17d7280906d6e58962df319800da6cdd26.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3ffd4827f51ef94200078d7c4082c57d739095ed6ed8962db759808da6cdd26.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_x.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffb5097e84c54a621799d8601d9966d213cd67c039d876d078d866d869d8f7.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffbd097e84c54a621799d8601d9966d253cc27c039d876d078d866d869d8f7.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffb5097e84c54a621799d8601d9966d213cd67c039d876d078d866d869d8f7.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffbd097e84c54a621799d8601d9966d253cc27c039d876d078d866d869d8f7.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_y.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07c586cd001da69897e5838.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07cd86cd001da68897e58a8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7efb6367f008d97338fc973e435d86ef030c86ed070d86cd030d86d89f0d82c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07c586cd001da69897e5838.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a7ffb6067f008d87339bc973e435d86ef034c87ad07cd86cd001da68897e58a8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a7efb6367f008d97338fc973e435d86ef030c86ed070d86cd030d86d89f0d82c.png"
     ], 
     "iris.tests.test_plot.TestQuickplotPlot.test_z.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc1dc7e00b0dc66179d95f127cfc9d44959ba846658e891075a3e99415a2f.png"
     ], 
     "iris.tests.test_plot.TestSimple.test_bounds.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa9562fcc7c0b50bb53b9f8085727a157a95c0f67a85e07e0be08069e07d9fa0.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa9562fcc7c0b50bb53b9f8085727a157a95c0f67a85e07e0be08069e07d9fa0.png"
     ], 
     "iris.tests.test_plot.TestSimple.test_points.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
     ], 
     "iris.tests.test_plot.TestSymbols.test_cloud_cover.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e95a330c96a5ccf2695a330c96a5ccf2695a330c96b5ccf3694a330c96b5ccf3.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e95a330c96a5ccf2695a330c96a5ccf2695a330c96b5ccf3694a330c96b5ccf3.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_alignment.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa95350f952ad2f0c1f66ac1c55a4af4e550a52b3e05905e1e419e6f937e3b21.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa95350f952ad3f0c1f66a81e55a4af4e550a52b3e05905e1e419e6f937e1b21.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa95350f952ad2f0c1f66ac1c55a4af4e550a52b3e05905e1e419e6f937e3b21.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa95350f952ad3f0c1f66a81e55a4af4e550a52b3e05905e1e419e6f937e1b21.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee321fc96666919b6ec15fdca593600d2586785a259dfa5a01.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee3217c9e66691996ec15fdca593680d2586785a259dfa5a01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee321fc96666919b6ec15fdca593600d2586785a259dfa5a01.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a3fd956a7a01a5ee3217c9e66691996ec15fdca593680d2586785a259dfa5a01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contour.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fe812f88957a955a857a9257c17f7aa5c03dc0bf5a85c07e7f402d40a57a3f01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fe812f88957a955a857a9257c17f7aa5c03dc0bf5a85c07e7f402d40a57a3f01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/faa12bc1954ef43fc0bf9f02854a4ee48548c17a5ab5c17e7a0d7875a17e3a81.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa852f81955ac532c0bf9e89c57edae69357e13f4ea0c05a3f8561a4935a3e01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa852f81955ac532c0bf9e89c57edae69357e13f4ea0c05a3f8561a4935a3e01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_contourf_nameless.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/faa52ec1955ac536c0bf9e09c57edae69357e13f4e80c0da2f81618493da3f01.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/faa52ec1955ac536c0bf9e09c57edae69357e13f4e80c0da2f81618493da3f01.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_map.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_map.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4ecef19a6e9b64cb609925cd25.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4ecef19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolor.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb423d4e94a5c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bb423d4e94a5c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
     ], 
     "iris.tests.test_quickplot.TestLabels.test_pcolormesh.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bb433d4e94a4c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bb433d4e94a4c6b9c15adaadc1fb6a469c8de43a3e07904e5f016b57984e1ea1.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_non_cube_coordinate.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa816a85857a955ae17e957ec57e7a81855fc17e3a81c57e1a813a85c57a1a05.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa816a85857a955ae17e957ec57e7a81855fc17e3a81c57e1a813a85c57a1a05.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa856a95e15ab51a953e9485857a1f409552857e1fc1c07e5abd4a35e07f4aa5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa856a95e15ab51a953e9485857a1f409552857e1fc1c07e5abd4a35e07f4aa5.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa8562b7c2763d09956a955a855a1d88d45ec57a3f81c07e6ae16b21c0ff7a81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8aff878b7f00953062179561f087953ad167997a80784a7fc1e5d86d9978485f.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/8aff878b7f80953860179561f087953ad167997a80784a7fc1e5d86d9978485b.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8aff878b7f00953062179561f087953ad167997a80784a7fc1e5d86d9978485f.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8aff878b7f80953860179561f087953ad167997a80784a7fc1e5d86d9978485b.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82ff8db67f94952e76159d6bb01dcd629059c962c1fbd9c1c062da74d820ca74.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82be8db67f95952e761d9d6bb01dcd628059c962c1fbd9e1c072da64d060ca74.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe8db67f95952e76159d6bb01dcd629059c962c1fbd9e1c072da64d020ca74.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82ff8db67f94952e76159d6bb01dcd629059c962c1fbd9c1c062da74d820ca74.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82be8db67f95952e761d9d6bb01dcd628059c962c1fbd9e1c072da64d060ca74.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82fe8db67f95952e76159d6bb01dcd629059c962c1fbd9e1c072da64d020ca74.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aa97b70ff5f0970f20b2956a6a17957af805da71d06f5a75d02cd870d800d8f2.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e1faa549de9497090697971d60539f3ef171c87ac075487ad025d87ed801da3e.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/aa97b70ff5f0970f20b2956a6a17957af805da71d06f5a75d02cd870d800d8f2.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e1faa549de9497090697971d60539f3ef171c87ac075487ad025d87ed801da3e.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e8faad47f784bd0596859d03969f9962c05dc96ee07189fe6870c862687178f8.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a8fa2d4797859585b6959d07605f896ee051697ad061d9fad0619aaed801deae.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e8faad47f784bd0596859d03969f9962c05dc96ee07189fe6870c862687178f8.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a8fa2d4797859585b6959d07605f896ee051697ad061d9fad0619aaed801deae.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_x.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6ffb5097e84cde2224598d1649f8d6cd2388c76d0799867d009da76c9f8d866.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a6bfb5097f84cde2224599d1649f8d6cd2388c76d0799867d009da76c1f8d866.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a6ffb5097e84cde2224598d1649f8d6cd2388c76d0799867d009da76c9f8d866.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a6bfb5097f84cde2224599d1649f8d6cd2388c76d0799867d009da76c1f8d866.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_y.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ff978b7f00c9c830d7992166179e969509d866c478d964d079c876d869da26.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a7ff97837f00c9c830d79921661f9e9695099876c478d964c079c876d879da26.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a7ff978b7f00c9c830d7992166179e969509d866c478d964d079c876d869da26.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a7ff97837f00c9c830d79921661f9e9695099876c478d964c079c876d879da26.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea856a9ff16eb740954a9e05855a19a3c0fbc13e1ea5c07d5ad0cb58e45e3c35.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea856a9ff16eb740954a9e05855a19a3c0fbc13e1ea5c07d5ad0cb58e45e3c35.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e5a565b69e1a9a42917e1a19c17b3a619e59c47b3a25c53e3b8430e5c57a3e85.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e5a565b69e1a9a42917e1a19c17b3a619e59c47b3a25c53e3b8430e5c57a3e85.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/afffe6d67700958636179d92e019992dd039daf5817d987a807a48e499684a6d.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/aeffe6d67780958636179d92e019892dd139daf5815d987a807a48e699684a6d.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/afffe6d67700958636179d92e019992dd039daf5817d987a807a48e499684a6d.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/aeffe6d67780958636179d92e019892dd139daf5815d987a807a48e699684a6d.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea5e618434ac36e5c1c9369b95b39c38c3a39a4fcee19a6e9b64cb609925cd25.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d67d2c696ce0653c3ac2b1d976da05c2c4.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d27d2c696ce0e53c3ad2b1d976da01c2c4.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d67d2c696ce0653c3ac2b1d976da05c2c4.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ad2f6d2fd2d09295c2d1c3d33c1bc2d27d2c696ce0e53c3ad2b1d976da01c2c4.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_yx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e968658e969692c797879e3b86929e58696d49cd6869c9a37962c923990d9c6d.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e9e1658e961e92569e9e3c7966d36c586165698c70e1ce739b3698619e1e984c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e968658e969692c797879e3b86929e58696d49cd6869c9a37962c923990d9c6d.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9e1658e961e92569e9e3c7966d36c586165698c70e1ce739b3698619e1e984c.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/bf813f80c156c05dc0fec29dc17f1a6dd05fc0ff1aa1c57e3b243b20375a1e81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/bf813f80c156c05dc0fec29dc17f1a6dd05fc0ff1aa1c57e3b243b20375a1e81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.1": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ea95629d956a996069939e9bc07f7aad856cc47e5e81857a1e254a35c1be1b81.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea95629d956a996069939e9bc07f7aad856cc47e5e81857a1e254a35c1be1b81.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.2": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f867f008d8220179852f01fd9bed1789a6c847cc877c46ac972987ec8fd.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179852f01fd9bed1789a6c847cc877c468c9f6987ec8fd.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179c52f01fd9bed1789a6c847cc877c560c976987ec8fd.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ed2f867f008d8220179852f01fd9bed1789a6c847cc877c46ac972987ec8fd.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179852f01fd9bed1789a6c847cc877c468c9f6987ec8fd.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/87ed2f067f008d8220179c52f01fd9bed1789a6c847cc877c560c976987ec8fd.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.3": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600a56962df9e96f01dc926c498cc46847f9d6cd0244bf19a6b19f1.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600856962df9e96f01dcd26c498cc46847f9d6cd0244bf19a6b1975.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600a56962df9e96f01dc926c498cc46847f9d6cd0244bf19a6b19f1.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a2f9b5ba7600856962df9e96f01dcd26c498cc46847f9d6cd0244bf19a6b1975.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.4": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d86801f91ee6e1591fe7e117876c07d6877d068d878d800d07a.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d87801b91ee6e1599fe7e117874c07d6877d068d878d800d07a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d86801f91ee6e1591fe7e117876c07d6877d068d878d800d07a.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ae953f87d5e82d87801b91ee6e1599fe7e117874c07d6877d068d878d800d07a.png"
     ], 
     "iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_zx.5": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ee0519d6ee07f9b6a78619b2a79711a2a.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ae0519d6ee07f996a78719b2a79711a3a.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ee0519d6ee07f9b6a78619b2a79711a2a.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e87a952d96856943969f694696858d4ae0519d6ee07f996a78719b2a79711a3a.png"
     ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_not_reference_time_units.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82faa1977fdf89976200ddf6e000d9e7f75f9866d560dae4dc00d966dc005e20.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82b8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00d966fc005e20.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200ddf6e000d9e7f77f9866d560dee4dc00d966dc005e20.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00dd64dc005e20.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82faa1977fdf89976200ddf6e000d9e7f75f9866d560dae4dc00d966dc005e20.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82b8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00d966fc005e20.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200ddf6e000d9e7f77f9866d560dee4dc00d966dc005e20.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82f8a1977fdf89876200dde6e000d9e7f77f9866d560dfe4dc00dd64dc005e20.png"
     ], 
     "iris.tests.test_quickplot.TestTimeReferenceUnitsLabels.test_reference_time_units.0": [
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fd777ffe0002addd4002805dda8de65dde9d4625bfddc209841de20.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002a9dd4002805ddaade65d9a9d5625bfddc209841de20.png", 
-        "https://bjlittle.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002addd4002805dd28df67d9a9d4625bfddc209841de20.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82fe81987fd777ffe0002addd4002805dda8de65dde9d4625bfddc209841de20.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002a9dd4002805ddaade65d9a9d5625bfddc209841de20.png", 
+        "https://scitools.github.io/test-iris-imagehash/images/v4/82fe81987fdf77ffe0002addd4002805dd28df67d9a9d4625bfddc209841de20.png"
     ]
 }

--- a/lib/iris/tests/test_image_json.py
+++ b/lib/iris/tests/test_image_json.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2017, Met Office
+# (C) British Crown Copyright 2016 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -56,15 +56,15 @@ class TestImageFile(tests.IrisTest):
             return unittest.skip("Less than {} anonymous calls to "
                                  "GH API left!".format(amin))
         iuri = ('https://api.github.com/repos/scitools/'
-                'test-iris-imagehash/contents/images')
+                'test-iris-imagehash/contents/images/v4')
         r = requests.get(iuri, headers=headers)
         if r.status_code != 200:
             raise ValueError('Github API get failed: {}'.format(iuri,
                                                                 r.text))
         rj = r.json()
-        prefix = 'https://scitools.github.io/test-iris-imagehash/images/'
+        base = 'https://scitools.github.io/test-iris-imagehash/images/v4'
 
-        known_image_uris = set([prefix + rji['name'] for rji in rj])
+        known_image_uris = set([os.path.join(base, rji['name']) for rji in rj])
 
         repo_fname = os.path.join(os.path.dirname(__file__), 'results',
                                   'imagerepo.json')
@@ -72,11 +72,10 @@ class TestImageFile(tests.IrisTest):
             repo = json.load(codecs.getreader('utf-8')(fi))
         uris = set(itertools.chain.from_iterable(six.itervalues(repo)))
 
-        amsg = ('Images are referenced in imagerepo.json but not published'
-                ' in https://scitools.github.io/test-iris-imagehash/'
-                'images:\n{}')
+        amsg = ('Images are referenced in imagerepo.json but not published '
+                'in {}:\n{}')
         diffs = list(uris.difference(known_image_uris))
-        amsg = amsg.format('\n'.join(diffs))
+        amsg = amsg.format(base, '\n'.join(diffs))
 
         self.assertTrue(uris.issubset(known_image_uris), msg=amsg)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,5 @@ mock
 nose
 pep8
 filelock
-imagehash
+imagehash>=4.0
 requests


### PR DESCRIPTION
This PR addresses the issue of the `imagehash` package releasing version `4.0`, which addresses an error in the creation of hashes, see https://github.com/JohannesBuchner/imagehash#changelog

- [x] Apply fix to `idiff`
- [x] Investigate new test failure image and update `imagerepo.json` and `test-iris-imagehash` repo
- [x] Check `.travis-ci` for `test-iris-imagehash` repo

Closes #2973, #2974 