### PR TITLE
Update docs CubeList.extract method

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Apr-03_extract_clarification.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Apr-03_extract_clarification.txt
@@ -1,0 +1,1 @@
+* Updated the documentation for the :meth:`iris.cube.CubeList.extract` method, to specify when a single cube, as opposed to a CubeList, may be returned.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -282,7 +282,8 @@ class CubeList(list):
 
         * strict - boolean
             If strict is True, then there must be exactly one cube which is
-            filtered per constraint.
+            filtered per constraint. Note: if a single constraint is given, a
+            Cube is returned rather than a CubeList.
 
         """
         return self._extract_and_merge(


### PR DESCRIPTION
This originated from a support query. The user was using cubelist.extract_strict() with a single constraint and was confused why this was returning a *cube* rather than a *cubelist*. The pertinent lines are these: 
https://github.com/SciTools/iris/blob/cbfbbb2ba9a8aff046b20e46d56810d34d6a1d11/lib/iris/cube.py#L324-L325

I think we need to highlight the fact that using strict=True and one constraint returns a single cube.