### PR TITLE
[WIP] Silence userwarnings

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -105,6 +105,7 @@ import glob
 import itertools
 import os.path
 import threading
+import warnings
 
 import iris.config
 import iris.cube
@@ -112,6 +113,7 @@ import iris._constraints
 from iris._deprecation import IrisDeprecation, warn_deprecated
 import iris.fileformats
 import iris.io
+from iris.exceptions import IrisUserWarning
 
 
 try:
@@ -119,6 +121,7 @@ try:
 except ImportError:
     iris_sample_data = None
 
+warnings.filterwarnings('ignore', category=IrisUserWarning)
 
 # Iris revision.
 __version__ = '2.3.0dev0'

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -31,6 +31,7 @@ from iris.analysis._interpolation import (EXTRAPOLATION_MODES,
                                           get_xy_dim_coords, snapshot_grid)
 from iris.analysis._scipy_interpolate import _RegularGridInterpolator
 import iris.cube
+from iris.exceptions import IrisUserWarning
 from iris.util import _meshgrid
 
 

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -451,7 +451,7 @@ class RectilinearRegridder(object):
             except KeyError:
                 msg = 'Cannot update aux_factory {!r} because of dropped' \
                       ' coordinates.'.format(factory.name())
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
         return result
 
     def _check_units(self, coord):

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -520,7 +520,7 @@ def cosine_latitude_weights(cube):
             np.any(lat.points > np.pi / 2. + threshold):
         warnings.warn('Out of range latitude values will be '
                       'clipped to the valid range.',
-                      UserWarning)
+                      IrisUserWarning)
     points = lat.points
     l_weights = np.cos(points).clip(0., 1.)
 

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -522,7 +522,8 @@ def cosine_latitude_weights(cube):
     threshold = np.deg2rad(0.001)  # small value for grid resolution
     if np.any(lat.points < -np.pi / 2. - threshold) or \
             np.any(lat.points > np.pi / 2. + threshold):
-        msg = 'Out of range latitude values will be clipped to the valid range.'
+        msg = ('Out of range latitude values will be clipped to the valid '
+               'range.')
         warnings.warn(msg, IrisUserWarning)
     points = lat.points
     l_weights = np.cos(points).clip(0., 1.)
@@ -614,8 +615,8 @@ def project(cube, target_proj, nx=None, ny=None):
     # Determine source coordinate system
     if lat_coord.coord_system is None:
         # Assume WGS84 latlon if unspecified
-        msg = ('Coordinate system of latitude and longitude coordinates is not '
-               'specified. Assuming WGS84 Geodetic.')
+        msg = ('Coordinate system of latitude and longitude coordinates is '
+               'not specified. Assuming WGS84 Geodetic.')
         warnings.warn(msg, IrisUserWarning)
         orig_cs = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                             inverse_flattening=298.257223563)

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -383,15 +383,18 @@ def area_weights(cube, normalize=False):
     cs = cube.coord_system("CoordSystem")
     if isinstance(cs, iris.coord_systems.GeogCS):
         if cs.inverse_flattening != 0.0:
-            warnings.warn("Assuming spherical earth from ellipsoid.")
+            msg = "Assuming spherical earth from ellipsoid."
+            warnings.warn(msg, IrisUserWarning)
         radius_of_earth = cs.semi_major_axis
     elif (isinstance(cs, iris.coord_systems.RotatedGeogCS) and
             (cs.ellipsoid is not None)):
         if cs.ellipsoid.inverse_flattening != 0.0:
-            warnings.warn("Assuming spherical earth from ellipsoid.")
+            msg = "Assuming spherical earth from ellipsoid."
+            warnings.warn(msg, IrisUserWarning)
         radius_of_earth = cs.ellipsoid.semi_major_axis
     else:
-        warnings.warn("Using DEFAULT_SPHERICAL_EARTH_RADIUS.")
+        msg = "Using DEFAULT_SPHERICAL_EARTH_RADIUS."
+        warnings.warn(msg, IrisUserWarning)
         radius_of_earth = DEFAULT_SPHERICAL_EARTH_RADIUS
 
     # Get the lon and lat coords and axes
@@ -518,9 +521,8 @@ def cosine_latitude_weights(cube):
     threshold = np.deg2rad(0.001)  # small value for grid resolution
     if np.any(lat.points < -np.pi / 2. - threshold) or \
             np.any(lat.points > np.pi / 2. + threshold):
-        warnings.warn('Out of range latitude values will be '
-                      'clipped to the valid range.',
-                      IrisUserWarning)
+        msg = 'Out of range latitude values will be clipped to the valid range.'
+        warnings.warn(msg, IrisUserWarning)
     points = lat.points
     l_weights = np.cos(points).clip(0., 1.)
 
@@ -611,8 +613,9 @@ def project(cube, target_proj, nx=None, ny=None):
     # Determine source coordinate system
     if lat_coord.coord_system is None:
         # Assume WGS84 latlon if unspecified
-        warnings.warn('Coordinate system of latitude and longitude '
-                      'coordinates is not specified. Assuming WGS84 Geodetic.')
+        msg = ('Coordinate system of latitude and longitude coordinates is not '
+               'specified. Assuming WGS84 Geodetic.')
+        warnings.warn(msg, IrisUserWarning)
         orig_cs = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                             inverse_flattening=298.257223563)
     else:
@@ -772,11 +775,10 @@ def project(cube, target_proj, nx=None, ny=None):
             new_cube.add_aux_coord(coord.copy(), cube.coord_dims(coord))
     discarded_coords = coords_to_ignore.difference([lat_coord, lon_coord])
     if discarded_coords:
-        warnings.warn('Discarding coordinates that share dimensions with '
-                      '{} and {}: {}'.format(lat_coord.name(),
-                                             lon_coord.name(),
-                                             [coord.name() for
-                                              coord in discarded_coords]))
+        msg = 'Discarding coordinates that share dimensions with {} and {}: {}'
+        msg = msg.format(lat_coord.name(), lon_coord.name(),
+                         [coord.name() for coord in discarded_coords])
+        warnings.warn(msg, IrisUserWarning)
 
     # TODO handle derived coords/aux_factories
 

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -37,6 +37,7 @@ import iris.coords
 import iris.coord_systems
 import iris.exceptions
 from iris.util import _meshgrid
+from iris.exceptions import IrisUserWarning
 from ._grid_angles import gridcell_angles, rotate_grid_vectors
 
 # List of contents to control Sphinx autodocs.

--- a/lib/iris/analysis/geometry.py
+++ b/lib/iris/analysis/geometry.py
@@ -32,6 +32,7 @@ from shapely.geometry import Polygon
 import numpy as np
 
 import iris.exceptions
+from iris.exceptions import IrisUserWarning
 
 
 def _extract_relevant_cube_slice(cube, geometry):

--- a/lib/iris/analysis/geometry.py
+++ b/lib/iris/analysis/geometry.py
@@ -86,7 +86,7 @@ def _extract_relevant_cube_slice(cube, geometry):
         x_min_ix = x_min_ix[np.argmax(x_bounds_lower[x_min_ix])]
     except ValueError:
         warnings.warn("The geometry exceeds the cube's x dimension at the "
-                      "lower end.", UserWarning)
+                      "lower end.", IrisUserWarning)
         x_min_ix = 0 if x_ascending else x_coord.points.size - 1
 
     try:
@@ -94,7 +94,7 @@ def _extract_relevant_cube_slice(cube, geometry):
         x_max_ix = x_max_ix[np.argmin(x_bounds_upper[x_max_ix])]
     except ValueError:
         warnings.warn("The geometry exceeds the cube's x dimension at the "
-                      "upper end.", UserWarning)
+                      "upper end.", IrisUserWarning)
         x_max_ix = x_coord.points.size - 1 if x_ascending else 0
 
     try:
@@ -102,7 +102,7 @@ def _extract_relevant_cube_slice(cube, geometry):
         y_min_ix = y_min_ix[np.argmax(y_bounds_lower[y_min_ix])]
     except ValueError:
         warnings.warn("The geometry exceeds the cube's y dimension at the "
-                      "lower end.", UserWarning)
+                      "lower end.", IrisUserWarning)
         y_min_ix = 0 if y_ascending else y_coord.points.size - 1
 
     try:
@@ -110,7 +110,7 @@ def _extract_relevant_cube_slice(cube, geometry):
         y_max_ix = y_max_ix[np.argmin(y_bounds_upper[y_max_ix])]
     except ValueError:
         warnings.warn("The geometry exceeds the cube's y dimension at the "
-                      "upper end.", UserWarning)
+                      "upper end.", IrisUserWarning)
         y_max_ix = y_coord.points.size - 1 if y_ascending else 0
 
     # extract coordinate values at these indices
@@ -160,7 +160,7 @@ def geometry_area_weights(cube, geometry, normalize=False):
         geometry's bounds lie outside the physically realistic range
         (i.e., abs(latitude) > 90., as it is commonly the case when
         bounds are constructed via guess_bounds()), the weights
