### PR TITLE
Fix for netCDF4 1.4 behaviour change.

### DIFF
--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -936,6 +936,11 @@ class CFReader(object):
 
         self._dataset = netCDF4.Dataset(self._filename, mode='r')
 
+        # Return variable data as np.ma.MaskedArray *only* when masked points
+        # are found in the slice requested, otherwise as 'normal' np.ndarray.
+        # Note: this suits us better, and was standard up to netcdf 1.3.
+        self._dataset.set_always_mask(False)
+
         # Issue load optimisation warning.
         if warn and self._dataset.file_format in ['NETCDF3_CLASSIC', 'NETCDF3_64BIT']:
             warnings.warn('Optimise CF-netCDF loading by converting data from NetCDF3 ' \


### PR DESCRIPTION
This follows various user enquiries about changed behaviour.
Since the incorporation of netcdf 1.4, ***all*** cubes read from netcdf now have masked data arrays
 -- for data with no masked points, the mask is now typically empty (or False), which was previously not possible.

It is also this that has caused a large increase in the occurrence of the "Gracefully filling" warnings,
as noted in #3171
