### PR TITLE
Test with newest cf-units: no longer called cf_units.

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,7 +5,7 @@
 
 cartopy
 #conda: proj4<5
-cf_units>=2
+cf-units>=2
 cftime==1.0.1
 dask[array]  #conda: dask
 matplotlib>=2,<3


### PR DESCRIPTION
Like #3276 replaces original #3267, which was accepted + reverted by #3274 ...
So this replaces #3265, which was reverted by #3275 

Rebased + retargetted onto v2.2.x