### PR TITLE
Test contig tol

### DIFF
--- a/lib/iris/tests/unit/plot/_blockplot_common.py
+++ b/lib/iris/tests/unit/plot/_blockplot_common.py
@@ -1,0 +1,97 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Common test code for `iris.plot.pcolor` and `iris.plot.pcolormesh`."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+from iris.tests.stock import simple_2d
+from iris.tests.unit.plot import MixinCoords
+
+if tests.MPL_AVAILABLE:
+    import iris.plot as iplt
+
+
+class MixinStringCoordPlot(object):
+    # Mixin for common string-coord tests on pcolor/pcolormesh.
+    # To use, make a class that inherits from this *and*
+    # :class:`iris.tests.unit.plot.TestGraphicStringCoord`,
+    # and defines "self.blockplot_func()", to return the `iris.plot` function.
+    def test_yaxis_labels(self):
+        self.blockplot_func()(self.cube, coords=('bar', 'str_coord'))
+        self.assertBoundsTickLabels('yaxis')
+
+    def test_xaxis_labels(self):
+        self.blockplot_func()(self.cube, coords=('str_coord', 'bar'))
+        self.assertBoundsTickLabels('xaxis')
+
+    def test_xaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_xlim(0, 3)
+        self.blockplot_func()(self.cube, coords=('str_coord', 'bar'), axes=ax)
+        plt.close(fig)
+        self.assertPointsTickLabels('xaxis', ax)
+
+    def test_yaxis_labels_with_axes(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.set_ylim(0, 3)
+        self.blockplot_func()(self.cube, axes=ax, coords=('bar', 'str_coord'))
+        plt.close(fig)
+        self.assertPointsTickLabels('yaxis', ax)
+
+    def test_geoaxes_exception(self):
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        self.assertRaises(TypeError, self.blockplot_func(),
+                          self.lat_lon_cube, axes=ax)
+        plt.close(fig)
+
+
+class Mixin2dCoordsPlot(MixinCoords):
+    # Mixin for common coordinate tests on pcolor/pcolormesh.
+    # To use, make a class that inherits from this *and*
+    # :class:`iris.tests.IrisTest`,
+    # and defines "self.blockplot_func()", to return the `iris.plot` function.
+    def blockplot_setup(self):
+        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
+        self.cube = simple_2d(with_bounds=True)
+        coord = self.cube.coord('foo')
+        self.foo = coord.contiguous_bounds()
+        self.foo_index = np.arange(coord.points.size + 1)
+        coord = self.cube.coord('bar')
+        self.bar = coord.contiguous_bounds()
+        self.bar_index = np.arange(coord.points.size + 1)
+        self.data = self.cube.data
+        self.dataT = self.data.T
+        self.draw_func = self.blockplot_func()
+        patch_target_name = 'matplotlib.pyplot.' + self.draw_func.__name__
+        self.mpl_patch = self.patch(patch_target_name)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,64 +26,29 @@ import iris.tests as tests
 import numpy as np
 
 from iris.tests.stock import simple_2d
-from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
+import iris.plot
+from iris.tests.unit.plot import TestGraphicStringCoord
+from iris.tests.unit.plot._blockplot_common import \
+    MixinStringCoordPlot, Mixin2dCoordsPlot
+
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
 
 
 @tests.skip_plot
-class TestStringCoordPlot(TestGraphicStringCoord):
-    def test_yaxis_labels(self):
-        iplt.pcolor(self.cube, coords=('bar', 'str_coord'))
-        self.assertBoundsTickLabels('yaxis')
-
-    def test_xaxis_labels(self):
-        iplt.pcolor(self.cube, coords=('str_coord', 'bar'))
-        self.assertBoundsTickLabels('xaxis')
-
-    def test_xaxis_labels_with_axes(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.set_xlim(0, 3)
-        iplt.pcolor(self.cube, coords=('str_coord', 'bar'), axes=ax)
-        plt.close(fig)
-        self.assertPointsTickLabels('xaxis', ax)
-
-    def test_yaxis_labels_with_axes(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.set_ylim(0, 3)
-        iplt.pcolor(self.cube, axes=ax, coords=('bar', 'str_coord'))
-        plt.close(fig)
-        self.assertPointsTickLabels('yaxis', ax)
-
-    def test_geoaxes_exception(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        self.assertRaises(TypeError, iplt.pcolor,
-                          self.lat_lon_cube, axes=ax)
-        plt.close(fig)
+class TestStringCoordPlot(MixinStringCoordPlot, TestGraphicStringCoord):
+    def blockplot_func(self):
+        return iris.plot.pcolor
 
 
 @tests.skip_plot
-class TestCoords(tests.IrisTest, MixinCoords):
+class Test2dCoords(tests.IrisTest, Mixin2dCoordsPlot):
     def setUp(self):
-        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
-        self.cube = simple_2d(with_bounds=True)
-        coord = self.cube.coord('foo')
-        self.foo = coord.contiguous_bounds()
-        self.foo_index = np.arange(coord.points.size + 1)
-        coord = self.cube.coord('bar')
-        self.bar = coord.contiguous_bounds()
-        self.bar_index = np.arange(coord.points.size + 1)
-        self.data = self.cube.data
-        self.dataT = self.data.T
-        self.mpl_patch = self.patch('matplotlib.pyplot.pcolor')
-        self.draw_func = iplt.pcolor
+        self.blockplot_setup()
+
+    def blockplot_func(self):
+        return iris.plot.pcolor
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolor.py
+++ b/lib/iris/tests/unit/plot/test_pcolor.py
@@ -26,20 +26,20 @@ import iris.tests as tests
 import numpy as np
 
 from iris.tests.stock import simple_2d
-import iris.plot
 from iris.tests.unit.plot import TestGraphicStringCoord
 from iris.tests.unit.plot._blockplot_common import \
-    MixinStringCoordPlot, Mixin2dCoordsPlot
+    MixinStringCoordPlot, Mixin2dCoordsPlot, Mixin2dCoordsContigTol
 
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
+    PLOT_FUNCTION_TO_TEST = iplt.pcolor
 
 
 @tests.skip_plot
 class TestStringCoordPlot(MixinStringCoordPlot, TestGraphicStringCoord):
     def blockplot_func(self):
-        return iris.plot.pcolor
+        return PLOT_FUNCTION_TO_TEST
 
 
 @tests.skip_plot
@@ -48,7 +48,16 @@ class Test2dCoords(tests.IrisTest, Mixin2dCoordsPlot):
         self.blockplot_setup()
 
     def blockplot_func(self):
-        return iris.plot.pcolor
+        return PLOT_FUNCTION_TO_TEST
+
+
+@tests.skip_plot
+class Test2dContigTol(tests.IrisTest, Mixin2dCoordsContigTol):
+    # Extra call kwargs expected.
+    additional_kwargs = dict(antialiased=True, snap=False)
+
+    def blockplot_func(self):
+        return PLOT_FUNCTION_TO_TEST
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2018, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,64 +26,29 @@ import iris.tests as tests
 import numpy as np
 
 from iris.tests.stock import simple_2d
-from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
+import iris.plot
+from iris.tests.unit.plot import TestGraphicStringCoord
+from iris.tests.unit.plot._blockplot_common import \
+    MixinStringCoordPlot, Mixin2dCoordsPlot
+
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
 
 
 @tests.skip_plot
-class TestStringCoordPlot(TestGraphicStringCoord):
-    def test_yaxis_labels(self):
-        iplt.pcolormesh(self.cube, coords=('bar', 'str_coord'))
-        self.assertBoundsTickLabels('yaxis')
-
-    def test_xaxis_labels(self):
-        iplt.pcolormesh(self.cube, coords=('str_coord', 'bar'))
-        self.assertBoundsTickLabels('xaxis')
-
-    def test_xaxis_labels_with_axes(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.set_xlim(0, 3)
-        iplt.pcolormesh(self.cube, axes=ax, coords=('str_coord', 'bar'),)
-        plt.close(fig)
-        self.assertPointsTickLabels('xaxis', ax)
-
-    def test_yaxis_labels_with_axes(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.set_ylim(0, 3)
-        iplt.pcolormesh(self.cube, axes=ax, coords=('bar', 'str_coord'))
-        plt.close(fig)
-        self.assertPointsTickLabels('yaxis', ax)
-
-    def test_geoaxes_exception(self):
-        import matplotlib.pyplot as plt
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        self.assertRaises(TypeError, iplt.pcolormesh,
-                          self.lat_lon_cube, axes=ax)
-        plt.close(fig)
+class TestStringCoordPlot(MixinStringCoordPlot, TestGraphicStringCoord):
+    def blockplot_func(self):
+        return iris.plot.pcolormesh
 
 
 @tests.skip_plot
-class TestCoords(tests.IrisTest, MixinCoords):
+class Test2dCoords(tests.IrisTest, Mixin2dCoordsPlot):
     def setUp(self):
-        # We have a 2d cube with dimensionality (bar: 3; foo: 4)
-        self.cube = simple_2d(with_bounds=True)
-        coord = self.cube.coord('foo')
-        self.foo = coord.contiguous_bounds()
-        self.foo_index = np.arange(coord.points.size + 1)
-        coord = self.cube.coord('bar')
-        self.bar = coord.contiguous_bounds()
-        self.bar_index = np.arange(coord.points.size + 1)
-        self.data = self.cube.data
-        self.dataT = self.data.T
-        self.mpl_patch = self.patch('matplotlib.pyplot.pcolormesh')
-        self.draw_func = iplt.pcolormesh
+        self.blockplot_setup()
+
+    def blockplot_func(self):
+        return iris.plot.pcolormesh
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/plot/test_pcolormesh.py
+++ b/lib/iris/tests/unit/plot/test_pcolormesh.py
@@ -26,20 +26,20 @@ import iris.tests as tests
 import numpy as np
 
 from iris.tests.stock import simple_2d
-import iris.plot
 from iris.tests.unit.plot import TestGraphicStringCoord
 from iris.tests.unit.plot._blockplot_common import \
-    MixinStringCoordPlot, Mixin2dCoordsPlot
+    MixinStringCoordPlot, Mixin2dCoordsPlot, Mixin2dCoordsContigTol
 
 
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
+    PLOT_FUNCTION_TO_TEST = iplt.pcolormesh
 
 
 @tests.skip_plot
 class TestStringCoordPlot(MixinStringCoordPlot, TestGraphicStringCoord):
     def blockplot_func(self):
-        return iris.plot.pcolormesh
+        return PLOT_FUNCTION_TO_TEST
 
 
 @tests.skip_plot
@@ -48,7 +48,16 @@ class Test2dCoords(tests.IrisTest, Mixin2dCoordsPlot):
         self.blockplot_setup()
 
     def blockplot_func(self):
-        return iris.plot.pcolormesh
+        return PLOT_FUNCTION_TO_TEST
+
+
+@tests.skip_plot
+class Test2dContigTol(tests.IrisTest, Mixin2dCoordsContigTol):
+    # Extra call kwargs expected -- unlike 'pcolor', there are none.
+    additional_kwargs = {}
+
+    def blockplot_func(self):
+        return PLOT_FUNCTION_TO_TEST
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*First* commit tidies the pcolor/pcolormesh tests to combine all the common code (no functional change).
*Second* add tests that check the new 'contiguity_tolerance' kwarg is passed down from `iris.plot.pcolor` and `..pcolormesh` into the internal common routine `iris.plot._draw_2d_from_bounds`.

Closes #3164