### PR TITLE
Catch IsADirectoryError and continue without file handle

### DIFF
--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -197,10 +197,12 @@ def load_files(filenames, callback, constraints=None):
     for fn in all_file_paths:
         try:
             with open(fn, 'rb') as fh:
-                handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), fh)
+                handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(
+                    os.path.basename(fn), fh)
                 handler_map[handling_format_spec].append(fn)
         except IsADirectoryError:
-            handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), None)
+            handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(
+                os.path.basename(fn), None)
             handler_map[handling_format_spec].append(fn)
 
     # Call each iris format handler with the approriate filenames

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -195,8 +195,12 @@ def load_files(filenames, callback, constraints=None):
     # Create default dict mapping iris format handler to its associated filenames
     handler_map = collections.defaultdict(list)
     for fn in all_file_paths:
-        with open(fn, 'rb') as fh:
-            handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), fh)
+        try:
+            with open(fn, 'rb') as fh:
+                handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), fh)
+                handler_map[handling_format_spec].append(fn)
+        except IsADirectoryError:
+            handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(os.path.basename(fn), None)
             handler_map[handling_format_spec].append(fn)
 
     # Call each iris format handler with the approriate filenames


### PR DESCRIPTION
Fixes #3121 

If the file iris is trying to load is a directory based data format (such as [zarr](https://github.com/zarr-developers/zarr)) it will throw an` IsADirectoryError` when trying to open the file for reading. 

As these formats will use the `iris.io.format_picker.FileExtension` check the file handle is not necessary. In this PR I've added a `try... except...` to catch the error and to try again without the file handle.