### PR TITLE
pp.py - add new example of STASH object and string comparison

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -245,6 +245,11 @@ class STASH(collections.namedtuple('STASH', 'model section item')):
         >>> print(iris.fileformats.pp.STASH(1, 16, 203))
         m01s16i203
 
+    A stash object can be compared directly
+    to its string representation:
+    >>> iris.fileformats.pp.STASH(1, 0, 4) == 'm01s0i004'
+    True
+
     """
 
     __slots__ = ()


### PR DESCRIPTION
This is a second attempt to deal with issue #3063 by branching directly from upstream/v2.1.x