### PR TITLE
test_pearsonr: reflect new latitude guess_bounds behaviour

### DIFF
--- a/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
+++ b/lib/iris/tests/unit/analysis/stats/test_pearsonr.py
@@ -85,12 +85,12 @@ class Test(tests.IrisTest):
         r = stats.pearsonr(self.cube_a, self.cube_b,
                            ['latitude', 'longitude'],
                            self.weights)
-        self.assertArrayAlmostEqual(r.data, [0.79106045,
-                                             0.79989169,
-                                             0.78826918,
-                                             0.79925855,
-                                             0.79011544,
-                                             0.80115837])
+        self.assertArrayAlmostEqual(r.data, [0.79105429,
+                                             0.79988078,
+                                             0.78825089,
+                                             0.79925653,
+                                             0.79009810,
+                                             0.80115292])
 
     def test_broadcast_cubes_weighted(self):
         r = stats.pearsonr(self.cube_a, self.cube_b[0, :, :],


### PR DESCRIPTION
Following #2960, I've changed the reference data for `test_compatible_cubes_weighted`.  The difference is purely due to the change in default behaviour of `cube.coords('latitude').guess_bounds()` at Iris 2.0.0.