### PR TITLE
Improved Aux factory error handling: better message, delivered earlier

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -994,6 +994,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if not isinstance(aux_factory, iris.aux_factory.AuxCoordFactory):
             raise TypeError('Factory must be a subclass of '
                             'iris.aux_factory.AuxCoordFactory.')
+        coords = self.coords()
+        for dependency in aux_factory.dependencies:
+            if aux_factory.dependencies[dependency] not in coords:
+                msg = "Coordinate for factory is not present on cube {}"
+                raise ValueError(msg.format(self.name()))
         self._aux_factories.append(aux_factory)
 
     def add_cell_measure(self, cell_measure, data_dims=None):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -997,7 +997,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         cube_coords = self.coords()
         for dependency in aux_factory.dependencies:
             factory_coord = aux_factory.dependencies[dependency]
-            if factory_coord not in cube_coords:
+            if factory_coord is not None and factory_coord not in cube_coords:
                 msg = "{} coordinate for factory is not present on cube {}"
                 raise ValueError(msg.format(factory_coord.name(), self.name()))
         self._aux_factories.append(aux_factory)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -994,11 +994,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if not isinstance(aux_factory, iris.aux_factory.AuxCoordFactory):
             raise TypeError('Factory must be a subclass of '
                             'iris.aux_factory.AuxCoordFactory.')
-        coords = self.coords()
+        cube_coords = self.coords()
         for dependency in aux_factory.dependencies:
-            if aux_factory.dependencies[dependency] not in coords:
-                msg = "Coordinate for factory is not present on cube {}"
-                raise ValueError(msg.format(self.name()))
+            factory_coord = aux_factory.dependencies[dependency]
+            if factory_coord not in cube_coords:
+                msg = "{} coordinate for factory is not present on cube {}"
+                raise ValueError(msg.format(factory_coord.name(), self.name()))
         self._aux_factories.append(aux_factory)
 
     def add_cell_measure(self, cell_measure, data_dims=None):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -996,10 +996,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             'iris.aux_factory.AuxCoordFactory.')
         cube_coords = self.coords()
         for dependency in aux_factory.dependencies:
-            reference_coord = aux_factory.dependencies[dependency]
-            if reference_coord is not None and reference_coord not in cube_coords:
+            ref_coord = aux_factory.dependencies[dependency]
+            if ref_coord is not None and ref_coord not in cube_coords:
                 msg = "{} coordinate for factory is not present on cube {}"
-                raise ValueError(msg.format(reference_coord.name(), self.name()))
+                raise ValueError(msg.format(ref_coord.name(), self.name()))
         self._aux_factories.append(aux_factory)
 
     def add_cell_measure(self, cell_measure, data_dims=None):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -996,10 +996,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             'iris.aux_factory.AuxCoordFactory.')
         cube_coords = self.coords()
         for dependency in aux_factory.dependencies:
-            factory_coord = aux_factory.dependencies[dependency]
-            if factory_coord is not None and factory_coord not in cube_coords:
+            reference_coord = aux_factory.dependencies[dependency]
+            if reference_coord is not None and reference_coord not in cube_coords:
                 msg = "{} coordinate for factory is not present on cube {}"
-                raise ValueError(msg.format(factory_coord.name(), self.name()))
+                raise ValueError(msg.format(reference_coord.name(), self.name()))
         self._aux_factories.append(aux_factory)
 
     def add_cell_measure(self, cell_measure, data_dims=None):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1558,7 +1558,7 @@ class Test_add_metadata(tests.IrisTest):
         self.assertIsNone(cube.add_aux_factory(factory))
 
     def test_error_for_add_invalid_aux_factory(self):
-        cube = Cube(np.arange(8).reshape(2, 2, 2))
+        cube = Cube(np.arange(8).reshape(2, 2, 2), long_name='bar')
         delta = AuxCoord(points=[0, 1], long_name='delta', units='m')
         sigma = AuxCoord(points=[0, 1], long_name='sigma')
         orog = AuxCoord(np.arange(4).reshape(2, 2), units='m', long_name='foo')
