### PR TITLE
Support Standard Name Modifiers

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Sep-02_standard_name_modifiers.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Sep-02_standard_name_modifiers.txt
@@ -1,0 +1,1 @@
+* Iris now supports standard name modifiers. See `Appendix C, Standard Name Modifiers <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#standard-name-modifiers>`_ for more information.

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1075,6 +1075,7 @@ fc_extras
     import iris.exceptions
     import iris.std_names
     import iris.util
+    from iris._cube_coord_common import get_valid_standard_name
     from iris._lazy_data import as_lazy_data
 
 
@@ -1186,13 +1187,16 @@ fc_extras
         cube.long_name = long_name
 
         if standard_name is not None:
-            if standard_name in iris.std_names.STD_NAMES:
-                cube.standard_name = standard_name
-            else:
-                if cube.long_name is not None:
-                    cube.attributes['invalid_standard_name'] = standard_name
+            try:
+                cube.standard_name = get_valid_standard_name(standard_name)
+            except ValueError as e:
+                if str(e) != '{!r} is not a valid standard_name'.format(standard_name):
+                    raise
                 else:
-                    cube.long_name = standard_name
+                    if cube.long_name is not None:
+                        cube.attributes['invalid_standard_name'] = standard_name
+                    else:
+                        cube.long_name = standard_name
 
         # Determine the cube units.
         attr_units = get_attr_units(cf_var, cube.attributes)
@@ -1523,19 +1527,25 @@ fc_extras
         cf_name = str(cf_coord_var.cf_name)
 
         if standard_name is not None:
-            if standard_name not in iris.std_names.STD_NAMES:
-                if long_name is not None:
-                    attributes['invalid_standard_name'] = standard_name
-                    if coord_name is not None:
-                        standard_name = coord_name
-                    else:
-                        standard_name = None
+            try:
+                standard_name = get_valid_standard_name(standard_name)
+            except ValueError as e:
+                if str(e) != '{!r} is not a valid standard_name'.format(standard_name):
+                    raise
                 else:
-                    if coord_name is not None:
+                    if long_name is not None:
                         attributes['invalid_standard_name'] = standard_name
-                        standard_name = coord_name
+                        if coord_name is not None:
+                            standard_name = coord_name
+                        else:
+                            standard_name = None
                     else:
-                        standard_name = None
+                        if coord_name is not None:
+                            attributes['invalid_standard_name'] = standard_name
+                            standard_name = coord_name
+                        else:
+                            standard_name = None
+
         else:
             if coord_name is not None:
                 standard_name = coord_name

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1536,7 +1536,6 @@ fc_extras
                         standard_name = coord_name
                     else:
                         standard_name = None
-                        long_name = standard_name
         else:
             if coord_name is not None:
                 standard_name = coord_name

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -74,6 +74,13 @@ reference_terms = dict(atmosphere_sigma_coordinate=['ps'],
                        ocean_s_coordinate_g1=['eta', 'depth'],
                        ocean_s_coordinate_g2=['eta', 'depth'])
 
+# Supported standard name modifiers and their associated units. Ref: [CF]
+# Appendix C.
+STD_NAME_MODIFIERS_UNITS = ['detection_minimum',
+                            'number_of_observations',
+                            'standard_error',
+                            'status_flag']
+
 
 # NetCDF returns a different type for strings depending on Python version.
 def _is_str_dtype(var):

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -427,6 +427,16 @@ class TestScalarCube(tests.IrisTest):
             iris.save(cube, fout)
             scalar_cube = iris.load_cube(fout)
             self.assertEqual(scalar_cube.name(), 'scalar_cube')
