### PR TITLE
deprecated future flags

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/deprecate_2019-Oct-14_remove_deprecated_future_flags.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/deprecate_2019-Oct-14_remove_deprecated_future_flags.txt
@@ -1,0 +1,3 @@
+* The deprecated :class:`iris.Future` flags `cell_date_time_objects`,
+  `netcfd_promote`, `netcdf_no_unlimited` and `clip_latitudes` have
+  been removed.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -144,33 +144,32 @@ class Future(threading.local):
         To adjust the values simply update the relevant attribute from
         within your code. For example::
 
-            iris.FUTURE.cell_datetime_objects = False
+            iris.FUTURE.example_future_flag = False
 
         If Iris code is executed with multiple threads, note the values of
         these options are thread-specific.
 
         .. note::
 
-            iris.FUTURE.cell_datetime_objects has been removed from the
-            code and is left in only as a template for when flags are added
-            to Future.
+            iris.FUTURE.example_future_flag does not exist. It is provided
+            as an example because there are currently no flags in
+            iris.Future.
 
         """
-        # The flag 'cell_datetime_objects' has been removed, it has been
-        # left in some comments as a template for future reference when
-        # adding flags to Future.
+        # The flag 'example_future_flag' is provided as a future reference
+        # for the structure of this class.
         #
-        # self.__dict__['cell_datetime_objects'] = cell_datetime_objects
+        # self.__dict__['example_future_flag'] = example_future_flag
         pass
 
     def __repr__(self):
 
-        # msg = ('Future(cell_datetime_objects={})')
-        # return msg.format(self.cell_datetime_objects)
+        # msg = ('Future(example_future_flag={})')
+        # return msg.format(self.example_future_flag)
         msg = ('Future()')
         return msg.format()
 
-    # deprecated_options = {'cell_datetime_objects': 'warning',}
+    # deprecated_options = {'example_future_flag': 'warning',}
     deprecated_options = {}
 
     def __setattr__(self, name, value):
@@ -203,14 +202,14 @@ class Future(threading.local):
         statement, the previous state is restored.
 
         For example::
-            with iris.FUTURE.context(cell_datetime_objects=False):
-                # ... code that expects numbers and not datetimes
+            with iris.FUTURE.context(example_future_flag=False):
+                # ... code that expects some past behaviour
 
         .. note::
 
-            iris.FUTURE.cell_datetime_objects has been removed from the
-            code and is left in only as a template for when flags are added
-            to Future.
+            iris.FUTURE.example_future_flag does not exist and is
+            provided only as an example since there are currently no
+            flags in Future.
 
         """
         # Save the current context

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -137,8 +137,7 @@ AttributeConstraint = iris._constraints.AttributeConstraint
 class Future(threading.local):
     """Run-time configuration controller."""
 
-    def __init__(self, cell_datetime_objects=True, netcdf_promote=True,
-                 netcdf_no_unlimited=True, clip_latitudes=True):
+    def __init__(self):
         """
         A container for run-time options controls.
 
@@ -150,76 +149,29 @@ class Future(threading.local):
         If Iris code is executed with multiple threads, note the values of
         these options are thread-specific.
 
-        .. deprecated:: 2.0.0
+        .. note::
 
-            The option `cell_datetime_objects` is deprecated and will be
-            removed in a future release. `cell_datetime_objects` is set
-            to True by default and should not be altered.
-
-            The option `cell_datetime_objects` controlled whether the
-            :meth:`iris.coords.Coord.cell()` method would return time
-            coordinate values as simple numbers or as time objects with
-            attributes for year, month, day, etc.
-
-            Cells are now represented as time objects by default, allowing
-            you to express time constraints using a simpler syntax. For
-            example::
-
-                # To select all data defined at midday.
-                Constraint(time=lambda cell: cell.point.hour == 12)
-
-                # To ignore the 29th of February.
-                Constraint(time=lambda cell: cell.point.day != 29 and
-                                             cell.point.month != 2)
-
-            For more details, see :ref:`using-time-constraints`.
-
-        .. deprecated:: 2.0.0
-
-            The option `netcdf_promote` is deprecated and will be removed in a
-            future release and the deprecated code paths this option used to
-            toggle have been removed.
-
-            The option `netcdf_promote` controlled whether the netCDF loader
-            exposed variables that defined reference surfaces for
-            dimensionless vertical coordinates as independent Cubes.
-
-        .. deprecated:: 2.0.0
-
-            The option `netcdf_no_unlimited` is deprecated and will be removed
-            in a future release. The deprecated code paths this option used to
-            toggle have been removed.
-
-            The option `netcdf_no_unlimited` changed the behaviour of the
-            netCDF saver regarding unlimited dimensions. The netCDF saver now
-            sets no dimensions to unlimited.
-
-        .. deprecated:: 2.0.0
-
-            The option `clip_latitudes` is deprecated and will be removed in a
-            future release. `clip_latitudes` is set to True by default and
-            should not be altered.
-
-            The option `clip_latitudes` controlled whether the
-            :meth:`iris.coords.Coord.guess_bounds()` method would limit the
-            guessed bounds to [-90, 90] for latitudes.
+            iris.FUTURE.cell_datetime_objects has been removed from the
+            code and is left in only as a template for when flags are added
+            to Future.
 
         """
