### PR TITLE
PI-3473 Rename "engine.provides"

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -42,7 +42,7 @@ fc_provides_grid_mapping_rotated_latitude_longitude
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_rotated_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, rotated_latitude_longitude)
         python engine.rule_triggered.add(rule.name)
 
@@ -62,7 +62,7 @@ fc_provides_grid_mapping_latitude_longitude
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_coordinate_system(cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, latitude_longitude)
         python engine.rule_triggered.add(rule.name)
 
@@ -81,7 +81,7 @@ fc_provides_grid_mapping_transverse_mercator
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_transverse_mercator_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, transverse_mercator)
         python engine.rule_triggered.add(rule.name)
 
@@ -102,7 +102,7 @@ fc_provides_grid_mapping_mercator
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_mercator_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, mercator)
         python engine.rule_triggered.add(rule.name)
 
@@ -123,7 +123,7 @@ fc_provides_grid_mapping_stereographic
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_stereographic_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, stereographic)
         python engine.rule_triggered.add(rule.name)
 
@@ -142,7 +142,7 @@ fc_provides_grid_mapping_lambert_conformal
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_lambert_conformal_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, lambert_conformal)
         python engine.rule_triggered.add(rule.name)
 
@@ -161,7 +161,7 @@ fc_provides_grid_mapping_lambert_azimuthal_equal_area
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_lambert_azimuthal_equal_area_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, lambert_azimuthal_equal_area)
         python engine.rule_triggered.add(rule.name)
 
@@ -180,7 +180,7 @@ fc_provides_grid_mapping_albers_equal_area
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_albers_equal_area_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, albers_equal_area)
         python engine.rule_triggered.add(rule.name)
 
@@ -200,7 +200,7 @@ fc_provides_grid_mapping_vertical_perspective
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = \
             build_vertical_perspective_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, vertical_perspective)
         python engine.rule_triggered.add(rule.name)
 
@@ -221,7 +221,7 @@ fc_provides_grid_mapping_geostationary
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = \
             build_geostationary_coordinate_system(engine, cf_grid_var)
-        python engine.cube_bits['coordinate_system'] = coordinate_system
+        python engine.cube_parts['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, geostationary)
         python engine.rule_triggered.add(rule.name)
 
@@ -531,7 +531,7 @@ fc_build_coordinate_latitude
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LAT,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -552,7 +552,7 @@ fc_build_coordinate_latitude_rotated
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_GRID_LAT,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -573,7 +573,7 @@ fc_build_coordinate_longitude
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LON,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -594,7 +594,7 @@ fc_build_coordinate_longitude_rotated
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_GRID_LON,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -660,7 +660,7 @@ fc_build_coordinate_projection_x_transverse_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -680,7 +680,7 @@ fc_build_coordinate_projection_y_transverse_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -699,7 +699,7 @@ fc_build_coordinate_projection_x_lambert_conformal
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -719,7 +719,7 @@ fc_build_coordinate_projection_y_lambert_conformal
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -739,7 +739,7 @@ fc_build_coordinate_projection_x_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -758,7 +758,7 @@ fc_build_coordinate_projection_y_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -777,7 +777,7 @@ fc_build_coordinate_projection_x_stereographic
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -796,7 +796,7 @@ fc_build_coordinate_projection_y_stereographic
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -816,7 +816,7 @@ fc_build_coordinate_projection_x_lambert_azimuthal_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -836,7 +836,7 @@ fc_build_coordinate_projection_y_lambert_azimuthal_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -855,7 +855,7 @@ fc_build_coordinate_projection_x_albers_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -875,7 +875,7 @@ fc_build_coordinate_projection_y_albers_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -894,7 +894,7 @@ fc_build_coordinate_projection_x_vertical_perspective
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -914,7 +914,7 @@ fc_build_coordinate_projection_y_vertical_perspective
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -933,7 +933,7 @@ fc_build_coordinate_projection_x_geostationary
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -953,7 +953,7 @@ fc_build_coordinate_projection_y_geostationary
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.cube_bits['coordinate_system'])
+                                          coord_system=engine.cube_parts['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -1892,7 +1892,7 @@ fc_extras
                 cube.add_aux_coord(coord, data_dims)
 
         # Update the coordinate to CF-netCDF variable mapping.
-        engine.cube_bits['coordinates'].append((coord, cf_coord_var.cf_name))
+        engine.cube_parts['coordinates'].append((coord, cf_coord_var.cf_name))
 
 
     ################################################################################
@@ -1958,7 +1958,7 @@ fc_extras
         cube.add_aux_coord(coord, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.cube_bits['coordinates'].append((coord, cf_coord_var.cf_name))
+        engine.cube_parts['coordinates'].append((coord, cf_coord_var.cf_name))
 
 
     ################################################################################
@@ -2002,7 +2002,7 @@ fc_extras
         cube.add_cell_measure(cell_measure, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.cube_bits['cell_measures'].append((cell_measure, cf_cm_var.cf_name))
+        engine.cube_parts['cell_measures'].append((cell_measure, cf_cm_var.cf_name))
 
 
 
@@ -2044,7 +2044,7 @@ fc_extras
         cube.add_ancillary_variable(av, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.cube_bits['ancillary_variables'].append((av, cf_av_var.cf_name))
+        engine.cube_parts['ancillary_variables'].append((av, cf_av_var.cf_name))
 
 
 

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -42,7 +42,7 @@ fc_provides_grid_mapping_rotated_latitude_longitude
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_rotated_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, rotated_latitude_longitude)
         python engine.rule_triggered.add(rule.name)
 
@@ -62,7 +62,7 @@ fc_provides_grid_mapping_latitude_longitude
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_coordinate_system(cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, latitude_longitude)
         python engine.rule_triggered.add(rule.name)
 
@@ -81,7 +81,7 @@ fc_provides_grid_mapping_transverse_mercator
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_transverse_mercator_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, transverse_mercator)
         python engine.rule_triggered.add(rule.name)
 
@@ -102,7 +102,7 @@ fc_provides_grid_mapping_mercator
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_mercator_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, mercator)
         python engine.rule_triggered.add(rule.name)
 
@@ -123,7 +123,7 @@ fc_provides_grid_mapping_stereographic
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_stereographic_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, stereographic)
         python engine.rule_triggered.add(rule.name)
 
