### PR TITLE
Add NameConstraint with relaxed name loading

### DIFF
--- a/docs/iris/src/userguide/loading_iris_cubes.rst
+++ b/docs/iris/src/userguide/loading_iris_cubes.rst
@@ -166,18 +166,36 @@ As we have seen, loading the following file creates several Cubes::
     cubes = iris.load(filename)
 
 Specifying a name as a constraint argument to :py:func:`iris.load` will mean 
-only cubes with a matching :meth:`name <iris.cube.Cube.name>` 
+only cubes with matching :meth:`name <iris.cube.Cube.names>`
 will be returned::
 
     filename = iris.sample_data_path('uk_hires.pp')
-    cubes = iris.load(filename, 'specific_humidity')
+    cubes = iris.load(filename, 'surface_altitude')
 
-To constrain the load to multiple distinct constraints, a list of constraints 
+Note that, the provided name will match against either the standard name,
+long name, NetCDF variable name or STASH metadata of a cube. Therefore, the
+previous example using the ``surface_altitude`` standard name constraint can
+also be achieved using the STASH value of ``m01s00i033``::
+
+    filename = iris.sample_data_path('uk_hires.pp')
+    cubes = iris.load(filename, 'm01s00i033')
+
+If further specific name constraint control is required i.e., to constrain
+against a combination of standard name, long name, NetCDF variable name and/or
+STASH metadata, consider using the :class:`iris.NameConstraint`. For example,
+to constrain against both a standard name of ``surface_altitude`` **and** a STASH
+of ``m01s00i033``::
+
+    filename = iris.sample_data_path('uk_hires.pp')
+    constraint = iris.NameConstraint(standard_name='surface_altitude', STASH='m01s00i033')
+    cubes = iris.load(filename, constraint)
+
+To constrain the load to multiple distinct constraints, a list of constraints
 can be provided.  This is equivalent to running load once for each constraint 
 but is likely to be more efficient::
 
     filename = iris.sample_data_path('uk_hires.pp')
