### PR TITLE
Support wider range of climatologies on pp/fields file read

### DIFF
--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -983,17 +983,12 @@ def _all_other_rules(f):
                                            coords='time',
                                            intervals=intervals))
             unhandled_lbproc = False
-        elif f.lbtim.ib == 3 and f.lbproc == 128:
-            # Aggregation over a period of time within a year, over a number
-            # of years.
-            # Only mean (lbproc of 128) is handled as the min/max
-            # interpretation is ambiguous e.g. decadal mean of daily max,
-            # decadal max of daily mean, decadal mean of max daily mean etc.
+        elif f.lbtim.ib == 3:
             cell_methods.append(
                 CellMethod('{} within years'.format(time_method),
                            coords='time', intervals=intervals))
             cell_methods.append(
-                CellMethod('{} over years'.format(time_method),
+                CellMethod('mean over years',
                            coords='time'))
             unhandled_lbproc = False
         else:

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
@@ -107,7 +107,7 @@ class TestCellMethods(tests.IrisTest):
 
     def test_climatology_max(self):
         field = mock.MagicMock(lbproc=8192,
-                               lbtim=mock.Mock(ia=24, ib=3, ic=3))
+                               lbtim=mock.Mock(ia=0, ib=3, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
         expected = [CellMethod('maximum within years', 'time'),
                     CellMethod('mean over years', 'time')]
@@ -115,7 +115,7 @@ class TestCellMethods(tests.IrisTest):
 
     def test_climatology_min(self):
         field = mock.MagicMock(lbproc=4096,
-                               lbtim=mock.Mock(ia=24, ib=3, ic=3))
+                               lbtim=mock.Mock(ia=0, ib=3, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
         expected = [CellMethod('minimum with years', 'time'),
                     CellMethod('mean over years', 'time')]

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
@@ -109,14 +109,16 @@ class TestCellMethods(tests.IrisTest):
         field = mock.MagicMock(lbproc=8192,
                                lbtim=mock.Mock(ia=24, ib=3, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
-        expected = [CellMethod('maximum', 'time')]
+        expected = [CellMethod('maximum within years', 'time'),
+                    CellMethod('mean over years', 'time')]
         self.assertEqual(res, expected)
 
-    def test_climatology_max(self):
+    def test_climatology_min(self):
         field = mock.MagicMock(lbproc=4096,
                                lbtim=mock.Mock(ia=24, ib=3, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
-        expected = [CellMethod('minimum', 'time')]
+        expected = [CellMethod('minimum with years', 'time'),
+                    CellMethod('mean over years', 'time')]
         self.assertEqual(res, expected)
 
     def test_other_lbtim_ib(self):

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
@@ -117,7 +117,7 @@ class TestCellMethods(tests.IrisTest):
         field = mock.MagicMock(lbproc=4096,
                                lbtim=mock.Mock(ia=0, ib=3, ic=3))
         res = _all_other_rules(field)[CELL_METHODS_INDEX]
-        expected = [CellMethod('minimum with years', 'time'),
+        expected = [CellMethod('minimum within years', 'time'),
                     CellMethod('mean over years', 'time')]
         self.assertEqual(res, expected)
 


### PR DESCRIPTION
Could you give me feedback on this pull request - it isn't for merging at this stage - I just want to gauge your view on it.

This ticket aims to interpret a wider range of climatology fields from pp and fields files. Currently iris only interprets multi year climatologies that are means of means (For instance, multi year means of monthly mean data, multi year means of daily data).  I think the wording of F03 suggests we can do more than this.

The F03 document says:
  IB = 3 if the field is a time mean from T1 to T2 for each year from LBYR to LBYRD.
  
This will always be 'mean over years' as a CF cell method.  The statistical processing within the year is given by lbproc.  So and lbproc of 128 is a mean within years, lbproc of 4096 is a minumum within the year. 

Do you agree?