### PR TITLE
Remove specific NumPy pin

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -10,5 +10,5 @@ cftime
 dask[array]  #conda: dask
 matplotlib>=2,<3
 netcdf4
-numpy>=1.14,!=1.15.2
+numpy>=1.14
 scipy


### PR DESCRIPTION
Remove the pin to not NumPy v1.15.2, as this is [now apparently fixed](https://github.com/conda-forge/iris-feedstock/pull/41#discussion_r224928363).

Now, the only question is, why are the checks not running?