### PR TITLE
check on maskedArray with core_data

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4144,7 +4144,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # Determine aggregation result data type for the aggregate-by
                 # cube data on first pass.
                 if i == 0:
-                    if ma.isMaskedArray(self.data):
+                    if ma.isMaskedArray(self.core_data()):
                         aggregateby_data = ma.zeros(
                             data_shape, dtype=result.dtype
                         )


### PR DESCRIPTION
Use of core_data instead of data to not realizing the data.

I had some issues with a custom aggregator that in this step got an extra dimension when computed in dask. 
I had no idea where the extra dimension came from, but the error vanished using core_data() instead. The results were not of any difference, so it should be save to use core_data().