### PR TITLE
Add dask-array as a requirement when pip installing.

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,9 +6,8 @@
 cartopy
 cf_units>=2
 cftime
-dask>=0.17.1
+dask[array]>=0.17.1  #conda: dask>=0.17.1
 matplotlib>=2
 netcdf4<1.4
 numpy>=1.14
-# pyke (not pip installable)  #conda: pyke
 scipy


### PR DESCRIPTION
Closes #2994.