### PR TITLE
seperate whatsnew entries for discontiguity checking and masking

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_find_discontiguities_in_bounds.txt
+++ b/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_find_discontiguities_in_bounds.txt
@@ -1,0 +1,2 @@
+* :func:`iris.util.find_discontiguities_in_bounds` now gives users the
+ability to check iris cubes for discontiguities in the bounds arrays.

--- a/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_mask_data_at_discontiguities.txt
+++ b/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_mask_data_at_discontiguities.txt
@@ -1,0 +1,2 @@
+* Users can now mask Cube data at discontiguous points to avoid plotting
+errors with the function :func:`iris.util.mask_data_at_discontiguities`.


### PR DESCRIPTION
DO NOT MERGE YET.

Waiting for:
- `iris.util` contiguity functions and tests have been merged (#3144 )
- another PR demonstrating the alternative option of a combined whatsnew entry for public contiguity checking/masking (#3188)