### PR TITLE
Dress naked excepts #2

### DIFF
--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -25,7 +25,7 @@ import six
 
 try:  # Python 3
     from collections.abc import Iterable, Mapping
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterable, Mapping
 import operator
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -53,7 +53,7 @@ import six
 from collections import OrderedDict
 try:  # Python 3
     from collections.abc import Iterable
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterable
 from functools import wraps
 

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,10 +22,11 @@ Basic mathematical and statistical operations.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-import warnings
+import inspect
 import math
 import operator
-import inspect
+import six
+import warnings
 
 import cf_units
 import numpy as np
@@ -917,9 +918,15 @@ class IFunc(object):
         if hasattr(data_func, 'nin'):
             self.nin = data_func.nin
         else:
-            (args, varargs, keywords, defaults) = inspect.getargspec(data_func)
-            self.nin = len(args) - (
-                len(defaults) if defaults is not None else 0)
+            if six.PY2:
+                (args, _, _, defaults) = inspect.getargspec(data_func)
+                self.nin = len(args) - (
+                    len(defaults) if defaults is not None else 0)
+            else:
+                sig = inspect.signature(data_func)
+                args = [param for param in sig.parameters.values()
+                        if '=' not in str(param)]
+                self.nin = len(args)
 
         if self.nin not in [1, 2]:
             msg = ('{} requires {} input data arrays, the IFunc class '

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -925,7 +925,8 @@ class IFunc(object):
             else:
                 sig = inspect.signature(data_func)
                 args = [param for param in sig.parameters.values()
-                        if '=' not in str(param)]
+                        if (param.kind != param.KEYWORD_ONLY and
+                            param.default is param.empty)]
                 self.nin = len(args)
 
         if self.nin not in [1, 2]:

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -27,7 +27,7 @@ from abc import ABCMeta, abstractproperty
 from collections import namedtuple
 try:  # Python 3
     from collections.abc import Iterator
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterator
 import copy
 from itertools import chain

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -31,7 +31,7 @@ try:  # Python 3
                                  Mapping,
                                  MutableMapping,
                                  Iterator)
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import (Iterable,
                              Container,
                              Mapping,

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -33,7 +33,7 @@ from abc import ABCMeta, abstractmethod
 
 try:  # Python 3
     from collections.abc import Iterable, MutableMapping
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterable, MutableMapping
 import os
 import re

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -57,7 +57,7 @@ import six
 
 try:  # Python 3
     from collections.abc import Callable
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Callable
 import functools
 import os

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -24,7 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 try:  # Python 3
     from collections.abc import Iterator
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterator
 import itertools
 import warnings

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -602,8 +602,7 @@ class TestIFunc(tests.IrisTest):
         self.assertArrayAlmostEqual(b.data, b2.data)
 
         cs_ifunc = iris.analysis.maths.IFunc(np.cumsum,
-                   lambda a: a.units
-                   )
+                   lambda a: a.units)
 
         b = cs_ifunc(a, axis=1)
         ans = a.data.copy()

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -596,13 +596,13 @@ class TestIFunc(tests.IrisTest):
         def vec_mag_data_func(u_data, v_data):
             return np.sqrt( u_data**2 + v_data**2 )
 
-        vec_mag_ifunc = iris.analysis.maths.IFunc(vec_mag_data_func, lambda a,b: (a + b).units)
+        vec_mag_ifunc = iris.analysis.maths.IFunc(vec_mag_data_func,
+                                                  lambda a, b: (a + b).units)
         b2 = vec_mag_ifunc(a, c)
 
         self.assertArrayAlmostEqual(b.data, b2.data)
 
-        cs_ifunc = iris.analysis.maths.IFunc(np.cumsum,
-                   lambda a: a.units)
+        cs_ifunc = iris.analysis.maths.IFunc(np.cumsum, lambda a: a.units)
 
         b = cs_ifunc(a, axis=1)
         ans = a.data.copy()

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -28,7 +28,7 @@ import iris.tests as tests
 
 try:  # Python 3
     from collections.abc import Iterable
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Iterable
 import datetime
 import itertools

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -25,7 +25,7 @@ import six
 
 try:  # Python 3
     from collections.abc import Hashable
-except:  # Python 2.7
+except ImportError:  # Python 2.7
     from collections import Hashable
 import abc
 from contextlib import contextmanager


### PR DESCRIPTION
Replaces #3366,
just so we can resolve in @bjlittle absence

Original head
> This PR fixes the iris travis-ci tests after moving to the latest numpy 1.17.0 - and it also follows-up from #3320 to dress the naked try...excepts with an ImportError

Closes #3365  (ref [old comment](https://github.com/SciTools/iris/pull/3366#issuecomment-519952864))