### PR TITLE
Drop Dask 1 (tidy up test_co_realise_cubes)

### DIFF
--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -72,9 +72,6 @@ class Test_co_realise_cubes(tests.IrisTest):
         self.assertTrue(cube_inner.has_lazy_data())
 
     def test_combined_access(self):
-        import dask
-        from distutils.version import StrictVersion as Version
-
         wrapped_array = ArrayAccessCounter(np.arange(3.))
         lazy_array = as_lazy_data(wrapped_array)
         derived_a = lazy_array + 1
@@ -84,17 +81,7 @@ class Test_co_realise_cubes(tests.IrisTest):
         cube_b = Cube(derived_b)
         cube_c = Cube(derived_c)
         co_realise_cubes(cube_a, cube_b, cube_c)
-        # Though used more than once, the source data should only get fetched
-        # once by dask.
-        if Version(dask.__version__) < Version('2.0.0'):
-            self.assertEqual(wrapped_array.access_count, 1)
-        else:
-            # dask 2+, now performs an initial data access with no data payload
-            # to ascertain the metadata associated with the dask.array, thus
-            # accounting for one additional access to the data from the
-            # perspective of this particular unit test.
-            # See dask.array.utils.meta_from_array
-            self.assertEqual(wrapped_array.access_count, 2)
+        self.assertEqual(wrapped_array.access_count, 2)
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -77,10 +77,20 @@ class Test_co_realise_cubes(tests.IrisTest):
         derived_a = lazy_array + 1
         derived_b = lazy_array + 2
         derived_c = lazy_array + 3
+        derived_d = lazy_array + 4
+        derived_e = lazy_array + 5
         cube_a = Cube(derived_a)
         cube_b = Cube(derived_b)
         cube_c = Cube(derived_c)
-        co_realise_cubes(cube_a, cube_b, cube_c)
+        cube_d = Cube(derived_d)
+        cube_e = Cube(derived_e)
+        co_realise_cubes(cube_a, cube_b, cube_c, cube_d, cube_e)
+        # Though used more than once, the source data should only get fetched
+        # twice by dask. Once when dask performs an initial data access with
+        # no data payload to ascertain the metadata associated with the
+        # dask.array (this access is specific to dask 2+, see
+        # dask.array.utils.meta_from_array), and again when the whole data is
+        # accessed.
         self.assertEqual(wrapped_array.access_count, 2)
 
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -7,7 +7,7 @@ cartopy
 #conda: proj4<6
 cf-units>=2
 cftime
-dask[array]>=1.2.0  #conda: dask>=1.2.0
+dask[array]>=2  #conda: dask>=2
 matplotlib>=2,<3
 netcdf4
 numpy>=1.14


### PR DESCRIPTION
As per #3356, iris.tests.unit.lazy_data.test_co_realise_cubes no longer tests on versions of dask less than 2. dask>=2 is added as a requirement.