### PR TITLE
Fixed asv project name to 'scitools-iris'.

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -2,7 +2,7 @@
 // details on what can be included in this file.
 {
     "version": 1,
-    "project": "iris",
+    "project": "scitools-iris",
     "project_url": "https://github.com/SciTools/iris",
     "repo": ".",
     "environment_type": "conda",


### PR DESCRIPTION
Without this, airspeed velocity is unable to pip uninstall iris after benchmarking a commit, resulting in the same commit being benchmarked repeatedly under the names of previous commits.

Appropriate for merging once we are satisfied that the performance issues related to Dask v2.0 are addressed (e.g. #3659).