### PR TITLE
PI-2472: Refactor AreaWeightedRegridder

### DIFF
--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -51,8 +51,6 @@ class AreaWeightedRegridder:
         # impervious to external changes to the original source cubes.
         self._src_grid = snapshot_grid(src_grid_cube)
         self._target_grid = snapshot_grid(target_grid_cube)
-        self._src_grid_cube = src_grid_cube.copy()
-        self._target_grid_cube = target_grid_cube.copy()
         # Missing data tolerance.
         if not (0 <= mdtol <= 1):
             msg = "Value for mdtol must be in range 0 - 1, got {}."
@@ -61,6 +59,33 @@ class AreaWeightedRegridder:
 
         # Cache the regrid info.
         self._regrid_info_cache = None
+
+        # The need for an actual Cube is an implementation quirk caused by the
+        # current usage of the experimental regrid function.
+        self._src_grid_cube_cache = None
+        self._target_grid_cube_cache = None
+
+    @property
+    def _src_grid_cube(self):
+        if self._src_grid_cube_cache is None:
+            x, y = self._src_grid
+            data = np.empty((y.points.size, x.points.size))
+            cube = iris.cube.Cube(data)
+            cube.add_dim_coord(y, 0)
+            cube.add_dim_coord(x, 1)
+            self._src_grid_cube_cache = cube
+        return self._src_grid_cube_cache
+
+    @property
+    def _target_grid_cube(self):
+        if self._target_grid_cube_cache is None:
+            x, y = self._target_grid
+            data = np.empty((y.points.size, x.points.size))
+            cube = iris.cube.Cube(data)
+            cube.add_dim_coord(y, 0)
+            cube.add_dim_coord(x, 1)
+            self._target_grid_cube_cache = cube
+        return self._target_grid_cube_cache
 
     def _regrid_info(self):
         if self._regrid_info_cache is None:

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -65,7 +65,8 @@ class AreaWeightedRegridder:
         self._target_grid_cube_cache = None
 
         self._regrid_info = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
-                src_grid_cube, self._target_grid_cube)
+            src_grid_cube, self._target_grid_cube
+        )
 
     @property
     def _target_grid_cube(self):

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -57,9 +57,6 @@ class AreaWeightedRegridder:
             raise ValueError(msg.format(mdtol))
         self._mdtol = mdtol
 
-        # Cache the regrid info.
-        self._regrid_info_cache = None
-
         # The need for an actual Cube is an implementation quirk caused by the
         # current usage of the experimental regrid function.
         self._target_grid_cube_cache = None

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -59,7 +59,23 @@ class AreaWeightedRegridder:
 
         # The need for an actual Cube is an implementation quirk caused by the
         # current usage of the experimental regrid function.
+        self._src_grid_cube_cache = None
         self._target_grid_cube_cache = None
+
+        self._regrid_info = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
+            self._src_grid_cube, self._target_grid_cube
+        )
+
+    @property
+    def _src_grid_cube(self):
+        if self._src_grid_cube_cache is None:
+            x, y = self._src_grid
+            data = np.empty((y.points.size, x.points.size))
+            cube = iris.cube.Cube(data)
+            cube.add_dim_coord(y, 0)
+            cube.add_dim_coord(x, 1)
+            self._src_grid_cube_cache = cube
+        return self._src_grid_cube_cache
 
     @property
     def _target_grid_cube(self):
@@ -97,6 +113,6 @@ class AreaWeightedRegridder:
                 "The given cube is not defined on the same "
                 "source grid as this regridder."
             )
-        return eregrid.regrid_area_weighted_rectilinear_src_and_grid(
-            cube, self._target_grid_cube, mdtol=self._mdtol
+        return eregrid._regrid_area_weighted_rectilinear_src_and_grid__perform(
+            cube, self._regrid_info, mdtol=self._mdtol
         )

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -62,19 +62,10 @@ class AreaWeightedRegridder:
 
         # The need for an actual Cube is an implementation quirk caused by the
         # current usage of the experimental regrid function.
-        self._src_grid_cube_cache = None
         self._target_grid_cube_cache = None
 
-    @property
-    def _src_grid_cube(self):
-        if self._src_grid_cube_cache is None:
-            x, y = self._src_grid
-            data = np.empty((y.points.size, x.points.size))
-            cube = iris.cube.Cube(data)
-            cube.add_dim_coord(y, 0)
-            cube.add_dim_coord(x, 1)
-            self._src_grid_cube_cache = cube
-        return self._src_grid_cube_cache
+        self._regrid_info = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
+                src_grid_cube, self._target_grid_cube)
 
     @property
     def _target_grid_cube(self):
