### PR TITLE
Ensure cubelists only contain cubes

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
@@ -1,0 +1,3 @@
+* The `append`, `extend` and `insert` methods of :class:`iris.cube.CubeList`
+now perform a check to ensure that only :class:`iris.cube.Cube` instances are
+added.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -184,6 +184,26 @@ class _CubeFilterCollection(object):
         return _CubeFilterCollection([pair.merged(unique) for pair in
                                       self.pairs])
 
+def _check_iscube(obj):
+    """
+    Raise a warning if obj does not look like a cube.
+    """
+    if not hasattr(obj, 'add_aux_coord'):
+        msg = ("Cubelist now contains object of type '{}'.  This may "
+               "adversely affect subsequent operations.")
+        warnings.warn(msg.format(type(obj).__name__))
+
+def _check_cube_sequence(sequence):
+    """
+    Raise one or more warnings if sequence contains elements that are not
+    Cubes (or cube-like).  Skip this if the sequence is a CubeList, as we can
+    assume it was already checked.
+    """
+    if (isinstance(sequence, collections.Iterable) and
+            not isinstance(sequence, Cube) and
+            not isinstance(sequence, CubeList)):
+        for obj in sequence:
+            _check_iscube(obj)
 
 class CubeList(list):
     """
@@ -215,28 +235,6 @@ class CubeList(list):
     def __repr__(self):
         """Runs repr on every cube."""
         return '[%s]' % ',\n'.join([repr(cube) for cube in self])
-
-    def _check_iscube(self, obj):
-        """
-        Raise a warning if obj is not a cube.
-        """
-        if not isinstance(obj, Cube):
-            msg = ('Cubelist now contains object of type {}.  This may '
-                   'adversely affect subsequent operations.')
-            warnings.warn(msg.format(type(obj)))
-
-    def _check_cube_sequence(self, sequence):
-        """
-        Raise one or more warnings if sequence contains elements that are not
-        Cubes.  Skip this if the sequence is a CubeList, as we can assume it
-        was already checked.
-        """
-        if (isinstance(sequence, collections.Iterable) and
-                not isinstance(sequence, Cube) and
-                not isinstance(sequence, CubeList)):
-            for obj in sequence:
-                self._check_iscube(obj)
-
     # TODO #370 Which operators need overloads?
 
     def __add__(self, other):
@@ -264,31 +262,31 @@ class CubeList(list):
         """
         Add a sequence of cubes to the cubelist in place.
         """
-        self._check_cube_sequence(other_cubes)
+        _check_cube_sequence(other_cubes)
         super(CubeList, self).__iadd__(other_cubes)
 
     def __setitem__(self, key, cube_or_sequence):
         """Set self[key] to cube or sequence of cubes"""
         if isinstance(key, int):
             # should have single cube.
-            self._check_iscube(cube_or_sequence)
+            _check_iscube(cube_or_sequence)
         else:
             # key is a slice (or exception will come from list method).
-            self._check_cube_sequence(cube_or_sequence)
+            _check_cube_sequence(cube_or_sequence)
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     #  __setslice__ is only required for python2.7 compatibility.
     def __setslice__(self, *args):
         cubes = args[-1]
-        self._check_cube_sequence(cubes)
+        _check_cube_sequence(cubes)
         super(CubeList, self).__setslice__(*args)
 
     def append(self, cube):
         """
         Append a cube.
         """
-        self._check_iscube(cube)
+        _check_iscube(cube)
         super(CubeList, self).append(cube)
 
     def extend(self, other_cubes):
@@ -300,14 +298,14 @@ class CubeList(list):
         * other_cubes:
            A cubelist or other sequence of cubes.
         """
-        self._check_cube_sequence(other_cubes)
+        _check_cube_sequence(other_cubes)
         super(CubeList, self).extend(other_cubes)
 
     def insert(self, index, cube):
         """
         Insert a cube before index.
         """
