### PR TITLE
Avoid numpy FutureWarning about indexing with sequence.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -1341,7 +1341,9 @@ def _peak(array, **kwargs):
 
     # Collapse array to its final data shape.
     slices = [slice(None)] * array.ndim
-    slices[-1] = 0
+    endslice = slice(0, 1) if len(slices) == 1 else 0
+    slices[-1] = endslice
+    slices = tuple(slices)  # Numpy>=1.16 : index with tuple, *not* list.
 
     if isinstance(array.dtype, np.float):
         data = array[slices]

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -717,6 +717,7 @@ def project(cube, target_proj, nx=None, ny=None):
         index = list(index)
         index[xdim] = slice(None, None)
         index[ydim] = slice(None, None)
+        index = tuple(index)  # Numpy>=1.16 : index with tuple, *not* list.
         new_data[index] = cartopy.img_transform.regrid(ll_slice.data,
                                                        source_x, source_y,
                                                        source_cs,

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -197,16 +197,16 @@ class TestDataMergeCombos(tests.IrisTest):
     def test__masked_masked(self):
         for (lazy0, lazy1), (fill0, fill1) in self.combos:
             cubes = iris.cube.CubeList()
-            mask = [(0,), (0,)]
+            mask = ((0,), (0,))
             cubes.append(self._make_cube(0, mask=mask, lazy=lazy0,
                                          dtype=self.dtype,
                                          fill_value=fill0))
-            mask = [(1,), (1,)]
+            mask = ((1,), (1,))
             cubes.append(self._make_cube(1, mask=mask, lazy=lazy1,
                                          dtype=self.dtype,
                                          fill_value=fill1))
             result = cubes.merge_cube()
-            mask = [(0, 1), (0, 1), (0, 1)]
+            mask = ((0, 1), (0, 1), (0, 1))
             expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=expected_fill_value)


### PR DESCRIPTION
This has been cropping up in our tests, [e.g. here](https://travis-ci.org/SciTools/iris/jobs/489641793#L1634).

It also reportedly affects some uses of interpolation (? though not seen in tests ?).
