### PR TITLE
Cube HTML repr CSS improvements

### DIFF
--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -285,7 +285,7 @@ class CubeRepresentation(object):
                 for line in v:
                     # Add every other row in the sub-heading.
                     if k in self.dim_desc_coords:
-                        body = re.findall(r'[\w-]+', line)
+                        body = re.findall(r"[\w-]+", line)
                         title = body.pop(0)
                         colspan = 0
                     elif k in self.two_cell_headers:
@@ -314,7 +314,7 @@ class CubeRepresentation(object):
                     elements.extend(
                         self._make_row(title, body=body, col_span=colspan)
                     )
-        return '\n'.join(element for element in elements)
+        return "\n".join(element for element in elements)
 
     def repr_html(self):
         """The `repr` interface for Jupyter."""
@@ -323,7 +323,7 @@ class CubeRepresentation(object):
 
         # Check if we have a scalar cube.
         if self.scalar_cube:
-            shape = ''
+            shape = ""
             # We still need a single content column!
             self.ndims = 1
         else:
@@ -334,7 +334,7 @@ class CubeRepresentation(object):
         # If we only have a single line `cube_str` we have no coords / attrs!
         # We need to handle this case specially.
         if len(lines) == 1:
-            content = ''
+            content = ""
         else:
             self._get_bits(lines)
             content = self._make_content()

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -13,7 +13,7 @@ from html import escape
 import re
 
 
-class CubeRepresentation:
+class CubeRepresentation(object):
     """
     Produce representations of a :class:`~iris.cube.Cube`.
 
@@ -285,7 +285,7 @@ class CubeRepresentation:
                 for line in v:
                     # Add every other row in the sub-heading.
                     if k in self.dim_desc_coords:
-                        body = re.findall(r"[\w-]+", line)
+                        body = re.findall(r'[\w-]+', line)
                         title = body.pop(0)
                         colspan = 0
                     elif k in self.two_cell_headers:
@@ -314,7 +314,7 @@ class CubeRepresentation:
                     elements.extend(
                         self._make_row(title, body=body, col_span=colspan)
                     )
-        return "\n".join(element for element in elements)
+        return '\n'.join(element for element in elements)
 
     def repr_html(self):
         """The `repr` interface for Jupyter."""
@@ -323,7 +323,7 @@ class CubeRepresentation:
 
         # Check if we have a scalar cube.
         if self.scalar_cube:
-            shape = ""
+            shape = ''
             # We still need a single content column!
             self.ndims = 1
         else:
@@ -334,7 +334,7 @@ class CubeRepresentation:
         # If we only have a single line `cube_str` we have no coords / attrs!
         # We need to handle this case specially.
         if len(lines) == 1:
-            content = ""
+            content = ''
         else:
             self._get_bits(lines)
             content = self._make_content()

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -33,24 +33,24 @@ class CubeRepresentation:
   table.iris {{
       white-space: pre;
       border: 1px solid;
-      border-color: #9c9c9c;
-      font-family: monaco, monospace;
+      border-color: var(--jp-border-color2);
+      font-family: var(--jp-code-font-family);
   }}
   th.iris {{
-      background: #303f3f;
-      color: #e0e0e0;
+      background: var(--jp-layout-color4);
+      color: var(--jp-ui-inverse-font-color1);
       border-left: 1px solid;
-      border-color: #9c9c9c;
-      font-size: 1.05em;
+      border-color: var(--jp-border-color2);
+      font-size: var(--jp-code-font-size);
       min-width: 50px;
-      max-width: 125px;
   }}
   tr.iris :first-child {{
-      border-right: 1px solid #9c9c9c !important;
+      border-right: 1px solid var(--jp-border-color2) !important;
   }}
   td.iris-title {{
-      background: #d5dcdf;
-      border-top: 1px solid #9c9c9c;
+      background: var(--jp-layout-color3);
+      border-top: 1px solid;
+      border-top-color: var(--jp-border-color2);
       font-weight: bold;
   }}
   .iris-word-cell {{


### PR DESCRIPTION
Use CSS variables defined in Jupyterlab for styling custom elements of the cube repr table. The primary advantage of doing this is that the cube html repr table will correctly follow different Jupyterlab themes:

_Light theme:_
![Screenshot 2019-08-27 at 12 00 58](https://user-images.githubusercontent.com/3473068/63766111-624dfe80-c8c2-11e9-97ee-6abea888854f.png)
_Dark theme:_
![Screenshot 2019-08-27 at 12 00 40](https://user-images.githubusercontent.com/3473068/63766117-6548ef00-c8c2-11e9-87e9-263e4c7c4ed2.png)

Also removed `max-width` attribute of table columns.