### PR TITLE
http -> https for copybutton.js

### DIFF
--- a/docs/iris/src/_templates/layout.html
+++ b/docs/iris/src/_templates/layout.html
@@ -6,7 +6,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="{{ pathto('_static/style.css', 1) }}" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="{{ pathto('_static/favicon-32x32.png', 1) }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ pathto('_static/favicon-16x16.png', 1) }}">


### PR DESCRIPTION
#3057
Re-enable copybutton by switching to https. 