-        self._check_iscube(cube)
+        _check_iscube(cube)
         super(CubeList, self).insert(index, cube)
 
     def xml(self, checksum=False, order=True, byteorder=True):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -258,7 +258,8 @@ class CubeList(list):
         if isinstance(cube, Cube):
             super(CubeList, self).__setitem__(key, cube)
         else:
-            raise TypeError('Elements of cubelists must be Cube instances')
+            raise TypeError('Elements of cubelists must be Cube instances.  '
+                            'Got {}.'.format(type(cube)))
 
     def append(self, cube):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -185,32 +185,6 @@ class _CubeFilterCollection(object):
                                       self.pairs])
 
 
-def _check_iscube(obj):
-    """
-    Raise an exception if obj does not look like a cube.
-    """
-    if not hasattr(obj, 'add_aux_coord'):
-        msg = ("Object of type '{}' does not look like a cube so can't be "
-               "included in cubelist.")
-        raise TypeError(msg.format(type(obj).__name__))
-
-
-def _check_cube_sequence(sequence):
-    """
-    Raise an exception if sequence contains an element that is not a Cube (or
-    cube-like).  Skip this if the sequence is a CubeList, as we can assume it
-    was already checked.
-    """
-    if (isinstance(sequence, collections.Iterable) and
-            not isinstance(sequence, Cube) and
-            not isinstance(sequence, CubeList)):
-        for obj in sequence:
-            if not hasattr(obj, 'add_aux_coord'):
-                msg = ("Sequence contains object of type '{}', which does not "
-                       "look like a cube so can't be included in cubelist.")
-                raise ValueError(msg.format(type(obj).__name__))
-
-
 class CubeList(list):
     """
     All the functionality of a standard :class:`list` with added "Cube"
@@ -241,6 +215,13 @@ class CubeList(list):
     def __repr__(self):
         """Runs repr on every cube."""
         return '[%s]' % ',\n'.join([repr(cube) for cube in self])
+
+    @staticmethod
+    def _assert_is_cube(obj):
+        if not isinstance(obj, Cube):
+            msg = ("Object of type '{}' does not belong in a cubelist.")
+            raise ValueError(msg.format(type(obj).__name__))
+
     # TODO #370 Which operators need overloads?
 
     def __add__(self, other):
@@ -268,31 +249,30 @@ class CubeList(list):
         """
         Add a sequence of cubes to the cubelist in place.
         """
-        _check_cube_sequence(other_cubes)
-        super(CubeList, self).__iadd__(other_cubes)
+        super(CubeList, self).__iadd__(CubeList(other_cubes))
 
     def __setitem__(self, key, cube_or_sequence):
         """Set self[key] to cube or sequence of cubes"""
         if isinstance(key, int):
             # should have single cube.
-            _check_iscube(cube_or_sequence)
+            self._assert_is_cube(cube_or_sequence)
         else:
             # key is a slice (or exception will come from list method).
-            _check_cube_sequence(cube_or_sequence)
+            cube_or_sequence = CubeList(cube_or_sequence)
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     #  __setslice__ is only required for python2.7 compatibility.
     def __setslice__(self, *args):
-        cubes = args[-1]
-        _check_cube_sequence(cubes)
-        super(CubeList, self).__setslice__(*args)
+        args_list = list(args)
+        args_list[-1] = CubeList(args[-1])
+        super(CubeList, self).__setslice__(*args_list)
 
     def append(self, cube):
         """
         Append a cube.
         """
-        _check_iscube(cube)
+        self._assert_is_cube(cube)
         super(CubeList, self).append(cube)
 
     def extend(self, other_cubes):
@@ -304,14 +284,13 @@ class CubeList(list):
         * other_cubes:
            A cubelist or other sequence of cubes.
         """
-        _check_cube_sequence(other_cubes)
-        super(CubeList, self).extend(other_cubes)
+        super(CubeList, self).extend(CubeList(other_cubes))
 
     def insert(self, index, cube):
         """
         Insert a cube before index.
         """
