### PR TITLE
Amend var_name documentation

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -138,18 +138,18 @@ class CFVariableMixin(object):
 
     @property
     def var_name(self):
-        """The CF variable name for the object."""
+        """The netCDF variable name for the object."""
         return self._var_name
 
     @var_name.setter
     def var_name(self, name):
         if name is not None:
             if not name:
-                raise ValueError('An empty string is not a valid CF variable '
-                                 'name.')
+                raise ValueError('An empty string is not a valid netCDF '
+                                 'variable name.')
             elif set(name).intersection(string.whitespace):
-                raise ValueError('{!r} is not a valid CF variable name because'
-                                 ' it contains whitespace.'.format(name))
+                raise ValueError('{!r} is not a valid netCDF variable name '
+                                 'because it contains whitespace.'.format(name))
         self._var_name = name
 
     @property

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -149,7 +149,7 @@ class CFVariableMixin(object):
                                  'variable name.')
             elif set(name).intersection(string.whitespace):
                 raise ValueError('{!r} is not a valid netCDF variable name '
-                                 'because it contains whitespace.'.format(name))
+                                 'as it contains whitespace.'.format(name))
         self._var_name = name
 
     @property

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -51,7 +51,7 @@ class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):
         #: Descriptive name of the coordinate made by the factory
         self.long_name = None
 
-        #: CF variable name of the coordinate made by the factory
+        #: netCDF variable name for the coordinate made by the factory
         self.var_name = None
 
         #: Coordinate system (if any) of the coordinate made by the factory

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -419,11 +419,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         Kwargs:
 
         * standard_name:
-            CF standard name of coordinate
+            CF standard name of the coordinate.
         * long_name:
-            Descriptive name of coordinate
+            Descriptive name of the coordinate.
         * var_name:
-            CF variable name of coordinate
+            The netCDF variable name for the coordinate.
         * units
             The :class:`~cf_units.Unit` of the coordinate's values.
             Can be a string, which will be converted to a Unit object.
@@ -447,7 +447,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         #: Descriptive name of the coordinate.
         self.long_name = long_name
 
-        #: The CF variable name for the coordinate.
+        #: The netCDF variable name for the coordinate.
         self.var_name = var_name
 
         #: Unit of the quantity that the coordinate represents.
@@ -1884,11 +1884,11 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
         Kwargs:
 
         * standard_name:
-            CF standard name of coordinate
+            CF standard name of the coordinate.
         * long_name:
-            Descriptive name of coordinate
+            Descriptive name of the coordinate.
         * var_name:
-            CF variable name of coordinate
+            The netCDF variable name for the coordinate.
         * units
             The :class:`~cf_units.Unit` of the coordinate's values.
             Can be a string, which will be converted to a Unit object.
@@ -1905,7 +1905,7 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
         #: Descriptive name of the coordinate.
         self.long_name = long_name
 
-        #: The CF variable name for the coordinate.
+        #: The netCDF variable name for the coordinate.
         self.var_name = var_name
 
         #: Unit of the quantity that the coordinate represents.


### PR DESCRIPTION
Following https://github.com/SciTools/iris/pull/2874 this PR makes all docstrings/comments/exception messages refer to `var_name` as netCDF variable name.
