### PR TITLE
Have Travis test with iris-grib, remove problem tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,11 +101,10 @@ install:
   - python setup.py --quiet install
 
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.
-# TODO: uncomment and address the 5 failures and 10 errors in iris-grib.
-#  - if [[ "${TEST_MINIMAL}" != true ]]; then
-#        conda install --quiet -n ${ENV_NAME} python-eccodes;
-#        conda install --quiet -n ${ENV_NAME} --no-deps iris-grib;
-#    fi
+  - if [[ "${TEST_MINIMAL}" != true ]]; then
+        conda install --quiet -n ${ENV_NAME} python-eccodes;
+        conda install --quiet -n ${ENV_NAME} --no-deps iris-grib;
+    fi
 
 script:
   # Capture install-dir: As a test command must be last for get Travis to check

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,10 @@ install:
   - python setup.py --quiet install
 
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.
+  # test against the latest version of python-eccodes.
+  # Conda-forge versioning is out of order (0.9.* is later than 2.12.*).
   - if [[ "${TEST_MINIMAL}" != true ]]; then
-        conda install --quiet -n ${ENV_NAME} python-eccodes;
+        conda install --quiet -n ${ENV_NAME} python-eccodes=0.9.3;
         conda install --quiet -n ${ENV_NAME} --no-deps iris-grib;
     fi
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1206,6 +1206,12 @@ skip_grib = unittest.skipIf(not GRIB_AVAILABLE,
                             'which is not available.')
 
 
+# TODO: remove these skips when iris-grib is fixed
+skip_grib_fail = unittest.skipIf(True,
+                                 'Test(s) are failing due to known problems '
+                                 'with "iris-grib".')
+
+
 skip_sample_data = unittest.skipIf(not SAMPLE_DATA_AVAILABLE,
                                    ('Test(s) require "iris-sample-data", '
                                     'which is not available.'))

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -22,7 +22,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
-from unittest import skip
 
 from cf_units import Unit
 import numpy.ma as ma
@@ -50,7 +49,7 @@ class TestImport(tests.IrisTest):
         cube = load_cube(path)
         self.assertCMLApproxData(cube)
 
-    @skip('iris-grib is currently causing errors')
+    @tests.skip_grib_fail
     def test_gdt90_with_bitmap(self):
         path = tests.get_data_path(('GRIB', 'umukv', 'ukv_chan9.grib2'))
         cube = load_cube(path)
@@ -282,7 +281,7 @@ class TestGDT40(tests.IrisTest):
         cube = load_cube(path)
         self.assertCMLApproxData(cube)
 
-    @skip('iris-grib is currently causing failures')
+    @tests.skip_grib_fail
     def test_reduced(self):
         path = tests.get_data_path(('GRIB', 'reduced', 'reduced_gg.grib2'))
         cube = load_cube(path)

--- a/lib/iris/tests/integration/test_grib2.py
+++ b/lib/iris/tests/integration/test_grib2.py
@@ -22,6 +22,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests
+from unittest import skip
 
 from cf_units import Unit
 import numpy.ma as ma
@@ -49,6 +50,7 @@ class TestImport(tests.IrisTest):
         cube = load_cube(path)
         self.assertCMLApproxData(cube)
 
+    @skip('iris-grib is currently causing errors')
     def test_gdt90_with_bitmap(self):
         path = tests.get_data_path(('GRIB', 'umukv', 'ukv_chan9.grib2'))
         cube = load_cube(path)
@@ -280,6 +282,7 @@ class TestGDT40(tests.IrisTest):
         cube = load_cube(path)
         self.assertCMLApproxData(cube)
 
+    @skip('iris-grib is currently causing failures')
     def test_reduced(self):
         path = tests.get_data_path(('GRIB', 'reduced', 'reduced_gg.grib2'))
         cube = load_cube(path)

--- a/lib/iris/tests/integration/test_grib_load.py
+++ b/lib/iris/tests/integration/test_grib_load.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/test_grib_load.py
+++ b/lib/iris/tests/integration/test_grib_load.py
@@ -65,7 +65,6 @@ class TestBasicLoad(tests.GraphicsTest):
                                                "time_bound.grib2")))
         self.assertCML(cubes, ("grib_load", "time_bound_grib2.cml"))
 
-    @skip('iris-grib is currently causing errors')
     def test_load_3_layer(self):
         cubes = iris.load(tests.get_data_path(('GRIB', "3_layer_viz",
                                                "3_layer.grib2")))

