### PR TITLE
Handle no time coord when saving to PP

### DIFF
--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -124,12 +124,19 @@ def _general_time_rules(cube, pp):
     cm_time_min = scalar_cell_method(cube, 'minimum', 'time')
     cm_time_max = scalar_cell_method(cube, 'maximum', 'time')
 
+    # Handle case of no time coordinate.
+    if time_coord is None and fp_coord is None and frt_coord is None:
+        # Deal with the cftime error:
+        # "date 0000-00-00 does not exist in the standard calendar".
+        pp.t1 = cftime.datetime(1, 1, 1)
+        pp.t2 = cftime.datetime(1, 1, 1)
+
     # No forecast.
     if time_coord is not None and fp_coord is None and frt_coord is None:
         pp.lbtim.ia = 0
         pp.lbtim.ib = 0
         pp.t1 = time_coord.units.num2date(time_coord.points[0])
-        pp.t2 = cftime.datetime(0, 0, 0)
+        pp.t2 = cftime.datetime(1, 1, 1)
 
     # Forecast.
     if (time_coord is not None and


### PR DESCRIPTION
In cases where a cube without a time coordinate is saved to PP, the default value for a PP field header element (0) is not changed for the elements that make up the header's `T1` and `T2` elements. This now causes errors to surface in cftime, because the 0 values in the header elements are interpreted as a datetime value of `0000-00-00`, which cftime does not accept as a valid date. See, for example, [this failing Iris test](https://travis-ci.org/SciTools/iris/jobs/467504312#L7082), which I think originates from this. 