### PR TITLE
Change default loading unit from "1" to "unknown" (correct branch)

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
@@ -1,0 +1,1 @@
+* NetCDF files containing variables without units will be given a unit of "unknown" rather than "1"

--- a/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
@@ -1,1 +1,1 @@
-* NetCDF files containing variables without units will be given a unit of "unknown" rather than "1"
+* When loading data from netcdf-CF files, where a variable has no "units" property, the corresponding Iris object will have "units='unknown'". Prior to Iris 3.0, these cases defaulted to "units='1'".

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1195,6 +1195,8 @@ fc_extras
     UD_UNITS_LON = ['degrees_east', 'degree_east', 'degree_e', 'degrees_e',
                     'degreee', 'degreese', 'degrees', 'degrees east',
                     'degree east', 'degree e', 'degrees e']
+    UNKNOWN_UNIT_STRING = str(cf_units.as_unit(None))
+    NO_UNIT_STRING = str(cf_units.as_unit("no_unit"))
 
     #
     # CF Dimensionless Vertical Coordinates
@@ -1651,9 +1653,9 @@ fc_extras
 
     ################################################################################
     def get_attr_units(cf_var, attributes):
-        attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNKNOWN_UNIT_STRING)
+        attr_units = getattr(cf_var, CF_ATTR_UNITS, UNKNOWN_UNIT_STRING)
         if not attr_units:
-            attr_units = cf_units._UNKNOWN_UNIT_STRING
+            attr_units = UNKNOWN_UNIT_STRING
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:
@@ -1668,10 +1670,10 @@ fc_extras
                 cf_var.cf_name, attr_units)
             warnings.warn(msg)
             attributes['invalid_units'] = attr_units
-            attr_units = cf_units._UNKNOWN_UNIT_STRING
+            attr_units = UNKNOWN_UNIT_STRING
 
         if np.issubdtype(cf_var.dtype, np.str_):
-            attr_units = cf_units._NO_UNIT_STRING
+            attr_units = NO_UNIT_STRING
 
         # Get any assoicated calendar for a time reference coordinate.
         if cf_units.as_unit(attr_units).is_time_reference():

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1651,7 +1651,7 @@ fc_extras
 
     ################################################################################
     def get_attr_units(cf_var, attributes):
-        attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNIT_DIMENSIONLESS)
+        attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNKNOWN_UNIT_STRING)
         if not attr_units:
             attr_units = cf_units._UNKNOWN_UNIT_STRING
 

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1195,8 +1195,8 @@ fc_extras
     UD_UNITS_LON = ['degrees_east', 'degree_east', 'degree_e', 'degrees_e',
                     'degreee', 'degreese', 'degrees', 'degrees east',
                     'degree east', 'degree e', 'degrees e']
-    UNKNOWN_UNIT_STRING = str(cf_units.as_unit(None))
-    NO_UNIT_STRING = str(cf_units.as_unit("no_unit"))
+    UNKNOWN_UNIT_STRING = "?"
+    NO_UNIT_STRING = "-"
 
     #
     # CF Dimensionless Vertical Coordinates

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1653,7 +1653,7 @@ fc_extras
     def get_attr_units(cf_var, attributes):
         attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNIT_DIMENSIONLESS)
         if not attr_units:
-            attr_units = '1'
+            attr_units = cf_units._UNKNOWN_UNIT_STRING
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:

