### PR TITLE
Fix AncillaryVariable doc-string

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -658,7 +658,7 @@ class AncillaryVariable(_DimensionalMetadata):
 
         Args:
 
-        * values:
+        * data:
             The values of the ancillary variable.
 
         Kwargs:


### PR DESCRIPTION
This simple PR aligns the `iris.coords.AncillaryVariable` doc-string with it's `__init__` formal arguments i.e., use `data` not `values`.