### PR TITLE
Update copyright years in license headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,16 +125,19 @@ install:
     fi
 
 script:
-  - if [[ $TEST_TARGET == 'default' ]]; then
-      python -m iris.tests.runner --default-tests --system-tests --coding-tests --print-failed-images --num-processors=3;
-    fi
-  - if [[ $TEST_TARGET == 'example' ]]; then
-      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=3;
-    fi
-
   # Capture install-dir: As a test command must be last for get Travis to check
   # the RC, so it's best to start each operation with an absolute cd.
   - INSTALL_DIR=$(pwd)
+
+  - >
+    if [[ $TEST_TARGET == 'default' ]]; then
+      export IRIS_REPO_DIR=$INSTALL_DIR;
+      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=3;
+    fi
+
+  - if [[ $TEST_TARGET == 'example' ]]; then
+      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=3;
+    fi
 
   - >
     if [[ $TEST_TARGET == 'doctest' ]]; then

--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/experimental/stratify.py
+++ b/lib/iris/experimental/stratify.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/name_loaders.py
+++ b/lib/iris/fileformats/name_loaders.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/plot/test_vector_plots.py
+++ b/lib/iris/tests/integration/plot/test_vector_plots.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/analysis/test_PROPORTION.py
+++ b/lib/iris/tests/unit/analysis/test_PROPORTION.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/coords/test_AuxCoord.py
+++ b/lib/iris/tests/unit/coords/test_AuxCoord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/util/test_new_axis.py
+++ b/lib/iris/tests/unit/util/test_new_axis.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/requirements/gen_conda_requirements.py
+++ b/requirements/gen_conda_requirements.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
The license header check doesn't run in this branch so we missed a few copyright years that need updating.

This is needed so before we can do the mergeback of this branch (see #3316 )