### PR TITLE
Unpin dask

### DIFF
--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -64,7 +64,7 @@ class Test__create_field_data(tests.IrisTest):
         field = mock.Mock(core_data=core_data)
         data_shape = (100, 120)
         proxy = mock.Mock(dtype=np.dtype('f4'), shape=data_shape,
-                          spec=pp.PPDataProxy)
+                          spec=pp.PPDataProxy, ndim=len(data_shape))
         # We can't directly inspect the concrete data source underlying
         # the dask array, so instead we patch the proxy creation and check it's
         # being created and invoked correctly.

--- a/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -34,6 +34,7 @@ class MyProxy(object):
     def __init__(self, a):
         self.shape = a.shape
         self.dtype = a.dtype
+        self.ndim = a.ndim
         self.a = a
 
     def __getitem__(self, keys):

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2018 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -36,6 +36,7 @@ class ArrayAccessCounter(object):
     def __init__(self, array):
         self.dtype = array.dtype
         self.shape = array.shape
+        self.ndim = array.ndim
         self._array = array
         self.access_count = 0
 

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -72,15 +72,29 @@ class Test_co_realise_cubes(tests.IrisTest):
         self.assertTrue(cube_inner.has_lazy_data())
 
     def test_combined_access(self):
+        import dask
+        from distutils.version import StrictVersion as Version
+
         wrapped_array = ArrayAccessCounter(np.arange(3.))
         lazy_array = as_lazy_data(wrapped_array)
         derived_a = lazy_array + 1
         derived_b = lazy_array + 2
+        derived_c = lazy_array + 3
         cube_a = Cube(derived_a)
         cube_b = Cube(derived_b)
-        co_realise_cubes(cube_a, cube_b)
-        # Though used twice, the source data should only get fetched once.
-        self.assertEqual(wrapped_array.access_count, 1)
+        cube_c = Cube(derived_c)
+        co_realise_cubes(cube_a, cube_b, cube_c)
+        # Though used more than once, the source data should only get fetched
+        # once by dask.
+        if Version(dask.__version__) < Version('2.0.0'):
+            self.assertEqual(wrapped_array.access_count, 1)
+        else:
+            # dask 2+, now performs an initial data access with no data payload
+            # to ascertain the metadata associated with the dask.array, thus
+            # accounting for one additional access to the data from the
+            # perspective of this particular unit test.
+            # See dask.array.utils.meta_from_array
+            self.assertEqual(wrapped_array.access_count, 2)
 
 
 if __name__ == '__main__':

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -7,7 +7,7 @@ cartopy
 #conda: proj4<5
 cf-units>=2
 cftime
-dask[array]<2  #conda: dask<2
+dask[array]  #conda: dask
 matplotlib>=2,<3
 netcdf4
 numpy>=1.14


### PR DESCRIPTION
This PR undoes the temporary workaround implemented by PR https://github.com/SciTools/iris/pull/3350, which pinned `dask<2`.

The latest version of `dask` version `2.1.0` (only a few days old now) resolves the outstanding `stack overflow` issues avoided by our pin. 

Also see https://github.com/ESMValGroup/ESMValTool/issues/1188 for further details.