### PR TITLE
Mentioned random CubeList order in the docs

### DIFF
--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -52,7 +52,12 @@ The ``air_potential_temperature`` cubes were 4 dimensional with:
      The result of :func:`iris.load` is **always** a 
      :class:`list of cubes <iris.cube.CubeList>`. 
      Anything that can be done with a Python :class:`list` can be done 
-     with the resultant list of cubes.
+     with the resultant list of cubes. It is worth noting, however, that
+     there is no inherent order to this
+     :class:`list of cubes <iris.cube.CubeList>`.
+     Because of this, indexing may be inconsistent. A more consistent way to
+     extract a cube is by using the :class:`iris.Constraint` class as
+     described in :ref:`constrained`.
 
 .. hint::
 
@@ -145,6 +150,8 @@ This is referred to as 'lazy' data.  It allows loading to be much quicker, and t
 
 For more on the benefits, handling and uses of lazy data, see :doc:`Real and Lazy Data </userguide/real_and_lazy_data>`.
 
+
+.. _constrained:
 
 Constrained loading
 -----------------------

--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -57,7 +57,7 @@ The ``air_potential_temperature`` cubes were 4 dimensional with:
      :class:`list of cubes <iris.cube.CubeList>`.
      Because of this, indexing may be inconsistent. A more consistent way to
      extract a cube is by using the :class:`iris.Constraint` class as
-     described in :ref:`constrained`.
+     described in :ref:`constrained-loading`.
 
 .. hint::
 
@@ -151,7 +151,7 @@ This is referred to as 'lazy' data.  It allows loading to be much quicker, and t
 For more on the benefits, handling and uses of lazy data, see :doc:`Real and Lazy Data </userguide/real_and_lazy_data>`.
 
 
-.. _constrained:
+.. _constrained-loading:
 
 Constrained loading
 -----------------------

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -337,7 +337,9 @@ def load(uris, constraints=None, callback=None):
         A modifier/filter function.
 
     Returns:
-        An :class:`iris.cube.CubeList`.
+        An :class:`iris.cube.CubeList`. Note that there is no inherent order
+        to this :class:`iris.cube.CubeList` and it should be treated as if it
+        were random.
 
     """
     return _load_collection(uris, constraints, callback).merged().cubes()
@@ -402,7 +404,9 @@ def load_cubes(uris, constraints=None, callback=None):
         A modifier/filter function.
 
     Returns:
-        An :class:`iris.cube.CubeList`.
+        An :class:`iris.cube.CubeList`. Note that there is no inherent order
+        to this :class:`iris.cube.CubeList` and it should be treated as if it
+        were random.
 
     """
     # Merge the incoming cubes


### PR DESCRIPTION
As requested in #3314, there is now a mention in the documentation of the unordered state of loaded CubeLists.