-        calculation might be wrong. In this case, a UserWarning will
+        calculation might be wrong. In this case, a IrisUserWarning will
         be issued.
 
     Args:

--- a/lib/iris/analysis/geometry.py
+++ b/lib/iris/analysis/geometry.py
@@ -85,32 +85,32 @@ def _extract_relevant_cube_slice(cube, geometry):
         x_min_ix = np.where(x_bounds_lower <= x_min_geom)[0]
         x_min_ix = x_min_ix[np.argmax(x_bounds_lower[x_min_ix])]
     except ValueError:
-        warnings.warn("The geometry exceeds the cube's x dimension at the "
-                      "lower end.", IrisUserWarning)
+        msg = "The geometry exceeds the cube's x dimension at the lower end."
+        warnings.warn(msg, IrisUserWarning)
         x_min_ix = 0 if x_ascending else x_coord.points.size - 1
 
     try:
         x_max_ix = np.where(x_bounds_upper >= x_max_geom)[0]
         x_max_ix = x_max_ix[np.argmin(x_bounds_upper[x_max_ix])]
     except ValueError:
-        warnings.warn("The geometry exceeds the cube's x dimension at the "
-                      "upper end.", IrisUserWarning)
+        msg = "The geometry exceeds the cube's x dimension at the upper end."
+        warnings.warn(msg, IrisUserWarning)
         x_max_ix = x_coord.points.size - 1 if x_ascending else 0
 
     try:
         y_min_ix = np.where(y_bounds_lower <= y_min_geom)[0]
         y_min_ix = y_min_ix[np.argmax(y_bounds_lower[y_min_ix])]
     except ValueError:
-        warnings.warn("The geometry exceeds the cube's y dimension at the "
-                      "lower end.", IrisUserWarning)
+        msg = "The geometry exceeds the cube's y dimension at the lower end."
+        warnings.warn(msg, IrisUserWarning)
         y_min_ix = 0 if y_ascending else y_coord.points.size - 1
 
     try:
         y_max_ix = np.where(y_bounds_upper >= y_max_geom)[0]
         y_max_ix = y_max_ix[np.argmin(y_bounds_upper[y_max_ix])]
     except ValueError:
-        warnings.warn("The geometry exceeds the cube's y dimension at the "
-                      "upper end.", IrisUserWarning)
+        msg = "The geometry exceeds the cube's y dimension at the upper end."
+        warnings.warn(msg, IrisUserWarning)
         y_max_ix = y_coord.points.size - 1 if y_ascending else 0
 
     # extract coordinate values at these indices

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -36,6 +36,7 @@ import iris.coords
 import iris.cube
 import iris.exceptions
 import iris.util
+from iris.exceptions import IrisUserWarning
 
 import dask.array as da
 from dask.array.core import broadcast_shapes

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -810,8 +810,9 @@ def _broadcast_cube_coord_data(cube, other, operation_name, dim=None):
         raise iris.exceptions.CoordinateMultiDimError(other)
 
     if other.has_bounds():
-        warnings.warn('Using {!r} with a bounded coordinate is not well '
-                      'defined; ignoring bounds.'.format(operation_name))
+        msg = ('Using {!r} with a bounded coordinate is not well defined; '
+               'ignoring bounds.').format(operation_name)
+        warnings.warn(msg, IrisUserWarning)
 
     points = other.points
 

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -383,7 +383,7 @@ class HybridHeightFactory(AuxCoordFactory):
         if orography and orography.nbounds:
             msg = 'Orography coordinate {!r} has bounds.' \
                   ' These will be disregarded.'.format(orography.name())
-            warnings.warn(msg, UserWarning, stacklevel=2)
+            warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         self.delta = delta
         self.sigma = sigma
@@ -455,7 +455,7 @@ class HybridHeightFactory(AuxCoordFactory):
             if orography.shape[-1:] not in [(), (1,)]:
                 warnings.warn('Orography coordinate has bounds. '
                               'These are being disregarded.',
-                              UserWarning, stacklevel=2)
+                              IrisUserWarning, stacklevel=2)
                 orography_pts = nd_points_by_key['orography']
                 bds_shape = list(orography_pts.shape) + [1]
                 orography = orography_pts.reshape(bds_shape)
