### PR TITLE
Update add_weekday for latest cftime

### DIFF
--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -182,7 +182,7 @@ def add_day_of_year(cube, coord, name="day_of_year"):
 def add_weekday_number(cube, coord, name="weekday_number"):
     """Add a categorical weekday coordinate, values 0..6  [0=Monday]."""
     add_categorised_coord(
-        cube, name, coord, lambda coord, x: _pt_date(coord, x).weekday()
+        cube, name, coord, lambda coord, x: _pt_date(coord, x).dayofwk
     )
 
 
@@ -192,7 +192,7 @@ def add_weekday_fullname(cube, coord, name="weekday_fullname"):
         cube,
         name,
         coord,
-        lambda coord, x: calendar.day_name[_pt_date(coord, x).weekday()],
+        lambda coord, x: calendar.day_name[_pt_date(coord, x).dayofwk],
         units="no_unit",
     )
 
@@ -203,7 +203,7 @@ def add_weekday(cube, coord, name="weekday"):
         cube,
         name,
         coord,
-        lambda coord, x: calendar.day_abbr[_pt_date(coord, x).weekday()],
+        lambda coord, x: calendar.day_abbr[_pt_date(coord, x).dayofwk],
         units="no_unit",
     )
 


### PR DESCRIPTION
[cftime PR 135](https://github.com/Unidata/cftime/pull/135) has now been released ([see v1.1.0 in the changelog](https://github.com/Unidata/cftime/blob/master/Changelog)), meaning that datetimes are `cftime.datetime` by default, instead of `datetime.datetime`.

This means that the datetimes Iris uses no longer have the `weekday()` method, but instead have the `dayofwk` attribute.

Have therefore adjusted the 3 methods that were using `weekday()` to use `dayofwk`.

Note that this will not currently pass Travis CI while #3682 remains open (which is pending some other fixes to get Travis to pass).