### PR TITLE
Update .gitignore for .ipynb_checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ docs/iris/iris_image_test_output/
 \#*
 \.\#*
 *.swp
+.ipynb_checkpoints


### PR DESCRIPTION
This PR includes the `.ipynb_checkpoints` directory in the `.gitignore`.