-    cubes = iris.load(filename, ['air_potential_temperature', 'specific_humidity'])
+    cubes = iris.load(filename, ['air_potential_temperature', 'surface_altitude'])
 
 The :class:`iris.Constraint` class can be used to restrict coordinate values 
 on load. For example, to constrain the load to match 

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_nameconstraint.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_nameconstraint.txt
@@ -1,0 +1,1 @@
+* The :class:`~iris.NameConstraint` provides richer name constraint matching when loading or extracting against cubes, by supporting a constraint against any combination of ``standard_name``, ``long_name``, NetCDF ``var_name`` and ``STASH`` from the attributes dictionary of a :class:`~iris.cube.Cube`.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_names_property.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_names_property.txt
@@ -1,0 +1,1 @@
+* Cubes and coordinates now have a new ``names`` property that contains a tuple of the ``standard_name``, ``long_name``, NetCDF ``var_name``, and ``STASH`` attributes metadata.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_relaxed_name_loading.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-15_relaxed_name_loading.txt
@@ -1,0 +1,1 @@
+* Name constraint matching against cubes during loading or extracting has been relaxed from strictly matching against the :meth:`~iris.cube.Cube.name`, to matching against either the ``standard_name``, ``long_name``, NetCDF ``var_name``, or ``STASH`` attributes metadata of a cube.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -117,7 +117,7 @@ __all__ = [
     "save",
     "Constraint",
     "AttributeConstraint",
-    "NameConstraint"
+    "NameConstraint",
     "sample_data_path",
     "site_configuration",
     "Future",

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -117,6 +117,7 @@ __all__ = [
     "save",
     "Constraint",
     "AttributeConstraint",
+    "NameConstraint"
     "sample_data_path",
     "site_configuration",
     "Future",
@@ -127,6 +128,7 @@ __all__ = [
 
 Constraint = iris._constraints.Constraint
 AttributeConstraint = iris._constraints.AttributeConstraint
+NameConstraint = iris._constraints.NameConstraint
 
 
 class Future(threading.local):

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -130,8 +130,10 @@ class Constraint:
         """
         match = True
         if self._name:
-            match = (self._name in cube.names or
-                     self._name == CFVariableMixin._DEFAULT_NAME)
+            match = (
+                self._name in cube.names
+                or self._name == CFVariableMixin._DEFAULT_NAME
+            )
         if match and self._cube_func:
             match = self._cube_func(cube)
         return match
@@ -505,8 +507,14 @@ class NameConstraint(Constraint):
     The name constraint will only succeed if all of the provided names match.
 
     """
-    def __init__(self, standard_name='none', long_name='none',
-                 var_name='none', STASH='none'):
+
+    def __init__(
+        self,
+        standard_name="none",
+        long_name="none",
+        var_name="none",
+        STASH="none",
+    ):
         """
         Example usage::
 
@@ -525,7 +533,7 @@ class NameConstraint(Constraint):
         self.long_name = long_name
         self.var_name = var_name
         self.STASH = STASH
-        self._names = ('standard_name', 'long_name', 'var_name', 'STASH')
+        self._names = ("standard_name", "long_name", "var_name", "STASH")
         super().__init__(cube_func=self._cube_func)
 
     def _cube_func(self, cube):
@@ -538,11 +546,11 @@ class NameConstraint(Constraint):
 
         match = True
         for name in self._names:
-            if name == 'STASH' and self.STASH != 'none':
-                match = matcher(cube.attributes.get('STASH'), self.STASH)
+            if name == "STASH" and self.STASH != "none":
+                match = matcher(cube.attributes.get("STASH"), self.STASH)
             else:
                 expected = getattr(self, name)
-                if expected != 'none':
+                if expected != "none":
                     actual = getattr(cube, name)
                     match = matcher(actual, expected)
             # This is a short-cut match.
@@ -555,6 +563,6 @@ class NameConstraint(Constraint):
         names = []
         for name in self._names:
             value = getattr(self, name)
-            if value != 'none':
-                names.append('{}={!r}'.format(name, value))
-        return '{}({})'.format(self.__class__.__name__, ', '.join(names))
+            if value != "none":
+                names.append("{}={!r}".format(name, value))
+        return "{}({})".format(self.__class__.__name__, ", ".join(names))

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -513,7 +513,7 @@ class NameConstraint(Constraint):
             iris.NameConstraint(long_name='air temp')
 
             iris.NameConstraint(standard_name='air_temperature',
-                                STASH=lambda stash: stash.item == 203
+                                STASH=lambda stash: stash.item == 203)
 
             .. note::
 

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -511,7 +511,10 @@ class NameConstraint(Constraint):
             iris.NameConstraint(standard_name='air_temperature',
                                 STASH=lambda stash: stash.item == 203
 
-            .. note:: Name constraint names are case sensitive.
+            .. note::
+
+                Name constraint names are case sensitive i.e., use the
+                ``STASH`` keyword argument and not ``stash``.
 
         """
         self._names = names

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -533,10 +533,6 @@ class NameConstraint(Constraint):
             value to be matched against e.g., to constrain against all cubes
             where the standard_name is not set, then use standard_name=None.
 
-        ... note::
-            The None value will not be passed through to a callable. Instead
-            use the "<name>=None" pattern.
-
         Returns:
         * Boolean
 

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -466,7 +466,7 @@ class AttributeConstraint(Constraint):
 
         """
         self._attributes = attributes
-        Constraint.__init__(self, cube_func=self._cube_func)
+        super().__init__(cube_func=self._cube_func)
 
     def _cube_func(self, cube):
         match = True
@@ -518,7 +518,7 @@ class NameConstraint(Constraint):
 
         """
         self._names = names
-        super(NameConstraint, self).__init__(cube_func=self._cube_func)
+        super().__init__(cube_func=self._cube_func)
 
     def _cube_func(self, cube):
         def matcher(target, value):

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -129,6 +129,8 @@ class Constraint:
         """
         match = True
         if self._name:
+            # Require to also check against cube.name() for the fallback
+            # "unknown" default case, when there is no name metadata available.
             match = self._name in cube.names or self._name == cube.name()
         if match and self._cube_func:
             match = self._cube_func(cube)

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -13,6 +13,7 @@ import operator
 
 import numpy as np
 
+from iris._cube_coord_common import CFVariableMixin
 import iris.coords
 import iris.exceptions
 
@@ -129,7 +130,8 @@ class Constraint:
         """
         match = True
         if self._name:
-            match = self._name in cube.names
+            match = (self._name in cube.names or
+                     self._name == CFVariableMixin._DEFAULT_NAME)
         if match and self._cube_func:
             match = self._cube_func(cube)
         return match

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -35,7 +35,8 @@ class Constraint:
         Args:
 
         * name:   string or None
-            If a string, it is used as the name to match against Cube.name().
+            If a string, it is used as the name to match against the
+            `~iris.cube.Cube.names` property.
         * cube_func:   callable or None
             If a callable, it must accept a Cube as its first and only argument
             and return either True or False.

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -192,7 +192,9 @@ class CFVariableMixin:
         standard_name = self.standard_name
         long_name = self.long_name
         var_name = self.var_name
-        stash_name = str(self.attributes.get('STASH', ''))
+        stash_name = self.attributes.get('STASH')
+        if stash_name is not None:
+            stash_name = str(stash_name)
         return (standard_name, long_name, var_name, stash_name)
 
     def rename(self, name):

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -17,8 +17,9 @@ import iris.std_names
 _TOKEN_PARSE = re.compile(r"""^[a-zA-Z0-9][\w\.\+\-@]*$""")
 
 
-class Names(namedtuple('Names',
-                       ['standard_name', 'long_name', 'var_name', 'STASH'])):
+class Names(
+    namedtuple("Names", ["standard_name", "long_name", "var_name", "STASH"])
+):
     """
     Immutable container for name metadata.
 
@@ -217,7 +218,7 @@ class CFVariableMixin:
         standard_name = self.standard_name
         long_name = self.long_name
         var_name = self.var_name
-        stash_name = self.attributes.get('STASH')
+        stash_name = self.attributes.get("STASH")
         if stash_name is not None:
             stash_name = str(stash_name)
         return Names(standard_name, long_name, var_name, stash_name)

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -181,6 +181,20 @@ class CFVariableMixin:
 
         return result
 
+    @property
+    def names(self):
+        """
+        A tuple containing all of the metadata names. This includes the
+        standard name, long name, NetCDF variable name, and attributes
+        STASH name.
+
+        """
+        standard_name = self.standard_name
+        long_name = self.long_name
+        var_name = self.var_name
+        stash_name = str(self.attributes.get('STASH', ''))
+        return (standard_name, long_name, var_name, stash_name)
+
     def rename(self, name):
         """
         Changes the human-readable name.

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -4,6 +4,8 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
+
+from collections import namedtuple
 import re
 
 import cf_units
@@ -13,6 +15,29 @@ import iris.std_names
 
 # https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#object_name
 _TOKEN_PARSE = re.compile(r"""^[a-zA-Z0-9][\w\.\+\-@]*$""")
+
+
+class Names(namedtuple('Names',
+                       ['standard_name', 'long_name', 'var_name', 'STASH'])):
+    """
+    Immutable container for name metadata.
+
+    Args:
+
+    * standard_name:
+        A string representing the CF Conventions and Metadata standard name, or
+        None.
+    * long_name:
+        A string representing the CF Conventions and Metadata long name, or
+        None
+    * var_name:
+        A string representing the associated NetCDF variable name, or None.
+    * STASH:
+        A string representing the `~iris.fileformats.pp.STASH` code, or None.
+
+    """
+
+    __slots__ = ()
 
 
 def get_valid_standard_name(name):
@@ -195,7 +220,7 @@ class CFVariableMixin:
         stash_name = self.attributes.get('STASH')
         if stash_name is not None:
             stash_name = str(stash_name)
-        return (standard_name, long_name, var_name, stash_name)
+        return Names(standard_name, long_name, var_name, stash_name)
 
     def rename(self, name):
         """

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -334,6 +334,17 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         self.assertIsNotNone(result)
         self.assertEqual(str(result.attributes['STASH']), self.stash)
 
+    def test_unknown(self):
+        # Clear the cube metadata.
+        self.cube.standard_name = None
+        self.cube.long_name = None
+        self.cube.var_name = None
+        self.cube.attributes = None
+        # Extract the unknown cube.
+        constraint = iris.Constraint('unknown')
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
 
 @tests.skip_data
 class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -305,7 +305,7 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         cube = iris.load_cube(self.theta_path)
         # Expected names...
         self.standard_name = "air_potential_temperature"
-        self.long_name = "air potential temperature"
+        self.long_name = "AIR POTENTIAL TEMPERATURE"
         self.var_name = "apt"
         self.stash = "m01s00i004"
         # Configure missing names...

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -302,10 +302,10 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         TestMixin.setUp(self)
         self.cube = iris.load_cube(self.theta_path)
         # Expected names...
-        self.standard_name = 'air_potential_temperature'
-        self.long_name = 'air potential temperature'
-        self.var_name = 'apt'
-        self.stash = 'm01s00i004'
+        self.standard_name = "air_potential_temperature"
+        self.long_name = "air potential temperature"
+        self.var_name = "apt"
+        self.stash = "m01s00i004"
         # Configure missing names...
         self.cube.long_name = self.long_name
         self.cube.var_name = self.var_name
@@ -332,7 +332,7 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         constraint = iris.Constraint(self.stash)
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
-        self.assertEqual(str(result.attributes['STASH']), self.stash)
+        self.assertEqual(str(result.attributes["STASH"]), self.stash)
 
     def test_unknown(self):
         # Clear the cube metadata.
@@ -341,7 +341,7 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         self.cube.var_name = None
         self.cube.attributes = None
         # Extract the unknown cube.
-        constraint = iris.Constraint('unknown')
+        constraint = iris.Constraint("unknown")
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
@@ -352,17 +352,17 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         TestMixin.setUp(self)
         self.cube = iris.load_cube(self.theta_path)
         # Expected names...
-        self.standard_name = 'air_potential_temperature'
-        self.long_name = 'air potential temperature'
-        self.var_name = 'apt'
-        self.stash = 'm01s00i004'
+        self.standard_name = "air_potential_temperature"
+        self.long_name = "air potential temperature"
+        self.var_name = "apt"
+        self.stash = "m01s00i004"
         # Configure missing names...
         self.cube.long_name = self.long_name
         self.cube.var_name = self.var_name
 
     def test_standard_name(self):
         # No match.
-        constraint = NameConstraint(standard_name='wibble')
+        constraint = NameConstraint(standard_name="wibble")
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
@@ -372,14 +372,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         self.assertIsNotNone(result)
 
         # Match - callable.
-        kwargs = dict(standard_name=lambda item: item.startswith('air_pot'))
+        kwargs = dict(standard_name=lambda item: item.startswith("air_pot"))
         constraint = NameConstraint(**kwargs)
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
     def test_long_name(self):
         # No match.
-        constraint = NameConstraint(long_name='wibble')
+        constraint = NameConstraint(long_name="wibble")
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
@@ -389,14 +389,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         self.assertIsNotNone(result)
 
         # Match - callable.
-        kwargs = dict(long_name=lambda item: item.startswith('air pot'))
+        kwargs = dict(long_name=lambda item: item.startswith("air pot"))
         constraint = NameConstraint(**kwargs)
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
     def test_var_name(self):
         # No match.
-        constraint = NameConstraint(var_name='wibble')
+        constraint = NameConstraint(var_name="wibble")
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
@@ -406,14 +406,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         self.assertIsNotNone(result)
 
         # Match - callable.
-        kwargs = dict(var_name=lambda item: item.startswith('ap'))
+        kwargs = dict(var_name=lambda item: item.startswith("ap"))
         constraint = NameConstraint(**kwargs)
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
     def test_stash(self):
         # No match.
-        constraint = NameConstraint(STASH='m01s00i444')
+        constraint = NameConstraint(STASH="m01s00i444")
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
@@ -430,46 +430,57 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
 
     def test_compound(self):
         # Match.
-        constraint = NameConstraint(standard_name=self.standard_name,
-                                    long_name=self.long_name)
+        constraint = NameConstraint(
+            standard_name=self.standard_name, long_name=self.long_name
+        )
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
         # No match - var_name.
-        constraint = NameConstraint(standard_name=self.standard_name,
-                                    long_name=self.long_name,
-                                    var_name='wibble')
+        constraint = NameConstraint(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name="wibble",
+        )
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
         # Match.
-        constraint = NameConstraint(standard_name=self.standard_name,
-                                    long_name=self.long_name,
-                                    var_name=self.var_name)
+        constraint = NameConstraint(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+        )
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
         # No match - STASH.
-        constraint = NameConstraint(standard_name=self.standard_name,
-                                    long_name=self.long_name,
-                                    var_name=self.var_name,
-                                    STASH='m01s00i444')
+        constraint = NameConstraint(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            STASH="m01s00i444",
+        )
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
         # Match.
-        constraint = NameConstraint(standard_name=self.standard_name,
-                                    long_name=self.long_name,
-                                    var_name=self.var_name,
-                                    STASH=self.stash)
+        constraint = NameConstraint(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            STASH=self.stash,
+        )
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)
 
         # No match - standard_name.
-        constraint = NameConstraint(standard_name='wibble',
-                                    long_name=self.long_name,
-                                    var_name=self.var_name,
-                                    STASH=self.stash)
+        constraint = NameConstraint(
+            standard_name="wibble",
+            long_name=self.long_name,
+            var_name=self.var_name,
+            STASH=self.stash,
+        )
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -14,6 +14,7 @@ import iris.tests as tests
 import datetime
 
 import iris
+from iris import AttributeConstraint, NameConstraint
 import iris.tests.stock as stock
 
 
@@ -296,49 +297,209 @@ class TestCubeListStrictConstraint(StrictConstraintMixin, tests.IrisTest):
 
 
 @tests.skip_data
+class TestCubeExtract__names(TestMixin, tests.IrisTest):
+    def setUp(self):
+        TestMixin.setUp(self)
+        self.cube = iris.load_cube(self.theta_path)
+        # Expected names...
+        self.standard_name = 'air_potential_temperature'
+        self.long_name = 'air potential temperature'
+        self.var_name = 'apt'
+        self.stash = 'm01s00i004'
+        # Configure missing names...
+        self.cube.long_name = self.long_name
+        self.cube.var_name = self.var_name
+
+    def test_standard_name(self):
+        constraint = iris.Constraint(self.standard_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.standard_name, self.standard_name)
+
+    def test_long_name(self):
+        constraint = iris.Constraint(self.long_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.long_name, self.long_name)
+
+    def test_var_name(self):
+        constraint = iris.Constraint(self.var_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.var_name, self.var_name)
+
+    def test_stash(self):
+        constraint = iris.Constraint(self.stash)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result.attributes['STASH']), self.stash)
+
+
+@tests.skip_data
+class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
+    def setUp(self):
+        TestMixin.setUp(self)
+        self.cube = iris.load_cube(self.theta_path)
+        # Expected names...
+        self.standard_name = 'air_potential_temperature'
+        self.long_name = 'air potential temperature'
+        self.var_name = 'apt'
+        self.stash = 'm01s00i004'
+        # Configure missing names...
+        self.cube.long_name = self.long_name
+        self.cube.var_name = self.var_name
+
+    def test_standard_name(self):
+        # No match.
+        constraint = NameConstraint(standard_name='wibble')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(standard_name=self.standard_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # Match - callable.
+        kwargs = dict(standard_name=lambda item: item.startswith('air_pot'))
+        constraint = NameConstraint(**kwargs)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+    def test_long_name(self):
+        # No match.
+        constraint = NameConstraint(long_name='wibble')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(long_name=self.long_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # Match - callable.
+        kwargs = dict(long_name=lambda item: item.startswith('air pot'))
+        constraint = NameConstraint(**kwargs)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+    def test_var_name(self):
+        # No match.
+        constraint = NameConstraint(var_name='wibble')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(var_name=self.var_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # Match - callable.
+        kwargs = dict(var_name=lambda item: item.startswith('ap'))
+        constraint = NameConstraint(**kwargs)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+    def test_stash(self):
+        # No match.
+        constraint = NameConstraint(STASH='m01s00i444')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(STASH=self.stash)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # Match - callable.
+        kwargs = dict(STASH=lambda stash: stash.item==4)
+        constraint = NameConstraint(**kwargs)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+    def test_compound(self):
+        # Match.
+        constraint = NameConstraint(standard_name=self.standard_name,
+                                    long_name=self.long_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # No match - var_name.
+        constraint = NameConstraint(standard_name=self.standard_name,
+                                    long_name=self.long_name,
+                                    var_name='wibble')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(standard_name=self.standard_name,
+                                    long_name=self.long_name,
+                                    var_name=self.var_name)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # No match - STASH.
+        constraint = NameConstraint(standard_name=self.standard_name,
+                                    long_name=self.long_name,
+                                    var_name=self.var_name,
+                                    STASH='m01s00i444')
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+        # Match.
+        constraint = NameConstraint(standard_name=self.standard_name,
+                                    long_name=self.long_name,
+                                    var_name=self.var_name,
+                                    STASH=self.stash)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
+        # No match - standard_name.
+        constraint = NameConstraint(standard_name='wibble',
+                                    long_name=self.long_name,
+                                    var_name=self.var_name,
+                                    STASH=self.stash)
+        result = self.cube.extract(constraint)
+        self.assertIsNone(result)
+
+
+@tests.skip_data
 class TestCubeExtract(TestMixin, tests.IrisTest):
     def setUp(self):
         TestMixin.setUp(self)
         self.cube = iris.load_cube(self.theta_path)
 
     def test_attribute_constraint(self):
-        # there is no my_attribute attribute on the cube, so ensure it returns None
-        cube = self.cube.extract(
-            iris.AttributeConstraint(my_attribute="foobar")
-        )
+        # There is no my_attribute on the cube, so ensure it returns None.
+        constraint = AttributeConstraint(my_attribute="foobar")
+        cube = self.cube.extract(constraint)
         self.assertIsNone(cube)
 
         orig_cube = self.cube
         # add an attribute to the cubes
         orig_cube.attributes["my_attribute"] = "foobar"
 
-        cube = orig_cube.extract(
-            iris.AttributeConstraint(my_attribute="foobar")
-        )
+        constraint = AttributeConstraint(my_attribute="foobar")
+        cube = orig_cube.extract(constraint)
         self.assertCML(cube, ("constrained_load", "attribute_constraint.cml"))
 
-        cube = orig_cube.extract(
-            iris.AttributeConstraint(my_attribute="not me")
-        )
+        constraint = AttributeConstraint(my_attribute="not me")
+        cube = orig_cube.extract(constraint)
         self.assertIsNone(cube)
 
-        cube = orig_cube.extract(
-            iris.AttributeConstraint(
-                my_attribute=lambda val: val.startswith("foo")
-            )
-        )
+        kwargs = dict(my_attribute=lambda val: val.startswith("foo"))
+        constraint = AttributeConstraint(**kwargs)
+        cube = orig_cube.extract(constraint)
         self.assertCML(cube, ("constrained_load", "attribute_constraint.cml"))
 
-        cube = orig_cube.extract(
-            iris.AttributeConstraint(
-                my_attribute=lambda val: not val.startswith("foo")
-            )
-        )
+        kwargs = dict(my_attribute=lambda val: not val.startswith("foo"))
+        constraint = AttributeConstraint(**kwargs)
+        cube = orig_cube.extract(constraint)
         self.assertIsNone(cube)
 
-        cube = orig_cube.extract(
-            iris.AttributeConstraint(my_non_existant_attribute="hello world")
-        )
+        kwargs = dict(my_non_existant_attribute="hello world")
+        constraint = AttributeConstraint(**kwargs)
+        cube = orig_cube.extract(constraint)
         self.assertIsNone(cube)
 
     def test_standard_name(self):
@@ -360,7 +521,7 @@ class TestCubeExtract(TestMixin, tests.IrisTest):
         cube = self.cube.extract(self.level_10).extract(self.level_10)
         self.assertTrue(cube.has_lazy_data())
 
-    def test_non_existant_coordinate(self):
+    def test_non_existent_coordinate(self):
         # Check the behaviour when a constraint is given for a coordinate which does not exist/span a dimension
         self.assertEqual(self.cube[0, :, :].extract(self.level_10), None)
 

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -473,6 +473,15 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         result = self.cube.extract(constraint)
         self.assertIsNone(result)
 
+    def test_unknown(self):
+        self.cube.standard_name = None
+        self.cube.long_name = None
+        self.cube.var_name = None
+        self.cube.attributes = None
+        constraint = NameConstraint(None, None, None, None)
+        result = self.cube.extract(constraint)
+        self.assertIsNotNone(result)
+
 
 @tests.skip_data
 class TestCubeExtract(TestMixin, tests.IrisTest):

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -412,7 +412,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         self.assertIsNotNone(result)
 
         # Match - callable.
-        kwargs = dict(STASH=lambda stash: stash.item==4)
+        kwargs = dict(STASH=lambda stash: stash.item == 4)
         constraint = NameConstraint(**kwargs)
         result = self.cube.extract(constraint)
         self.assertIsNotNone(result)

--- a/lib/iris/tests/unit/constraints/__init__.py
+++ b/lib/iris/tests/unit/constraints/__init__.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright Iris contributors
 #
-# This file is part of Iris.
-#
-# Iris is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Iris is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the :mod:`iris._constraints` module."""
 
 from __future__ import (absolute_import, division, print_function)

--- a/lib/iris/tests/unit/constraints/__init__.py
+++ b/lib/iris/tests/unit/constraints/__init__.py
@@ -5,5 +5,5 @@
 # licensing details.
 """Unit tests for the :mod:`iris._constraints` module."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
+from __future__ import absolute_import, division, print_function
+from six.moves import filter, input, map, range, zip  # noqa

--- a/lib/iris/tests/unit/constraints/__init__.py
+++ b/lib/iris/tests/unit/constraints/__init__.py
@@ -1,0 +1,20 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`iris._constraints` module."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/iris/tests/unit/constraints/test_NameConstraint.py
+++ b/lib/iris/tests/unit/constraints/test_NameConstraint.py
@@ -5,8 +5,8 @@
 # licensing details.
 """Unit tests for the `iris._constraints.NameConstraint` class."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
+from __future__ import absolute_import, division, print_function
+from six.moves import filter, input, map, range, zip  # noqa
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
@@ -19,7 +19,7 @@ from iris._constraints import NameConstraint
 
 class Test___init__(tests.IrisTest):
     def setUp(self):
-        self.default = 'none'
+        self.default = "none"
 
     def test_default(self):
         constraint = NameConstraint()
@@ -75,10 +75,12 @@ class Test__cube_func(tests.IrisTest):
         self.long_name = sentinel.long_name
         self.var_name = sentinel.var_name
         self.STASH = sentinel.STASH
-        self.cube = Mock(standard_name=self.standard_name,
-                         long_name=self.long_name,
-                         var_name=self.var_name,
-                         attributes=dict(STASH=self.STASH))
+        self.cube = Mock(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            attributes=dict(STASH=self.STASH),
+        )
 
     def test_standard_name(self):
         # Match.
@@ -88,10 +90,10 @@ class Test__cube_func(tests.IrisTest):
         constraint = NameConstraint(self.standard_name)
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint(standard_name='wibble')
+        constraint = NameConstraint(standard_name="wibble")
         self.assertFalse(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint('wibble')
+        constraint = NameConstraint("wibble")
         self.assertFalse(constraint._cube_func(self.cube))
 
     def test_long_name(self):
@@ -113,8 +115,9 @@ class Test__cube_func(tests.IrisTest):
         constraint = NameConstraint(var_name=self.var_name)
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
-        constraint = NameConstraint(self.standard_name, self.long_name,
-                                    self.var_name)
+        constraint = NameConstraint(
+            self.standard_name, self.long_name, self.var_name
+        )
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(var_name=None)
@@ -128,8 +131,9 @@ class Test__cube_func(tests.IrisTest):
         constraint = NameConstraint(STASH=self.STASH)
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
-        constraint = NameConstraint(self.standard_name, self.long_name,
-                                    self.var_name, self.STASH)
+        constraint = NameConstraint(
+            self.standard_name, self.long_name, self.var_name, self.STASH
+        )
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(STASH=None)
@@ -145,15 +149,15 @@ class Test___repr__(tests.IrisTest):
         self.long_name = sentinel.long_name
         self.var_name = sentinel.var_name
         self.STASH = sentinel.STASH
-        self.msg = 'NameConstraint({})'
-        self.f_standard_name = 'standard_name={!r}'.format(self.standard_name)
-        self.f_long_name = 'long_name={!r}'.format(self.long_name)
-        self.f_var_name = 'var_name={!r}'.format(self.var_name)
-        self.f_STASH = 'STASH={!r}'.format(self.STASH)
+        self.msg = "NameConstraint({})"
+        self.f_standard_name = "standard_name={!r}".format(self.standard_name)
+        self.f_long_name = "long_name={!r}".format(self.long_name)
+        self.f_var_name = "var_name={!r}".format(self.var_name)
+        self.f_STASH = "STASH={!r}".format(self.STASH)
 
     def test(self):
         constraint = NameConstraint()
-        expected = self.msg.format('')
+        expected = self.msg.format("")
         self.assertEqual(repr(constraint), expected)
 
     def test_standard_name(self):
@@ -166,7 +170,7 @@ class Test___repr__(tests.IrisTest):
         expected = self.msg.format(self.f_long_name)
         self.assertEqual(repr(constraint), expected)
         constraint = NameConstraint(self.standard_name, self.long_name)
-        args = '{}, {}'.format(self.f_standard_name, self.f_long_name)
+        args = "{}, {}".format(self.f_standard_name, self.f_long_name)
         expected = self.msg.format(args)
         self.assertEqual(repr(constraint), expected)
 
@@ -174,10 +178,12 @@ class Test___repr__(tests.IrisTest):
         constraint = NameConstraint(var_name=self.var_name)
         expected = self.msg.format(self.f_var_name)
         self.assertEqual(repr(constraint), expected)
-        constraint = NameConstraint(self.standard_name, self.long_name,
-                                    self.var_name)
-        args = '{}, {}, {}'.format(self.f_standard_name, self.f_long_name,
-                                   self.f_var_name)
+        constraint = NameConstraint(
+            self.standard_name, self.long_name, self.var_name
+        )
+        args = "{}, {}, {}".format(
+            self.f_standard_name, self.f_long_name, self.f_var_name
+        )
         expected = self.msg.format(args)
         self.assertEqual(repr(constraint), expected)
 
@@ -185,13 +191,18 @@ class Test___repr__(tests.IrisTest):
         constraint = NameConstraint(STASH=self.STASH)
         expected = self.msg.format(self.f_STASH)
         self.assertEqual(repr(constraint), expected)
-        constraint = NameConstraint(self.standard_name, self.long_name,
-                                    self.var_name, self.STASH)
-        args = '{}, {}, {}, {}'.format(self.f_standard_name, self.f_long_name,
-                                       self.f_var_name, self.f_STASH)
+        constraint = NameConstraint(
+            self.standard_name, self.long_name, self.var_name, self.STASH
+        )
+        args = "{}, {}, {}, {}".format(
+            self.f_standard_name,
+            self.f_long_name,
+            self.f_var_name,
+            self.f_STASH,
+        )
         expected = self.msg.format(args)
         self.assertEqual(repr(constraint), expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/constraints/test_NameConstraint.py
+++ b/lib/iris/tests/unit/constraints/test_NameConstraint.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright Iris contributors
 #
-# This file is part of Iris.
-#
-# Iris is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Iris is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the `iris._constraints.NameConstraint` class."""
 
 from __future__ import (absolute_import, division, print_function)

--- a/lib/iris/tests/unit/constraints/test_NameConstraint.py
+++ b/lib/iris/tests/unit/constraints/test_NameConstraint.py
@@ -32,7 +32,7 @@ class Test___init__(tests.IrisTest):
         standard_name = sentinel.standard_name
         constraint = NameConstraint(standard_name=standard_name)
         self.assertEqual(constraint.standard_name, standard_name)
-        constraint = NameConstraint(standard_name)
+        constraint = NameConstraint(standard_name=standard_name)
         self.assertEqual(constraint.standard_name, standard_name)
 
     def test_long_name(self):
@@ -40,7 +40,7 @@ class Test___init__(tests.IrisTest):
         constraint = NameConstraint(long_name=long_name)
         self.assertEqual(constraint.standard_name, self.default)
         self.assertEqual(constraint.long_name, long_name)
-        constraint = NameConstraint(None, long_name)
+        constraint = NameConstraint(standard_name=None, long_name=long_name)
         self.assertIsNone(constraint.standard_name)
         self.assertEqual(constraint.long_name, long_name)
 
@@ -50,7 +50,9 @@ class Test___init__(tests.IrisTest):
         self.assertEqual(constraint.standard_name, self.default)
         self.assertEqual(constraint.long_name, self.default)
         self.assertEqual(constraint.var_name, var_name)
-        constraint = NameConstraint(None, None, var_name)
+        constraint = NameConstraint(
+            standard_name=None, long_name=None, var_name=var_name
+        )
         self.assertIsNone(constraint.standard_name)
         self.assertIsNone(constraint.long_name)
         self.assertEqual(constraint.var_name, var_name)
@@ -62,7 +64,9 @@ class Test___init__(tests.IrisTest):
         self.assertEqual(constraint.long_name, self.default)
         self.assertEqual(constraint.var_name, self.default)
         self.assertEqual(constraint.STASH, STASH)
-        constraint = NameConstraint(None, None, None, STASH)
+        constraint = NameConstraint(
+            standard_name=None, long_name=None, var_name=None, STASH=STASH
+        )
         self.assertIsNone(constraint.standard_name)
         self.assertIsNone(constraint.long_name)
         self.assertIsNone(constraint.var_name)
@@ -87,13 +91,13 @@ class Test__cube_func(tests.IrisTest):
         constraint = NameConstraint(standard_name=self.standard_name)
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
-        constraint = NameConstraint(self.standard_name)
+        constraint = NameConstraint(standard_name=self.standard_name)
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(standard_name="wibble")
         self.assertFalse(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint("wibble")
+        constraint = NameConstraint(standard_name="wibble")
         self.assertFalse(constraint._cube_func(self.cube))
 
     def test_long_name(self):
@@ -101,13 +105,17 @@ class Test__cube_func(tests.IrisTest):
         constraint = NameConstraint(long_name=self.long_name)
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
-        constraint = NameConstraint(self.standard_name, self.long_name)
+        constraint = NameConstraint(
+            standard_name=self.standard_name, long_name=self.long_name
+        )
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(long_name=None)
         self.assertFalse(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint(None, self.long_name)
+        constraint = NameConstraint(
+            standard_name=None, long_name=self.long_name
+        )
         self.assertFalse(constraint._cube_func(self.cube))
 
     def test_var_name(self):
@@ -116,14 +124,18 @@ class Test__cube_func(tests.IrisTest):
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
         constraint = NameConstraint(
-            self.standard_name, self.long_name, self.var_name
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
         )
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(var_name=None)
         self.assertFalse(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint(None, None, self.var_name)
+        constraint = NameConstraint(
+            standard_name=None, long_name=None, var_name=self.var_name
+        )
         self.assertFalse(constraint._cube_func(self.cube))
 
     def test_STASH(self):
@@ -132,14 +144,19 @@ class Test__cube_func(tests.IrisTest):
         self.assertTrue(constraint._cube_func(self.cube))
         # Match.
         constraint = NameConstraint(
-            self.standard_name, self.long_name, self.var_name, self.STASH
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            STASH=self.STASH,
         )
         self.assertTrue(constraint._cube_func(self.cube))
         # No match.
         constraint = NameConstraint(STASH=None)
         self.assertFalse(constraint._cube_func(self.cube))
         # No match.
-        constraint = NameConstraint(None, None, None, self.STASH)
+        constraint = NameConstraint(
+            standard_name=None, long_name=None, var_name=None, STASH=self.STASH
+        )
         self.assertFalse(constraint._cube_func(self.cube))
 
 
@@ -161,7 +178,7 @@ class Test___repr__(tests.IrisTest):
         self.assertEqual(repr(constraint), expected)
 
     def test_standard_name(self):
-        constraint = NameConstraint(self.standard_name)
+        constraint = NameConstraint(standard_name=self.standard_name)
         expected = self.msg.format(self.f_standard_name)
         self.assertEqual(repr(constraint), expected)
 
@@ -169,7 +186,9 @@ class Test___repr__(tests.IrisTest):
         constraint = NameConstraint(long_name=self.long_name)
         expected = self.msg.format(self.f_long_name)
         self.assertEqual(repr(constraint), expected)
-        constraint = NameConstraint(self.standard_name, self.long_name)
+        constraint = NameConstraint(
+            standard_name=self.standard_name, long_name=self.long_name
+        )
         args = "{}, {}".format(self.f_standard_name, self.f_long_name)
         expected = self.msg.format(args)
         self.assertEqual(repr(constraint), expected)
@@ -179,7 +198,9 @@ class Test___repr__(tests.IrisTest):
         expected = self.msg.format(self.f_var_name)
         self.assertEqual(repr(constraint), expected)
         constraint = NameConstraint(
-            self.standard_name, self.long_name, self.var_name
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
         )
         args = "{}, {}, {}".format(
             self.f_standard_name, self.f_long_name, self.f_var_name
@@ -192,7 +213,10 @@ class Test___repr__(tests.IrisTest):
         expected = self.msg.format(self.f_STASH)
         self.assertEqual(repr(constraint), expected)
         constraint = NameConstraint(
-            self.standard_name, self.long_name, self.var_name, self.STASH
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            STASH=self.STASH,
         )
         args = "{}, {}, {}, {}".format(
             self.f_standard_name,

--- a/lib/iris/tests/unit/constraints/test_NameConstraint.py
+++ b/lib/iris/tests/unit/constraints/test_NameConstraint.py
@@ -1,0 +1,208 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `iris._constraints.NameConstraint` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from unittest.mock import Mock, sentinel
+
+from iris._constraints import NameConstraint
+
+
+class Test___init__(tests.IrisTest):
+    def setUp(self):
+        self.default = 'none'
+
+    def test_default(self):
+        constraint = NameConstraint()
+        self.assertEqual(constraint.standard_name, self.default)
+        self.assertEqual(constraint.long_name, self.default)
+        self.assertEqual(constraint.var_name, self.default)
+        self.assertEqual(constraint.STASH, self.default)
+
+    def test_standard_name(self):
+        standard_name = sentinel.standard_name
+        constraint = NameConstraint(standard_name=standard_name)
+        self.assertEqual(constraint.standard_name, standard_name)
+        constraint = NameConstraint(standard_name)
+        self.assertEqual(constraint.standard_name, standard_name)
+
+    def test_long_name(self):
+        long_name = sentinel.long_name
+        constraint = NameConstraint(long_name=long_name)
+        self.assertEqual(constraint.standard_name, self.default)
+        self.assertEqual(constraint.long_name, long_name)
+        constraint = NameConstraint(None, long_name)
+        self.assertIsNone(constraint.standard_name)
+        self.assertEqual(constraint.long_name, long_name)
+
+    def test_var_name(self):
+        var_name = sentinel.var_name
+        constraint = NameConstraint(var_name=var_name)
+        self.assertEqual(constraint.standard_name, self.default)
+        self.assertEqual(constraint.long_name, self.default)
+        self.assertEqual(constraint.var_name, var_name)
+        constraint = NameConstraint(None, None, var_name)
+        self.assertIsNone(constraint.standard_name)
+        self.assertIsNone(constraint.long_name)
+        self.assertEqual(constraint.var_name, var_name)
+
+    def test_STASH(self):
+        STASH = sentinel.STASH
+        constraint = NameConstraint(STASH=STASH)
+        self.assertEqual(constraint.standard_name, self.default)
+        self.assertEqual(constraint.long_name, self.default)
+        self.assertEqual(constraint.var_name, self.default)
+        self.assertEqual(constraint.STASH, STASH)
+        constraint = NameConstraint(None, None, None, STASH)
+        self.assertIsNone(constraint.standard_name)
+        self.assertIsNone(constraint.long_name)
+        self.assertIsNone(constraint.var_name)
+        self.assertEqual(constraint.STASH, STASH)
+
+
+class Test__cube_func(tests.IrisTest):
+    def setUp(self):
+        self.standard_name = sentinel.standard_name
+        self.long_name = sentinel.long_name
+        self.var_name = sentinel.var_name
+        self.STASH = sentinel.STASH
+        self.cube = Mock(standard_name=self.standard_name,
+                         long_name=self.long_name,
+                         var_name=self.var_name,
+                         attributes=dict(STASH=self.STASH))
+
+    def test_standard_name(self):
+        # Match.
+        constraint = NameConstraint(standard_name=self.standard_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # Match.
+        constraint = NameConstraint(self.standard_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(standard_name='wibble')
+        self.assertFalse(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint('wibble')
+        self.assertFalse(constraint._cube_func(self.cube))
+
+    def test_long_name(self):
+        # Match.
+        constraint = NameConstraint(long_name=self.long_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # Match.
+        constraint = NameConstraint(self.standard_name, self.long_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(long_name=None)
+        self.assertFalse(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(None, self.long_name)
+        self.assertFalse(constraint._cube_func(self.cube))
+
+    def test_var_name(self):
+        # Match.
+        constraint = NameConstraint(var_name=self.var_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # Match.
+        constraint = NameConstraint(self.standard_name, self.long_name,
+                                    self.var_name)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(var_name=None)
+        self.assertFalse(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(None, None, self.var_name)
+        self.assertFalse(constraint._cube_func(self.cube))
+
+    def test_STASH(self):
+        # Match.
+        constraint = NameConstraint(STASH=self.STASH)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # Match.
+        constraint = NameConstraint(self.standard_name, self.long_name,
+                                    self.var_name, self.STASH)
+        self.assertTrue(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(STASH=None)
+        self.assertFalse(constraint._cube_func(self.cube))
+        # No match.
+        constraint = NameConstraint(None, None, None, self.STASH)
+        self.assertFalse(constraint._cube_func(self.cube))
+
+
+class Test___repr__(tests.IrisTest):
+    def setUp(self):
+        self.standard_name = sentinel.standard_name
+        self.long_name = sentinel.long_name
+        self.var_name = sentinel.var_name
+        self.STASH = sentinel.STASH
+        self.msg = 'NameConstraint({})'
+        self.f_standard_name = 'standard_name={!r}'.format(self.standard_name)
+        self.f_long_name = 'long_name={!r}'.format(self.long_name)
+        self.f_var_name = 'var_name={!r}'.format(self.var_name)
+        self.f_STASH = 'STASH={!r}'.format(self.STASH)
+
+    def test(self):
+        constraint = NameConstraint()
+        expected = self.msg.format('')
+        self.assertEqual(repr(constraint), expected)
+
+    def test_standard_name(self):
+        constraint = NameConstraint(self.standard_name)
+        expected = self.msg.format(self.f_standard_name)
+        self.assertEqual(repr(constraint), expected)
+
+    def test_long_name(self):
+        constraint = NameConstraint(long_name=self.long_name)
+        expected = self.msg.format(self.f_long_name)
+        self.assertEqual(repr(constraint), expected)
+        constraint = NameConstraint(self.standard_name, self.long_name)
+        args = '{}, {}'.format(self.f_standard_name, self.f_long_name)
+        expected = self.msg.format(args)
+        self.assertEqual(repr(constraint), expected)
+
+    def test_var_name(self):
+        constraint = NameConstraint(var_name=self.var_name)
+        expected = self.msg.format(self.f_var_name)
+        self.assertEqual(repr(constraint), expected)
+        constraint = NameConstraint(self.standard_name, self.long_name,
+                                    self.var_name)
+        args = '{}, {}, {}'.format(self.f_standard_name, self.f_long_name,
+                                   self.f_var_name)
+        expected = self.msg.format(args)
+        self.assertEqual(repr(constraint), expected)
+
+    def test_STASH(self):
+        constraint = NameConstraint(STASH=self.STASH)
+        expected = self.msg.format(self.f_STASH)
+        self.assertEqual(repr(constraint), expected)
+        constraint = NameConstraint(self.standard_name, self.long_name,
+                                    self.var_name, self.STASH)
+        args = '{}, {}, {}, {}'.format(self.f_standard_name, self.f_long_name,
+                                       self.f_var_name, self.f_STASH)
+        expected = self.msg.format(args)
+        self.assertEqual(repr(constraint), expected)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -143,25 +143,33 @@ class Test_names(tests.IrisTest):
         standard_name = 'air_temperature'
         self.cf_var.standard_name = standard_name
         expected = (standard_name, None, None, None)
-        self.assertEqual(expected, self.cf_var.names)
+        result = self.cf_var.names
+        self.assertEqual(expected, result)
+        self.assertEqual(result.standard_name, standard_name)
 
     def test_long_name(self):
         long_name = 'air temperature'
         self.cf_var.long_name = long_name
         expected = (None, long_name, None, None)
-        self.assertEqual(expected, self.cf_var.names)
+        result = self.cf_var.names
+        self.assertEqual(expected, result)
+        self.assertEqual(result.long_name, long_name)
 
     def test_var_name(self):
         var_name = 'atemp'
         self.cf_var.var_name = var_name
         expected = (None, None, var_name, None)
-        self.assertEqual(expected, self.cf_var.names)
+        result = self.cf_var.names
+        self.assertEqual(expected, result)
+        self.assertEqual(result.var_name, var_name)
 
     def test_STASH(self):
         stash = 'm01s16i203'
         self.cf_var.attributes = dict(STASH=stash)
         expected = (None, None, None, stash)
-        self.assertEqual(expected, self.cf_var.names)
+        result = self.cf_var.names
+        self.assertEqual(expected, result)
+        self.assertEqual(result.STASH, stash)
 
 
 class Test_standard_name__setter(tests.IrisTest):

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -171,6 +171,11 @@ class Test_names(tests.IrisTest):
         self.assertEqual(expected, result)
         self.assertEqual(result.STASH, stash)
 
+    def test_None(self):
+        expected = (None, None, None, None)
+        result = self.cf_var.names
+        self.assertEqual(expected, result)
+
 
 class Test_standard_name__setter(tests.IrisTest):
     def test_valid_standard_name(self):

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -142,19 +142,19 @@ class Test_names(tests.IrisTest):
     def test_standard_name(self):
         standard_name = 'air_temperature'
         self.cf_var.standard_name = standard_name
-        expected = (standard_name, None, None, '')
+        expected = (standard_name, None, None, None)
         self.assertEqual(expected, self.cf_var.names)
 
     def test_long_name(self):
         long_name = 'air temperature'
         self.cf_var.long_name = long_name
-        expected = (None, long_name, None, '')
+        expected = (None, long_name, None, None)
         self.assertEqual(expected, self.cf_var.names)
 
     def test_var_name(self):
         var_name = 'atemp'
         self.cf_var.var_name = var_name
-        expected = (None, None, var_name, '')
+        expected = (None, None, var_name, None)
         self.assertEqual(expected, self.cf_var.names)
 
     def test_STASH(self):

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -140,7 +140,7 @@ class Test_names(tests.IrisTest):
         self.cf_var.attributes = dict()
 
     def test_standard_name(self):
-        standard_name = 'air_temperature'
+        standard_name = "air_temperature"
         self.cf_var.standard_name = standard_name
         expected = (standard_name, None, None, None)
         result = self.cf_var.names
@@ -148,7 +148,7 @@ class Test_names(tests.IrisTest):
         self.assertEqual(result.standard_name, standard_name)
 
     def test_long_name(self):
-        long_name = 'air temperature'
+        long_name = "air temperature"
         self.cf_var.long_name = long_name
         expected = (None, long_name, None, None)
         result = self.cf_var.names
@@ -156,7 +156,7 @@ class Test_names(tests.IrisTest):
         self.assertEqual(result.long_name, long_name)
 
     def test_var_name(self):
-        var_name = 'atemp'
+        var_name = "atemp"
         self.cf_var.var_name = var_name
         expected = (None, None, var_name, None)
         result = self.cf_var.names
@@ -164,7 +164,7 @@ class Test_names(tests.IrisTest):
         self.assertEqual(result.var_name, var_name)
 
     def test_STASH(self):
-        stash = 'm01s16i203'
+        stash = "m01s16i203"
         self.cf_var.attributes = dict(STASH=stash)
         expected = (None, None, None, stash)
         result = self.cf_var.names

--- a/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_CFVariableMixin.py
@@ -131,6 +131,39 @@ class Test_name(tests.IrisTest):
             self.cf_var.name(default="_nope", token=True)
 
 
+class Test_names(tests.IrisTest):
+    def setUp(self):
+        self.cf_var = CFVariableMixin()
+        self.cf_var.standard_name = None
+        self.cf_var.long_name = None
+        self.cf_var.var_name = None
+        self.cf_var.attributes = dict()
+
+    def test_standard_name(self):
+        standard_name = 'air_temperature'
+        self.cf_var.standard_name = standard_name
+        expected = (standard_name, None, None, '')
+        self.assertEqual(expected, self.cf_var.names)
+
+    def test_long_name(self):
+        long_name = 'air temperature'
+        self.cf_var.long_name = long_name
+        expected = (None, long_name, None, '')
+        self.assertEqual(expected, self.cf_var.names)
+
+    def test_var_name(self):
+        var_name = 'atemp'
+        self.cf_var.var_name = var_name
+        expected = (None, None, var_name, '')
+        self.assertEqual(expected, self.cf_var.names)
+
+    def test_STASH(self):
+        stash = 'm01s16i203'
+        self.cf_var.attributes = dict(STASH=stash)
+        expected = (None, None, None, stash)
+        self.assertEqual(expected, self.cf_var.names)
+
+
 class Test_standard_name__setter(tests.IrisTest):
     def test_valid_standard_name(self):
         cf_var = CFVariableMixin()


### PR DESCRIPTION
This PR introduces the `names` property to both cubes and coordinates - a property that returns a tuple of the `standard_name`, `long_name`, `var_name` and `STASH`.

This property is needed as a means to support more flexible `name` loading i.e., a `iris._constraints.Constraint._coordless_match` that will succeed for a match on either of the `names` property values, rather than depending on the behaviour of the `iris._cube_coord_common.CFVariableMixin.name` method. Note that, this also applies to `iris.cube.Cube.extract` and `iris.cube.CubeList.extract` et al.

This PR also introduces the `iris.NameConstraint` for more specific control of `names` related matching.

----

Closes #3407 