### PR TITLE
Update RMS aggregator with lazy function

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1272,7 +1272,9 @@ def _lazy_rms(array, axis, **kwargs):
     # However `da.average` current doesn't handle masked weights correctly
     # (see https://github.com/dask/dask/issues/3846).
     # To work around this we use da.mean, which doesn't support weights at
-    # all, so we raise an error rather than silently giving the wrong answer.
+    # all. Thus trying to use this aggregator with weights will currently
+    # raise an error in dask due to the unexpected keyword `weights`,
+    # rather than silently returning the wrong answer.
     return da.sqrt(da.mean(array ** 2, axis=axis, **kwargs))
 
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1268,7 +1268,12 @@ def _rms(array, axis, **kwargs):
 
 @_build_dask_mdtol_function
 def _lazy_rms(array, axis, **kwargs):
-    return da.sqrt(da.average(array ** 2, axis=axis, **kwargs))
+    # XXX This should use `da.average` and not `da.mean`, as does the above.
+    # However `da.average` current doesn't handle masked weights correctly
+    # (see https://github.com/dask/dask/issues/3846).
+    # To work around this we use da.mean, which doesn't support weights at
+    # all, so we raise an error rather than silently giving the wrong answer.
+    return da.sqrt(da.mean(array ** 2, axis=axis, **kwargs))
 
 
 @_build_dask_mdtol_function

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1267,6 +1267,11 @@ def _rms(array, axis, **kwargs):
 
 
 @_build_dask_mdtol_function
+def _lazy_rms(array, axis, **kwargs):
+    return da.sqrt(da.average(array ** 2, axis=axis, **kwargs))
+
+
+@_build_dask_mdtol_function
 def _lazy_sum(array, **kwargs):
     array = iris._lazy_data.as_lazy_data(array)
     # weighted or scaled sum
@@ -1654,7 +1659,8 @@ This aggregator handles masked data.
 """
 
 
-RMS = WeightedAggregator('root mean square', _rms)
+RMS = WeightedAggregator('root mean square', _rms,
+                         lazy_func=_build_dask_mdtol_function(_lazy_rms))
 """
 An :class:`~iris.analysis.Aggregator` instance that calculates
 the root mean square over a :class:`~iris.cube.Cube`, as computed by

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1260,6 +1260,11 @@ def _proportion(array, function, axis, **kwargs):
 
 
 def _rms(array, axis, **kwargs):
+    # XXX due to the current limitations in `da.average` (see below), maintain
+    # an explicit non-lazy aggregation function for now.
+    # Note: retaining this function also means that if weights are passed to
+    # the lazy aggregator, the aggregation will fall back to using this
+    # non-lazy aggregator.
     rval = np.sqrt(ma.average(np.square(array), axis=axis, **kwargs))
     if not ma.isMaskedArray(array):
         rval = np.asarray(rval)

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -26,6 +26,7 @@ import iris.tests as tests
 import numpy as np
 import numpy.ma as ma
 
+from iris._lazy_data import as_lazy_data
 from iris.analysis import RMS
 
 
@@ -63,6 +64,72 @@ class Test_aggregate(tests.IrisTest):
     def test_unit_weighted(self):
         # unit weights should be the same as no weights
         data = np.array([5, 2, 6, 4], dtype=np.float64)
