### PR TITLE
fix for pandas column object bug

### DIFF
--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -115,7 +115,8 @@ def as_cube(pandas_array, copy=True, calendars=None):
     _add_iris_coord(cube, "index", pandas_array.index, 0,
                     calendars.get(0, None))
     if pandas_array.ndim == 2:
-        _add_iris_coord(cube, "columns", pandas_array.columns, 1,
+        _add_iris_coord(cube, "columns", np.array([k for k in
+                                                   pandas_array.columns]), 1,
                         calendars.get(1, None))
     return cube
 

--- a/lib/iris/pandas.py
+++ b/lib/iris/pandas.py
@@ -115,8 +115,7 @@ def as_cube(pandas_array, copy=True, calendars=None):
     _add_iris_coord(cube, "index", pandas_array.index, 0,
                     calendars.get(0, None))
     if pandas_array.ndim == 2:
-        _add_iris_coord(cube, "columns", np.array([k for k in
-                                                   pandas_array.columns]), 1,
+        _add_iris_coord(cube, "columns", pandas_array.columns.values, 1,
                         calendars.get(1, None))
     return cube
 

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_multidim.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_multidim.cml
@@ -3,7 +3,7 @@
   <cube dtype="int64" units="unknown">
     <coords>
       <coord datadims="[1]">
-        <auxCoord id="d00b57c8" long_name="columns" points="[col_1, col_2, col_3, col_4, col_5]" shape="(5,)" units="Unit('unknown')" value_type="string"/>
+        <auxCoord id="d00b57c8" long_name="columns" points="[col_1, col_2, col_3, col_4, col_5]" shape="(5,)" units="Unit('unknown')" value_type="object"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="343cbc01" long_name="index" points="[0, 1]" shape="(2,)" units="Unit('unknown')" value_type="int64"/>

--- a/lib/iris/tests/results/pandas/as_cube/data_frame_multidim.cml
+++ b/lib/iris/tests/results/pandas/as_cube/data_frame_multidim.cml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int64" units="unknown">
+    <coords>
+      <coord datadims="[1]">
+        <auxCoord id="d00b57c8" long_name="columns" points="[col_1, col_2, col_3, col_4, col_5]" shape="(5,)" units="Unit('unknown')" value_type="string"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="343cbc01" long_name="index" points="[0, 1]" shape="(2,)" units="Unit('unknown')" value_type="int64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x5e85e4a4" dtype="int64" mask_checksum="no-masked-elements" shape="(2, 5)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_pandas.py
+++ b/lib/iris/tests/test_pandas.py
@@ -398,6 +398,17 @@ class TestDataFrameAsCube(tests.IrisTest):
             tests.get_result_path(('pandas', 'as_cube',
                                    'data_frame_masked.cml')))
 
+    def test_data_frame_multidim(self):
+        data_frame = pandas.DataFrame([[0, 1, 2, 3, 4],
+                                       [5, 6, 7, 8, 9]],
+                                      index=[0, 1],
+                                      columns=['col_1', 'col_2', 'col_3',
+                                               'col_4', 'col_5'])
+        self.assertCML(
+            iris.pandas.as_cube(data_frame),
+            tests.get_result_path(('pandas', 'as_cube',
+                                   'data_frame_multidim.cml')))
+
     def test_data_frame_cftime_360(self):
         data_frame = pandas.DataFrame(
             [[0, 1, 2, 3, 4],


### PR DESCRIPTION
@DavidSimonin pointed out that if a 2-dimensional pandas DataFrame contains string-type column headers, then it is not currently being handled correctly.

This change treats the list of column headers as an array of strings rather than a single object, which enables subsequent operations to run without error.