### PR TITLE
Include AncillaryVariables and restructure Cube metadata.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-14_cf_ancillary_data.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-14_cf_ancillary_data.txt
@@ -1,0 +1,1 @@
+* CF Ancillary Data are now supported in cubes.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-14_cf_ancillary_data.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-14_cf_ancillary_data.txt
@@ -1,1 +1,1 @@
-* CF Ancillary Data are now supported in cubes.
+* CF Ancillary Variables are now supported in cubes.

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2019, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -301,8 +301,7 @@ def concatenate(cubes, error_on_mismatch=False, check_aux_coords=True):
 class _CubeSignature(object):
     """
     Template for identifying a specific type of :class:`iris.cube.Cube` based
-    on its metadata and dimensional metadata, including: coordinates,
-    cell_measures and ancillary_variables.
+    on its metadata, coordinates and cell_measures.
 
     """
     def __init__(self, cube):
@@ -323,7 +322,6 @@ class _CubeSignature(object):
         self.ndim = cube.ndim
         self.scalar_coords = []
         self.cell_measures_and_dims = cube._cell_measures_and_dims
-        self.ancillary_variables_and_dims = cube._ancillary_variables_and_dims
         self.dim_mapping = []
 
         # Determine whether there are any anonymous cube dimensions.
@@ -417,8 +415,6 @@ class _CubeSignature(object):
             - dimensions metadata
             - aux coords metadata
             - scalar coords
-            - cell measures
-            - ancillary variables
             - attributes
             - dtype
 
@@ -474,14 +470,6 @@ class _CubeSignature(object):
             msgs.append(msg_template.format('CellMeasures', '',
                                             self.cell_measures_and_dims,
                                             other.cell_measures_and_dims))
-
-        # Check ancillary_variables_and_dims
-        if self.ancillary_variables_and_dims != \
-                other.ancillary_variables_and_dims:
-            msgs.append(msg_template.format(
-                'AncillaryVariables', '',
-                self.ancillary_variables_and_dims,
-                other.ancillary_variables_and_dims))
 
         match = not bool(msgs)
         if error_on_mismatch and not match:
@@ -682,15 +670,11 @@ class _ProtoCube(object):
             kwargs = cube_signature.defn._asdict()
             new_cm_and_dims = [(deepcopy(cm), dims) for cm, dims
                                in self._cube._cell_measures_and_dims]
-            new_av_and_dims = [(deepcopy(av), dims) for av, dims
-                               in self._cube._ancillary_variables_and_dims]
-            cube = iris.cube.Cube(
-                data,
-                dim_coords_and_dims=dim_coords_and_dims,
-                aux_coords_and_dims=aux_coords_and_dims,
-                cell_measures_and_dims=new_cm_and_dims,
-                ancillary_variables_and_dims=new_av_and_dims,
-                **kwargs)
+            cube = iris.cube.Cube(data,
+                                  dim_coords_and_dims=dim_coords_and_dims,
+                                  aux_coords_and_dims=aux_coords_and_dims,
+                                  cell_measures_and_dims=new_cm_and_dims,
+                                  **kwargs)
         else:
             # There are no other source-cubes to concatenate
             # with this proto-cube.

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -315,7 +315,8 @@ class _CoordSignature(namedtuple('CoordSignature',
 
 class _CubeSignature(namedtuple('CubeSignature',
                                 ['defn', 'data_shape', 'data_type',
-                                 'cell_measures_and_dims'])):
+                                 'cell_measures_and_dims',
+                                 'ancillary_variables_and_dims'])):
     """
     Criterion for identifying a specific type of :class:`iris.cube.Cube`
     based on its metadata.
@@ -333,6 +334,9 @@ class _CubeSignature(namedtuple('CubeSignature',
 
     * cell_measures_and_dims:
         A list of cell_measures and dims for the cube.
+
+    * ancillary_variables_and_dims:
+        A list of ancillary_variables and dims for the cube.
 
     """
 