@@ -1566,7 +1566,8 @@ class Test_add_metadata(tests.IrisTest):
         cube.add_aux_coord(sigma, 0)
         # Note orography is not added to the cube here
         factory = HybridHeightFactory(delta=delta, sigma=sigma, orography=orog)
-        expected_error = "foo coordinate for factory is not present on cube"
+        expected_error = ("foo coordinate for factory is not present on cube "
+                          "bar")
         with self.assertRaisesRegexp(ValueError, expected_error):
             cube.add_aux_factory(factory)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1561,12 +1561,12 @@ class Test_add_metadata(tests.IrisTest):
         cube = Cube(np.arange(8).reshape(2, 2, 2))
         delta = AuxCoord(points=[0, 1], long_name='delta', units='m')
         sigma = AuxCoord(points=[0, 1], long_name='sigma')
-        orog = AuxCoord(np.arange(4).reshape(2, 2), units='m')
+        orog = AuxCoord(np.arange(4).reshape(2, 2), units='m', long_name='foo')
         cube.add_aux_coord(delta, 0)
         cube.add_aux_coord(sigma, 0)
         # Note orography is not added to the cube here
         factory = HybridHeightFactory(delta=delta, sigma=sigma, orography=orog)
-        expected_error = "Coordinate for factory is not present on cube"
+        expected_error = "foo coordinate for factory is not present on cube"
         with self.assertRaisesRegexp(ValueError, expected_error):
             cube.add_aux_factory(factory)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -34,9 +34,9 @@ import iris.analysis
 import iris.aux_factory
 import iris.coords
 import iris.exceptions
-from iris import FUTURE
 from iris.analysis import WeightedAggregator, Aggregator
 from iris.analysis import MEAN
+from iris.aux_factory import HybridHeightFactory
 from iris.cube import Cube
 from iris.coords import AuxCoord, DimCoord, CellMeasure
 from iris.exceptions import (CoordinateNotFoundError, CellMeasureNotFoundError,
@@ -1545,6 +1545,30 @@ class Test_add_metadata(tests.IrisTest):
                                      long_name='area', measure='area')
         cube.add_cell_measure(a_cell_measure, [0, 1])
         self.assertEqual(cube.cell_measure('area'), a_cell_measure)
+
+    def test_add_valid_aux_factory(self):
+        cube = Cube(np.arange(8).reshape(2, 2, 2))
+        delta = AuxCoord(points=[0, 1], long_name='delta', units='m')
+        sigma = AuxCoord(points=[0, 1], long_name='sigma')
+        orog = AuxCoord(np.arange(4).reshape(2, 2), units='m')
+        cube.add_aux_coord(delta, 0)
+        cube.add_aux_coord(sigma, 0)
+        cube.add_aux_coord(orog, (1, 2))
+        factory = HybridHeightFactory(delta=delta, sigma=sigma, orography=orog)
+        self.assertIsNone(cube.add_aux_factory(factory))
+
+    def test_error_for_add_invalid_aux_factory(self):
+        cube = Cube(np.arange(8).reshape(2, 2, 2))
+        delta = AuxCoord(points=[0, 1], long_name='delta', units='m')
+        sigma = AuxCoord(points=[0, 1], long_name='sigma')
+        orog = AuxCoord(np.arange(4).reshape(2, 2), units='m')
+        cube.add_aux_coord(delta, 0)
+        cube.add_aux_coord(sigma, 0)
+        # Note orography is not added to the cube here
+        factory = HybridHeightFactory(delta=delta, sigma=sigma, orography=orog)
+        expected_error = "Coordinate for factory is not present on cube"
+        with self.assertRaisesRegexp(ValueError, expected_error):
+            cube.add_aux_factory(factory)
 
 
 class Test_remove_metadata(tests.IrisTest):


### PR DESCRIPTION
As per conversation with @corinnebosley , we had an issue where we were creating an orography as a standalone coordinate that wasn't attached to a cube.  Trying to use this in a hybrid height factory resulted in a hard to interpret error message.  I'm proposing adding a check when adding a hybrid height factory or other aux factory to a cube to ensure that the coordinates are present on the cube; and if not raising a hopefully more helpful error.