### PR TITLE
(v2.4) Removed non-int arguments for linspace num parameter

### DIFF
--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -115,8 +115,9 @@ def _resampled_coord(coord, samplefactor):
     delta = 0.00001 * np.sign(upper - lower) * abs(bounds[0, 1] - bounds[0, 0])
     lower = lower + delta
     upper = upper - delta
+    samples = int(len(bounds) * samplefactor)
     new_points, step = np.linspace(lower, upper,
-                                   len(bounds) * samplefactor,
+                                   samples,
                                    endpoint=False, retstep=True)
     new_points += step * 0.5
     new_coord = coord.copy(points=new_points)

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2020, Met Office
 #
 # This file is part of Iris.
 #
@@ -79,7 +79,11 @@ class TestAll(tests.IrisTest):
     @tests.skip_data
     def test_bad_resolution_non_numeric(self):
         cube = low_res_4d()
-        with self.assertRaises(ValueError):
+        if np.__version__ < '1.18':
+            target_error = ValueError
+        else:
+            target_error = TypeError
+        with self.assertRaises(target_error):
             project(cube, ROBINSON, nx=200, ny='abc')
 
     @tests.skip_data


### PR DESCRIPTION
Inputting non-int `num` arguments for [numpy.linspace](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linspace.html) has been [deprecated since Numpy v1.12](https://github.com/numpy/numpy/pull/7328).

Support has now been [entirely removed](https://github.com/numpy/numpy/pull/14620), and a few of Iris' tests were deliberately leaning on Numpy's attempted `int()` conversion. These tests have been fixed.