### PR TITLE
Fix bug with html_repr

### DIFF
--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -271,9 +271,14 @@ class CubeRepresentation(object):
                         title = body.pop(0)
                         colspan = 0
                     else:
-                        split_point = line.index(':')
-                        title = line[:split_point].strip()
-                        body = line[split_point + 2:].strip()
+                        try:
+                            split_point = line.index(':')
+                        except ValueError:
+                            title = ''
+                            body = line.strip()
+                        else:
+                            title = line[:split_point].strip()
+                            body = line[split_point + 2:].strip()
                         colspan = self.ndims
                     elements.extend(
                         self._make_row(title, body=body, col_span=colspan))

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2018-2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -258,6 +258,11 @@ class CubeRepresentation(object):
         row.append('</tr>')
         return row
 
+    def _expand_last_cell(self, element, body):
+        split_point = element.index('</td>')
+        element = element[:split_point] + '<br>' + body + element[split_point:]
+        return element
+
     def _make_content(self):
         elements = []
         for k, v in self.str_headings.items():
@@ -274,8 +279,11 @@ class CubeRepresentation(object):
                         try:
                             split_point = line.index(':')
                         except ValueError:
-                            title = ''
                             body = line.strip()
+                            element = elements[-2]
+                            element = self._expand_last_cell(element, body)
+                            elements[-2] = element
+                            continue
                         else:
                             title = line[:split_point].strip()
                             body = line[split_point + 2:].strip()

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -259,6 +259,7 @@ class CubeRepresentation(object):
         return row
 
     def _expand_last_cell(self, element, body):
+        '''Expand an element containing a cell by adding a new line.'''
         split_point = element.index('</td>')
         element = element[:split_point] + '<br>' + body + element[split_point:]
         return element
@@ -279,7 +280,13 @@ class CubeRepresentation(object):
                         try:
                             split_point = line.index(':')
                         except ValueError:
+                            # When a line exists in v without a ':', we expect
+                            # that this is due to the value of some attribute
+                            # containing multiple lines. We collect all these
+                            # lines in the same cell.
                             body = line.strip()
+                            # We choose the element containing the last cell
+                            # in the last row.
                             element = elements[-2]
                             element = self._expand_last_cell(element, body)
                             elements[-2] = element

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018-2019, Met Office
+# (C) British Crown Copyright 2018 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -291,6 +291,20 @@ class Test__make_row(tests.IrisTest):
 
 
 @tests.skip_data
+class Test__expand_last_cell(tests.IrisTest):
+    def setUp(self):
+        self.cube = stock.simple_3d()
+        self.representer = CubeRepresentation(self.cube)
+        self.representer._get_bits(self.representer._get_lines())
+        col_span = self.representer.ndims
+        self.row = self.representer._make_row('title', body='first',
+                                              col_span=col_span)
+
+    def test_add_line(self):
+        cell = self.representer._expand_last_cell(self.row[-2], 'second')
+        self.assertIn('first<br>second', cell)
+
+@tests.skip_data
 class Test__make_content(tests.IrisTest):
     def setUp(self):
         self.cube = stock.simple_3d()
@@ -311,6 +325,14 @@ class Test__make_content(tests.IrisTest):
         not_included.pop(not_included.index('Dimension coordinates:'))
         for heading in not_included:
             self.assertNotIn(heading, self.result)
+
+    def test_handle_newline(self):
+        cube = self.cube
+        cube.attributes['lines'] = 'first\nsecond'
+        representer = CubeRepresentation(cube)
+        representer._get_bits(representer._get_lines())
+        result = representer._make_content()
+        self.assertIn('first<br>second', result)
 
 
 @tests.skip_data

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -304,6 +304,7 @@ class Test__expand_last_cell(tests.IrisTest):
         cell = self.representer._expand_last_cell(self.row[-2], 'second')
         self.assertIn('first<br>second', cell)
 
+
 @tests.skip_data
 class Test__make_content(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
Fixes the bug with #3351.

Previously, if a cube had an attribute which was a string containing '\n', attempting to get the html_repr of that cube would cause an exception.  This pull request would instead add what is in that new line to a new row of the html_repr.
A cube whose string representation looks like:
```
sea_water_potential_temperature / (degC) (-- : 148; -- : 180)
     Auxiliary coordinates:
          latitude                           x         x
          longitude                          x         x
     Scalar coordinates:
          depth: 4.999938 m, bound=(0.0, 10.0) m
          time: 0001-01-01 12:00:00
     Attributes:
          Conventions: CF-1.5
          history: Wed Jul 10 11:00:19 2019: ncks -A -v LON surface_20150112.nc 1997_mon06.nc4
...
     Cell methods:
          mean: time
```
will now have a html_repr which creates a table looking something like:
<table class="iris" id="140242688578000">
    <tr class="iris">
<th class="iris iris-word-cell">Sea Water Potential Temperature (degC)</th>
<th class="iris iris-word-cell">--</th>
<th class="iris iris-word-cell">--</th>
</tr>
    <tr class="iris">
<td class="iris-word-cell iris-subheading-cell">Shape</td>
<td class="iris iris-inclusion-cell">148</td>
<td class="iris iris-inclusion-cell">180</td>
</td>
    <tr class="iris">
    <td class="iris-title iris-word-cell">Auxiliary coordinates</td>
    <td class="iris-title"></td>
    <td class="iris-title"></td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	latitude</td>
    <td class="iris-inclusion-cell">x</td>
    <td class="iris-inclusion-cell">x</td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	longitude</td>
    <td class="iris-inclusion-cell">x</td>
    <td class="iris-inclusion-cell">x</td>
</tr>
<tr class="iris">
    <td class="iris-title iris-word-cell">Scalar coordinates</td>
    <td class="iris-title"></td>
    <td class="iris-title"></td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	depth</td>
    <td class="iris-word-cell" colspan="2">4.999938 m, bound=(0.0, 10.0) m</td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	time</td>
    <td class="iris-word-cell" colspan="2">0001-01-01 12:00:00</td>
</tr>
<tr class="iris">
    <td class="iris-title iris-word-cell">Attributes</td>
    <td class="iris-title"></td>
    <td class="iris-title"></td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	Conventions</td>
    <td class="iris-word-cell" colspan="2">CF-1.5</td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	history</td>
    <td class="iris-word-cell" colspan="2">Wed Jul 10 11:00:19 2019: ncks -A -v LON surface_20150112.nc 1997_mon06.nc4</td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	</td>
    <td class="iris-word-cell" colspan="2">...</td>
</tr>
<tr class="iris">
    <td class="iris-title iris-word-cell">Cell methods</td>
    <td class="iris-title"></td>
    <td class="iris-title"></td>
</tr>
<tr class="iris">
    <td class="iris-word-cell iris-subheading-cell">	mean</td>
    <td class="iris-word-cell" colspan="2">time</td>
</tr>
</table>

This cube and its representations were created with the following code using attributes taken from #3351:
```
import iris
from iris.experimental.representation import CubeRepresentation

filepath = iris.sample_data_path('orca2_votemper.nc')
cube = iris.load_cube(filepath)

cube.attributes['history'] = "Wed Jul 10 11:00:19 2019: ncks -A -v LON surface_20150112.nc 1997_mon06.nc4\n "+\
                             "Wed Jul 10 10:51:41 2019: cdo splitmon CNRR-GSISAT_hourly_rain_1997.nc4 1997_mon"

print(str(cube))
rep = CubeRepresentation(cube).repr_html()
print(rep)
```