### PR TITLE
(WIP) Alternative method for assigning flags "no_unit"

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1669,7 +1669,7 @@ fc_extras
     def get_attr_units(cf_var, attributes):
         attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNIT_DIMENSIONLESS)
         if not attr_units:
-            attr_units = cf_units._UNKNOWN_UNIT_STRING
+            attr_units = '1'
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:

--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1669,7 +1669,7 @@ fc_extras
     def get_attr_units(cf_var, attributes):
         attr_units = getattr(cf_var, CF_ATTR_UNITS, cf_units._UNIT_DIMENSIONLESS)
         if not attr_units:
-            attr_units = '1'
+            attr_units = cf_units._UNKNOWN_UNIT_STRING
 
         # Sanitise lat/lon units.
         if attr_units in UD_UNITS_LAT or attr_units in UD_UNITS_LON:

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -614,8 +614,13 @@ def _load_cube(engine, cf, cf_var, filename):
 
     def add_unused_attributes(iris_object, cf_var):
         tmpvar = filter(attribute_predicate, cf_var.cf_attrs_unused())
+        null_units = False
         for attr_name, attr_value in tmpvar:
             _set_attributes(iris_object.attributes, attr_name, attr_value)
+            if attr_name in ["flag_meanings", "flag_values", "flag_masks"]:
+                null_units = True
+        if null_units:
+            iris_object.units = "no_unit"
 
     def fix_attributes_all_elements(role_name):
         elements_and_names = engine.provides.get(role_name, [])

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -337,7 +337,7 @@ class TestNetCDFLoad(tests.IrisTest):
             np.ma.array([1, 1, 2], dtype=np.int8),
             long_name="qq status_flag",
             var_name="my_av",
-            units="unknown",
+            units="no_unit",
             attributes={
                 "flag_values": np.array([1, 2], dtype=np.int8),
                 "flag_meanings": "a b",


### PR DESCRIPTION
An alternative approach to #3613. The reason there are multiple approaches is due to the fact that it is necessary to check the attributes of an ancillary variable to know if it is a flag. However, with the current method of loading NetCDF files, some steps are done in [netcdf.py](https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/netcdf.py) (i.e. loading in attributes) and others are done in [fc_pyke_rules.krb](https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb) (i.e. determining units).

#3613 took the approach of having all the code determining units in the same place. This meant that attributes had to be loaded prematurely (and probably redundantly) in order to make this check. This pull request takes the approach that attributes should be loaded all at once and only when they are loaded should this check take place. The downside to this is that the unit has already been determined and will have to be overwritten. To summarize, #3613 has redundancy in the reading of NetCDF file and this pull request has redundancy in the writing iris objects.

It may well be possible to find a more elegant approach, in which case these two pull requests act as an illustration of the problem that must be overcome.