-        _check_iscube(cube)
+        self._assert_is_cube(cube)
         super(CubeList, self).insert(index, cube)
 
     def xml(self, checksum=False, order=True, byteorder=True):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -187,25 +187,28 @@ class _CubeFilterCollection(object):
 
 def _check_iscube(obj):
     """
-    Raise a warning if obj does not look like a cube.
+    Raise an exception if obj does not look like a cube.
     """
     if not hasattr(obj, 'add_aux_coord'):
-        msg = ("Cubelist now contains object of type '{}'.  This may "
-               "adversely affect subsequent operations.")
-        warnings.warn(msg.format(type(obj).__name__))
+        msg = ("Object of type '{}' does not look like a cube so can't be "
+               "included in cubelist.")
+        raise TypeError(msg.format(type(obj).__name__))
 
 
 def _check_cube_sequence(sequence):
     """
-    Raise one or more warnings if sequence contains elements that are not
-    Cubes (or cube-like).  Skip this if the sequence is a CubeList, as we can
-    assume it was already checked.
+    Raise an exception if sequence contains an element that is not a Cube (or
+    cube-like).  Skip this if the sequence is a CubeList, as we can assume it
+    was already checked.
     """
     if (isinstance(sequence, collections.Iterable) and
             not isinstance(sequence, Cube) and
             not isinstance(sequence, CubeList)):
         for obj in sequence:
-            _check_iscube(obj)
+            if not hasattr(obj, 'add_aux_coord'):
+                msg = ("Sequence contains object of type '{}', which does not "
+                       "look like a cube so can't be included in cubelist.")
+                raise ValueError(msg.format(type(obj).__name__))
 
 
 class CubeList(list):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -232,11 +232,10 @@ class CubeList(list):
         was already checked.
         """
         if (isinstance(sequence, collections.Iterable) and
-            not isinstance(sequence, Cube) and
-            not isinstance(sequence, CubeList)):
+                not isinstance(sequence, Cube) and
+                not isinstance(sequence, CubeList)):
             for obj in sequence:
                 self._check_iscube(obj)
-
 
     # TODO #370 Which operators need overloads?
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -184,6 +184,7 @@ class _CubeFilterCollection(object):
         return _CubeFilterCollection([pair.merged(unique) for pair in
                                       self.pairs])
 
+
 def _check_iscube(obj):
     """
     Raise a warning if obj does not look like a cube.
@@ -192,6 +193,7 @@ def _check_iscube(obj):
         msg = ("Cubelist now contains object of type '{}'.  This may "
                "adversely affect subsequent operations.")
         warnings.warn(msg.format(type(obj).__name__))
+
 
 def _check_cube_sequence(sequence):
     """
@@ -204,6 +206,7 @@ def _check_cube_sequence(sequence):
             not isinstance(sequence, CubeList)):
         for obj in sequence:
             _check_iscube(obj)
+
 
 class CubeList(list):
     """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -216,7 +216,30 @@ class CubeList(list):
         """Runs repr on every cube."""
         return '[%s]' % ',\n'.join([repr(cube) for cube in self])
 
+    def _check_iscube(self, obj):
+        """
+        Raise a warning if obj is not a cube.
+        """
+        if not isinstance(obj, Cube):
+            msg = ('Cubelist now contains object of type {}.  This may '
+                   'adversely affect subsequent operations.')
+            warnings.warn(msg.format(type(obj)))
+
+    def _check_cube_sequence(self, sequence):
+        """
+        Raise one or more warnings if sequence contains elements that are not
+        Cubes.  Skip this if the sequence is a CubeList, as we can assume it
+        was already checked.
+        """
+        if (isinstance(sequence, collections.Iterable) and
+            not isinstance(sequence, Cube) and
+            not isinstance(sequence, CubeList)):
+            for obj in sequence:
+                self._check_iscube(obj)
+
+
     # TODO #370 Which operators need overloads?
+
     def __add__(self, other):
         return CubeList(list.__add__(self, other))
 
@@ -242,57 +265,32 @@ class CubeList(list):
         """
         Add a sequence of cubes to the cubelist in place.
         """
