### PR TITLE
Prevent creation of invalid CF variable names.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/bugfix_2018-May-03_var_name_constraint.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/bugfix_2018-May-03_var_name_constraint.txt
@@ -1,0 +1,2 @@
+* All var names being written to NetCDF are now CF compliant. Non alpha-numeric characters are replaced with '_', and must always have a leading letter.
+  Ref: https://github.com/SciTools/iris/pull/2930

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1340,6 +1340,27 @@ class Saver(object):
         return dimension_names
 
     @staticmethod
+    def cf_valid_var_name(var_name):
+        """
+        Return a valid CF var_name given a potentially invalid name.
+
+        Args:
+
+        * var_name (str):
+            The var_name to normalise
+
+        Returns:
+            A var_name suitable for passing through for variable creation.
+
+        """
+        # Replace invalid charaters with an underscore ("_").
+        var_name = re.sub(r'[^a-zA-Z0-9]', "_", var_name)
+        # Ensure the variable name starts with a letter.
+        if re.match(r'^[^a-zA-Z]', var_name):
+            var_name = 'var_{}'.format(var_name)
+        return var_name
+
+    @staticmethod
     def _cf_coord_identity(coord):
         """
         Determine a suitable units from a given coordinate.
@@ -1448,6 +1469,7 @@ class Saver(object):
             # Convert to lower case and replace whitespace by underscores.
             cf_name = '_'.join(cube.name().lower().split())
 
+        cf_name = self.cf_valid_var_name(cf_name)
         return cf_name
 
     def _get_coord_variable_name(self, cube, coord):
@@ -1480,6 +1502,8 @@ class Saver(object):
                     name = 'unknown_scalar'
             # Convert to lower case and replace whitespace by underscores.
             cf_name = '_'.join(name.lower().split())
+
+        cf_name = self.cf_valid_var_name(cf_name)
         return cf_name
 
     def _create_cf_cell_measure_variable(self, cube, dimension_names,

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -486,8 +486,8 @@ class Test_cf_valid_var_name(tests.IrisTest):
                          'var__invalid')
 
     def test_leading_number(self):
-        self.assertEqual(Saver.cf_valid_var_name('_invalid'),
-                         'var__invalid')
+        self.assertEqual(Saver.cf_valid_var_name('2invalid'),
+                         'var_2invalid')
 
     def test_leading_invalid(self):
         self.assertEqual(Saver.cf_valid_var_name('?invalid'),

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -470,6 +470,33 @@ class Test_write_fill_value(tests.IrisTest):
         with self.assertNoWarningsRegexp(r'\(fill\|mask\)'):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
+
+
+class Test_cf_valid_var_name(tests.IrisTest):
+    def test_no_replacement(self):
+        self.assertEqual(Saver.cf_valid_var_name('valid_Nam3'),
+                         'valid_Nam3')
+
+    def test_special_chars(self):
+        self.assertEqual(Saver.cf_valid_var_name('inv?alid'),
+                         'inv_alid')
+
+    def test_leading_underscore(self):
+        self.assertEqual(Saver.cf_valid_var_name('_invalid'),
+                         'var__invalid')
+
+    def test_leading_number(self):
+        self.assertEqual(Saver.cf_valid_var_name('_invalid'),
+                         'var__invalid')
+
+    def test_leading_invalid(self):
+        self.assertEqual(Saver.cf_valid_var_name('?invalid'),
+                         'var__invalid')
+
+    def test_no_hyphen(self):
+        # CF explicitly prohibits hyphen, even though it is fine in NetCDF.
+        self.assertEqual(Saver.cf_valid_var_name('valid-netcdf'),
+                         'valid_netcdf')
 
 
 class _Common__check_attribute_compliance(object):


### PR DESCRIPTION
This came up in #2930.

The following code:

```
import iris
cube = iris.cube.Cube([1, 2, 3])
cube.var_name = 'm??s122i123'
iris.save(cube, 'foo.nc')
```

Would previously have created the following NetCDF:

```
netcdf foo {
dimensions:
	dim0 = 3 ;
variables:
	int64 m\?\?s122i123(dim0) ;

// global attributes:
		:Conventions = "CF-1.5" ;
}
```

This file is both invalid NetCDF, and explicitly invalid CF.