### PR TITLE
fix for mercator test failures

### DIFF
--- a/lib/iris/tests/unit/coord_systems/test_Mercator.py
+++ b/lib/iris/tests/unit/coord_systems/test_Mercator.py
@@ -49,7 +49,8 @@ class Test_Mercator__as_cartopy_crs(tests.IrisTest):
         # converted to a cartopy CRS.
         merc_cs = Mercator()
         res = merc_cs.as_cartopy_crs()
-        expected = ccrs.Mercator(globe=ccrs.Globe())
+        # expected = ccrs.Mercator(globe=ccrs.Globe())
+        expected = ccrs.Mercator(globe=ccrs.Globe(), latitude_true_scale=0.0)
         self.assertEqual(res, expected)
 
     def test_extra_kwargs(self):
@@ -81,7 +82,7 @@ class Test_as_cartopy_projection(tests.IrisTest):
         # converted to a cartopy projection.
         merc_cs = Mercator()
         res = merc_cs.as_cartopy_projection()
-        expected = ccrs.Mercator(globe=ccrs.Globe())
+        expected = ccrs.Mercator(globe=ccrs.Globe(), latitude_true_scale=0.0)
         self.assertEqual(res, expected)
 
     def test_extra_kwargs(self):

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,7 +6,7 @@
 cartopy
 #conda: proj4<5
 cf_units>=2
-cftime
+cftime!=1.0.2.1
 dask[array]  #conda: dask
 matplotlib>=2,<3
 netcdf4


### PR DESCRIPTION
- Added `latitude_true_scale=0.0` args to expected result in mercator tests
- Pinned cftime to !=1.0.2.1 for 2.2.x branch