@@ -86,13 +77,6 @@ class AreaWeightedRegridder:
             cube.add_dim_coord(x, 1)
             self._target_grid_cube_cache = cube
         return self._target_grid_cube_cache
-
-    def _regrid_info(self):
-        if self._regrid_info_cache is None:
-            self._regrid_info_cache = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
-                self._src_grid_cube, self._target_grid_cube
-            )
-        return self._regrid_info_cache
 
     def __call__(self, cube):
         """
@@ -120,5 +104,5 @@ class AreaWeightedRegridder:
                 "source grid as this regridder."
             )
         return eregrid._regrid_area_weighted_rectilinear_src_and_grid__perform(
-            cube, self._regrid_info(), mdtol=self._mdtol
+            cube, self._regrid_info, mdtol=self._mdtol
         )

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -51,42 +51,23 @@ class AreaWeightedRegridder:
         # impervious to external changes to the original source cubes.
         self._src_grid = snapshot_grid(src_grid_cube)
         self._target_grid = snapshot_grid(target_grid_cube)
+        self._src_grid_cube = src_grid_cube.copy()
+        self._target_grid_cube = target_grid_cube.copy()
         # Missing data tolerance.
         if not (0 <= mdtol <= 1):
             msg = "Value for mdtol must be in range 0 - 1, got {}."
             raise ValueError(msg.format(mdtol))
         self._mdtol = mdtol
 
-        # The need for an actual Cube is an implementation quirk caused by the
-        # current usage of the experimental regrid function.
-        self._src_grid_cube_cache = None
-        self._target_grid_cube_cache = None
+        # Cache the regrid info.
+        self._regrid_info_cache = None
 
-        self._regrid_info = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
-            self._src_grid_cube, self._target_grid_cube
-        )
-
-    @property
-    def _src_grid_cube(self):
-        if self._src_grid_cube_cache is None:
-            x, y = self._src_grid
-            data = np.empty((y.points.size, x.points.size))
-            cube = iris.cube.Cube(data)
-            cube.add_dim_coord(y, 0)
-            cube.add_dim_coord(x, 1)
-            self._src_grid_cube_cache = cube
-        return self._src_grid_cube_cache
-
-    @property
-    def _target_grid_cube(self):
-        if self._target_grid_cube_cache is None:
-            x, y = self._target_grid
-            data = np.empty((y.points.size, x.points.size))
-            cube = iris.cube.Cube(data)
-            cube.add_dim_coord(y, 0)
-            cube.add_dim_coord(x, 1)
-            self._target_grid_cube_cache = cube
-        return self._target_grid_cube_cache
+    def _regrid_info(self):
+        if self._regrid_info_cache is None:
+            self._regrid_info_cache = eregrid._regrid_area_weighted_rectilinear_src_and_grid__prepare(
+                self._src_grid_cube, self._target_grid_cube
+            )
+        return self._regrid_info_cache
 
     def __call__(self, cube):
         """
@@ -114,5 +95,5 @@ class AreaWeightedRegridder:
                 "source grid as this regridder."
             )
         return eregrid._regrid_area_weighted_rectilinear_src_and_grid__perform(
-            cube, self._regrid_info, mdtol=self._mdtol
+            cube, self._regrid_info(), mdtol=self._mdtol
         )

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -41,16 +41,22 @@ class AreaWeightedRegridder:
 
         .. Note::
 
