### PR TITLE
Add dask array html repr to cube html repr

### DIFF
--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -229,7 +229,7 @@ class CubeRepresentation(object):
         try:
             content = self.cube.lazy_data()._repr_html_()
         except AttributeError:
-            content = '&nbsp;'
+            content = "&nbsp;"
         return content
 
     def _make_row(self, title, body=None, col_span=0):
@@ -343,7 +343,7 @@ class CubeRepresentation(object):
         header = self._make_header()
 
         # Add content describing the cube's data attribute.
-        data = self._lazy_data_repr() if self.lazy_data else '&nbsp;'
+        data = self._lazy_data_repr() if self.lazy_data else "&nbsp;"
 
         # Check if we have a scalar cube.
         if self.scalar_cube:
@@ -363,11 +363,13 @@ class CubeRepresentation(object):
             self._get_bits(lines)
             content = self._make_content()
 
-        return self._template.format(header=header,
-                                     id=self.cube_id,
-                                     shape=shape,
-                                     content=content,
-                                     data=data)
+        return self._template.format(
+            header=header,
+            id=self.cube_id,
+            shape=shape,
+            content=content,
+            data=data,
+        )
 
 
 class CubeListRepresentation:

--- a/lib/iris/tests/integration/experimental/test_CubeRepresentation.py
+++ b/lib/iris/tests/integration/experimental/test_CubeRepresentation.py
@@ -172,13 +172,13 @@ class TestLazyDataRepr(tests.IrisTest):
         cube = stock.lat_lon_cube()
         representer = CubeRepresentation(cube)
         result = representer.repr_html()
-        exp_str = '&nbsp;'
+        exp_str = "&nbsp;"
         self.assertIn(exp_str, result)
 
-    @skip('Dask version does not include html repr')
+    @skip("Dask version does not include html repr")
     def test_lazy_data_repr(self):
         # Dask array repr uses an SVG.
-        exp_str = '<svg'
+        exp_str = "<svg"
         representer = CubeRepresentation(self.cube)
         result = representer._lazy_data_repr()
         self.assertIn(exp_str, result)
@@ -186,13 +186,14 @@ class TestLazyDataRepr(tests.IrisTest):
     def test_cannot_repr(self):
         # Test cases where the dask array repr cannot be made.
         cube = mock.MagicMock(spec=self.cube)
-        cube.lazy_data()._repr_html_ = \
-            mock.MagicMock(side_effect=AttributeError)
+        cube.lazy_data()._repr_html_ = mock.MagicMock(
+            side_effect=AttributeError
+        )
         representer = CubeRepresentation(cube)
         result = representer._lazy_data_repr()
-        exp_str = '&nbsp;'
+        exp_str = "&nbsp;"
         self.assertIn(exp_str, result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/integration/experimental/test_CubeRepresentation.py
+++ b/lib/iris/tests/integration/experimental/test_CubeRepresentation.py
@@ -169,8 +169,7 @@ class TestLazyDataRepr(tests.IrisTest):
         self.cube = stock.lazy_data_cube()
 
     def test_not_lazy(self):
-        cube = self.cube
-        _ = cube.data
+        cube = stock.lat_lon_cube()
         representer = CubeRepresentation(cube)
         result = representer.repr_html()
         exp_str = '&nbsp;'

--- a/lib/iris/tests/stock/__init__.py
+++ b/lib/iris/tests/stock/__init__.py
@@ -20,6 +20,7 @@ import iris.aux_factory
 import iris.coords
 import iris.coords as icoords
 from iris.coords import DimCoord, AuxCoord, CellMethod
+import iris._lazy_data as _lazy
 import iris.tests as tests
 from iris.coord_systems import GeogCS, RotatedGeogCS
 from ._stock_2d_latlons import (  # noqa
@@ -50,6 +51,13 @@ def lat_lon_cube():
         coord_system=cs,
     )
     cube.add_dim_coord(coord, 1)
+    return cube
+
+
+def lazy_data_cube():
+    cube = lat_lon_cube()
+    lazy_data = _lazy.as_lazy_data(cube.data)
+    cube.data = lazy_data
     return cube
 
 


### PR DESCRIPTION
Extend the cube html repr to include the html repr of the cube's lazy dask array, if present. If the cube is not lazy or the dask version does not support html repr of arrays then the dask array repr is skipped without erroring.

Here's an example:
![Screenshot 2019-08-28 at 16 29 51](https://user-images.githubusercontent.com/3473068/63870822-a6203100-c9b2-11e9-9af2-bcc68ffae9fa.png)