--- a/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
+        <auxCoord id="df8e91b1" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_auxiliary_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('1')" value_type="int32" var_name="x"/>
+        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('1')" value_type="int32" var_name="x"/>
+        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/int64_dimension_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
+        <dimCoord id="df8e91b1" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_cell_methods.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="int32" long_name="cube_axes_0" units="1" var_name="cube_axes_0">
+  <cube dtype="int32" long_name="cube_axes_0" units="unknown" var_name="cube_axes_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -20,7 +20,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_axes_1" units="1" var_name="cube_axes_1">
+  <cube dtype="int32" long_name="cube_axes_1" units="unknown" var_name="cube_axes_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -41,7 +41,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_axes_2" units="1" var_name="cube_axes_2">
+  <cube dtype="int32" long_name="cube_axes_2" units="unknown" var_name="cube_axes_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -66,7 +66,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_axes_3" units="1" var_name="cube_axes_3">
+  <cube dtype="int32" long_name="cube_axes_3" units="unknown" var_name="cube_axes_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -89,7 +89,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_axes_4" units="1" var_name="cube_axes_4">
+  <cube dtype="int32" long_name="cube_axes_4" units="unknown" var_name="cube_axes_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -112,7 +112,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_comment_0" units="1" var_name="cube_comment_0">
+  <cube dtype="int32" long_name="cube_comment_0" units="unknown" var_name="cube_comment_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -131,7 +131,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_comment_1" units="1" var_name="cube_comment_1">
+  <cube dtype="int32" long_name="cube_comment_1" units="unknown" var_name="cube_comment_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -150,7 +150,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_comment_2" units="1" var_name="cube_comment_2">
+  <cube dtype="int32" long_name="cube_comment_2" units="unknown" var_name="cube_comment_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -170,7 +170,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_comment_3" units="1" var_name="cube_comment_3">
+  <cube dtype="int32" long_name="cube_comment_3" units="unknown" var_name="cube_comment_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -190,7 +190,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_comment_4" units="1" var_name="cube_comment_4">
+  <cube dtype="int32" long_name="cube_comment_4" units="unknown" var_name="cube_comment_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -213,7 +213,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_interval_0" units="1" var_name="cube_interval_0">
+  <cube dtype="int32" long_name="cube_interval_0" units="unknown" var_name="cube_interval_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -232,7 +232,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_interval_1" units="1" var_name="cube_interval_1">
+  <cube dtype="int32" long_name="cube_interval_1" units="unknown" var_name="cube_interval_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -252,7 +252,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_interval_2" units="1" var_name="cube_interval_2">
+  <cube dtype="int32" long_name="cube_interval_2" units="unknown" var_name="cube_interval_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -272,7 +272,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_interval_3" units="1" var_name="cube_interval_3">
+  <cube dtype="int32" long_name="cube_interval_3" units="unknown" var_name="cube_interval_3">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -295,7 +295,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_interval_4" units="1" var_name="cube_interval_4">
+  <cube dtype="int32" long_name="cube_interval_4" units="unknown" var_name="cube_interval_4">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -320,7 +320,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_maximum" units="1" var_name="cube_maximum">
+  <cube dtype="int32" long_name="cube_maximum" units="unknown" var_name="cube_maximum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -333,7 +333,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mean" units="1" var_name="cube_mean">
+  <cube dtype="int32" long_name="cube_mean" units="unknown" var_name="cube_mean">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -346,7 +346,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_median" units="1" var_name="cube_median">
+  <cube dtype="int32" long_name="cube_median" units="unknown" var_name="cube_median">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -359,7 +359,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mid_range" units="1" var_name="cube_mid_range">
+  <cube dtype="int32" long_name="cube_mid_range" units="unknown" var_name="cube_mid_range">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -372,7 +372,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_minimum" units="1" var_name="cube_minimum">
+  <cube dtype="int32" long_name="cube_minimum" units="unknown" var_name="cube_minimum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -385,7 +385,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mix_0" units="1" var_name="cube_mix_0">
+  <cube dtype="int32" long_name="cube_mix_0" units="unknown" var_name="cube_mix_0">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -404,7 +404,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mix_1" units="1" var_name="cube_mix_1">
+  <cube dtype="int32" long_name="cube_mix_1" units="unknown" var_name="cube_mix_1">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -424,7 +424,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mix_2" units="1" var_name="cube_mix_2">
+  <cube dtype="int32" long_name="cube_mix_2" units="unknown" var_name="cube_mix_2">
     <coords>
       <coord datadims="[1]">
         <dimCoord id="4a0cb9d8" points="[0, 1]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="int32" var_name="lat"/>
@@ -447,7 +447,7 @@
     </cellMethods>
     <data checksum="0xecbb4b55" dtype="int32" mask_checksum="0xf626d399" shape="(1, 2, 2)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_mode" units="1" var_name="cube_mode">
