### PR TITLE
v2.2.x branch mergeback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ git:
 
 install:
   - >
-    export IRIS_TEST_DATA_REF="2f3a6bcf25f81bd152b3d66223394074c9069a96";
+    export IRIS_TEST_DATA_REF="dba47566a9147645fea586f94a138e0a8d45a48e";
     export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//");
 
   # Cut short doctest phase under Python 2 : now only supports Python 3

--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -21,6 +21,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *
 from sphinx.util import force_decode
+from sphinx.util.docstrings import prepare_docstring
 
 import inspect
 

--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -20,6 +20,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *
+from sphinx.util import force_decode
 
 import inspect
 

--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -97,10 +97,6 @@ For an example of using this functionality, the
 in the gallery takes a zonal mean of an ``XYT`` cube by using the
 ``collapsed`` method with ``latitude`` and ``iris.analysis.MEAN`` as arguments.
 
-You cannot partially collapse a multi-dimensional coordinate. See
-:ref:`cube.collapsed <partially_collapse_multi-dim_coord>` for more
-information.
-
 .. _cube-statistics-collapsing-average:
 
 Area averaging

--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -66,6 +66,9 @@ Iris 2.2 Features
   discontiguous points in coordinates can be explicitly masked
   using another new feature :func:`iris.util.mask_cube`.
 
+* :func:`iris.util.array_equal` now has a 'withnans' keyword, which provides
+  a NaN-tolerant array comparison.
+
 
 Iris 2.2 Dependency updates
 =============================
@@ -95,9 +98,15 @@ Bugs fixed in v2.2.1
 
 * Iris can now correctly unpack a column of header objects when saving a
   pandas DataFrame to a cube.
-
+  
 * fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
   resulted in an exception, if it contained an aux-factory.
+
+* :class:`iris.coords.AuxCoord`_'s can now test as 'equal' even when the points
+  or bounds arrays contain NaN values, if values are the same at all points.
+  Previously this would fail, as conventionally "NaN != NaN" in normal
+  floating-point arithmetic.
+
 
 
 Documentation Changes

--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -89,8 +89,15 @@ Bugs Fixed
 * "Gracefully filling..." warnings are now only issued when the coordinate or
   bound data is actually masked.
 
+
+Bugs fixed in v2.2.1
+--------------------
+
 * Iris can now correctly unpack a column of header objects when saving a
   pandas DataFrame to a cube.
+
+* fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
+  resulted in an exception, if it contained an aux-factory.
 
 
 Documentation Changes

--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -102,7 +102,7 @@ Bugs fixed in v2.2.1
 * fixed a bug in :meth:`iris.util.new_axis` : copying the resulting cube
   resulted in an exception, if it contained an aux-factory.
 
-* :class:`iris.coords.AuxCoord`_'s can now test as 'equal' even when the points
+* :class:`iris.coords.AuxCoord`'s can now test as 'equal' even when the points
   or bounds arrays contain NaN values, if values are the same at all points.
   Previously this would fail, as conventionally "NaN != NaN" in normal
   floating-point arithmetic.

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1341,7 +1341,9 @@ def _peak(array, **kwargs):
 
     # Collapse array to its final data shape.
     slices = [slice(None)] * array.ndim
-    slices[-1] = 0
+    endslice = slice(0, 1) if len(slices) == 1 else 0
+    slices[-1] = endslice
+    slices = tuple(slices)  # Numpy>=1.16 : index with tuple, *not* list.
 
     if isinstance(array.dtype, np.float):
         data = array[slices]

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -717,6 +717,7 @@ def project(cube, target_proj, nx=None, ny=None):
         index = list(index)
         index[xdim] = slice(None, None)
         index[ydim] = slice(None, None)
