### PR TITLE
iris.util.reverse on cubes

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-03_reverse_cube.txt
+++ b/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-03_reverse_cube.txt
@@ -1,0 +1,1 @@
+* :func:`iris.util.reverse` can now be used to reverse a cube by specifying one or more coordinates.

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -93,31 +93,6 @@ class TestMonotonic(tests.IrisTest):
         self.assertMonotonic(b)
 
 
-class TestReverse(tests.IrisTest):
-    def test_simple(self):
-        a = np.arange(12).reshape(3, 4)
-        np.testing.assert_array_equal(a[::-1], iris.util.reverse(a, 0))
-        np.testing.assert_array_equal(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
-        np.testing.assert_array_equal(a[:, ::-1], iris.util.reverse(a, 1))
-        np.testing.assert_array_equal(a[:, ::-1], iris.util.reverse(a, [1]))
-        self.assertRaises(ValueError, iris.util.reverse, a, [])
-        self.assertRaises(ValueError, iris.util.reverse, a, -1)
-        self.assertRaises(ValueError, iris.util.reverse, a, 10)
-        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
-        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
-
-    def test_single(self):
-        a = np.arange(36).reshape(3, 4, 3)
-        np.testing.assert_array_equal(a[::-1], iris.util.reverse(a, 0))
-        np.testing.assert_array_equal(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
-        np.testing.assert_array_equal(a[:, ::-1, ::-1], iris.util.reverse(a, [1, 2]))
-        np.testing.assert_array_equal(a[..., ::-1], iris.util.reverse(a, 2))
-        self.assertRaises(ValueError, iris.util.reverse, a, -1)
-        self.assertRaises(ValueError, iris.util.reverse, a, 10)
-        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
-        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
-
-
 class TestClipString(tests.IrisTest):
     def setUp(self):
         self.test_string = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -170,9 +170,15 @@ class Test_cube(tests.IrisTest):
         with self.assertRaisesRegexp(ValueError, msg):
             reverse(self.cube1, [])
 
-        msg = 'coords_or_dims must be int, str, coordinate or *'
+        msg = ('coords_or_dims must be int, str, coordinate or sequence of '
+               'these.  Got cube.')
         with self.assertRaisesRegexp(TypeError, msg):
             reverse(self.cube1, self.cube1)
+
+        msg = ('coords_or_dims must be int, str, coordinate or sequence of '
+               'these.')
+        with self.assertRaisesRegexp(TypeError, msg):
+            reverse(self.cube1, 3.)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -1,0 +1,100 @@
+# (C) British Crown Copyright 2010 - 2018, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Test function :func:`iris.util.reverse`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import unittest
+
+import iris
+import numpy as np
+
+
+class Test(tests.IrisTest):
+    def SetUpReversed(self):
+        # On this cube pair, the coordinates to perform operations on have
+        # matching long names but the points array on one cube is reversed
+        # with respect to that on the other.
+        data = np.zeros((3, 4))
+        a1 = iris.coords.DimCoord([1, 2, 3], long_name='a')
+        b1 = iris.coords.DimCoord([1, 2, 3, 4], long_name='b')
+        a2 = iris.coords.DimCoord([3, 2, 1], long_name='a')
+        b2 = iris.coords.DimCoord([4, 3, 2, 1], long_name='b')
+
+        reversed1 = iris.cube.Cube(
+            data, dim_coords_and_dims=[(a1, 0), (b1, 1)])
+        reversed2 = iris.cube.Cube(
+            data, dim_coords_and_dims=[(a2, 0), (b2, 1)])
+
+        return reversed1, reversed2
+
+    def test_simple_array(self):
+        a = np.arange(12).reshape(3, 4)
+        self.assertArrayEqual(a[::-1], iris.util.reverse(a, 0))
+        self.assertArrayEqual(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
+        self.assertArrayEqual(a[:, ::-1], iris.util.reverse(a, 1))
+        self.assertArrayEqual(a[:, ::-1], iris.util.reverse(a, [1]))
+        self.assertRaises(ValueError, iris.util.reverse, a, [])
+        self.assertRaises(ValueError, iris.util.reverse, a, -1)
+        self.assertRaises(ValueError, iris.util.reverse, a, 10)
+        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
+        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
+
+    def test_single_array(self):
+        a = np.arange(36).reshape(3, 4, 3)
+        self.assertArrayEqual(a[::-1], iris.util.reverse(a, 0))
+        self.assertArrayEqual(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
+        self.assertArrayEqual(a[:, ::-1, ::-1], iris.util.reverse(a, [1, 2]))
+        self.assertArrayEqual(a[..., ::-1], iris.util.reverse(a, 2))
+        self.assertRaises(ValueError, iris.util.reverse, a, -1)
+        self.assertRaises(ValueError, iris.util.reverse, a, 10)
+        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
+        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
+
+    def test_cube(self):
+        cube1, cube2 = self.SetUpReversed()
+
+        cube1_reverse0 = iris.util.reverse(cube1, 0)
+        cube1_reverse1 = iris.util.reverse(cube1, 1)
+        cube1_reverse_both = iris.util.reverse(cube1, (0, 1))
+
+        self.assertArrayEqual(cube1.data[::-1], cube1_reverse0.data)
+        self.assertArrayEqual(cube2.coord('a').points,
+                              cube1_reverse0.coord('a').points)
+        self.assertArrayEqual(cube1.coord('b').points,
+                              cube1_reverse0.coord('b').points)
+
+        self.assertArrayEqual(cube1.data[:, ::-1], cube1_reverse1.data)
+        self.assertArrayEqual(cube1.coord('a').points,
+                              cube1_reverse1.coord('a').points)
+        self.assertArrayEqual(cube2.coord('b').points,
+                              cube1_reverse1.coord('b').points)
+
+        self.assertArrayEqual(cube1.data[::-1, ::-1], cube1_reverse_both.data)
+        self.assertArrayEqual(cube2.coord('a').points,
+                              cube1_reverse_both.coord('a').points)
+        self.assertArrayEqual(cube2.coord('b').points,
+                              cube1_reverse_both.coord('b').points)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -42,6 +42,7 @@ class Test_array(tests.IrisTest):
         self.assertRaises(ValueError, reverse, a, 10)
         self.assertRaises(ValueError, reverse, a, [-1])
         self.assertRaises(ValueError, reverse, a, [0, -1])
+        self.assertRaises(TypeError, reverse, a, 'latitude')
 
     def test_single_array(self):
         a = np.arange(36).reshape(3, 4, 3)
@@ -53,6 +54,7 @@ class Test_array(tests.IrisTest):
         self.assertRaises(ValueError, reverse, a, 10)
         self.assertRaises(ValueError, reverse, a, [-1])
         self.assertRaises(ValueError, reverse, a, [0, -1])
+        self.assertRaises(TypeError, reverse, a, 'latitude')
 
 
 class Test_cube(tests.IrisTest):
@@ -61,17 +63,21 @@ class Test_cube(tests.IrisTest):
         # matching long names but the points array on one cube is reversed
         # with respect to that on the other.
         data = np.arange(12).reshape(3, 4)
-        a1 = iris.coords.DimCoord([1, 2, 3], long_name='a')
-        b1 = iris.coords.DimCoord([1, 2, 3, 4], long_name='b')
+        self.a1 = iris.coords.DimCoord([1, 2, 3], long_name='a')
+        self.b1 = iris.coords.DimCoord([1, 2, 3, 4], long_name='b')
         a2 = iris.coords.DimCoord([3, 2, 1], long_name='a')
         b2 = iris.coords.DimCoord([4, 3, 2, 1], long_name='b')
+        self.span = iris.coords.AuxCoord(np.arange(12).reshape(3, 4),
+                                         long_name='spanning')
 
         self.cube1 = iris.cube.Cube(
-            data, dim_coords_and_dims=[(a1, 0), (b1, 1)])
+            data, dim_coords_and_dims=[(self.a1, 0), (self.b1, 1)],
+            aux_coords_and_dims=[(self.span, (0, 1))])
+
         self.cube2 = iris.cube.Cube(
             data, dim_coords_and_dims=[(a2, 0), (b2, 1)])
 
-    def test_cube(self):
+    def test_cube_dim(self):
         cube1_reverse0 = reverse(self.cube1, 0)
         cube1_reverse1 = reverse(self.cube1, 1)
         cube1_reverse_both = reverse(self.cube1, (0, 1))
@@ -94,6 +100,46 @@ class Test_cube(tests.IrisTest):
                               cube1_reverse_both.coord('a').points)
         self.assertArrayEqual(self.cube2.coord('b').points,
                               cube1_reverse_both.coord('b').points)
+
+    def test_cube_coord(self):
+        cube1_reverse0 = reverse(self.cube1, self.a1)
+        cube1_reverse1 = reverse(self.cube1, 'b')
+        cube1_reverse_both = reverse(self.cube1, (self.a1, self.b1))
+        cube1_reverse_spanning = reverse(self.cube1, 'spanning')
+
+        self.assertArrayEqual(self.cube1.data[::-1], cube1_reverse0.data)
+        self.assertArrayEqual(self.cube2.coord('a').points,
+                              cube1_reverse0.coord('a').points)
+        self.assertArrayEqual(self.cube1.coord('b').points,
+                              cube1_reverse0.coord('b').points)
+
+        self.assertArrayEqual(self.cube1.data[:, ::-1], cube1_reverse1.data)
+        self.assertArrayEqual(self.cube1.coord('a').points,
+                              cube1_reverse1.coord('a').points)
+        self.assertArrayEqual(self.cube2.coord('b').points,
+                              cube1_reverse1.coord('b').points)
+
+        self.assertArrayEqual(self.cube1.data[::-1, ::-1],
+                              cube1_reverse_both.data)
+        self.assertArrayEqual(self.cube2.coord('a').points,
+                              cube1_reverse_both.coord('a').points)
+        self.assertArrayEqual(self.cube2.coord('b').points,
+                              cube1_reverse_both.coord('b').points)
+
+        self.assertArrayEqual(self.cube1.data[::-1, ::-1],
+                              cube1_reverse_spanning.data)
+        self.assertArrayEqual(self.cube2.coord('a').points,
+                              cube1_reverse_spanning.coord('a').points)
+        self.assertArrayEqual(self.cube2.coord('b').points,
+                              cube1_reverse_spanning.coord('b').points)
+        self.assertArrayEqual(
+            self.span.points[::-1, ::-1],
+            cube1_reverse_spanning.coord('spanning').points)
+
+        self.assertRaises(iris.exceptions.CoordinateNotFoundError, reverse,
+                          self.cube1, 'latitude')
+        self.assertRaises(ValueError, reverse, self.cube1, [])
+        self.assertRaises(TypeError, reverse, self.cube1, self.cube1)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,73 +26,73 @@ import iris.tests as tests
 import unittest
 
 import iris
+from iris.util import reverse
 import numpy as np
 
 
-class Test(tests.IrisTest):
-    def SetUpReversed(self):
+class Test_array(tests.IrisTest):
+    def test_simple_array(self):
+        a = np.arange(12).reshape(3, 4)
+        self.assertArrayEqual(a[::-1], reverse(a, 0))
+        self.assertArrayEqual(a[::-1, ::-1], reverse(a, [0, 1]))
+        self.assertArrayEqual(a[:, ::-1], reverse(a, 1))
+        self.assertArrayEqual(a[:, ::-1], reverse(a, [1]))
+        self.assertRaises(ValueError, reverse, a, [])
+        self.assertRaises(ValueError, reverse, a, -1)
+        self.assertRaises(ValueError, reverse, a, 10)
+        self.assertRaises(ValueError, reverse, a, [-1])
+        self.assertRaises(ValueError, reverse, a, [0, -1])
+
+    def test_single_array(self):
+        a = np.arange(36).reshape(3, 4, 3)
+        self.assertArrayEqual(a[::-1], reverse(a, 0))
+        self.assertArrayEqual(a[::-1, ::-1], reverse(a, [0, 1]))
+        self.assertArrayEqual(a[:, ::-1, ::-1], reverse(a, [1, 2]))
+        self.assertArrayEqual(a[..., ::-1], reverse(a, 2))
+        self.assertRaises(ValueError, reverse, a, -1)
+        self.assertRaises(ValueError, reverse, a, 10)
+        self.assertRaises(ValueError, reverse, a, [-1])
+        self.assertRaises(ValueError, reverse, a, [0, -1])
+
+
+class Test_cube(tests.IrisTest):
+    def setUp(self):
         # On this cube pair, the coordinates to perform operations on have
         # matching long names but the points array on one cube is reversed
         # with respect to that on the other.
-        data = np.zeros((3, 4))
+        data = np.arange(12).reshape(3, 4)
         a1 = iris.coords.DimCoord([1, 2, 3], long_name='a')
         b1 = iris.coords.DimCoord([1, 2, 3, 4], long_name='b')
         a2 = iris.coords.DimCoord([3, 2, 1], long_name='a')
         b2 = iris.coords.DimCoord([4, 3, 2, 1], long_name='b')
 
-        reversed1 = iris.cube.Cube(
+        self.cube1 = iris.cube.Cube(
             data, dim_coords_and_dims=[(a1, 0), (b1, 1)])
-        reversed2 = iris.cube.Cube(
+        self.cube2 = iris.cube.Cube(
             data, dim_coords_and_dims=[(a2, 0), (b2, 1)])
 
-        return reversed1, reversed2
-
-    def test_simple_array(self):
-        a = np.arange(12).reshape(3, 4)
-        self.assertArrayEqual(a[::-1], iris.util.reverse(a, 0))
-        self.assertArrayEqual(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
-        self.assertArrayEqual(a[:, ::-1], iris.util.reverse(a, 1))
-        self.assertArrayEqual(a[:, ::-1], iris.util.reverse(a, [1]))
-        self.assertRaises(ValueError, iris.util.reverse, a, [])
-        self.assertRaises(ValueError, iris.util.reverse, a, -1)
-        self.assertRaises(ValueError, iris.util.reverse, a, 10)
-        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
-        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
-
-    def test_single_array(self):
-        a = np.arange(36).reshape(3, 4, 3)
-        self.assertArrayEqual(a[::-1], iris.util.reverse(a, 0))
-        self.assertArrayEqual(a[::-1, ::-1], iris.util.reverse(a, [0, 1]))
-        self.assertArrayEqual(a[:, ::-1, ::-1], iris.util.reverse(a, [1, 2]))
-        self.assertArrayEqual(a[..., ::-1], iris.util.reverse(a, 2))
-        self.assertRaises(ValueError, iris.util.reverse, a, -1)
-        self.assertRaises(ValueError, iris.util.reverse, a, 10)
-        self.assertRaises(ValueError, iris.util.reverse, a, [-1])
-        self.assertRaises(ValueError, iris.util.reverse, a, [0, -1])
-
     def test_cube(self):
-        cube1, cube2 = self.SetUpReversed()
+        cube1_reverse0 = reverse(self.cube1, 0)
+        cube1_reverse1 = reverse(self.cube1, 1)
+        cube1_reverse_both = reverse(self.cube1, (0, 1))
 
-        cube1_reverse0 = iris.util.reverse(cube1, 0)
-        cube1_reverse1 = iris.util.reverse(cube1, 1)
-        cube1_reverse_both = iris.util.reverse(cube1, (0, 1))
-
-        self.assertArrayEqual(cube1.data[::-1], cube1_reverse0.data)
-        self.assertArrayEqual(cube2.coord('a').points,
+        self.assertArrayEqual(self.cube1.data[::-1], cube1_reverse0.data)
+        self.assertArrayEqual(self.cube2.coord('a').points,
                               cube1_reverse0.coord('a').points)
-        self.assertArrayEqual(cube1.coord('b').points,
+        self.assertArrayEqual(self.cube1.coord('b').points,
                               cube1_reverse0.coord('b').points)
 
-        self.assertArrayEqual(cube1.data[:, ::-1], cube1_reverse1.data)
-        self.assertArrayEqual(cube1.coord('a').points,
+        self.assertArrayEqual(self.cube1.data[:, ::-1], cube1_reverse1.data)
+        self.assertArrayEqual(self.cube1.coord('a').points,
                               cube1_reverse1.coord('a').points)
-        self.assertArrayEqual(cube2.coord('b').points,
+        self.assertArrayEqual(self.cube2.coord('b').points,
                               cube1_reverse1.coord('b').points)
 
-        self.assertArrayEqual(cube1.data[::-1, ::-1], cube1_reverse_both.data)
-        self.assertArrayEqual(cube2.coord('a').points,
+        self.assertArrayEqual(self.cube1.data[::-1, ::-1],
+                              cube1_reverse_both.data)
+        self.assertArrayEqual(self.cube2.coord('a').points,
                               cube1_reverse_both.coord('a').points)
-        self.assertArrayEqual(cube2.coord('b').points,
+        self.assertArrayEqual(self.cube2.coord('b').points,
                               cube1_reverse_both.coord('b').points)
 
 

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -37,12 +37,24 @@ class Test_array(tests.IrisTest):
         self.assertArrayEqual(a[::-1, ::-1], reverse(a, [0, 1]))
         self.assertArrayEqual(a[:, ::-1], reverse(a, 1))
         self.assertArrayEqual(a[:, ::-1], reverse(a, [1]))
-        self.assertRaises(ValueError, reverse, a, [])
-        self.assertRaises(ValueError, reverse, a, -1)
-        self.assertRaises(ValueError, reverse, a, 10)
-        self.assertRaises(ValueError, reverse, a, [-1])
-        self.assertRaises(ValueError, reverse, a, [0, -1])
-        self.assertRaises(TypeError, reverse, a, 'latitude')
+
+        msg = 'Reverse was expecting a single axis or a 1d array *'
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [])
+
+        msg = 'An axis value out of range for the number of dimensions *'
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, -1)
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, 10)
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [-1])
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [0, -1])
+
+        msg = 'To reverse an array, provide an int *'
+        with self.assertRaisesRegexp(TypeError, msg):
+            reverse(a, 'latitude')
 
     def test_single_array(self):
         a = np.arange(36).reshape(3, 4, 3)
@@ -50,11 +62,24 @@ class Test_array(tests.IrisTest):
         self.assertArrayEqual(a[::-1, ::-1], reverse(a, [0, 1]))
         self.assertArrayEqual(a[:, ::-1, ::-1], reverse(a, [1, 2]))
         self.assertArrayEqual(a[..., ::-1], reverse(a, 2))
-        self.assertRaises(ValueError, reverse, a, -1)
-        self.assertRaises(ValueError, reverse, a, 10)
-        self.assertRaises(ValueError, reverse, a, [-1])
-        self.assertRaises(ValueError, reverse, a, [0, -1])
-        self.assertRaises(TypeError, reverse, a, 'latitude')
+
+        msg = 'Reverse was expecting a single axis or a 1d array *'
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [])
+
+        msg = 'An axis value out of range for the number of dimensions *'
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, -1)
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, 10)
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [-1])
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(a, [0, -1])
+
+        with self.assertRaisesRegexp(
+                TypeError, 'To reverse an array, provide an int *'):
+            reverse(a, 'latitude')
 
 
 class Test_cube(tests.IrisTest):
@@ -136,10 +161,18 @@ class Test_cube(tests.IrisTest):
             self.span.points[::-1, ::-1],
             cube1_reverse_spanning.coord('spanning').points)
 
-        self.assertRaises(iris.exceptions.CoordinateNotFoundError, reverse,
-                          self.cube1, 'latitude')
-        self.assertRaises(ValueError, reverse, self.cube1, [])
-        self.assertRaises(TypeError, reverse, self.cube1, self.cube1)
+        msg = 'Expected to find exactly 1 latitude coordinate, but found none.'
+        with self.assertRaisesRegexp(
+                iris.exceptions.CoordinateNotFoundError, msg):
+            reverse(self.cube1, 'latitude')
+
+        msg = 'Reverse was expecting a single axis or a 1d array *'
+        with self.assertRaisesRegexp(ValueError, msg):
+            reverse(self.cube1, [])
+
+        msg = 'coords_or_dims must be int, str, coordinate or *'
+        with self.assertRaisesRegexp(TypeError, msg):
+            reverse(self.cube1, self.cube1)
 
 
 if __name__ == '__main__':

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -453,7 +453,8 @@ def reverse(cube_or_array, coords_or_dims):
     """
     index = [slice(None, None)] * cube_or_array.ndim
 
-    if iris.cube._is_single_item(coords_or_dims):
+    if (iris.cube._is_single_item(coords_or_dims) or
+            isinstance(coords_or_dims, iris.cube.Cube)):
         coords_or_dims = [coords_or_dims]
 
     axes = set()
@@ -471,7 +472,7 @@ def reverse(cube_or_array, coords_or_dims):
                                 'or sequence of these.')
 
     axes = np.array(list(axes), ndmin=1)
-    if axes.ndim != 1:
+    if axes.ndim != 1 or axes.size == 0:
         raise ValueError('Reverse was expecting a single axis or a 1d array '
                          'of axes, got %r' % axes)
     if np.min(axes) < 0 or np.max(axes) > cube_or_array.ndim-1:

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -406,16 +406,16 @@ def between(lh, rh, lh_inclusive=True, rh_inclusive=True):
         return lambda c: lh < c < rh
 
 
-def reverse(array, axes):
+def reverse(cube_or_array, axes):
     """
-    Reverse the array along the given axes.
+    Reverse the cube or array along the given axes.
 
     Args:
 
-    * array
-        The array to reverse
-    * axes
-        A single value or array of values of axes to reverse
+    * cube_or_array: :class:`iris.cube.Cube` or :class:`numpy.ndarray`
+        The cube or array to reverse
+    * axes: int or sequence of ints
+        One or more axes to reverse.
 
     ::
 
@@ -447,20 +447,20 @@ def reverse(array, axes):
           [15 14 13 12]]]
 
     """
-    index = [slice(None, None)] * array.ndim
+    index = [slice(None, None)] * cube_or_array.ndim
     axes = np.array(axes, ndmin=1)
     if axes.ndim != 1:
         raise ValueError('Reverse was expecting a single axis or a 1d array '
                          'of axes, got %r' % axes)
-    if np.min(axes) < 0 or np.max(axes) > array.ndim-1:
+    if np.min(axes) < 0 or np.max(axes) > cube_or_array.ndim-1:
         raise ValueError('An axis value out of range for the number of '
                          'dimensions from the given array (%s) was received. '
-                         'Got: %r' % (array.ndim, axes))
+                         'Got: %r' % (cube_or_array.ndim, axes))
 
     for axis in axes:
         index[axis] = slice(None, None, -1)
 
-    return array[tuple(index)]
+    return cube_or_array[tuple(index)]
 
 
 def monotonic(array, strict=False, return_direction=False):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -453,8 +453,11 @@ def reverse(cube_or_array, coords_or_dims):
     """
     index = [slice(None, None)] * cube_or_array.ndim
 
-    if (iris.cube._is_single_item(coords_or_dims) or
-            isinstance(coords_or_dims, iris.cube.Cube)):
+    if isinstance(coords_or_dims, iris.cube.Cube):
+        raise TypeError('coords_or_dims must be int, str, coordinate or '
+                        'sequence of these.  Got cube.')
+
+    if iris.cube._is_single_item(coords_or_dims):
         coords_or_dims = [coords_or_dims]
 
     axes = set()


### PR DESCRIPTION
The `iris.util.reverse` [documentation](https://scitools.org.uk/iris/docs/v2.1/iris/iris/util.html?highlight=util%20reverse#iris.util.reverse) states that it can be used for reversing an array, but it works equally well for reversing a cube.  Since I use it this way in my code, I'd like to make this usage official by:

- Updating the docstring to indicate the function works on a cube.
- Adding a test for reversing a cube.

I also moved the existing array tests into `tests/unit` and swapped out `np.testing.assert_array_equal` for `self.assertArrayEqual`.

Note that for numpy arrays there is also [`numpy.flip`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.flip.html)