--- a/lib/iris/tests/integration/test_grib_load.py
+++ b/lib/iris/tests/integration/test_grib_load.py
@@ -31,7 +31,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris tests first so that some things can be initialised before
 # importing anything else
 import iris.tests as tests
-from unittest import skip
 
 import iris
 import iris.exceptions
@@ -132,7 +131,7 @@ class TestBasicLoad(tests.GraphicsTest):
             ("GRIB", "reduced", "reduced_ll.grib1")))
         self.assertCML(cube, ("grib_load", "reduced_ll_grib1.cml"))
 
-    @skip('iris-grib is currently causing failures')
+    @tests.skip_grib_fail
     def test_reduced_gg(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "reduced", "reduced_gg.grib2")))

--- a/lib/iris/tests/integration/test_grib_load.py
+++ b/lib/iris/tests/integration/test_grib_load.py
@@ -31,6 +31,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris tests first so that some things can be initialised before
 # importing anything else
 import iris.tests as tests
+from unittest import skip
 
 import iris
 import iris.exceptions
@@ -64,6 +65,7 @@ class TestBasicLoad(tests.GraphicsTest):
                                                "time_bound.grib2")))
         self.assertCML(cubes, ("grib_load", "time_bound_grib2.cml"))
 
+    @skip('iris-grib is currently causing errors')
     def test_load_3_layer(self):
         cubes = iris.load(tests.get_data_path(('GRIB', "3_layer_viz",
                                                "3_layer.grib2")))
@@ -131,6 +133,7 @@ class TestBasicLoad(tests.GraphicsTest):
             ("GRIB", "reduced", "reduced_ll.grib1")))
         self.assertCML(cube, ("grib_load", "reduced_ll_grib1.cml"))
 
+    @skip('iris-grib is currently causing failures')
     def test_reduced_gg(self):
         cube = iris.load_cube(tests.get_data_path(
             ("GRIB", "reduced", "reduced_gg.grib2")))

--- a/lib/iris/tests/test_grib_load_translations.py
+++ b/lib/iris/tests/test_grib_load_translations.py
@@ -24,7 +24,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else
 import iris.tests as tests
-from unittest import skip
 
 import datetime
 from unittest import mock
@@ -61,7 +60,7 @@ def _mock_gribapi_fetch(message, key):
     if key in message:
         return message[key]
     else:
-        raise _mock_gribapi.GribInternalError
+        raise _mock_gribapi.errors.GribInternalError
 
 
 def _mock_gribapi__grib_is_missing(grib_message, keyname):
