### PR TITLE
Removal of a cube's cell measure by name (#3081)

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Mar-08_remove_cell_measure_by_name.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Mar-08_remove_cell_measure_by_name.txt
@@ -1,0 +1,2 @@
+* :meth:`iris.cube.Cube.remove_cell_measure` now also allows removal of a cell
+measure by its name (previously only accepted a CellMeasure object).

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1117,14 +1117,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         for factory in self.aux_factories:
             factory.update(coord)
 
-    def remove_cell_measure(self, name_or_cell_measure):
+    def remove_cell_measure(self, cell_measure):
         """
         Removes a cell measure from the cube.
 
         Args:
 
-        * name_or_cell_measure
-            The cell measure to remove from the cube. As either
+        * cell_measure (string or cell_measure)
+            The (name of the) cell measure to remove from the cube. As either
 
             (a) a :attr:`standard_name`, :attr:`long_name`, or
             :attr:`var_name`. Defaults to value of `default`
@@ -1145,7 +1145,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             :meth:`Cube.add_cell_measure()<iris.cube.Cube.add_cell_measure>`
 
         """
-        cell_measure = self.cell_measure(name_or_cell_measure)
+        cell_measure = self.cell_measure(cell_measure)
 
         self._cell_measures_and_dims = [[cell_measure_, dim] for cell_measure_,
                                         dim in self._cell_measures_and_dims

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -1117,19 +1117,36 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         for factory in self.aux_factories:
             factory.update(coord)
 
-    def remove_cell_measure(self, cell_measure):
+    def remove_cell_measure(self, name_or_cell_measure):
         """
         Removes a cell measure from the cube.
 
         Args:
 
-        * cell_measure (CellMeasure)
-            The CellMeasure to remove from the cube.
+        * name_or_cell_measure
+            The cell measure to remove from the cube. As either
 
-        See also
-        :meth:`Cube.add_cell_measure()<iris.cube.Cube.add_cell_measure>`
+            (a) a :attr:`standard_name`, :attr:`long_name`, or
+            :attr:`var_name`. Defaults to value of `default`
+            (which itself defaults to `unknown`) as defined in
+            :class:`iris._cube_coord_common.CFVariableMixin`.
+
+            (b) a cell_measure instance with metadata equal to that of
+            the desired cell_measures.
+
+        .. note::
+
+            If the argument given does not represent a valid cell_measure on
+            the cube, an :class:`iris.exceptions.CellMeasureNotFoundError`
+            is raised.
+
+        .. seealso::
+
+            :meth:`Cube.add_cell_measure()<iris.cube.Cube.add_cell_measure>`
 
         """
+        cell_measure = self.cell_measure(name_or_cell_measure)
+
         self._cell_measures_and_dims = [[cell_measure_, dim] for cell_measure_,
                                         dim in self._cell_measures_and_dims
                                         if cell_measure_ is not cell_measure]

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -1647,6 +1647,15 @@ class Test_remove_metadata(tests.IrisTest):
         self.cube.remove_cell_measure(self.cube.cell_measure('area'))
         self.assertEqual(self.cube._cell_measures_and_dims,
                          [[self.b_cell_measure, (0, 1)]])
+
+    def test_remove_cell_measure_by_name(self):
+        self.cube.remove_cell_measure('area')
+        self.assertEqual(self.cube._cell_measures_and_dims,
+                         [[self.b_cell_measure, (0, 1)]])
+
+    def test_fail_remove_cell_measure_by_name(self):
+        with self.assertRaises(CellMeasureNotFoundError):
+            self.cube.remove_cell_measure('notarea')
 
 
 class Test__getitem_CellMeasure(tests.IrisTest):


### PR DESCRIPTION
Although labelled as a bug I don't think #3081 is a bug strictly speaking. As far as I can tell its behaviour is as expected from the reference docs at https://scitools.org.uk/iris/docs/latest/iris/iris/cube.html#iris.cube.Cube.remove_cell_measure.  In as much as the argument to the method is documented as having to be a CellMeasure instance (not a name of a cell measure).

Having said that it could be a bit misleading as other public Cube methods such as Cube.cell_measure take either a CellMeasure object OR the name of a cell measure (https://scitools.org.uk/iris/docs/latest/iris/iris/cube.html#iris.cube.Cube.cell_measure), and currently if you attempt to pass in the name of a cell measure to be removed it isn't removed, silently

So although maybe not a bug in the strict sense it seemed a good candidate for a minor new feature to accept a name of a cell measure when calling the Cube.remove_cell_measure method

Especially as I'm a newbie contributor let me know what you think, and if I've forgotten anything here (I've updated the docstring, added new tests and added a 'whats new' entry but I may have missed something?)