### PR TITLE
Update license header in translation tool

### DIFF
--- a/tools/gen_translations.py
+++ b/tools/gen_translations.py
@@ -25,22 +25,11 @@ from translator import (FORMAT_URIS, FieldcodeCFMappings, StashCFNameMappings,
                         CFConstrainedGRIB1LocalParamMappings,
                         CFGRIB2ParamMappings, CFGRIB1LocalParamMappings)
 
-HEADER = """# Copyright Iris contributors
+HEADER = """# Copyright {name} contributors
 #
-# This file is part of {name}.
-#
-# {name} is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# {name} is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with {name}.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of {name} and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 #
 # DO NOT EDIT: AUTO-GENERATED
 # Created on {datestamp} from 


### PR DESCRIPTION
Came across a license header that needed updating now that both iris and iris-grib have simplified their license headers