### PR TITLE
tidy requirements and site.cfg

### DIFF
--- a/lib/iris/etc/site.cfg.template
+++ b/lib/iris/etc/site.cfg.template
@@ -1,8 +1,6 @@
 [System]
-udunits2_path = /path/to/libudunits2.so
 dot_path = /path/to/dot # see iris.fileformats.dot
 
 [Resources]
 sample_data_dir = /path/to/iris/resources/sample_data
 test_data_dir = /path/to/iris/resources/test_data
-

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -53,15 +53,11 @@ import shutil
 import subprocess
 import sys
 import unittest
+from unittest import mock
 import threading
 import warnings
 import xml.dom.minidom
 import zlib
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 import filelock
 import numpy as np

--- a/lib/iris/tests/integration/test_ff.py
+++ b/lib/iris/tests/integration/test_ff.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,10 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris
-from iris.tests import mock
 
 
 @tests.skip_data

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -29,6 +29,7 @@ from itertools import repeat
 import os.path
 import shutil
 import tempfile
+from unittest import mock
 import warnings
 
 import netCDF4 as nc
@@ -41,7 +42,6 @@ from iris.cube import Cube, CubeList
 from iris.fileformats.netcdf import CF_CONVENTIONS_VERSION
 from iris.fileformats.netcdf import Saver
 from iris.fileformats.netcdf import UnknownCellMethodWarning
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -25,6 +25,7 @@ import iris.tests as tests
 
 import numpy as np
 import os
+from unittest import mock
 
 from cf_units import Unit
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
@@ -34,7 +35,6 @@ import iris.fileformats.pp
 import iris.fileformats.pp_load_rules
 from iris.fileformats.pp_save_rules import verify
 from iris.exceptions import IgnoreCubeException
-from iris.tests import mock
 from iris.fileformats.pp import load_pairs_from_fields
 import iris.util
 

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,9 +25,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import iris
 import iris.fileformats.cf as cf
-from iris.tests import mock
 
 
 class TestCaching(tests.IrisTest):

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ import iris.tests as tests
 
 import os
 import tempfile
+from unittest import mock
 
 import cf_units
 import numpy as np
@@ -32,7 +33,6 @@ import iris.coords
 import iris.coord_systems
 import iris.fileformats.pp
 from iris.fileformats.pp import PPField3
-from iris.tests import mock
 import iris.tests.pp as pp
 import iris.util
 import iris.tests.stock as stock

--- a/lib/iris/tests/test_grib_load_translations.py
+++ b/lib/iris/tests/test_grib_load_translations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,13 +26,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import datetime
+from unittest import mock
 
 import cf_units
 import numpy as np
 
 import iris
 import iris.exceptions
-from iris.tests import mock
 import iris.tests.stock
 import iris.util
 

--- a/lib/iris/tests/test_grib_save_rules.py
+++ b/lib/iris/tests/test_grib_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,6 +22,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
 
+from unittest import mock
 import warnings
 
 import cf_units
@@ -29,7 +30,6 @@ import numpy as np
 
 import iris.cube
 import iris.coords
-from iris.tests import mock
 
 if tests.GRIB_AVAILABLE:
     import gribapi

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -32,6 +32,7 @@ import os.path
 import shutil
 import stat
 import tempfile
+from unittest import mock
 
 import netCDF4 as nc
 import numpy as np
@@ -44,7 +45,6 @@ import iris.fileformats.netcdf
 import iris.std_names
 import iris.util
 import iris.coord_systems as icoord_systems
-from iris.tests import mock
 import iris.tests.stock as stock
 from iris._lazy_data import is_lazy_data
 

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -25,13 +25,13 @@ from copy import deepcopy
 import os
 from types import GeneratorType
 import unittest
+from unittest import mock
 
 import cftime
 from numpy.testing import assert_array_equal
 
 import iris.fileformats
 import iris.fileformats.pp as pp
-from iris.tests import mock
 import iris.util
 
 @tests.skip_data