+
+
+class TestStandardName(tests.IrisTest):
+    def test_standard_name_roundtrip(self):
+        standard_name = 'air_temperature detection_minimum'
+        cube = iris.cube.Cube(1, standard_name=standard_name)
+        with self.temp_filename(suffix='.nc') as fout:
+            iris.save(cube, fout)
+            scalar_cube = iris.load_cube(fout)
+            self.assertEqual(scalar_cube.standard_name, standard_name)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube_coord_common/__init__.py
+++ b/lib/iris/tests/unit/cube_coord_common/__init__.py
@@ -1,0 +1,20 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris._cube_coord_common` module."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -1,0 +1,48 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the :class:`iris._cube_coord_common.CFVariableMixin`.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from iris._cube_coord_common import CFVariableMixin
+
+
+class Test_standard_name__setter(tests.IrisTest):
+    def test_valid_standard_name(self):
+        cf_var = CFVariableMixin()
+        cf_var.standard_name = 'air_temperature'
+
+    def test_invalid_standard_name(self):
+        cf_var = CFVariableMixin()
+        emsg = "'not_a_standard_name' is not a valid standard_name"
+        with self.assertRaisesRegexp(ValueError, emsg):
+            cf_var.standard_name = 'not_a_standard_name'
+
+    def test_none_standard_name(self):
+        cf_var = CFVariableMixin()
+        cf_var.standard_name = None
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -1,0 +1,70 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the :func:`iris._cube_coord_common.get_valid_standard_name`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from iris._cube_coord_common import get_valid_standard_name
+
+
+class Test(tests.IrisTest):
+    def setUp(self):
+        self.emsg = "'{}' is not a valid standard_name"
+
+    def test_valid_standard_name(self):
+        name = 'air_temperature'
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_invalid_standard_name(self):
+        name = 'not_a_standard_name'
+        with self.assertRaisesRegexp(ValueError, self.emsg.format(name)):
+            get_valid_standard_name(name)
+
+    def test_valid_standard_name_valid_modifier(self):
+        name = 'air_temperature standard_error'
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_valid_standard_name_valid_modifier_extra_spaces(self):
+        name = 'air_temperature      standard_error'
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_invalid_standard_name_valid_modifier(self):
+        name = 'not_a_standard_name standard_error'
+        with self.assertRaisesRegexp(ValueError, self.emsg.format(name)):
+            get_valid_standard_name(name)
+
+    def test_valid_standard_invalid_name_modifier(self):
+        name = 'air_temperature extra_names standard_error'
+        with self.assertRaisesRegexp(ValueError, self.emsg.format(name)):
+            get_valid_standard_name(name)
+
+    def test_valid_standard_valid_name_modifier_extra_names(self):
+        name = 'air_temperature standard_error extra words'
+        with self.assertRaisesRegexp(ValueError, self.emsg.format(name)):
+            get_valid_standard_name(name)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -35,33 +35,33 @@ from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
 from iris.tests import mock
 
 
+def _make_engine(global_attributes=None, standard_name=None, long_name=None):
+    if global_attributes is None:
+        global_attributes = {}
+
+    cf_group = mock.Mock(global_attributes=global_attributes)
+
+    cf_var = mock.Mock(
+        cf_name='wibble',
+        standard_name=standard_name,
+        long_name=long_name,
+        units='m',
+        dtype=np.float64,
+        cell_methods=None,
+        cf_group=cf_group)
+
+    engine = mock.Mock(
+        cube=Cube([23]),
+        cf_var=cf_var)
+
+    return engine
+
+
 class TestInvalidGlobalAttributes(tests.IrisTest):
-    @staticmethod
-    def _make_engine(global_attributes=None):
-        if global_attributes is None:
-            global_attributes = {}
-
-        cf_group = mock.Mock(global_attributes=global_attributes)
-
-        cf_var = mock.Mock(
-            cf_name='wibble',
-            standard_name=None,
-            long_name=None,
-            units='m',
-            dtype=np.float64,
-            cell_methods=None,
-            cf_group=cf_group)
-
-        engine = mock.Mock(
-            cube=Cube([23]),
-            cf_var=cf_var)
-
-        return engine
-
     def test_valid(self):
         global_attributes = {'Conventions': 'CF-1.5',
                              'comment': 'Mocked test object'}
-        engine = self._make_engine(global_attributes)
+        engine = _make_engine(global_attributes)
         build_cube_metadata(engine)
         expected = global_attributes
         self.assertEqual(engine.cube.attributes, expected)
@@ -70,7 +70,7 @@ class TestInvalidGlobalAttributes(tests.IrisTest):
         global_attributes = {'Conventions': 'CF-1.5',
                              'comment': 'Mocked test object',
                              'calendar': 'standard'}
-        engine = self._make_engine(global_attributes)
+        engine = _make_engine(global_attributes)
         with mock.patch('warnings.warn') as warn:
             build_cube_metadata(engine)
         # Check for a warning.
@@ -82,6 +82,51 @@ class TestInvalidGlobalAttributes(tests.IrisTest):
         global_attributes.pop('calendar')
         expected = global_attributes
         self.assertEqual(engine.cube.attributes, expected)
+
+
+class TestCubeName(tests.IrisTest):
+    def check_cube_names(self, inputs, expected):
+        # Inputs - attributes on the fake CF Variable.
+        standard_name, long_name = inputs
+        # Expected - The expected cube attributes.
+        exp_standard_name, exp_long_name = expected
+
+        engine = _make_engine(standard_name=standard_name, long_name=long_name)
+        build_cube_metadata(engine)
+
+        # Check the cube's standard name and long name are as expected.
+        self.assertEqual(engine.cube.standard_name, exp_standard_name)
+        self.assertEqual(engine.cube.long_name, exp_long_name)
+
+    def test_standard_name_none_long_name_none(self):
+        inputs = (None, None)
+        expected = (None, None)
+        self.check_cube_names(inputs, expected)
+
+    def test_standard_name_none_long_name_set(self):
+        inputs = (None, 'ice_thickness_long_name')
+        expected = (None, 'ice_thickness_long_name')
+        self.check_cube_names(inputs, expected)
+
+    def test_standard_name_valid_long_name_none(self):
+        inputs = ('sea_ice_thickness', None)
+        expected = ('sea_ice_thickness', None)
+        self.check_cube_names(inputs, expected)
+
+    def test_standard_name_valid_long_name_set(self):
+        inputs = ('sea_ice_thickness', 'ice_thickness_long_name')
+        expected = ('sea_ice_thickness', 'ice_thickness_long_name')
+        self.check_cube_names(inputs, expected)
+
+    def test_standard_name_invalid_long_name_none(self):
+        inputs = ('not_a_standard_name', None)
+        expected = (None, 'not_a_standard_name',)
+        self.check_cube_names(inputs, expected)
+
+    def test_standard_name_invalid_long_name_set(self):
+        inputs = ('not_a_standard_name', 'ice_thickness_long_name')
+        expected = (None, 'ice_thickness_long_name')
+        self.check_cube_names(inputs, expected)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_names.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_names.py
@@ -1,0 +1,258 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test function :func:`iris.fileformats._pyke_rules.compiled_krb.\
+fc_rules_cf_fc.get_names`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+import numpy as np
+
+from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import get_names
+from iris.tests import mock
+
+
+class TestGetNames(tests.IrisTest):
+    """
+    The tests included in this class cover all the variations of possible
+    combinations of the following inputs:
+    * standard_name = [None, 'projection_y_coordinate', 'latitude_coordinate']
+    * long_name = [None, 'lat_long_name']
+    * var_name = ['grid_latitude', 'lat_var_name']
+    * coord_name = [None, 'latitude']
+
+    standard_name, var_name and coord_name each contain a different valid CF
+    standard name so that it is clear which is being used to set the resulting
+    standard_name.
+
+    """
+    @staticmethod
+    def _make_cf_var(standard_name, long_name, cf_name):
+        cf_var = mock.Mock(
+            cf_name=cf_name,
+            standard_name=standard_name,
+            long_name=long_name,
+            units='degrees',
+            dtype=np.float64,
+            cell_methods=None,
+            cf_group=mock.Mock(global_attributes={}))
+        return cf_var
+
+    def check_names(self, inputs, expected):
+        # Inputs - attributes on the fake CF Variable. Note: coord_name is
+        # optionally set in some pyke rules.
+        standard_name, long_name, var_name, coord_name = inputs
+        # Expected - The expected names and attributes.
+        exp_std_name, exp_long_name, exp_var_name, exp_attributes = expected
+
+        cf_var = self._make_cf_var(standard_name=standard_name,
+                                   long_name=long_name, cf_name=var_name)
+        attributes = {}
+        res_standard_name, res_long_name, res_var_name = get_names(
+            cf_var, coord_name, attributes)
+
+        # Check the names and attributes are as expected.
+        self.assertEqual(res_standard_name, exp_std_name)
+        self.assertEqual(res_long_name, exp_long_name)
+        self.assertEqual(res_var_name, exp_var_name)
+        self.assertEqual(attributes, exp_attributes)
+
+    def test_var_name_valid(self):
+        # Only var_name is set and it is set to a valid standard_name.
+        inp = (None, None, 'grid_latitude', None)
+        exp = ('grid_latitude', None, 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_var_name_valid_coord_name_set(self):
+        # var_name is a valid standard_name, coord_name is also set.
+        inp = (None, None, 'grid_latitude', 'latitude')
+        exp = ('latitude', None, 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_var_name_invalid(self):
+        # Only var_name is set but it is not a valid standard_name.
+        inp = (None, None, 'lat_var_name', None)
+        exp = (None, None, 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_var_name_invalid_coord_name_set(self):
+        # var_name is not a valid standard_name, the coord_name is also set.
+        inp = (None, None, 'lat_var_name', 'latitude')
+        exp = ('latitude', None, 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_long_name_set_var_name_valid(self):
+        # long_name is not None, var_name is set to a valid standard_name.
+        inp = (None, 'lat_long_name', 'grid_latitude', None)
+        exp = ('grid_latitude', 'lat_long_name', 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_long_name_set_var_name_valid_coord_name_set(self):
+        # long_name is not None, var_name is set to a valid standard_name, and
+        # coord_name is set.
+        inp = (None, 'lat_long_name', 'grid_latitude', 'latitude')
+        exp = ('latitude', 'lat_long_name', 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_long_name_set_var_name_invalid(self):
+        # long_name is not None, var_name is not set to a valid standard_name.
+        inp = (None, 'lat_long_name', 'lat_var_name', None)
+        exp = (None, 'lat_long_name', 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_long_name_set_var_name_invalid_coord_name_set(self):
+        # long_name is not None, var_name is not set to a valid standard_name,
+        # and coord_name is set.
+        inp = (None, 'lat_long_name', 'lat_var_name', 'latitude')
+        exp = ('latitude', 'lat_long_name', 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_var_name_valid(self):
+        # standard_name is a valid standard name, var_name is a valid standard
+        # name.
+        inp = ('projection_y_coordinate', None, 'grid_latitude', None)
+        exp = ('projection_y_coordinate', None, 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_var_name_valid_coord_name_set(self):
+        # standard_name is a valid standard name, var_name is a valid standard
+        # name, coord_name is set.
+        inp = ('projection_y_coordinate', None, 'grid_latitude', 'latitude')
+        exp = ('projection_y_coordinate', None, 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_var_name_invalid(self):
+        # standard_name is a valid standard name, var_name is not a valid
+        # standard name.
+        inp = ('projection_y_coordinate', None, 'lat_var_name', None)
+        exp = ('projection_y_coordinate', None, 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_var_name_invalid_coord_name_set(self):
+        # standard_name is a valid standard name, var_name is not a valid
+        # standard name, coord_name is set.
+        inp = ('projection_y_coordinate', None, 'lat_var_name', 'latitude')
+        exp = ('projection_y_coordinate', None, 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_long_name_set_var_name_valid(self):
+        # standard_name is a valid standard name, long_name is not None,
+        # var_name is a valid standard name.
+        inp = ('projection_y_coordinate', 'lat_long_name', 'grid_latitude',
+               None)
+        exp = ('projection_y_coordinate', 'lat_long_name', 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_long_name_set_var_name_valid_coord_name_set(self):
+        # standard_name is a valid standard name, long_name is not None,
+        # var_name is a valid standard name, coord_name is set.
+        inp = ('projection_y_coordinate', 'lat_long_name', 'grid_latitude',
+               'latitude')
+        exp = ('projection_y_coordinate', 'lat_long_name', 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_long_name_set_var_name_invalid(self):
+        # standard_name is a valid standard name, long_name is not None,
+        # var_name is not a valid standard name.
+        inp = ('projection_y_coordinate', 'lat_long_name', 'lat_var_name',
+               None)
+        exp = ('projection_y_coordinate', 'lat_long_name', 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_valid_long_name_set_var_name_invalid_coord_name_set(
+            self):
+        # standard_name is a valid standard name, long_name is not None,
+        # var_name is not a valid standard name, coord_name is set.
+        inp = ('projection_y_coordinate', 'lat_long_name', 'lat_var_name',
+               'latitude')
+        exp = ('projection_y_coordinate', 'lat_long_name', 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_var_name_valid(self):
+        # standard_name is not a valid standard name, var_name is a valid
+        # standard name.
+        inp = ('latitude_coord', None, 'grid_latitude', None)
+        exp = ('grid_latitude', None, 'grid_latitude', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_var_name_valid_coord_name_set(self):
+        # standard_name is not a valid standard name, var_name is a valid
+        # standard name, coord_name is set.
+        inp = ('latitude_coord', None, 'grid_latitude', 'latitude')
+        exp = ('latitude', None, 'grid_latitude',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_var_name_invalid(self):
+        # standard_name is not a valid standard name, var_name is not a valid
+        # standard name.
+        inp = ('latitude_coord', None, 'lat_var_name', None)
+        exp = (None, None, 'lat_var_name', {})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_var_name_invalid_coord_name_set(self):
+        # standard_name is not a valid standard name, var_name is not a valid
+        # standard name, coord_name is set.
+        inp = ('latitude_coord', None, 'lat_var_name', 'latitude')
+        exp = ('latitude', None, 'lat_var_name',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_long_name_set_var_name_valid(self):
+        # standard_name is not a valid standard name, long_name is not None
+        # var_name is a valid standard name.
+        inp = ('latitude_coord', 'lat_long_name', 'grid_latitude', None)
+        exp = ('grid_latitude', 'lat_long_name', 'grid_latitude',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_long_name_set_var_name_valid_coord_name_set(
+            self):
+        # standard_name is not a valid standard name, long_name is not None,
+        # var_name is a valid standard name, coord_name is set.
+        inp = ('latitude_coord', 'lat_long_name', 'grid_latitude', 'latitude')
+        exp = ('latitude', 'lat_long_name', 'grid_latitude',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_long_name_set_var_name_invalid(self):
+        # standard_name is not a valid standard name, long_name is not None
+        # var_name is not a valid standard name.
+        inp = ('latitude_coord', 'lat_long_name', 'lat_var_name', None)
+        exp = (None, 'lat_long_name', 'lat_var_name',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+    def test_std_name_invalid_long_name_set_var_name_invalid_coord_name_set(
+            self):
+        # standard_name is not a valid standard name, long_name is not None,
+        # var_name is not a valid standard name, coord_name is set.
+        inp = ('latitude_coord', 'lat_long_name', 'lat_var_name', 'latitude')
+        exp = ('latitude', 'lat_long_name', 'lat_var_name',
+               {'invalid_standard_name': 'latitude_coord'})
+        self.check_names(inp, exp)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
CF conventions support a set of standard_name modifiers.  See [3.3. Standard Name](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#standard-name) for more details, specifically:

> A standard name is associated with a variable via the attribute standard_name which takes a string value comprised of a standard name optionally followed by one or more blanks and a standard name modifier (a string value from Appendix C, Standard Name Modifiers).

This PR modifies the CFVariableMixin standard_name setter (and the pyke rules) to support standard name modifiers. 


I found there wasn't much testing of cube/coord names so I have split this PR into two commits:
1. The first commit has no functional changes. It just adds testing of the pyke rules to show that they don't break later when I add the functional changes
2. The second commit adds the changes to include the standard_name modifiers

I hope that is clear!
