### PR TITLE
Remove obsolete test.

### DIFF
--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -76,19 +76,6 @@ class SystemInitialTest(tests.IrisTest):
                 new_cube, ("system", "supported_filetype_%s.cml" % filetype)
             )
 
-    @tests.skip_grib
-    def system_test_grib_patch(self):
-        import gribapi
-
-        gm = gribapi.grib_new_from_samples("GRIB2")
-        _ = gribapi.grib_get_double(gm, "missingValue")
-
-        new_missing_value = 123456.0
-        gribapi.grib_set_double(gm, "missingValue", new_missing_value)
-        new_result = gribapi.grib_get_double(gm, "missingValue")
-
-        self.assertEqual(new_result, new_missing_value)
-
     def system_test_imports_general(self):
         if tests.MPL_AVAILABLE:
             import matplotlib  # noqa


### PR DESCRIPTION
The patch which this tests is long since gone.

From a ticket on our very old pre-github FCM project ...
```
From: Daniel Varela Santoalla [mailto:dvarela@ecmwf.int] 
Sent: 02 March 2012 17:40
To: Blay, Byron; Green, Thomas
Cc: Hodkinson, Mark; software support; advisory
Subject: Re: GRIB API bug (ref SUP-87)

Hi Byron and Thomas

This bug in the python interface was fixed some time ago and will be included
in the next release, 1.9.14, which will be released very soon. However, if you
are in an urgent need of a solution you could apply the following patch.


Index: python/grib_interface.c
===================================================================
diff -u -N -r51092 -r60810
--- python/grib_interface.c	(.../grib_interface.c)	(revision 51092)
+++ python/grib_interface.c	(.../grib_interface.c)	(revision 60810)
@@ -1562,7 +1562,7 @@
 
   if(!h) return GRIB_INVALID_GRIB;
 
-  return grib_get_double(h, key, val);
+  return grib_set_double(h, key, *val);
 }
 
 int grib_c_get_real8_element(int* gid, char* key,int* index, double* val){




Best regards
Daniel Varela
ECMWF Software support
```