@@ -84,13 +83,13 @@ def _mock_gribapi__grib_get_native_type(grib_message, keyname):
     """
     if keyname in grib_message:
         return type(grib_message[keyname])
-    raise _mock_gribapi.GribInternalError(keyname)
+    raise _mock_gribapi.errors.GribInternalError(keyname)
 
 
 if tests.GRIB_AVAILABLE:
     # Construct a mock object to mimic the gribapi for GribWrapper testing.
     _mock_gribapi = mock.Mock(spec=gribapi)
-    _mock_gribapi.GribInternalError = Exception
+    _mock_gribapi.errors.GribInternalError = Exception
 
     _mock_gribapi.grib_get_long = mock.Mock(side_effect=_mock_gribapi_fetch)
     _mock_gribapi.grib_get_string = mock.Mock(side_effect=_mock_gribapi_fetch)
@@ -270,7 +269,6 @@ class TestGribTimecodes(tests.IrisTest):
     # Test groups of testcases for various time-units and grib-editions.
     # Format: (edition, code, expected-exception,
     #          equivalent-seconds, description-string)
-    @skip('iris-grib is currently causing errors')
     def test_timeunits_common(self):
         tests = (
             (1, 0, None, 60.0, 'minutes'),
@@ -289,7 +287,6 @@ class TestGribTimecodes(tests.IrisTest):
             'indicatorOfUnitOfTimeRange : {code}'.format(code=code)
         )
 
-    @skip('iris-grib is currently causing errors')
     def test_timeunits_grib1_specific(self):
         tests = (
             (1, 13, None, 0.25 * _hour_secs, '15 minutes'),
@@ -299,7 +296,6 @@ class TestGribTimecodes(tests.IrisTest):
         )
         TestGribTimecodes._run_timetests(self, tests)
 
-    @skip('iris-grib is currently causing errors')
     def test_timeunits_calendar(self):
         tests = (
             (1, 3, TestGribTimecodes._err_bad_timeunit(3), 0.0, 'months'),
@@ -310,7 +306,6 @@ class TestGribTimecodes(tests.IrisTest):
         )
         TestGribTimecodes._run_timetests(self, tests)
 
-    @skip('iris-grib is currently causing errors')
     def test_timeunits_invalid(self):
         tests = (
             (1, 111, TestGribTimecodes._err_bad_timeunit(111), 1.0, '??'),
@@ -375,7 +370,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         grib.edition = 1
         return grib
 
-    @skip('iris-grib is currently causing errors')
     def test_grib1_unknownparam(self):
         grib = self.mock_grib()
         grib.table2Version = 0
@@ -385,7 +379,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
-    @skip('iris-grib is currently causing errors')
     def test_grib1_unknown_local_param(self):
         grib = self.mock_grib()
         grib.table2Version = 128
@@ -395,7 +388,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, 'UNKNOWN LOCAL PARAM 999.128')
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
-    @skip('iris-grib is currently causing errors')
     def test_grib1_unknown_standard_param(self):
         grib = self.mock_grib()
         grib.table2Version = 1
@@ -414,7 +406,6 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit(units_str))
 
-    @skip('iris-grib is currently causing errors')
     def test_grib1_known_standard_params(self):
         # at present, there are just a very few of these
         self.known_grib1(11, 'air_temperature', 'kelvin')

--- a/lib/iris/tests/test_grib_load_translations.py
+++ b/lib/iris/tests/test_grib_load_translations.py
@@ -24,6 +24,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # Import iris.tests first so that some things can be initialised before
 # importing anything else
 import iris.tests as tests
+from unittest import skip
 
 import datetime
 from unittest import mock
@@ -269,6 +270,7 @@ class TestGribTimecodes(tests.IrisTest):
     # Test groups of testcases for various time-units and grib-editions.
     # Format: (edition, code, expected-exception,
     #          equivalent-seconds, description-string)
+    @skip('iris-grib is currently causing errors')
     def test_timeunits_common(self):
         tests = (
             (1, 0, None, 60.0, 'minutes'),
@@ -287,6 +289,7 @@ class TestGribTimecodes(tests.IrisTest):
             'indicatorOfUnitOfTimeRange : {code}'.format(code=code)
         )
 
+    @skip('iris-grib is currently causing errors')
     def test_timeunits_grib1_specific(self):
         tests = (
             (1, 13, None, 0.25 * _hour_secs, '15 minutes'),
@@ -296,6 +299,7 @@ class TestGribTimecodes(tests.IrisTest):
         )
         TestGribTimecodes._run_timetests(self, tests)
 
+    @skip('iris-grib is currently causing errors')
     def test_timeunits_calendar(self):
         tests = (
             (1, 3, TestGribTimecodes._err_bad_timeunit(3), 0.0, 'months'),
@@ -306,6 +310,7 @@ class TestGribTimecodes(tests.IrisTest):
         )
         TestGribTimecodes._run_timetests(self, tests)
 
+    @skip('iris-grib is currently causing errors')
     def test_timeunits_invalid(self):
         tests = (
             (1, 111, TestGribTimecodes._err_bad_timeunit(111), 1.0, '??'),
@@ -370,6 +375,7 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         grib.edition = 1
         return grib
 
+    @skip('iris-grib is currently causing errors')
     def test_grib1_unknownparam(self):
         grib = self.mock_grib()
         grib.table2Version = 0
@@ -379,6 +385,7 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
+    @skip('iris-grib is currently causing errors')
     def test_grib1_unknown_local_param(self):
         grib = self.mock_grib()
         grib.table2Version = 128
@@ -388,6 +395,7 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, 'UNKNOWN LOCAL PARAM 999.128')
         self.assertEqual(cube.units, cf_units.Unit("???"))
 
+    @skip('iris-grib is currently causing errors')
     def test_grib1_unknown_standard_param(self):
         grib = self.mock_grib()
         grib.table2Version = 1
@@ -406,6 +414,7 @@ class TestGrib1LoadPhenomenon(TestGribSimple):
         self.assertEqual(cube.long_name, None)
         self.assertEqual(cube.units, cf_units.Unit(units_str))
 
+    @skip('iris-grib is currently causing errors')
     def test_grib1_known_standard_params(self):
         # at present, there are just a very few of these
         self.known_grib1(11, 'air_temperature', 'kelvin')

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2017, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -20,7 +20,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
-from unittest import skip
 
 import os
 import datetime
@@ -45,7 +44,6 @@ class TestLoadSave(tests.TestGribMessage):
     def setUp(self):
         self.skip_keys = []
 
-    @skip('iris-grib is currently causing failures')
     def test_latlon_forecast_plev(self):
         source_grib = tests.get_data_path(("GRIB", "uk_t", "uk_t.grib2"))
         cubes = iris.load(source_grib)
@@ -58,6 +56,10 @@ class TestLoadSave(tests.TestGribMessage):
                             'shapeOfTheEarth': (0, 1),
                             'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                     6367470),
+                            'scaledValueOfEarthMajorAxis': (MDI, 0),
+                            'scaleFactorOfEarthMajorAxis': (MDI, 0),
+                            'scaledValueOfEarthMinorAxis': (MDI, 0),
+                            'scaleFactorOfEarthMinorAxis': (MDI, 0),
                             'typeOfGeneratingProcess': (0, 255),
                             'generatingProcessIdentifier': (128, 255),
                             }
@@ -65,7 +67,6 @@ class TestLoadSave(tests.TestGribMessage):
                                              expect_diffs, self.skip_keys,
                                              skip_sections=[2])
 
-    @skip('iris-grib is currently causing failures')
     def test_rotated_latlon(self):
         source_grib = tests.get_data_path(("GRIB", "rotated_nae_t",
                                            "sensible_pole.grib2"))
@@ -79,6 +80,10 @@ class TestLoadSave(tests.TestGribMessage):
                             'shapeOfTheEarth': (0, 1),
                             'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                     6367470),
+                            'scaledValueOfEarthMajorAxis': (MDI, 0),
+                            'scaleFactorOfEarthMajorAxis': (MDI, 0),
+                            'scaledValueOfEarthMinorAxis': (MDI, 0),
+                            'scaleFactorOfEarthMinorAxis': (MDI, 0),
                             'longitudeOfLastGridPoint': (392109982, 32106370),
                             'latitudeOfLastGridPoint': (19419996, 19419285),
                             'typeOfGeneratingProcess': (0, 255),
@@ -88,7 +93,6 @@ class TestLoadSave(tests.TestGribMessage):
                                              expect_diffs, self.skip_keys,
                                              skip_sections=[2])
 
-    @skip('iris-grib is currently causing failures')
     def test_time_mean(self):
         # This test for time-mean fields also tests negative forecast time.
         source_grib = tests.get_data_path(("GRIB", "time_processed",
@@ -101,6 +105,10 @@ class TestLoadSave(tests.TestGribMessage):
                         'shapeOfTheEarth': (0, 1),
                         'scaledValueOfRadiusOfSphericalEarth': (MDI,
                                                                 6367470),
+                        'scaledValueOfEarthMajorAxis': (MDI, 0),
+                        'scaleFactorOfEarthMajorAxis': (MDI, 0),
+                        'scaledValueOfEarthMinorAxis': (MDI, 0),
+                        'scaleFactorOfEarthMinorAxis': (MDI, 0),
                         'longitudeOfLastGridPoint': (356249908, 356249809),
                         'latitudeOfLastGridPoint': (-89999938, -89999944),
                         'typeOfGeneratingProcess': (0, 255),

--- a/lib/iris/tests/test_grib_save.py
+++ b/lib/iris/tests/test_grib_save.py
@@ -20,6 +20,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris tests first so that some things can be initialised before importing anything else
 import iris.tests as tests
+from unittest import skip
 
 import os
 import datetime
@@ -44,6 +45,7 @@ class TestLoadSave(tests.TestGribMessage):
     def setUp(self):
         self.skip_keys = []
 
+    @skip('iris-grib is currently causing failures')
     def test_latlon_forecast_plev(self):
         source_grib = tests.get_data_path(("GRIB", "uk_t", "uk_t.grib2"))
         cubes = iris.load(source_grib)
@@ -63,6 +65,7 @@ class TestLoadSave(tests.TestGribMessage):
                                              expect_diffs, self.skip_keys,
                                              skip_sections=[2])
 
+    @skip('iris-grib is currently causing failures')
     def test_rotated_latlon(self):
         source_grib = tests.get_data_path(("GRIB", "rotated_nae_t",
                                            "sensible_pole.grib2"))
@@ -85,6 +88,7 @@ class TestLoadSave(tests.TestGribMessage):
                                              expect_diffs, self.skip_keys,
                                              skip_sections=[2])
 
+    @skip('iris-grib is currently causing failures')
     def test_time_mean(self):
         # This test for time-mean fields also tests negative forecast time.
         source_grib = tests.get_data_path(("GRIB", "time_processed",


### PR DESCRIPTION
As per #3447, this allows Travis to test all grib tests except the ones currently failing/erroring.