### PR TITLE
Added axes to _invert_yaxis call in _draw_1d_from_points

### DIFF
--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -621,7 +621,7 @@ def _draw_1d_from_points(draw_method_name, arg_func, *args, **kwargs):
     _string_coord_axis_tick_labels(string_axes, axes)
 
     # Invert y-axis if necessary.
-    _invert_yaxis(v_object)
+    _invert_yaxis(v_object, axes)
 
     return result
 


### PR DESCRIPTION
In code that was running in batch mode and not using matplotlib.pyplot, I came across a failure that was a direct result of pyplot being invoked to identify the figure and axes I was working on. If the figure was not created with pyplot then pyplot cannot find the figure and hence the axes.

In this particular case the call to _invert_yaxis from _draw_1d_from_points does not include the axes argument hence _invert_yaxis tries to identify the active axes using pyplot. Adding `axes` to the _invert_yaxis call prevents this and also matches the behaviour in _draw_2d_from_points and _draw_2d_from_bounds.