### PR TITLE
Release branch close (v1.13.x, v2.0.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,10 +127,6 @@ script:
   # the RC, so it's best to start each operation with an absolute cd.
   - INSTALL_DIR=$(pwd)
 
-  # "make html" produces an error when run on Travis that does not
-  # affect any downstream functionality but causes the build to fail
-  # spuriously. The echo-backtick workaround gets around this error,
-  # which should be investigated further in the future.
   - >
     if [[ $TEST_TARGET == 'doctest' ]]; then
       MPL_RC_DIR=$HOME/.config/matplotlib;

--- a/docs/iris/src/sphinxext/gen_gallery.py
+++ b/docs/iris/src/sphinxext/gen_gallery.py
@@ -13,7 +13,9 @@ import os
 import glob
 import re
 import warnings
+
 import matplotlib.image as image
+from sphinx.util import status_iterator
 
 from sphinx.util import status_iterator
 
@@ -65,8 +67,7 @@ def gen_gallery(app, doctree):
         'mathtext_examples',
         'matshow_02',
         'matshow_03',
-        'matplotlib_icon',
-        ])
+        'matplotlib_icon'])
 
     thumbnails = {}
     rows = []
@@ -194,8 +195,7 @@ images = new Array();
         with open(gallery_path, 'w') as fh:
             fh.write(content)
 
-    for key in status_iterator(thumbnails,
-                               'generating thumbnails... ',
+    for key in status_iterator(thumbnails, 'generating thumbnails... ',
                                length=len(thumbnails)):
         image.thumbnail(key, thumbnails[key], 0.3)
 


### PR DESCRIPTION
No changes from me in this PR, simply merging v1.13.x and v2.0.x into master (hence these aren't my commits). I'm pushing here for transparency and Travis testing, but am comfortable merging this myself.

Once merged, I'll go ahead and remove the v1.13.x and v2.0.x branches, which are currently at a6d2764a71f21e9c5a4a7ac897a9efc654f735ad and 70a4052299a6c135990098ccbad006a57458be70 respectively.