### PR TITLE
Mergeback master to 2.2.x

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -1324,7 +1324,9 @@ def _peak(array, **kwargs):
 
     # Collapse array to its final data shape.
     slices = [slice(None)] * array.ndim
-    slices[-1] = 0
+    endslice = slice(0, 1) if len(slices) == 1 else 0
+    slices[-1] = endslice
+    slices = tuple(slices)  # Numpy>=1.16 : index with tuple, *not* list.
 
     if isinstance(array.dtype, np.float):
         data = array[slices]

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -717,6 +717,7 @@ def project(cube, target_proj, nx=None, ny=None):
         index = list(index)
         index[xdim] = slice(None, None)
         index[ydim] = slice(None, None)
+        index = tuple(index)  # Numpy>=1.16 : index with tuple, *not* list.
         new_data[index] = cartopy.img_transform.regrid(ll_slice.data,
                                                        source_x, source_y,
                                                        source_cs,

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -197,16 +197,16 @@ class TestDataMergeCombos(tests.IrisTest):
     def test__masked_masked(self):
         for (lazy0, lazy1), (fill0, fill1) in self.combos:
             cubes = iris.cube.CubeList()
-            mask = [(0,), (0,)]
+            mask = ((0,), (0,))
             cubes.append(self._make_cube(0, mask=mask, lazy=lazy0,
                                          dtype=self.dtype,
                                          fill_value=fill0))
-            mask = [(1,), (1,)]
+            mask = ((1,), (1,))
             cubes.append(self._make_cube(1, mask=mask, lazy=lazy1,
                                          dtype=self.dtype,
                                          fill_value=fill1))
             result = cubes.merge_cube()
-            mask = [(0, 1), (0, 1), (0, 1)]
+            mask = ((0, 1), (0, 1), (0, 1))
             expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=expected_fill_value)

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,7 +5,7 @@
 
 cartopy
 #conda: proj4<5
-cf_units>=2
+cf-units>=2
 cftime==1.0.1
 dask[array]  #conda: dask
 matplotlib>=2,<3


### PR DESCRIPTION
Two PRs were incorrectly targeted and merged into master:
#3265 Test with newest cf-units: no longer called cf_units.
#3267 Avoid numpy FutureWarning about indexing with sequence

This cherrypicks those two commits and adds them to the `v2.2.x` branch