@@ -500,7 +500,7 @@ class HybridHeightFactory(AuxCoordFactory):
             if new_coord and new_coord.nbounds:
                 msg = 'Orography coordinate {!r} has bounds.' \
                       ' These will be disregarded.'.format(new_coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
             self.orography = new_coord
 
 
@@ -567,7 +567,7 @@ class HybridPressureFactory(AuxCoordFactory):
         if surface_air_pressure and surface_air_pressure.nbounds:
             msg = 'Surface pressure coordinate {!r} has bounds. These will' \
                   ' be disregarded.'.format(surface_air_pressure.name())
-            warnings.warn(msg, UserWarning, stacklevel=2)
+            warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         # Check units.
         if sigma is not None and not sigma.units.is_dimensionless():
@@ -754,7 +754,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
             if coord is not None and coord.nbounds:
                 msg = 'The {} coordinate {!r} has bounds. ' \
                     'These are being disregarded.'.format(term, coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         for coord, term in ((depth_c, 'depth_c'), (nsigma, 'nsigma')):
             if coord is not None and coord.shape != (1,):
@@ -898,7 +898,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
                     name = self.dependencies[key].name()
                     msg = 'The {} coordinate {!r} has bounds. ' \
                         'These are being disregarded.'.format(key, name)
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warnings.warn(msg, IrisUserWarning, stacklevel=2)
                     # Swap bounds with points.
                     bds_shape = list(nd_points_by_key[key].shape) + [1]
                     bounds = nd_points_by_key[key].reshape(bds_shape)
@@ -997,7 +997,7 @@ class OceanSigmaFactory(AuxCoordFactory):
             if coord is not None and coord.nbounds:
                 msg = 'The {} coordinate {!r} has bounds. ' \
                     'These are being disregarded.'.format(term, coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         # Check units.
         if sigma is not None and not sigma.units.is_dimensionless():
@@ -1064,7 +1064,7 @@ class OceanSigmaFactory(AuxCoordFactory):
                     name = self.dependencies[key].name()
                     msg = 'The {} coordinate {!r} has bounds. ' \
                         'These are being disregarded.'.format(key, name)
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warnings.warn(msg, IrisUserWarning, stacklevel=2)
                     # Swap bounds with points.
                     bds_shape = list(nd_points_by_key[key].shape) + [1]
                     bounds = nd_points_by_key[key].reshape(bds_shape)
@@ -1170,7 +1170,7 @@ class OceanSg1Factory(AuxCoordFactory):
             if coord is not None and coord.nbounds:
                 msg = 'The {} coordinate {!r} has bounds. ' \
                     'These are being disregarded.'.format(term, coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         if depth_c is not None and depth_c.shape != (1,):
             msg = 'Expected scalar {} coordinate {!r}: ' \
@@ -1248,7 +1248,7 @@ class OceanSg1Factory(AuxCoordFactory):
                     name = self.dependencies[key].name()
                     msg = 'The {} coordinate {!r} has bounds. ' \
                         'These are being disregarded.'.format(key, name)
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warnings.warn(msg, IrisUserWarning, stacklevel=2)
                     # Swap bounds with points.
                     bds_shape = list(nd_points_by_key[key].shape) + [1]
                     bounds = nd_points_by_key[key].reshape(bds_shape)
@@ -1353,7 +1353,7 @@ class OceanSFactory(AuxCoordFactory):
             if coord is not None and coord.nbounds:
                 msg = 'The {} coordinate {!r} has bounds. ' \
                     'These are being disregarded.'.format(term, coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         coords = ((a, 'a'), (b, 'b'), (depth_c, 'depth_c'))
         for coord, term in coords:
@@ -1433,7 +1433,7 @@ class OceanSFactory(AuxCoordFactory):
                     name = self.dependencies[key].name()
                     msg = 'The {} coordinate {!r} has bounds. ' \
                         'These are being disregarded.'.format(key, name)
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warnings.warn(msg, IrisUserWarning, stacklevel=2)
                     # Swap bounds with points.
                     bds_shape = list(nd_points_by_key[key].shape) + [1]
                     bounds = nd_points_by_key[key].reshape(bds_shape)
@@ -1543,7 +1543,7 @@ class OceanSg2Factory(AuxCoordFactory):
             if coord is not None and coord.nbounds:
                 msg = 'The {} coordinate {!r} has bounds. ' \
                     'These are being disregarded.'.format(term, coord.name())
-                warnings.warn(msg, UserWarning, stacklevel=2)
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
 
         if depth_c is not None and depth_c.shape != (1,):
             msg = 'Expected scalar depth_c coordinate {!r}: ' \
@@ -1621,7 +1621,7 @@ class OceanSg2Factory(AuxCoordFactory):
                     name = self.dependencies[key].name()
                     msg = 'The {} coordinate {!r} has bounds. ' \
                         'These are being disregarded.'.format(key, name)
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warnings.warn(msg, IrisUserWarning, stacklevel=2)
                     # Swap bounds with points.
                     bds_shape = list(nd_points_by_key[key].shape) + [1]
                     bounds = nd_points_by_key[key].reshape(bds_shape)

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -453,9 +453,9 @@ class HybridHeightFactory(AuxCoordFactory):
             if sigma.shape[-1:] not in ok_bound_shapes:
                 raise ValueError('Invalid sigma coordinate bounds.')
             if orography.shape[-1:] not in [(), (1,)]:
-                warnings.warn('Orography coordinate has bounds. '
-                              'These are being disregarded.',
-                              IrisUserWarning, stacklevel=2)
+                msg = ('Orography coordinate has bounds. '
+                       'These are being disregarded.')
+                warnings.warn(msg, IrisUserWarning, stacklevel=2)
                 orography_pts = nd_points_by_key['orography']
                 bds_shape = list(orography_pts.shape) + [1]
                 orography = orography_pts.reshape(bds_shape)
@@ -639,8 +639,9 @@ class HybridPressureFactory(AuxCoordFactory):
             if sigma.shape[-1:] not in ok_bound_shapes:
                 raise ValueError('Invalid sigma coordinate bounds.')
             if surface_air_pressure.shape[-1:] not in [(), (1,)]:
-                warnings.warn('Surface pressure coordinate has bounds. '
-                              'These are being disregarded.')
+                msg = ('Surface pressure coordinate has bounds. '
+                       'These are being disregarded.')
+                warnings.warn(msg, IrisUserWarning)
                 surface_air_pressure_pts = nd_points_by_key[
                     'surface_air_pressure']
                 bds_shape = list(surface_air_pressure_pts.shape) + [1]

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -31,6 +31,7 @@ import numpy as np
 
 from iris._cube_coord_common import CFVariableMixin
 import iris.coords
+from iris.exceptions import IrisUserWarning
 
 
 class AuxCoordFactory(six.with_metaclass(ABCMeta, CFVariableMixin)):

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -29,6 +29,7 @@ import warnings
 import numpy as np
 import cartopy
 import cartopy.crs as ccrs
+from iris.exceptions import IrisUserWarning
 
 
 class CoordSystem(six.with_metaclass(ABCMeta, object)):

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -347,10 +347,10 @@ class RotatedGeogCS(CoordSystem):
                           'globe': globe}
 
         if cartopy.__version__ < '0.12':
-            warnings.warn('"central_rotated_longitude" is not supported by '
-                          'cartopy{} and has been ignored in the '
-                          'creation of the cartopy '
-                          'projection/crs.'.format(cartopy.__version__))
+            msg = ('"central_rotated_longitude" is not supported by cartopy{} '
+                   'and has been ignored in the creation of the cartopy '
+                   'projection/crs.').format(cartopy.__version__)
+            warnings.warn(msg, IrisUserWarning)
         else:
             crl = 'central_rotated_longitude'
             cartopy_kwargs[crl] = self.north_pole_grid_longitude
@@ -539,8 +539,9 @@ class Orthographic(CoordSystem):
         else:
             globe = ccrs.Globe()
 
-        warnings.warn('Discarding false_easting and false_northing that are '
-                      'not used by Cartopy.')
+        msg = ('Discarding false_easting and false_northing that are not used '
+               'by Cartopy.')
+        warnings.warn(msg, IrisUserWarning)
 
         return ccrs.Orthographic(
             central_longitude=self.longitude_of_projection_origin,

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1134,13 +1134,16 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         """
         if not self.has_bounds():
             if self.ndim == 1:
-                warnings.warn('Coordinate {!r} is not bounded, guessing '
-                              'contiguous bounds.'.format(self.name()))
+                msg = ('Coordinate {!r} is not bounded, guessing contiguous '
+                       'bounds.').format(self.name())
+                warnings.warn(msg, IrisUserWarning)
                 bounds = self._guess_bounds()
             elif self.ndim == 2:
-                raise ValueError('2D coordinate {!r} is not bounded. Guessing '
-                                 'bounds of 2D coords is not currently '
-                                 'supported.'.format(self.name()))
+                msg = (
+                    '2D coordinate {!r} is not bounded. Guessing bounds of '
+                    '2D coords is not currently supported.'
+                    ).format(self.name())
+                raise ValueError(msg, IrisUserWarning)
         else:
             self._sanity_check_bounds()
             bounds = self.bounds
@@ -1346,13 +1349,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         else:
             # Collapse the coordinate by calculating the bounded extremes.
             if self.ndim > 1:
-                msg = 'Collapsing a multi-dimensional coordinate. ' \
-                    'Metadata may not be fully descriptive for {!r}.'
-                warnings.warn(msg.format(self.name()))
+                msg = ('Collapsing a multi-dimensional coordinate. '
+                       'Metadata may not be fully descriptive for {!r}.')
+                warnings.warn(msg.format(self.name()), IrisUserWarning)
             elif not self.is_contiguous():
-                msg = 'Collapsing a non-contiguous coordinate. ' \
-                    'Metadata may not be fully descriptive for {!r}.'
-                warnings.warn(msg.format(self.name()))
+                msg = ('Collapsing a non-contiguous coordinate. '
+                       'Metadata may not be fully descriptive for {!r}.')
+                warnings.warn(msg.format(self.name()), IrisUserWarning)
 
             # Determine the array library for stacking
             al = da if self.has_bounds() \

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -46,6 +46,7 @@ import iris.util
 
 from iris._cube_coord_common import CFVariableMixin
 from iris.util import points_step
+from iris.exceptions import IrisUserWarning
 
 
 class CoordDefn(collections.namedtuple('CoordDefn',

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3177,7 +3177,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                          if 'latitude' in coord.name()]
             if lat_match:
                 for coord in lat_match:
-                    warnings.warn(msg.format(coord.name()))
+                    warnings.warn(msg.format(coord.name()), IrisUserWarning)
 
         # Determine the dimensions we need to collapse (and those we don't)
         if aggregator.cell_method == 'peak':
@@ -3588,8 +3588,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # now update all of the coordinates to reflect the aggregation
         for coord_ in self.coords(dimensions=dimension):
             if coord_.has_bounds():
-                warnings.warn('The bounds of coordinate %r were ignored in '
-                              'the rolling window operation.' % coord_.name())
+                msg = ('The bounds of coordinate %r were ignored in the '
+                       'rolling window operation.' % coord_.name())
+                warnings.warn(msg, IrisUserWarning)
 
             if coord_.ndim != 1:
                 raise ValueError('Cannot calculate the rolling '

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -53,6 +53,7 @@ import iris.coord_systems
 import iris.coords
 import iris.exceptions
 import iris.util
+from iris.exceptions import IrisUserWarning
 
 
 __all__ = ['Cube', 'CubeList', 'CubeMetadata']

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -24,7 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 
 class IrisUserWarning(UserWarning):
-    """An Iris UserWarning."""
+    """An Iris IrisUserWarning."""
     pass
 
 

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -23,6 +23,11 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
 
+class IrisUserWarning(UserWarning):
+    """An Iris UserWarning."""
+    pass
+
+
 class IrisError(Exception):
     """Base class for errors in the Iris package."""
     pass

--- a/lib/iris/experimental/animate.py
+++ b/lib/iris/experimental/animate.py
@@ -110,14 +110,14 @@ def animate(cube_iterator, plot_func, fig=None, **kwargs):
         msg = ('Given plotting module "{}" may not be supported, intended '
                'use: {}.')
         msg = msg.format(plot_func.__module__, supported)
-        warnings.warn(msg, UserWarning)
+        warnings.warn(msg, IrisUserWarning)
 
     supported = ['contour', 'contourf', 'pcolor', 'pcolormesh']
     if plot_func.__name__ not in supported:
         msg = ('Given plotting function "{}" may not be supported, intended '
                'use: {}.')
         msg = msg.format(plot_func.__name__, supported)
-        warnings.warn(msg, UserWarning)
+        warnings.warn(msg, IrisUserWarning)
 
     # Determine plot range.
     vmin = kwargs.pop('vmin', min([cc.data.min() for cc in cubes]))

--- a/lib/iris/experimental/animate.py
+++ b/lib/iris/experimental/animate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,6 +28,7 @@ import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
 import iris
+from iris.exceptions import IrisUserWarning
 
 
 def animate(cube_iterator, plot_func, fig=None, **kwargs):

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -42,6 +42,7 @@ from iris.analysis._regrid import RectilinearRegridder
 import iris.coord_systems
 import iris.cube
 from iris.util import _meshgrid, promote_aux_coord_to_dim_coord
+from iris.exceptions import IrisUserWarning
 
 
 _Version = namedtuple('Version', ('major', 'minor', 'micro'))

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -867,7 +867,7 @@ def _regrid_weighted_curvilinear_to_rectilinear__prepare(
     """
     if src_cube.aux_factories:
         msg = 'All source cube derived coordinates will be ignored.'
-        warnings.warn(msg)
+        warnings.warn(msg, IrisUserWarning)
 
     # Get the source cube x and y 2D auxiliary coordinates.
     sx, sy = src_cube.coord(axis='x'), src_cube.coord(axis='y')
@@ -1561,7 +1561,7 @@ class _ProjectedUnstructuredRegridder(object):
             except KeyError:
                 msg = 'Cannot update aux_factory {!r} because of dropped' \
                       ' coordinates.'.format(factory.name())
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
         return result
 
     def __call__(self, src_cube):

--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,7 +27,7 @@ import warnings
 
 import numpy as np
 
-from iris.exceptions import NotYetImplementedError
+from iris.exceptions import NotYetImplementedError, IrisUserWarning
 from iris.fileformats._ff_cross_references import STASH_TRANS
 from . import pp
 

--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -422,9 +422,9 @@ class FFHeader(object):
         grid_class = self.GRID_STAGGERING_CLASS.get(self.grid_staggering)
         if grid_class is None:
             grid_class = NewDynamics
-            warnings.warn(
-                'Staggered grid type: {} not currently interpreted, assuming '
-                'standard C-grid'.format(self.grid_staggering))
+            msg = ('Staggered grid type: {} not currently interpreted, '
+                   'assuming standard C-grid').format(self.grid_staggering)
+            warnings.warn(msg, IrisUserWarning)
         grid = grid_class(self.column_dependent_constants,
                           self.row_dependent_constants,
                           self.real_constants, self.horiz_grid_type)
@@ -604,10 +604,10 @@ class FF2PP(object):
             field.y = self._det_border(field.y, boundary_packing.y_halo)
         else:
             if field.bdy < 0:
-                warnings.warn('The LBC has a bdy less than 0. No '
-                              'case has previously been seen of '
-                              'this, and the decompression may be '
-                              'erroneous.')
+                msg = ('The LBC has a bdy less than 0. No case has previously '
+                       'been seen of this, and the decompression may be '
+                       'erroneous.')
+                warnings.warn(msg, IrisUserWarning)
             field.bzx -= field.bdx * boundary_packing.x_halo
             field.bzy -= field.bdy * boundary_packing.y_halo
 
@@ -707,11 +707,11 @@ class FF2PP(object):
                     else:
                         subgrid = stash_entry.grid_code
                         if subgrid not in HANDLED_GRIDS:
-                            warnings.warn('The stash code {} is on a grid {} '
-                                          'which has not been explicitly '
-                                          'handled by the fieldsfile loader.'
-                                          ' Assuming the data is on a P grid'
-                                          '.'.format(stash, subgrid))
+                            msg = ('The stash code {} is on a grid {} which '
+                                   'has not been explicitly handled by the '
+                                   'fieldsfile loader. Assuming the data is on '
+                                   'a P grid.').format(stash, subgrid)
+                            warnings.warn(msg, IrisUserWarning)
 
                     field.x, field.y = grid.vectors(subgrid)
 
@@ -730,8 +730,8 @@ class FF2PP(object):
                         field.bplat = grid.pole_lat
                         field.bplon = grid.pole_lon
                     elif no_x or no_y:
-                        warnings.warn(
-                            'Partially missing X or Y coordinate values.')
+                        msg = 'Partially missing X or Y coordinate values.'
+                        warnings.warn(msg, IrisUserWarning)
 
                     # Check for LBC fields.
                     is_boundary_packed = self._ff_header.dataset_type == 5
@@ -769,7 +769,7 @@ class FF2PP(object):
                 except ValueError as valerr:
                     msg = ('Input field skipped as PPField creation failed :'
                            ' error = {!r}')
-                    warnings.warn(msg.format(str(valerr)))
+                    warnings.warn(msg.format(str(valerr)), IrisUserWarning)
 
     def __iter__(self):
         return pp._interpret_fields(self._extract_field())

--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -709,8 +709,8 @@ class FF2PP(object):
                         if subgrid not in HANDLED_GRIDS:
                             msg = ('The stash code {} is on a grid {} which '
                                    'has not been explicitly handled by the '
-                                   'fieldsfile loader. Assuming the data is on '
-                                   'a P grid.').format(stash, subgrid)
+                                   'fieldsfile loader. Assuming the data is '
+                                   'on a P grid.').format(stash, subgrid)
                             warnings.warn(msg, IrisUserWarning)
 
                     field.x, field.y = grid.vectors(subgrid)

--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -538,7 +538,7 @@ class FF2PP(object):
             msg = ('The x or y coordinates of your boundary condition field '
                    'may be incorrect, not having taken into account the '
                    'boundary size.')
-            warnings.warn(msg)
+            warnings.warn(msg, IrisUserWarning)
         else:
             range2 = field_dim[0] - res_low
             range1 = field_dim[0] - halo_dim * res_low
@@ -724,7 +724,7 @@ class FF2PP(object):
                             msg = ('The STASH code {0} was not found in the '
                                    'STASH to grid type mapping. Picking the P '
                                    'position as the cell type'.format(stash))
-                            warnings.warn(msg)
+                            warnings.warn(msg, IrisUserWarning)
                         field.bzx, field.bdx = grid.regular_x(subgrid)
                         field.bzy, field.bdy = grid.regular_y(subgrid)
                         field.bplat = grid.pole_lat

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1225,7 +1225,7 @@ fc_extras
                     cube.attributes[str(attr_name)] = attr_value
             except ValueError as e:
                 msg = 'Skipping global attribute {!r}: {}'
-                warnings.warn(msg.format(attr_name, str(e)))
+                warnings.warn(msg.format(attr_name, str(e)), IrisUserWarning)
 
 
 
@@ -1263,7 +1263,8 @@ fc_extras
         north_pole_latitude = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_LAT, 90.0)
         north_pole_longitude = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_LON, 0.0)
         if north_pole_latitude is None or north_pole_longitude is None:
-            warnings.warn('Rotated pole position is not fully specified')
+            warnings.warn('Rotated pole position is not fully specified', 
+                          IrisUserWarning)
 
         north_pole_grid_lon = getattr(cf_grid_var, CF_ATTR_GRID_NORTH_POLE_GRID_LON, 0.0)
 
@@ -1495,9 +1496,10 @@ fc_extras
             msg = u'Ignoring netCDF variable {!r} invalid units {!r}'.format(
                 cf_var.cf_name, attr_units)
             if six.PY3:
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
             else:
-                warnings.warn(msg.encode('ascii', errors='backslashreplace'))
+                warnings.warn(msg.encode('ascii', errors='backslashreplace'),
+                              IrisUserWarning)
             attributes['invalid_units'] = attr_units
             attr_units = cf_units._UNKNOWN_UNIT_STRING
 
@@ -1576,7 +1578,7 @@ fc_extras
         if attr_bounds is not None and attr_climatology is not None:
             warnings.warn('Ignoring climatology in favour of bounds attribute '
                           'on NetCDF variable {!r}.'.format(
-                          cf_coord_var.cf_name))
+                          cf_coord_var.cf_name), IrisUserWarning)
 
         return cf_bounds_var
 
