### PR TITLE
Replace version pin on proj4 to permit proj 4 v5.

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -4,6 +4,7 @@
 # Without these, iris won't even import.
 
 cartopy
+#conda: proj4<6
 cf-units>=2
 cftime
 dask[array]  #conda: dask

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -4,7 +4,6 @@
 # Without these, iris won't even import.
 
 cartopy
-#conda: proj4<5
 cf-units>=2
 cftime
 dask[array]  #conda: dask


### PR DESCRIPTION
Simply replaces #3353, which was over-complicated by a different issue

Relates to (but no longer closes)  #3154 

There is a chance we'll have to exclude proj4 >= 6.0 (newly out I think).
But I think cartopy dependencies should sort that out for us.
Here goes ...