+        index = tuple(index)  # Numpy>=1.16 : index with tuple, *not* list.
         new_data[index] = cartopy.img_transform.regrid(ll_slice.data,
                                                        source_x, source_y,
                                                        source_cs,

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -817,11 +817,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             eq = self._as_defn() == other._as_defn()
             # points comparison
             if eq:
-                eq = iris.util.array_equal(self.points, other.points)
+                eq = iris.util.array_equal(self.points, other.points,
+                                           withnans=True)
             # bounds comparison
             if eq:
                 if self.has_bounds() and other.has_bounds():
-                    eq = iris.util.array_equal(self.bounds, other.bounds)
+                    eq = iris.util.array_equal(self.bounds, other.bounds,
+                                               withnans=True)
                 else:
                     eq = self.bounds is None and other.bounds is None
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -115,7 +115,9 @@ except ImportError:
     NC_TIME_AXIS_AVAILABLE = False
 
 try:
-    requests.get('https://github.com/SciTools/iris')
+    # Added a timeout to stop the call to requests.get hanging when running
+    # on a platform which has restricted/no internet access.
+    requests.get('https://github.com/SciTools/iris', timeout=10.0)
     INET_AVAILABLE = True
 except requests.exceptions.ConnectionError:
     INET_AVAILABLE = False

--- a/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
+++ b/lib/iris/tests/results/COLPEX/small_colpex_theta_p_alt.cml
@@ -396,8 +396,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="1d45e087" points="[0.166666664183, 0.333333332092, 0.5,
-		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="1d45e087" points="[0.166666666686, 0.333333333314, 0.5,
+		0.666666666686, 0.833333333314, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="9c8bdf81" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>
@@ -919,8 +919,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="1d45e087" points="[0.166666664183, 0.333333332092, 0.5,
-		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord id="1d45e087" points="[0.166666666686, 0.333333333314, 0.5,
+		0.666666666686, 0.833333333314, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <dimCoord id="9c8bdf81" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64"/>

--- a/lib/iris/tests/results/grib_load/polar_stereo_grib1.cml
+++ b/lib/iris/tests/results/grib_load/polar_stereo_grib1.cml
@@ -3,7 +3,7 @@
   <cube dtype="float64" units="unknown">
     <coords>
       <coord>
-        <dimCoord bounds="[[0.0, 0.999999996275]]" id="1d45e087" points="[0.499999998137]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
+        <dimCoord bounds="[[0.0, 1.0]]" id="1d45e087" points="[0.5]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord>
         <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -261,7 +261,8 @@
     ],
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83fec2ff7c00a56de9023b52e4143da5d16d7ecad1b76f2094c963929c6471c8.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfec2d77e01a5a5ed013b4ac4521c94817d4e6d91ff63349c6d61991e3278cc.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfec2d77e01a5a5ed013b4ac4521c94817d4e6d91ff63349c6d61991e3278cc.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfec2577e01b5a5ed013b4ac4521c94817d4e4d91ff63369c6d61991e3278cc.png"
     ],
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_coord_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/87ff95776a01e1f67801cc36f4075b81c5437668c1167c88d2676d39d6867b68.png",
@@ -277,7 +278,8 @@
     ],
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4ea6c059d2ff1494e4b90f26304846d78d1872a6cfc938b2e3e.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4ea6c059d2ff1494e4b90f26304846d78d1872a6cfc938b2e3e.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4fa6c059d2ef1494e4b90f26304847d78c1872a6cfc938b2e3e.png"
     ],
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83fec1ff7e0098757103a71ce4506dc3d11e7b20d2477ec094857db895217f6a.png",
@@ -286,7 +288,8 @@
     "iris.tests.test_plot.Test1dPlotMultiArgs.test_cube_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c2d73a09b4a76c099d26f14b0e5ad0d643b0d42763e9d51378f895867c39.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/8fe8c0173a19b4066d599946f35f0ed5d0b74729d40369d8953678e897877879.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c0567a01b096e4019daff10b464bd4da6391943678e5879f7e3103e67f1c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c0567a01b096e4019daff10b464bd4da6391943678e5879f7e3103e67f1c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c0567a01b296e4019d2ff10b464bd4da6391943678e5879f7e3903e63f1c.png"
     ],
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83fec2777e04256f68023352f6d61da5c109dec8d19bcf089cc9d99a9c85d999.png",
@@ -296,7 +299,8 @@
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83fe9dd77f00e1d73000cc1df707db8184427ef8d1367c88d2667d39d0866b68.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/83fe9d977f41e1d73000cc1df707d98184427ef8d1367c88d2667d39d0866b68.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/83ff9d9f7e01e1c2b001c8f8f63e1b1d81cf36e1837e259982ce2f215c9a626c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ff9d9f7e01e1c2b001c8f8f63e1b1d81cf36e1837e259982ce2f215c9a626c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ff9d9f7e01e1c2b001c8f8f63e1b1d81cf36e1837e258982c66f215c9a6a6c.png"
     ],
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_coord_coord_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fbe0623dc9879d91b41e4b449b6579e78798a49b7872d2644b8c919b39306e6c.png",
@@ -318,7 +322,8 @@
     "iris.tests.test_plot.Test1dQuickplotPlotMultiArgs.test_cube_cube.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc8967e0098a6241f9d26e34b8e42f4d20bb4942759e9941f78f8d7867a39.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/83f9c8967e009da6245f9946e25f9ed6f0940f29f40749d8853678e8d7857879.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc9d67e00909624079daef160cf4bd45a439184367ae5979f7e3119e6261c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc9d67e00909624079daef160cf4bd45a439184367ae5979f7e3119e6261c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/83ffc9d67e00909624059daef160cf4bd45a4b9184367ae5979f7e3909e6261c.png"
     ],
     "iris.tests.test_plot.Test1dQuickplotScatter.test_coord_coord.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/a3fac1947c99184e62669ca7f65bc96ab81d97b7e248199cc7913662d94ac5a1.png",