-        if isinstance(other_cubes, Cube) or not isinstance(
-                other_cubes, collections.Iterable):
-            raise TypeError(
-                'Can only add a sequence of Cube instances.')
-        elif isinstance(other_cubes, CubeList) or all(
-                [isinstance(cube, Cube) for cube in other_cubes]):
-            super(CubeList, self).__iadd__(other_cubes)
-        else:
-            raise ValueError('All items in added sequence must be Cube '
-                             'instances.')
+        self._check_cube_sequence(other_cubes)
+        super(CubeList, self).__iadd__(other_cubes)
 
     def __setitem__(self, key, cube_or_sequence):
         """Set self[key] to cube or sequence of cubes"""
         if isinstance(key, int):
-            if not isinstance(cube_or_sequence, Cube):
-                raise TypeError('Elements of cubelists must be Cube instances.'
-                                '  Got {}.'.format(type(cube_or_sequence)))
+            # should have single cube.
+            self._check_iscube(cube_or_sequence)
         else:
             # key is a slice (or exception will come from list method).
-            if isinstance(cube_or_sequence, Cube) or not isinstance(
-                    cube_or_sequence, collections.Iterable):
-                raise TypeError('Assigning to a slice of a cubelist requires '
-                                'a sequence of cubes.')
-            elif not all([isinstance(cube, Cube) for
-                          cube in cube_or_sequence]):
-                raise ValueError(
-                    'Elements of cubelists must be Cube instances.')
+            self._check_cube_sequence(cube_or_sequence)
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     #  __setslice__ is only required for python2.7 compatibility.
     def __setslice__(self, *args):
         cubes = args[-1]
-        if isinstance(cubes, Cube) or not isinstance(
-                cubes, collections.Iterable):
-            raise TypeError('Assigning to a slice of a cubelist requires '
-                            'a sequence of cubes.')
-        elif not all([isinstance(cube, Cube) for cube in cubes]):
-            raise ValueError('Elements of cubelists must be Cube instances.')
-
+        self._check_cube_sequence(cubes)
         super(CubeList, self).__setslice__(*args)
 
     def append(self, cube):
         """
         Append a cube.
         """
-        if isinstance(cube, Cube):
-            super(CubeList, self).append(cube)
-        else:
-            raise TypeError('Only Cube instances can be appended to cubelists.'
-                            '  Got {}.'.format(type(cube)))
+        self._check_iscube(cube)
+        super(CubeList, self).append(cube)
 
     def extend(self, other_cubes):
         """
@@ -303,28 +301,15 @@ class CubeList(list):
         * other_cubes:
            A cubelist or other sequence of cubes.
         """
-        if isinstance(other_cubes, Cube):
-            raise TypeError(
-                'Use append to add a single cube to the cubelist.')
-        elif not isinstance(other_cubes, collections.Iterable):
-            raise TypeError(
-                'Can only extend with a sequence of Cube instances.')
-        elif isinstance(other_cubes, CubeList) or all(
-                [isinstance(cube, Cube) for cube in other_cubes]):
-            super(CubeList, self).extend(other_cubes)
-        else:
-            raise ValueError('All items in other_cubes must be Cube '
-                             'instances.')
+        self._check_cube_sequence(other_cubes)
+        super(CubeList, self).extend(other_cubes)
 
     def insert(self, index, cube):
         """
         Insert a cube before index.
         """
