### PR TITLE
Add netcdftime as a dependency

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,8 +5,7 @@
 
 cartopy
 matplotlib<1.9
-netcdf4
-netcdftime
+netcdf4<1.4
 numpy
 scipy
 # pyke (not pip installable)  #conda: pyke

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,6 +6,7 @@
 cartopy
 matplotlib<1.9
 netcdf4
+netcdftime
 numpy
 scipy
 # pyke (not pip installable)  #conda: pyke


### PR DESCRIPTION
As netcdf4 v1.4.0, netcdftime has been removed and so needs to be added as a separate dependency

The conda-forge recipe will also need updating

The conda build of cf_units v1.2 will also need updating (The latestcf_units has removed the dependency on netcdftime)