### PR TITLE
PI-2370: Improved text for whatsnew on cached area-weights

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Dec-20_cache_area_weights.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Dec-20_cache_area_weights.txt
@@ -1,2 +1,5 @@
-* The area weights used when performing area weighted regridding are now
-  cached. 
+* The area weights used when performing area weighted regridding with :class:`iris.analysis.AreaWeighted`
+  are now cached.
+  This allows a significant speedup when regridding multiple similar cubes, by repeatedly using
+  a `'regridder' object <../iris/iris/analysis.html?highlight=regridder#iris.analysis.AreaWeighted.regridder>`_
+  which you created first.


### PR DESCRIPTION
As re-written for [iris 2.4](#3638), in [this commit](https://github.com/SciTools/iris/pull/3638/commits/8849a7556192c1512efa1c13f66efbb40432bff6)