### PR TITLE
Coord.collapsed:  lazy points should stay lazy

### DIFF
--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -280,6 +280,13 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
             self.assertArrayEqual(collapsed_coord.bounds,
                                   [[coord.bounds.min(), coord.bounds.max()]])
 
+    def test_lazy_points(self):
+        # Lazy points should stay lazy after collapse.
+        coord = AuxCoord(points=da.from_array(np.arange(5), chunks=5))
+        collapsed_coord = coord.collapsed()
+        self.assertTrue(collapsed_coord.has_lazy_bounds())
+        self.assertTrue(collapsed_coord.has_lazy_points())
+
     def test_numeric_nd(self):
         coord = AuxCoord(points=np.array([[1, 2, 4, 5],
                                           [4, 5, 7, 8],


### PR DESCRIPTION
As noted at #3363, when an AuxCoord with lazy points is collapsed, the points are currently realised in the process.  This was inadvertently fixed by #3302, but I thought it worth adding a test as well.

Once #3302 is merged, I can rebase and then this new test should pass.