+        weights = np.ones_like(data)
+        rms = RMS.aggregate(data, 0, weights=weights)
+        expected_rms = 4.5
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked(self):
+        # masked entries should be completely ignored
+        data = ma.array([5, 10, 2, 11, 6, 4],
+                        mask=[False, True, False, True, False, False],
+                        dtype=np.float64)
+        expected_rms = 4.5
+        rms = RMS.aggregate(data, 0)
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked_weighted(self):
+        # weights should work properly with masked arrays
+        data = ma.array([4, 7, 18, 10, 11, 8],
+                        mask=[False, False, True, False, True, False],
+                        dtype=np.float64)
+        weights = np.array([1, 4, 5, 3, 8, 2], dtype=np.float64)
+        expected_rms = 8.0
+        rms = RMS.aggregate(data, 0, weights=weights)
+        self.assertAlmostEqual(rms, expected_rms)
+
+
+class Test_lazy_aggregate(tests.IrisTest):
+    def test_1d(self):
+        # 1-dimensional input
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
+                            chunks=-1)
+        rms = RMS.aggregate(data, 0)
+        expected_rms = 4.5
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d(self):
+        # 2-dimensional input
+        data = as_lazy_data(np.array([[5, 2, 6, 4], [12, 4, 10, 8]],
+                                     dtype=np.float64),
+                            chunks=-1)
+        expected_rms = np.array([4.5, 9.0], dtype=np.float64)
+        rms = RMS.aggregate(data, 1)
+        self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_1d_weighted(self):
+        # 1-dimensional input with weights
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
+                            chunks=-1)
+        weights = np.array([1, 4, 3, 2], dtype=np.float64)
+        expected_rms = 8.0
+        rms = RMS.aggregate(data, 0, weights=weights)
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d_weighted(self):
+        # 2-dimensional input with weights
+        data = as_lazy_data(np.array([[4, 7, 10, 8], [14, 16, 20, 8]],
+                                     dtype=np.float64),
+                            chunks=-1)
+        weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
+        expected_rms = np.array([8.0, 16.0], dtype=np.float64)
+        rms = RMS.aggregate(data, 1, weights=weights)
+        self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_unit_weighted(self):
+        # unit weights should be the same as no weights
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
+                            chunks=-1)
         weights = np.ones_like(data)
         rms = RMS.aggregate(data, 0, weights=weights)
         expected_rms = 4.5

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -156,8 +156,8 @@ class Test_lazy_aggregate(tests.IrisTest):
     def test_masked(self):
         # Masked entries should be completely ignored.
         data = as_lazy_data(ma.array([5, 10, 2, 11, 6, 4],
-                        mask=[False, True, False, True, False, False],
-                        dtype=np.float64),
+                            mask=[False, True, False, True, False, False],
+                            dtype=np.float64),
                             chunks=-1)
         expected_rms = 4.5
         rms = RMS.lazy_aggregate(data, 0)

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -114,7 +114,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         weights = np.array([1, 4, 3, 2], dtype=np.float64)
         expected_rms = 8.0
         # https://github.com/dask/dask/issues/3846.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
             rms = RMS.lazy_aggregate(data, 0, weights=weights)
             self.assertAlmostEqual(rms, expected_rms)
 
@@ -126,7 +126,7 @@ class Test_lazy_aggregate(tests.IrisTest):
                                chunks=-1)
         expected_rms = 8.0
         # https://github.com/dask/dask/issues/3846.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
             rms = RMS.lazy_aggregate(data, 0, weights=weights)
             self.assertAlmostEqual(rms, expected_rms)
 
@@ -138,7 +138,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
         expected_rms = np.array([8.0, 16.0], dtype=np.float64)
         # https://github.com/dask/dask/issues/3846.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
             rms = RMS.lazy_aggregate(data, 1, weights=weights)
             self.assertArrayAlmostEqual(rms, expected_rms)
 
@@ -149,7 +149,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         weights = np.ones_like(data)
         expected_rms = 4.5
         # https://github.com/dask/dask/issues/3846.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
             rms = RMS.lazy_aggregate(data, 0, weights=weights)
             self.assertAlmostEqual(rms, expected_rms)
 

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -91,70 +91,91 @@ class Test_aggregate(tests.IrisTest):
 
 class Test_lazy_aggregate(tests.IrisTest):
     def test_1d(self):
-        # 1-dimensional input
+        # 1-dimensional input.
         data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
                             chunks=-1)
-        rms = RMS.aggregate(data, 0)
+        rms = RMS.lazy_aggregate(data, 0)
         expected_rms = 4.5
         self.assertAlmostEqual(rms, expected_rms)
 
     def test_2d(self):
-        # 2-dimensional input
+        # 2-dimensional input.
         data = as_lazy_data(np.array([[5, 2, 6, 4], [12, 4, 10, 8]],
                                      dtype=np.float64),
                             chunks=-1)
         expected_rms = np.array([4.5, 9.0], dtype=np.float64)
-        rms = RMS.aggregate(data, 1)
+        rms = RMS.lazy_aggregate(data, 1)
         self.assertArrayAlmostEqual(rms, expected_rms)
 
     def test_1d_weighted(self):
-        # 1-dimensional input with weights
+        # 1-dimensional input with weights.
         data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
                             chunks=-1)
         weights = np.array([1, 4, 3, 2], dtype=np.float64)
         expected_rms = 8.0
