### PR TITLE
combined whatsnew entry for discontiguity checking and masking

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_contiguity-checking-and-masking.txt
+++ b/docs/iris/src/whatsnew/contributions_2.2.0/newfeature_2018-Oct-05_contiguity-checking-and-masking.txt
@@ -1,0 +1,5 @@
+* Users can now check their cubes for any discontiguities in bounds arrays
+using the function :func:`iris.util.find_discontiguities_in_bounds`.
+Additionally, users can choose to mask their data at discontiguous points
+with the function :func:`iris.util.mask_data_at_discontiguities`, which could
+prevent plotting errors in some cases.


### PR DESCRIPTION
DO NOT MERGE YET.

Waiting for:

- iris.util contiguity functions and tests have been merged (#3144 )
- another PR demonstrating the alternative option of separated whatsnew entries for public contiguity checking/masking (#3187 )
