### PR TITLE
Generic 'cube_dims' function for all _DimensionMetadata objects.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -173,6 +173,22 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
 
         return new_metadata
 
+    @abstractmethod
+    def cube_dims(self, cube):
+        """
+        Identify the cube dims of any _DimensionalMetadata object.
+
+        Return the dimensions in the cube of a matching _DimensionalMetadata
+        object, if any.
+
+        Equivalent to cube.coord_dims(self) for a Coord,
+        or cube.cell_measure_dims for a CellMeasure, and so on.
+        Simplifies generic code to handle any _DimensionalMetadata objects.
+
+        """
+        # Only makes sense for specific subclasses.
+        raise NotImplementedError()
+
     def _sanitise_array(self, src, ndmin):
         if _lazy.is_lazy_data(src):
             # Lazy data : just ensure ndmin requirement.
@@ -744,6 +760,15 @@ class AncillaryVariable(_DimensionalMetadata):
         """
         return super()._has_lazy_values()
 
+    def cube_dims(self, cube):
+        """
+        Return the cube dimensions of this AncillaryVariable.
+
+        Equivalent to "cube.ancillary_variable_dims(self)".
+
+        """
+        return cube.ancillary_variable_dims(self)
+
 
 class CellMeasure(AncillaryVariable):
     """
@@ -845,6 +870,15 @@ class CellMeasure(AncillaryVariable):
             self.measure,
         )
         return defn
