### PR TITLE
ENH: Working zonal mean linear regridding for circular sources or with use of extrapolation

### DIFF
--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -231,8 +231,9 @@ class RectilinearRegridder(object):
             data = np.empty(shape, dtype=dtype)
 
         # The interpolation class requires monotonically increasing
-        # coordinates, so flip the coordinate(s) and data if the aren't.
-        reverse_x = src_x_coord.points[0] > src_x_coord.points[1]
+        # coordinates, so flip the coordinate(s) and data if they aren't.
+        reverse_x = (src_x_coord.points[0] > src_x_coord.points[1] if
+                     src_x_coord.points.size > 1 else False)
         reverse_y = src_y_coord.points[0] > src_y_coord.points[1]
         flip_index = [slice(None)] * src_data.ndim
         if reverse_x:

--- a/lib/iris/tests/integration/test_regridding.py
+++ b/lib/iris/tests/integration/test_regridding.py
@@ -167,6 +167,9 @@ class TestZonalMean_regional(TestZonalMean_global, tests.IrisTest):
         grid.add_dim_coord(grid_y, 0)
         grid.add_dim_coord(grid_x, 1)
 
+        # The target result is derived by regridding a multi-column version of
+        # the source to the target (i.e. turning a zonal mean regrid into a
+        # conventional regrid).
         self.tar = self.zonal_mean_as_multi_column(self.src).regrid(
             grid, iris.analysis.Linear())
         self.grid = grid
@@ -185,30 +188,32 @@ class TestZonalMean_regional(TestZonalMean_global, tests.IrisTest):
 
     def test_linear_rotated_regional(self):
         # Ensure that zonal mean source data is linearly interpolated onto a
-        # high resolution target.  We turn a zonal mean source into a multi
-        # column in order to derive the target values we expect the regridder
-        # to return (munge function below).
+        # high resolution target.
         regridder = iris.analysis.Linear()
         res = self.src.regrid(self.grid, regridder)
         self.assertArrayAlmostEqual(res.data, self.tar.data)
 
     def test_linear_rotated_regional_no_extrapolation(self):
+        # Capture the case where our source remains circular but we don't use
+        # extrapolation.
         regridder = iris.analysis.Linear(extrapolation_mode='nan')
         res = self.src.regrid(self.grid, regridder)
         self.assertArrayAlmostEqual(res.data, self.tar.data)
 
     def test_linear_rotated_regional_not_circular(self):
+        # Capture the case where our source is not circular but we utilise
+        # extrapolation.
         regridder = iris.analysis.Linear()
         self.src.coord(axis='x').circular = False
         res = self.src.regrid(self.grid, regridder)
         self.assertArrayAlmostEqual(res.data, self.tar.data)
 
     def test_linear_rotated_regional_no_extrapolation_not_circular(self):
-        # This technically is a test that confirm how zonal mean actually works
-        # in so far as, that extrapolation and circular source handling is the
-        # means by which these usecases are supported.
+        # Confirm how zonal mean actually works in so far as, that
+        # extrapolation and circular source handling is the means by which
+        # these usecases are supported.
         # In the case where the source is neither using extrapolation and is
-        # not circular, then 'nan' values will result.
+        # not circular, then 'nan' values will result (as we would expect).
         regridder = iris.analysis.Linear(extrapolation_mode='nan')
         self.src.coord(axis='x').circular = False
         res = self.src.regrid(self.grid, regridder)

--- a/lib/iris/tests/integration/test_regridding.py
+++ b/lib/iris/tests/integration/test_regridding.py
@@ -109,5 +109,102 @@ class TestUnstructured(tests.IrisTest):
         self.assertArrayShapeStats(res, (1, 6, 3, 4), 315.890808, 11.000724)
 
 