@@ -394,7 +399,8 @@
     "iris.tests.test_plot.TestContour.test_tz.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe81ff780185fff800955ad4027e00d517d400855f7e0085ff7e8085ff6aed.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe81ff780085fff800855fd4027e00d517d400855f7e0085ff7e8085ff6aed.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe817ffc00855ef0007e81d4027e80815fd56a03ff7a8085ff3aa883ff6aa5.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe817ffc00855ef0007e81d4027e80815fd56a03ff7a8085ff3aa883ff6aa5.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8bff817ffc00857ef0007a81d4027e80815fd56a03ff7a8085ff3aa881ff6aa5.png"
     ],
     "iris.tests.test_plot.TestContour.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa56c3cc34e891b1c9a91c36c5a170e3c71b3e5993a784e492c49b4ecec76393.png",
@@ -402,11 +408,13 @@
     ],
     "iris.tests.test_plot.TestContour.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8bfe857f7a01a56afa05854ad015bd00d015d50a90577e80857f7ea0857f7abf.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/affe815ffc008554f8007e01d0027e808557d5ea815f7ea0817f2fea817d2aff.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/affe815ffc008554f8007e01d0027e808557d5ea815f7ea0817f2fea817d2aff.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/affe805ffc008554f8007e01d0027e808557d5ea815f7ea0817f2eea817f2bff.png"
     ],
     "iris.tests.test_plot.TestContour.test_zy.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8bff81ff7a0195fcf8019578d4027e00d550d402857c7e0185fe7a8385fe6aaf.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/abff857ff8018578f8017a80d4027e00855ec42a81fe7a8185fe6a8f85fe6ab7.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abff857ff8018578f8017a80d4027e00855ec42a81fe7a8185fe6a8f85fe6ab7.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abff817ff8018578fc017a80d4027e00855ec42a81fe7a8185fe7a8f85fe6ab5.png"
     ],
     "iris.tests.test_plot.TestContourf.test_tx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/faa562ed68569d52857abd12953a8f12951f64e0d30f3ac96a4d6a696ee06a32.png",
@@ -627,16 +635,20 @@
     ],
     "iris.tests.test_plot.TestPlot.test_z.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/8ffac1547a0792546c179db7f1254f6d945b7392841678e895017e3e91c17a0f.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4ea6c059d2ff1494e4b90f26304846d78d1872a6cfc938b2e3e.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4ea6c059d2ff1494e4b90f26304846d78d1872a6cfc938b2e3e.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/8ff8c1fa7a05b4fa6c059d2ef1494e4b90f26304847d78c1872a6cfc938b2e3e.png"
     ],
     "iris.tests.test_plot.TestPlotCitation.test.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895467a1d9506f811783485437abd85427ab995067ab9f00687f96afe87c8.png"
     ],
     "iris.tests.test_plot.TestPlotCitation.test_axes.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895467a1d9506f811783485437abd85427ab995067ab9f00687f96afe87c8.png"
     ],
     "iris.tests.test_plot.TestPlotCitation.test_figure.0": [
-        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895067a1d9506f811783585437abd85426ab995067af9f00687f96afe87c8.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/abf895467a1d9506f811783485437abd85427ab995067ab9f00687f96afe87c8.png"
     ],
     "iris.tests.test_plot.TestPlotCoordinatesGiven.test_non_cube_coordinate.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7e81857e7a81857e7a81857e7a818576c02a7e95856a7e81c17a.png",

--- a/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_save_load_hybrid_height.cml
@@ -414,8 +414,8 @@
         </auxCoord>
       </coord>
       <coord datadims="[0]">
