### PR TITLE
Partial collapse of multi-dimensional coordinates

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-May-03_multidim_collapse.txt
+++ b/docs/iris/src/whatsnew/contributions_2.1/newfeature_2018-May-03_multidim_collapse.txt
@@ -1,0 +1,2 @@
+* The partial collapse of multi-dimensional auxiliary coordinates is now
+  supported. Collapsed bounds span the range of the collapsed dimension(s).

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1169,20 +1169,14 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         the specified dimensions.
 
         Replaces the points & bounds with a simple bounded region.
-
-        .. note::
-            You cannot partially collapse a multi-dimensional coordinate. See
-            :ref:`cube.collapsed <partially_collapse_multi-dim_coord>` for more
-            information.
-
         """
+        import dask.array as da
+        # Ensure dims_to_collapse is a tuple to be able to pass
+        # through to numpy
         if isinstance(dims_to_collapse, (int, np.integer)):
-            dims_to_collapse = [dims_to_collapse]
-
-        if dims_to_collapse is not None and \
-                set(range(self.ndim)) != set(dims_to_collapse):
-            raise ValueError('Cannot partially collapse a coordinate (%s).'
-                             % self.name())
+            dims_to_collapse = (dims_to_collapse, )
+        if isinstance(dims_to_collapse, list):
+            dims_to_collapse = tuple(dims_to_collapse)
 
         if np.issubdtype(self.dtype, np.str_):
             # Collapse the coordinate by serializing the points and
@@ -1215,28 +1209,20 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                     'Metadata may not be fully descriptive for {!r}.'
                 warnings.warn(msg.format(self.name()))
 
-            # Create bounds for the new collapsed coordinate.
-            item = self.core_bounds() if self.has_bounds() \
+            # Determine the array library for stacking
+            al = da if self.has_bounds() \
+                and _lazy.is_lazy_data(self.core_bounds()) else np
+
+            item = al.concatenate(self.core_bounds()) if self.has_bounds() \
                 else self.core_points()
-            lower, upper = item.min(), item.max()
-            bounds_dtype = item.dtype
-            # Ensure 2D shape of new bounds.
-            bounds = np.empty((1, 2), 'object')
-            bounds[0, 0] = lower
-            bounds[0, 1] = upper
-            # Create points for the new collapsed coordinate.
-            points_dtype = self.dtype
-            points = (float(lower) + float(upper)) * 0.5
+
+            # Calculate the bounds and points along the right dims
+            bounds = al.stack([item.min(axis=dims_to_collapse),
+                               item.max(axis=dims_to_collapse)]).T
+            points = al.array(bounds.sum(axis=-1) * 0.5, dtype=self.dtype)
 
             # Create the new collapsed coordinate.
-            if _lazy.is_lazy_data(item):
-                bounds = _lazy.multidim_lazy_stack(bounds)
-                coord = self.copy(points=points, bounds=bounds)
-            else:
-                bounds = np.concatenate(bounds)
-                bounds = np.array(bounds, dtype=bounds_dtype)
-                coord = self.copy(points=np.array(points, dtype=points_dtype),
-                                  bounds=bounds)
+            coord = self.copy(points=points, bounds=bounds)
         return coord
 
     def _guess_bounds(self, bound_position=0.5):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3155,22 +3155,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
                 cube.collapsed(['latitude', 'longitude'],
                                iris.analysis.VARIANCE)
-
-        .. _partially_collapse_multi-dim_coord:
-
-        .. note::
-            You cannot partially collapse a multi-dimensional coordinate. Doing
-            so would result in a partial collapse of the multi-dimensional
-            coordinate. Instead you must either:
-                 * collapse in a single operation all cube axes that the
-                   multi-dimensional coordinate spans,
-                 * remove the multi-dimensional coordinate from the cube before
-                   performing the collapse operation, or
-                 * not collapse the coordinate at all.
-
-            Multi-dimensional derived coordinates will not prevent a successful
-            collapse operation.
-
         """
         # Convert any coordinate names to coordinates
         coords = self._as_list_of_coords(coords)

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -308,6 +308,54 @@ class TestMissingData(tests.IrisTest):
 
         cube = self.cube_with_mask.collapsed('foo', iris.analysis.SUM)
         np.testing.assert_array_equal(cube.data, np.array([6, 18, 17]))
+
+
+class TestAuxCoordCollapse(tests.IrisTest):
+
+    def setUp(self):
+        self.cube_with_aux_coord = tests.stock.simple_4d_with_hybrid_height()
+
+        # Guess bounds to get the weights
+        self.cube_with_aux_coord.coord('grid_latitude').guess_bounds()
+        self.cube_with_aux_coord.coord('grid_longitude').guess_bounds()
+
+    def test_max(self):
+        cube = self.cube_with_aux_coord.collapsed('grid_latitude',
+                                                  iris.analysis.MAX)
+        np.testing.assert_array_equal(cube.coord('surface_altitude').points,
+                                      np.array([112, 113, 114,
+                                                115, 116, 117]))
+
+        np.testing.assert_array_equal(cube.coord('surface_altitude').bounds,
+                                      np.array([[100, 124],
+                                                [101, 125],
+                                                [102, 126],
+                                                [103, 127],
+                                                [104, 128],
+                                                [105, 129]]))
+
+        # Check collapsing over the whole coord still works
+        cube = self.cube_with_aux_coord.collapsed('altitude',
+                                                  iris.analysis.MAX)
+
+        np.testing.assert_array_equal(cube.coord('surface_altitude').points,
+                                      np.array([114]))
+
+        np.testing.assert_array_equal(cube.coord('surface_altitude').bounds,
+                                      np.array([[100, 129]]))
+
+        cube = self.cube_with_aux_coord.collapsed('grid_longitude',
+                                                  iris.analysis.MAX)
+
+        np.testing.assert_array_equal(cube.coord('surface_altitude').points,
+                                      np.array([102, 108, 114, 120, 126]))
+
+        np.testing.assert_array_equal(cube.coord('surface_altitude').bounds,
+                                      np.array([[100, 105],
+                                                [106, 111],
+                                                [112, 117],
+                                                [118, 123],
+                                                [124, 129]]))
 
 
 class TestAggregator_mdtol_keyword(tests.IrisTest):


### PR DESCRIPTION
Follow up on #3008 - Adding support for partial collapse of multi-dimensional coordinates (while keeping the current behaviour of points being the mid-points of bounds)