### PR TITLE
[ENH] Concatenate usability improvements

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -346,8 +346,9 @@ class _CubeSignature(object):
         self.aux_metadata = []
         self.dim_coords = cube.dim_coords
         self.dim_metadata = []
-        self.ndim = cube.ndim
+        self.scalar_coords = []
         self.scalar_metadata = []
+        self.ndim = cube.ndim
         self.cell_measures_and_dims = cube._cell_measures_and_dims
         self.dim_mapping = []
 
@@ -391,6 +392,7 @@ class _CubeSignature(object):
             else:
                 metadata = _CoordMetaData(coord, None)
                 self.scalar_metadata.append(metadata)
+                self.scalar_coords.append(coord)
 
     @staticmethod
     def _coordinate_attribute_differences(name, coord_1, coord_2):
@@ -925,7 +927,7 @@ class _ProtoCube(object):
             aux_coords_and_dims.append((coord.copy(), dims))
 
         # Generate all the scalar coordinates for the new concatenated cube.
-        for coord in cube_signature.scalar_metadata:
+        for coord in cube_signature.scalar_coords:
             aux_coords_and_dims.append((coord.copy(), ()))
 
         return aux_coords_and_dims

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -423,11 +423,11 @@ class _CubeSignature(object):
             if coord_1_key == 'defn':
                 defn_1 = coord_1_value._asdict()
                 defn_2 = coord_2_value._asdict()
-                msg = '{} ({!r} != {!r})'
+                msg = '{!r} {} ({!r} != {!r})'
                 for key, value_1 in defn_1.items():
                     value_2 = defn_2[key]
                     if value_1 != value_2:
