### PR TITLE
PI-3483: Make changes to coord_comparison private

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -187,6 +187,14 @@ class _CoordGroup:
 
 
 def _dimensional_metadata_comparison(*cubes, object_get=None):
+    """
+    This is a generalised form of :func:`coord_comparison`. See that function
+    for a more detailed description.
+
+    Additionally, this function can compare over different types of dimensional
+    metadata with the argument object_get. For example, :func:`coord_comparison`
+    effectively has object_get=:meth:`iris.cube.Cube.coords`.
+    """
     if object_get is None:
         from iris.cube import Cube
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -194,6 +194,7 @@ def _dimensional_metadata_comparison(*cubes, object_get=None):
     Additionally, this function can compare over different types of dimensional
     metadata with the argument object_get. For example, :func:`coord_comparison`
     effectively has object_get=:meth:`iris.cube.Cube.coords`.
+
     """
     if object_get is None:
         from iris.cube import Cube

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -186,60 +186,7 @@ class _CoordGroup:
         return any(self.matches(predicate))
 
 
-def coord_comparison(*cubes, object_get=None):
-    """
-    Convenience function to help compare coordinates on one or more cubes
-    by their metadata.
-
-    Return a dictionary where the key represents the statement,
-    "Given these cubes list the coordinates which,
-    when grouped by metadata, are/have..."
-
-    Keys:
-
-    * grouped_coords
-       A list of coordinate groups of all the coordinates grouped together
-       by their coordinate definition
-    * ungroupable
-       A list of coordinate groups which contain at least one None,
-       meaning not all Cubes provide an equivalent coordinate
-    * not_equal
-       A list of coordinate groups of which not all are equal
-       (superset of ungroupable)
-    * no_data_dimension
-       A list of coordinate groups of which all have no data dimensions on
-       their respective cubes
-    * scalar
-       A list of coordinate groups of which all have shape (1, )
-    * non_equal_data_dimension
-       A list of coordinate groups of which not all have the same
-       data dimension on their respective cubes
-    * non_equal_shape
-       A list of coordinate groups of which not all have the same shape
-    * equal_data_dimension
-       A list of coordinate groups of which all have the same data dimension
-       on their respective cubes
-    * equal
-       A list of coordinate groups of which all are equal
-    * ungroupable_and_dimensioned
-       A list of coordinate groups of which not all cubes had an equivalent
-       (in metadata) coordinate which also describe a data dimension
-    * dimensioned
-       A list of coordinate groups of which all describe a data dimension on
-       their respective cubes
-    * ignorable
-       A list of scalar, ungroupable non_equal coordinate groups
-    * resamplable
-        A list of equal, different data dimensioned coordinate groups
-    * transposable
-       A list of non equal, same data dimensioned, non scalar coordinate groups
-
-    Example usage::
-
-        result = coord_comparison(cube1, cube2)
-        print('All equal coordinates: ', result['equal'])
-
-    """
+def _dimensional_metadata_comparison(*cubes, object_get=None):
     if object_get is None:
         from iris.cube import Cube
 
@@ -395,6 +342,63 @@ def coord_comparison(*cubes, object_get=None):
         result[key] = sorted(groups, key=lambda group: group.name())
 
     return result
+
+
+def coord_comparison(*cubes):
+    """
+    Convenience function to help compare coordinates on one or more cubes
+    by their metadata.
+
+    Return a dictionary where the key represents the statement,
+    "Given these cubes list the coordinates which,
+    when grouped by metadata, are/have..."
+
+    Keys:
+
+    * grouped_coords
+       A list of coordinate groups of all the coordinates grouped together
+       by their coordinate definition
+    * ungroupable
+       A list of coordinate groups which contain at least one None,
+       meaning not all Cubes provide an equivalent coordinate
+    * not_equal
+       A list of coordinate groups of which not all are equal
+       (superset of ungroupable)
+    * no_data_dimension
+       A list of coordinate groups of which all have no data dimensions on
+       their respective cubes
+    * scalar
+       A list of coordinate groups of which all have shape (1, )
+    * non_equal_data_dimension
+       A list of coordinate groups of which not all have the same
+       data dimension on their respective cubes
+    * non_equal_shape
+       A list of coordinate groups of which not all have the same shape
+    * equal_data_dimension
+       A list of coordinate groups of which all have the same data dimension
+       on their respective cubes
+    * equal
+       A list of coordinate groups of which all are equal
+    * ungroupable_and_dimensioned
+       A list of coordinate groups of which not all cubes had an equivalent
+       (in metadata) coordinate which also describe a data dimension
+    * dimensioned
+       A list of coordinate groups of which all describe a data dimension on
+       their respective cubes
+    * ignorable
+       A list of scalar, ungroupable non_equal coordinate groups
+    * resamplable
+        A list of equal, different data dimensioned coordinate groups
+    * transposable
+       A list of non equal, same data dimensioned, non scalar coordinate groups
+
+    Example usage::
+
+        result = coord_comparison(cube1, cube2)
+        print('All equal coordinates: ', result['equal'])
+
+    """
+    return _dimensional_metadata_comparison(*cubes)
 
 
 class _Aggregator:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3575,23 +3575,23 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 )
 
             if result:
-                coord_comparison = iris.analysis.coord_comparison(
+                comparison = iris.analysis._dimensional_metadata_comparison(
                     self, other, object_get=Cube.cell_measures,
                 )
                 # if there are any cell measures which are not equal
                 result = not (
-                    coord_comparison["not_equal"]
-                    or coord_comparison["non_equal_data_dimension"]
+                    comparison["not_equal"]
+                    or comparison["non_equal_data_dimension"]
                 )
 
             if result:
-                coord_comparison = iris.analysis.coord_comparison(
+                comparison = iris.analysis._dimensional_metadata_comparison(
                     self, other, object_get=Cube.ancillary_variables,
                 )
                 # if there are any ancillary variables which are not equal
                 result = not (
-                    coord_comparison["not_equal"]
-                    or coord_comparison["non_equal_data_dimension"]
+                    comparison["not_equal"]
+                    or comparison["non_equal_data_dimension"]
                 )
 
             # Having checked everything else, check approximate data equality.


### PR DESCRIPTION
This addresses comments on #3546. At a minimum, this causes `coord_comparison` to have the same behaviour as it did previously. The internals of the function still refer to coords rather than, say, ancillary variables. Ideally there would be a more generic name to use as keys for the generic function (preferably one less cumbersome than 'dimensional metadata').