### PR TITLE
Quick fix to get tests passing

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,7 +6,7 @@
 cartopy
 cf_units>=2
 cftime
-dask[array]>=0.17.1  #conda: dask>=0.17.1
+dask[array]>=0.17.1,<0.18.1  #conda: dask>=0.17.1,<0.18.1
 matplotlib>=2
 netcdf4
 numpy>=1.14


### PR DESCRIPTION
Further pin the dask dependency version as a quick workaround for [this failing test](https://travis-ci.org/SciTools/iris/jobs/397436711#L5120-L5128). For clarification, the test passes at dask=0.18.0, but fails at dask=0.18.1.

I'm certain there's a proper code fix to this currently-failing test, but this change as a temporary measure at least lets us get the tests passing again.

@pelson @ajdawson do you have any space to offer a review?