@@ -142,7 +142,7 @@ fc_provides_grid_mapping_lambert_conformal
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_lambert_conformal_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, lambert_conformal)
         python engine.rule_triggered.add(rule.name)
 
@@ -161,7 +161,7 @@ fc_provides_grid_mapping_lambert_azimuthal_equal_area
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_lambert_azimuthal_equal_area_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, lambert_azimuthal_equal_area)
         python engine.rule_triggered.add(rule.name)
 
@@ -180,7 +180,7 @@ fc_provides_grid_mapping_albers_equal_area
     assert
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = build_albers_equal_area_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, albers_equal_area)
         python engine.rule_triggered.add(rule.name)
 
@@ -200,7 +200,7 @@ fc_provides_grid_mapping_vertical_perspective
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = \
             build_vertical_perspective_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, vertical_perspective)
         python engine.rule_triggered.add(rule.name)
 
@@ -221,7 +221,7 @@ fc_provides_grid_mapping_geostationary
         python cf_grid_var = engine.cf_var.cf_group.grid_mappings[$grid_mapping]
         python coordinate_system = \
             build_geostationary_coordinate_system(engine, cf_grid_var)
-        python engine.provides['coordinate_system'] = coordinate_system
+        python engine.cube_bits['coordinate_system'] = coordinate_system
         facts_cf.provides(coordinate_system, geostationary)
         python engine.rule_triggered.add(rule.name)
 
