### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,27 @@
 # we will use conda to give us a much faster setup time.
 
 
-language: python
-python:
-  - 2.7
-  - 3.6
-sudo: false
+language: minimal
+dist: xenial
 
 env:
-  matrix:
-    - TEST_TARGET=default TEST_MINIMAL=true
-    - TEST_TARGET=default
-    - TEST_TARGET=example
-    - TEST_TARGET=doctest
-
   global:
     # The decryption key for the encrypted .github/deploy_key.scitools-docs.enc.
     - secure: "N9/qBUT5CqfC7KQBDy5mIWZcGNuUJk3e/qmKJpotWYV+zwOI4GghJsRce6nFnlRiwl65l5oBEcvf3+sBvUfbZqh7U0MdHpw2tHhr2FSCmMB3bkvARZblh9M37f4da9G9VmRkqnyBM5G5TImXtoq4dusvNWKvLW0qETciaipq7ws="
+  matrix:
+    - PYTHON_VERSION=2.7 TEST_TARGET=default TEST_MINIMAL=true
+    - PYTHON_VERSION=2.7 TEST_TARGET=default
+    - PYTHON_VERSION=2.7 TEST_TARGET=example
+
+    - PYTHON_VERSION=3.6 TEST_TARGET=default TEST_MINIMAL=true
+    - PYTHON_VERSION=3.6 TEST_TARGET=default
+    - PYTHON_VERSION=3.6 TEST_TARGET=example
+    - PYTHON_VERSION=3.6 TEST_TARGET=doctest
+
+    - PYTHON_VERSION=3.7 TEST_TARGET=default TEST_MINIMAL=true
+    - PYTHON_VERSION=3.7 TEST_TARGET=default
+    - PYTHON_VERSION=3.7 TEST_TARGET=example
+    - PYTHON_VERSION=3.7 TEST_TARGET=doctest
 
 git:
   # We need a deep clone so that we can compute the age of the files using their git history.
@@ -31,27 +36,18 @@ install:
     export IRIS_TEST_DATA_REF="dba47566a9147645fea586f94a138e0a8d45a48e";
     export IRIS_TEST_DATA_SUFFIX=$(echo "${IRIS_TEST_DATA_REF}" | sed "s/^v//");
 
-  # Cut short doctest phase under Python 2 : now only supports Python 3
-  # SEE : https://github.com/SciTools/iris/pull/3134
-  # ------------
-  - >
-    if [[ $TEST_TARGET == 'doctest' && ${TRAVIS_PYTHON_VERSION} != 3* ]]; then
-        echo "DOCTEST phase only valid in Python 3 : ABORTING during 'install'."
-        exit 0
-    fi
-
   # Install miniconda
   # -----------------
   - >
     echo 'Installing miniconda';
-    export CONDA_BASE=https://repo.continuum.io/miniconda/Miniconda;
-    if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+    export CONDA_BASE="https://repo.continuum.io/miniconda/Miniconda";
+    if [[ "${PYTHON_VERSION}" == 2* ]]; then
       wget --quiet ${CONDA_BASE}2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget --quiet ${CONDA_BASE}3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi;
-    bash miniconda.sh -b -p $HOME/miniconda;
-    export PATH="$HOME/miniconda/bin:$PATH";
+    bash miniconda.sh -b -p ${HOME}/miniconda;
+    export PATH="${HOME}/miniconda/bin:${PATH}";
 
   # Create the basic testing environment
   # ------------------------------------
@@ -63,8 +59,8 @@ install:
     conda config --add channels conda-forge;
     conda update --quiet conda;
     ENV_NAME='test-environment';
-    conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION pip;
-    source activate $ENV_NAME;
+    conda create --quiet -n ${ENV_NAME} python=${PYTHON_VERSION} pip;
+    source activate ${ENV_NAME};
 
   # Customise the testing environment
   # ---------------------------------
@@ -72,26 +68,26 @@ install:
     echo 'Install Iris dependencies';
     CONDA_REQS_FLAGS="";
     CONDA_REQS_GROUPS="test";
-    if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+    if [[ "${PYTHON_VERSION}" == 2* ]]; then
         CONDA_REQS_FLAGS="${CONDA_REQS_FLAGS} --py2";
     fi;
-    if [[ "$TEST_MINIMAL" != true ]]; then
+    if [[ "${TEST_MINIMAL}" != true ]]; then
         CONDA_REQS_GROUPS="${CONDA_REQS_GROUPS} all";
     fi;
     if [[ "${TEST_TARGET}" == 'doctest' ]]; then
         CONDA_REQS_GROUPS="${CONDA_REQS_GROUPS} docs";
     fi;
