### PR TITLE
[DOC] Remove first 'and' from strapline to make it easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <h4 align="center">
-    Iris is a powerful, format-agnostic, and community-driven Python library for
+    Iris is a powerful, format-agnostic, community-driven Python library for
     analysing and visualising Earth science data
 </h4>
 

--- a/docs/iris/src/_templates/layout.html
+++ b/docs/iris/src/_templates/layout.html
@@ -40,7 +40,7 @@
           Iris <span class="version">v2.1</span>
       </h1>
       <p>
-         A powerful, format-agnostic, and community-driven Python library for analysing and
+         A powerful, format-agnostic, community-driven Python library for analysing and
          visualising Earth science data.
       </p>
     </div>

--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,7 @@ setup(
     url='http://scitools.org.uk/iris/',
     author='UK Met Office',
     author_email='scitools-iris-dev@googlegroups.com',
-    description="A powerful, format-agnostic, and community-driven Python "
+    description="A powerful, format-agnostic, community-driven Python "
                 "library for analysing and visualising Earth science data",
     long_description=description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The strapline for the Iris 2.1 version of the documentation was, while a better description than before, still a little clunky due to the first 'and' in the sentence. This PR changes the sentence from:
`"A powerful, format-agnostic, and community-driven Python library for analysing and visualising Earth science data."`
to:
`"A powerful, format-agnostic, community-driven Python library for analysing and visualising Earth science data."`

This has been changed in:
- `README.md`
- `docs/iris/src/_templates/layout.html`
- `setup.py`