### PR TITLE
BUG: Cube equality boolean data

### DIFF
--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -85,6 +85,8 @@ Iris 2.2 Dependency updates
 Bugs Fixed
 ==========
 
+* Cube equality of boolean data is now handled correctly.
+
 * The bug has been fixed that prevented printing time coordinates with bounds
   when the time coordinate was measured on a long interval (that is, ``months``
   or ``years``).

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -3018,11 +3018,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 result = not (coord_comparison['not_equal'] or
                               coord_comparison['non_equal_data_dimension'])
 
-            # having checked everything else, check approximate data
-            # equality - loading the data if has not already been loaded.
+            # Having checked everything else, check approximate data equality.
             if result:
-                result = np.all(np.abs(self.data - other.data) < 1e-8)
-
+                result = da.allclose(self.core_data(),
+                                     other.core_data()).compute()
         return result
 
     # Must supply __ne__, Python does not defer to __eq__ for negative equality


### PR DESCRIPTION
Issue introduced in numpy 1.14 I think where subtracting two boolean arrays was deprecated.

```Python
  File "/path/to/iris/cube.py", line 3024, in __eq__
    result = np.all(np.abs(self.data - other.data) < 1e-8)
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```

This may be better placed as a more general numpy comparison operator in iris but I don't see there is anywhere suitable for such a thing to live currently.