### PR TITLE
Catch failed html_repr for cube

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2561,7 +2561,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         from iris.experimental.representation import CubeRepresentation
 
         representer = CubeRepresentation(self)
-        return representer.repr_html()
+        # Catch exceptions in the html repr rather than passing them,
+        # and so fall back to the default cube repr.
+        try:
+            result = representer.repr_html()
+        except (IndexError, ValueError):
+            result = None
+        finally:
+            return result
 
     def __iter__(self):
         raise TypeError("Cube is not iterable")

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -38,7 +38,6 @@ from iris.exceptions import (
     AncillaryVariableNotFoundError,
     UnitConversionError,
 )
-from iris.experimental.representation import CubeRepresentation
 from iris._lazy_data import as_lazy_data
 import iris.tests.stock as stock
 
@@ -2417,15 +2416,12 @@ class Test__repr_html(tests.IrisTest):
     def test_bad_repr(self):
         # If an html repr fails we don't want it to pass the error.
         cube = stock.simple_3d()
-        bad_attr = {'history': 'First edit\nSecond edit'}
-        cube.attributes.update(bad_attr)
-        representer = CubeRepresentation(cube)
-
-        # Confirm we get an exception when we make the html repr...
-        with self.assertRaisesRegexp(ValueError, 'substring'):
-            representer.repr_html()
-        # ... and that it's not returned by the cube method.
-        self.assertIsNone(cube._repr_html_())
+        with mock.patch(
+                "iris.experimental.representation.CubeRepresentation.repr_html",
+                side_effect=ValueError('Bad substring')):
+            # Confirm the exception when we make the html repr is not returned
+            # by the cube method.
+            self.assertIsNone(cube._repr_html_())
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -38,6 +38,7 @@ from iris.exceptions import (
     AncillaryVariableNotFoundError,
     UnitConversionError,
 )
+from iris.experimental.representation import CubeRepresentation
 from iris._lazy_data import as_lazy_data
 import iris.tests.stock as stock
 
@@ -2409,6 +2410,22 @@ class Test__eq__meta(tests.IrisTest):
         cube2.add_cell_method(cmth1)
         cube2.add_cell_method(cmth2)
         self.assertTrue(cube1 == cube2)
+
+
+@tests.skip_data
+class Test__repr_html(tests.IrisTest):
+    def test_bad_repr(self):
+        # If an html repr fails we don't want it to pass the error.
+        cube = stock.simple_3d()
+        bad_attr = {'history': 'First edit\nSecond edit'}
+        cube.attributes.update(bad_attr)
+        representer = CubeRepresentation(cube)
+
+        # Confirm we get an exception when we make the html repr...
+        with self.assertRaisesRegexp(ValueError, 'substring'):
+            representer.repr_html()
+        # ... and that it's not returned by the cube method.
+        self.assertIsNone(cube._repr_html_())
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2417,8 +2417,9 @@ class Test__repr_html(tests.IrisTest):
         # If an html repr fails we don't want it to pass the error.
         cube = stock.simple_3d()
         with mock.patch(
-                "iris.experimental.representation.CubeRepresentation.repr_html",
-                side_effect=ValueError('Bad substring')):
+            "iris.experimental.representation.CubeRepresentation.repr_html",
+            side_effect=ValueError("Bad substring"),
+        ):
             # Confirm the exception when we make the html repr is not returned
             # by the cube method.
             self.assertIsNone(cube._repr_html_())


### PR DESCRIPTION
In jupyter, if an enhanced repr (such as `_repr_html_`) fails, the exception is raised but the execution continues, also returning the standard repr. This is useful for noting that there's a problem with the `_repr_html_`, but very bad for UX (as reflected in #3351).

As such, here we catch exceptions raised by constructing the html repr and explicitly return `None` so that the default repr is returned instead.