### PR TITLE
Fallback to no syntax hightlighting without warning.

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -148,9 +148,9 @@ exclude_patterns = ['sphinxext', 'build']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-# Definer the default highlight language. This also allows the >>> removal
+# Define the default highlight language. This also allows the >>> removal
 # javascript (copybutton.js) to function.
-highlight_language = 'python'
+highlight_language = 'default'
 
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['iris']


### PR DESCRIPTION
Related to #3065 

Fixes:
iris/docs/iris/src/developers_guide/gitwash/development_workflow.rst:317: WARNING: Could not lex literal_block as "python". Highlighting skipped.

Reference:
http://www.sphinx-doc.org/en/stable/config.html#confval-highlight_language