-            Both sourge and target cubes must have an XY grid defined by
+            Both source and target cubes must have an XY grid defined by
             separate X and Y dimensions with dimension coordinates.
             All of the XY dimension coordinates must also be bounded, and have
             the same cooordinate system.
 
         """
         # Snapshot the state of the cubes to ensure that the regridder is
-        # impervious to external changes to the original source cubes.
+        # impervious to external changes to the original cubes.
         self._src_grid = snapshot_grid(src_grid_cube)
         self._target_grid = snapshot_grid(target_grid_cube)
+
+        # Store the x_dim and y_dim of the source cube.
+        x, y = get_xy_dim_coords(src_grid_cube)
+        self._src_x_dim = src_grid_cube.coord_dims(x)
+        self._src_y_dim = src_grid_cube.coord_dims(y)
+
         # Missing data tolerance.
         if not (0 <= mdtol <= 1):
             msg = "Value for mdtol must be in range 0 - 1, got {}."
@@ -96,7 +102,9 @@ class AreaWeightedRegridder:
             area-weighted regridding.
 
         """
-        if get_xy_dim_coords(cube) != self._src_grid:
+        if get_xy_dim_coords(cube) != self._src_grid or not (
+            _xy_data_dims_are_equal(cube, self._src_x_dim, self._src_y_dim)
+        ):
             raise ValueError(
                 "The given cube is not defined on the same "
                 "source grid as this regridder."
@@ -104,3 +112,12 @@ class AreaWeightedRegridder:
         return eregrid._regrid_area_weighted_rectilinear_src_and_grid__perform(
             cube, self._regrid_info, mdtol=self._mdtol
         )
+
+
+def _xy_data_dims_are_equal(cube, x_dim, y_dim):
+    """
+    Return whether the data dimensions of the x and y coordinates on the
+    the cube are equal to the values ``x_dim`` and ``y_dim``, respectively.
+    """
+    x1, y1 = get_xy_dim_coords(cube)
+    return cube.coord_dims(x1) == x_dim and cube.coord_dims(y1) == y_dim

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -881,9 +881,9 @@ class RectilinearRegridder:
         def copy_coords(src_coords, add_method):
             for coord in src_coords:
                 dims = src.coord_dims(coord)
-                if coord is src_x_coord:
+                if coord == src_x_coord:
                     coord = grid_x_coord
-                elif coord is src_y_coord:
+                elif coord == src_y_coord:
                     coord = grid_y_coord
                 elif x_dim in dims or y_dim in dims:
                     continue

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -881,9 +881,9 @@ class RectilinearRegridder:
         def copy_coords(src_coords, add_method):
             for coord in src_coords:
                 dims = src.coord_dims(coord)
-                if coord == src_x_coord:
+                if coord is src_x_coord:
                     coord = grid_x_coord
-                elif coord == src_y_coord:
+                elif coord is src_y_coord:
                     coord = grid_y_coord
                 elif x_dim in dims or y_dim in dims:
                     continue

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -42,20 +42,13 @@ class Test(tests.IrisTest):
 
     def check_mdtol(self, mdtol=None):
         src_grid, target_grid = self.grids()
-
-        with mock.patch(
-            "iris.experimental.regrid."
-            "_regrid_area_weighted_rectilinear_src_and_grid__prepare",
-            return_value=mock.sentinel.result,
-        ) as prepare:
-            if mdtol is None:
-                regridder = AreaWeightedRegridder(src_grid, target_grid)
-                mdtol = 1
-            else:
-                regridder = AreaWeightedRegridder(
-                    src_grid, target_grid, mdtol=mdtol
-                )
-        self.assertEqual(prepare.call_count, 1)
+        if mdtol is None:
+            regridder = AreaWeightedRegridder(src_grid, target_grid)
+            mdtol = 1
+        else:
+            regridder = AreaWeightedRegridder(
+                src_grid, target_grid, mdtol=mdtol
+            )
 
         # Make a new cube to regrid with different data so we can
         # distinguish between regridding the original src grid
@@ -65,11 +58,16 @@ class Test(tests.IrisTest):
 
         with mock.patch(
             "iris.experimental.regrid."
-            "_regrid_area_weighted_rectilinear_src_and_grid__perform",
-            return_value=mock.sentinel.result,
-        ) as perform:
-            result = regridder(src)
+            "_regrid_area_weighted_rectilinear_src_and_grid__prepare"
+        ) as prepare:
+            with mock.patch(
+                "iris.experimental.regrid."
+                "_regrid_area_weighted_rectilinear_src_and_grid__perform",
+                return_value=mock.sentinel.result,
+            ) as perform:
+                result = regridder(src)
 
