### PR TITLE
Change default loading unit from "1" to "unknown"

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1669,7 +1669,7 @@ fc_extras
     def get_attr_units(cf_var, attributes):
         attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNIT_DIMENSIONLESS)
         if not attr_units:
-            attr_units = '1'
+            attr_units = cf_units._UNKNOWN_UNIT_STRING
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:


### PR DESCRIPTION
Adresses the loading part of #3585 and the remaining issues with quality flags discussed in #3358 and #3474. A NetCDF variable without a unit will be asigned a unit of "unknown" when loaded. When this is then saved, the resulting NetCDF file will now have no unit. This is particularly important in the case of quality flags where the convention is to be represented as a unitless NetCDF variable.