### PR TITLE
Skip ngvat

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -80,6 +80,7 @@ try:
     from iris_grib.message import GribMessage
 
     GRIB_AVAILABLE = True
+    del GribMessage  # just to satisfy flake8 usage check.
 except ImportError:
     GRIB_AVAILABLE = False
 
@@ -1208,6 +1209,12 @@ skip_inet = unittest.skipIf(
 skip_stratify = unittest.skipIf(
     not STRATIFY_AVAILABLE,
     'Test(s) require "python-stratify", which is not available.',
+)
+
+# POC skippage : Cover tests broken by POC code (=technical debt!)
+_NGVAT_POC_BREAKAGE = True
+skip_poc = unittest.skipIf(
+    _NGVAT_POC_BREAKAGE, "Test(s) skipped for NG-VAT POC."
 )
 
 


### PR DESCRIPTION
Define a skipper for tests broken in the NG-VAT POC.
I.E. stuff that we accept is broken, but won't fix for now.
This helps us to keep automated testing functional, and also marks the technical debt of things we might still need to fix.