@@ -405,6 +409,9 @@ class _CubeSignature(namedtuple('CubeSignature',
             msgs.append(msg.format(self.data_type, other.data_type))
         if (self.cell_measures_and_dims != other.cell_measures_and_dims):
             msgs.append('cube.cell_measures differ')
+        if (self.ancillary_variables_and_dims !=
+                other.ancillary_variables_and_dims):
+            msgs.append('cube.ancillary_variables differ')
 
         match = not bool(msgs)
         if error_on_mismatch and not match:
@@ -1134,6 +1141,10 @@ class ProtoCube(object):
         # they are checked and preserved through merge
         self._cell_measures_and_dims = cube._cell_measures_and_dims
 
+        # ancillary_variables are not merge candidates
+        # they are checked and preserved through merge
+        self._ancillary_variables_and_dims = cube._ancillary_variables_and_dims
+
     def _report_duplicate(self, nd_indexes, group_by_nd_index):
         # Find the first offending source-cube with duplicate metadata.
         index = [group_by_nd_index[nd_index][1]
@@ -1483,10 +1494,13 @@ class ProtoCube(object):
 
         cms_and_dims = [(deepcopy(cm), dims)
                         for cm, dims in self._cell_measures_and_dims]
+        av_and_dims = [(deepcopy(av), dims)
+                       for av, dims in self._ancillary_variables_and_dims]
         cube = iris.cube.Cube(data,
                               dim_coords_and_dims=dim_coords_and_dims,
                               aux_coords_and_dims=aux_coords_and_dims,
                               cell_measures_and_dims=cms_and_dims,
+                              ancillary_variables_and_dims=av_and_dims,
                               **kwargs)
 
         # Add on any aux coord factories.
@@ -1607,7 +1621,8 @@ class ProtoCube(object):
         """
 
         return _CubeSignature(cube.metadata, cube.shape,
-                              cube.dtype, cube._cell_measures_and_dims)
+                              cube.dtype, cube._cell_measures_and_dims,
+                              cube._ancillary_variables_and_dims)
 
     def _add_cube(self, cube, coord_payload):
         """Create and add the source-cube skeleton to the ProtoCube."""

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2019, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -315,8 +315,7 @@ class _CoordSignature(namedtuple('CoordSignature',
 
 class _CubeSignature(namedtuple('CubeSignature',
                                 ['defn', 'data_shape', 'data_type',
-                                 'cell_measures_and_dims',
-                                 'ancillary_variables_and_dims'])):
+                                 'cell_measures_and_dims'])):
     """
     Criterion for identifying a specific type of :class:`iris.cube.Cube`
     based on its metadata.
@@ -334,9 +333,6 @@ class _CubeSignature(namedtuple('CubeSignature',
 
     * cell_measures_and_dims:
         A list of cell_measures and dims for the cube.
-
-    * ancillary_variables_and_dims:
-        A list of ancillary_variables and dims for the cube.
 
     """
 
@@ -409,9 +405,6 @@ class _CubeSignature(namedtuple('CubeSignature',
             msgs.append(msg.format(self.data_type, other.data_type))
         if (self.cell_measures_and_dims != other.cell_measures_and_dims):
             msgs.append('cube.cell_measures differ')
-        if (self.ancillary_variables_and_dims !=
-                other.ancillary_variables_and_dims):
-            msgs.append('cube.ancillary_variables differ')
 
         match = not bool(msgs)
         if error_on_mismatch and not match:
@@ -1141,10 +1134,6 @@ class ProtoCube(object):
         # they are checked and preserved through merge
         self._cell_measures_and_dims = cube._cell_measures_and_dims
 
-        # ancillary_variables are not merge candidates
-        # they are checked and preserved through merge
-        self._ancillary_variables_and_dims = cube._ancillary_variables_and_dims
-
     def _report_duplicate(self, nd_indexes, group_by_nd_index):
         # Find the first offending source-cube with duplicate metadata.
         index = [group_by_nd_index[nd_index][1]
@@ -1494,13 +1483,10 @@ class ProtoCube(object):
 
         cms_and_dims = [(deepcopy(cm), dims)
                         for cm, dims in self._cell_measures_and_dims]
-        av_and_dims = [(deepcopy(av), dims)
-                       for av, dims in self._ancillary_variables_and_dims]
         cube = iris.cube.Cube(data,
                               dim_coords_and_dims=dim_coords_and_dims,
                               aux_coords_and_dims=aux_coords_and_dims,
                               cell_measures_and_dims=cms_and_dims,
-                              ancillary_variables_and_dims=av_and_dims,
                               **kwargs)
 
         # Add on any aux coord factories.
@@ -1621,8 +1607,7 @@ class ProtoCube(object):
         """
 
         return _CubeSignature(cube.metadata, cube.shape,
-                              cube.dtype, cube._cell_measures_and_dims,
-                              cube._ancillary_variables_and_dims)
+                              cube.dtype, cube._cell_measures_and_dims)
 
     def _add_cube(self, cube, coord_payload):
         """Create and add the source-cube skeleton to the ProtoCube."""

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -143,7 +143,7 @@ class _DimensionalMetadata(six.with_metaclass(ABCMeta, CFVariableMixin)):
             values, keys)
 
         # Copy values after indexing to avoid making metadata that is a
-        # view on another metadata.
+        # view on another metadata. This will not realise lazy data.
         values = values.copy()
 
         # If the metadata is a coordinate and it has bounds, repeat the above
@@ -676,10 +676,9 @@ class AncillaryVariable(_DimensionalMetadata):
             A dictionary containing other cf and user-defined attributes.
 
         """
-        super(AncillaryVariable, self).__init__(
-            values=data, standard_name=standard_name,
-            long_name=long_name, var_name=var_name,
-            units=units, attributes=attributes)
+        super().__init__(values=data, standard_name=standard_name,
+                         long_name=long_name, var_name=var_name,
+                         units=units, attributes=attributes)
 
     @property
     def data(self):
@@ -704,7 +703,7 @@ class AncillaryVariable(_DimensionalMetadata):
             A lazy array, representing the ancillary variable data array.
 
         """
-        return super(AncillaryVariable, self)._lazy_values()
+        return super()._lazy_values()
 
     def core_data(self):
         """
@@ -712,7 +711,7 @@ class AncillaryVariable(_DimensionalMetadata):
         NumPy array or a dask array.
 
         """
-        return super(AncillaryVariable, self)._core_values()
+        return super()._core_values()
 
     def has_lazy_data(self):
         """
@@ -720,7 +719,7 @@ class AncillaryVariable(_DimensionalMetadata):
         is a lazy dask array or not.
 
         """
-        return super(AncillaryVariable, self)._has_lazy_values()
+        return super()._has_lazy_values()
 
 
 class CellMeasure(AncillaryVariable):
@@ -761,10 +760,9 @@ class CellMeasure(AncillaryVariable):
             are the only valid entries.
 
         """
-        super(CellMeasure, self).__init__(
-            data=data, standard_name=standard_name,
-            long_name=long_name, var_name=var_name,
-            units=units, attributes=attributes)
+        super().__init__(data=data, standard_name=standard_name,
+                         long_name=long_name, var_name=var_name,
+                         units=units, attributes=attributes)
 
         #: String naming the measure type.
         self.measure = measure
@@ -1233,9 +1231,9 @@ class Coord(_DimensionalMetadata):
             from NetCDF.
             Always False if no bounds exist.
         """
-        super(Coord, self).__init__(values=points, standard_name=standard_name,
-                                    long_name=long_name, var_name=var_name,
-                                    units=units, attributes=attributes)
+        super().__init__(values=points, standard_name=standard_name,
+                         long_name=long_name, var_name=var_name,
+                         units=units, attributes=attributes)
 
         #: Relevant coordinate system (if any).
         self.coord_system = coord_system
@@ -1269,7 +1267,7 @@ class Coord(_DimensionalMetadata):
             raise ValueError('If bounds are specified, points must also be '
                              'specified')
 
-        new_coord = super(Coord, self).copy(values=points)
+        new_coord = super().copy(values=points)
         if points is not None:
             # Regardless of whether bounds are provided as an argument, new
             # points will result in new bounds, discarding those copied from
@@ -1380,7 +1378,7 @@ class Coord(_DimensionalMetadata):
             A lazy array, representing the coord points array.
 
         """
-        return super(Coord, self)._lazy_values()
+        return super()._lazy_values()
 
     def lazy_bounds(self):
         """
@@ -1409,7 +1407,7 @@ class Coord(_DimensionalMetadata):
         or a dask array.
 
         """
-        return super(Coord, self)._core_values()
+        return super()._core_values()
 
     def core_bounds(self):
         """
@@ -1430,7 +1428,7 @@ class Coord(_DimensionalMetadata):
         lazy dask array or not.
 
         """
-        return super(Coord, self)._has_lazy_values()
+        return super()._has_lazy_values()
 
     def has_lazy_bounds(self):
         """
@@ -1444,7 +1442,7 @@ class Coord(_DimensionalMetadata):
         return result
 
     def _repr_other_metadata(self):
-        result = super(Coord, self)._repr_other_metadata()
+        result = super()._repr_other_metadata()
         if self.coord_system:
             result += ', coord_system={}'.format(self.coord_system)
         if self.climatological:
@@ -1482,7 +1480,7 @@ class Coord(_DimensionalMetadata):
         :attr:`~iris.coords.Coord.bounds` by 180.0/:math:`\pi`.
 
         """
-        super(Coord, self).convert_units(unit=unit)
+        super().convert_units(unit=unit)
 
     def cells(self):
         """
@@ -1699,8 +1697,7 @@ class Coord(_DimensionalMetadata):
         """
         compatible = False
         if (self.coord_system == other.coord_system):
-            compatible = super(Coord, self).is_compatible(other=other,
-                                                          ignore=ignore)
+            compatible = super().is_compatible(other=other, ignore=ignore)
 
         return compatible
 
@@ -2116,7 +2113,7 @@ class Coord(_DimensionalMetadata):
         """Return a DOM element describing this Coord."""
         # Create the XML element as the camelCaseEquivalent of the
         # class name
-        element = super(Coord, self).xml_element(doc=doc)
+        element = super().xml_element(doc=doc)
 
         if hasattr(self.points, 'to_xml_attr'):
             element.setAttribute('points', self.points.to_xml_attr())
@@ -2200,13 +2197,12 @@ class DimCoord(Coord):
         read-only points and bounds.
 
         """
-        super(DimCoord, self).__init__(
-            points, standard_name=standard_name,
-            long_name=long_name, var_name=var_name,
-            units=units, bounds=bounds,
-            attributes=attributes,
-            coord_system=coord_system,
-            climatological=climatological)
+        super().__init__(points, standard_name=standard_name,
+                         long_name=long_name, var_name=var_name,
+                         units=units, bounds=bounds,
+                         attributes=attributes,
+                         coord_system=coord_system,
+                         climatological=climatological)
 
         #: Whether the coordinate wraps by ``coord.units.modulus``.
         self.circular = bool(circular)
@@ -2218,7 +2214,7 @@ class DimCoord(Coord):
         Used if copy.deepcopy is called on a coordinate.
 
         """
-        new_coord = copy.deepcopy(super(DimCoord, self), memo)
+        new_coord = copy.deepcopy(super(), memo)
         # Ensure points and bounds arrays are read-only.
         new_coord._values_dm.data.flags.writeable = False
         if new_coord._bounds_dm is not None:
@@ -2226,7 +2222,7 @@ class DimCoord(Coord):
         return new_coord
 
     def copy(self, points=None, bounds=None):
-        new_coord = super(DimCoord, self).copy(points=points, bounds=bounds)
+        new_coord = super().copy(points=points, bounds=bounds)
         # Make the arrays read-only.
         new_coord._values_dm.data.flags.writeable = False
         if bounds is not None:
@@ -2253,7 +2249,7 @@ class DimCoord(Coord):
     __hash__ = Coord.__hash__
 
     def __getitem__(self, key):
-        coord = super(DimCoord, self).__getitem__(key)
+        coord = super().__getitem__(key)
         coord.circular = self.circular and coord.shape == self.shape
         return coord
 
@@ -2399,7 +2395,7 @@ class DimCoord(Coord):
 
     def xml_element(self, doc):
         """Return DOM element describing this :class:`iris.coords.DimCoord`."""
-        element = super(DimCoord, self).xml_element(doc)
+        element = super().xml_element(doc)
         if self.circular:
             element.setAttribute('circular', str(self.circular))
         return element

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2203,7 +2203,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 ancillary_variable_summary, cube_header = vector_summary(
                     [], cube_header, max_line_offset,
                     ancillary_variables=vector_ancillary_variables)
-                summary += '\n     Ancillary Datasets:\n'
+                summary += '\n     Ancillary Variables:\n'
                 summary += '\n'.join(ancillary_variable_summary)
 
             #

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2148,7 +2148,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
                         for dim in range(len(self.shape)):
                             width = alignment[dim] - len(vector_summary[index])
-                            char = 'x'
+                            char = 'x' if dim in dims else '-'
                             line = '{pad:{width}}{char}'.format(pad=' ',
                                                                 width=width,
                                                                 char=char)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -692,7 +692,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                  var_name=None, units=None, attributes=None,
                  cell_methods=None, dim_coords_and_dims=None,
                  aux_coords_and_dims=None, aux_factories=None,
-                 cell_measures_and_dims=None):
+                 cell_measures_and_dims=None,
+                 ancillary_variables_and_dims=None):
         """
         Creates a cube with data and optional metadata.
 
@@ -739,6 +740,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             :mod:`iris.aux_factory`.
         * cell_measures_and_dims
             A list of CellMeasures with dimension mappings.
+        * ancillary_variables_and_dims
+            A list of AncillaryVariables with dimension mappings.
 
         For example::
             >>> from iris.coords import DimCoord
@@ -787,6 +790,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Cell Measures
         self._cell_measures_and_dims = []
 
+        # Ancillary Variables
+        self._ancillary_variables_and_dims = []
+
         identities = set()
         if dim_coords_and_dims:
             dims = set()
@@ -815,6 +821,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if cell_measures_and_dims:
             for cell_measure, dims in cell_measures_and_dims:
                 self.add_cell_measure(cell_measure, dims)
+
+        if ancillary_variables_and_dims:
+            for ancillary_variable, dims in ancillary_variables_and_dims:
+                self.add_ancillary_variable(ancillary_variable, dims)
 
     @property
     def metadata(self):
@@ -1049,6 +1059,34 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         self._cell_measures_and_dims.sort(key=lambda cm_dims:
                                           (cm_dims[0]._as_defn(), cm_dims[1]))
 
+    def add_ancillary_variable(self, ancillary_variable, data_dims=None):
+        """
+        Adds a CF ancillary variable to the cube.
+
+        Args:
+
+        * ancillary_variable
+            The :class:`iris.coords.AncillaryVariable` instance to be added to
+            the cube
+
+        Kwargs:
+        * data_dims
+            Integer or iterable of integers giving the data dimensions spanned
+            by the ancillary variable.
+
+        Raises a ValueError if an ancillary variable with identical metadata
+        already exists on the cube.
+        """
+        if self.ancillary_variables(ancillary_variable):
+            raise ValueError('Duplicate ancillary variables not permitted')
+
+        data_dims = self._check_multi_dim_metadata(ancillary_variable,
+                                                   data_dims)
+        self._ancillary_variables_and_dims.append([ancillary_variable,
+                                                   data_dims])
+        self._ancillary_variables_and_dims.sort(
+            key=lambda av_dims: (av_dims[0]._as_defn(), av_dims[1]))
+
     def add_dim_coord(self, dim_coord, data_dim):
         """
         Add a CF coordinate to the cube.
@@ -1168,6 +1206,22 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                         dim in self._cell_measures_and_dims
                                         if cell_measure_ is not cell_measure]
 
+    def remove_ancillary_variable(self, ancillary_variable):
+
+        """
+        Removes an ancillary variable from the cube.
+
+        Args:
+
+        * ancillary_variable (AncillaryVariable)
+            The AncillaryVariable to remove from the cube.
+
+        """
+        self._ancillary_variables_and_dims = [
+            [ancillary_variable_, dim] for ancillary_variable_, dim in
+            self._ancillary_variables_and_dims
+            if ancillary_variable_ is not ancillary_variable]
+
     def replace_coord(self, new_coord):
         """
         Replace the coordinate whose metadata matches the given coordinate.
@@ -1242,6 +1296,26 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         if not matches:
             raise iris.exceptions.CellMeasureNotFoundError(cell_measure.name())
+
+        return matches[0]
+
+    def ancillary_variable_dims(self, ancillary_variable):
+        """
+        Returns a tuple of the data dimensions relevant to the given
+        AncillaryVariable.
+
+        * ancillary_variable
+            The AncillaryVariable to look for.
+
+        """
+        # Search for existing ancillary variable (object) on the cube, faster
+        # lookup than equality - makes no functional difference.
+        matches = [dims for av, dims in self._ancillary_variables_and_dims
+                   if av is ancillary_variable]
+
+        if not matches:
+            raise iris.exceptions.AncillaryVariableNotFoundError(
+                ancillary_variable.name())
 
         return matches[0]
 
@@ -1623,6 +1697,84 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return cell_measures[0]
 
+    def ancillary_variables(self, name_or_ancillary_variable=None):
+        """
+        Return a list of ancillary variable in this cube fitting the given
+        criteria.
+
+        Kwargs:
+
+        * name_or_ancillary_variable
+            Either
+
+            (a) a :attr:`standard_name`, :attr:`long_name`, or
+            :attr:`var_name`. Defaults to value of `default`
+            (which itself defaults to `unknown`) as defined in
+            :class:`iris._cube_coord_common.CFVariableMixin`.
+
+            (b) a ancillary_variable instance with metadata equal to that of
+            the desired ancillary_variables.
+
+        See also
+        :meth:`Cube.ancillary_variable()<iris.cube.Cube.ancillary_variable>`.
+
+        """
+        name = None
+
+        if isinstance(name_or_ancillary_variable, six.string_types):
+            name = name_or_ancillary_variable
+        else:
+            ancillary_variable = name_or_ancillary_variable
+        ancillary_variables = []
+        for av, _ in self._ancillary_variables_and_dims:
+            if name is not None:
+                if av.name() == name:
+                    ancillary_variables.append(av)
+            elif ancillary_variable is not None:
+                if av == ancillary_variable:
+                    ancillary_variables.append(av)
+            else:
+                ancillary_variables.append(av)
+        return ancillary_variables
+
+    def ancillary_variable(self, name_or_ancillary_variable=None):
+        """
+        Return a single ancillary_variable given the same arguments as
+        :meth:`Cube.ancillary_variables`.
+
+        .. note::
+
+            If the arguments given do not result in precisely 1
+            ancillary_variable being matched, an
+            :class:`iris.exceptions.AncillaryVariableNotFoundError` is raised.
+
+        .. seealso::
+
+            :meth:`Cube.ancillary_variables()<iris.cube.Cube.ancillary_variables>`
+            for full keyword documentation.
+
+        """
+        ancillary_variables = self.ancillary_variables(
+            name_or_ancillary_variable)
+
+        if len(ancillary_variables) > 1:
+            msg = ('Expected to find exactly 1 ancillary_variable, but found '
+                   '{}. They were: {}.')
+            msg = msg.format(len(ancillary_variables), ', '.join(anc_var.name()
+                             for anc_var in ancillary_variables))
+            raise iris.exceptions.AncillaryVariableNotFoundError(msg)
+        elif len(ancillary_variables) == 0:
+            if isinstance(name_or_ancillary_variable, six.string_types):
+                bad_name = name_or_ancillary_variable
+            else:
+                bad_name = (name_or_ancillary_variable and
+                            name_or_ancillary_variable.name()) or ''
+            msg = 'Expected to find exactly 1 {!s} ancillary_variable, but ' \
+                  'found none.'.format(bad_name)
+            raise iris.exceptions.AncillaryVariableNotFoundError(msg)
+
+        return ancillary_variables[0]
+
     @property
     def cell_methods(self):
         """
@@ -1892,6 +2044,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             vector_cell_measures = [cm for cm in self.cell_measures()
                                     if cm.shape != (1,)]
 
+            # Ancillary Variables
+            vector_ancillary_variables = [av for av in
+                                          self.ancillary_variables()]
+
             # Determine the cube coordinates that don't describe the cube and
             # are most likely erroneous.
             vector_coords = vector_dim_coords + vector_aux_coords + \
@@ -1916,7 +2072,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # Generate textual summary of cube vector coordinates.
             #
             def vector_summary(vector_coords, cube_header, max_line_offset,
-                               cell_measures=None):
+                               cell_measures=None, ancillary_variables=None):
                 """
                 Generates a list of suitably aligned strings containing coord
                 names and dimensions indicated by one or more 'x' symbols.
@@ -1929,6 +2085,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 """
                 if cell_measures is None:
                     cell_measures = []
+                if ancillary_variables is None:
+                    ancillary_variables = []
                 vector_summary = []
                 vectors = []
 
@@ -1939,9 +2097,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
                 # Generate basic textual summary for each vector coordinate
                 # - WITHOUT dimension markers.
-                for coord in vector_coords + cell_measures:
+                for dim_meta in (
+                        vector_coords + cell_measures + ancillary_variables):
                     vector_summary.append('%*s%s' % (
-                        indent, ' ', iris.util.clip_string(coord.name())))
+                        indent, ' ', iris.util.clip_string(dim_meta.name())))
                 min_alignment = min(alignment)
 
                 # Determine whether the cube header requires realignment
@@ -1968,10 +2127,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             vector_summary[index] += line
                     vectors = vectors + vector_coords
                 if cell_measures:
-                    # Generate full textual summary for each vector coordinate
-                    # - WITH dimension markers.
-                    for index, coord in enumerate(cell_measures):
-                        dims = self.cell_measure_dims(coord)
+                    # Generate full textual summary for each vector cell
+                    # measure - WITH dimension markers.
+                    for index, cell_measure in enumerate(cell_measures):
+                        dims = self.cell_measure_dims(cell_measure)
 
                         for dim in range(len(self.shape)):
                             width = alignment[dim] - len(vector_summary[index])
@@ -1981,6 +2140,20 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                                                 char=char)
                             vector_summary[index] += line
                     vectors = vectors + cell_measures
+                if ancillary_variables:
+                    # Generate full textual summary for each vector ancillary
+                    # variable - WITH dimension markers.
+                    for index, av in enumerate(ancillary_variables):
+                        dims = self.ancillary_variable_dims(av)
+
+                        for dim in range(len(self.shape)):
+                            width = alignment[dim] - len(vector_summary[index])
+                            char = 'x'
+                            line = '{pad:{width}}{char}'.format(pad=' ',
+                                                                width=width,
+                                                                char=char)
+                            vector_summary[index] += line
+                    vectors = vectors + ancillary_variables
                 # Interleave any extra lines that are needed to distinguish
                 # the coordinates.
                 vector_summary = self._summary_extra(vectors,
@@ -2022,6 +2195,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     cell_measures=vector_cell_measures)
                 summary += '\n     Cell Measures:\n'
                 summary += '\n'.join(cell_measure_summary)
+
+            #
+            # Generate summary of cube ancillary variables attribute
+            #
+            if vector_ancillary_variables:
+                ancillary_variable_summary, cube_header = vector_summary(
+                    [], cube_header, max_line_offset,
+                    ancillary_variables=vector_ancillary_variables)
+                summary += '\n     Ancillary Datasets:\n'
+                summary += '\n'.join(ancillary_variable_summary)
 
             #
             # Generate textual summary of cube scalar coordinates.
@@ -2840,6 +3023,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                                              self._aux_coords_and_dims))
         self._cell_measures_and_dims = list(map(remap_cube_metadata,
                                                 self._cell_measures_and_dims))
+        self._ancillary_variables_and_dims = list(map(
+            remap_cube_metadata, self._ancillary_variables_and_dims))
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """

--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -40,6 +40,11 @@ class CoordinateNotFoundError(KeyError):
 
 class CellMeasureNotFoundError(KeyError):
     """Raised when a search yields no cell measures."""
+    pass
+
+
+class AncillaryVariableNotFoundError(KeyError):
+    """Raised when a search yields no ancillary variables."""
     pass
 
 

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -631,7 +631,7 @@ class TestGetterSetter(tests.IrisTest):
 
         # set bounds from non-numpy pair.
         # First reset the underlying shape of the coordinate.
-        coord._points_dm = DataManager(1)
+        coord._values_dm = DataManager(1)
         coord.points = 1
         coord.bounds = [123, 456]
         self.assertEqual(coord.shape, (1, ))
@@ -639,7 +639,7 @@ class TestGetterSetter(tests.IrisTest):
 
         # set bounds from non-numpy pairs
         # First reset the underlying shape of the coord's points and bounds.
-        coord._points_dm = DataManager(np.arange(3))
+        coord._values_dm = DataManager(np.arange(3))
         coord.bounds = None
         coord.bounds = [[123, 456], [234, 567], [345, 678]]
         self.assertEqual(coord.shape, (3, ))

--- a/lib/iris/tests/unit/coords/test_AncillaryVariable.py
+++ b/lib/iris/tests/unit/coords/test_AncillaryVariable.py
@@ -1,0 +1,628 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :class:`iris.coords.AncillaryVariable` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import dask.array as da
+import numpy as np
+import numpy.ma as ma
+
+from iris.tests.unit.coords import CoordTestMixin, lazyness_string
+
+from cf_units import Unit
+from iris.coords import AncillaryVariable
+from iris._lazy_data import as_lazy_data
+
+
+def data_all_dtypes_and_lazynesses(self):
+    # Generate ancillary variables with real and lazy data, and a few different
+    # dtypes.
+    data_types = ['real', 'lazy']
+    dtypes = [np.int16, np.int32, np.float32, np.float64]
+    for dtype in dtypes:
+        for data_type_name in data_types:
+                data = np.asarray(self.data_real, dtype=dtype)
+                if data_type_name == 'lazy':
+                    data = da.from_array(data, data.shape)
+                ancill_var = AncillaryVariable(data)
+                result = (ancill_var, data_type_name)
+                yield result
+
+
+class AncillaryVariableTestMixin(CoordTestMixin):
+    # Define a 2-D default array shape.
+    def setupTestArrays(self, shape=(2, 3), masked=False):
+        # Create concrete and lazy data test arrays, given a desired shape.
+        # If masked=True, also add masked arrays with some or no masked data.
+        n_vals = np.prod(shape)
+        # Note: the values must be integral for testing integer dtypes.
+        values = 100.0 + 10.0 * np.arange(n_vals, dtype=float).reshape(shape)
+        self.data_real = values
+        self.data_lazy = da.from_array(values, values.shape)
+
+        if masked:
+            mvalues = ma.array(values)
+            self.no_masked_data_real = mvalues
+            self.no_masked_data_lazy = da.from_array(mvalues, mvalues.shape,
+                                                     asarray=False)
+            mvalues = ma.array(mvalues, copy=True)
+            mvalues[0] = ma.masked
+            self.masked_data_real = mvalues
+            self.masked_data_lazy = da.from_array(mvalues, mvalues.shape,
+                                                  asarray=False)
+
+
+class Test__init__(tests.IrisTest, AncillaryVariableTestMixin):
+    # Test for AncillaryVariable creation, with real / lazy data
+    def setUp(self):
+        self.setupTestArrays(masked=True)
+
+    def test_lazyness_and_dtype_combinations(self):
+        for (ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self, ):
+            data = ancill_var.core_data()
+            # Check properties of data.
+            if data_lazyness == 'real':
+                # Real data.
+                if ancill_var.dtype == self.data_real.dtype:
+                    self.assertArraysShareData(
+                        data, self.data_real,
+                        'Data values are not the same '
+                        'data as the provided array.')
+                    self.assertIsNot(
+                        data, self.data_real,
+                        'Data array is the same instance as the provided '
+                        'array.')
+                else:
+                    # the original data values were cast to a test dtype.
+                    check_data = self.data_real.astype(ancill_var.dtype)
+                    self.assertEqualRealArraysAndDtypes(data, check_data)
+            else:
+                # Lazy data : the core data may be promoted to float.
+                check_data = self.data_lazy.astype(data.dtype)
+                self.assertEqualLazyArraysAndDtypes(data, check_data)
+                # The realisation type should be correct, though.
+                target_dtype = ancill_var.dtype
+                self.assertEqual(ancill_var.data.dtype, target_dtype)
+
+    def test_no_masked_data_real(self):
+        data = self.no_masked_data_real
+        self.assertTrue(ma.isMaskedArray(data))
+        self.assertEqual(ma.count_masked(data), 0)
+        ancill_var = AncillaryVariable(data)
+        self.assertFalse(ancill_var.has_lazy_data())
+        self.assertTrue(ma.isMaskedArray(ancill_var.data))
+        self.assertEqual(ma.count_masked(ancill_var.data), 0)
+
+    def test_no_masked_data_lazy(self):
+        data = self.no_masked_data_lazy
+        computed = data.compute()
+        self.assertTrue(ma.isMaskedArray(computed))
+        self.assertEqual(ma.count_masked(computed), 0)
+        ancill_var = AncillaryVariable(data)
+        self.assertTrue(ancill_var.has_lazy_data())
+        self.assertTrue(ma.isMaskedArray(ancill_var.data))
+        self.assertEqual(ma.count_masked(ancill_var.data), 0)
+
+    def test_masked_data_real(self):
+        data = self.masked_data_real
+        self.assertTrue(ma.isMaskedArray(data))
+        self.assertTrue(ma.count_masked(data))
+        ancill_var = AncillaryVariable(data)
+        self.assertFalse(ancill_var.has_lazy_data())
+        self.assertTrue(ma.isMaskedArray(ancill_var.data))
+        self.assertTrue(ma.count_masked(ancill_var.data))
+
+    def test_masked_data_lazy(self):
+        data = self.masked_data_lazy
+        computed = data.compute()
+        self.assertTrue(ma.isMaskedArray(computed))
+        self.assertTrue(ma.count_masked(computed))
+        ancill_var = AncillaryVariable(data)
+        self.assertTrue(ancill_var.has_lazy_data())
+        self.assertTrue(ma.isMaskedArray(ancill_var.data))
+        self.assertTrue(ma.count_masked(ancill_var.data))
+
+
+class Test_core_data(tests.IrisTest, AncillaryVariableTestMixin):
+    # Test for AncillaryVariable.core_data() with various lazy/real data.
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_real_data(self):
+        ancill_var = AncillaryVariable(self.data_real)
+        result = ancill_var.core_data()
+        self.assertArraysShareData(
+            result, self.data_real,
+            'core_data() do not share data with the internal array.')
+
+    def test_lazy_data(self):
+        ancill_var = AncillaryVariable(self.data_lazy)
+        result = ancill_var.core_data()
+        self.assertEqualLazyArraysAndDtypes(result, self.data_lazy)
+
+    def test_lazy_points_realise(self):
+        ancill_var = AncillaryVariable(self.data_lazy)
+        real_data = ancill_var.data
+        result = ancill_var.core_data()
+        self.assertEqualRealArraysAndDtypes(result, real_data)
+
+
+class Test_lazy_data(tests.IrisTest, AncillaryVariableTestMixin):
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_real_core(self):
+        ancill_var = AncillaryVariable(self.data_real)
+        result = ancill_var.lazy_data()
+        self.assertEqualLazyArraysAndDtypes(result, self.data_lazy)
+
+    def test_lazy_core(self):
+        ancill_var = AncillaryVariable(self.data_lazy)
+        result = ancill_var.lazy_data()
+        self.assertIs(result, self.data_lazy)
+
+
+class Test_has_lazy_data(tests.IrisTest, AncillaryVariableTestMixin):
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_real_core(self):
+        ancill_var = AncillaryVariable(self.data_real)
+        result = ancill_var.has_lazy_data()
+        self.assertFalse(result)
+
+    def test_lazy_core(self):
+        ancill_var = AncillaryVariable(self.data_lazy)
+        result = ancill_var.has_lazy_data()
+        self.assertTrue(result)
+
+    def test_lazy_core_realise(self):
+        ancill_var = AncillaryVariable(self.data_lazy)
+        ancill_var.data
+        result = ancill_var.has_lazy_data()
+        self.assertFalse(result)
+
+
+class Test__getitem__(tests.IrisTest, AncillaryVariableTestMixin):
+    # Test for AncillaryVariable indexing with various types of data.
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_partial_slice_data_copy(self):
+        parent_ancill_var = AncillaryVariable([1., 2., 3.])
+        sub_ancill_var = parent_ancill_var[:1]
+        values_before_change = sub_ancill_var.data.copy()
+        parent_ancill_var.data[:] = -999.9
+        self.assertArrayEqual(sub_ancill_var.data, values_before_change)
+
+    def test_full_slice_data_copy(self):
+        parent_ancill_var = AncillaryVariable([1., 2., 3.])
+        sub_ancill_var = parent_ancill_var[:]
+        values_before_change = sub_ancill_var.data.copy()
+        parent_ancill_var.data[:] = -999.9
+        self.assertArrayEqual(sub_ancill_var.data, values_before_change)
+
+    def test_dtypes(self):
+        # Index ancillary variables with real+lazy data, and either an int or
+        # floating dtype.
+        # Check that dtypes remain the same in all cases, taking the dtypes
+        # directly from the core data as we have no masking).
+        for (main_ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self):
+
+            sub_ancill_var = main_ancill_var[:2, 1]
+
+            ancill_var_dtype = main_ancill_var.dtype
+            msg = ('Indexing main_ancill_var of dtype {} with {} data changed'
+                   'dtype of {} to {}.')
+
+            sub_data = sub_ancill_var.core_data()
+            self.assertEqual(
+                sub_data.dtype, ancill_var_dtype,
+                msg.format(ancill_var_dtype, data_lazyness,
+                           'data', sub_data.dtype))
+
+    def test_lazyness(self):
+        # Index ancillary variables with real+lazy data, and either an int or
+        # floating dtype.
+        # Check that lazy data stays lazy and real stays real, in all cases.
+        for (main_ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self):
+
+            sub_ancill_var = main_ancill_var[:2, 1]
+
+            msg = ('Indexing main_ancill_var of dtype {} with {} data '
+                   'changed laziness of {} from {!r} to {!r}.')
+            ancill_var_dtype = main_ancill_var.dtype
+            sub_data_lazyness = lazyness_string(sub_ancill_var.core_data())
+            self.assertEqual(
+                sub_data_lazyness, data_lazyness,
+                msg.format(ancill_var_dtype, data_lazyness,
+                           'data', data_lazyness, sub_data_lazyness))
+
+    def test_real_data_copies(self):
+        # Index ancillary variables with real+lazy data.
+        # In all cases, check that any real arrays are copied by the indexing.
+        for (main_ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self):
+
+            sub_ancill_var = main_ancill_var[:2, 1]
+
+            msg = ('Indexed ancillary variable with {} data '
+                   'does not have its own separate {} array.')
+            if data_lazyness == 'real':
+                main_data = main_ancill_var.core_data()
+                sub_data = sub_ancill_var.core_data()
+                sub_main_data = main_data[:2, 1]
+                self.assertEqualRealArraysAndDtypes(sub_data,
+                                                    sub_main_data)
+                self.assertArraysDoNotShareData(
+                    sub_data, sub_main_data,
+                    msg.format(data_lazyness, 'points'))
+
+
+class Test_copy(tests.IrisTest, AncillaryVariableTestMixin):
+    # Test for AncillaryVariable.copy() with various types of data.
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_lazyness(self):
+        # Copy ancillary variables with real+lazy data, and either an int or
+        # floating dtype.
+        # Check that lazy data stays lazy and real stays real, in all cases.
+        for (main_ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self):
+
+            ancill_var_dtype = main_ancill_var.dtype
+            copied_ancill_var = main_ancill_var.copy()
+
+            msg = ('Copying main_ancill_var of dtype {} with {} data '
+                   'changed lazyness of {} from {!r} to {!r}.')
+
+            copied_data_lazyness = lazyness_string(
+                copied_ancill_var.core_data())
+            self.assertEqual(copied_data_lazyness, data_lazyness,
+                             msg.format(ancill_var_dtype, data_lazyness,
+                                        'points',
+                                        data_lazyness, copied_data_lazyness))
+
+    def test_realdata_copies(self):
+        # Copy ancillary variables with real+lazy data.
+        # In all cases, check that any real arrays are copies, not views.
+        for (main_ancill_var, data_lazyness) in \
+                data_all_dtypes_and_lazynesses(self):
+
+            copied_ancill_var = main_ancill_var.copy()
+
+            msg = ('Copied ancillary variable with {} data '
+                   'does not have its own separate {} array.')
+
+            if data_lazyness == 'real':
+                main_data = main_ancill_var.core_data()
+                copied_data = copied_ancill_var.core_data()
+                self.assertEqualRealArraysAndDtypes(main_data, copied_data)
+                self.assertArraysDoNotShareData(
+                    main_data, copied_data,
+                    msg.format(data_lazyness, 'points'))
+
+
+class Test_data__getter(tests.IrisTest, AncillaryVariableTestMixin):
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_mutable_real_data(self):
+        # Check that ancill_var.data returns a modifiable array, and changes
+        # to it are reflected to the ancillary_var.
+        data = np.array([1.0, 2.0, 3.0, 4.0])
+        ancill_var = AncillaryVariable(data)
+        initial_values = data.copy()
+        ancill_var.data[1:2] += 33.1
+        result = ancill_var.data
+        self.assertFalse(np.all(result == initial_values))
+
+    def test_real_data(self):
+        # Getting real data does not change or copy them.
+        ancill_var = AncillaryVariable(self.data_real)
+        result = ancill_var.data
+        self.assertArraysShareData(
+            result, self.data_real,
+            'Data values do not share data with the provided array.')
+
+    def test_lazy_data(self):
+        # Getting lazy data realises them.
+        ancill_var = AncillaryVariable(self.data_lazy)
+        self.assertTrue(ancill_var.has_lazy_data())
+        result = ancill_var.data
+        self.assertFalse(ancill_var.has_lazy_data())
+        self.assertEqualRealArraysAndDtypes(result, self.data_real)
+
+
+class Test_data__setter(tests.IrisTest, AncillaryVariableTestMixin):
+    def setUp(self):
+        self.setupTestArrays()
+
+    def test_real_set_real(self):
+        # Setting new real data does not make a copy.
+        ancill_var = AncillaryVariable(self.data_real)
+        new_data = self.data_real + 102.3
+        ancill_var.data = new_data
+        result = ancill_var.core_data()
+        self.assertArraysShareData(
+            result, new_data,
+            'Data values do not share data with the assigned array.')
+
+    def test_fail_bad_shape(self):
+        # Setting real data requires matching shape.
+        ancill_var = AncillaryVariable([1.0, 2.0])
+        msg = 'Require data with shape \(2,\), got \(3,\)'
+        with self.assertRaisesRegexp(ValueError, msg):
+            ancill_var.data = np.array([1.0, 2.0, 3.0])
+
+    def test_real_set_lazy(self):
+        # Setting new lazy data does not make a copy.
+        ancill_var = AncillaryVariable(self.data_real)
+        new_data = self.data_lazy + 102.3
+        ancill_var.data = new_data
+        result = ancill_var.core_data()
+        self.assertEqualLazyArraysAndDtypes(result, new_data)
+
+
+class Test__str__(tests.IrisTest):
+    def test_non_time_values(self):
+        ancillary_var = AncillaryVariable(
+            np.array([2, 5, 9]),
+            standard_name='height',
+            long_name='height of detector',
+            var_name='height',
+            units='m',
+            attributes={'notes': 'Measured from sea level'})
+        expected = ("AncillaryVariable(array([2, 5, 9]), "
+                    "standard_name='height', units=Unit('m'), "
+                    "long_name='height of detector', var_name='height', "
+                    "attributes={'notes': 'Measured from sea level'})")
+        self.assertEqual(expected, ancillary_var.__str__(), )
+
+    def test_time_values(self):
+        ancillary_var = AncillaryVariable(
+            np.array([2, 5, 9]),
+            units='hours since 1970-01-01 01:00',
+            long_name='time of previous valid detection')
+        expected = ("AncillaryVariable([1970-01-01 03:00:00, "
+                    "1970-01-01 06:00:00, 1970-01-01 10:00:00], "
+                    "standard_name=None, calendar='gregorian', "
+                    "long_name='time of previous valid detection')")
+        self.assertEqual(expected, ancillary_var.__str__(), )
+
+
+class Test__repr__(tests.IrisTest):
+    def test_non_time_values(self):
+        ancillary_var = AncillaryVariable(
+            np.array([2, 5, 9]),
+            standard_name='height',
+            long_name='height of detector',
+            var_name='height',
+            units='m',
+            attributes={'notes': 'Measured from sea level'})
+        expected = ("AncillaryVariable(array([2, 5, 9]), "
+                    "standard_name='height', units=Unit('m'), "
+                    "long_name='height of detector', var_name='height', "
+                    "attributes={'notes': 'Measured from sea level'})")
+        self.assertEqual(expected, ancillary_var.__repr__(), )
+
+    def test_time_values(self):
+        ancillary_var = AncillaryVariable(
+            np.array([2, 5, 9]),
+            units='hours since 1970-01-01 01:00',
+            long_name='time of previous valid detection')
+        expected = ("AncillaryVariable(array([2, 5, 9]), standard_name=None, "
+                    "units=Unit('hours since 1970-01-01 01:00', "
+                    "calendar='gregorian'), "
+                    "long_name='time of previous valid detection')")
+        self.assertEqual(expected, ancillary_var.__repr__())
+
+
+class Test___binary_operator__(tests.IrisTest, AncillaryVariableTestMixin):
+    # Test maths operations on on real+lazy data.
+    def setUp(self):
+        self.setupTestArrays()
+
+        self.real_ancill_var = AncillaryVariable(self.data_real)
+        self.lazy_ancill_var = AncillaryVariable(self.data_lazy)
+
+        self.test_combinations = [
+            (self.real_ancill_var, self.data_real, 'real'),
+            (self.lazy_ancill_var, self.data_lazy, 'lazy')]
+
+    def _check(self, result_ancill_var, expected_data, lazyness):
+        # Test each operation on
+        data = result_ancill_var.core_data()
+        if lazyness == 'real':
+            self.assertEqualRealArraysAndDtypes(expected_data, data)
+        else:
+            self.assertEqualLazyArraysAndDtypes(expected_data, data)
+
+    def test_add(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = ancill_var + 10
+            expected_data = orig_data + 10
+            self._check(result, expected_data, data_lazyness)
+
+    def test_add_inplace(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            ancill_var += 10
+            expected_data = orig_data + 10
+            self._check(ancill_var, expected_data, data_lazyness)
+
+    def test_right_add(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = 10 + ancill_var
+            expected_data = 10 + orig_data
+            self._check(result, expected_data, data_lazyness)
+
+    def test_subtract(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = ancill_var - 10
+            expected_data = orig_data - 10
+            self._check(result, expected_data, data_lazyness)
+
+    def test_subtract_inplace(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            ancill_var -= 10
+            expected_data = orig_data - 10
+            self._check(ancill_var, expected_data, data_lazyness)
+
+    def test_right_subtract(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = 10 - ancill_var
+            expected_data = 10 - orig_data
+            self._check(result, expected_data, data_lazyness)
+
+    def test_multiply(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = ancill_var * 10
+            expected_data = orig_data * 10
+            self._check(result, expected_data, data_lazyness)
+
+    def test_multiply_inplace(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            ancill_var *= 10
+            expected_data = orig_data * 10
+            self._check(ancill_var, expected_data, data_lazyness)
+
+    def test_right_multiply(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = 10 * ancill_var
+            expected_data = 10 * orig_data
+            self._check(result, expected_data, data_lazyness)
+
+    def test_divide(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = ancill_var / 10
+            expected_data = orig_data / 10
+            self._check(result, expected_data, data_lazyness)
+
+    def test_divide_inplace(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            ancill_var /= 10
+            expected_data = orig_data / 10
+            self._check(ancill_var, expected_data, data_lazyness)
+
+    def test_right_divide(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = 10 / ancill_var
+            expected_data = 10 / orig_data
+            self._check(result, expected_data, data_lazyness)
+
+    def test_negative(self):
+        for (ancill_var, orig_data, data_lazyness) in self.test_combinations:
+            result = -ancill_var
+            expected_data = -orig_data
+            self._check(result, expected_data, data_lazyness)
+
+
+class Test_has_bounds(tests.IrisTest):
+    def test(self):
+        ancillary_var = AncillaryVariable(np.array([2, 9, 5]))
+        self.assertFalse(ancillary_var.has_bounds())
+
+
+class Test_convert_units(tests.IrisTest):
+    def test_preserves_lazy(self):
+        test_data = np.array([[11.1, 12.2, 13.3],
+                              [21.4, 22.5, 23.6]])
+        lazy_data = as_lazy_data(test_data)
+        ancill_var = AncillaryVariable(data=lazy_data, units='m')
+        ancill_var.convert_units('ft')
+        self.assertTrue(ancill_var.has_lazy_data())
+        test_data_ft = Unit('m').convert(test_data, 'ft')
+        self.assertArrayAllClose(ancill_var.data, test_data_ft)
+
+
+class Test_is_compatible(tests.IrisTest):
+    def setUp(self):
+        self.ancill_var = AncillaryVariable(
+            [1., 8., 22.],
+            standard_name='number_of_observations', units='1')
+        self.modified_ancill_var = self.ancill_var.copy()
+
+    def test_not_compatible_diff_name(self):
+        # Different name() - not compatible
+        self.modified_ancill_var.rename('air_temperature')
+        self.assertFalse(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_not_compatible_diff_units(self):
+        # Different units- not compatible
+        self.modified_ancill_var.units = 'm'
+        self.assertFalse(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_not_compatible_diff_common_attrs(self):
+        # Different common attributes - not compatible.
+        self.ancill_var.attributes['source'] = 'A'
+        self.modified_ancill_var.attributes['source'] = 'B'
+        self.assertFalse(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_compatible_diff_data(self):
+        # Different data values - compatible.
+        self.modified_ancill_var.data = [10., 20., 100.]
+        self.assertTrue(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_compatible_diff_var_name(self):
+        # Different var_name (but same name()) - compatible.
+        self.modified_ancill_var.var_name = 'obs_num'
+        self.assertTrue(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_compatible_diff_non_common_attributes(self):
+        # Different non-common attributes - compatible.
+        self.ancill_var.attributes['source'] = 'A'
+        self.modified_ancill_var.attributes['origin'] = 'B'
+        self.assertTrue(
+            self.ancill_var.is_compatible(self.modified_ancill_var))
+
+    def test_compatible_ignore_common_attribute(self):
+        # ignore different common attributes - compatible.
+        self.ancill_var.attributes['source'] = 'A'
+        self.modified_ancill_var.attributes['source'] = 'B'
+        self.assertTrue(
+            self.ancill_var.is_compatible(self.modified_ancill_var,
+                                          ignore='source'))
+
+
+class TestEquality(tests.IrisTest):
+    def test_nanpoints_eq_self(self):
+        av1 = AncillaryVariable([1., np.nan, 2.])
+        self.assertEqual(av1, av1)
+
+    def test_nanpoints_eq_copy(self):
+        av1 = AncillaryVariable([1., np.nan, 2.])
+        av2 = av1.copy()
+        self.assertEqual(av1, av2)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/coords/test_CellMeasure.py
+++ b/lib/iris/tests/unit/coords/test_CellMeasure.py
@@ -74,7 +74,7 @@ class Tests(tests.IrisTest):
 
     def test_data_different_shape(self):
         new_vals = np.array((1., 2., 3.))
-        msg = 'New data shape must match existing data shape.'
+        msg = 'Require data with shape.'
         with self.assertRaisesRegexp(ValueError, msg):
             self.measure.data = new_vals
 
@@ -123,6 +123,7 @@ class Tests(tests.IrisTest):
 
     def test__eq__(self):
         self.assertEqual(self.measure, self.measure)
+
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -739,7 +739,7 @@ class Test_convert_units(tests.IrisTest):
     def test_convert_unknown_units(self):
         coord = iris.coords.AuxCoord(1, units='unknown')
         emsg = ('Cannot convert from unknown units. '
-                'The "coord.units" attribute may be set directly.')
+                'The "units" attribute may be set directly.')
         with self.assertRaisesRegexp(UnitConversionError, emsg):
             coord.convert_units('degrees')
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -425,14 +425,15 @@ class Test_summary(tests.IrisTest):
         self.assertIn(str_value, summary)
 
     def test_ancillary_variable(self):
-        cube = Cube(np.arange(6).reshape(2,3))
-        av = AncillaryVariable([1,2], 'status_flag')
+        cube = Cube(np.arange(6).reshape(2, 3))
+        av = AncillaryVariable([1, 2], 'status_flag')
         cube.add_ancillary_variable(av, 0)
         expected_summary = \
             'unknown / (unknown)                 (-- : 2; -- : 3)\n' \
             '     Ancillary Variables:\n' \
             '          status_flag                   x       -'
         self.assertEqual(cube.summary(), expected_summary)
+
 
 class Test_is_compatible(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -38,8 +38,9 @@ from iris.analysis import WeightedAggregator, Aggregator
 from iris.analysis import MEAN
 from iris.aux_factory import HybridHeightFactory
 from iris.cube import Cube
-from iris.coords import AuxCoord, DimCoord, CellMeasure
+from iris.coords import AuxCoord, DimCoord, CellMeasure, AncillaryVariable
 from iris.exceptions import (CoordinateNotFoundError, CellMeasureNotFoundError,
+                             AncillaryVariableNotFoundError,
                              UnitConversionError)
 from iris._lazy_data import as_lazy_data
 from iris.tests import mock
@@ -1670,6 +1671,15 @@ class Test_add_metadata(tests.IrisTest):
         cube.add_cell_measure(a_cell_measure, [0, 1])
         self.assertEqual(cube.cell_measure('area'), a_cell_measure)
 
+    def test_add_ancillary_variable(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        ancillary_variable = AncillaryVariable(
+            data=np.arange(6).reshape(2, 3),
+            long_name='detection quality')
+        cube.add_ancillary_variable(ancillary_variable, [0, 1])
+        self.assertEqual(cube.ancillary_variable('detection quality'),
+                         ancillary_variable)
+
     def test_add_valid_aux_factory(self):
         cube = Cube(np.arange(8).reshape(2, 2, 2))
         delta = AuxCoord(points=[0, 1], long_name='delta', units='m')
@@ -1712,6 +1722,10 @@ class Test_remove_metadata(tests.IrisTest):
                                           measure='area')
         cube.add_cell_measure(a_cell_measure, [0, 1])
         cube.add_cell_measure(self.b_cell_measure, [0, 1])
+        ancillary_variable = AncillaryVariable(
+            data=np.arange(6).reshape(2, 3),
+            long_name='Quality of Detection')
+        cube.add_ancillary_variable(ancillary_variable, [0, 1])
         self.cube = cube
 
     def test_remove_dim_coord(self):
@@ -1735,6 +1749,11 @@ class Test_remove_metadata(tests.IrisTest):
     def test_fail_remove_cell_measure_by_name(self):
         with self.assertRaises(CellMeasureNotFoundError):
             self.cube.remove_cell_measure('notarea')
+
+    def test_remove_ancilliary_variable(self):
+        self.cube.remove_ancillary_variable(
+            self.cube.ancillary_variable('Quality of Detection'))
+        self.assertEqual(self.cube._ancillary_variables_and_dims, [])
 
 
 class Test__getitem_CellMeasure(tests.IrisTest):
@@ -1765,6 +1784,50 @@ class Test__getitem_CellMeasure(tests.IrisTest):
         self.assertEqual(len(result.cell_measures()), 1)
         self.assertEqual(result.shape,
                          result.cell_measures()[0].data.shape)
+
+
+class TestAncillaryVariables(tests.IrisTest):
+    def setUp(self):
+        cube = Cube(10 * np.arange(6).reshape(2, 3))
+        self.ancill_var = AncillaryVariable(
+            np.arange(6).reshape(2, 3),
+            standard_name='number_of_observations', units='1')
+        cube.add_ancillary_variable(self.ancill_var, [0, 1])
+        self.cube = cube
+
+    def test_get_ancillary_variable(self):
+        ancill_var = self.cube.ancillary_variable('number_of_observations')
+        self.assertEqual(ancill_var, self.ancill_var)
+
+    def test_get_ancillary_variables(self):
+        ancill_vars = self.cube.ancillary_variables('number_of_observations')
+        self.assertEqual(len(ancill_vars), 1)
+        self.assertEqual(ancill_vars[0], self.ancill_var)
+
+    def test_get_ancillary_variable_obj(self):
+        ancill_vars = self.cube.ancillary_variables(self.ancill_var)
+        self.assertEqual(len(ancill_vars), 1)
+        self.assertEqual(ancill_vars[0], self.ancill_var)
+
+    def test_fail_get_ancillary_variables(self):
+        with self.assertRaises(AncillaryVariableNotFoundError):
+            self.cube.ancillary_variable('other_ancill_var')
+
+    def test_fail_get_ancillary_variables_obj(self):
+        ancillary_variable = self.ancill_var.copy()
+        ancillary_variable.long_name = 'Number of observations at site'
+        with self.assertRaises(AncillaryVariableNotFoundError):
+            self.cube.ancillary_variable(ancillary_variable)
+
+    def test_ancillary_variable_dims(self):
+        ancill_var_dims = self.cube.ancillary_variable_dims(self.ancill_var)
+        self.assertEqual(ancill_var_dims, (0, 1))
+
+    def test_fail_ancill_variable_dims(self):
+        ancillary_variable = self.ancill_var.copy()
+        ancillary_variable.long_name = 'Number of observations at site'
+        with self.assertRaises(AncillaryVariableNotFoundError):
+            self.cube.ancillary_variable_dims(ancillary_variable)
 
 
 class TestCellMeasures(tests.IrisTest):
@@ -1885,6 +1948,14 @@ class Test_transpose(tests.IrisTest):
         self.cube.transpose()
         self.assertEqual(self.cube._cell_measures_and_dims,
                          [(area_cm, (2, 0))])
+
+    def test_ancillary_variables(self):
+        ancill_var = AncillaryVariable(data=np.arange(8).reshape(2, 4),
+                                       long_name='instrument error')
+        self.cube.add_ancillary_variable(ancill_var, (1, 2))
+        self.cube.transpose()
+        self.assertEqual(self.cube._ancillary_variables_and_dims,
+                         [(ancill_var, (1, 0))])
 
 
 class Test_convert_units(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -424,6 +424,15 @@ class Test_summary(tests.IrisTest):
         summary = self.cube.summary()
         self.assertIn(str_value, summary)
 
+    def test_ancillary_variable(self):
+        cube = Cube(np.arange(6).reshape(2,3))
+        av = AncillaryVariable([1,2], 'status_flag')
+        cube.add_ancillary_variable(av, 0)
+        expected_summary = \
+            'unknown / (unknown)                 (-- : 2; -- : 3)\n' \
+            '     Ancillary Variables:\n' \
+            '          status_flag                   x       -'
+        self.assertEqual(cube.summary(), expected_summary)
 
 class Test_is_compatible(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
This includes the functionality to represent CF Ancillary variables on a cube.

This PR also includes a restructuring of dimensional metadata objects (coords, cell measures and ancillary dataset) in a hope to avoid code duplication.

Below is a rough diagram of the new structure:
![IrisCoordsUML](https://user-images.githubusercontent.com/8101163/65649805-fa452200-dfff-11e9-9b11-0c5da9fc9cac.jpg)