@@ -1624,7 +1626,8 @@ fc_extras
         if ma.is_masked(points_data):
             points_data = ma.filled(points_data)
             msg = 'Gracefully filling {!r} dimension coordinate masked points'
-            warnings.warn(msg.format(str(cf_coord_var.cf_name)))
+            warnings.warn(msg.format(str(cf_coord_var.cf_name)),
+                          IrisUserWarning)
 
         # Get any coordinate bounds.
         cf_bounds_var = get_cf_bounds_var(cf_coord_var)
@@ -1634,7 +1637,8 @@ fc_extras
             if ma.is_masked(bounds_data):
                 bounds_data = ma.filled(bounds_data)
                 msg = 'Gracefully filling {!r} dimension coordinate masked bounds'
-                warnings.warn(msg.format(str(cf_coord_var.cf_name)))
+                warnings.warn(msg.format(str(cf_coord_var.cf_name)),
+                              IrisUserWarning)
             # Handle transposed bounds where the vertex dimension is not
             # the last one. Test based on shape to support different
             # dimension names.
@@ -1687,8 +1691,8 @@ fc_extras
             cube.add_aux_coord(coord, data_dims)
             msg = 'Failed to create {name!r} dimension coordinate: {error}\n' \
                   'Gracefully creating {name!r} auxiliary coordinate instead.'
-            warnings.warn(msg.format(name=str(cf_coord_var.cf_name),
-                                     error=e_msg))
+            msg = msg.format(name=str(cf_coord_var.cf_name), error=e_msg)
+            warnings.warn(msg, IrisUserWarning)
         else:
             # Add the dimension coordinate to the cube.
             if data_dims:
@@ -1991,25 +1995,23 @@ fc_extras
         standard_parallel = getattr(
             cf_grid_var, CF_ATTR_GRID_STANDARD_PARALLEL, None)
 
