### PR TITLE
update readme.md docs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@
 
 <p align="center">
 <!-- https://shields.io/ is a good source of these -->
-<a href="https://anaconda.org/conda-forge/iris">
-<img src="https://img.shields.io/conda/dn/conda-forge/iris.svg"
-     alt="conda-forge downloads" /></a>
-<a href="https://github.com/SciTools/iris/releases">
-<img src="https://img.shields.io/github/tag/SciTools/iris.svg"
-     alt="Latest version" /></a>
-<a href="https://github.com/SciTools/iris/commits/master">
-<img src="https://img.shields.io/github/commits-since/SciTools/iris/latest.svg"
-     alt="Commits since last release" /></a>
-<a href="https://github.com/SciTools/iris/graphs/contributors">
-<img src="https://img.shields.io/github/contributors/SciTools/iris.svg"
-     alt="# contributors" /></a>
 <a href="https://travis-ci.org/SciTools/iris/branches">
 <img src="https://api.travis-ci.org/repositories/SciTools/iris.svg?branch=master"
      alt="Travis-CI" /></a>
+<a href="https://anaconda.org/conda-forge/iris">
+<img src="https://img.shields.io/conda/dn/conda-forge/iris.svg"
+     alt="conda-forge downloads" /></a>
+<a href="https://github.com/SciTools/iris/graphs/contributors">
+<img src="https://img.shields.io/github/contributors/SciTools/iris.svg"
+     alt="# contributors" /></a>
+<a href="https://github.com/SciTools/iris/releases">
+<img src="https://img.shields.io/github/tag/SciTools/iris.svg"
+     alt="Latest version" /></a>
 <a href="https://scitools.org.uk/iris/docs/latest/index.html">
 <img src="https://img.shields.io/badge/docs-stable-green.svg"
      alt="Stable docs" /></a>
+<a href="https://github.com/SciTools/iris/commits/master">
+<img src="https://img.shields.io/github/commits-since/SciTools/iris/latest.svg"
+     alt="Commits since last release" /></a>
 <a href="https://scitools-docs.github.io/iris/master/index.html">
 <img src="https://img.shields.io/badge/docs-latest-blue.svg"
      alt="Latest docs" /></a>

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@
 <a href="https://travis-ci.org/SciTools/iris/branches">
 <img src="https://api.travis-ci.org/repositories/SciTools/iris.svg?branch=master"
      alt="Travis-CI" /></a>
+<a href="https://scitools.org.uk/iris/docs/latest/index.html">
+<img src="https://img.shields.io/badge/docs-stable-green.svg"
+     alt="Stable docs" /></a>
 <a href="https://scitools-docs.github.io/iris/master/index.html">
-<img src="https://img.shields.io/badge/docs-master-blue.svg"
-     alt="Master docs build" /></a>
+<img src="https://img.shields.io/badge/docs-latest-blue.svg"
+     alt="Latest docs" /></a>
 <a href="https://zenodo.org/badge/latestdoi/5312648">
 <img src="https://zenodo.org/badge/5312648.svg"
      alt="zenodo" /></a>
@@ -85,11 +88,10 @@ use of standard NumPy/dask arrays as its underlying data storage.
 
 # Documentation
 
-The documentation for Iris is available at <https://scitools.org.uk/iris/docs/latest>,
-including a user guide, example code, and gallery.
+<a href="https://scitools.org.uk/iris/docs/latest/index.html"> <img src="https://img.shields.io/badge/docs-stable-green.svg" alt="Stable docs" /></a> The documentation for *stable released versions* of Iris, including a user guide, example code, and gallery.
 
-A documentation build for the latest development code is visible at
-<https://scitools-docs.github.io/iris/master/index.html>.
+<a href="https://scitools-docs.github.io/iris/master/index.html"> <img src="https://img.shields.io/badge/docs-latest-blue.svg" alt="Latest docs" /></a> The documentation for the *latest development version* of Iris.
+
 
 # Installation
 


### PR DESCRIPTION
This PR creates documentation badges to link to both the stable released versions of Iris e.g., scitools, and the lastest development version of Iris e.g., master 

Example of the rendered `README.md` can be seen [here](https://github.com/bjlittle/iris/tree/readme-docs-badges).