### PR TITLE
PI-3473: Whatsnews relating to ancillary load + save.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
@@ -1,0 +1,2 @@
+* Fixed a bug where the attributes of cell methods in netcdf-CF files were discarded on
+  loading.  They now appear on the CellMethod in the loaded cube.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
@@ -1,2 +1,2 @@
-* Fixed a bug where the attributes of cell methods in netcdf-CF files were discarded on
-  loading.  They now appear on the CellMethod in the loaded cube.
+* Fixed a bug where the attributes of cell measures in netcdf-CF files were discarded on
+  loading.  They now appear on the CellMeasure in the loaded cube.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Nov-21_netcdf_ancillary_data.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Nov-21_netcdf_ancillary_data.txt
@@ -1,0 +1,2 @@
+* CF Ancillary Variables are now loaded from and saved to netcdf-CF files.
+


### PR DESCRIPTION
Covers changes from #3550 and #3556

**NOTE: why this targets the 'launch_ancils' feature branch** 
We are still reserving the right to ***not*** announce ancillary variables in Iris 3.0, in which case this will be deferred from merging to master :  see [comment here](https://github.com/SciTools/iris/pull/3556#issue-343470988).