### PR TITLE
Removed non-int arguments for linspace num parameter

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -108,8 +108,9 @@ def _resampled_coord(coord, samplefactor):
     delta = 0.00001 * np.sign(upper - lower) * abs(bounds[0, 1] - bounds[0, 0])
     lower = lower + delta
     upper = upper - delta
+    samples = int(len(bounds) * samplefactor)
     new_points, step = np.linspace(
-        lower, upper, len(bounds) * samplefactor, endpoint=False, retstep=True
+        lower, upper, samples, endpoint=False, retstep=True
     )
     new_points += step * 0.5
     new_coord = coord.copy(points=new_points)

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -81,7 +81,7 @@ class TestAll(tests.IrisTest):
     @tests.skip_data
     def test_bad_resolution_non_numeric(self):
         cube = low_res_4d()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             project(cube, ROBINSON, nx=200, ny="abc")
 
     @tests.skip_data


### PR DESCRIPTION
Inputting non-int `num` arguments for [numpy.linspace](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linspace.html) has been [deprecated since Numpy v1.12](https://github.com/numpy/numpy/pull/7328).

Support has now been [entirely removed](https://github.com/numpy/numpy/pull/14620), and a few of Iris' tests were deliberately leaning on Numpy's attempted `int()` conversion. These tests have been fixed.