### PR TITLE
PI-3677: Remove regex from standard names check

### DIFF
--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -46,7 +46,6 @@ def get_valid_standard_name(name):
     # modifier, separated by one or more blank spaces
 
     if name is not None:
-        name_is_valid = False
         # Supported standard name modifiers. Ref: [CF] Appendix C.
         valid_std_name_modifiers = [
             "detection_minimum",
@@ -56,17 +55,22 @@ def get_valid_standard_name(name):
         ]
 
         name_groups = name.split(maxsplit=1)
-        std_name = name_groups[0]
-        name_is_valid = std_name in iris.std_names.STD_NAMES
-        try:
-            std_name_modifier = name_groups[1]
-        except IndexError:
-            pass  # No modifier
-        else:
-            name_is_valid &= (std_name_modifier in valid_std_name_modifiers)
+        if name_groups:
+            std_name = name_groups[0]
+            name_is_valid = std_name in iris.std_names.STD_NAMES
+            try:
+                std_name_modifier = name_groups[1]
+            except IndexError:
+                pass  # No modifier
+            else:
+                name_is_valid &= (
+                    std_name_modifier in valid_std_name_modifiers)
 
-        if not name_is_valid:
-            raise ValueError("{!r} is not a valid standard_name".format(name))
+            if not name_is_valid:
+                raise ValueError(
+                    "{!r} is not a valid standard_name".format(name))
+        else:
+            name_is_valid = False
 
     return name
 

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -55,18 +55,17 @@ def get_valid_standard_name(name):
             "status_flag",
         ]
 
-        valid_name_pattern = re.compile(r"""^([a-zA-Z_]+)( *)([a-zA-Z_]*)$""")
-        name_groups = valid_name_pattern.match(name)
+        name_groups = name.split(maxsplit=1)
+        std_name = name_groups[0]
+        name_is_valid = std_name in iris.std_names.STD_NAMES
+        try:
+            std_name_modifier = name_groups[1]
+        except IndexError:
+            pass  # No modifier
+        else:
+            name_is_valid &= (std_name_modifier in valid_std_name_modifiers)
 
-        if name_groups:
-            std_name, whitespace, std_name_modifier = name_groups.groups()
-            if (std_name in iris.std_names.STD_NAMES) and (
-                bool(whitespace)
-                == (std_name_modifier in valid_std_name_modifiers)
-            ):
-                name_is_valid = True
-
-        if name_is_valid is False:
+        if not name_is_valid:
             raise ValueError("{!r} is not a valid standard_name".format(name))
 
     return name

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -69,8 +69,6 @@ def get_valid_standard_name(name):
             if not name_is_valid:
                 raise ValueError(
                     "{!r} is not a valid standard_name".format(name))
-        else:
-            name_is_valid = False
 
     return name
 

--- a/lib/iris/_cube_coord_common.py
+++ b/lib/iris/_cube_coord_common.py
@@ -63,12 +63,12 @@ def get_valid_standard_name(name):
             except IndexError:
                 pass  # No modifier
             else:
-                name_is_valid &= (
-                    std_name_modifier in valid_std_name_modifiers)
+                name_is_valid &= std_name_modifier in valid_std_name_modifiers
 
             if not name_is_valid:
                 raise ValueError(
-                    "{!r} is not a valid standard_name".format(name))
+                    "{!r} is not a valid standard_name".format(name)
+                )
 
     return name
 

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -19,6 +19,22 @@ class Test(tests.IrisTest):
     def setUp(self):
         self.emsg = "'{}' is not a valid standard_name"
 
+    def test_none_is_valid(self):
+        name = None
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_empty_is_not_valid(self):
+        name = ''
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_only_whitespace_is_not_valid(self):
+        name = '       '
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_none_is_valid(self):
+        name = None
+        self.assertEqual(get_valid_standard_name(name), name)
+
     def test_valid_standard_name(self):
         name = "air_temperature"
         self.assertEqual(get_valid_standard_name(name), name)

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -23,6 +23,14 @@ class Test(tests.IrisTest):
         name = "air_temperature"
         self.assertEqual(get_valid_standard_name(name), name)
 
+    def test_standard_name_alias(self):
+        name = "atmosphere_optical_thickness_due_to_pm1_ambient_aerosol"
+        self.assertEqual(get_valid_standard_name(name), name)
+
+    def test_valid_standard_name(self):
+        name = "air_temperature"
+        self.assertEqual(get_valid_standard_name(name), name)
+
     def test_invalid_standard_name(self):
         name = "not_a_standard_name"
         with self.assertRaisesRegex(ValueError, self.emsg.format(name)):

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -19,15 +19,15 @@ class Test(tests.IrisTest):
     def setUp(self):
         self.emsg = "'{}' is not a valid standard_name"
 
-    def test_none_is_valid(self):
+    def test_pass_thru_none(self):
         name = None
         self.assertEqual(get_valid_standard_name(name), name)
 
-    def test_empty_is_not_valid(self):
+    def test_pass_thru_empty(self):
         name = ''
         self.assertEqual(get_valid_standard_name(name), name)
 
-    def test_only_whitespace_is_not_valid(self):
+    def test_pass_thru_whitespace(self):
         name = '       '
         self.assertEqual(get_valid_standard_name(name), name)
 

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -27,10 +27,6 @@ class Test(tests.IrisTest):
         name = "atmosphere_optical_thickness_due_to_pm1_ambient_aerosol"
         self.assertEqual(get_valid_standard_name(name), name)
 
-    def test_valid_standard_name(self):
-        name = "air_temperature"
-        self.assertEqual(get_valid_standard_name(name), name)
-
     def test_invalid_standard_name(self):
         name = "not_a_standard_name"
         with self.assertRaisesRegex(ValueError, self.emsg.format(name)):

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -31,10 +31,6 @@ class Test(tests.IrisTest):
         name = '       '
         self.assertEqual(get_valid_standard_name(name), name)
 
-    def test_none_is_valid(self):
-        name = None
-        self.assertEqual(get_valid_standard_name(name), name)
-
     def test_valid_standard_name(self):
         name = "air_temperature"
         self.assertEqual(get_valid_standard_name(name), name)

--- a/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
+++ b/lib/iris/tests/unit/cube_coord_common/test_get_valid_standard_name.py
@@ -24,11 +24,11 @@ class Test(tests.IrisTest):
         self.assertEqual(get_valid_standard_name(name), name)
 
     def test_pass_thru_empty(self):
-        name = ''
+        name = ""
         self.assertEqual(get_valid_standard_name(name), name)
 
     def test_pass_thru_whitespace(self):
-        name = '       '
+        name = "       "
         self.assertEqual(get_valid_standard_name(name), name)
 
     def test_valid_standard_name(self):


### PR DESCRIPTION
The regex in `get_valid_standard_name` was an overkill as the function was already checking the values against a list that contained all the possible values.

This pull request replaces it with a simple split and fixes the bug that was making iris not to accept `atmosphere_optical_thickness_due_to_pm1_ambient_aerosol` as a valid standard_name

Fixes #3677

