### PR TITLE
Chunk control

### DIFF
--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -60,9 +60,9 @@ def is_lazy_data(data):
     return result
 
 
-def _optimise_chunksize(chunks, shape,
-                        limit=None,
-                        dtype=np.dtype('f4')):
+def _optimum_chunksize(chunks, shape,
+                       limit=None,
+                       dtype=np.dtype('f4')):
     """
     Reduce or increase an initial chunk shape to get close to a chosen ideal
     size, while prioritising the splitting of the earlier (outer) dimensions
@@ -177,7 +177,7 @@ def as_lazy_data(data, chunks=None, asarray=False):
         chunks = list(data.shape)
 
     # Expand or reduce the basic chunk shape to an optimum size.
-    chunks = _optimise_chunksize(chunks, shape=data.shape)
+    chunks = _optimum_chunksize(chunks, shape=data.shape, dtype=data.dtype)
 
     if isinstance(data, ma.core.MaskedConstant):
         data = ma.masked_array(data.data, mask=data.mask)

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -23,7 +23,10 @@ To avoid replicating implementation-dependent test and conversion code.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-from collections import Iterable
+try:  # Python 3
+    from collections.abc import Iterable
+except ImportError:  # Python 2
+    from collections import Iterable
 from functools import wraps
 
 import dask

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -510,8 +510,10 @@ def _get_cf_var_data(cf_var, filename):
                          netCDF4.default_fillvals[cf_var.dtype.str[1:]])
     proxy = NetCDFDataProxy(cf_var.shape, dtype, filename, cf_var.cf_name,
                             fill_value)
+    # Get the chunking specified for the variable : this is either a shape, or
+    # maybe the string "contiguous".
     chunks = cf_var.cf_data.chunking()
-    # Chunks can be an iterable, or `'contiguous'`.
+    # In the "contiguous" case, pass chunks=None to 'as_lazy_data'.
     if chunks == 'contiguous':
         chunks = None
     return as_lazy_data(proxy, chunks=chunks)

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -511,7 +511,7 @@ def _get_cf_var_data(cf_var, filename):
     proxy = NetCDFDataProxy(cf_var.shape, dtype, filename, cf_var.cf_name,
                             fill_value)
     chunks = cf_var.cf_data.chunking()
-    # Chunks can be an iterable, None, or `'contiguous'`.
+    # Chunks can be an iterable, or `'contiguous'`.
     if chunks == 'contiguous':
         chunks = None
     return as_lazy_data(proxy, chunks=chunks)

--- a/lib/iris/tests/unit/analysis/test_RMS.py
+++ b/lib/iris/tests/unit/analysis/test_RMS.py
@@ -92,8 +92,7 @@ class Test_aggregate(tests.IrisTest):
 class Test_lazy_aggregate(tests.IrisTest):
     def test_1d(self):
         # 1-dimensional input.
-        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
-                            chunks=-1)
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64))
         rms = RMS.lazy_aggregate(data, 0)
         expected_rms = 4.5
         self.assertAlmostEqual(rms, expected_rms)
@@ -101,16 +100,14 @@ class Test_lazy_aggregate(tests.IrisTest):
     def test_2d(self):
         # 2-dimensional input.
         data = as_lazy_data(np.array([[5, 2, 6, 4], [12, 4, 10, 8]],
-                                     dtype=np.float64),
-                            chunks=-1)
+                                     dtype=np.float64))
         expected_rms = np.array([4.5, 9.0], dtype=np.float64)
         rms = RMS.lazy_aggregate(data, 1)
         self.assertArrayAlmostEqual(rms, expected_rms)
 
     def test_1d_weighted(self):
         # 1-dimensional input with weights.
-        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
-                            chunks=-1)
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64))
         weights = np.array([1, 4, 3, 2], dtype=np.float64)
         expected_rms = 8.0
         # https://github.com/dask/dask/issues/3846.
@@ -120,10 +117,8 @@ class Test_lazy_aggregate(tests.IrisTest):
 
     def test_1d_lazy_weighted(self):
         # 1-dimensional input with lazy weights.
-        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64),
-                            chunks=-1)
-        weights = as_lazy_data(np.array([1, 4, 3, 2], dtype=np.float64),
-                               chunks=-1)
+        data = as_lazy_data(np.array([4, 7, 10, 8], dtype=np.float64))
+        weights = as_lazy_data(np.array([1, 4, 3, 2], dtype=np.float64))
         expected_rms = 8.0
         # https://github.com/dask/dask/issues/3846.
         with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):
@@ -133,8 +128,7 @@ class Test_lazy_aggregate(tests.IrisTest):
     def test_2d_weighted(self):
         # 2-dimensional input with weights.
         data = as_lazy_data(np.array([[4, 7, 10, 8], [14, 16, 20, 8]],
-                                     dtype=np.float64),
-                            chunks=-1)
+                                     dtype=np.float64))
         weights = np.array([[1, 4, 3, 2], [2, 1, 1.5, 0.5]], dtype=np.float64)
         expected_rms = np.array([8.0, 16.0], dtype=np.float64)
         # https://github.com/dask/dask/issues/3846.
@@ -144,8 +138,7 @@ class Test_lazy_aggregate(tests.IrisTest):
 
     def test_unit_weighted(self):
         # Unit weights should be the same as no weights.
-        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64),
-                            chunks=-1)
+        data = as_lazy_data(np.array([5, 2, 6, 4], dtype=np.float64))
         weights = np.ones_like(data)
         expected_rms = 4.5
         # https://github.com/dask/dask/issues/3846.
@@ -157,8 +150,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         # Masked entries should be completely ignored.
         data = as_lazy_data(ma.array([5, 10, 2, 11, 6, 4],
                             mask=[False, True, False, True, False, False],
-                            dtype=np.float64),
-                            chunks=-1)
+                            dtype=np.float64))
         expected_rms = 4.5
         rms = RMS.lazy_aggregate(data, 0)
         self.assertAlmostEqual(rms, expected_rms)
@@ -169,8 +161,7 @@ class Test_lazy_aggregate(tests.IrisTest):
         # For now, masked weights are simply not supported.
         data = as_lazy_data(ma.array([4, 7, 18, 10, 11, 8],
                             mask=[False, False, True, False, True, False],
-                            dtype=np.float64),
-                            chunks=-1)
+                            dtype=np.float64))
         weights = np.array([1, 4, 5, 3, 8, 2])
         expected_rms = 8.0
         with self.assertRaisesRegexp(TypeError, 'unexpected keyword argument'):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1475,9 +1475,7 @@ class Test_copy(tests.IrisTest):
         self._check_copy(cube, cube.copy())
 
     def test__lazy(self):
-        # Note: multiple chunks added as a workaround suggested to dask#3751,
-        # which is fixed in dask#3754.
-        cube = Cube(as_lazy_data(np.array([1, 0]), chunks=(1, 1)))
+        cube = Cube(as_lazy_data(np.array([1, 0])))
         self._check_copy(cube, cube.copy())
 
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
@@ -26,7 +26,7 @@ import iris.tests as tests
 from dask.array import Array as dask_array
 import numpy as np
 
-from iris._lazy_data import _optimise_chunksize
+from iris._lazy_data import _optimum_chunksize
 import iris.fileformats.cf
 from iris.fileformats.netcdf import _get_cf_var_data
 from iris.tests import mock
@@ -36,7 +36,7 @@ class Test__get_cf_var_data(tests.IrisTest):
     def setUp(self):
         self.filename = 'DUMMY'
         self.shape = (300000, 240, 200)
-        self.expected_chunks = _optimise_chunksize(self.shape, self.shape)
+        self.expected_chunks = _optimum_chunksize(self.shape, self.shape)
 
     def _make(self, chunksizes):
         cf_data = mock.Mock(_FillValue=None)
@@ -59,12 +59,12 @@ class Test__get_cf_var_data(tests.IrisTest):
         cf_var = self._make(chunks)
         lazy_data = _get_cf_var_data(cf_var, self.filename)
         lazy_data_chunks = [c[0] for c in lazy_data.chunks]
-        expected_chunks = _optimise_chunksize(chunks, self.shape)
+        expected_chunks = _optimum_chunksize(chunks, self.shape)
         self.assertArrayEqual(lazy_data_chunks, expected_chunks)
 
     def test_cf_data_no_chunks(self):
         # No chunks means chunks are calculated from the array's shape by
-        # `iris._lazy_data._optimise_chunksize()`.
+        # `iris._lazy_data._optimum_chunksize()`.
         chunks = None
         cf_var = self._make(chunks)
         lazy_data = _get_cf_var_data(cf_var, self.filename)

--- a/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
@@ -26,7 +26,7 @@ import iris.tests as tests
 from dask.array import Array as dask_array
 import numpy as np
 
-from iris._lazy_data import _limited_shape
+from iris._lazy_data import _optimised_chunks
 import iris.fileformats.cf
 from iris.fileformats.netcdf import _get_cf_var_data
 from iris.tests import mock
@@ -36,7 +36,7 @@ class Test__get_cf_var_data(tests.IrisTest):
     def setUp(self):
         self.filename = 'DUMMY'
         self.shape = (3, 240, 200)
-        self.expected_chunks = _limited_shape(self.shape)
+        self.expected_chunks = _optimised_chunks(self.shape)
 
     def _make(self, chunksizes):
         cf_data = mock.Mock(_FillValue=None)
@@ -63,7 +63,7 @@ class Test__get_cf_var_data(tests.IrisTest):
 
     def test_cf_data_no_chunks(self):
         # No chunks means chunks are calculated from the array's shape by
-        # `iris._lazy_data._limited_shape()`.
+        # `iris._lazy_data._optimised_chunks()`.
         chunks = None
         cf_var = self._make(chunks)
         lazy_data = _get_cf_var_data(cf_var, self.filename)

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -125,18 +125,6 @@ class Test__optimised_chunks(tests.IrisTest):
                                     shape=test_shape,
                                     dtype=np.dtype('f4'))])
 
-    def test_large_specific_chunk_passthrough(self):
-        # Check that even a too-large specific 'chunks' arg is honoured.
-        limitcall_patch = self.patch('iris._lazy_data._optimum_chunksize')
-        huge_test_shape = (1001, 1002, 1003, 1004)
-        data = self._dummydata(huge_test_shape)
-        result = as_lazy_data(data, chunks=huge_test_shape)
-        self.assertEqual(limitcall_patch.call_args_list,
-                         [mock.call(huge_test_shape,
-                                    shape=huge_test_shape,
-                                    dtype=np.dtype('f4'))])
-        self.assertEqual(result.shape, huge_test_shape)
-
     def test_shapeless_data(self):
         # Check that chunk optimisation is skipped if shape contains a zero.
         limitcall_patch = self.patch('iris._lazy_data._optimum_chunksize')
@@ -144,7 +132,6 @@ class Test__optimised_chunks(tests.IrisTest):
         data = self._dummydata(test_shape)
         result = as_lazy_data(data, chunks=test_shape)
         self.assertFalse(limitcall_patch.called)
-        self.assertEqual(result.shape, test_shape)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -27,7 +27,6 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
-import iris._lazy_data
 from iris._lazy_data import as_lazy_data, _MAX_CHUNK_SIZE, _optimise_chunksize
 from iris.tests import mock
 

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -99,7 +99,7 @@ class Test__optimised_chunks(tests.IrisTest):
     def test_chunk_size_expanding(self):
         # Check the default chunksizes for small data.
         given_shapes_and_resulting_chunks = [
-            ((1, 100, 100), (16, 100, 100), (16, 100, 100)),  # largest unmodified
+            ((1, 100, 100), (16, 100, 100), (16, 100, 100)),  # large case
             ((1, 100, 100), (5000, 100, 100), (1677, 100, 100)),
             ((3, 300, 200), (10000, 3000, 2000), (3, 2700, 2000)),
             ((3, 300, 200), (10000, 300, 2000), (27, 300, 2000)),
@@ -112,7 +112,8 @@ class Test__optimised_chunks(tests.IrisTest):
             self.assertEqual(chunks, expected, msg)
 
     def test_default_chunks_limiting(self):
-        # Check that chunking is still controlled when no specific 'chunks' given.
+        # Check that chunking is still controlled when no specific 'chunks'
+        # is passed.
         limitcall_patch = self.patch('iris._lazy_data._optimise_chunksize')
         test_shape = (3, 2, 4)
         data = self._dummydata(test_shape)

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -130,7 +130,7 @@ class Test__optimised_chunks(tests.IrisTest):
         limitcall_patch = self.patch('iris._lazy_data._optimum_chunksize')
         test_shape = (2, 1, 0, 2)
         data = self._dummydata(test_shape)
-        result = as_lazy_data(data, chunks=test_shape)
+        as_lazy_data(data, chunks=test_shape)
         self.assertFalse(limitcall_patch.called)
 
 

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -50,21 +50,11 @@ class Test_as_lazy_data(tests.IrisTest):
         self.assertIsInstance(result, da.core.Array)
 
     def test_non_default_chunks(self):
-        data = np.arange(30)
-        chunks = 12
-        old_limit = iris._lazy_data._MAX_CHUNK_SIZE
-        iris._lazy_data._MAX_CHUNK_SIZE = 25
+        data = np.arange(24)
+        chunks = (12,)
         lazy_data = as_lazy_data(data, chunks=chunks)
-        iris._lazy_data._MAX_CHUNK_SIZE = old_limit
-        result = lazy_data.chunks[0][0]
-        self.assertEqual(result, 24)
-
-    def test_non_default_chunks__chunks_already_set(self):
-        chunks = 12
-        data = da.from_array(np.arange(24), chunks=chunks)
-        lazy_data = as_lazy_data(data)
         result, = np.unique(lazy_data.chunks)
-        self.assertEqual(result, chunks)
+        self.assertEqual(result, 24)
 
     def test_with_masked_constant(self):
         masked_data = ma.masked_array([8], mask=True)

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -120,8 +120,8 @@ class Test__optimised_chunks(tests.IrisTest):
             # A multi-dimensional case, where trailing dims are 'filled'.
             ((4, 5, 100), (25, 10, 200), 16*2000, (16, 10, 200)),
             # Equivalent case with additional initial dimensions.
-             ((1, 1, 4, 5, 100), (3, 5, 25, 10, 200), 16*2000,
-              (1, 1, 16, 10, 200)),  # effectively the same as the previous.
+            ((1, 1, 4, 5, 100), (3, 5, 25, 10, 200), 16*2000,
+             (1, 1, 16, 10, 200)),  # effectively the same as the previous.
         ]
         err_fmt_main = ('Main chunks result of optimising '
                         'chunks={},shape={},limit={} '

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -137,6 +137,15 @@ class Test__optimised_chunks(tests.IrisTest):
                                     dtype=np.dtype('f4'))])
         self.assertEqual(result.shape, huge_test_shape)
 
+    def test_shapeless_data(self):
+        # Check that chunk optimisation is skipped if shape contains a zero.
+        limitcall_patch = self.patch('iris._lazy_data._optimum_chunksize')
+        test_shape = (2, 1, 0, 2)
+        data = self._dummydata(test_shape)
+        result = as_lazy_data(data, chunks=test_shape)
+        self.assertFalse(limitcall_patch.called)
+        self.assertEqual(result.shape, test_shape)
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -93,10 +93,11 @@ class Test__optimised_chunks(tests.IrisTest):
         # Check the expansion of small chunks, (with a known size limit).
         given_shapes_and_resulting_chunks = [
             ((1, 100, 100), (16, 100, 100), (16, 100, 100)),
-            ((1, 100, 100), (5000, 100, 100), (1677, 100, 100)),
-            ((3, 300, 200), (10000, 3000, 2000), (3, 2700, 2000)),
+            ((1, 100, 100), (5000, 100, 100), (1667, 100, 100)),
+            ((3, 300, 200), (10000, 3000, 2000), (3, 1500, 2000)),
             ((3, 300, 200), (10000, 300, 2000), (27, 300, 2000)),
             ((3, 300, 200), (8, 300, 2000), (8, 300, 2000)),
+            ((3, 300, 200), (117, 300, 1000), (39, 300, 1000)),
         ]
         err_fmt = 'Result of optimising shape={};chunks={} was {}, expected {}'
         for (shape, fullshape, expected) in given_shapes_and_resulting_chunks:
@@ -104,6 +105,82 @@ class Test__optimised_chunks(tests.IrisTest):
                                         limit=self.FIXED_CHUNKSIZE_LIMIT)
             msg = err_fmt.format(fullshape, shape, chunks, expected)
             self.assertEqual(chunks, expected, msg)
+
+    def test_chunk_expanding_equal_division(self):
+        # Check that expansion chooses equal chunk sizes as far as possible.
+
+        # Table of test cases:
+        # (input-chunks, full-shape, size-limit, result, division)
+        # Note : "division" is the resulting sizes of the chunks in the
+        #     outermost chunked dimension (see code below).
+        testcases_chunksin_shape_limit_chunksout_division = [
+            # Simple 1-D cases : chunk multiples with increasing target shape
+            ((4,), (5,), 15, (5,), [5]),
+            ((4,), (12,), 15, (12,), [12]),
+            ((4,), (13,), 15, (8,), [8, 5]),
+            ((4,), (15,), 15, (8,), [8, 7]),
+            ((4,), (16,), 15, (8,), [8, 8]),
+            ((4,), (17,), 15, (12,), [12, 5]),
+            ((4,), (23,), 15, (12,), [12, 11]),
+            ((4,), (24,), 15, (12,), [12, 12]),
+            ((4,), (25,), 15, (12,), [12, 12, 1]),
+            ((4,), (96,), 15, (12,), [12, 12, 12, 12, 12, 12, 12, 12]),
+            ((4,), (96,), 16, (16,), [16, 16, 16, 16, 16, 16]),
+            ((4,), (96,), 21, (20,), [20, 20, 20, 20, 16]),
+            ((4,), (96,), 24, (24,), [24, 24, 24, 24]),
+            ((4,), (96,), 28, (24,), [24, 24, 24, 24]),
+            ((4,), (97,), 28, (28,), [28, 28, 28, 13]),
+            ((4,), (96,), 32, (32,), [32, 32, 32]),
+            # multi-dimensional cases, similar but trailing dims are 'full'.
+            ((4, 10, 100), (12, 10, 200), 16*2000, (12, 10, 200), [12]),
+            ((4, 10, 100), (12, 10*2, 200/2), 16*2000, (12, 20, 100), [12]),
+            ((4, 10, 100), (12, 10/2, 200*2), 16*2000, (12, 5, 400), [12]),
+            ((4, 10, 100), (15, 10, 200), 16*2000, (15, 10, 200), [15]),
+            ((4, 10, 100), (16, 10, 200), 16*2000, (16, 10, 200), [16]),
+            ((4, 10, 100), (17, 10, 200), 16*2000, (12, 10, 200), [12, 5]),
+            ((4, 10, 100), (23, 10, 200), 16*2000, (12, 10, 200), [12, 11]),
+            ((4, 10, 100), (24, 10, 200), 16*2000, (12, 10, 200), [12, 12]),
+            ((4, 10, 100), (25, 10, 200), 16*2000, (16, 10, 200), [16, 9]),
+            # an equivalent testcase with extra initial dimensions (undivided).
+            ((1, 1, 4, 10, 100), (3, 5, 25, 10, 200), 16*2000,
+                (1, 1, 16, 10, 200), [16, 9]),
+            # some further 'ordinary' multidimensional cases.
+            ((4, 10, 100), (31, 10, 200), 16*2000, (16, 10, 200), [16, 15]),
+            ((4, 10, 100), (32, 10, 200), 16*2000, (16, 10, 200), [16, 16]),
+            ((4, 10, 100), (81, 10, 200), 16*2000, (16, 10, 200),
+                [16, 16, 16, 16, 16, 1]),
+        ]
+        err_fmt_main = ('Main chunks result of optimising '
+                        'chunks={},shape={},limit={} '
+                        'was {}, expected {}')
+        err_fmt_division = ('\nDivision result from optimising '
+                            'chunks={},shape={},limit={} : '
+                            ' was {}, expected {}')
+        for (chunks, shape, limit, expect_chunks, expect_division) in \
+                testcases_chunksin_shape_limit_chunksout_division:
+            result = _optimum_chunksize(chunks=chunks,
+                                        shape=shape,
+                                        limit=limit,
+                                        dtype=np.dtype('b1'))
+            msg = err_fmt_main.format(chunks, shape, limit,
+                                      result, expect_chunks)
+            self.assertEqual(result, expect_chunks, msg)
+
+            # From result, make a list of chunk sizes in the outer chunked dim.
+            i_chunked_dim = [ind for ind, dim in enumerate(result)
+                             if dim > 1][0]
+            chunksize = result[i_chunked_dim]
+            fullsize = shape[i_chunked_dim]
+            n_full_chunks = int(np.floor(fullsize / chunksize))
+            division = [chunksize] * n_full_chunks
+            n_rest = int(fullsize - n_full_chunks * chunksize)
+            if n_rest > 0:
+                # Chunksize is not an exact fit, so add a final, partial chunk.
+                division += [n_rest]
+            # Check the calculated division, too.
+            msg = err_fmt_division.format(chunks, shape, limit, division,
+                                          expect_division)
+            self.assertEqual(division, expect_division, msg)
 
     def test_default_chunksize(self):
         # Check that the "ideal" chunksize is taken from the dask config.

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -27,7 +27,7 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
-from iris._lazy_data import as_lazy_data, _MAX_CHUNK_SIZE, _limited_shape
+from iris._lazy_data import as_lazy_data, _MAX_CHUNK_SIZE, _optimised_chunks
 from iris.tests import mock
 
 
@@ -53,7 +53,7 @@ class Test_as_lazy_data(tests.IrisTest):
         chunks = 12
         lazy_data = as_lazy_data(data, chunks=chunks)
         result, = np.unique(lazy_data.chunks)
-        self.assertEqual(result, chunks)
+        self.assertEqual(result, 24)
 
     def test_non_default_chunks__chunks_already_set(self):
         chunks = 12
@@ -68,6 +68,8 @@ class Test_as_lazy_data(tests.IrisTest):
         result = as_lazy_data(masked_constant)
         self.assertIsInstance(result, da.core.Array)
 
+
+class Test__optimised_chunks(tests.IrisTest):
     @staticmethod
     def _dummydata(shape):
         return mock.Mock(spec=da.core.Array,
@@ -84,28 +86,45 @@ class Test_as_lazy_data(tests.IrisTest):
             ((17, 1, 1011, 1022), (8, 1, 1011, 1022)),
             ((11, 2, 1011, 1022), (5, 2, 1011, 1022))
         ]
-        err_fmt = 'Result of reducing shape {} was {}, expected {}'
+        err_fmt = 'Result of optimising chunks {} was {}, expected {}'
         for (shape, expected) in given_shapes_and_resulting_chunks:
-            chunks = _limited_shape(shape)
+            chunks = _optimised_chunks(shape)
             msg = err_fmt.format(shape, chunks, expected)
+            self.assertEqual(chunks, expected, msg)
+
+    def test_chunk_size_expanding(self):
+        # Check the default chunksizes for small data.
+        given_shapes_and_resulting_chunks = [
+            ((1, 100, 100), (16, 100, 100), (16, 100, 100)),  # largest unmodified
+            ((1, 100, 100), (5000, 100, 100), (420, 100, 100)),
+            ((3, 300, 200), (10000, 3000, 2000), (3, 900, 2000)),
+            ((3, 300, 200), (10000, 300, 2000), (9, 300, 2000)),
+            ((3, 300, 200), (8, 300, 2000), (8, 300, 2000)),
+        ]
+        err_fmt = 'Result of optimising shape={}/chunks={} was {}, expected {}'
+        for (shape, fullshape, expected) in given_shapes_and_resulting_chunks:
+            chunks = _optimised_chunks(shape, full_shape=fullshape)
+            msg = err_fmt.format(fullshape, shape, chunks, expected)
             self.assertEqual(chunks, expected, msg)
 
     def test_default_chunks_limiting(self):
         # Check that chunking is limited when no specific 'chunks' given.
-        limitcall_patch = self.patch('iris._lazy_data._limited_shape')
+        limitcall_patch = self.patch('iris._lazy_data._optimised_chunks')
         test_shape = (3, 2, 4)
         data = self._dummydata(test_shape)
         as_lazy_data(data)
         self.assertEqual(limitcall_patch.call_args_list,
-                         [mock.call(test_shape)])
+                         [mock.call(list(test_shape), full_shape=test_shape)])
 
     def test_large_specific_chunk_passthrough(self):
         # Check that even a too-large specific 'chunks' arg is honoured.
-        limitcall_patch = self.patch('iris._lazy_data._limited_shape')
+        limitcall_patch = self.patch('iris._lazy_data._optimised_chunks')
         huge_test_shape = (1001, 1002, 1003, 1004)
         data = self._dummydata(huge_test_shape)
         result = as_lazy_data(data, chunks=huge_test_shape)
-        self.assertEqual(limitcall_patch.call_args_list, [])
+        self.assertEqual(limitcall_patch.call_args_list,
+                         [mock.call(huge_test_shape,
+                                    full_shape=huge_test_shape)])
         self.assertEqual(result.shape, huge_test_shape)
 
 

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_is_lazy_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,13 +26,13 @@ import iris.tests as tests
 import dask.array as da
 import numpy as np
 
-from iris._lazy_data import is_lazy_data, _MAX_CHUNK_SIZE
+from iris._lazy_data import is_lazy_data
 
 
 class Test_is_lazy_data(tests.IrisTest):
     def test_lazy(self):
         values = np.arange(30).reshape((2, 5, 3))
-        lazy_array = da.from_array(values, chunks=_MAX_CHUNK_SIZE)
+        lazy_array = da.from_array(values, chunks='auto')
         self.assertTrue(is_lazy_data(lazy_array))
 
     def test_real(self):


### PR DESCRIPTION
Revised chunking policy, which will mostly affect loading from netcdf files.
Key change : allows multiplying up as well as dividing chunks, mainly to fix the #3357.

Closes #3357 #3362