### PR TITLE
__getitem__ gets ancillary variables

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2592,6 +2592,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 if dimension_mapping[d] is not None
             ]
 
+        def new_ancillary_variable_dims(av_):
+            return [
+                dimension_mapping[d]
+                for d in self.ancillary_variable_dims(av_)
+                if dimension_mapping[d] is not None
+            ]
+
         # Fetch the data as a generic array-like object.
         cube_data = self._data_manager.core_data()
 
@@ -2666,6 +2673,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             cm_keys = tuple([full_slice[dim] for dim in dims])
             new_cm = cellmeasure[cm_keys]
             cube.add_cell_measure(new_cm, new_cell_measure_dims(cellmeasure))
+
+        # slice the ancillary variables and add them to the cube
+        for ancvar in self.ancillary_variables():
+            dims = self.ancillary_variable_dims(ancvar)
+            av_keys = tuple([full_slice[dim] for dim in dims])
+            new_av = ancvar[av_keys]
+            cube.add_ancillary_variable(
+                new_av, new_ancillary_variable_dims(ancvar)
+            )
 
         return cube
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1959,6 +1959,36 @@ class Test__getitem_CellMeasure(tests.IrisTest):
         self.assertEqual(result.shape, result.cell_measures()[0].data.shape)
 
 
+class Test__getitem_AncillaryVariables(tests.IrisTest):
+    def setUp(self):
+        cube = Cube(np.arange(6).reshape(2, 3))
+        x_coord = DimCoord(points=np.array([2, 3, 4]), long_name="x")
+        cube.add_dim_coord(x_coord, 1)
+        y_coord = DimCoord(points=np.array([5, 6]), long_name="y")
+        cube.add_dim_coord(y_coord, 0)
+        z_coord = AuxCoord(points=np.arange(6).reshape(2, 3), long_name="z")
+        cube.add_aux_coord(z_coord, [0, 1])
+        a_ancillary_variable = AncillaryVariable(
+            data=np.arange(6).reshape(2, 3), long_name="foo"
+        )
+        cube.add_ancillary_variable(a_ancillary_variable, [0, 1])
+        self.cube = cube
+
+    def test_ancillary_variables_2d(self):
+        result = self.cube[0:2, 0:2]
+        self.assertEqual(len(result.ancillary_variables()), 1)
+        self.assertEqual(
+            result.shape, result.ancillary_variables()[0].data.shape
+        )
+
+    def test_ancillary_variables_1d(self):
+        result = self.cube[0, 0:2]
+        self.assertEqual(len(result.ancillary_variables()), 1)
+        self.assertEqual(
+            result.shape, result.ancillary_variables()[0].data.shape
+        )
+
+
 class TestAncillaryVariables(tests.IrisTest):
     def setUp(self):
         cube = Cube(10 * np.arange(6).reshape(2, 3))


### PR DESCRIPTION
Fixes another issue in #3483.