-        if false_easting is not None and \
-                false_easting != 0:
+        if false_easting is not None and false_easting != 0:
             warnings.warn('False eastings other than 0.0 not yet supported '
-                          'for Mercator projections')
+                          'for Mercator projections', IrisUserWarning)
             is_valid = False
-        if false_northing is not None and \
-                false_northing != 0:
+        if false_northing is not None and false_northing != 0:
             warnings.warn('False northings other than 0.0 not yet supported '
-                          'for Mercator projections')
+                          'for Mercator projections', IrisUserWarning)
             is_valid = False
         if scale_factor_at_projection_origin is not None and \
                 scale_factor_at_projection_origin != 1:
             warnings.warn('Scale factors other than 1.0 not yet supported for '
-                          'Mercator projections')
+                          'Mercator projections', IrisUserWarning)
             is_valid = False
-        if standard_parallel is not None and \
-                standard_parallel != 0:
+        if standard_parallel is not None and standard_parallel != 0:
             warnings.warn('Standard parallels other than 0.0 not yet '
-                          'supported for Mercator projections')
+                          'supported for Mercator projections',
+                          IrisUserWarning)
             is_valid = False
 
         return is_valid
@@ -2029,7 +2031,7 @@ fc_extras
         if scale_factor_at_projection_origin is not None and \
                 scale_factor_at_projection_origin != 1:
             warnings.warn('Scale factors other than 1.0 not yet supported for '
-                          'stereographic projections')
+                          'stereographic projections', IrisUserWarning)
             is_valid = False
 
         return is_valid
@@ -2051,8 +2053,9 @@ fc_extras
                 if method_words[0].lower() not in CM_KNOWN_METHODS:
                     msg = 'NetCDF variable {!r} contains unknown cell ' \
                           'method {!r}'
-                    warnings.warn(msg.format('{}'.format(cf_var_name),
-                                             '{}'.format(method_words[0])))
+                    msg = msg.format('{}'.format(cf_var_name), 
+                                     '{}'.format(method_words[0]))
+                    warnings.warn(msg, IrisUserWarning)
                 d[CM_METHOD] = method
                 name = d[CM_NAME]
                 name = name.replace(' ', '')

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1076,8 +1076,9 @@ fc_extras
     import iris.std_names
     import iris.util
     from iris._lazy_data import as_lazy_data
-
-
+    from iris.exceptions import IrisUserWarning
+    
+    
     #
     # UD Units Constants (based on Unidata udunits.dat definition file)
     #

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -41,6 +41,7 @@ import numpy.ma as ma
 
 from iris._deprecation import warn_deprecated
 import iris.util
+from iris.exceptions import IrisUserWarning
 
 
 #

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -276,8 +276,10 @@ class CFAncillaryDataVariable(CFVariable):
                     if name not in ignore:
                         if name not in variables:
                             if warn:
-                                message = 'Missing CF-netCDF ancillary data variable %r, referenced by netCDF variable %r'
-                                warnings.warn(message % (name, nc_var_name))
+                                msg = ('Missing CF-netCDF ancillary data '
+                                       'variable %r, referenced by netCDF '
+                                       'variable %r' % (name, nc_var_name))
+                                warnings.warn(msg, IrisUserWarning)
                         else:
                             result[name] = CFAncillaryDataVariable(name, variables[name])
 
@@ -316,8 +318,10 @@ class CFAuxiliaryCoordinateVariable(CFVariable):
                     if name not in ignore:
                         if name not in variables:
                             if warn:
-                                message = 'Missing CF-netCDF auxiliary coordinate variable %r, referenced by netCDF variable %r'
-                                warnings.warn(message % (name, nc_var_name))
+                                msg = ('Missing CF-netCDF auxiliary coordinate '
+                                       'variable %r, referenced by netCDF '
+                                       'variable %r' % (name, nc_var_name))
+                                warnings.warn(msg, IrisUserWarning)
                         else:
                             # Restrict to non-string type i.e. not a CFLabelVariable.
                             if not _is_str_dtype(variables[name]):
@@ -359,8 +363,10 @@ class CFBoundaryVariable(CFVariable):
                 if name not in ignore:
                     if name not in variables:
                         if warn:
-                            message = 'Missing CF-netCDF boundary variable %r, referenced by netCDF variable %r'
-                            warnings.warn(message % (name, nc_var_name))
+                            msg = ('Missing CF-netCDF boundary variable %r, '
+                                   'referenced by netCDF variable %r' %
+                                   (name, nc_var_name))
+                            warnings.warn(msg, IrisUserWarning)
                     else:
                         result[name] = CFBoundaryVariable(name, variables[name])
 
@@ -427,8 +433,10 @@ class CFClimatologyVariable(CFVariable):
                 if name not in ignore:
                     if name not in variables:
                         if warn:
-                            message = 'Missing CF-netCDF climatology variable %r, referenced by netCDF variable %r'
-                            warnings.warn(message % (name, nc_var_name))
+                            msg = ('Missing CF-netCDF climatology variable %r, '
+                                   'referenced by netCDF variable %r' %
+                                   (name, nc_var_name))
+                            warnings.warn(msg, IrisUserWarning)
                     else:
                         result[name] = CFClimatologyVariable(name, variables[name])
 
@@ -553,8 +561,11 @@ class _CFFormulaTermsVariable(CFVariable):
                     if variable_name not in ignore:
                         if variable_name not in variables:
                             if warn:
-                                message = 'Missing CF-netCDF formula term variable %r, referenced by netCDF variable %r'
-                                warnings.warn(message % (variable_name, nc_var_name))
+                                msg = ('Missing CF-netCDF formula term '
+                                       'variable %r, referenced by netCDF '
+                                       'variable %r' %
+                                       (variable_name, nc_var_name))
+                                warnings.warn(msg, IrisUserWarning)
                         else:
                             if variable_name not in result:
                                 result[variable_name] = _CFFormulaTermsVariable(variable_name,
@@ -605,8 +616,10 @@ class CFGridMappingVariable(CFVariable):
                 if name not in ignore:
                     if name not in variables:
                         if warn:
-                            message = 'Missing CF-netCDF grid mapping variable %r, referenced by netCDF variable %r'
-                            warnings.warn(message % (name, nc_var_name))
+                            msg = ('Missing CF-netCDF grid mapping variable '
+                                   '%r, referenced by netCDF variable %r' %
+                                   (name, nc_var_name))
+                            warnings.warn(msg, IrisUserWarning)
                     else:
                         result[name] = CFGridMappingVariable(name, variables[name])
 
@@ -641,8 +654,10 @@ class CFLabelVariable(CFVariable):
                     if name not in ignore:
                         if name not in variables:
                             if warn:
-                                message = 'Missing CF-netCDF label variable %r, referenced by netCDF variable %r'
-                                warnings.warn(message % (name, nc_var_name))
+                                msg = ('Missing CF-netCDF label variable %r, '
+                                       'referenced by netCDF variable %r' %
+                                       (name, nc_var_name))
+                                warnings.warn(msg, IrisUserWarning)
                         else:
                             # Register variable, but only allow string type.
                             var = variables[name]
@@ -794,8 +809,10 @@ class CFMeasureVariable(CFVariable):
                     if variable_name not in ignore:
                         if variable_name not in variables:
                             if warn:
-                                message = 'Missing CF-netCDF measure variable %r, referenced by netCDF variable %r'
-                                warnings.warn(message % (variable_name, nc_var_name))
+                                msg = ('Missing CF-netCDF measure variable %r, '
+                                       'referenced by netCDF variable %r' %
+                                       (variable_name, nc_var_name))
+                                warnings.warn(msg, IrisUserWarning)
                         else:
                             result[variable_name] = CFMeasureVariable(variable_name, variables[variable_name], measure)
 
@@ -938,8 +955,9 @@ class CFReader(object):
 
         # Issue load optimisation warning.
         if warn and self._dataset.file_format in ['NETCDF3_CLASSIC', 'NETCDF3_64BIT']:
-            warnings.warn('Optimise CF-netCDF loading by converting data from NetCDF3 ' \
-                          'to NetCDF4 file format using the "nccopy" command.')
+            msg = ('Optimise CF-netCDF loading by converting data from NetCDF3 '
+                   'to NetCDF4 file format using the "nccopy" command.')
+            warnings.warn(msg, IrisUserWarning)
 
         self._check_monotonic = monotonic
 

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1030,7 +1030,7 @@ class CFReader(object):
                                                cf_variable.cf_name,
                                                cf_var.dimensions,
                                                cf_variable.dimensions)
-                        warnings.warn(msg)
+                        warnings.warn(msg, IrisUserWarning)
 
             # Build CF data variable relationships.
             if isinstance(cf_variable, CFDataVariable):
@@ -1066,7 +1066,7 @@ class CFReader(object):
                                                        cf_root,
                                                        cf_var.dimensions,
                                                        cf_variable.dimensions)