-        <auxCoord id="1d45e087" points="[0.166666664183, 0.333333332092, 0.5,
-		0.666666667908, 0.833333335817, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64" var_name="forecast_period"/>
+        <auxCoord id="1d45e087" points="[0.166666666686, 0.333333333314, 0.5,
+		0.666666666686, 0.833333333314, 1.0]" shape="(6,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64" var_name="forecast_period"/>
       </coord>
       <coord>
         <dimCoord id="9c8bdf81" points="[347926.0]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='gregorian')" value_type="float64" var_name="forecast_reference_time"/>

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -197,16 +197,16 @@ class TestDataMergeCombos(tests.IrisTest):
     def test__masked_masked(self):
         for (lazy0, lazy1), (fill0, fill1) in self.combos:
             cubes = iris.cube.CubeList()
-            mask = [(0,), (0,)]
+            mask = ((0,), (0,))
             cubes.append(self._make_cube(0, mask=mask, lazy=lazy0,
                                          dtype=self.dtype,
                                          fill_value=fill0))
-            mask = [(1,), (1,)]
+            mask = ((1,), (1,))
             cubes.append(self._make_cube(1, mask=mask, lazy=lazy1,
                                          dtype=self.dtype,
                                          fill_value=fill1))
             result = cubes.merge_cube()
-            mask = [(0, 1), (0, 1), (0, 1)]
+            mask = ((0, 1), (0, 1), (0, 1))
             expected_fill_value = self._expected_fill_value(fill0, fill1)
             expected = self._make_data([0, 1], mask=mask, dtype=self.dtype,
                                        fill_value=expected_fill_value)

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -443,7 +443,7 @@ class TestPPDataProxyEquality(tests.IrisTest):
     def test_not_implemented(self):
         class Terry(object): pass
         pox = pp.PPDataProxy("john", "michael", "eric", "graham", "brian",
-                             "spam", "beans", "eggs", "parrot")
+                             "spam", "beans", "eggs")
         self.assertIs(pox.__eq__(Terry()), NotImplemented)
         self.assertIs(pox.__ne__(Terry()), NotImplemented)
 

--- a/lib/iris/tests/unit/coords/test_AuxCoord.py
+++ b/lib/iris/tests/unit/coords/test_AuxCoord.py
@@ -624,5 +624,20 @@ class Test_convert_units(tests.IrisTest):
         self.assertArrayAllClose(coord.bounds, test_bounds_ft)
 
 
+class TestEquality(tests.IrisTest):
+    def test_nanpoints_eq_self(self):
+        co1 = AuxCoord([1., np.nan, 2.])
+        self.assertEqual(co1, co1)
+
+    def test_nanpoints_eq_copy(self):
+        co1 = AuxCoord([1., np.nan, 2.])
+        co2 = co1.copy()
+        self.assertEqual(co1, co2)
+
+    def test_nanbounds_eq_self(self):
+        co1 = AuxCoord([15., 25.], bounds=[[14., 16.], [24., np.nan]])
+        self.assertEqual(co1, co1)
+
+
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/coords/test_AuxCoord.py
+++ b/lib/iris/tests/unit/coords/test_AuxCoord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -31,14 +31,14 @@ class Test_lbpack(tests.IrisTest):
     def test_lbpack_SplittableInt(self):
         lbpack = mock.Mock(spec_set=SplittableInt)
         proxy = PPDataProxy(None, None, None, None,
-                            None, lbpack, None, None, None)
+                            None, lbpack, None, None)
         self.assertEqual(proxy.lbpack, lbpack)
         self.assertIs(proxy.lbpack, lbpack)
 
     def test_lnpack_raw(self):
         lbpack = 4321
         proxy = PPDataProxy(None, None, None, None,
-                            None, lbpack, None, None, None)
+                            None, lbpack, None, None)
         self.assertEqual(proxy.lbpack, lbpack)
         self.assertIsNot(proxy.lbpack, lbpack)
         self.assertIsInstance(proxy.lbpack, SplittableInt)

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -63,7 +63,6 @@ class Test__create_field_data(tests.IrisTest):
         core_data = mock.MagicMock(return_value=deferred_bytes)
         field = mock.Mock(core_data=core_data)
         data_shape = (100, 120)
-        land_mask = mock.Mock()
         proxy = mock.Mock(dtype=np.dtype('f4'), shape=data_shape,
                           spec=pp.PPDataProxy)
         # We can't directly inspect the concrete data source underlying
@@ -71,7 +70,7 @@ class Test__create_field_data(tests.IrisTest):
         # being created and invoked correctly.
         with mock.patch('iris.fileformats.pp.PPDataProxy') as PPDataProxy:
             PPDataProxy.return_value = proxy
-            pp._create_field_data(field, data_shape, land_mask)
+            pp._create_field_data(field, data_shape, land_mask_field=None)
         # The data should be assigned via field.data. As this is a mock object
         # we can check the attribute directly.
         self.assertEqual(field.data.shape, data_shape)
@@ -84,8 +83,7 @@ class Test__create_field_data(tests.IrisTest):
                                             n_bytes,
                                             field.raw_lbpack,
                                             field.boundary_packing,
