### PR TITLE
Climatological xml

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1712,6 +1712,8 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if self.var_name:
             element.setAttribute('var_name', str(self.var_name))
         element.setAttribute('units', repr(self.units))
+        if self.climatological:
+            element.setAttribute('climatological', str(self.climatological))
 
         if self.attributes:
             attributes_element = doc.createElement('attributes')

--- a/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_tmerc_and_climatology.cml
@@ -62,7 +62,7 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord bounds="[[113225.0, 113589.0]]" id="b8b34212" long_name="time" points="[113406.0]" shape="(1,)" standard_name="time" units="Unit('days since 1600-1-1 0:0:0', calendar='gregorian')" value_type="float64" var_name="time"/>
+        <dimCoord bounds="[[113225.0, 113589.0]]" climatological="True" id="b8b34212" long_name="time" points="[113406.0]" shape="(1,)" standard_name="time" units="Unit('days since 1600-1-1 0:0:0', calendar='gregorian')" value_type="float64" var_name="time"/>
       </coord>
     </coords>
     <cellMethods>


### PR DESCRIPTION
Follow-up from #3395, adding changes to support the `climatological` property in our `cml` test output.