### PR TITLE
Unstructured multiple region extracts

### DIFF
--- a/lib/iris/tests/integration/ugrid/test_ucube_operations.py
+++ b/lib/iris/tests/integration/ugrid/test_ucube_operations.py
@@ -138,7 +138,7 @@ class TestlatlonExtract(tests.IrisTest):
     def test_indexer(self):
         cube = load_unstructured_testcube()
         region = [-20, 60, 20, 65]
-        region_cube = latlon_extract_faces(cube, region)
+        region_cube = latlon_extract_faces(cube, region, "centre")
         self.assertIsNotNone(region_cube.ugrid)
         self.assertEqual(region_cube.ugrid.grid.mesh_name, "mesh")
         self.assertEqual(region_cube.shape, (7,))

--- a/lib/iris/util/ucube_operations.py
+++ b/lib/iris/util/ucube_operations.py
@@ -711,55 +711,6 @@ class PseudoshapedCubeIndexer:
         return ucube_subset(self.cube, reqd_elem_inds)
 
 
-def latlon_extract_faces(cube, region_lon01_lat01, slice_type="enclose"):
-    """
-    Extract a latlon region from a structured cube.
-
-    This version only works with face data, and returns faces whose centres
-    lie within the region.
-
-    """
-    ug = cube.ugrid.grid
-    lon_0, lon_1, lat_0, lat_1 = region_lon01_lat01
-
-    def check_coords(coord_array):
-        # Get x coords, normalise to -180..+180 .
-        xx = (coord_array[..., 0] + 360.0 + 180.0) % 360.0 - 180.0
-        # Get y coords
-        yy = coord_array[..., 1]
-
-        # Build a boolean array from 4 threshold tests.
-        coords_wanted = xx > lon_0
-        coords_wanted = coords_wanted & (xx < lon_1)
-        coords_wanted = coords_wanted & (yy > lat_0)
-        coords_wanted = coords_wanted & (yy < lat_1)
-
-        return coords_wanted
-
-    # Alternative behaviours for filtering the faces with the bounding region.
-    if slice_type == "centre":
-        # Get face centre info.
-        if ug.face_coordinates is None:
-            ug.build_face_coordinates()
-        faces_wanted = check_coords(ug.face_coordinates)
-    elif slice_type in ("intersect", "enclose"):
-        nodes_wanted = check_coords(ug.nodes)
-        face_nodes = ug.faces
-        face_nodes_wanted = nodes_wanted[face_nodes]
-        if type == "intersect":
-            agg_method = np.any
-        else:
-            agg_method = np.all
-        faces_wanted = agg_method(face_nodes_wanted, axis=1)
-    else:
-        msg = "Unsupported slicing type: {}"
-        raise ValueError(msg.format(type))
-
-    # Return a cube subset based on the selected points.
-    region_cube = ucube_subset(cube, faces_wanted)
-    return region_cube
-
-
 def coords_within_regions(coords_array, regions_array_xy0_xy1):
     """
     Check that a given array of coordinates is within a given array of


### PR DESCRIPTION
Enhanced region-based extraction:
 - [x] Work with nodes, edges or faces
 - [x] Work with multiple regions
 - [x] "centre" slice type
 - [x] "enclose" slice type
 - [ ] "intersect" slice type
 - [ ] "trim" slice type
 - [ ] support variable node numbers in faces
 - [ ] comprehensive tests

## Remaining work
#### "Intersect" slice type
Current intersect method checks that at least one of the face/edge's nodes lie within the region(s) specified. This doesn't pick up faces/edges that might fully enclose a region in one/both dimensions, even though the face and region would definitely be considered as intersecting each other.

First attempt did not meet requirements. A shame since it had some good features: used numpy boolean arrays, taking advantage of some assumptions about cubespheres to get good performance without resorting to a fully generalisable intersect method (e.g. shapely, geopandas). Was also able to run the centre and enclose slice types. Should try to retain these features in any other attempts.

#### "Trim" slice type
Work not yet started. "Trim" describes a mode where any faces/edges crossing region bounds are cut so that only the parts within the bounds are retained. This will require a weighting method to determine the data values that are retained for any trimmed faces/edges. Probably see area-weighted regridding for inspiration.

#### Support variable node numbers in faces
The current code assumes that faces and their nodes can be represented in a numpy array. If the number of nodes in faces varies this would require a ragged array - not possible in numpy. Need to write an alternative slower method using loops / list comprehension for this situation, while retaining the numpy method for situations when it can still be used.

#### Comprehensive tests
This is a proof of concept so questionable how thorough the tests should be, but recorded here for information:
 - [x] Different slice types
 - [x] Multiple regions
 - [x] Faces
 - [ ] Nodes (need different data)
 - [ ] Edges (need different data)
 - [ ] Errors
 - [ ] Tests for the `coords_within_regions` function