### PR TITLE
Attempt to fix Matplotlib issue by resticting to 2.x

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -7,7 +7,7 @@ cartopy
 cf_units>=2
 cftime
 dask[array]==0.18.1  #conda: dask==0.18.1
-matplotlib>=2
+matplotlib>=2,<3
 netcdf4
 numpy>=1.14
 scipy


### PR DESCRIPTION
Matplotlib 3 was released a few days ago. Seems pulling in latest install from conda breaks a lot of functionality due to Matplotlib 3 not being supported.  Cartopy seems to have the biggest issues but might be other issues elsewhere.

For now suggest restricting to 2.x version of Matplotlib.