### PR TITLE
use @property everywhere

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -631,13 +631,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             result = result.view()
         return result
 
-    @property
-    def points(self):
+    def _points_getter(self):
         """The coordinate points values as a NumPy array."""
         return self._points_dm.data.view()
 
-    @points.setter
-    def points(self, points):
+    def _points_setter(self, points):
         # Set the points to a new array - as long as it's the same shape.
 
         # Ensure points has an ndmin of 1 and is either a numpy or lazy array.
@@ -651,8 +649,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         else:
             self._points_dm.data = points
 
-    @property
-    def bounds(self):
+    # Require to use this property pattern rather than @property due to
+    # subclass specialisation of _points_setter method
+    points = property(_points_getter, _points_setter)
+
+    def _bounds_getter(self):
         """
         The coordinate bounds values, as a NumPy array,
         or None if no bound values are defined.
@@ -666,8 +667,7 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             bounds = self._bounds_dm.data.view()
         return bounds
 
-    @bounds.setter
-    def bounds(self, bounds):
+    def _bounds_setter(self, bounds):
         # Ensure the bounds are a compatible shape.
         if bounds is None:
             self._bounds_dm = None
@@ -714,6 +714,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 raise ValueError(emsg)
 
         self._climatological = value
+
+    # Require to use this property pattern rather than @property due to
+    # subclass specialisation on _bounds_setter method
+    bounds = property(_bounds_getter, _bounds_setter)
 
     def lazy_points(self):
         """

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1940,12 +1940,7 @@ class DimCoord(Coord):
         if points.size > 1 and not iris.util.monotonic(points, strict=True):
             raise ValueError('The points array must be strictly monotonic.')
 
