### PR TITLE
Use the correct pypi name for nc-time-axis.

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -5,7 +5,7 @@
 #conda: esmpy>=7.0  (only python=2)
 #gdal : under review -- not tested at present
 mo_pack
-nc_time_axis
+nc-time-axis  # conda: nc_time_axis
 pandas
 stratify  #conda: python-stratify
 pyugrid


### PR DESCRIPTION
It is nc-time-axis on pypi: https://pypi.org/project/nc-time-axis/
But nc_time_axis on conda-forge: https://github.com/conda-forge/nc_time_axis-feedstock

Clearly, this hasn't been an issue for anybody, and it isn't tested, but nice to be correct too. 😉 