### PR TITLE
Fix unit test_Coord class name

### DIFF
--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1010,8 +1010,8 @@ class TestClimatology(tests.IrisTest):
         self.assertFalse(coord.climatological)
 
 
-class Test_Coord_is_abstract(tests.IrisTest):
-    def test_instantiate_fail(self):
+class Test___init____abstractmethod(tests.IrisTest):
+    def test(self):
         emsg = (
             "Can't instantiate abstract class Coord with abstract"
             " methods __init__"


### PR DESCRIPTION
This PR renames a recent, new unit test class to ensure that `iris.coords.Coord` is abstract.