### PR TITLE
Pin pillow to make graphics tests work again.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,6 +3,7 @@
 
 black==19.10b0  #conda: black=19.10b0
 filelock
+pillow<7
 imagehash>=4.0
 nose
 pre-commit


### PR DESCRIPTION
Discovered in course of #3628 that graphics tests have broken.

Explained here : https://github.com/SciTools/test-iris-imagehash/issues/28