### PR TITLE
Bugfix proportion aggregator

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,7 +73,7 @@ In order to run the tests, you will need to use the `test` and `docs` groups (we
 Hence the commands change to::
 
     python requirements/gen_conda_requirements.py --groups test docs > conda_requirements.txt
-    conda create -n my_iris_env --file conda_requirements.txt
+    conda create -n my_iris_env -c conda-forge --file conda_requirements.txt
     conda activate my_iris_env  # or whatever other name you gave it
     pip install -e .
 

--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Sep-17_aggregate_by_multdim_coords.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Sep-17_aggregate_by_multdim_coords.txt
@@ -1,0 +1,2 @@
+* :meth:`iris.cube.Cube.aggregated_by` now gives correct values in points and
+bounds when handling multidimensional coordinates.

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -297,7 +297,7 @@ class RectilinearInterpolator(object):
                                         self._coord_decreasing):
                 if flip:
                     dim_slices[interp_dim] = slice(-1, None, -1)
-            data = data[dim_slices]
+            data = data[tuple(dim_slices)]
         return data
 
     def _interpolate(self, data, interp_points):

--- a/lib/iris/analysis/_scipy_interpolate.py
+++ b/lib/iris/analysis/_scipy_interpolate.py
@@ -287,7 +287,7 @@ class _RegularGridInterpolator(object):
         idx_res = []
         for i, yi in zip(indices, norm_distances):
             idx_res.append(np.where(yi <= .5, i, i + 1))
-        return self.values[idx_res]
+        return self.values[tuple(idx_res)]
 
     def _find_indices(self, xi):
         # find relevant edges between which xi are situated

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -399,7 +399,7 @@ def interpolate(cube, sample_points, method=None):
                                 for i_dim in dims_order]
 
         # Apply the fancy indexing to get all the result data points.
-        source_data = source_data[fancy_source_indices]
+        source_data = source_data[tuple(fancy_source_indices)]
 
         # "Fix" problems with missing datapoints producing odd values
         # when copied from a masked into an unmasked array.
@@ -441,7 +441,8 @@ def interpolate(cube, sample_points, method=None):
                                         for src_dim in src_coord_dims]
 
             # Fill the new coord with all the correct points from the old one.
-            new_cube_coord.points = src_coord.points[fancy_coord_index_arrays]
+            new_cube_coord.points = src_coord.points[
+                tuple(fancy_coord_index_arrays)]
             # NOTE: the new coords do *not* have bounds.
 
     return new_cube

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3385,10 +3385,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # coordinate dimension.
         shared_coords = list(filter(
             lambda coord_: coord_ not in groupby_coords,
-            self.coords(dimensions=dimension_to_groupby)))
+            self.coords(contains_dimension=dimension_to_groupby)))
+
+        # Determine which of each shared coord's dimensions will be aggregated.
+        shared_coords_and_dims = [
+            (coord_, index)
+            for coord_ in shared_coords
+            for (index, dim) in enumerate(self.coord_dims(coord_))
+            if dim == dimension_to_groupby]
 
         # Create the aggregation group-by instance.
-        groupby = iris.analysis._Groupby(groupby_coords, shared_coords)
+        groupby = iris.analysis._Groupby(groupby_coords,
+                                         shared_coords_and_dims)
 
         # Create the resulting aggregate-by cube and remove the original
         # coordinates that are going to be groupedby.
