### PR TITLE
WIP: Unpin the numpy version in our CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ install:
     python requirements/gen_conda_requirements.py ${CONDA_REQS_FLAGS} --groups ${CONDA_REQS_GROUPS} > ${CONDA_REQS_FILE};
     cat ${CONDA_REQS_FILE};
     conda install --quiet --file ${CONDA_REQS_FILE};
+    conda install numpy=1.14 --force
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 


### PR DESCRIPTION
We are currently bound to an old numpy because we are pinned to an old matplotlib. @bjlittle is unpicking the matplotlib side of things, which seems to be bleeding into a numpy pinning issue. This is a WIP PR to unpin numpy separately from mpl, so that we can bank some of the great stuff that @bjlittle has been doing.