### PR TITLE
Fix conflicts in netcdf var_name

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1481,6 +1481,7 @@ class Saver:
                     while (
                         dim_name in self._existing_dim
                         or dim_name in self._name_coord_map.names
+                        or dim_name in self._dataset.variables
                     ):
                         dim_name = self._increment_name(dim_name)
 
@@ -1505,6 +1506,7 @@ class Saver:
                             dim_name in self._existing_dim
                             and self._existing_dim[dim_name] != cube.shape[dim]
                             or dim_name in self._name_coord_map.names
+                            or dim_name in self._dataset.variables
                         ):
                             dim_name = self._increment_name(dim_name)
                         # Update dictionary with new entry

--- a/lib/iris/tests/results/netcdf/netcdf_save_conf_name_2.cdl
+++ b/lib/iris/tests/results/netcdf/netcdf_save_conf_name_2.cdl
@@ -1,0 +1,16 @@
+dimensions:
+	dim0 = 10 ;
+	temp_0 = 10 ;
+variables:
+	double temp(dim0) ;
+		temp:standard_name = "air_temperature" ;
+		temp:units = "K" ;
+	double temp3(temp_0) ;
+		temp3:long_name = "air_temperature" ;
+		temp3:units = "K" ;
+	int64 temp_0(temp_0) ;
+		temp_0:units = "1" ;
+
+// global attributes:
+		:Conventions = "CF-1.7" ;
+}

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -822,6 +822,20 @@ class TestNetCDFSave(tests.IrisTest):
             # Check the netCDF file against CDL expected output.
             self.assertCDL(file_out, ("netcdf", "netcdf_save_conf_name.cdl"))
 
+    def test_netcdf_save_conflicting_names_cube_to_coord(self):
+        # Test saving CF-netCDF with a dimension name corresponding to
+        # an existing variable name (conflict).
+        self.cube6.add_dim_coord(
+            iris.coords.DimCoord(np.arange(10), var_name="temp"), 0
+        )
+
+        cubes = [self.cube4, self.cube6]
+        with self.temp_filename(suffix=".nc") as file_out:
+            iris.save(cubes, file_out)
+
+            # Check the netCDF file against CDL expected output.
+            self.assertCDL(file_out, ("netcdf", "netcdf_save_conf_name_2.cdl"))
+
     @tests.skip_data
     def test_trajectory(self):
         file_in = tests.get_data_path(("PP", "aPPglob1", "global.pp"))


### PR DESCRIPTION
There was a bug when two cubes were being saved where the first cube shared a var_name with a the var_name of a coordinate on the second cube. In such a case, Iris was failing to save. This can be solved by appropriately incrementing the var_name to avoid conflicts in such cases.