-                                            field.bmdi,
-                                            land_mask)
+                                            field.bmdi)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -111,16 +111,15 @@ class Test__data_bytes_to_shaped_array__land_packed(tests.IrisTest):
         return pp.SplittableInt(value, name_mapping)
 
     def test_no_land_mask(self):
+        # Check that without a mask, it returns the raw (compressed) data.
         with mock.patch('numpy.frombuffer',
                         return_value=np.arange(3)):
-            with self.assertRaises(ValueError) as err:
-                pp._data_bytes_to_shaped_array(mock.Mock(),
-                                               self.create_lbpack(120), None,
-                                               (3, 4), np.dtype('>f4'),
-                                               -999, mask=None)
-            self.assertEqual(str(err.exception),
-                             ('No mask was found to unpack the data. '
-                              'Could not load.'))
+            result = pp._data_bytes_to_shaped_array(
+                mock.Mock(),
+                self.create_lbpack(120), None,
+                (3, 4), np.dtype('>f4'),
+                -999, mask=None)
+            self.assertArrayAllClose(result, np.arange(3))
 
     def test_land_mask(self):
         # Check basic land unpacking.

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -140,8 +140,8 @@ class TestLBTIMx1x_Forecast(TestField):
             lbcode=_lbcode(1), lbtim=lbtim, epoch_hours_unit=_EPOCH_HOURS_UNIT,
             t1=t1, t2=t2, lbft=None)
         (fp, _), (t, _), (frt, _) = coords_and_dims
