### PR TITLE
pp.py - add new example of string comparison

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -121,7 +121,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '2.1.1dev0'
+__version__ = '2.2.0dev0'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -247,7 +247,7 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
 
     A stash object can be compared directly
     to its string representation:
-        >>> STASH(model=1, section=0, item=4) == 'm01s0i004'
+        >>> iris.fileformats.pp.STASH(1, 0, 4) == 'm01s0i004'
         True
 
     """

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -245,6 +245,11 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         >>> print(iris.fileformats.pp.STASH(1, 16, 203))
         m01s16i203
 
+    A stash object can be compared directly
+    to its string representation:
+        >>> STASH(model=1, section=0, item=4) == 'm01s0i004'
+        True
+
     """
 
     __slots__ = ()


### PR DESCRIPTION
Relates to issue #3063 - adds one extra example to doctests for iris.fileformats.pp.STASH