### PR TITLE
WIP: Hacky implementation of scalar pp saving.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1285,6 +1285,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             :class:`iris.coords.DimCoord`, :class:`iris.coords.AuxCoord`,
             :class:`iris.aux_factory.AuxCoordFactory`
             or :class:`iris.coords.CoordDefn`.
+
+            (c) a callable which takes a coordinate as its only argument,
+            and returns whether the coordinate should be returned (True for
+            returned or False for not returned).
         * standard_name
             The CF standard name of the desired coordinate. If None, does not
             check for standard name.
@@ -1322,9 +1326,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         """
         name = None
         coord = None
+        callback = None
 
         if isinstance(name_or_coord, six.string_types):
             name = name_or_coord
+        elif callable(name_or_coord):
+            callback = name_or_coord
         else:
             coord = name_or_coord
 
@@ -1336,6 +1343,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if dim_coords in [False, None]:
             coords_and_factories += list(self.aux_coords)
             coords_and_factories += list(self.aux_factories)
+
+        if callback is not None:
+            coords_and_factories = [coord_ for coord_ in coords_and_factories
+                                    if callback(coord_)]
 
         if name is not None:
             coords_and_factories = [coord_ for coord_ in coords_and_factories

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -374,7 +374,12 @@ def _grid_and_pole_rules(cube, pp):
         The PP field with updated metadata.
 
     """
-    lon_coord = vector_coord(cube, 'longitude')
+    try:
+        lon_coord = cube.coord(
+            lambda coord: coord.name() == 'longitude' and coord.ndim == 1)
+    except iris.exceptions.CoordinateNotFoundError:
+        lon_coord = None
+
     grid_lon_coord = vector_coord(cube, 'grid_longitude')
     lat_coord = vector_coord(cube, 'latitude')
     grid_lat_coord = vector_coord(cube, 'grid_latitude')


### PR DESCRIPTION
See discussion in https://github.com/SciTools/iris/issues/3022.

Fixes the following code:

```
import iris
import numpy as np

shape = (4, 1)
cube = iris.cube.Cube(np.arange(np.prod(shape)).reshape(shape).astype(np.float32),
                   standard_name='x_wind', units='m s-1')
cube.add_dim_coord(iris.coords.DimCoord(standard_name='latitude', points=range(shape[0])), 0)
cube.add_dim_coord(iris.coords.DimCoord(standard_name='longitude', points=np.linspace(10, 30, shape[1])), 1)

iris.save(cube, 'tmp.pp')
print(iris.load_cube('tmp.pp'))
```

Happy for somebody else to take this on if they'd like to.