+
+    def cube_dims(self, cube):
+        """
+        Return the cube dimensions of this CellMeasure.
+
+        Equivalent to "cube.cell_measure_dims(self)".
+
+        """
+        return cube.cell_measure_dims(self)
 
 
 class CoordDefn(
@@ -1595,6 +1629,15 @@ class Coord(_DimensionalMetadata):
     # Fixing it will require changing those uses.  See #962 and #1772.
     def __hash__(self):
         return hash(id(self))
+
+    def cube_dims(self, cube):
+        """
+        Return the cube dimensions of this Coord.
+
+        Equivalent to "cube.coord_dims(self)".
+
+        """
+        return cube.coord_dims(self)
 
     def convert_units(self, unit):
         r"""

--- a/lib/iris/tests/unit/coords/test_AncillaryVariable.py
+++ b/lib/iris/tests/unit/coords/test_AncillaryVariable.py
@@ -9,6 +9,8 @@
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import dask.array as da
 import numpy as np
 import numpy.ma as ma
@@ -17,6 +19,7 @@ from iris.tests.unit.coords import CoordTestMixin, lazyness_string
 
 from cf_units import Unit
 from iris.coords import AncillaryVariable
+from iris.cube import Cube
 from iris._lazy_data import as_lazy_data
 
 
@@ -681,6 +684,21 @@ class TestEquality(tests.IrisTest):
         av1 = AncillaryVariable([1.0, np.nan, 2.0])
         av2 = av1.copy()
         self.assertEqual(av1, av2)
+
+
+class Test_cube_dims(tests.IrisTest):
+    def test(self):
+        # Check that "coord.cube_dims(cube)" calls "cube.coord_dims(coord)".
+        mock_dims_result = mock.sentinel.AV_DIMS
+        mock_dims_call = mock.Mock(return_value=mock_dims_result)
+        mock_cube = mock.Mock(Cube,
+                              ancillary_variable_dims=mock_dims_call)
+        test_var = AncillaryVariable([1], long_name="test_name")
+
+        result = test_var.cube_dims(mock_cube)
+        self.assertEqual(result, mock_dims_result)
+        self.assertEqual(mock_dims_call.call_args_list,
+                         [mock.call(test_var)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_AncillaryVariable.py
+++ b/lib/iris/tests/unit/coords/test_AncillaryVariable.py
@@ -691,14 +691,12 @@ class Test_cube_dims(tests.IrisTest):
         # Check that "coord.cube_dims(cube)" calls "cube.coord_dims(coord)".
         mock_dims_result = mock.sentinel.AV_DIMS
         mock_dims_call = mock.Mock(return_value=mock_dims_result)
-        mock_cube = mock.Mock(Cube,
-                              ancillary_variable_dims=mock_dims_call)
+        mock_cube = mock.Mock(Cube, ancillary_variable_dims=mock_dims_call)
         test_var = AncillaryVariable([1], long_name="test_name")
 
         result = test_var.cube_dims(mock_cube)
         self.assertEqual(result, mock_dims_result)
-        self.assertEqual(mock_dims_call.call_args_list,
-                         [mock.call(test_var)])
+        self.assertEqual(mock_dims_call.call_args_list, [mock.call(test_var)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_CellMeasure.py
+++ b/lib/iris/tests/unit/coords/test_CellMeasure.py
@@ -127,14 +127,12 @@ class Test_cube_dims(tests.IrisTest):
         # Check that "coord.cube_dims(cube)" calls "cube.coord_dims(coord)".
         mock_dims_result = mock.sentinel.CM_DIMS
         mock_dims_call = mock.Mock(return_value=mock_dims_result)
-        mock_cube = mock.Mock(Cube,
-                              cell_measure_dims=mock_dims_call)
+        mock_cube = mock.Mock(Cube, cell_measure_dims=mock_dims_call)
         test_cm = CellMeasure([1], long_name="test_name")
 
         result = test_cm.cube_dims(mock_cube)
         self.assertEqual(result, mock_dims_result)
-        self.assertEqual(mock_dims_call.call_args_list,
-                         [mock.call(test_cm)])
+        self.assertEqual(mock_dims_call.call_args_list, [mock.call(test_cm)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_CellMeasure.py
+++ b/lib/iris/tests/unit/coords/test_CellMeasure.py
@@ -9,9 +9,12 @@
 # importing anything else.
 import iris.tests as tests
 
+from unittest import mock
+
 import numpy as np
 
 from iris.coords import CellMeasure
+from iris.cube import Cube
 from iris._lazy_data import as_lazy_data
 
 
@@ -117,6 +120,21 @@ class Tests(tests.IrisTest):
 
     def test__eq__(self):
         self.assertEqual(self.measure, self.measure)
+
+
+class Test_cube_dims(tests.IrisTest):
+    def test(self):
+        # Check that "coord.cube_dims(cube)" calls "cube.coord_dims(coord)".
+        mock_dims_result = mock.sentinel.CM_DIMS
+        mock_dims_call = mock.Mock(return_value=mock_dims_result)
+        mock_cube = mock.Mock(Cube,
+                              cell_measure_dims=mock_dims_call)
+        test_cm = CellMeasure([1], long_name="test_name")
+
+        result = test_cm.cube_dims(mock_cube)
+        self.assertEqual(result, mock_dims_result)
+        self.assertEqual(mock_dims_call.call_args_list,
+                         [mock.call(test_cm)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -17,6 +17,7 @@ import dask.array as da
 import numpy as np
 
 import iris
+from iris.cube import Cube
 from iris.coords import DimCoord, AuxCoord, Coord
 from iris.exceptions import UnitConversionError
 from iris.tests.unit.coords import CoordTestMixin
@@ -1018,6 +1019,20 @@ class Test___init____abstractmethod(tests.IrisTest):
         )
         with self.assertRaisesRegex(TypeError, emsg):
             _ = Coord(points=[0, 1])
+
+
+class Test_cube_dims(tests.IrisTest):
+    def test(self):
+        # Check that "coord.cube_dims(cube)" calls "cube.coord_dims(coord)".
+        mock_dims_result = mock.sentinel.COORD_DIMS
+        mock_dims_call = mock.Mock(return_value=mock_dims_result)
+        mock_cube = mock.Mock(Cube, coord_dims=mock_dims_call)
+        test_coord = AuxCoord([1], long_name="test_name")
+
+        result = test_coord.cube_dims(mock_cube)
+        self.assertEqual(result, mock_dims_result)
+        self.assertEqual(mock_dims_call.call_args_list,
+                         [mock.call(test_coord)])
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1031,8 +1031,9 @@ class Test_cube_dims(tests.IrisTest):
 
         result = test_coord.cube_dims(mock_cube)
         self.assertEqual(result, mock_dims_result)
-        self.assertEqual(mock_dims_call.call_args_list,
-                         [mock.call(test_coord)])
+        self.assertEqual(
+            mock_dims_call.call_args_list, [mock.call(test_coord)]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The idea of this is to enable writing code that handles _DimensionalMetadata objects in a generic way.
For example, it will avoid the need for [the extra method keyword here](https://github.com/SciTools/iris/blob/c0c715849602f2d98c7b23f5f2f36304389a6989/lib/iris/fileformats/netcdf.py#L1695).