### PR TITLE
Use iris.tests.mock for Python 3

### DIFF
--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,13 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import copy
-import mock
 import numpy as np
 import numpy.ma as ma
 import six
 
 from iris._data_manager import DataManager
 from iris._lazy_data import as_lazy_data
+from iris.tests import mock
 
 
 class Test___copy__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
+++ b/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,9 +26,8 @@ import iris.tests as tests
 import os.path
 import subprocess
 
-import mock
-
 from iris.fileformats.dot import _dot_path, _DOT_EXECUTABLE_PATH
+from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__FillValueMaskCheckAndStoreTarget.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__FillValueMaskCheckAndStoreTarget.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,10 +27,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import numpy as np
 
 from iris.fileformats.netcdf import _FillValueMaskCheckAndStoreTarget
+from iris.tests import mock
 
 
 class Test__FillValueMaskCheckAndStoreTarget(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_save.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,7 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
 import netCDF4 as nc
 import numpy as np
 
@@ -31,6 +30,7 @@ import iris
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 from iris.fileformats.netcdf import save, CF_CONVENTIONS_VERSION
+from iris.tests import mock
 from iris.tests.stock import lat_lon_cube
 
 

--- a/lib/iris/tests/unit/fileformats/rules/test_Loader.py
+++ b/lib/iris/tests/unit/fileformats/rules/test_Loader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,9 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.rules import Loader
+from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/um/test_um_to_pp.py
+++ b/lib/iris/tests/unit/fileformats/um/test_um_to_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,9 +27,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
-import mock
-
 from iris.fileformats.um import um_to_pp
+from iris.tests import mock
 
 
 class Test_call(tests.IrisTest):

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,13 +23,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
-
 import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
 from iris._lazy_data import as_lazy_data, _MAX_CHUNK_SIZE, _limited_shape
+from iris.tests import mock
 
 
 class Test_as_lazy_data(tests.IrisTest):

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2017, Met Office
+# (C) British Crown Copyright 2016 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,9 +28,8 @@ import os.path
 import shutil
 import tempfile
 
-import mock
-
 from iris import sample_data_path
+from iris.tests import mock
 
 
 def _temp_file(sample_dir):


### PR DESCRIPTION
Our test usage of `mock` should always come from `iris.tests.mock` rather than performing an explicit `import mock`.

The `iris.tests` module provides this [in a way](https://github.com/SciTools/iris/blob/master/lib/iris/tests/__init__.py#L61) that works in both Python 2 and Python 3 - since in Python 3 `mock` is bundled within `unittest`.

This PR purges our use of `import mock` from our tests. Note that, we will only be able to purge `mock` itself from our test dependencies once we stop supporting Iris on Python 2.