### PR TITLE
remove pin, see what blows up

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -7,7 +7,7 @@ cartopy
 cf_units>=2
 cftime
 dask[array]==0.18.1  #conda: dask==0.18.1
-matplotlib>=2,<3
+matplotlib>=2
 netcdf4
 numpy>=1.14
 scipy


### PR DESCRIPTION
This is a PR to enable iris to be compatible with matplotlib 3.x