### PR TITLE
Remove the CODING matrix item.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ sudo: false
 
 env:
   matrix:
-    - TEST_TARGET=coding
     - TEST_TARGET=default TEST_MINIMAL=true
     - TEST_TARGET=default
     - TEST_TARGET=example
@@ -118,7 +117,7 @@ install:
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=3;
+      python -m iris.tests.runner --default-tests --system-tests --coding-tests --print-failed-images --num-processors=3;
     fi
   - if [[ $TEST_TARGET == 'example' ]]; then
       python -m iris.tests.runner --example-tests --print-failed-images --num-processors=3;
@@ -160,10 +159,4 @@ script:
   - if [[ $TEST_TARGET == 'doctest' ]]; then
       cd $INSTALL_DIR/docs/iris/src/whatsnew;
       python aggregate_directory.py --checkonly;
-    fi
-  - if [[ $TEST_TARGET == 'coding' ]]; then
-      cd $INSTALL_DIR;
-      python setup.py pyke_rules;
-      python setup.py std_names;
-      python setup.py test --coding-tests;
     fi


### PR DESCRIPTION
These two items (one for py2 and one for py3) are redundant, but do give us a quick glance at whether there was a coding issue. Mostly this comes down to the license header check, as we now have sticker to give us pep8 info.