### PR TITLE
Cube-xml for cell measures and ancils.

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -884,6 +884,16 @@ class CellMeasure(AncillaryVariable):
         """
         return cube.cell_measure_dims(self)
 
+    def xml_element(self, doc):
+        # Create the XML element as the camelCaseEquivalent of the
+        # class name
+        element = super().xml_element(doc=doc)
+
+        # Add the 'measure' property
+        element.setAttribute("measure", self.measure)
+
+        return element
+
 
 class CoordDefn(
     namedtuple(

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -627,12 +627,8 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
             values_term = "points"
         else:
             values_term = "data"
-        if hasattr(self._values, "to_xml_attr"):
-            element.setAttribute(values_term, self._values.to_xml_attr())
-        else:
-            element.setAttribute(
-                values_term, iris.util.format_array(self._values)
-            )
+        element.setAttribute(values_term, self._xml_array_repr(self._values))
+
         return element
 
     def _xml_id_extra(self, unique_value):
@@ -656,6 +652,14 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
         # Mask to ensure consistency across Python versions & platforms.
         crc = zlib.crc32(unique_value) & 0xFFFFFFFF
         return "%08x" % (crc,)
+
+    @staticmethod
+    def _xml_array_repr(data):
+        if hasattr(data, "to_xml_attr"):
+            result = data._values.to_xml_attr()
+        else:
+            result = iris.util.format_array(data)
+        return result
 
     def _value_type_name(self):
         """
@@ -2368,19 +2372,11 @@ class Coord(_DimensionalMetadata):
         # class name
         element = super().xml_element(doc=doc)
 
-        if hasattr(self.points, "to_xml_attr"):
-            element.setAttribute("points", self.points.to_xml_attr())
-        else:
-            element.setAttribute("points", iris.util.format_array(self.points))
+        element.setAttribute("points", self._xml_array_repr(self.points))
 
         # Add bounds handling
         if self.has_bounds():
-            if hasattr(self.bounds, "to_xml_attr"):
-                element.setAttribute("bounds", self.bounds.to_xml_attr())
-            else:
-                element.setAttribute(
-                    "bounds", iris.util.format_array(self.bounds)
-                )
+            element.setAttribute("bounds", self._xml_array_repr(self.bounds))
 
         return element
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3452,8 +3452,26 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             cell_methods_xml_element.appendChild(cell_method_xml_element)
         cube_xml_element.appendChild(cell_methods_xml_element)
 
-        data_xml_element = doc.createElement("data")
+        # cell measures
+        cell_measures = sorted(self.cell_measures(), key=lambda cm: cm.name())
+        if cell_measures:
+            # This one is an optional subelement.
+            cms_xml_element = doc.createElement("cellMeasures")
+            for cm in cell_measures:
+                cms_xml_element.appendChild(cm.xml_element(doc))
+            cube_xml_element.appendChild(cms_xml_element)
 
+        # ancillary variables
+        ancils = sorted(self.ancillary_variables(), key=lambda anc: anc.name())
+        if ancils:
+            # This one is an optional subelement.
+            ancs_xml_element = doc.createElement("ancillaryVariables")
+            for anc in ancils:
+                ancs_xml_element.appendChild(anc.xml_element(doc))
+            cube_xml_element.appendChild(cms_xml_element)
+
+        # data
+        data_xml_element = doc.createElement("data")
         data_xml_element.setAttribute("shape", str(self.shape))
 
         # NB. Getting a checksum triggers any deferred loading,

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3429,7 +3429,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             cube_xml_element.appendChild(attributes_element)
 
-        def dimensionedCubeElement(element, typename, dimscall):
+        def dimmeta_xml_element(element, typename, dimscall):
+            # Make an inner xml element for a cube DimensionalMetadata element, with a
+            # 'datadims' property showing how it maps to the parent cube dims.
             xml_element = doc.createElement(typename)
             dims = list(dimscall(element))
             if dims:
@@ -3443,7 +3445,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # appropriate) which itself will have a sub-element of the
             # coordinate instance itself.
             coords_xml_element.appendChild(
-                dimensionedCubeElement(coord, "coord", self.coord_dims)
+                dimmeta_xml_element(coord, "coord", self.coord_dims)
             )
         cube_xml_element.appendChild(coords_xml_element)
 
