### PR TITLE
Save docs patch

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2080,8 +2080,8 @@ def save(cube, target, append=False, field_coords=None):
                          for slicing.
 
     See also :func:`iris.io.save`. Note that :func:`iris.save` is the preferred
-    method of saving. This allows an iris.cube.CubeList or a sequence of cubes
-    to be saved to a PP file.
+    method of saving. This allows an :class:`iris.cube.CubeList` or a sequence
+    of cubes to be saved to a PP file.
 
     """
     fields = as_fields(cube, field_coords, target)

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2079,7 +2079,9 @@ def save(cube, target, append=False, field_coords=None):
                          If None, the final two  dimensions are chosen
                          for slicing.
 
-    See also :func:`iris.io.save`.
+    See also :func:`iris.io.save`. Note that :func:`iris.save` is the preferred
+    method of saving. This allows an iris.cube.CubeList or a sequence of cubes
+    to be saved to a PP file.
 
     """
     fields = as_fields(cube, field_coords, target)

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2080,7 +2080,7 @@ def save(cube, target, append=False, field_coords=None):
                          for slicing.
 
     See also :func:`iris.io.save`. Note that :func:`iris.save` is the preferred
-    method of saving. This allows an :class:`iris.cube.CubeList` or a sequence
+    method of saving. This allows a :class:`iris.cube.CubeList` or a sequence
     of cubes to be saved to a PP file.
 
     """


### PR DESCRIPTION
This adds documentation requested in #425. The documentation that only Cubes can be passed was already added in #1952.