@@ -531,7 +531,7 @@ fc_build_coordinate_latitude
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LAT,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -552,7 +552,7 @@ fc_build_coordinate_latitude_rotated
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_GRID_LAT,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -573,7 +573,7 @@ fc_build_coordinate_longitude
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_LON,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -594,7 +594,7 @@ fc_build_coordinate_longitude_rotated
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_GRID_LON,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -660,7 +660,7 @@ fc_build_coordinate_projection_x_transverse_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -680,7 +680,7 @@ fc_build_coordinate_projection_y_transverse_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -699,7 +699,7 @@ fc_build_coordinate_projection_x_lambert_conformal
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -719,7 +719,7 @@ fc_build_coordinate_projection_y_lambert_conformal
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -739,7 +739,7 @@ fc_build_coordinate_projection_x_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -758,7 +758,7 @@ fc_build_coordinate_projection_y_mercator
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -777,7 +777,7 @@ fc_build_coordinate_projection_x_stereographic
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -796,7 +796,7 @@ fc_build_coordinate_projection_y_stereographic
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -816,7 +816,7 @@ fc_build_coordinate_projection_x_lambert_azimuthal_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -836,7 +836,7 @@ fc_build_coordinate_projection_y_lambert_azimuthal_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -855,7 +855,7 @@ fc_build_coordinate_projection_x_albers_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -875,7 +875,7 @@ fc_build_coordinate_projection_y_albers_equal_area
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -894,7 +894,7 @@ fc_build_coordinate_projection_x_vertical_perspective
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -914,7 +914,7 @@ fc_build_coordinate_projection_y_vertical_perspective
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 #
@@ -933,7 +933,7 @@ fc_build_coordinate_projection_x_geostationary
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_X,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -953,7 +953,7 @@ fc_build_coordinate_projection_y_geostationary
         python cf_coord_var = engine.cf_var.cf_group.coordinates[$coordinate]
         python build_dimension_coordinate(engine, cf_coord_var,
                                           coord_name=CF_VALUE_STD_NAME_PROJ_Y,
-                                          coord_system=engine.provides['coordinate_system'])
+                                          coord_system=engine.cube_bits['coordinate_system'])
         python engine.rule_triggered.add(rule.name)
 
 
@@ -1892,7 +1892,7 @@ fc_extras
                 cube.add_aux_coord(coord, data_dims)
 
         # Update the coordinate to CF-netCDF variable mapping.
-        engine.provides['coordinates'].append((coord, cf_coord_var.cf_name))
+        engine.cube_bits['coordinates'].append((coord, cf_coord_var.cf_name))
 
 
     ################################################################################
