### PR TITLE
Handle printing bounds of long time interval coords

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.2.0/bugfix_2018-Aug-20_print-long-time-interval-bounds.txt
+++ b/docs/iris/src/whatsnew/contributions_2.2.0/bugfix_2018-Aug-20_print-long-time-interval-bounds.txt
@@ -1,0 +1,2 @@
+* Fixed a bug that prevented printing time coordinates with bounds when the time
+  coordinate was measured on a long interval (that is, ``months`` or ``years``).

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -741,7 +741,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 points = self._str_dates(self.points)
             bounds = ''
             if self.has_bounds():
-                bounds = ', bounds=' + self._str_dates(self.bounds)
+                if self.units.is_long_time_interval():
+                    bounds_vals = self.bounds
+                else:
+                    bounds_vals = self._str_dates(self.bounds)
+                bounds = ', bounds={vals}'.format(vals=bounds_vals)
             result = fmt.format(self=self, cls=type(self).__name__,
                                 points=points, bounds=bounds,
                                 other_metadata=self._repr_other_metadata())

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -374,10 +374,30 @@ class Test___str__(tests.IrisTest):
         result = coord.__str__()
         self.assertEqual(expected, result)
 
+    def test_short_time_interval__bounded(self):
+        coord = DimCoord([5, 6], standard_name='time',
+                         units='days since 1970-01-01')
+        coord.guess_bounds()
+        expected = ("DimCoord([1970-01-06 00:00:00, 1970-01-07 00:00:00], "
+                    "bounds=[[1970-01-05 12:00:00, 1970-01-06 12:00:00],\n"
+                    "       [1970-01-06 12:00:00, 1970-01-07 12:00:00]], "
+                    "standard_name='time', calendar='gregorian')")
+        result = coord.__str__()
+        self.assertEqual(expected, result)
+
     def test_long_time_interval(self):
         coord = DimCoord([5], standard_name='time',
                          units='years since 1970-01-01')
         expected = "DimCoord([5], standard_name='time', calendar='gregorian')"
+        result = coord.__str__()
+        self.assertEqual(expected, result)
+
+    def test_long_time_interval__bounded(self):
+        coord = DimCoord([5, 6], standard_name='time',
+                         units='years since 1970-01-01')
+        coord.guess_bounds()
+        expected = ("DimCoord([5 6], bounds=[[ 4.5  5.5]\n [ 5.5  6.5]], "
+                    "standard_name='time', calendar='gregorian')")
         result = coord.__str__()
         self.assertEqual(expected, result)
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -396,7 +396,7 @@ class Test___str__(tests.IrisTest):
         coord = DimCoord([5, 6], standard_name='time',
                          units='years since 1970-01-01')
         coord.guess_bounds()
-        expected = ("DimCoord([5 6], bounds=[[ 4.5  5.5]\n [ 5.5  6.5]], "
+        expected = ("DimCoord([5 6], bounds=[[4.5 5.5]\n [5.5 6.5]], "
                     "standard_name='time', calendar='gregorian')")
         result = coord.__str__()
         self.assertEqual(expected, result)


### PR DESCRIPTION
In #2354 we added graceful handling of printing time coordinates with a long time interval (`months` or `years`). Unfortunately this was added for points only, meaning that printing such a time coordinate with bounds would still fail. This change extends the graceful handling to include bounds as well, if present, such that the literal bound numbers are printed, rather than the numbers being first converted to datetimes (which fails).

The origin of this problem is that `cftime` does not handle long time intervals, which I've [noted in the associated issue](https://github.com/SciTools/iris/issues/3098#issuecomment-412802384). This doesn't represent a fix for the problem, but it does avoid an error being thrown. Longer term a proper fix for this would be valuable – but this might need to be added to `cftime` itself.

Fixes #3098.