-        self.assertEqual(fp.points[0], 7.1666666641831398)
-        self.assertEqual(t.points[0], 394927.16666666418)
+        self.assertArrayAllClose(fp.points[0], 7.1666666, atol=0.0001, rtol=0)
+        self.assertArrayAllClose(t.points[0], 394927.166666, atol=0.01, rtol=0)
 
 
 class TestLBTIMx2x_TimePeriod(TestField):

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__epoch_date_hours.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__epoch_date_hours.py
@@ -1,0 +1,150 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for
+:func:`iris.fileformats.pp_load_rules._epoch_date_hours`.
+
+"""
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import cf_units
+from cf_units import Unit
+from cftime import datetime as nc_datetime
+
+from iris.fileformats.pp_load_rules \
+    import _epoch_date_hours as epoch_hours_call
+
+
+#
+# Run tests for each of the possible calendars from PPfield.calendar().
+# Test year=0 and all=0 cases, plus "normal" dates, for each calendar.
+# Result values are the same as from 'date2num' in cftime version <= 1.0.1.
+#
+
+class TestEpochHours__gregorian(tests.IrisTest):
+    def setUp(self):
+        self.hrs_unit = Unit('hours since epoch',
+                             calendar=cf_units.CALENDAR_GREGORIAN)
+
+    def test_1970_1_1(self):
+        test_date = nc_datetime(1970, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, 0.0)
+
+    def test_ymd_1_1_1(self):
+        test_date = nc_datetime(1, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17259936.0)
+
+    def test_year_0(self):
+        test_date = nc_datetime(0, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17268720.0)
+
+    def test_ymd_0_0_0(self):
+        test_date = nc_datetime(0, 0, 0)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17269488.0)
+
+    def test_ymd_0_preserves_timeofday(self):
+        hrs, mins, secs, usecs = (7, 13, 24, 335772)
+        hours_in_day = (hrs +
+                        1./60 * mins +
+                        1./3600 * secs +
+                        (1.0e-6) / 3600 * usecs)
+        test_date = nc_datetime(0, 0, 0,
+                                hour=hrs, minute=mins, second=secs,
+                                microsecond=usecs)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        # NOTE: the calculation is only accurate to approx +/- 0.5 seconds
+        # in such a large number of hours -- even 0.1 seconds is too fine.
+        absolute_tolerance = 0.5 / 3600
+        self.assertArrayAllClose(result, -17269488.0 + hours_in_day,
+                                 rtol=0, atol=absolute_tolerance)
+
+
+class TestEpochHours__360day(tests.IrisTest):
+    def setUp(self):
+        self.hrs_unit = Unit('hours since epoch',
+                             calendar=cf_units.CALENDAR_360_DAY)
+
+    def test_1970_1_1(self):
+        test_date = nc_datetime(1970, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, 0.0)
+
+    def test_ymd_1_1_1(self):
+        test_date = nc_datetime(1, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17012160.0)
+
+    def test_year_0(self):
+        test_date = nc_datetime(0, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17020800.0)
+
+    def test_ymd_0_0_0(self):
+        test_date = nc_datetime(0, 0, 0)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17021544.0)
+
+
+class TestEpochHours__365day(tests.IrisTest):
+    def setUp(self):
+        self.hrs_unit = Unit('hours since epoch',
+                             calendar=cf_units.CALENDAR_365_DAY)
+
+    def test_1970_1_1(self):
+        test_date = nc_datetime(1970, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, 0.0)
+
+    def test_ymd_1_1_1(self):
+        test_date = nc_datetime(1, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17248440.0)
+
+    def test_year_0(self):
+        test_date = nc_datetime(0, 1, 1)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17257200.0)
+
+    def test_ymd_0_0_0(self):
+        test_date = nc_datetime(0, 0, 0)
+        result = epoch_hours_call(self.hrs_unit, test_date)
+        self.assertEqual(result, -17257968.0)
+
+
+class TestEpochHours__invalid_calendar(tests.IrisTest):
+    def test_bad_calendar(self):
+        # Setup a unit with an unrecognised calendar
+        hrs_unit = Unit('hours since epoch',
+                        calendar=cf_units.CALENDAR_ALL_LEAP)
+        # Test against a date with year=0, which requires calendar correction.
+        test_date = nc_datetime(0, 1, 1)
+        # Check that this causes an error.
+        with self.assertRaisesRegexp(ValueError, 'unrecognised calendar'):
+            epoch_hours_call(hrs_unit, test_date)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -39,6 +39,14 @@ from iris.tests import mock
 import iris.tests.unit.fileformats
 
 
+def _mock_field(**kwargs):
+    # Generate a mock field, but ensure T1 and T2 viable for rules.
+    field = mock.MagicMock(t1=mock.MagicMock(year=1990, month=3, day=7),
+                           t2=mock.MagicMock(year=1990, month=3, day=7))
+    field.configure_mock(**kwargs)
+    return field
+
+
 class TestLBCODE(iris.tests.unit.fileformats.TestField):
     @staticmethod
     def _is_cross_section_height_coord(coord):
@@ -50,7 +58,7 @@ class TestLBCODE(iris.tests.unit.fileformats.TestField):
         lbcode = SplittableInt(19902, {'iy': slice(0, 2), 'ix': slice(2, 4)})
         points = np.array([10, 20, 30, 40])
         bounds = np.array([[0, 15], [15, 25], [25, 35], [35, 45]])
-        field = mock.MagicMock(lbcode=lbcode, bdy=0, y=points, y_bounds=bounds)
+        field = _mock_field(lbcode=lbcode, bdy=0, y=points, y_bounds=bounds)
         self._test_for_coord(field, convert,
                              TestLBCODE._is_cross_section_height_coord,
                              expected_points=points,
@@ -61,8 +69,8 @@ class TestLBCODE(iris.tests.unit.fileformats.TestField):
         points = np.array([10, 20, 30, 40])
         bounds = np.array([[0, 15], [15, 25], [25, 35], [35, 45]])
         bmdi = -1.07374e+09
-        field = mock.MagicMock(lbcode=lbcode, bdy=bmdi, bmdi=bmdi,
-                               y=points, y_bounds=bounds)
+        field = _mock_field(lbcode=lbcode, bdy=bmdi, bmdi=bmdi,
+                            y=points, y_bounds=bounds)
         self._test_for_coord(field, convert,
                              TestLBCODE._is_cross_section_height_coord,
                              expected_points=points,
@@ -105,7 +113,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_soil_levels(self):
         level = 1234
-        field = mock.MagicMock(lbvc=6, lblev=level, brsvd=[0, 0], brlev=0)
+        field = _mock_field(lbvc=6, lblev=level, brsvd=[0, 0], brlev=0)
         self._test_for_coord(field, convert,
                              self._is_soil_model_level_number_coord,
                              expected_points=[level],
@@ -113,8 +121,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_soil_depth(self):
         lower, point, upper = 1.2, 3.4, 5.6
-        field = mock.MagicMock(lbvc=6, blev=point, brsvd=[lower, 0],
-                               brlev=upper)
+        field = _mock_field(lbvc=6, blev=point, brsvd=[lower, 0], brlev=upper)
         self._test_for_coord(field, convert,
                              self._is_soil_depth_coord,
                              expected_points=[point],
@@ -122,9 +129,9 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_hybrid_pressure_model_level_number(self):
         level = 5678
-        field = mock.MagicMock(lbvc=9, lblev=level,
-                               blev=20, brlev=23, bhlev=42,
-                               bhrlev=45, brsvd=[17, 40])
+        field = _mock_field(lbvc=9, lblev=level,
+                            blev=20, brlev=23, bhlev=42,
+                            bhrlev=45, brsvd=[17, 40])
         self._test_for_coord(field, convert,
                              TestLBVC._is_model_level_number_coord,
                              expected_points=[level],
@@ -134,10 +141,10 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
         delta_point = 12.0
         delta_lower_bound = 11.0
         delta_upper_bound = 13.0
-        field = mock.MagicMock(lbvc=9, lblev=5678,
-                               blev=20, brlev=23, bhlev=delta_point,
-                               bhrlev=delta_lower_bound,
-                               brsvd=[17, delta_upper_bound])
+        field = _mock_field(lbvc=9, lblev=5678,
+                            blev=20, brlev=23, bhlev=delta_point,
+                            bhrlev=delta_lower_bound,
+                            brsvd=[17, delta_upper_bound])
         self._test_for_coord(field, convert,
                              TestLBVC._is_level_pressure_coord,
                              expected_points=[delta_point],
@@ -148,10 +155,10 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
         sigma_point = 0.5
         sigma_lower_bound = 0.6
         sigma_upper_bound = 0.4
-        field = mock.MagicMock(lbvc=9, lblev=5678,
-                               blev=sigma_point, brlev=sigma_lower_bound,
-                               bhlev=12, bhrlev=11,
-                               brsvd=[sigma_upper_bound, 13])
+        field = _mock_field(lbvc=9, lblev=5678,
+                            blev=sigma_point, brlev=sigma_lower_bound,
+                            bhlev=12, bhrlev=11,
+                            brsvd=[sigma_upper_bound, 13])
         self._test_for_coord(field, convert, TestLBVC._is_sigma_coord,
                              expected_points=[sigma_point],
                              expected_bounds=[[sigma_lower_bound,
@@ -159,7 +166,7 @@ class TestLBVC(iris.tests.unit.fileformats.TestField):
 
     def test_potential_temperature_levels(self):
         potm_value = 27.32
-        field = mock.MagicMock(lbvc=19, blev=potm_value)
+        field = _mock_field(lbvc=19, blev=potm_value)
         self._test_for_coord(field, convert, TestLBVC._is_potm_level_coord,
                              expected_points=np.array([potm_value]),
                              expected_bounds=None)
@@ -265,7 +272,7 @@ class TestLBRSVD(iris.tests.unit.fileformats.TestField):
         lbrsvd[3] = 71
         points = np.array([71])
         bounds = None
-        field = mock.MagicMock(lbrsvd=lbrsvd)
+        field = _mock_field(lbrsvd=lbrsvd)
         self._test_for_coord(field, convert,
                              TestLBRSVD._is_realization,
                              expected_points=points,
@@ -275,7 +282,7 @@ class TestLBRSVD(iris.tests.unit.fileformats.TestField):
 class TestLBSRCE(iris.tests.IrisTest):
     def check_um_source_attrs(self, lbsrce,
                               source_str=None, um_version_str=None):
-        field = mock.MagicMock(lbsrce=lbsrce)
+        field = _mock_field(lbsrce=lbsrce)
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,
          aux_coords_and_dims) = convert(field)
@@ -310,7 +317,7 @@ class Test_STASH_CF(iris.tests.unit.fileformats.TestField):
         lbuser = [1, 0, 0, 16203, 0, 0, 1]
         lbfc = 16
         stash = STASH(lbuser[6], lbuser[3] // 1000, lbuser[3] % 1000)
-        field = mock.MagicMock(lbuser=lbuser, lbfc=lbfc, stash=stash)
+        field = _mock_field(lbuser=lbuser, lbfc=lbfc, stash=stash)
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,
          aux_coords_and_dims) = convert(field)
@@ -321,7 +328,7 @@ class Test_STASH_CF(iris.tests.unit.fileformats.TestField):
         lbuser = [1, 0, 0, 0, 0, 0, 0]
         lbfc = 0
         stash = STASH(lbuser[6], lbuser[3] // 1000, lbuser[3] % 1000)
-        field = mock.MagicMock(lbuser=lbuser, lbfc=lbfc, stash=stash)
+        field = _mock_field(lbuser=lbuser, lbfc=lbfc, stash=stash)
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,
          aux_coords_and_dims) = convert(field)
@@ -334,7 +341,7 @@ class Test_LBFC_CF(iris.tests.unit.fileformats.TestField):
         lbuser = [1, 0, 0, 0, 0, 0, 0]
         lbfc = 16
         stash = STASH(lbuser[6], lbuser[3] // 1000, lbuser[3] % 1000)
-        field = mock.MagicMock(lbuser=lbuser, lbfc=lbfc, stash=stash)
+        field = _mock_field(lbuser=lbuser, lbfc=lbfc, stash=stash)
         (factories, references, standard_name, long_name, units,
          attributes, cell_methods, dim_coords_and_dims,
          aux_coords_and_dims) = convert(field)

--- a/lib/iris/tests/unit/util/test_array_equal.py
+++ b/lib/iris/tests/unit/util/test_array_equal.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -114,6 +114,25 @@ class Test(tests.IrisTest):
         self.assertTrue(array_equal(array_a, 'foobar'))
         self.assertFalse(array_equal(array_a, 'foo'))
         self.assertFalse(array_equal(array_a, 'foobar.'))
+
+    def test_nan_equality_nan_ne_nan(self):
+        array = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+        self.assertFalse(array_equal(array, array))
+
+    def test_nan_equality_nan_naneq_nan(self):
+        array_a = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+        array_b = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+        self.assertTrue(array_equal(array_a, array_b, withnans=True))
+
+    def test_nan_equality_nan_nanne_a(self):
+        array_a = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+        array_b = np.array([1.0, np.nan, 2.0, 0.0, 3.0])
+        self.assertFalse(array_equal(array_a, array_b, withnans=True))
+
+    def test_nan_equality_a_nanne_b(self):
+        array_a = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+        array_b = np.array([1.0, np.nan, 2.0, np.nan, 4.0])
+        self.assertFalse(array_equal(array_a, array_b, withnans=True))
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1062,8 +1062,12 @@ def new_axis(src_cube, scalar_coord=None):
         coord_dims = np.array(src_cube.coord_dims(coord)) + 1
         new_cube.add_dim_coord(coord.copy(), coord_dims)
 
+    nonderived_coords = src_cube.dim_coords + src_cube.aux_coords
+    coord_mapping = {id(old_co): new_cube.coord(old_co)
+                     for old_co in nonderived_coords}
     for factory in src_cube.aux_factories:
-        new_cube.add_aux_factory(copy.deepcopy(factory))
+        new_factory = factory.updated(coord_mapping)
+        new_cube.add_aux_factory(new_factory)
 
     return new_cube
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -332,19 +332,42 @@ def rolling_window(a, window=1, step=1, axis=-1):
     return rw
 
 
-def array_equal(array1, array2):
+def array_equal(array1, array2, withnans=False):
     """
     Returns whether two arrays have the same shape and elements.
 
