### PR TITLE
Workaround for dask array copy bug

### DIFF
--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1430,7 +1430,9 @@ class Test_copy(tests.IrisTest):
         self._check_copy(cube, cube.copy())
 
     def test__lazy(self):
-        cube = Cube(as_lazy_data(np.array([1, 0])))
+        # Note: multiple chunks added as a workaround suggested to dask#3751,
+        # which is fixed in dask#3754.
+        cube = Cube(as_lazy_data(np.array([1, 0]), chunks=(1, 1)))
         self._check_copy(cube, cube.copy())
 
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,7 +6,7 @@
 cartopy
 cf_units>=2
 cftime
-dask[array]>=0.17.1,<0.18.1  #conda: dask>=0.17.1,<0.18.1
+dask[array]>=0.17.1  #conda: dask>=0.17.1
 matplotlib>=2
 netcdf4
 numpy>=1.14


### PR DESCRIPTION
A code fix, rather than a library version pin, to fix [this failing test](https://travis-ci.org/SciTools/iris/jobs/397436711#L5120-L5128), while we await a dask release containing the [bugfix](https://github.com/dask/dask/pull/3754). The code fix implemented here was suggested as a workaround in the [dask bug report](https://github.com/dask/dask/issues/3751#issuecomment-404913371).

Backs out the library version pin temporarily introduced in #3086. 

Fixes #3087. 