+  <cube dtype="int32" long_name="cube_mode" units="unknown" var_name="cube_mode">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -460,7 +460,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_point" units="1" var_name="cube_point">
+  <cube dtype="int32" long_name="cube_point" units="unknown" var_name="cube_point">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -473,7 +473,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_standard_deviation" units="1" var_name="cube_standard_deviation">
+  <cube dtype="int32" long_name="cube_standard_deviation" units="unknown" var_name="cube_standard_deviation">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -486,7 +486,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_sum" units="1" var_name="cube_sum">
+  <cube dtype="int32" long_name="cube_sum" units="unknown" var_name="cube_sum">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>
@@ -499,7 +499,7 @@
     </cellMethods>
     <data checksum="0x2144df1c" dtype="int32" mask_checksum="0xa505df1b" shape="(1,)"/>
   </cube>
-  <cube dtype="int32" long_name="cube_variance" units="1" var_name="cube_variance">
+  <cube dtype="int32" long_name="cube_variance" units="unknown" var_name="cube_variance">
     <coords>
       <coord datadims="[0]">
         <dimCoord id="3a4420ff" points="[0]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-1-1 00:00:00', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="c15a8e5b" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="93a9a76c" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="4bb21cba" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="90e644bf" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems.cml
@@ -39,11 +39,11 @@
         <dimCoord circular="True" id="c15a8e5b" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="93a9a76c" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="4bb21cba" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="90e644bf" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_0.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="c15a8e5b" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="93a9a76c" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="4bb21cba" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="90e644bf" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_global_xyzt_gems_iter_1.cml
@@ -13,11 +13,11 @@
         <dimCoord circular="True" id="c15a8e5b" long_name="longitude" points="[0.0, 1.0, 2.0, ..., 357.0, 358.0, 359.0]" shape="(360,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="longitude"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="93a9a76c" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        <dimCoord id="4bb21cba" long_name="model_level_number" points="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
 		27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
 		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('1')" value_type="int32" var_name="levelist"/>
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60]" shape="(60,)" units="Unit('unknown')" value_type="int32" var_name="levelist"/>
       </coord>
       <coord datadims="[0]">
         <dimCoord id="90e644bf" long_name="time" points="[931344]" shape="(1,)" standard_name="time" units="Unit('hours since 1900-01-01 00:00:0.0', calendar='gregorian')" value_type="int32" var_name="time"/>

--- a/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
+        <auxCoord id="df8e91b1" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_auxiliary_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('1')" value_type="int32" var_name="x"/>
+        <auxCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('1')" value_type="int32" var_name="x"/>
+        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
+++ b/lib/iris/tests/results/netcdf/uint32_dimension_coord_netcdf3.cml
@@ -6,7 +6,7 @@
     </attributes>
     <coords>
       <coord datadims="[0]">
-        <dimCoord id="78a0dfe8" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
+        <dimCoord id="df8e91b1" long_name="x" points="[1, 2]" shape="(2,)" units="Unit('unknown')" value_type="int32" var_name="x"/>
       </coord>
     </coords>
     <cellMethods/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/002000000000.44.101.131200.1920.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="1" var_name="m__s44i101">
+  <cube dtype="float32" units="unknown" var_name="m__s44i101">
     <attributes>
       <attribute name="Conventions" value="CF-1.7"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/008000000000.44.101.000128.1890.09.01.00.00.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="1" var_name="m__s44i101">
+  <cube dtype="float32" units="unknown" var_name="m__s44i101">
     <attributes>
       <attribute name="Conventions" value="CF-1.7"/>
       <attribute name="STASH" value="m??s44i101"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc699.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="1" var_name="m02s00i___">
+  <cube dtype="float32" units="unknown" var_name="m02s00i___">
     <attributes>
       <attribute name="Conventions" value="CF-1.7"/>
       <attribute name="STASH" value="m02s00i???"/>

--- a/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
+++ b/lib/iris/tests/results/usecases/pp_to_cf_conversion/from_netcdf/st0fc942.b_0.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube dtype="float32" units="1" var_name="m02s00i___">
+  <cube dtype="float32" units="unknown" var_name="m02s00i___">
     <attributes>
       <attribute name="Conventions" value="CF-1.7"/>
       <attribute name="STASH" value="m02s00i???"/>


### PR DESCRIPTION
The same as #3705 except it is targeting a branch specifically for changes to default units. Because of this, the test is changed to no longer require the loading of ancillary variables.