### PR TITLE
PI-3483 (if not merging 3478) Safe arithmetic

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -2316,17 +2316,13 @@ class _Groupby:
 
 def clear_phenomenon_identity(cube):
     """
-    Helper function to clear the standard_name, attributes, cell_methods,
-    cell_measures and ancillary_variables of a cube.
+    Helper function to clear the standard_name, attributes and
+    cell_methods of a cube.
 
     """
     cube.rename(None)
     cube.attributes.clear()
     cube.cell_methods = tuple()
-    for cm in cube.cell_measures():
-        cube.remove_cell_measure(cm)
-    for av in cube.ancillary_variables():
-        cube.remove_ancillary_variable(av)
 
 
 ###############################################################################

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -2316,7 +2316,7 @@ class _Groupby:
 
 def clear_phenomenon_identity(cube):
     """
-    Helper function to clear the standard_name, attributes and
+    Helper function to clear the standard_name, attributes, and
     cell_methods of a cube.
 
     """

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -2316,13 +2316,17 @@ class _Groupby:
 
 def clear_phenomenon_identity(cube):
     """
-    Helper function to clear the standard_name, attributes, and
-    cell_methods of a cube.
+    Helper function to clear the standard_name, attributes, cell_methods,
+    cell_measures and ancillary_variables of a cube.
 
     """
     cube.rename(None)
     cube.attributes.clear()
     cube.cell_methods = tuple()
+    for cm in cube.cell_measures():
+        cube.remove_cell_measure(cm)
+    for av in cube.ancillary_variables():
+        cube.remove_ancillary_variable(av)
 
 
 ###############################################################################

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -945,9 +945,9 @@ def _math_op_common(
 
     iris.analysis.clear_phenomenon_identity(new_cube)
     for cm in cube.cell_measures():
-        cube.remove_cell_measure(cm)
+        new_cube.remove_cell_measure(cm)
     for av in cube.ancillary_variables():
-        cube.remove_ancillary_variable(av)
+        new_cube.remove_ancillary_variable(av)
     new_cube.units = new_unit
     return new_cube
 

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -944,6 +944,10 @@ def _math_op_common(
         new_cube.data = ma.masked_array(0, 1, dtype=new_dtype)
 
     iris.analysis.clear_phenomenon_identity(new_cube)
+    for cm in cube.cell_measures():
+        cube.remove_cell_measure(cm)
+    for av in cube.ancillary_variables():
+        cube.remove_ancillary_variable(av)
     new_cube.units = new_unit
     return new_cube
 

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy import ma
 
 from iris.analysis import MEAN
-from iris.coords import DimCoord
+from iris.coords import DimCoord, CellMeasure, AncillaryVariable
 from iris.cube import Cube
 import iris.tests as tests
 import iris.tests.stock as stock
@@ -212,3 +212,36 @@ class CubeArithmeticMaskedConstantTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(ma.masked_array(0, 1), res.data)
         self.assertEqual(dtype, res.dtype)
         self.assertIsNot(res, cube)
+
+
+class CubeArithmeticAncillaryHandlingTestMixin(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def cube_func(self):
+        # Define an iris arithmetic function to be called
+        # I.E. 'iris.analysis.maths.xx'.
+        pass
+
+    def test_cell_measure_removal(self):
+        cube1 = Cube([0])
+        cm = CellMeasure([0], long_name="cm")
+        cube1.add_cell_measure(cm)
+        cube2 = Cube([0])
+        res1 = cube1 + cube2
+        res2 = cube2 + cube1
+        res3 = cube1 + cube1
+        self.assertEqual(res1.cell_measures(), [])
+        self.assertEqual(res2.cell_measures(), [])
+        self.assertEqual(res3.cell_measures(), [])
+
+    def test_ancillary_removal(self):
+        cube1 = Cube([0])
+        av = AncillaryVariable([0], long_name="av")
+        cube1.add_ancillary_variable(av)
+        cube2 = Cube([0])
+        res1 = cube1 + cube2
+        res2 = cube2 + cube1
+        res3 = cube1 + cube1
+        self.assertEqual(res1.ancillary_variables(), [])
+        self.assertEqual(res2.ancillary_variables(), [])
+        self.assertEqual(res3.ancillary_variables(), [])

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -72,7 +72,7 @@ class TestMaskedConstant(
 
 
 @tests.iristest_timing_decorator
-class TestMaskedConstant(
+class TestAncillaryHandling(
     tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
 ):
     @property

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -17,6 +17,7 @@ from iris.tests.unit.analysis.maths import (
     CubeArithmeticCoordsTest,
     CubeArithmeticMaskedConstantTestMixin,
     CubeArithmeticMaskingTestMixin,
+    CubeArithmeticAncillaryHandlingTestMixin,
 )
 
 
@@ -65,6 +66,15 @@ class TestMaskedConstant(
     def data_op(self):
         return operator.add
 
+    @property
+    def cube_func(self):
+        return add
+
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(
+    tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
+):
     @property
     def cube_func(self):
         return add

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -18,6 +18,7 @@ from iris.tests.unit.analysis.maths import (
     CubeArithmeticBroadcastingTestMixin,
     CubeArithmeticMaskingTestMixin,
     CubeArithmeticCoordsTest,
+    CubeArithmeticAncillaryHandlingTestMixin,
 )
 
 
@@ -84,6 +85,15 @@ class TestCoordMatch(CubeArithmeticCoordsTest):
         cube1, cube2 = self.SetUpReversed()
         with self.assertRaises(ValueError):
             divide(cube1, cube2)
+
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(
+    tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
+):
+    @property
+    def cube_func(self):
+        return divide
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -88,7 +88,7 @@ class TestCoordMatch(CubeArithmeticCoordsTest):
 
 
 @tests.iristest_timing_decorator
-class TestMaskedConstant(
+class TestAncillaryHandling(
     tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
 ):
     @property

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -72,7 +72,7 @@ class TestMaskedConstant(
 
 
 @tests.iristest_timing_decorator
-class TestMaskedConstant(
+class TestAncillaryHandling(
     tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
 ):
     @property

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -17,6 +17,7 @@ from iris.tests.unit.analysis.maths import (
     CubeArithmeticCoordsTest,
     CubeArithmeticMaskedConstantTestMixin,
     CubeArithmeticMaskingTestMixin,
+    CubeArithmeticAncillaryHandlingTestMixin,
 )
 
 
@@ -65,6 +66,15 @@ class TestMaskedConstant(
     def data_op(self):
         return operator.mul
 
+    @property
+    def cube_func(self):
+        return multiply
+
+
+@tests.iristest_timing_decorator
+class TestMaskedConstant(
+    tests.IrisTest_nometa, CubeArithmeticAncillaryHandlingTestMixin
+):
     @property
     def cube_func(self):
         return multiply


### PR DESCRIPTION
Align arithmetic with previous behaviour wrt CellMeasure

In the absence of changes to arithmetic due with #3478, cube arithmetic is given the "safe" behaviour of always discarding cell measures and ancillary variables. This aligns with the previous behaviour of arithmetic discarding cell measures (which was previously due to copy discarding cell measures). This solves one of the remaining issues in #3483 and allows loading of ancillary variables to be merged in safely if the canges made to cube arithmetic don't make it into 3.0.