### PR TITLE
PI-2472: Fix issue related to comparison / equality in regridding code

### DIFF
--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -881,9 +881,9 @@ class RectilinearRegridder:
         def copy_coords(src_coords, add_method):
             for coord in src_coords:
                 dims = src.coord_dims(coord)
-                if coord is src_x_coord:
+                if coord == src_x_coord:
                     coord = grid_x_coord
-                elif coord is src_y_coord:
+                elif coord == src_y_coord:
                     coord = grid_y_coord
                 elif x_dim in dims or y_dim in dims:
                     continue

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -137,19 +137,26 @@ class Test(tests.IrisTest):
             src2.coord(name).guess_bounds()
 
         target = self.cube(np.linspace(20, 32, 2), np.linspace(10, 22, 2))
+        # Ensure the bounds of the target cover the same range as the
+        # source.
+        target_lat_bounds = np.column_stack(
+            (
+                src1.coord("latitude").bounds[[0, 1], [0, 1]],
+                src1.coord("latitude").bounds[[2, 3], [0, 1]],
+            )
+        )
+        target.coord("latitude").bounds = target_lat_bounds
+        target_lon_bounds = np.column_stack(
+            (
+                src1.coord("longitude").bounds[[0, 1], [0, 1]],
+                src1.coord("longitude").bounds[[2, 3], [0, 1]],
+            )
+        )
+        target.coord("longitude").bounds = target_lon_bounds
         for name in coord_names:
             # Remove coords system and units so it is no longer spherical.
             target.coord(name).coord_system = None
             target.coord(name).units = None
-            # Ensure the bounds of the target cover the same range as the
-            # source.
-            target_bounds = np.column_stack(
-                (
-                    src1.coord(name).bounds[[0, 1], [0, 1]],
-                    src1.coord(name).bounds[[2, 3], [0, 1]],
-                )
-            )
-            target.coord(name).bounds = target_bounds
 
         regridder = AreaWeightedRegridder(src1, target)
         result1 = regridder(src1)
@@ -162,6 +169,9 @@ class Test(tests.IrisTest):
                 [np.mean(src1.data[2:4, 0:2]), np.mean(src1.data[2:4, 2:4])],
             ]
         )
+        reference1.coord("latitude").bounds = target_lat_bounds
+        reference1.coord("longitude").bounds = target_lon_bounds
+
         reference2 = self.cube(np.linspace(20, 32, 2), np.linspace(10, 22, 2))
         reference2.data = np.array(
             [
@@ -169,6 +179,8 @@ class Test(tests.IrisTest):
                 [np.mean(src2.data[2:4, 0:2]), np.mean(src2.data[2:4, 2:4])],
             ]
         )
+        reference2.coord("latitude").bounds = target_lat_bounds
+        reference2.coord("longitude").bounds = target_lon_bounds
 
         for name in coord_names:
             # Remove coords system and units so it is no longer spherical.
@@ -176,8 +188,6 @@ class Test(tests.IrisTest):
             reference1.coord(name).units = None
             reference2.coord(name).coord_system = None
             reference2.coord(name).units = None
-            reference1.coord(name).bounds = target_bounds
-            reference2.coord(name).bounds = target_bounds
 
         # Compare the cubes rather than just the data.
         self.assertEqual(result1, reference1)


### PR DESCRIPTION
This pull request fixes the issue originally reported via [#3606](https://github.com/SciTools/iris/pull/3606#issuecomment-567450435).

When regridding a source cube that was used to create the regridder, the comparisons performed in `copy_coords` using `is` are True. However, when regridding a source cube that was not used to create the regridder, the comparisons are False, leading to cubes that have `latitude` and `longitude` coordinates without names (see [test failure for 6f2dcda](https://travis-ci.org/SciTools/iris/builds/628723295)).

The solution is the one proposed in [#3606](https://github.com/SciTools/iris/pull/3606#issuecomment-567450435).