### PR TITLE
Fix userguide: remove out of date comment

### DIFF
--- a/docs/iris/src/userguide/cube_statistics.rst
+++ b/docs/iris/src/userguide/cube_statistics.rst
@@ -97,10 +97,6 @@ For an example of using this functionality, the
 in the gallery takes a zonal mean of an ``XYT`` cube by using the
 ``collapsed`` method with ``latitude`` and ``iris.analysis.MEAN`` as arguments.
 
-You cannot partially collapse a multi-dimensional coordinate. See
-:ref:`cube.collapsed <partially_collapse_multi-dim_coord>` for more
-information.
-
 .. _cube-statistics-collapsing-average:
 
 Area averaging


### PR DESCRIPTION
Whilst building the docs I came across a warning complaining that the label `partially_collapse_multi-dim_coord` was undefined.

Turns out it was removed in [this PR](https://github.com/SciTools/iris/pull/3028/files) which was part of the 2.1 release.

I am adding this to the 2.2.x branch as it breaks the build of the 2.2.1 docs.

This fix will get added into master as part of a mergeback