-        rms = RMS.aggregate(data, 0, weights=weights)
-        self.assertAlmostEqual(rms, expected_rms)
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaises(TypeError):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
+
+    def test_1d_lazy_weighted(self):
+        # 1-dimensional input with lazy weights.
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
+                            chunks=-1)
+        weights = as_lazy_data(np.array([1, 4, 3, 2], dtype=np.float64),
+                               chunks=-1)
+        expected_rms = 8.0
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaises(TypeError):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
 
     def test_2d_weighted(self):
-        # 2-dimensional input with weights
+        # 2-dimensional input with weights.
         data = as_lazy_data(np.array([[4, 7, 10, 8], [14, 16, 20, 8]],
                                      dtype=np.float64),
                             chunks=-1)
         weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
         expected_rms = np.array([8.0, 16.0], dtype=np.float64)
-        rms = RMS.aggregate(data, 1, weights=weights)
-        self.assertArrayAlmostEqual(rms, expected_rms)
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaises(TypeError):
+            rms = RMS.lazy_aggregate(data, 1, weights=weights)
+            self.assertArrayAlmostEqual(rms, expected_rms)
 
     def test_unit_weighted(self):
-        # unit weights should be the same as no weights
+        # Unit weights should be the same as no weights.
         data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
                             chunks=-1)
         weights = np.ones_like(data)
-        rms = RMS.aggregate(data, 0, weights=weights)
         expected_rms = 4.5
-        self.assertAlmostEqual(rms, expected_rms)
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaises(TypeError):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
 
     def test_masked(self):
-        # masked entries should be completely ignored
+        # Masked entries should be completely ignored.
         data = as_lazy_data(ma.array([5, 10, 2, 11, 6, 4],
                         mask=[False, True, False, True, False, False],
                         dtype=np.float64),
                             chunks=-1)
         expected_rms = 4.5
-        rms = RMS.aggregate(data, 0)
+        rms = RMS.lazy_aggregate(data, 0)
         self.assertAlmostEqual(rms, expected_rms)
 
     def test_masked_weighted(self):
-        # weights should work properly with masked arrays
+        # Weights should work properly with masked arrays, but currently don't
+        # (see https://github.com/dask/dask/issues/3846).
+        # For now, masked weights are simply not supported.
         data = as_lazy_data(ma.array([4, 7, 18, 10, 11, 8],
-                        mask=[False, False, True, False, True, False],
-                        dtype=np.float64),
+                            mask=[False, False, True, False, True, False],
+                            dtype=np.float64),
                             chunks=-1)
-        weights = np.array([1, 4, 5, 3, 8, 2], dtype=np.float64)
+        weights = np.array([1, 4, 5, 3, 8, 2])
         expected_rms = 8.0
-        rms = RMS.aggregate(data, 0, weights=weights)
-        self.assertAlmostEqual(rms, expected_rms)
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
 
 
 class Test_name(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -137,18 +137,20 @@ class Test_lazy_aggregate(tests.IrisTest):
 
     def test_masked(self):
         # masked entries should be completely ignored
-        data = ma.array([5, 10, 2, 11, 6, 4],
+        data = as_lazy_data(ma.array([5, 10, 2, 11, 6, 4],
                         mask=[False, True, False, True, False, False],
-                        dtype=np.float64)
+                        dtype=np.float64),
+                            chunks=-1)
         expected_rms = 4.5
         rms = RMS.aggregate(data, 0)
         self.assertAlmostEqual(rms, expected_rms)
 
     def test_masked_weighted(self):
         # weights should work properly with masked arrays
-        data = ma.array([4, 7, 18, 10, 11, 8],
+        data = as_lazy_data(ma.array([4, 7, 18, 10, 11, 8],
                         mask=[False, False, True, False, True, False],
-                        dtype=np.float64)
+                        dtype=np.float64),
+                            chunks=-1)
         weights = np.array([1, 4, 5, 3, 8, 2], dtype=np.float64)
         expected_rms = 8.0
         rms = RMS.aggregate(data, 0, weights=weights)


### PR DESCRIPTION
Adds a lazy aggregation function to the RMS aggregator, which makes use of dask functionality to build the RMS equation.

Note that _currently_ this does not allow lazy weighted RMS aggregation when the input is also masked. This is in place because there appears to be [a limitation in `da.average`](https://github.com/dask/dask/issues/3846), which means the weights array is not masked to match the input data. 

Ping @niallrobinson - with thanks for raising the fact the RMS aggregator wasn't lazy, and for pairing on this update.