@@ -1958,7 +1958,7 @@ fc_extras
         cube.add_aux_coord(coord, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.provides['coordinates'].append((coord, cf_coord_var.cf_name))
+        engine.cube_bits['coordinates'].append((coord, cf_coord_var.cf_name))
 
 
     ################################################################################
@@ -2002,7 +2002,7 @@ fc_extras
         cube.add_cell_measure(cell_measure, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.provides['cell_measures'].append((cell_measure, cf_cm_var.cf_name))
+        engine.cube_bits['cell_measures'].append((cell_measure, cf_cm_var.cf_name))
 
 
 
@@ -2044,7 +2044,7 @@ fc_extras
         cube.add_ancillary_variable(av, data_dims)
 
         # Make a list with names, stored on the engine, so we can find them all later.
-        engine.provides['ancillary_variables'].append((av, cf_av_var.cf_name))
+        engine.cube_bits['ancillary_variables'].append((av, cf_av_var.cf_name))
 
 
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -460,9 +460,9 @@ class NetCDFDataProxy:
 def _assert_case_specific_facts(engine, cf, cf_group):
     # Initialise pyke engine "provides" hooks.
     # These are used to patch non-processed element attributes after rules activation.
-    engine.provides["coordinates"] = []
-    engine.provides["cell_measures"] = []
-    engine.provides["ancillary_variables"] = []
+    engine.cube_bits["coordinates"] = []
+    engine.cube_bits["cell_measures"] = []
+    engine.cube_bits["ancillary_variables"] = []
 
     # Assert facts for CF coordinates.
     for cf_name in cf_group.coordinates.keys():
@@ -595,7 +595,7 @@ def _load_cube(engine, cf, cf_var, filename):
     # Initialise pyke engine rule processing hooks.
     engine.cf_var = cf_var
     engine.cube = cube
-    engine.provides = {}
+    engine.cube_bits = {}
     engine.requires = {}
     engine.rule_triggered = set()
     engine.filename = filename
@@ -618,7 +618,7 @@ def _load_cube(engine, cf, cf_var, filename):
             _set_attributes(iris_object.attributes, attr_name, attr_value)
 
     def fix_attributes_all_elements(role_name):
-        elements_and_names = engine.provides.get(role_name, [])
+        elements_and_names = engine.cube_bits.get(role_name, [])
 
         for iris_object, cf_var_name in elements_and_names:
             add_unused_attributes(iris_object, cf.cf_group[cf_var_name])
@@ -677,7 +677,7 @@ def _load_aux_factory(engine, cube):
             # Convert term names to coordinates (via netCDF variable names).
             name = engine.requires["formula_terms"].get(term, None)
             if name is not None:
-                for coord, cf_var_name in engine.provides["coordinates"]:
+                for coord, cf_var_name in engine.cube_bits["coordinates"]:
                     if cf_var_name == name:
                         return coord
                 warnings.warn(

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -460,9 +460,9 @@ class NetCDFDataProxy:
 def _assert_case_specific_facts(engine, cf, cf_group):
     # Initialise pyke engine "provides" hooks.
     # These are used to patch non-processed element attributes after rules activation.
-    engine.cube_bits["coordinates"] = []
-    engine.cube_bits["cell_measures"] = []
-    engine.cube_bits["ancillary_variables"] = []
+    engine.cube_parts["coordinates"] = []
+    engine.cube_parts["cell_measures"] = []
+    engine.cube_parts["ancillary_variables"] = []
 
     # Assert facts for CF coordinates.
     for cf_name in cf_group.coordinates.keys():
@@ -595,7 +595,7 @@ def _load_cube(engine, cf, cf_var, filename):
     # Initialise pyke engine rule processing hooks.
     engine.cf_var = cf_var
     engine.cube = cube
-    engine.cube_bits = {}
+    engine.cube_parts = {}
     engine.requires = {}
     engine.rule_triggered = set()
     engine.filename = filename
@@ -618,7 +618,7 @@ def _load_cube(engine, cf, cf_var, filename):
             _set_attributes(iris_object.attributes, attr_name, attr_value)
 
     def fix_attributes_all_elements(role_name):
-        elements_and_names = engine.cube_bits.get(role_name, [])
+        elements_and_names = engine.cube_parts.get(role_name, [])
 
         for iris_object, cf_var_name in elements_and_names:
             add_unused_attributes(iris_object, cf.cf_group[cf_var_name])
@@ -677,7 +677,7 @@ def _load_aux_factory(engine, cube):
             # Convert term names to coordinates (via netCDF variable names).
             name = engine.requires["formula_terms"].get(term, None)
             if name is not None:
-                for coord, cf_var_name in engine.cube_bits["coordinates"]:
+                for coord, cf_var_name in engine.cube_parts["coordinates"]:
                     if cf_var_name == name:
                         return coord
                 warnings.warn(

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -24,9 +24,9 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
         standard_name = "atmosphere_hybrid_sigma_pressure_coordinate"
         self.requires = dict(formula_type=standard_name)
         coordinates = [(mock.sentinel.b, "b"), (mock.sentinel.ps, "ps")]
-        self.cube_bits = dict(coordinates=coordinates)
+        self.cube_parts = dict(coordinates=coordinates)
         self.engine = mock.Mock(
-            requires=self.requires, cube_bits=self.cube_bits
+            requires=self.requires, cube_parts=self.cube_parts
         )
         self.cube = mock.create_autospec(Cube, spec_set=True, instance=True)
         # Patch out the check_dependencies functionality.
@@ -36,7 +36,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
         self.addCleanup(patcher.stop)
 
     def test_formula_terms_ap(self):
-        self.cube_bits["coordinates"].append((mock.sentinel.ap, "ap"))
+        self.cube_parts["coordinates"].append((mock.sentinel.ap, "ap"))
         self.requires["formula_terms"] = dict(ap="ap", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         # Check cube.add_aux_coord method.
@@ -59,7 +59,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
             long_name="vertical pressure",
             var_name="ap",
         )
-        self.cube_bits["coordinates"].extend(
+        self.cube_parts["coordinates"].extend(
             [(coord_a, "a"), (coord_p0, "p0")]
         )
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps", p0="p0")
@@ -86,7 +86,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
 
     def test_formula_terms_p0_non_scalar(self):
         coord_p0 = DimCoord(np.arange(5))
-        self.cube_bits["coordinates"].append((coord_p0, "p0"))
+        self.cube_parts["coordinates"].append((coord_p0, "p0"))
         self.requires["formula_terms"] = dict(p0="p0")
         with self.assertRaises(ValueError):
             _load_aux_factory(self.engine, self.cube)
@@ -94,7 +94,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
     def test_formula_terms_p0_bounded(self):
         coord_a = DimCoord(np.arange(5))
         coord_p0 = DimCoord(1, bounds=[0, 2], var_name="p0")
-        self.cube_bits["coordinates"].extend(
+        self.cube_parts["coordinates"].extend(
             [(coord_a, "a"), (coord_p0, "p0")]
         )
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps", p0="p0")
@@ -137,14 +137,14 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
 
     def test_formula_terms_no_p0_term(self):
         coord_a = DimCoord(np.arange(5), units="Pa")
-        self.cube_bits["coordinates"].append((coord_a, "a"))
+        self.cube_parts["coordinates"].append((coord_a, "a"))
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         self._check_no_delta()
 
     def test_formula_terms_no_a_term(self):
         coord_p0 = DimCoord(10, units="1")
-        self.cube_bits["coordinates"].append((coord_p0, "p0"))
+        self.cube_parts["coordinates"].append((coord_p0, "p0"))
         self.requires["formula_terms"] = dict(a="p0", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         self._check_no_delta()

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_aux_factory.py
@@ -24,8 +24,10 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
         standard_name = "atmosphere_hybrid_sigma_pressure_coordinate"
         self.requires = dict(formula_type=standard_name)
         coordinates = [(mock.sentinel.b, "b"), (mock.sentinel.ps, "ps")]
-        self.provides = dict(coordinates=coordinates)
-        self.engine = mock.Mock(requires=self.requires, provides=self.provides)
+        self.cube_bits = dict(coordinates=coordinates)
+        self.engine = mock.Mock(
+            requires=self.requires, cube_bits=self.cube_bits
+        )
         self.cube = mock.create_autospec(Cube, spec_set=True, instance=True)
         # Patch out the check_dependencies functionality.
         func = "iris.aux_factory.HybridPressureFactory._check_dependencies"
@@ -34,7 +36,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
         self.addCleanup(patcher.stop)
 
     def test_formula_terms_ap(self):
-        self.provides["coordinates"].append((mock.sentinel.ap, "ap"))
+        self.cube_bits["coordinates"].append((mock.sentinel.ap, "ap"))
         self.requires["formula_terms"] = dict(ap="ap", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         # Check cube.add_aux_coord method.
@@ -57,7 +59,9 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
             long_name="vertical pressure",
             var_name="ap",
         )
-        self.provides["coordinates"].extend([(coord_a, "a"), (coord_p0, "p0")])
+        self.cube_bits["coordinates"].extend(
+            [(coord_a, "a"), (coord_p0, "p0")]
+        )
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps", p0="p0")
         _load_aux_factory(self.engine, self.cube)
         # Check cube.coord_dims method.
@@ -82,7 +86,7 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
 
     def test_formula_terms_p0_non_scalar(self):
         coord_p0 = DimCoord(np.arange(5))
-        self.provides["coordinates"].append((coord_p0, "p0"))
+        self.cube_bits["coordinates"].append((coord_p0, "p0"))
         self.requires["formula_terms"] = dict(p0="p0")
         with self.assertRaises(ValueError):
             _load_aux_factory(self.engine, self.cube)
@@ -90,7 +94,9 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
     def test_formula_terms_p0_bounded(self):
         coord_a = DimCoord(np.arange(5))
         coord_p0 = DimCoord(1, bounds=[0, 2], var_name="p0")
-        self.provides["coordinates"].extend([(coord_a, "a"), (coord_p0, "p0")])
+        self.cube_bits["coordinates"].extend(
+            [(coord_a, "a"), (coord_p0, "p0")]
+        )
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps", p0="p0")
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
@@ -131,14 +137,14 @@ class TestAtmosphereHybridSigmaPressureCoordinate(tests.IrisTest):
 
     def test_formula_terms_no_p0_term(self):
         coord_a = DimCoord(np.arange(5), units="Pa")
-        self.provides["coordinates"].append((coord_a, "a"))
+        self.cube_bits["coordinates"].append((coord_a, "a"))
         self.requires["formula_terms"] = dict(a="a", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         self._check_no_delta()
 
     def test_formula_terms_no_a_term(self):
         coord_p0 = DimCoord(10, units="1")
-        self.provides["coordinates"].append((coord_p0, "p0"))
+        self.cube_bits["coordinates"].append((coord_p0, "p0"))
         self.requires["formula_terms"] = dict(a="p0", b="b", ps="ps")
         _load_aux_factory(self.engine, self.cube)
         self._check_no_delta()

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -25,7 +25,7 @@ class TestCoordAttributes(tests.IrisTest):
         for coord in cf_group:
             engine.cube.add_aux_coord(coord)
             coordinates.append((coord, coord.name()))
-        engine.cube_bits["coordinates"] = coordinates
+        engine.cube_parts["coordinates"] = coordinates
 
     def setUp(self):
         this = "iris.fileformats.netcdf._assert_case_specific_facts"

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -25,7 +25,7 @@ class TestCoordAttributes(tests.IrisTest):
         for coord in cf_group:
             engine.cube.add_aux_coord(coord)
             coordinates.append((coord, coord.name()))
-        engine.provides["coordinates"] = coordinates
+        engine.cube_bits["coordinates"] = coordinates
 
     def setUp(self):
         this = "iris.fileformats.netcdf._assert_case_specific_facts"

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -63,7 +63,7 @@ class TestBoundsVertexDim(tests.IrisTest):
             cf_var=mock.Mock(dimensions=('foo', 'bar'),
                              cf_data=cf_data),
             filename='DUMMY',
-            cube_bits=dict(coordinates=[]))
+            cube_parts=dict(coordinates=[]))
 
         # Patch the deferred loading that prevents attempted file access.
         # This assumes that self.cf_bounds_var is defined in the test case.
@@ -120,9 +120,9 @@ class TestBoundsVertexDim(tests.IrisTest):
         self.engine.cube.add_aux_coord.assert_called_with(
             self.expected_coord, [0, 1])
 
-        # Test that engine.cube_bits container is correctly populated.
+        # Test that engine.cube_parts container is correctly populated.
         expected_list = [(self.expected_coord, self.cf_coord_var.cf_name)]
-        self.assertEqual(self.engine.cube_bits['coordinates'],
+        self.assertEqual(self.engine.cube_parts['coordinates'],
                          expected_list)
 
     def test_fastest_varying_vertex_dim(self):
@@ -163,7 +163,7 @@ class TestDtype(tests.IrisTest):
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            cube_bits=dict(coordinates=[]))
+            cube_parts=dict(coordinates=[]))
 
         def patched__getitem__(proxy_self, keys):
             if proxy_self.variable_name == self.cf_coord_var.cf_name:
@@ -181,7 +181,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.cube_bits['coordinates'][0]
+        coord, _ = self.engine.cube_parts['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'i')
 
     def test_scale_factor_float(self):
@@ -190,7 +190,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.cube_bits['coordinates'][0]
+        coord, _ = self.engine.cube_parts['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'f')
 
     def test_add_offset_float(self):
@@ -199,7 +199,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.cube_bits['coordinates'][0]
+        coord, _ = self.engine.cube_parts['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'f')
 
 
@@ -210,7 +210,7 @@ class TestCoordConstruction(tests.IrisTest):
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            cube_bits=dict(coordinates=[]))
+            cube_parts=dict(coordinates=[]))
 
         points = np.arange(6)
         self.cf_coord_var = mock.Mock(

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py
@@ -63,12 +63,11 @@ class TestBoundsVertexDim(tests.IrisTest):
             cf_var=mock.Mock(dimensions=('foo', 'bar'),
                              cf_data=cf_data),
             filename='DUMMY',
-            provides=dict(coordinates=[]))
+            cube_bits=dict(coordinates=[]))
 
         # Patch the deferred loading that prevents attempted file access.
         # This assumes that self.cf_bounds_var is defined in the test case.
         def patched__getitem__(proxy_self, keys):
-            variable = None
             for var in (self.cf_coord_var, self.cf_bounds_var):
                 if proxy_self.variable_name == var.cf_name:
                     return var[keys]
@@ -121,9 +120,9 @@ class TestBoundsVertexDim(tests.IrisTest):
         self.engine.cube.add_aux_coord.assert_called_with(
             self.expected_coord, [0, 1])
 
-        # Test that engine.provides container is correctly populated.
+        # Test that engine.cube_bits container is correctly populated.
         expected_list = [(self.expected_coord, self.cf_coord_var.cf_name)]
-        self.assertEqual(self.engine.provides['coordinates'],
+        self.assertEqual(self.engine.cube_bits['coordinates'],
                          expected_list)
 
     def test_fastest_varying_vertex_dim(self):
@@ -164,7 +163,7 @@ class TestDtype(tests.IrisTest):
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            provides=dict(coordinates=[]))
+            cube_bits=dict(coordinates=[]))
 
         def patched__getitem__(proxy_self, keys):
             if proxy_self.variable_name == self.cf_coord_var.cf_name:
@@ -182,7 +181,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.provides['coordinates'][0]
+        coord, _ = self.engine.cube_bits['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'i')
 
     def test_scale_factor_float(self):
@@ -191,7 +190,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.provides['coordinates'][0]
+        coord, _ = self.engine.cube_bits['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'f')
 
     def test_add_offset_float(self):
@@ -200,7 +199,7 @@ class TestDtype(tests.IrisTest):
         with self.deferred_load_patch:
             build_auxiliary_coordinate(self.engine, self.cf_coord_var)
 
-        coord, _ = self.engine.provides['coordinates'][0]
+        coord, _ = self.engine.cube_bits['coordinates'][0]
         self.assertEqual(coord.dtype.kind, 'f')
 
 
@@ -211,7 +210,7 @@ class TestCoordConstruction(tests.IrisTest):
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            provides=dict(coordinates=[]))
+            cube_bits=dict(coordinates=[]))
 
         points = np.arange(6)
         self.cf_coord_var = mock.Mock(

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -30,7 +30,7 @@ class RulesTestMixin:
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            cube_bits=dict(coordinates=[]))
+            cube_parts=dict(coordinates=[]))
 
         # Create patch for deferred loading that prevents attempted
         # file access. This assumes that self.cf_coord_var and
@@ -258,9 +258,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.cube_bits container is correctly populated.
+            # Test that engine.cube_parts container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.cube_bits['coordinates'],
+            self.assertEqual(self.engine.cube_parts['coordinates'],
                              expected_list)
 
     def test_fastest_varying_vertex_dim(self):
@@ -286,9 +286,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.cube_bits container is correctly populated.
+            # Test that engine.cube_parts container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.cube_bits['coordinates'],
+            self.assertEqual(self.engine.cube_parts['coordinates'],
                              expected_list)
 
     def test_fastest_with_different_dim_names(self):
@@ -317,9 +317,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.cube_bits container is correctly populated.
+            # Test that engine.cube_parts container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.cube_bits['coordinates'],
+            self.assertEqual(self.engine.cube_parts['coordinates'],
                              expected_list)
 
 

--- a/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_dimension_coordinate.py
@@ -30,7 +30,7 @@ class RulesTestMixin:
             cube=mock.Mock(),
             cf_var=mock.Mock(dimensions=('foo', 'bar')),
             filename='DUMMY',
-            provides=dict(coordinates=[]))
+            cube_bits=dict(coordinates=[]))
 
         # Create patch for deferred loading that prevents attempted
         # file access. This assumes that self.cf_coord_var and
@@ -258,9 +258,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.provides container is correctly populated.
+            # Test that engine.cube_bits container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.provides['coordinates'],
+            self.assertEqual(self.engine.cube_bits['coordinates'],
                              expected_list)
 
     def test_fastest_varying_vertex_dim(self):
@@ -286,9 +286,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.provides container is correctly populated.
+            # Test that engine.cube_bits container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.provides['coordinates'],
+            self.assertEqual(self.engine.cube_bits['coordinates'],
                              expected_list)
 
     def test_fastest_with_different_dim_names(self):
@@ -317,9 +317,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             self.engine.cube.add_dim_coord.assert_called_with(
                 expected_coord, [0])
 
-            # Test that engine.provides container is correctly populated.
+            # Test that engine.cube_bits container is correctly populated.
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
-            self.assertEqual(self.engine.provides['coordinates'],
+            self.assertEqual(self.engine.cube_bits['coordinates'],
                              expected_list)
 
 


### PR DESCRIPTION
During work on #3556, it became clear to me that the use of `engine.provides` within the pyke rules, and in a few places within `iris.fileformats.netcdf` is confusing :  Because this term collides with the special reserved meaning of "provides" within Pyke rules, as seen in the repeated usage of `facts_cf.provides(..)` in most of our Pyke rules.

In fact, although `engine` is a Pyke object,  `engine.provides` is just a monkey-patched additional property attached by our netcdf code, to keep track of cube component objects created during rules evaluation (coordinates, cell-measures and ancillaries).

So, this PR just renames it to something less confusing. 
This should produce **no functional change.**