### PR TITLE
Improve warning and error messages for old routine.

### DIFF
--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -85,14 +85,16 @@ def _construct_midpoint_coord(coord, circular=None):
 
     """
     if circular and not hasattr(coord, 'circular'):
-        raise ValueError('Cannot produce circular midpoint from a coord '
-                         'without the circular attribute')
+        msg = ("Cannot produce a circular midpoint for the '{}' coord, "
+               "which does not have a 'circular' attribute.")
+        raise ValueError(msg.format(coord.name()))
 
     if circular is None:
         circular = getattr(coord, 'circular', False)
     elif circular != getattr(coord, 'circular', False):
-        warnings.warn('circular flag and Coord.circular attribute do '
-                      'not match')
+        msg = ("Construction coordinate midpoints for the '{}' coordinate, "
+               "though it has the attribute 'circular'={}.")
+        warnings.warn(msg.format(circular, coord.circular, coord.name()))
 
     if coord.ndim != 1:
         raise iris.exceptions.CoordinateMultiDimError(coord)


### PR DESCRIPTION
This is a minimal improvement to the problems identified in #3449 with the error + warning messages produced by `iris.analysis.calculus._construct_midpoint_coord`.

Frankly there's a lot more that's wrong with this + I almost wish I hadn't bothered :  
  * the use of this private routine as a utility in the tests for another routine (_construct_delta_coord) is pretty horrible
  * the optional use of the 'circular' keyword is *only* used by the test code, not the main iris codebase : So it could, and  should be much simpler !
  * the routine raises an error if called with circular=True when coord.circular does not exist, but it only emits a *warning* if coord.circular==False  ((arrrrgh!))