-                                warnings.warn(msg)
+                                warnings.warn(msg, IrisUserWarning)
 
             # Add the CF group to the variable.
             cf_variable.cf_group = cf_group

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -31,7 +31,7 @@ import numpy as np
 from iris.coords import AuxCoord, DimCoord, CellMethod
 import iris.coord_systems
 import iris.cube
-from iris.exceptions import TranslationError
+from iris.exceptions import IrisUserWarning, TranslationError
 import iris.util
 
 from operator import itemgetter

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -267,7 +267,7 @@ def _parse_units(units):
     try:
         units = cf_units.Unit(units)
     except ValueError:
-        warnings.warn('Unknown units: {!r}'.format(units))
+        warnings.warn('Unknown units: {!r}'.format(units), IrisUserWarning)
         units = cf_units.Unit(None)
 
     return units
@@ -554,7 +554,7 @@ def _build_cell_methods(av_or_ints, coord):
         else:
             cell_method = None
             msg = 'Unknown {} statistic: {!r}. Unable to create cell method.'
-            warnings.warn(msg.format(coord, av_or_int))
+            warnings.warn(msg.format(coord, av_or_int), IrisUserWarning)
         cell_methods.append(cell_method)
     return cell_methods
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -624,7 +624,7 @@ def _load_aux_factory(engine, cube):
                         msg = 'Ignoring atmosphere hybrid sigma pressure ' \
                             'scalar coordinate {!r} bounds.'.format(
                                 coord_p0.name())
-                        warnings.warn(msg)
+                        warnings.warn(msg, IrisUserWarning)
                     coord_a = coord_from_term('a')
                     if coord_a is not None:
                         delta = coord_a * coord_p0.points[0]
@@ -1021,7 +1021,7 @@ class Saver(object):
             else:
                 msg = 'cf_profile is available but no {} defined.'.format(
                     'cf_patch')
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
 
     @staticmethod
     def check_attribute_compliance(container, data):
@@ -1227,7 +1227,7 @@ class Saver(object):
             if factory_defn is None:
                 msg = 'Unable to determine formula terms ' \
                       'for AuxFactory: {!r}'.format(factory)
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
             else:
                 # Override `standard_name`, `long_name`, and `axis` of the
                 # primary coord that signals the presense of a dimensionless
@@ -2080,7 +2080,7 @@ class Saver(object):
                 msg = '{attr_name!r} is being added as CF data variable ' \
                       'attribute, but {attr_name!r} should only be a CF ' \
                       'global attribute.'.format(attr_name=attr_name)
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
 
             _setncattr(cf_var, attr_name, value)
 
@@ -2369,7 +2369,7 @@ def save(cube, filename, netcdf_format='NETCDF4', local_keys=None,
             else:
                 msg = 'cf_profile is available but no {} defined.'.format(
                     'cf_patch_conventions')
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
 
         # Add conventions attribute.
         sman.update_global_attributes(Conventions=conventions)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -596,7 +596,7 @@ def _load_aux_factory(engine, cube):
                     if cf_var_name == name:
                         return coord
                 warnings.warn('Unable to find coordinate for variable '
-                              '{!r}'.format(name))
+                              '{!r}'.format(name), IrisUserWarning)
 
         if formula_type == 'atmosphere_hybrid_height_coordinate':
             delta = coord_from_term('a')
@@ -716,7 +716,7 @@ def load_cubes(filenames, callback=None):
             try:
                 _load_aux_factory(engine, cube)
             except ValueError as e:
-                warnings.warn('{}'.format(e))
+                warnings.warn('{}'.format(e), IrisUserWarning)
 
             # Perform any user registered callback function.
             cube = iris.io.run_callback(callback, cube, cf_var, filename)
@@ -1843,9 +1843,9 @@ class Saver(object):
                 # stereo
                 elif isinstance(cs, iris.coord_systems.Stereographic):
                     if cs.true_scale_lat is not None:
-                        warnings.warn('Stereographic coordinate systems with '
-                                      'true scale latitude specified are not '
-                                      'yet handled')
+                        msg = ('Stereographic coordinate systems with true '
+                               'scale latitude specified are not yet handled')
+                        warnings.warn(msg, IrisUserWarning)
                     else:
                         if cs.ellipsoid:
                             add_ellipsoid(cs.ellipsoid)
@@ -1861,7 +1861,8 @@ class Saver(object):
 
                 # osgb (a specific tmerc)
                 elif isinstance(cs, iris.coord_systems.OSGB):
-                    warnings.warn('OSGB coordinate system not yet handled')
+                    warnings.warn('OSGB coordinate system not yet handled',
+                                  IrisUserWarning)
 
                 # lambert azimuthal equal area
                 elif isinstance(cs,
@@ -1890,9 +1891,10 @@ class Saver(object):
 
                 # other
                 else:
-                    warnings.warn('Unable to represent the horizontal '
-                                  'coordinate system. The coordinate system '
-                                  'type %r is not yet implemented.' % type(cs))
+                    msg = ('Unable to represent the horizontal coordinate '
+                           'system. The coordinate system type %r is not yet '
+                           'implemented.' % type(cs))
+                    warnings.warn(msg, IrisUserWarning)
 
                 self._coord_systems.append(cs)
 
@@ -2028,14 +2030,14 @@ class Saver(object):
                        "points will read back as valid values. To save as "
                        "masked byte data, please explicitly specify the "
                        "'fill_value' keyword.")
-                warnings.warn(msg.format(cube.name()))
+                warnings.warn(msg.format(cube.name()), IrisUserWarning)
         elif contains_fill_value:
             msg = ("Cube '{}' contains unmasked data points equal to the "
                    "fill-value, {}. As saved, these points will read back "
                    "as missing data. To save these as normal values, please "
                    "specify a 'fill_value' keyword not equal to any valid "
                    "data points.")
-            warnings.warn(msg.format(cube.name(), fill_value))
+            warnings.warn(msg.format(cube.name(), fill_value), IrisUserWarning)
 
         if cube.standard_name:
             _setncattr(cf_var, 'standard_name', cube.standard_name)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -58,6 +58,7 @@ import iris.fileformats._pyke_rules
 import iris.io
 import iris.util
 from iris._lazy_data import as_lazy_data
+from iris.exceptions import IrisUserWarning
 
 # Show Pyke inference engine statistics.
 DEBUG = False

--- a/lib/iris/fileformats/nimrod_load_rules.py
+++ b/lib/iris/fileformats/nimrod_load_rules.py
@@ -28,7 +28,7 @@ import numpy as np
 
 import iris
 from iris.coords import DimCoord
-from iris.exceptions import TranslationError
+from iris.exceptions import IrisUserWarning, TranslationError
 
 
 __all__ = ['run']

--- a/lib/iris/fileformats/nimrod_load_rules.py
+++ b/lib/iris/fileformats/nimrod_load_rules.py
@@ -69,8 +69,8 @@ def units(cube, field):
         cube.units = units
     except ValueError:
         # Just add it as an attribute.
-        warnings.warn("Unhandled units '{0}' recorded in cube attributes.".
-                      format(units))
+        msg = "Unhandled units '{0}' recorded in cube attributes.".format(units)
+        warnings.warn(msg, IrisUserWarning)
         cube.attributes["invalid_units"] = units
 
 
@@ -135,9 +135,9 @@ def tm_meridian_scaling(cube, field):
         if abs(field.tm_meridian_scaling - MERIDIAN_SCALING_BNG) < 1e-6:
             pass  # This is the expected value for British National Grid
         else:
-            warnings.warn("tm_meridian_scaling not yet handled: {}"
-                          "".format(field.tm_meridian_scaling),
-                          TranslationWarning)
+            msg = "tm_meridian_scaling not yet handled: {}"
+            msg = msg.format(field.tm_meridian_scaling)
+            warnings.warn(msg, TranslationWarning)
 
 
 def british_national_grid_x(cube, field):
@@ -242,8 +242,8 @@ def vertical_coord(cube, field):
             elif vertical_code_name == "levels_below_ground":
                 levels_below_ground_vertical_coord(cube, field)
             else:
-                warnings.warn("Vertical coord {!r} not yet handled"
-                              "".format(v_type), TranslationWarning)
+                msg = "Vertical coord {!r} not yet handled".format(v_type)
+                warnings.warn(msg, TranslationWarning)
 
 
 def ensemble_member(cube, field):

--- a/lib/iris/fileformats/nimrod_load_rules.py
+++ b/lib/iris/fileformats/nimrod_load_rules.py
@@ -69,7 +69,7 @@ def units(cube, field):
         cube.units = units
     except ValueError:
         # Just add it as an attribute.
-        msg = "Unhandled units '{0}' recorded in cube attributes.".format(units)
+        msg = "Unhandled units '{}' recorded in cube attributes.".format(units)
         warnings.warn(msg, IrisUserWarning)
         cube.attributes["invalid_units"] = units
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -49,6 +49,7 @@ from iris.fileformats._pp_lbproc_pairs import (LBPROC_PAIRS,
                                                LBPROC_MAP as lbproc_map)
 import iris.fileformats.rules
 import iris.coord_systems
