### PR TITLE
PI-2472: Tweak area weighting regrid move averaging out of loop

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -382,13 +382,22 @@ class TestAreaWeightedRegrid(tests.IrisTest):
 
     def test_missing_data(self):
         src = self.simple_cube.copy()
-        src.data = ma.masked_array(src.data)
+        src.data = ma.masked_array(src.data, fill_value=999)
         src.data[1, 2] = ma.masked
         dest = _resampled_grid(self.simple_cube, 2.3, 2.4)
         res = regrid_area_weighted(src, dest)
         mask = np.zeros((7, 9), bool)
         mask[slice(2, 5), slice(4, 7)] = True
         self.assertArrayEqual(res.data.mask, mask)
+        self.assertArrayEqual(res.data.fill_value, 999)
+
+    def test_masked_data_all_false(self):
+        src = self.simple_cube.copy()
+        src.data = ma.masked_array(src.data, mask=False, fill_value=999)
+        dest = _resampled_grid(self.simple_cube, 2.3, 2.4)
+        res = regrid_area_weighted(src, dest)
+        self.assertArrayEqual(res.data.mask, False)
+        self.assertArrayEqual(res.data.fill_value, 999)
 
     def test_no_x_overlap(self):
         src = self.simple_cube


### PR DESCRIPTION
Optimise the averaging in the _regrid_area_weighted_array.

This is achieved by refactoring the weights calculation, collating the data and the weights in a single array, then finally computing the weighted mean as a whole-array-manipulation.

Calculating the weights first is necessary because the size (i.e. number of elements) of the weights and source data region varies per target grid point. In order to record all the values in a single array, the maximum size of the weights array needs to be established, so the single array can be setup. Therefore we first computing the weights and record the maximum weight-array size, hence we have refactored the weights calculation too.