### PR TITLE
Allow some 'key=None' args in Geostationary creation.

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2020-Jan-06_relax_geostationary.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2020-Jan-06_relax_geostationary.txt
@@ -1,0 +1,6 @@
+* :class:`iris.coord_systems.Geostationary` can now accept creation arguments of
+  `false_easting=None` or `false_northing=None`, equivalent to values of 0.
+  Previously these kwargs could be omitted, but could not be set to `None`.
+  This also enables loading netcdf data on a Geostationary grid, where either of these
+  keys is not present as a grid-mapping variable property : Previously, loading any
+  such data caused an exception.

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -714,8 +714,8 @@ class Geostationary(CoordSystem):
         longitude_of_projection_origin,
         perspective_point_height,
         sweep_angle_axis,
-        false_easting=0,
-        false_northing=0,
+        false_easting=None,
+        false_northing=None,
         ellipsoid=None,
     ):
 
@@ -768,9 +768,13 @@ class Geostationary(CoordSystem):
         self.perspective_point_height = float(perspective_point_height)
 
         #: X offset from planar origin in metres.
+        if false_easting is None:
+            false_easting = 0
         self.false_easting = float(false_easting)
 
         #: Y offset from planar origin in metres.
+        if false_northing is None:
+            false_northing = 0
         self.false_northing = float(false_northing)
 
         #: The axis along which the satellite instrument sweeps - 'x' or 'y'.


### PR DESCRIPTION
Closes #3626 

Targetting master for now, although this *may* be redirected to Iris 2.4 if we choose to go down that route.