-        self.__dict__['cell_datetime_objects'] = cell_datetime_objects
-        self.__dict__['netcdf_promote'] = netcdf_promote
-        self.__dict__['netcdf_no_unlimited'] = netcdf_no_unlimited
-        self.__dict__['clip_latitudes'] = clip_latitudes
+        # The flag 'cell_datetime_objects' has been removed, it has been
+        # left in some comments as a template for future reference when
+        # adding flags to Future.
+        #
+        # self.__dict__['cell_datetime_objects'] = cell_datetime_objects
+        pass
 
     def __repr__(self):
-        msg = ('Future(cell_datetime_objects={}, netcdf_promote={}, '
-               'netcdf_no_unlimited={}, clip_latitudes={})')
-        return msg.format(self.cell_datetime_objects, self.netcdf_promote,
-                          self.netcdf_no_unlimited, self.clip_latitudes)
 
-    deprecated_options = {'cell_datetime_objects': 'warning',
-                          'netcdf_no_unlimited': 'error',
-                          'netcdf_promote': 'error',
-                          'clip_latitudes': 'warning'}
+        # msg = ('Future(cell_datetime_objects={})')
+        # return msg.format(self.cell_datetime_objects)
+        msg = ('Future()')
+        return msg.format()
+
+    # deprecated_options = {'cell_datetime_objects': 'warning',}
+    deprecated_options = {}
 
     def __setattr__(self, name, value):
         if name in self.deprecated_options:
@@ -253,6 +205,12 @@ class Future(threading.local):
         For example::
             with iris.FUTURE.context(cell_datetime_objects=False):
                 # ... code that expects numbers and not datetimes
+
+        .. note::
+
+            iris.FUTURE.cell_datetime_objects has been removed from the
+            code and is left in only as a template for when flags are added
+            to Future.
 
         """
         # Save the current context

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1321,21 +1321,6 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         """
         Return the single :class:`Cell` instance which results from slicing the
         points/bounds with the given index.
-
-        .. note::
-
-            If `iris.FUTURE.cell_datetime_objects` is True, then this
-            method will return Cell objects whose `points` and `bounds`
-            attributes contain either datetime.datetime instances or
-            cftime.datetime instances (depending on the calendar).
-
-        .. deprecated:: 2.0.0
-
-            The option `iris.FUTURE.cell_datetime_objects` is deprecated and
-            will be removed in a future release; it is now set to True by
-            default. Please update your code to support using cells as
-            datetime objects.
-
         """
         index = iris.util._build_full_slice_given_keys(index, self.ndim)
 
@@ -1348,18 +1333,10 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
         if self.has_bounds():
             bound = tuple(np.array(self.bounds[index], ndmin=1).flatten())
 
-        if iris.FUTURE.cell_datetime_objects:
-            if self.units.is_time_reference():
-                point = self.units.num2date(point)
-                if bound is not None:
-                    bound = self.units.num2date(bound)
-        else:
-            wmsg = ("disabling cells as datetime objects is deprecated "
-                    "behaviour. "
-                    "Please update your code to support using cells as "
-                    "datetime objects."
-                    "See the userguide section 2.2.1 for examples of this.")
-            warn_deprecated(wmsg)
+        if self.units.is_time_reference():
+            point = self.units.num2date(point)
+            if bound is not None:
+                bound = self.units.num2date(bound)
 
         return Cell(point, bound)
 
@@ -1448,22 +1425,6 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
             This method only works for coordinates with ``coord.ndim == 1``.
 
-        .. note::
-
-            If `iris.FUTURE.clip_latitudes` is True, then this method
-            will clip the coordinate bounds to the range [-90, 90] when:
-
-            - it is a `latitude` or `grid_latitude` coordinate,
-            - the units are degrees,
-            - all the points are in the range [-90, 90].
-
-        .. deprecated:: 2.0.0
-
-            The `iris.FUTURE.clip_latitudes` option is now deprecated
-            and is set to True by default. Please remove code which
-            relies on coordinate bounds being outside the range
-            [-90, 90].
-
         """
         # XXX Consider moving into DimCoord
         # ensure we have monotonic points