+        self.assertEqual(prepare.call_count, 1)
         self.assertEqual(perform.call_count, 1)
         _, args, kwargs = perform.mock_calls[0]
 

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -174,8 +174,17 @@ class Test(tests.IrisTest):
 
     def test_mismatched_data_dims(self):
         coord_names = ["latitude", "longitude"]
-        src1 = self.cube(np.linspace(20, 32, 4), np.linspace(10, 22, 4))
-        src2 = self.cube(np.linspace(10, 22, 4), np.linspace(20, 32, 4))
+        x = np.linspace(20, 32, 4)
+        y = np.linspace(10, 22, 4)
+        src1 = self.cube(x, y)
+
+        data = np.arange(len(y) * len(x)).reshape(len(x), len(y))
+        src2 = Cube(data)
+        lat = DimCoord(y, "latitude", units="degrees")
+        lon = DimCoord(x, "longitude", units="degrees")
+        # Add dim coords in opposite order to self.cube.
+        src2.add_dim_coord(lat, 1)
+        src2.add_dim_coord(lon, 0)
         for name in coord_names:
             # Ensure contiguous bounds exists.
             src1.coord(name).guess_bounds()

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -67,14 +67,17 @@ class Test(tests.IrisTest):
             ) as perform:
                 result = regridder(src)
 
+        # Prepare:
         self.assertEqual(prepare.call_count, 1)
+        _, args, kwargs = prepare.mock_calls[0]
+        self.assertEqual(
+            self.extract_grid(args[1]), self.extract_grid(target_grid)
+        )
+
+        # Perform:
         self.assertEqual(perform.call_count, 1)
         _, args, kwargs = perform.mock_calls[0]
-
         self.assertEqual(args[0], src)
-        # self.assertEqual(
-        #    self.extract_grid(args[1]), self.extract_grid(target_grid)
-        # )
         self.assertEqual(kwargs, {"mdtol": mdtol})
         self.assertIs(result, mock.sentinel.result)
 

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -42,13 +42,17 @@ class Test(tests.IrisTest):
 
     def check_mdtol(self, mdtol=None):
         src_grid, target_grid = self.grids()
-        if mdtol is None:
-            regridder = AreaWeightedRegridder(src_grid, target_grid)
-            mdtol = 1
-        else:
-            regridder = AreaWeightedRegridder(
-                src_grid, target_grid, mdtol=mdtol
-            )
+        with mock.patch(
+            "iris.experimental.regrid."
+            "_regrid_area_weighted_rectilinear_src_and_grid__prepare"
+        ) as prepare:
+            if mdtol is None:
+                regridder = AreaWeightedRegridder(src_grid, target_grid)
+                mdtol = 1
+            else:
+                regridder = AreaWeightedRegridder(
+                    src_grid, target_grid, mdtol=mdtol
+                )
 
         # Make a new cube to regrid with different data so we can
         # distinguish between regridding the original src grid
@@ -58,14 +62,10 @@ class Test(tests.IrisTest):
 
         with mock.patch(
             "iris.experimental.regrid."
-            "_regrid_area_weighted_rectilinear_src_and_grid__prepare"
-        ) as prepare:
-            with mock.patch(
-                "iris.experimental.regrid."
-                "_regrid_area_weighted_rectilinear_src_and_grid__perform",
-                return_value=mock.sentinel.result,
-            ) as perform:
-                result = regridder(src)
+            "_regrid_area_weighted_rectilinear_src_and_grid__perform",
+            return_value=mock.sentinel.result,
+        ) as perform:
+            result = regridder(src)
 
         # Prepare:
         self.assertEqual(prepare.call_count, 1)


### PR DESCRIPTION
This pull request refactors `AreaWeightedRegridder` to call the relevant `__prepare` and `__perform` functions.

I've not come across `mock.sentinel` before, so I've had to comment out one assert that I can't get to work.