+def plot_cube(source):
+    import iris.plot as iplt
+    iplt.plt.switch_backend('TkAgg')
+    iplt.pcolormesh(source)
+    iplt.plt.gca().coastlines()
+    iplt.plt.colorbar(orientation='horizontal')
+    iplt.show()
+
+
+@tests.skip_data
+class TestZonalMean(tests.IrisTest):
+    def setUp(self):
+        np.random.seed(0)
+        self.src = iris.cube.Cube(np.random.random_integers(0, 10, (140, 1)))
+        s_crs = iris.coord_systems.GeogCS(6371229.0)
+        sy_coord = iris.coords.DimCoord(
+            np.linspace(-90, 90, 140), standard_name='latitude',
+            units='degrees', coord_system=s_crs)
+        sx_coord = iris.coords.DimCoord(
+            -180, bounds=[-180, 180], standard_name='longitude',
+            units='degrees', circular=True, coord_system=s_crs)
+        self.src.add_dim_coord(sy_coord, 0)
+        self.src.add_dim_coord(sx_coord, 1)
+
+    def test_linear_same_crs_global(self):
+        # Regrid the zonal mean onto an identical coordinate system target, but
+        # on a different set of longitudes - which should result in no change.
+        points = [-150, -90, -30, 30, 90, 150]
+        bounds = [[-180, -120], [-120, -60], [-60, 0], [0, 60], [60, 120],
+                  [120, 180]]
+        sx_coord = self.src.coord(axis='x')
+        sy_coord = self.src.coord(axis='y')
+        x_coord = sx_coord.copy(points, bounds=bounds)
+        grid = iris.cube.Cube(
+            np.zeros([sy_coord.points.size, x_coord.points.size]))
+        grid.add_dim_coord(sy_coord, 0)
+        grid.add_dim_coord(x_coord, 1)
+
+        res = self.src.regrid(grid, iris.analysis.Linear())
+
+        # Ensure data remains unchanged.
+        # (the same along each column)
+        self.assertTrue(
+            np.array([(res.data[:, 0]-res.data[:, i]).max() for i in
+                      range(1, res.shape[1])]).max() < 1e-10)
+        self.assertArrayAlmostEqual(res.data[:, 0], self.src.data.reshape(-1))
+
+    def test_linear_rotated_regional(self):
+        sx_coord = self.src.coord(axis='x')
+        sy_coord = self.src.coord(axis='y')
+        grid_crs = iris.coord_systems.RotatedGeogCS(
+            37.5, 177.5, ellipsoid=iris.coord_systems.GeogCS(6371229.0))
+        grid_x = sx_coord.copy(np.linspace(350, 370, 100))
+        grid_x.circular = False
+        grid_x.coord_system = grid_crs
+        grid_y = sy_coord.copy(np.linspace(-10, 10, 100))
+        grid_y.coord_system = grid_crs
+        grid = iris.cube.Cube(
+            np.zeros([grid_y.points.size, grid_x.points.size]))
+        grid.add_dim_coord(grid_y, 0)
+        grid.add_dim_coord(grid_x, 1)
+
+        res = self.src.regrid(grid, iris.analysis.Linear())
+
+        res_no_extrapolation = self.src.regrid(
+            grid, iris.analysis.Linear(extrapolation_mode='nan'))
+
+        self.src.coord(axis='x').circular = False
+        res_non_circular = self.src.regrid(grid, iris.analysis.Linear())
+
+        res_non_circular_no_extrapolation = self.src.regrid(
+            grid, iris.analysis.Linear(extrapolation_mode='nan'))
+
+        def munge(src_cube):
+            # Munge the source (duplicate source latitudes) so that we can
+            # utilise linear regridding in the ordinary case (that is, as
+            # though it was not a zonal mean).
+            src_cube2 = src_cube.copy()
+            src_cube2.coord(axis='x').points = -90
+            src_cube2.coord(axis='x').bounds = [-180, 0]
+            src_cube.coord(axis='x').points = 90
+            src_cube.coord(axis='x').bounds = [0, 180]
+            src_cubes = iris.cube.CubeList([src_cube, src_cube2])
+            return src_cubes.concatenate_cube()
+        tar = munge(self.src).regrid(grid, iris.analysis.Linear())
+
+        self.assertArrayAlmostEqual(res.data, tar.data)
+        self.assertArrayAlmostEqual(res_no_extrapolation.data, tar.data)
+        self.assertArrayAlmostEqual(res_non_circular.data, tar.data)
+
+        # Let's capture the fact that no extrapolation and a non circular
+        # source will not lead to the same results (given that Linear is a
+        # points based approach).
+        self.assertFalse(np.allclose(res_non_circular_no_extrapolation.data,
+                                     tar.data))
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Closes #2951 

Took me a while to convince myself why it was working after this one line change.
There are two circumstances when/why this works as desired:
- The source is circular (then existing code extends data and x points - using `iris.analysis._interpolation.extend_circular_coord_and_data`).
- The source is not circular but 'linear' (default) extrapolation is used.  Existing code means that a single point is taken as a zero gradient (I assume from looking at the results) in the x, which results in the desired outcome.
- The source is not circular and linear extrapolation is not used and so values are not populated as these would now be expected points for extrapolation (as expected).

Here are plots of the new tests (source and target respectively), nicely demonstrating how the values from the source when regridded to the target are no longer straight (as expected).
<img src="https://user-images.githubusercontent.com/2071643/42639692-8e7603b8-85e8-11e8-9bb0-1671c5aeaa68.png" width="300"><img src="https://user-images.githubusercontent.com/2071643/42639698-9235eb08-85e8-11e8-93b8-bbe948dd3d11.png" width="300">