### PR TITLE
Replace iris.co_realise_cubes with CubeList.realise_data.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-08_co_realise_cubes.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-Mar-08_co_realise_cubes.txt
@@ -1,3 +1,3 @@
-* Added new function :func:`iris.co_realise_cubes` to compute multiple lazy
-  values in a single operation, avoiding repeated re-loading of data or
-  re-calculation of expressions.
+* Added new function :func:`iris.cube.CubeList.realise_data` to compute
+  multiple lazy values in a single operation, avoiding repeated re-loading of
+  data or re-calculation of expressions.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -112,7 +112,6 @@ import iris._constraints
 from iris._deprecation import IrisDeprecation, warn_deprecated
 import iris.fileformats
 import iris.io
-from iris._lazy_data import co_realise_cubes
 
 
 try:
@@ -128,7 +127,7 @@ __version__ = '2.1.0dev0'
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',
            'save', 'Constraint', 'AttributeConstraint', 'sample_data_path',
            'site_configuration', 'Future', 'FUTURE',
-           'IrisDeprecation', 'co_realise_cubes']
+           'IrisDeprecation']
 
 
 Constraint = iris._constraints.Constraint

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -209,7 +209,7 @@ def co_realise_cubes(*cubes):
         std_err = (a_std * a_std + b_std * b_std) ** 0.5
 
         # Compute stats together (to avoid multiple data passes).
-        iris.co_realise_cubes(a_std, b_std, ab_mean_diff, std_err)
+        co_realise_cubes(a_std, b_std, ab_mean_diff, std_err)
 
 
     .. Note::

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -38,8 +38,10 @@ import numpy.ma as ma
 
 from iris._data_manager import DataManager
 from iris._deprecation import warn_deprecated
-from iris._lazy_data import (as_concrete_data, is_lazy_data,
-                             multidim_lazy_stack, lazy_elementwise)
+from iris._lazy_data import (as_concrete_data as _lazy_as_concrete_data,
+                             is_lazy_data as _lazy_is_lazy_data,
+                             multidim_lazy_stack as lazy_multidim_stack,
+                             lazy_elementwise as _lazy_elementwise)
 import iris.aux_factory
 import iris.exceptions
 import iris.time
@@ -554,7 +556,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         return cls(**kwargs)
 
     def _sanitise_array(self, src, ndmin):
-        if is_lazy_data(src):
+        if _lazy_is_lazy_data(src):
             # Lazy data : just ensure ndmin requirement.
             ndims_missing = ndmin - src.ndim
             if ndims_missing <= 0:
@@ -672,7 +674,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         """
         result = self._points_dm.core_data()
-        if not is_lazy_data(result):
+        if not _lazy_is_lazy_data(result):
             result = result.view()
         return result
 
@@ -685,7 +687,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         result = None
         if self.has_bounds():
             result = self._bounds_dm.core_data()
-            if not is_lazy_data(result):
+            if not _lazy_is_lazy_data(result):
                 result = result.view()
         return result
 
@@ -925,14 +927,14 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 return old_unit.convert(values, new_unit)
 
         if self.has_lazy_points():
-            new_points = lazy_elementwise(self.lazy_points(),
+            new_points = _lazy_elementwise(self.lazy_points(),
                                           pointwise_convert)
         else:
             new_points = self.units.convert(self.points, unit)
         self.points = new_points
         if self.has_bounds():
             if self.has_lazy_bounds():
-                new_bounds = lazy_elementwise(self.lazy_bounds(),
+                new_bounds = _lazy_elementwise(self.lazy_bounds(),
                                               pointwise_convert)
             else:
                 new_bounds = self.units.convert(self.bounds, unit)
@@ -1230,8 +1232,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             points = (float(lower) + float(upper)) * 0.5
 
             # Create the new collapsed coordinate.
-            if is_lazy_data(item):
-                bounds = multidim_lazy_stack(bounds)
+            if _lazy_is_lazy_data(item):
+                bounds = lazy_multidim_stack(bounds)
                 coord = self.copy(points=points, bounds=bounds)
             else:
                 bounds = np.concatenate(bounds)
@@ -1753,7 +1755,7 @@ class DimCoord(Coord):
         # DimCoord always realises the points, to allow monotonicity checks.
         # Ensure it is an actual array, and also make our own copy so that we
         # can make it read-only.
-        points = as_concrete_data(points)
+        points = _lazy_as_concrete_data(points)
         points = np.array(points)
 
         # Check validity requirements for dimension-coordinate points.
@@ -1812,7 +1814,7 @@ class DimCoord(Coord):
     def _bounds_setter(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.
-            bounds = as_concrete_data(bounds)
+            bounds = _lazy_as_concrete_data(bounds)
             bounds = np.array(bounds)
 
             # Check validity requirements for dimension-coordinate bounds.
@@ -1938,7 +1940,7 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if data is None:
             raise ValueError('The data payload of a CellMeasure may not be '
                              'None; it must be a numpy array or equivalent.')
-        if is_lazy_data(data) and data.dtype.kind in 'biu':
+        if _lazy_is_lazy_data(data) and data.dtype.kind in 'biu':
             # Non-floating cell measures are not valid up to CF v1.7
             msg = ('Cannot create cell measure with lazy data of type {}, as '
                    'integer types are not currently supported.')

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -41,7 +41,8 @@ from iris._cube_coord_common import CFVariableMixin
 import iris._concatenate
 import iris._constraints
 from iris._data_manager import DataManager
-from iris._lazy_data import lazy_elementwise, co_realise_cubes
+from iris._lazy_data import (lazy_elementwise as _lazy_elementwise,
+                             co_realise_cubes as _lazy_co_realise_cubes)
 
 import iris._merge
 import iris.analysis
@@ -617,7 +618,7 @@ class CubeList(list):
             Cubes with non-lazy data are not affected.
 
         """