@@ -3444,7 +3452,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                                dimension_to_groupby)
             else:
                 aggregateby_cube.add_aux_coord(coord.copy(),
-                                               dimension_to_groupby)
+                                               self.coord_dims(coord))
 
         # Attach the aggregate-by data into the aggregate-by cube.
         aggregateby_cube = aggregator.post_process(aggregateby_cube,

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -323,7 +323,7 @@ def _collapse_degenerate_points_and_bounds(points, bounds=None, rtol=1.0e-7):
         if array.shape[i_dim] > 1:
             slice_inds = [slice(None)] * points.ndim
             slice_inds[i_dim] = slice(0, 1)
-            slice_0 = array[slice_inds]
+            slice_0 = array[tuple(slice_inds)]
             if np.allclose(array, slice_0, rtol):
                 array = slice_0
 

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -147,7 +147,7 @@ class Test__regrid__linear(tests.IrisTest):
     def test_reverse_x_coord(self):
         index = [slice(None)] * self.data.ndim
         index[self.x_dim] = slice(None, None, -1)
-        result = regrid(self.data[index], self.x_dim,
+        result = regrid(self.data[tuple(index)], self.x_dim,
                         self.y_dim, self.x[::-1], self.y,
                         self.target_x, self.target_y)
         self.assertArrayEqual(result, self.expected)

--- a/lib/iris/tests/unit/analysis/test_PROPORTION.py
+++ b/lib/iris/tests/unit/analysis/test_PROPORTION.py
@@ -48,6 +48,15 @@ class Test_masked(tests.IrisTest):
         cube = self.cube.collapsed("foo", PROPORTION, function=self.func)
         self.assertArrayEqual(cube.data, [0.5])
 
+    def test_false_mask(self):
+        # Test corner case where mask is returned as boolean value rather
+        # than boolean array when the mask is unspecified on construction.
+        masked_cube = iris.cube.Cube(ma.array([1, 2, 3, 4, 5]))
+        masked_cube.add_dim_coord(DimCoord([6, 7, 8, 9, 10], long_name='foo'),
+                                  0)
+        cube = masked_cube.collapsed("foo", PROPORTION, function=self.func)
+        self.assertArrayEqual(cube.data, ma.array([0.6]))
+
 
 class Test_name(tests.IrisTest):
     def test(self):

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -26,6 +26,7 @@ import iris.tests as tests
 import numpy as np
 import numpy.ma as ma
 
+from iris._lazy_data import as_lazy_data
 from iris.analysis import RMS
 
 
@@ -86,6 +87,95 @@ class Test_aggregate(tests.IrisTest):
         expected_rms = 8.0
         rms = RMS.aggregate(data, 0, weights=weights)
         self.assertAlmostEqual(rms, expected_rms)
+
+
+class Test_lazy_aggregate(tests.IrisTest):
+    def test_1d(self):
+        # 1-dimensional input.
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
+                            chunks=-1)
+        rms = RMS.lazy_aggregate(data, 0)
+        expected_rms = 4.5
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d(self):
+        # 2-dimensional input.
+        data = as_lazy_data(np.array([[5, 2, 6, 4], [12, 4, 10, 8]],
+                                     dtype=np.float64),
+                            chunks=-1)
+        expected_rms = np.array([4.5, 9.0], dtype=np.float64)
+        rms = RMS.lazy_aggregate(data, 1)
+        self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_1d_weighted(self):
+        # 1-dimensional input with weights.
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
+                            chunks=-1)
+        weights = np.array([1, 4, 3, 2], dtype=np.float64)
+        expected_rms = 8.0
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
+
+    def test_1d_lazy_weighted(self):
+        # 1-dimensional input with lazy weights.
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
+                            chunks=-1)
+        weights = as_lazy_data(np.array([1, 4, 3, 2], dtype=np.float64),
+                               chunks=-1)
+        expected_rms = 8.0
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
+
+    def test_2d_weighted(self):
+        # 2-dimensional input with weights.
+        data = as_lazy_data(np.array([[4, 7, 10, 8], [14, 16, 20, 8]],
+                                     dtype=np.float64),
+                            chunks=-1)
+        weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
+        expected_rms = np.array([8.0, 16.0], dtype=np.float64)
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 1, weights=weights)
+            self.assertArrayAlmostEqual(rms, expected_rms)
+
+    def test_unit_weighted(self):
+        # Unit weights should be the same as no weights.
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
+                            chunks=-1)
+        weights = np.ones_like(data)
+        expected_rms = 4.5
+        # https://github.com/dask/dask/issues/3846.
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked(self):
+        # Masked entries should be completely ignored.
+        data = as_lazy_data(ma.array([5, 10, 2, 11, 6, 4],
+                            mask=[False, True, False, True, False, False],
+                            dtype=np.float64),
+                            chunks=-1)
+        expected_rms = 4.5
+        rms = RMS.lazy_aggregate(data, 0)
+        self.assertAlmostEqual(rms, expected_rms)
+
+    def test_masked_weighted(self):
+        # Weights should work properly with masked arrays, but currently don't
+        # (see https://github.com/dask/dask/issues/3846).
+        # For now, masked weights are simply not supported.
+        data = as_lazy_data(ma.array([4, 7, 18, 10, 11, 8],
+                            mask=[False, False, True, False, True, False],
+                            dtype=np.float64),
+                            chunks=-1)
+        weights = np.array([1, 4, 5, 3, 8, 2])
+        expected_rms = 8.0
+        with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
+            rms = RMS.lazy_aggregate(data, 0, weights=weights)
+            self.assertAlmostEqual(rms, expected_rms)
 
 
 class Test_name(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -449,7 +449,8 @@ class Test_is_compatible(tests.IrisTest):
 
 class Test_aggregated_by(tests.IrisTest):
     def setUp(self):
-        self.cube = Cube(np.arange(11))
+        self.cube = Cube(np.arange(44).reshape(4, 11))
+
         val_coord = AuxCoord([0, 0, 0, 1, 1, 2, 0, 0, 2, 0, 1],
                              long_name="val")
         label_coord = AuxCoord(['alpha', 'alpha', 'beta',
@@ -457,8 +458,19 @@ class Test_aggregated_by(tests.IrisTest):
                                 'alpha', 'alpha', 'alpha',
                                 'gamma', 'beta'],
                                long_name='label', units='no_unit')
-        self.cube.add_aux_coord(val_coord, 0)
-        self.cube.add_aux_coord(label_coord, 0)
+        simple_agg_coord = AuxCoord([1, 1, 2, 2], long_name='simple_agg')
+        spanning_coord = AuxCoord(np.arange(44).reshape(4, 11),
+                                  long_name='spanning')
+        spanning_label_coord = AuxCoord(
+            np.arange(1, 441, 10).reshape(4, 11).astype(str),
+            long_name='span_label', units='no_unit')
+
+        self.cube.add_aux_coord(simple_agg_coord, 0)
+        self.cube.add_aux_coord(val_coord, 1)
+        self.cube.add_aux_coord(label_coord, 1)
+        self.cube.add_aux_coord(spanning_coord, (0, 1))
+        self.cube.add_aux_coord(spanning_label_coord, (0, 1))
+
         self.mock_agg = mock.Mock(spec=Aggregator)
         self.mock_agg.cell_method = []
         self.mock_agg.aggregate = mock.Mock(
@@ -466,7 +478,20 @@ class Test_aggregated_by(tests.IrisTest):
         self.mock_agg.aggregate_shape = mock.Mock(return_value=())
         self.mock_agg.post_process = mock.Mock(side_effect=lambda x, y, z: x)
 
-    def test_string_coord_agg_by_label(self):
+    def test_2d_coord_simple_agg(self):
+        # For 2d coords, slices of aggregated coord should be the same as
+        # aggregated slices.
+        res_cube = self.cube.aggregated_by('simple_agg', self.mock_agg)
+        for res_slice, cube_slice in zip(res_cube.slices('simple_agg'),
+                                         self.cube.slices('simple_agg')):
+            cube_slice_agg = cube_slice.aggregated_by('simple_agg',
+                                                      self.mock_agg)
+            self.assertEqual(res_slice.coord('spanning'),
+                             cube_slice_agg.coord('spanning'))
+            self.assertEqual(res_slice.coord('span_label'),
+                             cube_slice_agg.coord('span_label'))
+
+    def test_agg_by_label(self):
         # Aggregate a cube on a string coordinate label where label
         # and val entries are not in step; the resulting cube has a val
         # coord of bounded cells and a label coord of single string entries.
@@ -479,7 +504,17 @@ class Test_aggregated_by(tests.IrisTest):
         self.assertEqual(res_cube.coord('val'), val_coord)
         self.assertEqual(res_cube.coord('label'), label_coord)
 
-    def test_string_coord_agg_by_val(self):
+    def test_2d_agg_by_label(self):
+        res_cube = self.cube.aggregated_by('label', self.mock_agg)
+        # For 2d coord, slices of aggregated coord should be the same as
+        # aggregated slices.
+        for res_slice, cube_slice in zip(res_cube.slices('val'),
+                                         self.cube.slices('val')):
+            cube_slice_agg = cube_slice.aggregated_by('label', self.mock_agg)
+            self.assertEqual(res_slice.coord('spanning'),
+                             cube_slice_agg.coord('spanning'))
+
+    def test_agg_by_val(self):
         # Aggregate a cube on a numeric coordinate val where label
         # and val entries are not in step; the resulting cube has a label
         # coord with serialised labels from the aggregated cells.
@@ -492,6 +527,16 @@ class Test_aggregated_by(tests.IrisTest):
                                long_name='label', units='no_unit')
         self.assertEqual(res_cube.coord('val'), val_coord)
         self.assertEqual(res_cube.coord('label'), label_coord)
+
+    def test_2d_agg_by_val(self):
+        res_cube = self.cube.aggregated_by('val', self.mock_agg)
+        # For 2d coord, slices of aggregated coord should be the same as
+        # aggregated slices.
+        for res_slice, cube_slice in zip(res_cube.slices('val'),
+                                         self.cube.slices('val')):
+            cube_slice_agg = cube_slice.aggregated_by('val', self.mock_agg)
+            self.assertEqual(res_slice.coord('spanning'),
+                             cube_slice_agg.coord('spanning'))
 
     def test_single_string_aggregation(self):
         aux_coords = [(AuxCoord(['a', 'b', 'a'], long_name='foo'), 0),

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -160,6 +160,7 @@ def delta(ndarray, dimension, circular=False):
         _delta = np.roll(ndarray, -1, axis=dimension)
         last_element = [slice(None, None)] * ndarray.ndim
         last_element[dimension] = slice(-1, None)
+        last_element = tuple(last_element)
 
         if not isinstance(circular, bool):
             result = np.where(ndarray[last_element] >= _delta[last_element])[0]


### PR DESCRIPTION
In numpy 1.15.2, if you construct a masked array without explicitly setting the mask to False, the array mask is a boolean value rather than an array:
```
>> import numpy.ma as ma
>> array = ma.array([1, 2, 3], mask=False)
>> array.mask
array([False, False, False])

>> array = ma.array([1, 2, 3])
>> array.mask
False
```
This is a catch for that scenario which calculates the number of unmasked points using the array itself, not the mask.

The assumption here is that if numpy returns a boolean as an array.mask, it will only ever be False.