### PR TITLE
disable python2 travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ env:
     # The decryption key for the encrypted .github/deploy_key.scitools-docs.enc.
     - secure: "N9/qBUT5CqfC7KQBDy5mIWZcGNuUJk3e/qmKJpotWYV+zwOI4GghJsRce6nFnlRiwl65l5oBEcvf3+sBvUfbZqh7U0MdHpw2tHhr2FSCmMB3bkvARZblh9M37f4da9G9VmRkqnyBM5G5TImXtoq4dusvNWKvLW0qETciaipq7ws="
   matrix:
-    - PYTHON_VERSION=2.7 TEST_TARGET=default TEST_MINIMAL=true
-    - PYTHON_VERSION=2.7 TEST_TARGET=default
-    - PYTHON_VERSION=2.7 TEST_TARGET=example
-
     - PYTHON_VERSION=3.6 TEST_TARGET=default TEST_MINIMAL=true
     - PYTHON_VERSION=3.6 TEST_TARGET=default
     - PYTHON_VERSION=3.6 TEST_TARGET=example
@@ -40,11 +36,7 @@ install:
   - >
     echo 'Installing miniconda';
     export CONDA_BASE="https://repo.continuum.io/miniconda/Miniconda";
-    if [[ "${PYTHON_VERSION}" == 2* ]]; then
-      wget --quiet ${CONDA_BASE}2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget --quiet ${CONDA_BASE}3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi;
+    wget --quiet ${CONDA_BASE}3-latest-Linux-x86_64.sh -O miniconda.sh;
     bash miniconda.sh -b -p ${HOME}/miniconda;
     export PATH="${HOME}/miniconda/bin:${PATH}";
 
@@ -65,11 +57,7 @@ install:
   # ---------------------------------
   - >
     echo 'Install Iris dependencies';
-    CONDA_REQS_FLAGS="";
     CONDA_REQS_GROUPS="test";
-    if [[ "${PYTHON_VERSION}" == 2* ]]; then
-        CONDA_REQS_FLAGS="${CONDA_REQS_FLAGS} --py2";
-    fi;
     if [[ "${TEST_MINIMAL}" != true ]]; then
         CONDA_REQS_GROUPS="${CONDA_REQS_GROUPS} all";
     fi;
@@ -77,7 +65,7 @@ install:
         CONDA_REQS_GROUPS="${CONDA_REQS_GROUPS} docs";
     fi;
     CONDA_REQS_FILE="conda-requirements.txt";
-    python requirements/gen_conda_requirements.py ${CONDA_REQS_FLAGS} --groups ${CONDA_REQS_GROUPS} > ${CONDA_REQS_FILE};
+    python requirements/gen_conda_requirements.py --groups ${CONDA_REQS_GROUPS} > ${CONDA_REQS_FILE};
     cat ${CONDA_REQS_FILE};
     conda install --quiet -n ${ENV_NAME} --file ${CONDA_REQS_FILE};
 
@@ -112,12 +100,12 @@ install:
 
   - python setup.py --quiet install
 
-  # JUST FOR NOW : Install latest version of iris-grib.
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.
-  - if [[ "${TEST_MINIMAL}" != true && ${PYTHON_VERSION} == 2* ]]; then
-        conda install --quiet -n ${ENV_NAME} python-ecmwf_grib;
-        pip install git+https://github.com/SciTools/iris-grib.git@v0.11.0;
-    fi
+# TODO: uncomment and address the 5 failures and 10 errors in iris-grib.
+#  - if [[ "${TEST_MINIMAL}" != true ]]; then
+#        conda install --quiet -n ${ENV_NAME} python-eccodes;
+#        conda install --quiet -n ${ENV_NAME} --no-deps iris-grib;
+#    fi
 
 script:
   # Capture install-dir: As a test command must be last for get Travis to check

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -2,7 +2,7 @@
 # ------------------------------------------------
 
 # esmpy regridding not available through pip.
-#conda: esmpy>=7.0  (only python=2)
+#conda: esmpy>=7.0
 #gdal : under review -- not tested at present
 mo_pack
 nc-time-axis

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -5,5 +5,5 @@
 # struggle. To install these extensions, ensure iris[core] has been installed
 # first.
 
-iris_grib;python_version<"3"  #conda:
+iris-grib  #conda:
 gdal

--- a/requirements/gen_conda_requirements.py
+++ b/requirements/gen_conda_requirements.py
@@ -23,7 +23,7 @@ REQS_DIR = os.path.dirname(__file__)
 CONDA_PATTERN = '#conda:'
 
 
-def read_conda_reqs(fname, options):
+def read_conda_reqs(fname):
     lines = []
     with open(fname, 'r') as fh:
         for line in fh:
@@ -31,33 +31,19 @@ def read_conda_reqs(fname, options):
             if CONDA_PATTERN in line:
                 line_start = line.index(CONDA_PATTERN) + len(CONDA_PATTERN)
                 line = line[line_start:].strip()
-                if 'only python=2' in line:
-                    if 'python=2' in options:
-                        line = line.replace('(only python=2)', '')
-                        lines.append(line)
-                    else:
-                        continue
-                else:
-                    lines.append(line)
-            else:
-                lines.append(line)
+            lines.append(line)
     return lines
 
 
-def compute_requirements(requirement_names=('core', ), options=None):
+def compute_requirements(requirement_names=('core', )):
     conda_reqs_lines = []
-
-    if 'python=2' in options:
-        conda_reqs_lines.append('python=2.*')
-    else:
-        conda_reqs_lines.append('# Python 3 conda configuration')
 
     for req_name in requirement_names:
         fname = os.path.join(REQS_DIR, '{}.txt'.format(req_name))
         if not os.path.exists(fname):
             raise RuntimeError('Unable to find the requirements file for {} '
                                'in {}'.format(req_name, fname))
-        conda_reqs_lines.extend(read_conda_reqs(fname, options))
+        conda_reqs_lines.extend(read_conda_reqs(fname))
         conda_reqs_lines.append('')
 
     return conda_reqs_lines
@@ -70,9 +56,6 @@ def main():
             "--groups", nargs='*', default=[],
             help=("Gather requirements for these given named groups "
                   "(as found in the requirements/ folder)"))
-    parser.add_argument(
-            "--py2", action="store_true",
-            help="Build the conda requirements for a python 2 installation")
 
     args = parser.parse_args()
 
@@ -80,11 +63,7 @@ def main():
     requirement_names.insert(0, 'core')
     requirement_names.insert(0, 'setup')
 
-    options = []
-    if args.py2:
-        options.append('python=2')
-
-    print('\n'.join(compute_requirements(requirement_names, options)))
+    print('\n'.join(compute_requirements(requirement_names)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR removes Python2 `travis-ci` testing :tada: 

As a part of technical debt, the appropriate changes are now in place within the `.travis.yml` to commence `iris-grib` tests.... however, there are 5 errors and 10 failures that require to be addressed.

I'll raise a separate issue to cover this, see https://github.com/SciTools/iris/issues/3447.