--- a/lib/iris/tests/unit/analysis/__init__.py
+++ b/lib/iris/tests/unit/analysis/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.analysis import Linear
-from iris.tests import mock
 
 
 class Test_Linear(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,13 +26,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.analysis._area_weighted import AreaWeightedRegridder
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord
 from iris.cube import Cube
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/cartography/test_rotate_grid_vectors.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_rotate_grid_vectors.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2018 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,7 +26,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from mock import Mock, call as mock_call
+from unittest.mock import Mock, call as mock_call
+
 import numpy as np
 
 from iris.cube import Cube

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 
@@ -31,7 +33,6 @@ from iris.aux_factory import HybridHeightFactory
 from iris.coord_systems import GeogCS, OSGB
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
-from iris.tests import mock
 from iris.tests.stock import global_pp, lat_lon_cube, realistic_4d
 
 

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import mock
-
 import numpy as np
 import numpy.ma as ma
 

--- a/lib/iris/tests/unit/analysis/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test__CurvilinearRegridder.py
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.analysis.cartography import rotate_pole
@@ -31,7 +33,6 @@ from iris.coords import AuxCoord, DimCoord
 from iris.coord_systems import GeogCS, RotatedGeogCS
 from iris.fileformats.pp import EARTH_RADIUS
 from iris.analysis._regrid import CurvilinearRegridder as Regridder
-from iris.tests import mock
 from iris.tests.stock import global_pp, lat_lon_cube
 
 

--- a/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
+++ b/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,12 +24,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import iris
 
 from iris.analysis._scipy_interpolate import _RegularGridInterpolator
 from scipy.sparse.csr import csr_matrix
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
+++ b/lib/iris/tests/unit/analysis/scipy_interpolate/test__RegularGridInterpolator.py
@@ -24,8 +24,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import mock
-
 import numpy as np
 import iris
 

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -23,12 +23,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 
 from iris.analysis import Aggregator
 from iris.exceptions import LazyAggregatorError
-from iris.tests import mock
 
 
 class Test_aggregate(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_AreaWeighted.py
+++ b/lib/iris/tests/unit/analysis/test_AreaWeighted.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.analysis import AreaWeighted
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_Linear.py
+++ b/lib/iris/tests/unit/analysis/test_Linear.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.analysis import Linear
-from iris.tests import mock
 
 
 def create_scheme(mode=None):

--- a/lib/iris/tests/unit/analysis/test_Nearest.py
+++ b/lib/iris/tests/unit/analysis/test_Nearest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.analysis import Nearest
-from iris.tests import mock
 
 
 def create_scheme(mode=None):

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,12 +26,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.analysis import PercentileAggregator, _percentile
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_PointInCell.py
+++ b/lib/iris/tests/unit/analysis/test_PointInCell.py
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.analysis import PointInCell
-from iris.tests import mock
 
 
 class Test_regridder(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_VARIANCE.py
+++ b/lib/iris/tests/unit/analysis/test_VARIANCE.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 
@@ -30,8 +32,6 @@ from iris._lazy_data import as_lazy_data, as_concrete_data
 from iris.analysis import VARIANCE
 import iris.cube
 from iris.coords import DimCoord
-
-from iris.tests import mock
 
 
 class Test_units_func(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_WeightedPercentileAggregator.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,12 +26,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.analysis import WeightedPercentileAggregator, _weighted_percentile
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/trajectory/test_Trajectory.py
+++ b/lib/iris/tests/unit/analysis/trajectory/test_Trajectory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,7 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
+from unittest import mock
 
 import numpy as np
 

--- a/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridPressureFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import cf_units
 import numpy as np
 
 import iris
 from iris.aux_factory import HybridPressureFactory
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
 from iris.aux_factory import OceanSFactory
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
 from iris.aux_factory import OceanSg1Factory
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
 from iris.aux_factory import OceanSg2Factory
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
 from iris.aux_factory import OceanSigmaFactory
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
 from iris.aux_factory import OceanSigmaZFactory
 from iris.coords import AuxCoord, DimCoord
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
+++ b/lib/iris/tests/unit/coord_categorisation/test_add_categorised_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import CALENDARS as calendars
 from cf_units import Unit
 import numpy as np
@@ -31,7 +33,6 @@ from iris.coord_categorisation import add_categorised_coord
 from iris.coord_categorisation import add_day_of_year
 from iris.cube import Cube
 from iris.coords import DimCoord
-from iris.tests import mock
 
 
 class Test_add_categorised_coord(tests.IrisTest):

--- a/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
+++ b/lib/iris/tests/unit/coord_systems/test_RotatedPole.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,10 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import cartopy
 import cartopy.crs as ccrs
 from iris.coord_systems import GeogCS, RotatedGeogCS
-from iris.tests import mock
 
 
 class Test_init(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,12 +24,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import datetime
-import numpy as np
+from unittest import mock
 
+import numpy as np
 import cftime
 
 from iris.coords import Cell
-from iris.tests import mock
 from iris.time import PartialDateTime
 
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -23,6 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import collections
+from unittest import mock
 import warnings
 
 import dask.array as da
@@ -31,7 +32,6 @@ import six
 
 import iris
 from iris.coords import DimCoord, AuxCoord, Coord
-from iris.tests import mock
 from iris.exceptions import UnitConversionError
 from iris.tests.unit.coords import CoordTestMixin
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -24,6 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from itertools import permutations
+from unittest import mock
 
 import numpy as np
 import numpy.ma as ma
@@ -42,7 +43,6 @@ from iris.coords import AuxCoord, DimCoord, CellMeasure
 from iris.exceptions import (CoordinateNotFoundError, CellMeasureNotFoundError,
                              UnitConversionError)
 from iris._lazy_data import as_lazy_data
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 import iris.tests.stock
 
+from unittest import mock
+
 from cf_units import Unit
 import numpy as np
 
@@ -32,7 +34,6 @@ from iris.coords import AuxCoord, DimCoord
 import iris.coord_systems
 import iris.exceptions
 from iris.fileformats.pp import STASH
-from iris.tests import mock
 
 
 class Test_concatenate_cube(tests.IrisTest):

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,13 +27,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import copy
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 import six
 
 from iris._data_manager import DataManager
 from iris._lazy_data import as_lazy_data
-from iris.tests import mock
 
 
 class Test___copy__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
+++ b/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.abf import ABFField
-from iris.tests import mock
 
 
 class MethodCounter(object):

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,11 +26,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris
 from iris.fileformats.cf import CFReader
-from iris.tests import mock
 
 
 def netcdf_variable(name, dimensions, dtype, ancillary_variables=None,

--- a/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
+++ b/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,9 +25,9 @@ import iris.tests as tests
 
 import os.path
 import subprocess
+from unittest import mock
 
 from iris.fileformats.dot import _dot_path, _DOT_EXECUTABLE_PATH
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,14 +26,15 @@ import iris.tests as tests
 
 import collections
 import contextlib
-import numpy as np
+from unittest import mock
 import warnings
+
+import numpy as np
 
 from iris.exceptions import NotYetImplementedError
 import iris.fileformats._ff as ff
 import iris.fileformats.pp as pp
 from iris.fileformats._ff import FF2PP
-from iris.tests import mock
 
 
 # PP-field: LBPACK N1 values.

--- a/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FFHeader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,10 +24,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import collections
+from unittest import mock
+
 import numpy as np
 
 from iris.fileformats._ff import FFHeader
-from iris.tests import mock
 
 
 MyGrid = collections.namedtuple('MyGrid', 'column row real horiz_grid_type')

--- a/lib/iris/tests/unit/fileformats/ff/test_Grid.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_Grid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats._ff import Grid
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__build_cell_methods.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,10 +26,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
 
 import iris.coords
 from iris.fileformats.name_loaders import _build_cell_methods
-from iris.tests import mock
 
 
 class Tests(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/name_loaders/test__generate_cubes.py
+++ b/lib/iris/tests/unit/fileformats/name_loaders/test__generate_cubes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,9 +26,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import iris.cube
 from iris.fileformats.name_loaders import _generate_cubes, NAMECoord
-from iris.tests import mock
 
 
 class TestCellMethods(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -25,6 +25,7 @@ import six
 import iris.tests as tests
 
 from contextlib import contextmanager
+from unittest import mock
 
 import netCDF4 as nc
 import numpy as np
@@ -40,7 +41,6 @@ from iris.coord_systems import (GeogCS, TransverseMercator, RotatedGeogCS,
 from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import Saver
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test__FillValueMaskCheckAndStoreTarget.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__FillValueMaskCheckAndStoreTarget.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# (C) British Crown Copyright 2017 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,10 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.fileformats.netcdf import _FillValueMaskCheckAndStoreTarget
-from iris.tests import mock
 
 
 class Test__FillValueMaskCheckAndStoreTarget(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
@@ -23,13 +23,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from dask.array import Array as dask_array
 import numpy as np
 
 from iris._lazy_data import _optimum_chunksize
 import iris.fileformats.cf
 from iris.fileformats.netcdf import _get_cf_var_data
-from iris.tests import mock
 
 
 class Test__get_cf_var_data(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,13 +23,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import warnings
 
 from iris.coords import DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import _load_aux_factory
-from iris.tests import mock
 
 
 class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,13 +23,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import netCDF4
 import numpy as np
 
 from iris.coords import DimCoord
 import iris.fileformats.cf
 from iris.fileformats.netcdf import _load_cube
-from iris.tests import mock
 
 
 class TestCoordAttributes(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_parse_cell_methods.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_parse_cell_methods.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2016, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,9 +26,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.coords import CellMethod
 from iris.fileformats.netcdf import parse_cell_methods
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_save.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import netCDF4 as nc
 import numpy as np
 
@@ -30,7 +32,6 @@ import iris
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 from iris.fileformats.netcdf import save, CF_CONVENTIONS_VERSION
-from iris.tests import mock
 from iris.tests.stock import lat_lon_cube
 
 

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_tm_meridian_scaling.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.nimrod_load_rules import (tm_meridian_scaling,
                                                 NIMROD_DEFAULT,
                                                 MERIDIAN_SCALING_BNG)
 from iris.fileformats.nimrod import NimrodField
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.nimrod_load_rules import (vertical_coord,
                                                 NIMROD_DEFAULT,
                                                 TranslationWarning)
 from iris.fileformats.nimrod import NimrodField
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPDataProxy.py
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.pp import PPDataProxy, SplittableInt
-from iris.tests import mock
 
 
 class Test_lbpack(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,6 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from contextlib import contextmanager
+from unittest import mock
 import warnings
 
 import numpy as np
@@ -31,7 +32,6 @@ import numpy as np
 import iris.fileformats.pp as pp
 from iris.fileformats.pp import PPField
 from iris.fileformats.pp import SplittableInt
-from iris.tests import mock
 
 # The PPField class is abstract, so to test we define a minimal,
 # concrete subclass with the `t1` and `t2` properties.

--- a/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__LBProc.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.pp import _LBProc
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__convert_constraints.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,10 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import iris
 from iris.fileformats.pp import _convert_constraints
 from iris.fileformats.pp import STASH
-from iris.tests import mock
 
 
 class Test_convert_constraints(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__create_field_data.py
@@ -23,10 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 class Test__create_field_data(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -27,12 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import io
+from unittest import mock
 
 import numpy as np
 import numpy.ma as ma
 
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 class Test__data_bytes_to_shaped_array__lateral_boundary_compression(

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,12 +26,12 @@ import iris.tests as tests
 
 import contextlib
 import io
+from unittest import mock
 import warnings
 
 import numpy as np
 
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__interpret_field.py
@@ -24,11 +24,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from copy import deepcopy
+from unittest import mock
+
 import numpy as np
 
 import iris
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 class Test__interpret_fields__land_packed_fields(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,10 +23,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.coords import DimCoord
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_as_fields.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import mock
-
 from iris.coords import DimCoord
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp

--- a/lib/iris/tests/unit/fileformats/pp/test_load.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_load.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 class Test_load(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,11 +26,12 @@ import cf_units
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.coords import DimCoord, CellMethod
 from iris.fileformats._ff_cross_references import STASH_TRANS
 import iris.fileformats.pp as pp
 from iris.fileformats.pp_save_rules import _lbproc_rules, verify
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,10 +24,11 @@ import six
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris.fileformats.pp as pp
-from iris.tests import mock
 
 
 def asave(afilehandle):

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__all_other_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,6 +26,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 from cf_units import Unit, CALENDAR_GREGORIAN, CALENDAR_360_DAY
 from cftime import datetime as nc_datetime
@@ -35,7 +37,6 @@ import iris
 from iris.fileformats.pp_load_rules import _all_other_rules
 from iris.fileformats.pp import SplittableInt
 from iris.coords import CellMethod, DimCoord, AuxCoord
-from iris.tests import mock
 from iris.tests.unit.fileformats import TestField
 
 

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
@@ -27,6 +27,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit, CALENDAR_GREGORIAN
 from cftime import datetime as nc_datetime
 import numpy as np
@@ -34,7 +36,6 @@ import numpy as np
 from iris.coords import DimCoord, AuxCoord
 from iris.fileformats.pp import SplittableInt
 from iris.fileformats.pp_load_rules import _convert_time_coords
-from iris.tests import mock
 from iris.tests.unit.fileformats import TestField
 
 

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
@@ -27,8 +27,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import mock
-
 from cf_units import Unit, CALENDAR_GREGORIAN
 from cftime import datetime as nc_datetime
 import numpy as np

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
@@ -25,7 +25,6 @@ import six
 import iris.tests as tests
 
 import cftime
-import types
 from unittest import mock
 
 import cf_units

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test_convert.py
@@ -24,8 +24,9 @@ import six
 # importing anything else.
 import iris.tests as tests
 
-import types
 import cftime
+import types
+from unittest import mock
 
 import cf_units
 import numpy as np
@@ -35,7 +36,6 @@ from iris.util import guess_coord_axis
 from iris.fileformats.pp import SplittableInt
 from iris.fileformats.pp import STASH
 from iris.fileformats.pp import PPField3
-from iris.tests import mock
 import iris.tests.unit.fileformats
 
 

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -27,13 +27,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.coords import AuxCoord
 from iris.fileformats.cf import CFVariable
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_auxiliary_coordinate
-from iris.tests import mock
 
 
 # from iris.tests.unit.fileformats.pyke_rules.compiled_krb\

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_cube_metadata.py
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.cube import Cube
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_cube_metadata
-from iris.tests import mock
 
 
 def _make_engine(global_attributes=None, standard_name=None, long_name=None):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -27,6 +27,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
 import warnings
 
 import numpy as np
@@ -34,7 +35,6 @@ import numpy as np
 from iris.coords import AuxCoord, DimCoord
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_dimension_coordinate
-from iris.tests import mock
 
 
 class RulesTestMixin(object):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_geostationary_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_geostationary_coordinate_system.py
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import iris
 from iris.coord_systems import Geostationary
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_geostationary_coordinate_system
-from iris.tests import mock
 
 
 class TestBuildGeostationaryCoordinateSystem(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_mercator_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_mercator_coordinate_system.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,13 +27,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris
 from iris.coord_systems import Mercator
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_mercator_coordinate_system
-from iris.tests import mock
 
 
 class TestBuildMercatorCoordinateSystem(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_stereographic_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_stereographic_coordinate_system.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,13 +27,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris
 from iris.coord_systems import Stereographic
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_stereographic_coordinate_system
-from iris.tests import mock
 
 
 class TestBuildStereographicCoordinateSystem(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_verticalp_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_verticalp_coordinate_system.py
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import iris
 from iris.coord_systems import VerticalPerspective
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     build_vertical_perspective_coordinate_system
-from iris.tests import mock
 
 
 class TestBuildVerticalPerspectiveCoordinateSystem(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_attr_units.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     get_attr_units
-from iris.tests import mock
 
 
 class TestGetAttrUnits(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_cf_bounds_var.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_cf_bounds_var.py
@@ -27,11 +27,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     get_cf_bounds_var, CF_ATTR_BOUNDS, CF_ATTR_CLIMATOLOGY
-
-from iris.tests import mock
 
 
 class TestGetCFBoundsVar(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_names.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_get_names.py
@@ -27,10 +27,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import get_names
-from iris.tests import mock
 
 
 class TestGetNames(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_mercator_parameters.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2017, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,12 +28,13 @@ import warnings
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import six
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     has_supported_mercator_parameters
-from iris.tests import mock
 
 
 def _engine(cf_grid_var, cf_name):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_has_supported_stereographic_parameters.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2017, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -28,13 +28,14 @@ import warnings
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import six
 
 from iris.coord_systems import Stereographic
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     has_supported_stereographic_parameters
-from iris.tests import mock
 
 
 def _engine(cf_grid_var, cf_name):

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_reorder_bounds_data.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,11 +27,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.fileformats._pyke_rules.compiled_krb.fc_rules_cf_fc import \
     reorder_bounds_data
-from iris.tests import mock
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/rules/test_Loader.py
+++ b/lib/iris/tests/unit/fileformats/rules/test_Loader.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,8 +23,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.rules import Loader
-from iris.tests import mock
 
 
 class Test___init__(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
+++ b/lib/iris/tests/unit/fileformats/rules/test__make_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,13 +24,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import six
+from unittest import mock
 import warnings
 
-from iris.fileformats.rules import ConversionMetadata
-from iris.tests import mock
 import numpy as np
 
 from iris.fileformats.rules import _make_cube
+from iris.fileformats.rules import ConversionMetadata
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/test_rules.py
+++ b/lib/iris/tests/unit/fileformats/test_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,6 +27,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import types
+from unittest import mock
 
 import numpy as np
 
@@ -37,7 +38,6 @@ from iris.fileformats.rules import (ConcreteReferenceTarget,
                                     Reference, ReferenceTarget, load_cubes,
                                     scalar_cell_method)
 from iris.coords import CellMethod
-from iris.tests import mock
 import iris.tests.stock as stock
 
 

--- a/lib/iris/tests/unit/fileformats/um/fast_load/test__convert_collation.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load/test__convert_collation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import cf_units
 import cftime
 import numpy as np
@@ -34,7 +36,6 @@ import iris.coord_systems
 import iris.coords
 import iris.fileformats.pp
 import iris.fileformats.rules
-from iris.tests import mock
 
 
 COORD_SYSTEM = iris.coord_systems.GeogCS(6371229.0)

--- a/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
+++ b/lib/iris/tests/unit/fileformats/um/fast_load_structured_fields/test_group_structured_fields.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,12 +27,13 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 import iris
 from iris.fileformats.um._fast_load_structured_fields import \
     group_structured_fields
-from iris.tests import mock
 
 
 def _convert_to_vector(value, length, default):

--- a/lib/iris/tests/unit/fileformats/um/test_um_to_pp.py
+++ b/lib/iris/tests/unit/fileformats/um/test_um_to_pp.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,8 +27,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 from iris.fileformats.um import um_to_pp
-from iris.tests import mock
 
 
 class Test_call(tests.IrisTest):

--- a/lib/iris/tests/unit/io/test_run_callback.py
+++ b/lib/iris/tests/unit/io/test_run_callback.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,9 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import iris.exceptions
 import iris.io
-from iris.tests import mock
 
 
 class Test_run_callback(tests.IrisTest):

--- a/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
@@ -23,11 +23,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 
 from iris._lazy_data import as_concrete_data, as_lazy_data, is_lazy_data
-from iris.tests import mock
 
 
 class MyProxy(object):

--- a/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_concrete_data.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest import mock
-
 import numpy as np
 import numpy.ma as ma
 

--- a/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_as_lazy_data.py
@@ -23,13 +23,14 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import dask.array as da
 import dask.config
 import numpy as np
 import numpy.ma as ma
 
 from iris._lazy_data import as_lazy_data, _optimum_chunksize
-from iris.tests import mock
 
 
 class Test_as_lazy_data(tests.IrisTest):

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -23,7 +23,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from mock import MagicMock
+from unittest.mock import MagicMock
+
 import numpy as np
 
 from iris.cube import Cube

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-from unittest.mock import MagicMock
-
 import numpy as np
 
 from iris.cube import Cube

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -25,6 +25,7 @@ import six
 import iris.tests as tests
 
 import abc
+from unittest import mock
 
 import numpy as np
 import numpy.ma as ma
@@ -34,7 +35,6 @@ from iris._merge import ProtoCube
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import DimCoord, AuxCoord
 from iris.exceptions import MergeError
-from iris.tests import mock
 
 
 def example_cube():

--- a/lib/iris/tests/unit/plot/_blockplot_common.py
+++ b/lib/iris/tests/unit/plot/_blockplot_common.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2018 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,9 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
-from iris.tests import mock
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import MixinCoords
 

--- a/lib/iris/tests/unit/plot/test__check_bounds_contiguity_and_mask.py
+++ b/lib/iris/tests/unit/plot/test__check_bounds_contiguity_and_mask.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2018 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -24,7 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import mock
+from unittest import mock
 
 import numpy as np
 import numpy.ma as ma

--- a/lib/iris/tests/unit/plot/test__check_geostationary_coords_and_convert.py
+++ b/lib/iris/tests/unit/plot/test__check_geostationary_coords_and_convert.py
@@ -24,8 +24,9 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest.mock import Mock
+
 import numpy as np
-from mock import Mock
 
 from cartopy.crs import Geostationary, NearsidePerspective
 from iris.plot import _check_geostationary_coords_and_convert

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,9 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
-from iris.tests import mock
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,9 +23,10 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
-from iris.tests import mock
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
 

--- a/lib/iris/tests/unit/test_sample_data_path.py
+++ b/lib/iris/tests/unit/test_sample_data_path.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -27,9 +27,9 @@ import os
 import os.path
 import shutil
 import tempfile
+from unittest import mock
 
 from iris import sample_data_path
-from iris.tests import mock
 
 
 def _temp_file(sample_dir):

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,10 +26,10 @@ import iris.tests as tests
 
 import datetime
 import operator
+from unittest import mock
 
 import cftime
 
-from iris.tests import mock
 from iris.time import PartialDateTime
 
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 # Dependencies needed to run the iris tests
 #------------------------------------------
 
-mock
 nose
 pep8
 filelock


### PR DESCRIPTION
This PR tidies the dependencies of `iris` now that it is exclusively Python3.