-        if isinstance(cube, Cube):
-            super(CubeList, self).insert(index, cube)
-        else:
-            raise TypeError('Only Cube instances can be inserted into '
-                            'cubelists.  Got {}.'.format(type(cube)))
+        self._check_iscube(cube)
+        super(CubeList, self).insert(index, cube)
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """Return a string of the XML that this list of cubes represents."""

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -272,6 +272,18 @@ class CubeList(list):
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
+    #  __setslice__ is only required for python2.7 compatibility.
+    def __setslice__(self, *args):
+        cubes = args[-1]
+        if isinstance(cubes, Cube) or not isinstance(
+                cubes, collections.Iterable):
+            raise TypeError('Assigning to a slice of a cubelist requires '
+                            'a sequence of cubes.')
+        elif not all([isinstance(cube, Cube) for cube in cubes]):
+            raise ValueError('Elements of cubelists must be Cube instances.')
+
+        super(CubeList, self).__setslice__(*args)
+
     def append(self, cube):
         """
         Append a cube.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -253,13 +253,24 @@ class CubeList(list):
             raise ValueError('All items in added sequence must be Cube '
                              'instances.')
 
-    def __setitem__(self, key, cube):
-        """Set self[key] to cube"""
-        if isinstance(cube, Cube):
-            super(CubeList, self).__setitem__(key, cube)
+    def __setitem__(self, key, cube_or_sequence):
+        """Set self[key] to cube or sequence of cubes"""
+        if isinstance(key, int):
+            if not isinstance(cube_or_sequence, Cube):
+                raise TypeError('Elements of cubelists must be Cube instances.'
+                                '  Got {}.'.format(type(cube_or_sequence)))
         else:
-            raise TypeError('Elements of cubelists must be Cube instances.  '
-                            'Got {}.'.format(type(cube)))
+            # key is a slice (or exception will come from list method).
+            if isinstance(cube_or_sequence, Cube) or not isinstance(
+                    cube_or_sequence, collections.Iterable):
+                raise TypeError('Assigning to a slice of a cubelist requires '
+                                'a sequence of cubes.')
+            elif not all([isinstance(cube, Cube) for
+                          cube in cube_or_sequence]):
+                raise ValueError(
+                    'Elements of cubelists must be Cube instances.')
+
+        super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     def append(self, cube):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -238,6 +238,28 @@ class CubeList(list):
         result = CubeList(result)
         return result
 
+    def __iadd__(self, other_cubes):
+        """
+        Add a sequence of cubes to the cubelist in place.
+        """
+        if isinstance(other_cubes, Cube) or not isinstance(
+                other_cubes, collections.Iterable):
+            raise TypeError(
+                'Can only add a sequence of Cube instances.')
+        elif isinstance(other_cubes, CubeList) or all(
+                [isinstance(cube, Cube) for cube in other_cubes]):
+            super(CubeList, self).__iadd__(other_cubes)
+        else:
+            raise ValueError('All items in added sequence must be Cube '
+                             'instances.')
+
+    def __setitem__(self, key, cube):
+        """Set self[key] to cube"""
+        if isinstance(cube, Cube):
+            super(CubeList, self).__setitem__(key, cube)
+        else:
+            raise TypeError('Elements of cubelists must be Cube instances')
+
     def append(self, cube):
         """
         Append a cube.
@@ -262,13 +284,13 @@ class CubeList(list):
                 'Use append to add a single cube to the cubelist.')
         elif not isinstance(other_cubes, collections.Iterable):
             raise TypeError(
-                'Can only extend with a sequece of Cube instances.')
+                'Can only extend with a sequence of Cube instances.')
         elif isinstance(other_cubes, CubeList) or all(
                 [isinstance(cube, Cube) for cube in other_cubes]):
             super(CubeList, self).extend(other_cubes)
         else:
-            raise TypeError('All items in other_cubes must be Cube '
-                            'instances.')
+            raise ValueError('All items in other_cubes must be Cube '
+                             'instances.')
 
     def insert(self, index, cube):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -196,10 +196,7 @@ class CubeList(list):
         """Given a :class:`list` of cubes, return a CubeList instance."""
         cube_list = list.__new__(cls, list_of_cubes)
 
-        # Check that all items in the incoming list are cubes. Note that this
-        # checking does not guarantee that a CubeList instance *always* has
-        # just cubes in its list as the append & __getitem__ methods have not
-        # been overridden.
+        # Check that all items in the incoming list are cubes.
         if not all([isinstance(cube, Cube) for cube in cube_list]):
             raise ValueError('All items in list_of_cubes must be Cube '
                              'instances.')