-    This provides the same functionality as :func:`numpy.array_equal` but with
-    additional support for arrays of strings.
+    Args:
+
+    * array1, array2 (arraylike):
+        args to be compared, after normalising with :func:`np.asarray`.
+
+    Kwargs:
+
+    * withnans (bool):
+        When unset (default), the result is False if either input contains NaN
+        points.  This is the normal floating-point arithmetic result.
+        When set, return True if inputs contain the same value in all elements,
+        _including_ any NaN values.
+
+    This provides much the same functionality as :func:`numpy.array_equal`, but
+    with additional support for arrays of strings and NaN-tolerant operation.
 
     """
     array1, array2 = np.asarray(array1), np.asarray(array2)
-    if array1.shape != array2.shape:
-        eq = False
-    else:
-        eq = bool(np.asarray(array1 == array2).all())
+
+    eq = (array1.shape == array2.shape)
+    if eq:
+        eqs = (array1 == array2)
+
+        if withnans and (array1.dtype.kind == 'f' or array2.dtype.kind == 'f'):
+            nans1, nans2 = np.isnan(array1), np.isnan(array2)
+            if not np.all(nans1 == nans2):
+                eq = False  # simply fail
+            else:
+                eqs[nans1] = True  # fix NaNs; check all the others
+
+        if eq:
+            eq = np.all(eqs)  # check equal at all points
 
     return eq
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,7 +5,7 @@
 
 cartopy
 #conda: proj4<5
-cf_units>=2
+cf-units>=2
 cftime==1.0.1
 dask[array]  #conda: dask
 matplotlib>=2,<3

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,7 +6,7 @@
 cartopy
 #conda: proj4<5
 cf-units>=2
-cftime==1.0.1
+cftime
 dask[array]  #conda: dask
 matplotlib>=2,<3
 netcdf4


### PR DESCRIPTION
There has been a fair amount of additions to the 2.2.x branch that should be merged back into master (especially since we just cut the 2.2.1 release).

To create this PR I did the following commands:

```$ git checkout upstream/v2.2.x -b 221_mergeback_rebase```
Then I did an interactive release to select the commits that were missing 
```$ git rebase -i --onto upstream/master HEAD~12```
Which were all the commits since `c3048cbf Fix for numpy 1v16. (#3257)` as this and `b0d5512b BLD: Pinning cftime to 1.0.1 (#3247)` were included in the last mergeback.