### PR TITLE
Use cell area for weights if available

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3210,8 +3210,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         if (isinstance(aggregator, iris.analysis.WeightedAggregator) and
                 not aggregator.uses_weighting(**kwargs)):
-
-            if "cell_area" in [c.standard_name for c in self.cell_measures()]:
+            cell_area = [
+                c for c in self.cell_measures()
+                if c.measure == 'area'
+            ]
+            assert len(cell_area) < 2, "more than one cell area measure"
+            cell_area = cell_area[0] if cell_area else None
+            if cell_area is not None:
                 lon, lat = iris.analysis.cartography._get_lon_lat_coords(self)
 
                 # would be ideal to resuse the below from
@@ -3227,7 +3232,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 lon_dim = self.coord_dims(lon)
                 lon_dim = lon_dim[0] if lon_dim else None
 
-                ll_weights = self.cell_measure('cell_area').data
+                ll_weights = cell_area.data
 
                 # Now we create an array of weights for each cell. This
                 # process will handle adding the required extra dimensions and

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -104,12 +104,15 @@ class CubeRepresentation(object):
             'Auxiliary coordinates:': None,
             'Derived coordinates:': None,
             'Scalar coordinates:': None,
+            'Scalar cell measures:': None,
+            'Cell Measures:': None,
             'Attributes:': None,
             'Cell methods:': None,
         }
         self.dim_desc_coords = ['Dimension coordinates:',
                                 'Auxiliary coordinates:',
-                                'Derived coordinates:']
+                                'Derived coordinates:',
+                                'Cell Measures:', ]
 
         # Important content that summarises a cube is defined here.
         self.shapes = self.cube.shape
@@ -171,6 +174,7 @@ class CubeRepresentation(object):
             else:
                 start_inds.append(start_ind)
         # Mark the end of the file.
+        start_inds.sort()
         start_inds.append(0)
 
         # Retrieve info for each heading from the printout.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -393,6 +393,25 @@ class Test_collapsed__warning(tests.IrisTest):
         coords = [coord for coord in coords if 'latitude' in coord]
         self._assert_warn_collapse_without_weight(coords, warn)
 
+    def test_lat_lon_cell_area_no_weights(self):
+        # Collapse grid_latitude coordinate with weighted aggregator without
+        # providing weights.  Tests coordinate matching logic.
+        cell_areas = CellMeasure(data=np.arange(4).reshape(2, 2),
+                                 long_name='area',
+                                 measure='area')
+
+        self.cube.add_cell_measure(cell_areas, [0, 1],)
+        self.cube.remove_coord('grid_latitude')
+        self.cube.remove_coord('grid_longitude')
+
+        coords = ['latitude', 'longitude']
+
+        with mock.patch('warnings.warn') as warn:
+            self.cube.collapsed(coords, iris.analysis.MEAN)
+
+        coords = [coord for coord in coords if 'latitude' in coord]
+        self._assert_nowarn_collapse_without_weight(coords, warn)
+
     def test_no_lat_weighted_aggregator_mixed(self):
         # Collapse grid_latitude and an unmatched coordinate (not lat/lon)
         # with weighted aggregator without providing weights.


### PR DESCRIPTION
This PR addresses #3169, allowing the user to use the weights provided in the cell measure more easily.

As mentioned in #3169, at the moment it's not that clear how to use cell measures for these weights. This is my attempt at doing so. It has a number of problems which I need help to address

- [ ] copying of code from `iris.analysis.cartography.area_weights`
- [ ] where the decision to use the area weights should go (feels wrong in `iris.analysis.cartography.area_weights` but is awkward to put in `iris.cube`)
- [ ] how cell measure should behave after collapsing (should cell area still be there, should it be the total area, the weighted average area?)
- [ ] how cell measure should appear in representation (I've made a change but not sure if it's what is desired)
- [ ] other PR bits e.g. docs, changelog