### PR TITLE
see if travis likes python 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 language: python
 python:
   - 2.7
-  - 3.6
+  - 3.7-dev
 sudo: false
 
 env:


### PR DESCRIPTION
In #3194 I tried upgrading the python matrix to look like this:
```
language: python
python:
  - 2.7
  - 3.7
sudo: false
```
This didn't work because Travis doesn't actually support Python 3.7 fully yet.

Suggested workaround is to try this instead:
```
language: python
python:
  - 2.7
  - 3.7-dev
sudo: false
```
So that's what this PR is.