### PR TITLE
Fix _repr_html_, close tags appropriately

### DIFF
--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -207,7 +207,7 @@ class CubeRepresentation(object):
         for shape in self.shapes:
             cells.append(
                 '<td class="iris iris-inclusion-cell">{}</td>'.format(shape))
-        cells.append('</td>')
+        cells.append('</tr>')
         return '\n'.join(cell for cell in cells)
 
     def _make_row(self, title, body=None, col_span=0):


### PR DESCRIPTION
Made the `_make_shapes_row` generate more proper html, the initial `<tr ...>` is now closed by `</tr>` rather than `</td>`.