### PR TITLE
what's new entry for unpinning mpl

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-17_unpin_mpl.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-17_unpin_mpl.txt
@@ -1,2 +1,2 @@
 * Supporting Iris for both Python2 and Python3 resulted in pinning our dependency on matplotlib at v2.x. 
-  Now that Python2 support has been dropped, Iris is now free to use the latest version of matplotlib.
+  Now that Python2 support has been dropped, Iris is free to use the latest version of matplotlib.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-17_unpin_mpl.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Oct-17_unpin_mpl.txt
@@ -1,0 +1,2 @@
+* Supporting Iris for both Python2 and Python3 resulted in pinning our dependency on matplotlib at v2.x. 
+  Now that Python2 support has been dropped, Iris is now free to use the latest version of matplotlib.


### PR DESCRIPTION
This PR is a follow-up to https://github.com/SciTools/iris/pull/3468, and adds a `whatsnew` entry highlighting that our `matplotlib` dependency is now unpinned.