-    CONDA_REQS_FILE=conda-requirements.txt;
+    CONDA_REQS_FILE="conda-requirements.txt";
     python requirements/gen_conda_requirements.py ${CONDA_REQS_FLAGS} --groups ${CONDA_REQS_GROUPS} > ${CONDA_REQS_FILE};
     cat ${CONDA_REQS_FILE};
-    conda install --quiet -n $ENV_NAME --file ${CONDA_REQS_FILE};
+    conda install --quiet -n ${ENV_NAME} --file ${CONDA_REQS_FILE};
 
-  - PREFIX=$HOME/miniconda/envs/$ENV_NAME
+  - PREFIX="${HOME}/miniconda/envs/${ENV_NAME}"
 
   # Output debug info
   - >
-    conda list -n $ENV_NAME;
-    conda list -n $ENV_NAME --explicit;
+    conda list -n ${ENV_NAME};
+    conda list -n ${ENV_NAME} --explicit;
     conda info -a;
 
 # Pre-load Natural Earth data to avoid multiple, overlapping downloads.
@@ -100,7 +96,7 @@ install:
 
 # iris test data
   - >
-    if [[ "$TEST_MINIMAL" != true ]]; then
+    if [[ "${TEST_MINIMAL}" != true ]]; then
       wget --quiet -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip;
       unzip -q iris-test-data.zip;
       mv "iris-test-data-${IRIS_TEST_DATA_SUFFIX}" iris-test-data;
@@ -108,19 +104,19 @@ install:
 
 # set config paths
   - >
-    SITE_CFG=lib/iris/etc/site.cfg;
-    echo "[Resources]" > $SITE_CFG;
-    echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> $SITE_CFG;
-    echo "doc_dir = $(pwd)/docs/iris" >> $SITE_CFG;
-    echo "[System]" >> $SITE_CFG;
-    echo "udunits2_path = $PREFIX/lib/libudunits2.so" >> $SITE_CFG;
+    SITE_CFG="lib/iris/etc/site.cfg";
+    echo "[Resources]" > ${SITE_CFG};
+    echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> ${SITE_CFG};
+    echo "doc_dir = $(pwd)/docs/iris" >> ${SITE_CFG};
+    echo "[System]" >> ${SITE_CFG};
+    echo "udunits2_path = ${PREFIX}/lib/libudunits2.so" >> ${SITE_CFG};
 
   - python setup.py --quiet install
 
   # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.
-  - if [[ "$TEST_MINIMAL" != true && ${TRAVIS_PYTHON_VERSION} == 2* ]]; then
-        conda install --quiet -n $ENV_NAME python-ecmwf_grib;
+  - if [[ "${TEST_MINIMAL}" != true && ${PYTHON_VERSION} == 2* ]]; then
+        conda install --quiet -n ${ENV_NAME} python-ecmwf_grib;
         pip install git+https://github.com/SciTools/iris-grib.git@v0.11.0;
     fi
 
@@ -130,22 +126,22 @@ script:
   - INSTALL_DIR=$(pwd)
 
   - >
-    if [[ $TEST_TARGET == 'default' ]]; then
-      export IRIS_REPO_DIR=$INSTALL_DIR;
-      python -m iris.tests.runner --default-tests --system-tests --print-failed-images --num-processors=3;
+    if [[ ${TEST_TARGET} == 'default' ]]; then
+      export IRIS_REPO_DIR=${INSTALL_DIR};
+      python -m iris.tests.runner --default-tests --system-tests --print-failed-images;
     fi
 
-  - if [[ $TEST_TARGET == 'example' ]]; then
-      python -m iris.tests.runner --example-tests --print-failed-images --num-processors=3;
+  - if [[ ${TEST_TARGET} == 'example' ]]; then
+      python -m iris.tests.runner --example-tests --print-failed-images;
     fi
 
   - >
-    if [[ $TEST_TARGET == 'doctest' ]]; then
-      MPL_RC_DIR=$HOME/.config/matplotlib;
-      mkdir -p $MPL_RC_DIR;
-      echo 'backend : agg' > $MPL_RC_DIR/matplotlibrc;
-      echo 'image.cmap : viridis' >> $MPL_RC_DIR/matplotlibrc;
-      cd $INSTALL_DIR/docs/iris;
+    if [[ ${TEST_TARGET} == 'doctest' ]]; then
+      MPL_RC_DIR="${HOME}/.config/matplotlib";
+      mkdir -p ${MPL_RC_DIR};
+      echo 'backend : agg' > ${MPL_RC_DIR}/matplotlibrc;
+      echo 'image.cmap : viridis' >> ${MPL_RC_DIR}/matplotlibrc;
+      cd ${INSTALL_DIR}/docs/iris;
       make clean html && make doctest;
     fi
 
