### PR TITLE
fix #conda requirement for nc_time_axis

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -5,7 +5,7 @@
 #conda: esmpy>=7.0  (only python=2)
 #gdal : under review -- not tested at present
 mo_pack
-nc-time-axis  # conda: nc_time_axis
+nc-time-axis  #conda: nc_time_axis
 pandas
 stratify  #conda: python-stratify
 pyugrid

--- a/requirements/gen_conda_requirements.py
+++ b/requirements/gen_conda_requirements.py
@@ -28,7 +28,7 @@ def read_conda_reqs(fname, options):
     with open(fname, 'r') as fh:
         for line in fh:
             line = line.strip()
-            if '#conda:' in line:
+            if CONDA_PATTERN in line:
                 line_start = line.index(CONDA_PATTERN) + len(CONDA_PATTERN)
                 line = line[line_start:].strip()
                 if 'only python=2' in line:


### PR DESCRIPTION
We should be using the `#conda:` directive and not `# conda:` for the requirements.