### PR TITLE
Added a timeout to stop requests.get hanging on platforms with no internet

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -115,7 +115,9 @@ except ImportError:
     NC_TIME_AXIS_AVAILABLE = False
 
 try:
-    requests.get('https://github.com/SciTools/iris')
+    # Added a timeout to stop the call to requests.get hanging on the HPC
+    # which has restricted/no internet access.
+    requests.get('https://github.com/SciTools/iris', timeout=1.0)
     INET_AVAILABLE = True
 except requests.exceptions.ConnectionError:
     INET_AVAILABLE = False

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -117,7 +117,7 @@ except ImportError:
 try:
     # Added a timeout to stop the call to requests.get hanging when running
     # on a platform which has restricted/no internet access.
-    requests.get('https://github.com/SciTools/iris', timeout=1.0)
+    requests.get('https://github.com/SciTools/iris', timeout=10.0)
     INET_AVAILABLE = True
 except requests.exceptions.ConnectionError:
     INET_AVAILABLE = False

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -115,8 +115,8 @@ except ImportError:
     NC_TIME_AXIS_AVAILABLE = False
 
 try:
-    # Added a timeout to stop the call to requests.get hanging on the HPC
-    # which has restricted/no internet access.
+    # Added a timeout to stop the call to requests.get hanging when running
+    # on a platform which has restricted/no internet access.
     requests.get('https://github.com/SciTools/iris', timeout=1.0)
     INET_AVAILABLE = True
 except requests.exceptions.ConnectionError:


### PR DESCRIPTION
When running our AT's ,we import 'IrisTest' from 'iris.tests'. Our tests run on the HPC which has restricted or no internet access, which causes the 'requests.get' call to hang indefinitely. 
In this PR, I've added a 1 second timeout to the 'requests.get' call to stop the call hanging.

Testing on the HPC:
The following call will return with a 'ConnectTimeoutError' on the HPC :
'
>>> import requests  
>>> try:
...     requests.get('https://github.com/scitools/iris', timeout=1.0)
... except:
...    print('Timed out')
... 
Timed out
>>>
 '
which would allow the code to continue....

However , without the timeout the following call will hang indefinitely  and has to be stopped, in this case,  with a keyboardInterrupt:
`
>>> requests.get('https://github.com/scitools/iris')            
^CTraceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/connection.py", line 301, in connect
    conn = self._new_conn()
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/connection.py", line 159, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File "/criticalA/scitools/environments/experimental/2019_02_18-1/lib/python3.6/site-packages/urllib3/util/connection.py", line 70, in create_connection
    sock.connect(sa)
KeyboardInterrupt
>>>
 `
