### PR TITLE
Revert "Test with newest cf-units: no longer called cf_units."

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,7 +5,7 @@
 
 cartopy
 #conda: proj4<5
-cf-units>=2
+cf_units>=2
 cftime==1.0.1
 dask[array]  #conda: dask
 matplotlib>=2,<3


### PR DESCRIPTION
Reverts SciTools/iris#3265

Following #3274 (thanks @lbdreyer !)
Likewise part of routing these changes via v2.2.x branch instead of direct to master ...