### PR TITLE
WIP: swap ckdtree for pykdtree

### DIFF
--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -28,7 +28,6 @@ import math
 from pykdtree.kdtree import KDTree
 
 import numpy as np
-from scipy.spatial import cKDTree
 
 import iris.analysis
 import iris.coord_systems

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -25,6 +25,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import math
+from pykdtree.kdtree import KDTree
 
 import numpy as np
 from scipy.spatial import cKDTree
@@ -618,11 +619,11 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_points, cache=None):
 
         # Convert to cartesian coordinates. Flatten for kdtree compatibility.
         cartesian_space_data_coords = \
-            _cartesian_sample_points(sample_space_data_positions,
-                                     sample_point_coord_names)
+            np.array(_cartesian_sample_points(sample_space_data_positions,
+                                              sample_point_coord_names))
 
         # Create a kdtree for the nearest-distance lookup to these 3d points.
-        kdtree = cKDTree(cartesian_space_data_coords)
+        kdtree = KDTree(cartesian_space_data_coords)
         # This can find the nearest datum point to any given target point,
         # which is the goal of this function.
 
@@ -633,8 +634,8 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_points, cache=None):
     # Convert the sample points to cartesian (3d) coords.
     # If there is no latlon within the coordinate there will be no change.
     # Otherwise, geographic latlon is replaced with cartesian xyz.
-    cartesian_sample_points = _cartesian_sample_points(
-        coord_values, sample_point_coord_names)
+    cartesian_sample_points = np.array(_cartesian_sample_points(
+        coord_values, sample_point_coord_names))
 
     # Use kdtree to get the nearest sourcepoint index for each target point.
     _, datum_index_lists = kdtree.query(cartesian_sample_points)

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -28,7 +28,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 import itertools
 
-from netCDF4 import netcdftime
+import netcdftime
 import numpy as np
 
 from iris._lazy_data import as_lazy_data, multidim_lazy_stack


### PR DESCRIPTION
This is a proof of concept of using `pykdtree` rather than `ckdtree` in the trajectory nearest-neighbour function `iris.analysis.trajectory._nearest_neighbour_indices_ndcoords`.

The diff shows a few small tweaks to the `trajectory` module which constitute the entire change, plus a tiny non-functional tweak to `...._fast_load_structured_fields` just to make it work now that it's broken.