@@ -3461,7 +3463,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             cms_xml_element = doc.createElement("cellMeasures")
             for cm in cell_measures:
                 cms_xml_element.appendChild(
-                    dimensionedCubeElement(
+                    dimmeta_xml_element(
                         cm, "cell-measure", self.cell_measure_dims
                     )
                 )
@@ -3474,7 +3476,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             ancs_xml_element = doc.createElement("ancillaryVariables")
             for anc in ancils:
                 ancs_xml_element.appendChild(
-                    dimensionedCubeElement(
+                    dimmeta_xml_element(
                         anc, "ancillary-var", self.ancillary_variable_dims
                     )
                 )

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3429,20 +3429,22 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             cube_xml_element.appendChild(attributes_element)
 
+        def dimensionedCubeElement(element, typename, dimscall):
+            xml_element = doc.createElement(typename)
+            dims = list(dimscall(element))
+            if dims:
+                xml_element.setAttribute("datadims", repr(dims))
+            xml_element.appendChild(element.xml_element(doc))
+            return xml_element
+
         coords_xml_element = doc.createElement("coords")
         for coord in sorted(self.coords(), key=lambda coord: coord.name()):
             # make a "cube coordinate" element which holds the dimensions (if
             # appropriate) which itself will have a sub-element of the
             # coordinate instance itself.
-            cube_coord_xml_element = doc.createElement("coord")
-            coords_xml_element.appendChild(cube_coord_xml_element)
-
-            dims = list(self.coord_dims(coord))
-            if dims:
-                cube_coord_xml_element.setAttribute("datadims", repr(dims))
-
-            coord_xml_element = coord.xml_element(doc)
-            cube_coord_xml_element.appendChild(coord_xml_element)
+            coords_xml_element.appendChild(
+                dimensionedCubeElement(coord, "coord", self.coord_dims)
+            )
         cube_xml_element.appendChild(coords_xml_element)
 
         # cell methods (no sorting!)
@@ -3458,7 +3460,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # This one is an optional subelement.
             cms_xml_element = doc.createElement("cellMeasures")
             for cm in cell_measures:
-                cms_xml_element.appendChild(cm.xml_element(doc))
+                cms_xml_element.appendChild(
+                    dimensionedCubeElement(
+                        cm, "cell-measure", self.cell_measure_dims
+                    )
+                )
             cube_xml_element.appendChild(cms_xml_element)
 
         # ancillary variables
@@ -3467,8 +3473,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             # This one is an optional subelement.
             ancs_xml_element = doc.createElement("ancillaryVariables")
             for anc in ancils:
-                ancs_xml_element.appendChild(anc.xml_element(doc))
-            cube_xml_element.appendChild(cms_xml_element)
+                ancs_xml_element.appendChild(
+                    dimensionedCubeElement(
+                        anc, "ancillary-var", self.ancillary_variable_dims
+                    )
+                )
+            cube_xml_element.appendChild(ancs_xml_element)
 
         # data
         data_xml_element = doc.createElement("data")

--- a/lib/iris/tests/results/unit/cube/Cube/xml/ancils.cml
+++ b/lib/iris/tests/results/unit/cube/Cube/xml/ancils.cml
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int32" long_name="thingness" units="1">
+    <coords>
+      <coord datadims="[0, 1]">
+        <auxCoord bounds="[[[0, 5],
+		 [5, 10],
+		 [10, 15],
+		 [15, 20]],
+
+		[[5, 15],
+		 [15, 20],
+		 [20, 35],
+		 [35, 50]],
+
+		[[10, 20],
+		 [20, 25],
+		 [25, 40],
+		 [40, 60]]]" id="434cbbd8" long_name="bar" points="[[2.5, 7.5, 12.5, 17.5],
+		[10.0, 17.5, 27.5, 42.5],
+		[15.0, 22.5, 32.5, 50.0]]" shape="(3, 4)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0, 1]">
+        <auxCoord bounds="[[[-15, 0],
+		 [0, 15],
+		 [15, 30],
+		 [30, 45]],
+
+		[[-25, 0],
+		 [0, 8],
+		 [8, 45],
+		 [45, 50]],
+
+		[[-5, 10],
+		 [10, 18],
+		 [18, 55],
+		 [18, 70]]]" id="b0d35dcf" long_name="foo" points="[[-7.5, 7.5, 22.5, 37.5],
+		[-12.5, 4.0, 26.5, 47.5],
+		[2.5, 14.0, 36.5, 44.0]]" shape="(3, 4)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <ancillaryVariables>
+      <ancillary-var datadims="[0, 1]">
+        <ancillaryVariable data="[[0.0, 0.0, 0.0, 0.0],
+		[0.0, 0.0, 0.0, 0.0],
+		[0.0, 0.0, 0.0, 0.0]]" id="a80ae209" long_name="xy" shape="(3, 4)" units="Unit('1')" value_type="float64" var_name="vxy"/>
+      </ancillary-var>
+    </ancillaryVariables>
+    <data checksum="0xb6520b51" dtype="int32" shape="(3, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/unit/cube/Cube/xml/cell_measures.cml
+++ b/lib/iris/tests/results/unit/cube/Cube/xml/cell_measures.cml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int32" long_name="thingness" units="1">
+    <coords>
+      <coord datadims="[1, 2]">
+        <auxCoord bounds="[[[0, 5],
+		 [5, 10],
+		 [10, 15],
+		 [15, 20]],
+
+		[[5, 15],
+		 [15, 20],
+		 [20, 35],
+		 [35, 50]],
+
+		[[10, 20],
+		 [20, 25],
+		 [25, 40],
+		 [40, 60]]]" id="434cbbd8" long_name="bar" points="[[2.5, 7.5, 12.5, 17.5],
+		[10.0, 17.5, 27.5, 42.5],
+		[15.0, 22.5, 32.5, 50.0]]" shape="(3, 4)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[1, 2]">
+        <auxCoord bounds="[[[-15, 0],
+		 [0, 15],
+		 [15, 30],
+		 [30, 45]],
+
+		[[-25, 0],
+		 [0, 8],
+		 [8, 45],
+		 [45, 50]],
+
+		[[-5, 10],
+		 [10, 18],
+		 [18, 55],
+		 [18, 70]]]" id="b0d35dcf" long_name="foo" points="[[-7.5, 7.5, 22.5, 37.5],
+		[-12.5, 4.0, 26.5, 47.5],
+		[2.5, 14.0, 36.5, 44.0]]" shape="(3, 4)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="10b8e1fc" long_name="wibble" points="[10.0, 30.0]" shape="(2,)" units="Unit('1')" value_type="float32"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <cellMeasures>
+      <cell-measure datadims="[0, 1, 2]">
+        <cellMeasure data="[[[0.0, 0.0, 0.0, 0.0],
+		 [0.0, 0.0, 0.0, 0.0],
+		 [0.0, 0.0, 0.0, 0.0]],
+
+		[[0.0, 0.0, 0.0, 0.0],
+		 [0.0, 0.0, 0.0, 0.0],
+		 [0.0, 0.0, 0.0, 0.0]]]" id="9ff02736" long_name="madeup" measure="volume" shape="(2, 3, 4)" units="Unit('m3')" value_type="float64"/>
+      </cell-measure>
+      <cell-measure datadims="[1, 2]">
+        <cellMeasure data="[[0.0, 0.0, 0.0, 0.0],
+		[0.0, 0.0, 0.0, 0.0],
+		[0.0, 0.0, 0.0, 0.0]]" id="e719d8ae" measure="area" shape="(3, 4)" units="Unit('1')" value_type="float64"/>
+      </cell-measure>
+    </cellMeasures>
+    <data checksum="0x1abadbcb" dtype="int32" shape="(2, 3, 4)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -273,6 +273,29 @@ class Test_xml(tests.IrisTest):
         cube = Cube(np.arange(3))
         self.assertIn("byteorder", cube.xml(byteorder=True))
 
+    def test_cell_measures(self):
+        cube = stock.simple_3d_w_multidim_coords()
+        cm_a = iris.coords.CellMeasure(
+            np.zeros(cube.shape[-2:]), measure="area"
+        )
+        cube.add_cell_measure(cm_a, (1, 2))
+        cm_v = iris.coords.CellMeasure(
+            np.zeros(cube.shape),
+            measure="volume",
+            long_name="madeup",
+            units="m3",
+        )
+        cube.add_cell_measure(cm_v, (0, 1, 2))
+        self.assertCML(cube)
+
+    def test_ancils(self):
+        cube = stock.simple_2d_w_multidim_coords()
+        av = iris.coords.AncillaryVariable(
+            np.zeros(cube.shape), long_name="xy", var_name="vxy", units="1"
+        )
+        cube.add_ancillary_variable(av, (0, 1))
+        self.assertCML(cube)
+
 
 class Test_collapsed__lazy(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
Add cell-measures and ancillary-variables sections to cube xml reprs.

Pretty simple, but should do the job.