@@ -1499,18 +1460,11 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
 
         bounds = np.array([min_bounds, max_bounds]).transpose()
 
-        if iris.FUTURE.clip_latitudes:
-            if (self.name() in ('latitude', 'grid_latitude') and
-                    self.units == 'degree'):
-                points = self.points
-                if (points >= -90).all() and (points <= 90).all():
-                    np.clip(bounds, -90, 90, out=bounds)
-        else:
-            wmsg = ("guessing latitude bounds outside of [-90, 90] is "
-                    "deprecated behaviour. "
-                    "All latitude points will be clipped to the range "
-                    "[-90, 90].")
-            warn_deprecated(wmsg)
+        if (self.name() in ('latitude', 'grid_latitude') and
+                self.units == 'degree'):
+            points = self.points
+            if (points >= -90).all() and (points <= 90).all():
+                np.clip(bounds, -90, 90, out=bounds)
 
         return bounds
 
@@ -1543,22 +1497,6 @@ class Coord(six.with_metaclass(ABCMeta, CFVariableMixin)):
             Unevenly spaced values, such from a wrapped longitude range, can
             produce unexpected results :  In such cases you should assign
             suitable values directly to the bounds property, instead.
-
-        .. note::
-
-            If `iris.FUTURE.clip_latitudes` is True, then this method
-            will clip the coordinate bounds to the range [-90, 90] when:
-
-            - it is a `latitude` or `grid_latitude` coordinate,
-            - the units are degrees,
-            - all the points are in the range [-90, 90].
-
-        .. deprecated:: 2.0.0
-
-            The `iris.FUTURE.clip_latitudes` option is now deprecated
-            and is set to True by default. Please remove code which
-            relies on coordinate bounds being outside the range
-            [-90, 90].
 
         """
         self.bounds = self._guess_bounds(bound_position)

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2017, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of Iris.
 #
@@ -23,6 +23,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+from unittest import skip
 
 import warnings
 
@@ -30,6 +31,7 @@ from iris import Future
 
 
 class Test___setattr__(tests.IrisTest):
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_valid_clip_latitudes(self):
         future = Future()
         new_value = not future.clip_latitudes
@@ -43,24 +45,14 @@ class Test___setattr__(tests.IrisTest):
         with self.assertRaises(AttributeError):
             future.numberwang = 7
 
-    def test_netcdf_promote(self):
-        future = Future()
-        exp_emsg = "'Future' property 'netcdf_promote' is deprecated"
-        with self.assertWarnsRegexp(exp_emsg):
-            future.netcdf_promote = True
-
-    def test_invalid_netcdf_promote(self):
-        future = Future()
-        exp_emsg = "'Future' property 'netcdf_promote' has been deprecated"
-        with self.assertRaisesRegexp(AttributeError, exp_emsg):
-            future.netcdf_promote = False
-
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_netcdf_no_unlimited(self):
         future = Future()
         exp_emsg = "'Future' property 'netcdf_no_unlimited' is deprecated"
         with self.assertWarnsRegexp(exp_emsg):
             future.netcdf_no_unlimited = True
 
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_invalid_netcdf_no_unlimited(self):
         future = Future()
         exp_emsg = \
@@ -68,6 +60,7 @@ class Test___setattr__(tests.IrisTest):
         with self.assertRaisesRegexp(AttributeError, exp_emsg):
             future.netcdf_no_unlimited = False
 
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_cell_datetime_objects(self):
         future = Future()
         new_value = not future.cell_datetime_objects
@@ -80,6 +73,8 @@ class Test___setattr__(tests.IrisTest):
 
 
 class Test_context(tests.IrisTest):
+    # Many of these tests will not work until another flag is put into Future.
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_no_args(self):
         # Catch the deprecation when explicitly setting `cell_datetime_objects`
         # as the test is still useful even though the Future property is
@@ -94,6 +89,7 @@ class Test_context(tests.IrisTest):
                 self.assertTrue(future.cell_datetime_objects)
             self.assertFalse(future.cell_datetime_objects)
 
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_with_arg(self):
         # Catch the deprecation when explicitly setting `cell_datetime_objects`
         # as the test is still useful even though the Future property is
@@ -115,6 +111,7 @@ class Test_context(tests.IrisTest):
                 # exception we're looking for.
                 pass
 
+    @skip("This flag has been removed. Test kept as a future template.")
     def test_exception(self):
         # Check that an interrupted context block restores the initial state.
         class LocalTestException(Exception):


### PR DESCRIPTION
Removes the deprecated flags from iris.Future (while keeping the skeleton of Future as a template).

This addresses several of the deprecations in #3443.