### PR TITLE
Fix problems with export and echo command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,11 @@ script:
     fi
 
   # Split the organisation out of the slug. See https://stackoverflow.com/a/5257398/741316 for description.
-  - export ORG=(${TRAVIS_REPO_SLUG//\// })
+  - >
+    ORG=$(echo ${TRAVIS_REPO_SLUG} | cut -d/ -f1);
+    export ORG
+
+  - "echo 'Travis job context: ORG=${ORG}; TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}; PUSH_BUILT_DOCS=${PUSH_BUILT_DOCS}'"
 
   # When we merge a change to SciTools/iris, we can push docs to github pages.
   # At present, only the Python 3.7 "doctest" job does this.

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ script:
     ORG=$(echo ${TRAVIS_REPO_SLUG} | cut -d/ -f1);
     export ORG
 
-  - "echo 'Travis job context: ORG=${ORG}; TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}; PUSH_BUILT_DOCS=${PUSH_BUILT_DOCS}'"
+  - echo "Travis job context ORG=${ORG}; TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}; PUSH_BUILT_DOCS=${PUSH_BUILT_DOCS}"
 
   # When we merge a change to SciTools/iris, we can push docs to github pages.
   # At present, only the Python 3.7 "doctest" job does this.


### PR DESCRIPTION
This intends to re-instate automatic docs build for the Github branches
Closes #3542

I think this is now correct.
I have left in a debug line that echoes the control variables, including the 'ORG' organisation identity (from the Travis SLUG), as I think this is generally useful to see in the logs.