### PR TITLE
Fix problem with factories in iris.util.new_axis().

### DIFF
--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -89,8 +89,15 @@ Bugs Fixed
 * "Gracefully filling..." warnings are now only issued when the coordinate or
   bound data is actually masked.
 
+
+Bugs fixed in v2.2.1
+--------------------
+
 * Iris can now correctly unpack a column of header objects when saving a
   pandas DataFrame to a cube.
+
+* fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
+  resulted in an exception, if it contained an aux-factory.
 
 
 Documentation Changes

--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Feb-07_newaxis_copy_bug.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Feb-07_newaxis_copy_bug.txt
@@ -1,2 +1,0 @@
-* fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
-resulted in an exception, if it contained an aux-factory.

--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Feb-07_newaxis_copy_bug.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Feb-07_newaxis_copy_bug.txt
@@ -1,0 +1,2 @@
+* fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
+resulted in an exception, if it contained an aux-factory.

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -25,11 +25,14 @@ import iris.tests as tests
 import iris.tests.stock as stock
 
 import copy
-from iris._lazy_data import as_lazy_data
 import numpy as np
 import unittest
 
+import six
+
 import iris
+from iris._lazy_data import as_lazy_data
+
 from iris.util import new_axis
 
 
@@ -135,6 +138,17 @@ class Test(tests.IrisTest):
 
         self.assertEqual(res, com)
         self._assert_cube_notis(res, cube)
+
+        # Check that factory dependencies are actual coords within the cube.
+        # Addresses a former bug : see XXXX
+        factory, = list(res.aux_factories)
+        deps = factory.dependencies
+        for dep_name, dep_coord in six.iteritems(deps):
+            coord_name = dep_coord.name()
+            msg = ('Factory dependency {!r} is a coord named {!r}, '
+                   'but it is *not* the coord of that name in the new cube.')
+            self.assertIs(dep_coord, res.coord(coord_name),
+                          msg.format(dep_name, coord_name))
 
     def test_lazy_data(self):
         cube = iris.cube.Cube(as_lazy_data(self.data))

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -140,7 +140,7 @@ class Test(tests.IrisTest):
         self._assert_cube_notis(res, cube)
 
         # Check that factory dependencies are actual coords within the cube.
-        # Addresses a former bug : see XXXX
+        # Addresses a former bug : https://github.com/SciTools/iris/pull/3263
         factory, = list(res.aux_factories)
         deps = factory.dependencies
         for dep_name, dep_coord in six.iteritems(deps):

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1061,8 +1061,12 @@ def new_axis(src_cube, scalar_coord=None):
         coord_dims = np.array(src_cube.coord_dims(coord)) + 1
         new_cube.add_dim_coord(coord.copy(), coord_dims)
 
+    nonderived_coords = src_cube.dim_coords + src_cube.aux_coords
+    coord_mapping = {id(old_co): new_cube.coord(old_co)
+                     for old_co in nonderived_coords}
     for factory in src_cube.aux_factories:
-        new_cube.add_aux_factory(copy.deepcopy(factory))
+        new_factory = factory.updated(coord_mapping)
+        new_cube.add_aux_factory(new_factory)
 
     return new_cube
 


### PR DESCRIPTION
It was found that adding an axis to a cube with an aux-factory had a subtle bug, which then causes errors _when you copy the result_ :

Example:
```
>>> cube
<iris 'Cube' of mass_fraction_of_ozone_in_air / (kg kg-1) (model_level_number: 63; grid_latitude: 182; grid_longitude: 146)>
>>> 
>>> # Presumably, something here is wrong ...
... cube2 = iutil.new_axis(cube, 'time')
>>> cube2
<iris 'Cube' of mass_fraction_of_ozone_in_air / (kg kg-1) (time: 1; model_level_number: 63; grid_latitude: 182; grid_longitude: 146)>
>>> 
>>> # ... but this is what actually fails :
... cube3 = cube2.copy()
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/opt/scitools/environments/experimental/2019_01_31-1/lib/python3.6/site-packages/iris/cube.py", line 2967, in copy
    cube = self._deepcopy(memo, data=data)
  File "/opt/scitools/environments/experimental/2019_01_31-1/lib/python3.6/site-packages/iris/cube.py", line 3003, in _deepcopy
    new_cube.add_aux_factory(factory.updated(coord_mapping))
  File "/opt/scitools/environments/experimental/2019_01_31-1/lib/python3.6/site-packages/iris/aux_factory.py", line 156, in updated
    coord = new_coord_mapping[id(coord)]
KeyError: 140318647616680
>>> 
```

The new addition to the test code should demonstrate this (fails when run against old code).