### PR TITLE
Remove comment about deprecated and deleted iris.Future

### DIFF
--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -411,8 +411,6 @@ class Test_summary(tests.IrisTest):
         self.cube = Cube(0)
 
     def test_cell_datetime_objects(self):
-        # Check the scalar coordinate summary still works even when
-        # iris.FUTURE.cell_datetime_objects is True.
         self.cube.add_aux_coord(AuxCoord(42, units='hours since epoch'))
         summary = self.cube.summary()
         self.assertIn('1970-01-02 18:00:00', summary)


### PR DESCRIPTION
Since #3459, iris.FUTURE.cell_datetime_objects is not only deprecated but also removed, and so we should remove references to it.