### PR TITLE
Support at least python>=3.6

### DIFF
--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -33,7 +33,6 @@ defined by :mod:`ConfigParser`.
 import configparser
 import contextlib
 import os.path
-import sys
 import warnings
 
 
@@ -79,10 +78,7 @@ ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 CONFIG_PATH = os.path.join(ROOT_PATH, "etc")
 
 # Load the optional "site.cfg" file if it exists.
-if sys.version_info >= (3, 2):
-    config = configparser.ConfigParser()
-else:
-    config = configparser.SafeConfigParser()
+config = configparser.ConfigParser()
 config.read([os.path.join(CONFIG_PATH, "site.cfg")])
 
 


### PR DESCRIPTION
This PR raises the minimum bar and commits `iris` to supporting `python` from at least `3.6.0`.

Note that, this PR is also in support of:
- PR #3527 
- PR #3533

both of which incorporate the use of `f-strings`, which were introduced in [python 3.6.0](https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals)

In `travis-ci` we currently test `python` at `3.6` and `3.7` (and shortly `3.8` when the ecosystem catches up). We can pin `python` to be `>=3.6` on `conda-forge`... so this PR is really more of a declaration rather than enforcing a minimum requirement i.e., it doesn't make sense to add `python>=3.6` to our `requirements`.