+from iris.exceptions import IrisUserWarning
 
 
 try:
@@ -1606,9 +1607,9 @@ def _interpret_fields(fields):
 
     if landmask_compressed_fields:
         if land_mask is None:
-            msg = 'Landmask compressed fields existed without a landmask to '
-                  'decompress with. The data will have a shape of (0, 0) and '
-                  'will not read.'
+            msg = ('Landmask compressed fields existed without a landmask to '
+                   'decompress with. The data will have a shape of (0, 0) and '
+                   'will not read.')
             warnings.warn(msg, IrisUserWarning)
             mask_shape = (0, 0)
         else:

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1694,7 +1694,7 @@ def _field_gen(filename, read_data_bytes, little_ended=False):
                 msg = 'Unable to interpret field {}. {}. Skipping ' \
                       'the remainder of the file.'.format(field_count,
                                                           str(e))
-                warnings.warn(msg)
+                warnings.warn(msg, IrisUserWarning)
                 break
 
             # Skip the trailing 4-byte word containing the header length

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1712,7 +1712,8 @@ def _field_gen(filename, read_data_bytes, little_ended=False):
                 wmsg = ('LBLREC has a different value to the integer recorded '
                         'after the header in the file ({} and {}). '
                         'Skipping the remainder of the file.')
-                wmsg = wmsg.format(pp_field.lblrec * PP_WORD_DEPTH, len_of_data_plus_extra)
+                wmsg = wmsg.format(pp_field.lblrec * PP_WORD_DEPTH,
+                                   len_of_data_plus_extra)
                 warnings.warn(wmsg, IrisUserWarning)
                 break
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1139,7 +1139,7 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
                    "value, {}. As saved, these points will read back as "
                    "missing data. To save these as normal values, please "
                    "set the field BMDI not equal to any valid data points.")
-            warnings.warn(msg.format(mdi))
+            warnings.warn(msg.format(mdi), IrisUserWarning)
         if isinstance(data, ma.MaskedArray):
             if ma.is_masked(data):
                 data = data.filled(fill_value=mdi)
@@ -1253,9 +1253,10 @@ class PPField(six.with_metaclass(abc.ABCMeta, object)):
         if data.dtype == np.dtype('>f4'):
             lb[self.HEADER_DICT['lbuser'][0]] = 1
         elif data.dtype == np.dtype('>f8'):
-            warnings.warn("Downcasting array precision from float64 to float32"
-                          " for save.If float64 precision is required then"
-                          " please save in a different format")
+            msg = ("Downcasting array precision from float64 to float32 for "
+                   "save.If float64 precision is required then please save in "
+                   "a different format")
+            warnings.warn(msg, IrisUserWarning)
             data = data.astype('>f4')
             lb[self.HEADER_DICT['lbuser'][0]] = 1
         elif data.dtype == np.dtype('>i4'):
@@ -1605,9 +1606,10 @@ def _interpret_fields(fields):
 
     if landmask_compressed_fields:
         if land_mask is None:
-            warnings.warn('Landmask compressed fields existed without a '
-                          'landmask to decompress with. The data will have '
-                          'a shape of (0, 0) and will not read.')
+            msg = 'Landmask compressed fields existed without a landmask to '
+                  'decompress with. The data will have a shape of (0, 0) and '
+                  'will not read.'
+            warnings.warn(msg, IrisUserWarning)
             mask_shape = (0, 0)
         else:
             mask_shape = (land_mask.lbrow, land_mask.lbnpt)
@@ -1709,8 +1711,8 @@ def _field_gen(filename, read_data_bytes, little_ended=False):
                 wmsg = ('LBLREC has a different value to the integer recorded '
                         'after the header in the file ({} and {}). '
                         'Skipping the remainder of the file.')
-                warnings.warn(wmsg.format(pp_field.lblrec * PP_WORD_DEPTH,
-                                          len_of_data_plus_extra))
+                wmsg = wmsg.format(pp_field.lblrec * PP_WORD_DEPTH, len_of_data_plus_extra)
+                warnings.warn(wmsg, IrisUserWarning)
                 break
 
             # calculate the extra length in bytes

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -811,4 +811,4 @@ def verify(cube, field):
 
 def _conditional_warning(condition, warning):
     if condition:
-        warnings.warn(warning)
+        warnings.warn(warning, IrisUserWarning)

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -32,6 +32,7 @@ from iris.fileformats.rules import (aux_factory,
                                     scalar_coord,
                                     vector_coord)
 from iris.util import is_regular, regular_step
+from iris.exceptions import IrisUserWarning
 import cftime
 
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -312,7 +312,7 @@ def _make_cube(field, converter):
             cube.units = metadata.units
         except ValueError:
             msg = 'Ignoring PP invalid units {!r}'.format(metadata.units)
-            warnings.warn(msg)
+            warnings.warn(msg, IrisUserWarning)
             cube.attributes['invalid_units'] = metadata.units
             cube.units = cf_units._UNKNOWN_UNIT_STRING
 

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -60,8 +60,8 @@ class ConcreteReferenceTarget(object):
                 # time-varying surface pressure in hybrid-presure.
                 src_cubes = src_cubes.merge(unique=False)
                 if len(src_cubes) > 1:
-                    warnings.warn('Multiple reference cubes for {}'
-                                  .format(self.name))
+                    msg = 'Multiple reference cubes for {}'.format(self.name)
+                    warnings.warn(msg, IrisUserWarning)
             src_cube = src_cubes[-1]
 
             if self.transform is None:
