### PR TITLE
Make PointInCell a public member of iris.analysis.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -75,7 +75,7 @@ __all__ = ('COUNT', 'GMEAN', 'HMEAN', 'MAX', 'MEAN', 'MEDIAN', 'MIN',
            'PEAK', 'PERCENTILE', 'PROPORTION', 'RMS', 'STD_DEV', 'SUM',
            'VARIANCE', 'WPERCENTILE', 'coord_comparison', 'Aggregator',
            'WeightedAggregator', 'clear_phenomenon_identity', 'Linear',
-           'AreaWeighted', 'Nearest', 'UnstructuredNearest')
+           'AreaWeighted', 'Nearest', 'UnstructuredNearest', 'PointInCell')
 
 
 class _CoordGroup(object):


### PR DESCRIPTION
This fixes a problem I found with the 2.3.0rc0 release candidate ...

The new public PointInCell scheme did not appear in the docs (and the link in the whatsnew was broken), because it is not public : 
Because `iris.analysis.__init__` defines an '__all__', the PointInCell must be added to that list too, to be "public".  
As Sphinx also respects that, it didn't appear in the docs either.