-        co_realise_cubes(*self)
+        _lazy_co_realise_cubes(*self)
 
 
 def _is_single_item(testee):
@@ -910,7 +911,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             def pointwise_convert(values):
                 return old_unit.convert(values, new_unit)
 
-            new_data = lazy_elementwise(self.lazy_data(), pointwise_convert)
+            new_data = _lazy_elementwise(self.lazy_data(), pointwise_convert)
         else:
             new_data = self.units.convert(self.data, unit)
         self.data = new_data

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -25,6 +25,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import collections
+import copy
 from copy import deepcopy
 import datetime
 from functools import reduce
@@ -41,8 +42,7 @@ from iris._cube_coord_common import CFVariableMixin
 import iris._concatenate
 import iris._constraints
 from iris._data_manager import DataManager
-from iris._lazy_data import (lazy_elementwise as _lazy_elementwise,
-                             co_realise_cubes as _lazy_co_realise_cubes)
+import iris._lazy_data as _lazy
 
 import iris._merge
 import iris.analysis
@@ -618,7 +618,7 @@ class CubeList(list):
             Cubes with non-lazy data are not affected.
 
         """
-        _lazy_co_realise_cubes(*self)
+        _lazy.co_realise_cubes(*self)
 
 
 def _is_single_item(testee):
@@ -911,7 +911,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             def pointwise_convert(values):
                 return old_unit.convert(values, new_unit)
 
-            new_data = _lazy_elementwise(self.lazy_data(), pointwise_convert)
+            new_data = _lazy.lazy_elementwise(self.lazy_data(),
+                                              pointwise_convert)
         else:
             new_data = self.units.convert(self.data, unit)
         self.data = new_data

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -308,7 +308,7 @@ class TestRealiseData(tests.IrisTest):
         # _lazy_data.co_realise_cubes.
         mock_cubes_list = [mock.Mock(ident=count) for count in range(3)]
         test_cubelist = CubeList(mock_cubes_list)
-        call_patch = self.patch('iris.cube.co_realise_cubes')
+        call_patch = self.patch('iris.cube._lazy_co_realise_cubes')
         test_cubelist.realise_data()
         # Check it was called once, passing cubes as *args.
         self.assertEqual(call_patch.call_args_list,

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -32,6 +32,7 @@ from iris.coords import AuxCoord, DimCoord
 import iris.coord_systems
 import iris.exceptions
 from iris.fileformats.pp import STASH
+from iris.tests import mock
 
 
 class Test_concatenate_cube(tests.IrisTest):
@@ -299,6 +300,19 @@ class TestPrint(tests.IrisTest):
         expected = ('0: m01s00i004 / (unknown)       '
                     '       (latitude: 3; longitude: 4)')
         self.assertEqual(str(self.cubes), expected)
+
+
+class TestRealiseData(tests.IrisTest):
+    def test_realise_data(self):
+        # Simply check that calling CubeList.realise_data is calling
+        # _lazy_data.co_realise_cubes.
+        mock_cubes_list = [mock.Mock(ident=count) for count in range(3)]
+        test_cubelist = CubeList(mock_cubes_list)
+        call_patch = self.patch('iris.cube.co_realise_cubes')
+        test_cubelist.realise_data()
+        # Check it was called once, passing cubes as *args.
+        self.assertEqual(call_patch.call_args_list,
+                         [mock.call(*mock_cubes_list)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -308,7 +308,7 @@ class TestRealiseData(tests.IrisTest):
         # _lazy_data.co_realise_cubes.
         mock_cubes_list = [mock.Mock(ident=count) for count in range(3)]
         test_cubelist = CubeList(mock_cubes_list)
-        call_patch = self.patch('iris.cube._lazy_co_realise_cubes')
+        call_patch = self.patch('iris.cube._lazy.co_realise_cubes')
         test_cubelist.realise_data()
         # Check it was called once, passing cubes as *args.
         self.assertEqual(call_patch.call_args_list,

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -308,7 +308,7 @@ class TestRealiseData(tests.IrisTest):
         # _lazy_data.co_realise_cubes.
         mock_cubes_list = [mock.Mock(ident=count) for count in range(3)]
         test_cubelist = CubeList(mock_cubes_list)
-        call_patch = self.patch('iris.cube._lazy.co_realise_cubes')
+        call_patch = self.patch('iris._lazy_data.co_realise_cubes')
         test_cubelist.realise_data()
         # Check it was called once, passing cubes as *args.
         self.assertEqual(call_patch.call_args_list,


### PR DESCRIPTION
Closes #3012 

I have to say though, that I find this much less obvious both in the usage and the naming.
The problem is that wrapping a bunch of cubes in a cubelist "just" in order to co-realise them seems clunky and non-obvious.  It means also that the documentation now appears in a much more obscure place.
The new name also does not sing for me : it does not highlight  what is **specifically useful** about the operation.
See the example docstring change here : https://github.com/pp-mo/iris/blob/9b24050b92559b467984bd98b57c7aeadcf2f39e/lib/iris/cube.py#L612
I think this will be typical usage, and it is a bit obscure and horrible IMO.

So frankly,  I still preferred it the way it was.
Please think on? @pelson @dkillick