### PR TITLE
Replace '__new__' with '__init__' in CubeList creation.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -165,19 +165,25 @@ class CubeList(list):
 
     """
 
-    def __new__(cls, list_of_cubes=None):
-        """Given a :class:`list` of cubes, return a CubeList instance."""
-        cube_list = list.__new__(cls, list_of_cubes)
+    def __init__(self, iterable_of_cubes=None):
+        """Given an iterable of cubes, return a CubeList instance."""
+        if iterable_of_cubes is None:
+            iterable_of_cubes = []
+        # Run the iterable, and capture as a list.
+        list_of_cubes = list(iterable_of_cubes)
 
-        # Check that all items in the incoming list are cubes. Note that this
-        # checking does not guarantee that a CubeList instance *always* has
-        # just cubes in its list as the append & __getitem__ methods have not
-        # been overridden.
-        if not all([isinstance(cube, Cube) for cube in cube_list]):
+        # Check that all items in the incoming list (if any) are cubes.
+        # Note that this checking does not (yet) guarantee that a CubeList
+        # instance *always* contains only cubes, as the append & __setitem__ methods
+        # (for example), have not  been overridden.
+        if not all(isinstance(cube, Cube) for cube in list_of_cubes):
             raise ValueError(
-                "All items in list_of_cubes must be Cube " "instances."
+                "CubeList create arguments are not all Cube "
+                "instances : {}".format(list_of_cubes)
             )
-        return cube_list
+
+        # Initialise "as a" list.
+        super().__init__(list_of_cubes)
 
     def __str__(self):
         """Runs short :meth:`Cube.summary` on every cube."""


### PR DESCRIPTION
"…  and typecheck content."

Raised in the course of #3238 

This is intended to combine with that, so 
 - (a) no whatsnew, though it is also applying that newly strict "only Cubes in CubeLists" approach
 - (b) doesn't anticipate other stuff there, like possibly [a better 'is a Cube' test](https://github.com/SciTools/iris/pull/3238#discussion_r254772464)