@@ -240,6 +237,48 @@ class CubeList(list):
         result = super(CubeList, self).__getslice__(start, stop)
         result = CubeList(result)
         return result
+
+    def append(self, cube):
+        """
+        Append a cube.
+        """
+        if isinstance(cube, Cube):
+            super(CubeList, self).append(cube)
+        else:
+            raise TypeError('Only Cube instances can be appended to cubelists.'
+                            '  Got {}.'.format(type(cube)))
+
+    def extend(self, other_cubes):
+        """
+        Extend cubelist by appending the cubes contained in other_cubes.
+
+        Args:
+
+        * other_cubes:
+           A cubelist or other sequence of cubes.
+        """
+        if isinstance(other_cubes, Cube):
+            raise TypeError(
+                'Use append to add a single cube to the cubelist.')
+        elif not isinstance(other_cubes, collections.Iterable):
+            raise TypeError(
+                'Can only extend with a sequece of Cube instances.')
+        elif isinstance(other_cubes, CubeList) or all(
+                [isinstance(cube, Cube) for cube in other_cubes]):
+            super(CubeList, self).extend(other_cubes)
+        else:
+            raise TypeError('All items in other_cubes must be Cube '
+                            'instances.')
+
+    def insert(self, index, cube):
+        """
+        Insert a cube before index.
+        """
+        if isinstance(cube, Cube):
+            super(CubeList, self).insert(index, cube)
+        else:
+            raise TypeError('Only Cube instances can be inserted into '
+                            'cubelists.  Got {}.'.format(type(cube)))
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """Return a string of the XML that this list of cubes represents."""

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -328,6 +328,23 @@ class Test_merge__time_triple(tests.IrisTest):
         self.assertCML(cube, checksum=False)
 
 
