### PR TITLE
Fix handling of cell measures during transposes of cubes

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Oct-01_cube_transpose_cell_measures.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2019-Oct-01_cube_transpose_cell_measures.txt
@@ -1,0 +1,1 @@
+* Cell measures are now handled correctly when a cube is transposed.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2819,17 +2819,22 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         dim_mapping = {src: dest for dest, src in enumerate(new_order)}
 
-        def remap_dim_coord(coord_and_dim):
-            coord, dim = coord_and_dim
-            return coord, dim_mapping[dim]
-        self._dim_coords_and_dims = list(map(remap_dim_coord,
-                                             self._dim_coords_and_dims))
+        # Remap all cube dimensional metadata (dim and aux coords and cell
+        # measures).
+        def remap_cube_metadata(metadata_and_dims):
+            metadata, dims = metadata_and_dims
+            if isinstance(dims, Iterable):
+                dims = tuple(dim_mapping[dim] for dim in dims)
+            else:
+                dims = dim_mapping[dims]
+            return metadata, dims
 
-        def remap_aux_coord(coord_and_dims):
-            coord, dims = coord_and_dims
-            return coord, tuple(dim_mapping[dim] for dim in dims)
-        self._aux_coords_and_dims = list(map(remap_aux_coord,
+        self._dim_coords_and_dims = list(map(remap_cube_metadata,
+                                             self._dim_coords_and_dims))
+        self._aux_coords_and_dims = list(map(remap_cube_metadata,
                                              self._aux_coords_and_dims))
+        self._cell_measures_and_dims = list(map(remap_cube_metadata,
+                                                self._cell_measures_and_dims))
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """

--- a/lib/iris/tests/unit/coords/test_CellMeasure.py
+++ b/lib/iris/tests/unit/coords/test_CellMeasure.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -132,6 +132,9 @@ class Tests(tests.IrisTest):
                     "units=Unit('m^2'), long_name='measured_area', "
                     "var_name='area', attributes={'notes': '1m accuracy'})")
         self.assertEqual(self.measure.__repr__(), expected)
+
+    def test__eq__(self):
+        self.assertEqual(self.measure, self.measure)
 
 if __name__ == '__main__':
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1863,6 +1863,29 @@ class Test_transpose(tests.IrisTest):
         with self.assertRaisesRegexp(ValueError, exp_emsg):
             self.cube.transpose([1])
 
+    def test_dim_coords(self):
+        x_coord = DimCoord(points=np.array([2, 3, 4]),
+                           long_name='x')
+        self.cube.add_dim_coord(x_coord, 0)
+        self.cube.transpose()
+        self.assertEqual(self.cube._dim_coords_and_dims, [(x_coord, 2)])
+
+    def test_aux_coords(self):
+        x_coord = AuxCoord(points=np.array([[2, 3], [8, 4], [7, 9]]),
+                           long_name='x')
+        self.cube.add_aux_coord(x_coord, (0, 1))
+        self.cube.transpose()
+        self.assertEqual(self.cube._aux_coords_and_dims,
+                         [(x_coord, (2, 1))])
+
+    def test_cell_measures(self):
+        area_cm = CellMeasure(data=np.arange(12).reshape(3, 4),
+                              long_name='area of cells', measure='area')
+        self.cube.add_cell_measure(area_cm, (0, 2))
+        self.cube.transpose()
+        self.assertEqual(self.cube._cell_measures_and_dims,
+                         [(area_cm, (2, 0))])
+
 
 class Test_convert_units(tests.IrisTest):
     def test_convert_unknown_units(self):


### PR DESCRIPTION
Currently cell measures are not handled when you do a transpose of a cube. 
```
>>> c = Cube(np.arange(6).reshape(2,3), 'x_wind')
>>> cm = CellMeasure(np.arange(6).reshape(2,3), measure='area')
>>> c.add_cell_measure(cm, (0,1))
>>> print(c._cell_measures_and_dims)
[[CellMeasure(array([[0, 1, 2],
       [3, 4, 5]]), measure=area, standard_name=None, units=Unit('1')), (0, 1)]]
>>> c.transpose()
>>> print(c._cell_measures_and_dims)
[[CellMeasure(array([[0, 1, 2],
       [3, 4, 5]]), measure=area, standard_name=None, units=Unit('1')), (0, 1)]]
```
Where I would expect the last line to return:

```
>>> print(c._cell_measures_and_dims)
[[CellMeasure(array([[0, 1, 2],
       [3, 4, 5]]), measure=area, standard_name=None, units=Unit('1')), (1, 0)]]
```
i.e. the dims swapped, as it does with auxiliary coords.

This PR includes the handling of the above, plus tests.