### PR TITLE
Temporary pin to avoid problems caused by Proj4 v5.1.

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -4,7 +4,7 @@
 # Without these, iris won't even import.
 
 cartopy
-#conda: proj4>=5
+#conda: proj4<5
 cf_units>=2
 cftime
 dask[array]==0.18.1  #conda: dask==0.18.1

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -4,6 +4,7 @@
 # Without these, iris won't even import.
 
 cartopy
+#conda: proj4>=5
 cf_units>=2
 cftime
 dask[array]==0.18.1  #conda: dask==0.18.1


### PR DESCRIPTION
Problems have arisen with Mollweide plots since Proj4 version 5.1 has become available
[e.g. see here](https://travis-ci.org/SciTools/iris/builds/422933777?utm_source=github_status&utm_medium=notification)
(though cartopy version is still 0.16, but this is thought to have known problems with Proj4 > 5).

This branch **first** adds a dependency requirement proj5>=5, 
which should reproduce the problems recently emerging with some plots (and spin fresh tests to show it).
**Then** change to proj4<5, which should fix it...

Background : @pelson thinks that cartopy is not ready for Proj4 > 5, but this is as yet neither pinned nor tested/fixed.
Simplest for now is to pin in Iris

N.B. for now, **targetting 2d_coords branch**, where we immediately need it.