### PR TITLE
Undo deprecation warning - should be regular warning?

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -26,11 +26,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import re
+import warnings
 
 import cf_units
 import numpy as np
 
-from iris._deprecation import warn_deprecated
 import iris.cube
 import iris.coords
 import iris.coord_systems
@@ -91,8 +91,8 @@ def _construct_midpoint_coord(coord, circular=None):
     if circular is None:
         circular = getattr(coord, 'circular', False)
     elif circular != getattr(coord, 'circular', False):
-        warn_deprecated('circular flag and Coord.circular attribute do '
-                        'not match')
+        warnings.warn('circular flag and Coord.circular attribute do '
+                      'not match')
 
     if coord.ndim != 1:
         raise iris.exceptions.CoordinateMultiDimError(coord)


### PR DESCRIPTION
Whilst looking for deprecations that needed removing in the Iris 3 release, I came across what looks like something that shouldn't be deprecated?

I'm not sure! So I thought I would raise it.

It was originally a regular warning, but #1993 changed it to a deprecation warning