### PR TITLE
add contact options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ are available in [INSTALL](INSTALL).
 
   * Report bugs, or suggest new features using an Issue or Pull Request on [Github](https://github.com/SciTools/iris). You can also comment on existing Issues and Pull Requests.
   * For discussions from a user perspective you could join our [SciTools Users Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
-  * For those involved in developing Iris we also have a [Iris Developers Google Group](https://groups.google.com/forum/#!forum/scitools-iris-dev).
+  * For those involved in developing Iris we also have an [Iris Developers Google Group](https://groups.google.com/forum/#!forum/scitools-iris-dev).
   * [StackOverflow](https://stackoverflow.com/questions/tagged/python-iris) For "How do I?".
 
 # Copyright and licence

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 + [Documentation](#documentation)
 + [Installation](#installation)
 + [Copyright and licence](#copyright-and-licence)
++ [Get in touch](#get-in-touch)
 + [Contributing](#contributing)
 
 [](TOC)
@@ -93,6 +94,12 @@ The easiest way to install Iris is with [conda](https://conda.io/miniconda.html)
 Detailed instructions, including information on installing from source,
 are available in [INSTALL](INSTALL).
 
+# Get in touch
+
+  * Report bugs, or suggest new features using an Issue or Pull Request on [Github](https://github.com/SciTools/iris). You can also comment on existing Issues and Pull Requests.
+  * For discussions from a user perspective you could join our [SciTools User's Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
+  * For those involved in developing Iris we also have a [Google Group](https://groups.google.com/forum/#!forum/scitools-iris-dev).
+  * [StackOverflow](https://stackoverflow.com/questions/tagged/python-iris) For "How do I?".
 
 # Copyright and licence
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ are available in [INSTALL](INSTALL).
 # Get in touch
 
   * Report bugs, or suggest new features using an Issue or Pull Request on [Github](https://github.com/SciTools/iris). You can also comment on existing Issues and Pull Requests.
-  * For discussions from a user perspective you could join our [SciTools User's Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
-  * For those involved in developing Iris we also have a [Google Group](https://groups.google.com/forum/#!forum/scitools-iris-dev).
+  * For discussions from a user perspective you could join our [SciTools Users Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
+  * For those involved in developing Iris we also have a [Iris Developers Google Group](https://groups.google.com/forum/#!forum/scitools-iris-dev).
   * [StackOverflow](https://stackoverflow.com/questions/tagged/python-iris) For "How do I?".
 
 # Copyright and licence


### PR DESCRIPTION
This is an amended (gitter link removed) and rebased version of #3092 to add some contact details to the Iris README.