-    @property
-    def points(self):
-        # Call the parent points getter.
-        return super(DimCoord, self).points
-
-    @points.setter
+    @Coord.points.setter
     def points(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
         # Ensure it is an actual array, and also make our own copy so that we
@@ -2004,12 +1999,7 @@ class DimCoord(Coord):
                     raise ValueError('The direction of monotonicity must be '
                                      'consistent across all bounds')
 
-    @property
-    def bounds(self):
-        # Call the parent bounds getter.
-        return super(DimCoord, self).bounds
-
-    @bounds.setter
+    @Coord.bounds.setter
     def bounds(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -631,11 +631,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             result = result.view()
         return result
 
-    def _points_getter(self):
+    @property
+    def points(self):
         """The coordinate points values as a NumPy array."""
         return self._points_dm.data.view()
 
-    def _points_setter(self, points):
+    @points.setter
+    def points(self, points):
         # Set the points to a new array - as long as it's the same shape.
 
         # Ensure points has an ndmin of 1 and is either a numpy or lazy array.
@@ -649,11 +651,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         else:
             self._points_dm.data = points
 
-    # Require to use this property pattern rather than @property due to
-    # subclass specialisation of _points_setter method
-    points = property(_points_getter, _points_setter)
-
-    def _bounds_getter(self):
+    @property
+    def bounds(self):
         """
         The coordinate bounds values, as a NumPy array,
         or None if no bound values are defined.
@@ -667,7 +666,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             bounds = self._bounds_dm.data.view()
         return bounds
 
-    def _bounds_setter(self, bounds):
+    @bounds.setter
+    def bounds(self, bounds):
         # Ensure the bounds are a compatible shape.
         if bounds is None:
             self._bounds_dm = None
@@ -683,8 +683,6 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 self._bounds_dm = DataManager(bounds)
             else:
                 self._bounds_dm.data = bounds
-
-    bounds = property(_bounds_getter, _bounds_setter)
 
     @property
     def climatological(self):
@@ -714,10 +712,6 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
                 raise ValueError(emsg)
 
         self._climatological = value
-
-    # Require to use this property pattern rather than @property due to
-    # subclass specialisation on _bounds_setter method
-    bounds = property(_bounds_getter, _bounds_setter)
 
     def lazy_points(self):
         """
@@ -1946,7 +1940,13 @@ class DimCoord(Coord):
         if points.size > 1 and not iris.util.monotonic(points, strict=True):
             raise ValueError('The points array must be strictly monotonic.')
 
-    def _points_setter(self, points):
+    @property
+    def points(self):
+        # Call the parent points getter.
+        return super(DimCoord, self).points
+
+    @points.setter
+    def points(self, points):
         # DimCoord always realises the points, to allow monotonicity checks.
         # Ensure it is an actual array, and also make our own copy so that we
         # can make it read-only.
@@ -1956,8 +1956,8 @@ class DimCoord(Coord):
         # Check validity requirements for dimension-coordinate points.
         self._new_points_requirements(points)
 
-        # Invoke the generic points setter.
-        super(DimCoord, self)._points_setter(points)
+        # Call the parent points setter.
+        super(DimCoord, self.__class__).points.fset(self, points)
 
         if self._points_dm is not None:
             # Re-fetch the core array, as the super call may replace it.
@@ -1966,8 +1966,6 @@ class DimCoord(Coord):
 
             # Make the array read-only.
             points.flags.writeable = False
-
-    points = property(Coord._points_getter, _points_setter)
 
     def _new_bounds_requirements(self, bounds):
         """
@@ -2006,7 +2004,13 @@ class DimCoord(Coord):
                     raise ValueError('The direction of monotonicity must be '
                                      'consistent across all bounds')
 
-    def _bounds_setter(self, bounds):
+    @property
+    def bounds(self):
+        # Call the parent bounds getter.
+        return super(DimCoord, self).bounds
+
+    @bounds.setter
+    def bounds(self, bounds):
         if bounds is not None:
             # Ensure we have a realised array of new bounds values.
             bounds = _lazy.as_concrete_data(bounds)
@@ -2015,8 +2019,8 @@ class DimCoord(Coord):
             # Check validity requirements for dimension-coordinate bounds.
             self._new_bounds_requirements(bounds)
 
-        # Invoke the generic bounds setter.
-        super(DimCoord, self)._bounds_setter(bounds)
+        # Call the parent bounds setter.
+        super(DimCoord, self.__class__).bounds.fset(self, bounds)
 
         if self._bounds_dm is not None:
             # Re-fetch the core array, as the super call may replace it.
@@ -2025,8 +2029,6 @@ class DimCoord(Coord):
 
             # Ensure the array is read-only.
             bounds.flags.writeable = False
-
-    bounds = property(Coord._bounds_getter, _bounds_setter)
 
     def is_monotonic(self):
         return True

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -631,11 +631,13 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             result = result.view()
         return result
 
-    def _points_getter(self):
+    @property
+    def points(self):
         """The coordinate points values as a NumPy array."""
         return self._points_dm.data.view()
 
-    def _points_setter(self, points):
+    @points.setter
+    def points(self, points):
         # Set the points to a new array - as long as it's the same shape.
 
         # Ensure points has an ndmin of 1 and is either a numpy or lazy array.
@@ -649,9 +651,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         else:
             self._points_dm.data = points
 
-    points = property(_points_getter, _points_setter)
-
-    def _bounds_getter(self):
+    @property
+    def bounds(self):
         """
         The coordinate bounds values, as a NumPy array,
         or None if no bound values are defined.
@@ -665,7 +666,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             bounds = self._bounds_dm.data.view()
         return bounds
 
-    def _bounds_setter(self, bounds):
+    @bounds.setter
+    def bounds(self, bounds):
         # Ensure the bounds are a compatible shape.
         if bounds is None:
             self._bounds_dm = None

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1446,8 +1446,11 @@ class PPField2(PPField):
 
     @property
     def t1(self):
-        "A cftime.datetime object consisting of the lbyr, lbmon,"
-        " lbdat, lbhr, and lbmin attributes."
+        """
+        A cftime.datetime object consisting of the lbyr, lbmon, lbdat, lbhr,
+        and lbmin attributes.
+
+        """
         if not hasattr(self, '_t1'):
             self._t1 = cftime.datetime(self.lbyr, self.lbmon, self.lbdat,
                                        self.lbhr, self.lbmin)
@@ -1466,8 +1469,11 @@ class PPField2(PPField):
 
     @property
     def t2(self):
-        "A cftime.datetime object consisting of the lbyrd, "
-        "lbmond, lbdatd, lbhrd, and lbmind attributes."
+        """
+        A cftime.datetime object consisting of the lbyrd, lbmond, lbdatd,
+        lbhrd, and lbmind attributes.
+
+        """
         if not hasattr(self, '_t2'):
             self._t2 = cftime.datetime(self.lbyrd, self.lbmond,
                                        self.lbdatd, self.lbhrd,

--- a/lib/iris/palette.py
+++ b/lib/iris/palette.py
@@ -197,10 +197,12 @@ class SymmetricNormalize(mpl_colors.Normalize, object):
         if update_max:
             self._vmax = self.pivot + diff
 
-    def _get_vmin(self):
+    @property
+    def vmin(self):
         return getattr(self, '_vmin')
 
-    def _set_vmin(self, val):
+    @vmin.setter
+    def vmin(self, val):
         if val is None:
             self._vmin = None
         elif self._vmax is None:
@@ -210,12 +212,12 @@ class SymmetricNormalize(mpl_colors.Normalize, object):
             # Set both _vmin and _vmax from value
             self._update(val)
 
-    vmin = property(_get_vmin, _set_vmin)
-
-    def _get_vmax(self):
+    @property
+    def vmax(self):
         return getattr(self, '_vmax')
 
-    def _set_vmax(self, val):
+    @vmax.setter
+    def vmax(self, val):
         if val is None:
             self._vmax = None
         elif self._vmin is None:
@@ -224,8 +226,6 @@ class SymmetricNormalize(mpl_colors.Normalize, object):
         else:
             # Set both _vmin and _vmax from value
             self._update(val)
-
-    vmax = property(_get_vmax, _set_vmax)
 
 
 def _load_palette():

--- a/lib/iris/palette.py
+++ b/lib/iris/palette.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #


### PR DESCRIPTION
This PR follows-up from the review of #3395 and more specifically this [comment](https://github.com/SciTools/iris/pull/3395#discussion_r327686889), to move away from using this property pattern:
```python
def _thing_getter(self):
    ...
def _thing_setter(self, ...):
    ...
thing = property(_thing_getter, _thing_setter)
```
to using this property pattern:
```python
@property
def thing(self):
    ...
@thing.setter
def thing(self, ...):
    ...
```
for reasons discussed in the #3395 [comment](https://github.com/SciTools/iris/pull/3395#discussion_r327686889).