### PR TITLE
Attempt to fix Sphinx import.

### DIFF
--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -20,6 +20,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *
+from sphinx.util import force_decode
 
 import inspect
 


### PR DESCRIPTION
Hopefully fixes the docs-build, which should get us back our :heavy_check_mark: on PRs.