-                        diffs.append(msg.format(key, value_1, value_2))
+                        diffs.append(msg.format(name, key, value_1, value_2))
             elif coord_1_key == 'dims':
                 if coord_1_value != coord_2_value:
                     msg = '{!r} {} ({} != {})'.format(name, coord_1_key,

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -52,16 +52,16 @@ _DECREASING = -1
 _INCREASING = 1
 
 
-def _can_cast_dtype(values):
+def _can_cast_dtype(dtype_1, dtype_2):
     """dtypes can be considered "equal" if they can be cast."""
-    dtype_is_none = [v is None for v in values]
+    dtype_is_none = [v is None for v in (dtype_1, dtype_2)]
     if all(dtype_is_none):
         can_cast = True
     elif any(dtype_is_none):
         can_cast = False
     else:
-        can_cast = any((np.can_cast(*values),
-                        np.can_cast(*values[::-1])))
+        can_cast = any((np.can_cast(dtype_1, dtype_2),
+                        np.can_cast(dtype_2, dtype_1)))
     return can_cast
 
 
@@ -171,10 +171,10 @@ class _CoordMetaData(namedtuple('CoordMetaData',
             sbounds_dtype = sprops.pop('bounds_dtype')
             obounds_dtype = oprops.pop('bounds_dtype')
             if spoints_dtype != opoints_dtype:
-                result = _can_cast_dtype((spoints_dtype, opoints_dtype))
+                result = _can_cast_dtype(spoints_dtype, opoints_dtype)
             if sbounds_dtype != obounds_dtype:
-                can_cast_bounds = _can_cast_dtype((sbounds_dtype,
-                                                   obounds_dtype))
+                can_cast_bounds = _can_cast_dtype(sbounds_dtype,
+                                                   obounds_dtype)
                 result = result and can_cast_bounds
             # Also check the rest of the props.
             result = result and sprops == oprops
@@ -433,7 +433,7 @@ class _CubeSignature(object):
                                                       coord_2_value)
                     diffs.append(msg)
             elif 'dtype' in coord_1_key:
-                can_cast = _can_cast_dtype((coord_1_value, coord_2_value))
+                can_cast = _can_cast_dtype(coord_1_value, coord_2_value)
                 if not can_cast:
                     msg = '{!r} {} ({} != {})'.format(name, coord_1_key,
                                                       coord_1_value,
@@ -551,7 +551,7 @@ class _CubeSignature(object):
 
         # Check data type.
         if self.data_type != other.data_type:
-            if not _can_cast_dtype((self.data_type, other.data_type)):
+            if not _can_cast_dtype(self.data_type, other.data_type):
                 msgs.append(msg_template.format('Data types', '',
                                                 self.data_type,
                                                 other.data_type))

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -174,7 +174,7 @@ class _CoordMetaData(namedtuple('CoordMetaData',
                 result = _can_cast_dtype(spoints_dtype, opoints_dtype)
             if sbounds_dtype != obounds_dtype:
                 can_cast_bounds = _can_cast_dtype(sbounds_dtype,
-                                                   obounds_dtype)
+                                                  obounds_dtype)
                 result = result and can_cast_bounds
             # Also check the rest of the props.
             result = result and sprops == oprops
@@ -529,20 +529,20 @@ class _CubeSignature(object):
         if self.dim_metadata != other.dim_metadata:
             differences = self._coordinate_differences(other, 'dim_metadata')
             diff_msg = 'Dimension coordinate metadata differs: {}'
-            msgs.extend([diff_msg.format(msg) for msg in differences])
+            msgs.extend([diff_msg.format(diff) for diff in differences])
 
         # Check auxiliary coordinates.
         if self.aux_metadata != other.aux_metadata:
             differences = self._coordinate_differences(other, 'aux_metadata')
             diff_msg = 'Auxiliary coordinate metadata differs: {}'
-            msgs.extend([diff_msg.format(msg) for msg in differences])
+            msgs.extend([diff_msg.format(diff) for diff in differences])
 
         # Check scalar coordinates.
         if self.scalar_metadata != other.scalar_metadata:
             differences = self._coordinate_differences(other,
                                                        'scalar_metadata')
             diff_msg = 'Scalar coordinate metadata differs: {}'
-            msgs.extend([diff_msg.format(msg) for msg in differences])
+            msgs.extend([diff_msg.format(diff) for diff in differences])
 
         # Check ndim.
         if self.ndim != other.ndim:

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -331,18 +331,20 @@ class _CubeSignature(object):
         self.defn = cube.metadata
         self.data_type = cube.dtype
 
-        #
-        # Collate the dimension coordinate metadata.
-        #
+        # Populate dim- and aux-coord metadata.
+        self._collate_dim_metadata(cube)
+        self._collate_aux_metadata(cube)
+
+    def _collate_dim_metadata(self, cube):
+        """Collate the dimension coordinate metadata."""
         for ind, coord in enumerate(self.dim_coords):
             dims = cube.coord_dims(coord)
             metadata = _CoordMetaData(coord, dims)
             self.dim_metadata.append(metadata)
             self.dim_mapping.append(dims[0])
 
-        #
-        # Collate the auxiliary coordinate metadata and scalar coordinates.
-        #
+    def _collate_aux_metadata(self, cube):
+        """Collate the auxiliary coordinate metadata and scalar coordinates."""
         axes = dict(T=0, Z=1, Y=2, X=3)
 
         # Coordinate sort function - by guessed coordinate axis, then
@@ -361,6 +363,14 @@ class _CubeSignature(object):
                 self.aux_coords_and_dims.append(coord_and_dims)
             else:
                 self.scalar_coords.append(coord)
+
+    def _can_and_will_cast(self, other, attr):
+        """
+        Determine whether the dtypes of `self.attr` and `other.attr` can be
+        cast. If they can be, cast both to be of the same appropriate dtype.
+
+        """
+        pass
 
     def _coordinate_differences(self, other, attr):
         """

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -158,10 +158,12 @@ class TestMessages(tests.IrisTest):
             concatenate([cube_1, cube_2], True)
 
     def test_dimensions_metadata_difference_message(self):
+        tgt_coord = 'latitude'
         cube_1 = self.cube
         cube_2 = cube_1.copy()
-        cube_2.coord('latitude').long_name = 'bob'
-        exc_regexp = 'Dimension .* differs: long_name (.* != .*)'
+        cube_2.coord(tgt_coord).long_name = 'bob'
+        exc_regexp = "Dimension .* differs: {!r} long_name (.* != .*)"
+        exc_regexp = exc_regexp.format(tgt_coord)
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
             concatenate([cube_1, cube_2], True)
 
@@ -174,10 +176,12 @@ class TestMessages(tests.IrisTest):
             concatenate([cube_1, cube_2], True)
 
     def test_aux_coords_metadata_difference_message(self):
+        tgt_coord = 'foo'
         cube_1 = self.cube
         cube_2 = cube_1.copy()
-        cube_2.coord('foo').units = 'm'
-        exc_regexp = 'Auxiliary .* differs: units (.* != .*)'
+        cube_2.coord(tgt_coord).units = 'm'
+        exc_regexp = 'Auxiliary .* differs: {!r} units (.* != .*)'
+        exc_regexp = exc_regexp.format(tgt_coord)
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
             concatenate([cube_1, cube_2], True)
 
@@ -206,10 +210,12 @@ class TestMessages(tests.IrisTest):
             concatenate([cube_1, cube_2], True)
 
     def test_scalar_coords_metadata_difference_message(self):
+        tgt_coord = 'height'
         cube_1 = self.cube
         cube_2 = cube_1.copy()
-        cube_2.coord('height').long_name = 'alice'
-        exc_regexp = 'Scalar .* differs: long_name (.* != .*)'
+        cube_2.coord(tgt_coord).long_name = 'alice'
+        exc_regexp = "Scalar .* differs: {!r} long_name (.* != .*)"
+        exc_regexp = exc_regexp.format(tgt_coord)
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
             concatenate([cube_1, cube_2], True)
 

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -100,55 +100,71 @@ class TestMessages(tests.IrisTest):
         cube_2.units = '1'
         exc_regexp = 'Cube metadata differs for phenomenon: *'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_dimensions_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.remove_coord('latitude')
-        exc_regexp = 'Dimension coordinates differ: .* != .*'
+        exc_regexp = 'Dimension .* metadata differs: name (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_dimensions_metadata_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.coord('latitude').long_name = 'bob'
-        exc_regexp = 'Dimension coordinates metadata differ: .* != .*'
+        exc_regexp = 'Dimension .* differs: long_name (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_aux_coords_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.remove_coord('foo')
-        exc_regexp = 'Auxiliary coordinates differ: .* != .*'
+        exc_regexp = 'Auxiliary .* metadata differs: name (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_aux_coords_metadata_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.coord('foo').units = 'm'
-        exc_regexp = 'Auxiliary coordinates metadata differ: .* != .*'
+        exc_regexp = 'Auxiliary .* differs: units (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
+
+    def _redim(self):
+        # Change the dimensions of an aux coord.
+        cube = self.cube.copy()
+        cube.remove_coord('wibble')
+        new_wibble_coord = iris.coords.AuxCoord(cube.data[..., 1],
+                                                long_name='wibble', units='1')
+        cube.add_aux_coord(new_wibble_coord, data_dims=(0, 1))
+        return cube
+
+    def test_dims_covered_difference_message(self):
+        cube_1 = self.cube
+        cube_2 = self._redim()
+        exc_regexp = "Auxiliary .* differs: 'wibble' dims (.* != .*)"
+        with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
+            concatenate([cube_1, cube_2], True)
 
     def test_scalar_coords_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.remove_coord('height')
-        exc_regexp = 'Scalar coordinates differ: .* != .*'
+        exc_regexp = 'Scalar .* differs: name (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_scalar_coords_metadata_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.coord('height').long_name = 'alice'
-        exc_regexp = 'Scalar coordinates metadata differ: .* != .*'
+        exc_regexp = 'Scalar .* differs: long_name (.* != .*)'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_ndim_difference_message(self):
         cube_1 = self.cube
@@ -161,15 +177,15 @@ class TestMessages(tests.IrisTest):
         cube_2.add_dim_coord(x_coord, 0)
         exc_regexp = 'Data dimensions differ: [0-9] != [0-9]'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
     def test_datatype_difference_message(self):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
-        cube_2.data.dtype = np.float64
+        cube_2.data = cube_2.data.astype(np.str)
         exc_regexp = 'Data types differ: .* != .*'
         with self.assertRaisesRegexp(ConcatenateError, exc_regexp):
-            result = concatenate([cube_1, cube_2], True)
+            concatenate([cube_1, cube_2], True)
 
 
 class TestOrder(tests.IrisTest):


### PR DESCRIPTION
Improve the usability of concatenate by:

* allowing concatenate to operate on cubes with differing data / coordinate points / coordinate bounds dtypes
* producing more descriptive error messages on failing to concatenate to a single cube.

Here's an example of some of the improved error messages:

```python
cubes.concatenate_cube()
```
```python-traceback
Traceback (most recent call last):
  ...
iris.exceptions.ConcatenateError: failed to concatenate into a single cube.
  Dimension coordinate metadata differs: name (latitude, longitude, time != longitude)
  Auxiliary coordinate metadata differs: units (Unit('1') != Unit('m'))
  Data types differ: float32 != <U32
  Scalar coordinate metadata differs: name (height != None)
  Data dimensions differ: 3 != 1
  Scalar coordinate metadata differs: long_name (None != 'alice')
```