### PR TITLE
Add another missing sphinx import

### DIFF
--- a/docs/iris/src/sphinxext/custom_class_autodoc.py
+++ b/docs/iris/src/sphinxext/custom_class_autodoc.py
@@ -21,6 +21,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *
 from sphinx.util import force_decode
+from sphinx.util.docstrings import prepare_docstring
 
 import inspect
 


### PR DESCRIPTION
Similar to #3310, the latest release of sphinx has included some things moving around so our import: 
```
 from sphinx.ext.autodoc import *
```
no longer imports everything we need.