### PR TITLE
bump version to 3.0.dev0

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -121,7 +121,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = '2.3.0dev0'
+__version__ = '3.0.dev0'
 
 # Restrict the names imported when using "from iris import *"
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',


### PR DESCRIPTION
Bump the `master` version to `3.0.dev0` :tada: 

Note that, the version isn't `3.0dev0` nor `3.0.0dev0` not even `3.0.0.dev0`. 

Patch versions don't appear on `master`, those are for `X.X.x` branches. The `master` branch is reserved for major and minor versions (and cycling `dev` appropriately, not that we ever have)

Also it's `3.0.dev0` instead of `3.0dev0` otherwise `setuptools` complains with:
```
setuptools/dist.py:472: UserWarning: Normalizing '3.0dev0' to '3.0.dev0'
```