### PR TITLE
Fix naming of cubes from abf/abl files

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Aug-29_abf_abl_cube_names.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Aug-29_abf_abl_cube_names.txt
@@ -1,0 +1,1 @@
+* The name of cubes loaded from abf/abl files has been corrected.

--- a/lib/iris/fileformats/abf.py
+++ b/lib/iris/fileformats/abf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2015, Met Office
+# (C) British Crown Copyright 2012 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -118,9 +118,9 @@ class ABFField(object):
 
         # Name.
         if self.format.lower() == "abf":
-            cube.rename("leaf_area_index")
-        elif self.format.lower() == "abl":
             cube.rename("FAPAR")
+        elif self.format.lower() == "abl":
+            cube.rename("leaf_area_index")
         else:
             msg = "Unknown ABF/ABL format: {}".format(self.format)
             raise iris.exceptions.TranslationError(msg)

--- a/lib/iris/tests/results/abf/load.cml
+++ b/lib/iris/tests/results/abf/load.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="uint8" standard_name="leaf_area_index" units="%">
+  <cube dtype="uint8" long_name="FAPAR" units="%">
     <attributes>
       <attribute name="source" value="Boston University"/>
     </attributes>


### PR DESCRIPTION
The abf/abl file loader was setting the name of the cubes incorrectly.

On [this page](http://wap.sciencenet.cn/home.php?mod=space&mobile=1&do=blog&id=889834&id=889834) explaining the LAI3g & FPAR3g datasets it states that:
abl <- LAI3g
abf <- FPAR3g
as opposed to what we currently have