@@ -331,7 +331,7 @@ def _resolve_factory_references(cube, factories, concrete_reference_targets,
         except _ReferenceError as e:
             msg = 'Unable to create instance of {factory}. ' + str(e)
             factory_name = factory.factory_class.__name__
-            warnings.warn(msg.format(factory=factory_name))
+            warnings.warn(msg.format(factory=factory_name), IrisUserWarning)
         else:
             aux_factory = factory.factory_class(*args)
             cube.add_aux_factory(aux_factory)

--- a/lib/iris/fileformats/rules.py
+++ b/lib/iris/fileformats/rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -32,6 +32,7 @@ from iris.analysis import Linear
 import iris.cube
 import iris.exceptions
 import iris.fileformats.um_cf_map
+from iris.exceptions import IrisUserWarning
 
 Factory = collections.namedtuple('Factory', ['factory_class', 'args'])
 ReferenceTarget = collections.namedtuple('ReferenceTarget',

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -159,9 +159,10 @@ def izip(*cubes, **kwargs):
                                  "to iterate over this coordinate in "
                                  "step." % coord_a.name())
             if coord_a != coord_b:
-                warnings.warn("Iterating over coordinate '%s' in step whose "
-                              "definitions match but whose values "
-                              "differ." % coord_a.name())
+                msg = ("Iterating over coordinate '%s' in step whose "
+                       "definitions match but whose values differ.")
+                msg = msg % coord_a.name()
+                warnings.warn(msg, IrisUserWarning)
 
     return _ZipSlicesIterator(cubes, requested_dims_by_cube, ordered,
                               coords_by_cube)

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,6 +29,7 @@ import warnings
 import numpy as np
 
 import iris.exceptions
+from iris.exceptions import IrisUserWarning
 
 __all__ = ['izip']
 

--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -53,6 +53,7 @@ import numpy as np  # noqa
 import requests  # noqa
 
 import iris.util as iutil  # noqa
+from iris.exceptions import IrisUserWarning  # noqa
 
 
 _POSTFIX_DIFF = '-failed-diff.png'

--- a/lib/iris/tests/idiff.py
+++ b/lib/iris/tests/idiff.py
@@ -217,8 +217,8 @@ def step_over_diffs(result_dir, action, display=True):
                 hash_index, distance = _calculate_hit(uris, phash, action)
                 uri = uris[hash_index]
             except KeyError:
-                wmsg = 'Ignoring unregistered test result {!r}.'
-                warnings.warn(wmsg.format(key))
+                msg = 'Ignoring unregistered test result {!r}.'.format(key)
+                warnings.warn(msg, IrisUserWarning)
                 continue
             with temp_png(key) as expected_fname:
                 processed = True

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -96,7 +96,7 @@ class Test_phenomenon(tests.IrisTest):
         with warnings.catch_warnings():
             # This should issue a warning about unrecognised data
             warnings.simplefilter("error")
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 grib_save_rules.set_discipline_and_parameter(cube, grib)
         # do it all again, and this time check the results
         grib = None

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,7 +29,6 @@ import numpy as np
 
 import iris.cube
 import iris.coords
-from iris.exceptions import IrisUserWarning
 from iris.tests import mock
 
 
@@ -98,7 +97,7 @@ class Test_phenomenon(tests.IrisTest):
         with warnings.catch_warnings():
             # This should issue a warning about unrecognised data
             warnings.simplefilter("error")
-            with self.assertRaises(IrisUserWarning):
+            with self.assertRaises(UserWarning):
                 grib_save_rules.set_discipline_and_parameter(cube, grib)
         # do it all again, and this time check the results
         grib = None

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,7 +29,9 @@ import numpy as np
 
 import iris.cube
 import iris.coords
+from iris.exceptions import IrisUserWarning
 from iris.tests import mock
+
 
 if tests.GRIB_AVAILABLE:
     import gribapi

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -140,7 +140,7 @@ class TestRealistic4d(tests.GraphicsTest):
         with warnings.catch_warnings():
             # Cause all warnings to raise Exceptions
             warnings.simplefilter("error")
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 factory = HybridHeightFactory(orography=sigma)
 
     def test_bounded_orography(self):
@@ -158,7 +158,7 @@ class TestRealistic4d(tests.GraphicsTest):
         with warnings.catch_warnings():
             # Cause all warnings to raise Exceptions
             warnings.simplefilter("error")
-            with self.assertRaisesRegexp(UserWarning, msg):
+            with self.assertRaisesRegexp(IrisUserWarning, msg):
                 self.cube.coord('altitude')
 
 
@@ -219,7 +219,7 @@ class TestHybridPressure(tests.IrisTest):
         with warnings.catch_warnings():
             # Cause all warnings to raise Exceptions
             warnings.simplefilter("error")
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 factory = HybridPressureFactory(
                     sigma=sigma, surface_air_pressure=sigma)
 
@@ -238,7 +238,7 @@ class TestHybridPressure(tests.IrisTest):
         with warnings.catch_warnings():
             # Cause all warnings to raise Exceptions
             warnings.simplefilter("error")
-            with self.assertRaisesRegexp(UserWarning, msg):
+            with self.assertRaisesRegexp(IrisUserWarning, msg):
                 self.cube.coord('air_pressure')
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -32,6 +32,7 @@ import warnings
 import numpy as np
 
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
+from iris.exceptions import IrisUserWarning
 import iris
 import iris.tests.stock
 

--- a/lib/iris/tests/test_iterate.py
+++ b/lib/iris/tests/test_iterate.py
@@ -349,11 +349,11 @@ class TestIterateFunctions(tests.IrisTest):
         # Same coord metadata and shape, but different values - check it produces a warning
         with warnings.catch_warnings():
             warnings.simplefilter("error")    # Cause all warnings to raise Exceptions
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 iris.iterate.izip(self.cube_a, self.cube_b,
                                   coords=self.coord_names)
             # Call with coordinates, rather than names
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 iris.iterate.izip(self.cube_a, self.cube_b, coords=[latitude,
                                                                     longitude])
         # Check it still iterates through as expected

--- a/lib/iris/tests/test_iterate.py
+++ b/lib/iris/tests/test_iterate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -37,6 +37,7 @@ import iris
 import iris.analysis
 import iris.iterate
 import iris.tests.stock
+from iris.exceptions import IrisUserWarning
 from functools import reduce
 
 

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -33,6 +33,7 @@ import numpy as np
 import iris
 import iris.coords as coords
 import iris.tests.stock
+from iris.exceptions import IrisUserWarning
 
 # Run tests in no graphics mode if matplotlib is not available.
 if tests.MPL_AVAILABLE:

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -506,7 +506,7 @@ class TestPcolormesh(tests.GraphicsTest, SliceMixin):
 def check_warnings(method):
     """
     Decorator that adds a catch_warnings and filter to assert
-    the method being decorated issues a UserWarning.
+    the method being decorated issues a IrisUserWarning.
 
     """
     @wraps(method)
@@ -519,7 +519,7 @@ def check_warnings(method):
         # Check that method raises warning.
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(IrisUserWarning):
                 return method(self, *args, **kwargs)
     return decorated_method
 
@@ -541,7 +541,7 @@ def ignore_warnings(method):
 class CheckForWarningsMetaclass(type):
     """
     Metaclass that adds a further test for each base class test
-    that checks that each test raises a UserWarning. Each base
+    that checks that each test raises a IrisUserWarning. Each base
     class test is then overriden to ignore warnings in order to
     check the underlying functionality.
 

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -157,9 +157,14 @@ class TestAll(tests.IrisTest):
             expected_msg = ('Coordinate system of latitude and longitude '
                             'coordinates is not specified. Assuming WGS84 '
                             'Geodetic.')
-            assert len(warn) == 1
-            assert issubclass(warn[-1].category, IrisUserWarning)
-            assert expected_msg in str(warn[-1].message)
+            warnings_ = [w for w in warn]
+
+        for warn in warnings_:
+            if issubclass(warn.category, IrisUserWarning):
+                assert expected_msg == str(warn.message)
+            else:
+                # re-raise other warnings that have been caught
+                warnings.warn(warn.message, warn.category)
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
+++ b/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
@@ -124,7 +124,7 @@ class Test(tests.IrisTest):
 
     @tests.skip_data
     def test_distinct_xy_bounds_pole(self):
-        # is UserWarning issued for out-of-bounds? results will be unexpected!
+        # is IrisUserWarning issued for out-of-bounds? results will be unexpected!
         cube = stock.simple_pp()
         cube = cube[:4, :4]
         lon = cube.coord('longitude')
@@ -146,7 +146,7 @@ class Test(tests.IrisTest):
             weights = geometry_area_weights(cube, geometry)
             self.assertEqual(str(w[-1].message), "The geometry exceeds the "
                              "cube's y dimension at the upper end.")
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
+            self.assertTrue(issubclass(w[-1].category, IrisUserWarning))
         target = np.array([
             [0, top_cell_half, top_cell_half, 0],
             [0, half, half, 0],

--- a/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
+++ b/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -36,6 +36,7 @@ import shapely.geometry
 from iris.analysis.geometry import geometry_area_weights
 from iris.coords import DimCoord
 from iris.cube import Cube
+from iris.exceptions import IrisUserWarning
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
+++ b/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
@@ -125,7 +125,8 @@ class Test(tests.IrisTest):
 
     @tests.skip_data
     def test_distinct_xy_bounds_pole(self):
-        # is IrisUserWarning issued for out-of-bounds? results will be unexpected!
+        # is IrisUserWarning issued for out-of-bounds? results will be
+        # unexpected!
         cube = stock.simple_pp()
         cube = cube[:4, :4]
         lon = cube.coord('longitude')

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -29,7 +29,7 @@ import contextlib
 import numpy as np
 import warnings
 
-from iris.exceptions import NotYetImplementedError
+from iris.exceptions import IrisUserWarning, NotYetImplementedError
 import iris.fileformats._ff as ff
 import iris.fileformats.pp as pp
 from iris.fileformats._ff import FF2PP
@@ -364,9 +364,12 @@ class Test__det_border(tests.IrisTest):
                'be incorrect, not having taken into account the boundary '
                'size.')
 
-        with mock.patch('warnings.warn') as warn:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             result = ff2pp._det_border(field_x, None)
-        warn.assert_called_with(msg)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, IrisUserWarning)
+            assert msg in str(w[-1].message)
         self.assertIs(result, field_x)
 
     def test_increasing_field_values(self):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -30,6 +30,7 @@ from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import _load_aux_factory
 from iris.tests import mock
+from iris.exceptions import IrisUserWarning
 
 
 class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
@@ -124,10 +125,13 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
 
     def test_formula_terms_ap_missing_coords(self):
         self.requires['formula_terms'] = dict(ap='ap', b='b', ps='ps')
-        with mock.patch('warnings.warn') as warn:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             _load_aux_factory(self.engine, self.cube)
-        warn.assert_called_once_with("Unable to find coordinate for variable "
-                                     "'ap'")
+            assert len(w) == 1
+            assert issubclass(w[-1].category, IrisUserWarning)
+            msg = "Unable to find coordinate for variable 'ap'"
+            assert msg in str(w[-1].message)
         self._check_no_delta()
 
     def test_formula_terms_no_delta_terms(self):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -127,6 +127,8 @@ class TestCoordConstruction(tests.IrisTest, RulesTestMixin):
             bounds=self.bounds)
 
         with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter('always')
             # Asserts must lie within context manager because of deferred
             # loading.
             with self.deferred_load_patch, self.get_cf_bounds_var_patch:
@@ -154,6 +156,8 @@ class TestCoordConstruction(tests.IrisTest, RulesTestMixin):
             bounds=self.bounds)
 
         with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter('always')
             # Asserts must lie within context manager because of deferred
             # loading.
             with self.deferred_load_patch, self.get_cf_bounds_var_patch:
@@ -178,6 +182,8 @@ class TestCoordConstruction(tests.IrisTest, RulesTestMixin):
             bounds=self.bounds)
 
         with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter('always')
             # Asserts must lie within context manager because of deferred
             # loading.
             with self.deferred_load_patch, self.get_cf_bounds_var_patch:


### PR DESCRIPTION
Closes #3078

- create `IrisUserWarning` and uses it where a `UserWarning` was raised before. This allows the silencing of all `IrisUserWarnings` from Iris without silencing `UserWarnings` from other libraries.
- silence all `IrisUserWarnings` (this can be made more specific)