### PR TITLE
Allow non-float cell measures

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Sep-27_cell_measure_integer_data.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/newfeature_2019-Sep-27_cell_measure_integer_data.txt
@@ -1,0 +1,1 @@
+* Loading CellMeasures with non-float values is now supported.

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2077,13 +2077,13 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
         Kwargs:
 
         * standard_name:
-            CF standard name of the coordinate.
+            CF standard name of the cell measure.
         * long_name:
-            Descriptive name of the coordinate.
+            Descriptive name of the cell measure.
         * var_name:
-            The netCDF variable name for the coordinate.
+            The netCDF variable name for the cell measure.
         * units
-            The :class:`~cf_units.Unit` of the coordinate's values.
+            The :class:`~cf_units.Unit` of the cell measure's values.
             Can be a string, which will be converted to a Unit object.
         * attributes
             A dictionary containing other CF and user-defined attributes.
@@ -2092,16 +2092,16 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
             are the only valid entries.
 
         """
-        #: CF standard name of the quantity that the coordinate represents.
+        #: CF standard name of the quantity that the cell measure represents.
         self.standard_name = standard_name
 
-        #: Descriptive name of the coordinate.
+        #: Descriptive name of the cell measure.
         self.long_name = long_name
 
-        #: The netCDF variable name for the coordinate.
+        #: The netCDF variable name for the cell measure.
         self.var_name = var_name
 
-        #: Unit of the quantity that the coordinate represents.
+        #: Unit of the quantity that the cell measure represents.
         self.units = units
 
         #: Other attributes, including user specified attributes that
@@ -2131,11 +2131,6 @@ class CellMeasure(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if data is None:
             raise ValueError('The data payload of a CellMeasure may not be '
                              'None; it must be a numpy array or equivalent.')
-        if _lazy.is_lazy_data(data) and data.dtype.kind in 'biu':
-            # Non-floating cell measures are not valid up to CF v1.7
-            msg = ('Cannot create cell measure with lazy data of type {}, as '
-                   'integer types are not currently supported.')
-            raise ValueError(msg.format(data.dtype))
         if data.shape == ():
             # If we have a scalar value, promote the shape from () to (1,).
             # NOTE: this way also *realises* it.  Don't think that matters.

--- a/lib/iris/tests/unit/coords/test_CellMeasure.py
+++ b/lib/iris/tests/unit/coords/test_CellMeasure.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -71,18 +71,6 @@ class Tests(tests.IrisTest):
         new_vals = as_lazy_data(np.array((1., 2., 3., 4.)))
         self.measure.data = new_vals
         self.assertArrayEqual(self.measure.data, new_vals)
-
-    def test_set_data__int__lazy(self):
-        new_vals = as_lazy_data(np.array((1, 2, 3, 4), dtype=np.int32))
-        exp_emsg = "Cannot create cell measure with lazy data of type int32"
-        with self.assertRaisesRegexp(ValueError, exp_emsg):
-            self.measure.data = new_vals
-
-    def test_set_data__uint__lazy(self):
-        new_vals = as_lazy_data(np.array((1, 2, 3, 4), dtype=np.uint32))
-        exp_emsg = "Cannot create cell measure with lazy data of type uint32"
-        with self.assertRaisesRegexp(ValueError, exp_emsg):
-            self.measure.data = new_vals
 
     def test_data_different_shape(self):
         new_vals = np.array((1., 2., 3.))


### PR DESCRIPTION
Currently, we do not allow the creation of cell measures with non-float data as it is claimed that this is not supported until CF1.7

As of #3406 we are now committed to CF1.7 so we can now support this.

It is worth mentioning that I struggled to find reference to the 
> Non-floating cell measures are not valid up to CF v1.7

in the CF documenstation. But regardless, we can remove this restriction now.