### PR TITLE
Populate `DimCoord.__init__` docstring

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1453,8 +1453,8 @@ class Coord(_DimensionalMetadata):
         Args:
 
         * points:
-            The values (or value in the case of a scalar coordinate) of the
-            coordinate for each cell.
+            The values (or value in the case of a scalar coordinate) for each
+            cell of the coordinate.
 
         Kwargs:
 
@@ -2484,6 +2484,54 @@ class DimCoord(Coord):
         """
         Create a 1D, numeric, and strictly monotonic :class:`Coord` with
         read-only points and bounds.
+
+        Args:
+
+        * points:
+            1D numpy array-like of values (or single value in the case of a
+            scalar coordinate) for each cell of the coordinate.  The values
+            must be strictly monotonic and masked values are not allowed.
+
+        Kwargs:
+
+        * standard_name:
+            CF standard name of the coordinate.
+        * long_name:
+            Descriptive name of the coordinate.
+        * var_name:
+            The netCDF variable name for the coordinate.
+        * units
+            The :class:`~cf_units.Unit` of the coordinate's values.
+            Can be a string, which will be converted to a Unit object.
+        * bounds
+            An array of values describing the bounds of each cell. Given n
+            bounds and m cells, the shape of the bounds array should be
+            (m, n). For each bound, the values must be strictly monotonic along
+            the cells, and the direction of monotonicity must be consistent
+            across the bounds.  For example, a DimCoord with 100 points and two
+            bounds per cell would have a bounds array of shape (100, 2), and
+            the slices ``bounds[:, 0]`` and ``bounds[:, 1]`` would be monotonic
+            in the same direction.  Masked values are not allowed.
+            Note if the data is a climatology, `climatological`
+            should be set.
+        * attributes
+            A dictionary containing other cf and user-defined attributes.
+        * coord_system
+            A :class:`~iris.coord_systems.CoordSystem` representing the
+            coordinate system of the coordinate,
+            e.g. a :class:`~iris.coord_systems.GeogCS` for a longitude Coord.
+        * circular (bool)
+            For units with a modulus (e.g. degrees), do the points wrap around
+            the full circle?
+        * climatological (bool):
+            When True: the coordinate is a NetCDF climatological time axis.
+            When True: saving in NetCDF will give the coordinate variable a
+            'climatology' attribute and will create a boundary variable called
+            '<coordinate-name>_climatology' in place of a standard bounds
+            attribute and bounds variable.
+            Will set to True when a climatological time axis is loaded
+            from NetCDF.
+            Always False if no bounds exist.
 
         """
         super().__init__(


### PR DESCRIPTION
Adds some detail about the args and kwargs to the `DimCoord.__init__` docstring.  I noticed this omission this morning while helping an inexperienced user who needs to create a `DimCoord` from scratch.

I've given some thought to the descriptions for `points`, `bounds` and `circular`, but everything else is a direct copy/paste from the equivalent `Coord` docstring.  I also tweaked the description for `points` in the `Coord` version, as this way scans better in my head.

A couple of things I'm not sure of:

* I've used "numpy array-like" in the new points description.  Is this a concept that we can assume users are familiar with, or is there a better way of saying it?  If this is the best way, should I also use it for bounds, and for points and bounds in the `Coord.__init__` docstring?
* Really not sure I've understood the `circular` attribute, so what I've written could be nonsense!

Closes #3520 