### PR TITLE
2d coords proj4 mod

### DIFF
--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -231,6 +231,9 @@
         "https://scitools.github.io/test-iris-imagehash/images/v4/bd913e01d07ee07e926e87876f8196c1e0d36967393c1f181e2c3cb8b0f960d7.png", 
         "https://scitools.github.io/test-iris-imagehash/images/v4/b9913d90c66eca6ec66ec2f3689195b6cf5b2f00392cb3496695621d34db6c92.png"
     ], 
+    "iris.tests.test_mapping.TestMappingSubRegion.test_simple__modified.0": [
+        "https://scitools.github.io/test-iris-imagehash/images/v4/f9913b919536c46e966ec2e96ac99726c7526d9139a03859b4b4932e974b6ce1.png"
+    ], 
     "iris.tests.test_mapping.TestUnmappable.test_simple.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fe818d6ac17e5a958d7ab12b9d677615986e666dc4f20dea7281d98833889b22.png", 
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa81b54a817eca35817ec701857e3e64943e7bb41b846f996e817e006ee1b19b.png"

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -117,7 +117,12 @@ class TestMappingSubRegion(tests.GraphicsTest):
         # make the data smaller to speed things up.
         self.cube = cube[::10, ::10]
 
+        # TESTONLY : code as was (will fail)
+#    def test_simple__modified(self):
     def test_simple(self):
+        # NOTE: temporarily renamed from 'test_simple', and changed,
+        # to avoid a problem with Mollweide in cartopy 0.16 when Proj4 > 4.9
+
         # First sub-plot
         plt.subplot(221)
         plt.title('Default')
@@ -125,8 +130,13 @@ class TestMappingSubRegion(tests.GraphicsTest):
         plt.gca().coastlines()
 
         # Second sub-plot
+        # TESTONLY : code as was (will fail)
         plt.subplot(222, projection=ccrs.Mollweide(central_longitude=120))
         plt.title('Molleweide')
+#        # NOTE: temporarily changed, to avoid a problem with Mollweide in
+#        # cartopy 0.16 when Proj4 > 4.9
+#        plt.subplot(222, projection=ccrs.NorthPolarStereo())
+#        plt.title('Polar Stereographic')
         iplt.contourf(self.cube)
         plt.gca().coastlines()
 

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -117,9 +117,7 @@ class TestMappingSubRegion(tests.GraphicsTest):
         # make the data smaller to speed things up.
         self.cube = cube[::10, ::10]
 
-        # TESTONLY : code as was (will fail)
-#    def test_simple__modified(self):
-    def test_simple(self):
+    def test_simple__modified(self):
         # NOTE: temporarily renamed from 'test_simple', and changed,
         # to avoid a problem with Mollweide in cartopy 0.16 when Proj4 > 4.9
 
@@ -130,13 +128,12 @@ class TestMappingSubRegion(tests.GraphicsTest):
         plt.gca().coastlines()
 
         # Second sub-plot
-        # TESTONLY : code as was (will fail)
-        plt.subplot(222, projection=ccrs.Mollweide(central_longitude=120))
-        plt.title('Molleweide')
-#        # NOTE: temporarily changed, to avoid a problem with Mollweide in
-#        # cartopy 0.16 when Proj4 > 4.9
-#        plt.subplot(222, projection=ccrs.NorthPolarStereo())
-#        plt.title('Polar Stereographic')
+#        plt.subplot(222, projection=ccrs.Mollweide(central_longitude=120))
+#        plt.title('Molleweide')
+        # NOTE: temporarily changed, to avoid a problem with Mollweide in
+        # cartopy 0.16 when Proj4 > 4.9
+        plt.subplot(222, projection=ccrs.NorthPolarStereo())
+        plt.title('Polar Stereographic')
         iplt.contourf(self.cube)
         plt.gca().coastlines()
 


### PR DESCRIPTION
Problems have arisen with Mollweide plots since Proj4 version 5.1 has become available
(though cartopy version is still 0.16, but this is thought to have known problems with Proj4 > 5). 

Changes initally disabled to confirm problem, then fixed.
The fix depends on https://github.com/SciTools/test-iris-imagehash/pull/17

NOTE: targetting 2d_coords feature branch, for now.