@@ -153,8 +149,8 @@ script:
   - ORG=(${TRAVIS_REPO_SLUG//\// })
 
   # When we merge a change, and we are running in python 3, push some docs. 
-  - if [[ $TEST_TARGET == 'doctest' && ${TRAVIS_EVENT_TYPE} == 'push' && ${TRAVIS_PYTHON_VERSION} == 3* && ${ORG} == "SciTools" ]]; then
-      cd $INSTALL_DIR;
+  - if [[ ${TEST_TARGET} == 'doctest' && ${TRAVIS_EVENT_TYPE} == 'push' && ${TRAVIS_PYTHON_VERSION} == 3* && ${ORG} == "SciTools" ]]; then
+      cd ${INSTALL_DIR};
       pip install doctr;
       doctr deploy --deploy-repo SciTools-docs/iris --built-docs docs/iris/build/html
         --key-path .github/deploy_key.scitools-docs.enc
@@ -164,7 +160,7 @@ script:
 
   # An extra call to check "whatsnew" contributions are valid, because the
   # Iris test for it needs a *developer* install to be able to find the docs.
-  - if [[ $TEST_TARGET == 'doctest' ]]; then
-      cd $INSTALL_DIR/docs/iris/src/whatsnew;
+  - if [[ ${TEST_TARGET} == 'doctest' ]]; then
+      cd ${INSTALL_DIR}/docs/iris/src/whatsnew;
       python aggregate_directory.py --checkonly;
     fi

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -291,15 +291,17 @@ class TestBasicMaths(tests.IrisTest):
         self.assertCMLApproxData(b, ('analysis', 'apply_ifunc_frompyfunc.cml'))
 
     def test_ifunc_init_fail(self):
+        import six
 
         # should fail because 'blah' is a string not a python function
         self.assertRaises(TypeError, iris.analysis.maths.IFunc, 'blah',
                           lambda cube: cf_units.Unit('1'))
 
-        # should fail because math.sqrt is built-in function, which can not be
-        # used in inspect.getargspec
-        self.assertRaises(TypeError, iris.analysis.maths.IFunc, math.sqrt,
-                          lambda cube: cf_units.Unit('1'))
+        if six.PY2:
+            # should fail because math.sqrt is built-in function, which can not be
+            # used in inspect.getargspec
+            self.assertRaises(TypeError, iris.analysis.maths.IFunc, math.sqrt,
+                              lambda cube: cf_units.Unit('1'))
 
         # should fail because np.frexp gives 2 arrays as output
         self.assertRaises(ValueError, iris.analysis.maths.IFunc, np.frexp,

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -298,8 +298,8 @@ class TestBasicMaths(tests.IrisTest):
                           lambda cube: cf_units.Unit('1'))
 
         if six.PY2:
-            # should fail because math.sqrt is built-in function, which can not be
-            # used in inspect.getargspec
+            # should fail because math.sqrt is built-in function, which cannot
+            # be used in inspect.getargspec
             self.assertRaises(TypeError, iris.analysis.maths.IFunc, math.sqrt,
                               lambda cube: cf_units.Unit('1'))
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -7,7 +7,7 @@ cartopy
 #conda: proj4<5
 cf-units>=2
 cftime
-dask[array]  #conda: dask
+dask[array]<2  #conda: dask<2
 matplotlib>=2,<3
 netcdf4
 numpy>=1.14


### PR DESCRIPTION
This PR fixes the travis-ci tests. It also tidies the `.travis-ci` script some what.

Additionally, it also extends the testing to incorporate Python 3.7. So now we have coverage of Python 2.7, 3.6 and 3.7.... well, I say 2.7, but not for long :wink: 

Note that, we need to pin to `dask<2` as there is some odd behaviour that is difficult to track-down and resolve for 3.6 and 3.7. As such, I've create this issue https://github.com/SciTools/iris/issues/3349.

I'm only happy to pin short-term, and investigate (and fix) the underlying issue asap, but pinning seems appropriate here in order to unblock PRs with successful CI.

Note that, I've moved to `language: minimal`, as this may speed-up the spin-up time of travis, see [Travis CI - Minimal and Generic Images](https://docs.travis-ci.com/user/languages/minimal-and-generic/). Also, since we're using `miniconda` to control our use of packages and Python, there is actually no need to use Python as provisioned with a Travis CI `language: python` image.