+class Test_setitem(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist = iris.cube.CubeList([self.cube1] * 3)
+
+    def test_pass(self):
+        self.cubelist[1] = self.cube2
+        self.assertEqual(self.cubelist[1], self.cube2)
+
+    def test_fail(self):
+        msg = ("Elements of cubelists must be Cube instances.  Got "
+               "<class 'NoneType'>.")
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[0] = None
+
+
 class Test_xml(tests.IrisTest):
     def setUp(self):
         self.cubes = CubeList([Cube(np.arange(3)),

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -351,7 +351,6 @@ class Test_setitem(tests.IrisTest):
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
-    def test_fail(self):
         msg = "can only assign an iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[:1] = 2.5

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -24,6 +24,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 import iris.tests.stock
 
+import copy
+
 from cf_units import Unit
 import numpy as np
 
@@ -48,8 +50,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = ("Only Cube instances can be appended to cubelists.  Got "
-               "<class 'NoneType'>")
+        msg = "Only Cube instances can be appended to cubelists.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist.append(None)
 
@@ -91,7 +92,7 @@ class Test_extend(tests.IrisTest):
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
     def test_pass(self):
-        cubelist = self.cubelist1.copy()
+        cubelist = copy.copy(self.cubelist1)
         cubelist.extend(self.cubelist2)
         self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
         cubelist.extend([self.cube2])
@@ -171,7 +172,7 @@ class Test_iadd(tests.IrisTest):
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
     def test_pass(self):
-        cubelist = self.cubelist1.copy()
+        cubelist = copy.copy(self.cubelist1)
         cubelist += self.cubelist2
         self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
         cubelist += [self.cube2]
@@ -199,8 +200,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_fail(self):
-        msg = ("Only Cube instances can be inserted into cubelists.  Got "
-               "<class 'NoneType'>")
+        msg = "Only Cube instances can be inserted into cubelists.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist.insert(0, None)
 
@@ -341,15 +341,21 @@ class Test_setitem(tests.IrisTest):
         self.cubelist[:2] = (self.cube2, self.cube3)
         self.assertEqual(
             self.cubelist,
-            iris.cube.Cubelist([self.cube2, self.cube3, self.cube1]))
+            iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
-        msg = ("Elements of cubelists must be Cube instances.  Got "
-               "<class 'NoneType'>.")
+        msg = "Elements of cubelists must be Cube instances.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[0] = None
-        with self.assertRaisesRegexp(TypeError, msg):
+        msg = "Elements of cubelists must be Cube instances."
+        with self.assertRaisesRegexp(ValueError, msg):
             self.cubelist[0:2] = [self.cube3, None]
+        msg = ('Assigning to a slice of a cubelist requires a sequence of '
+               'cubes.')
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[:1] = 2.5
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[:1] = self.cube1
 
 
 class Test_xml(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -36,7 +36,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 from iris.tests import mock
 
-NOT_CUBE_MSG = "Cubelist now contains object of type '{}'"
+NOT_CUBE_MSG = "bject of type '{}'"
 
 
 class Test_append(tests.IrisTest):
@@ -51,8 +51,9 @@ class Test_append(tests.IrisTest):
         self.cubelist.append(self.cube2)
         self.assertEqual(self.cubelist[-1], self.cube2)
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
 
@@ -105,9 +106,7 @@ class Test_extend(tests.IrisTest):
         msg = "'NoneType' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
-
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
             self.cubelist1.extend(range(3))
 
 
@@ -186,9 +185,7 @@ class Test_iadd(tests.IrisTest):
         msg = "'float' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += 1.
-
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
             self.cubelist1 += range(3)
 
 
@@ -202,8 +199,9 @@ class Test_insert(tests.IrisTest):
         self.cubelist.insert(1, self.cube2)
         self.assertEqual(self.cubelist[1], self.cube2)
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
 
@@ -345,10 +343,12 @@ class Test_setitem(tests.IrisTest):
             self.cubelist,
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegexp(ValueError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
     def test_fail(self):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -36,7 +36,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 from iris.tests import mock
 
-NOT_CUBE_MSG = 'Cubelist now contains object of type '
+NOT_CUBE_MSG = "Cubelist now contains object of type '{}'"
 
 
 class Test_append(tests.IrisTest):
@@ -52,7 +52,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
 
@@ -107,7 +107,7 @@ class Test_extend(tests.IrisTest):
             self.cubelist1.extend(None)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
             self.cubelist1.extend(range(3))
 
 
@@ -188,7 +188,7 @@ class Test_iadd(tests.IrisTest):
             self.cubelist1 += 1.
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
             self.cubelist1 += range(3)
 
 
@@ -203,7 +203,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
 
@@ -346,9 +346,9 @@ class Test_setitem(tests.IrisTest):
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
     def test_fail(self):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -332,17 +332,24 @@ class Test_setitem(tests.IrisTest):
     def setUp(self):
         self.cube1 = iris.cube.Cube(1, long_name='foo')
         self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube3 = iris.cube.Cube(1, long_name='boo')
         self.cubelist = iris.cube.CubeList([self.cube1] * 3)
 
     def test_pass(self):
         self.cubelist[1] = self.cube2
         self.assertEqual(self.cubelist[1], self.cube2)
+        self.cubelist[:2] = (self.cube2, self.cube3)
+        self.assertEqual(
+            self.cubelist,
+            iris.cube.Cubelist([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
         msg = ("Elements of cubelists must be Cube instances.  Got "
                "<class 'NoneType'>.")
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[0] = None
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[0:2] = [self.cube3, None]
 
 
 class Test_xml(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -36,6 +36,8 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 from iris.tests import mock
 
+NOT_CUBE_MSG = 'Cubelist now contains object of type '
+
 
 class Test_append(tests.IrisTest):
     def setUp(self):
@@ -49,9 +51,8 @@ class Test_append(tests.IrisTest):
         self.cubelist.append(self.cube2)
         self.assertEqual(self.cubelist[-1], self.cube2)
 
-    def test_fail(self):
-        msg = "Only Cube instances can be appended to cubelists.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist.append(None)
 
 
@@ -99,14 +100,14 @@ class Test_extend(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = 'Use append to add a single cube to the cubelist.'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegexp(TypeError, 'Cube is not iterable'):
             self.cubelist1.extend(self.cube1)
-        msg = 'Can only extend with a sequence of Cube instances.'
+        msg = "'NoneType' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
-        msg = 'All items in other_cubes must be Cube instances.'
-        with self.assertRaisesRegexp(ValueError, msg):
+
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist1.extend(range(3))
 
 
@@ -179,13 +180,15 @@ class Test_iadd(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = 'Can only add a sequence of Cube instances.'
+        msg = 'Cube is not iterable'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += self.cube1
+        msg = "'float' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += 1.
-        msg = 'All items in added sequence must be Cube instances.'
-        with self.assertRaisesRegexp(ValueError, msg):
+
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist1 += range(3)
 
 
@@ -199,9 +202,8 @@ class Test_insert(tests.IrisTest):
         self.cubelist.insert(1, self.cube2)
         self.assertEqual(self.cubelist[1], self.cube2)
 
-    def test_fail(self):
-        msg = "Only Cube instances can be inserted into cubelists.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist.insert(0, None)
 
 
@@ -343,15 +345,14 @@ class Test_setitem(tests.IrisTest):
             self.cubelist,
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
-    def test_fail(self):
-        msg = "Elements of cubelists must be Cube instances.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist[0] = None
-        msg = "Elements of cubelists must be Cube instances."
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist[0:2] = [self.cube3, None]
-        msg = ('Assigning to a slice of a cubelist requires a sequence of '
-               'cubes.')
+
+    def test_fail(self):
+        msg = "can only assign an iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[:1] = 2.5
         with self.assertRaisesRegexp(TypeError, msg):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -36,7 +36,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 from iris.tests import mock
 
-NOT_CUBE_MSG = "bject of type '{}'"
+NOT_CUBE_MSG = "Object of type '{}' does not belong in a cubelist."
 
 
 class Test_append(tests.IrisTest):
@@ -52,7 +52,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
@@ -200,7 +200,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
@@ -344,7 +344,7 @@ class Test_setitem(tests.IrisTest):
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
         with self.assertRaisesRegexp(ValueError,

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -101,11 +101,11 @@ class Test_extend(tests.IrisTest):
         msg = 'Use append to add a single cube to the cubelist.'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(self.cube1)
-        msg = 'Can only extend with a sequece of Cube instances.'
+        msg = 'Can only extend with a sequence of Cube instances.'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
         msg = 'All items in other_cubes must be Cube instances.'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegexp(ValueError, msg):
             self.cubelist1.extend(range(3))
 
 
@@ -161,6 +161,31 @@ class Test_extract_overlapping(tests.IrisTest):
         a, b = cubes.extract_overlapping('time')
         self.assertEqual(a.coord('time'), self.cube[::-1].coord('time')[2:4])
         self.assertEqual(b.coord('time'), self.cube.coord('time')[2:4])
+
+
+class Test_iadd(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist1 = iris.cube.CubeList([self.cube1])
+        self.cubelist2 = iris.cube.CubeList([self.cube2])
+
+    def test_pass(self):
+        cubelist = self.cubelist1.copy()
+        cubelist += self.cubelist2
+        self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
+        cubelist += [self.cube2]
+        self.assertEqual(cubelist[-1], self.cube2)
+
+    def test_fail(self):
+        msg = 'Can only add a sequence of Cube instances.'
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1 += self.cube1
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1 += 1.
+        msg = 'All items in added sequence must be Cube instances.'
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.cubelist1 += range(3)
 
 
 class Test_insert(tests.IrisTest):


### PR DESCRIPTION
See #1897.

For completeness, I have addressed `insert` and `extend` as well as `append` (have I missed any?), although
   * I can't think of a reason to ever use `insert`.
   * I'm not sure I've quite got the behaviour right for `extend`, particularly in the case where a cube is passed.  Would the distinction between `append` and `extend` seem a bit arbitrary to a new Python user?