### PR TITLE
Cubelist extract strict

### DIFF
--- a/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Apr-03_extract_clarification.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Apr-03_extract_clarification.txt
@@ -1,1 +1,0 @@
-* Updated the documentation for the :meth:`iris.cube.CubeList.extract` method, to specify when a single cube, as opposed to a CubeList, may be returned.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-22_cubelist_extract_cubes.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-22_cubelist_extract_cubes.txt
@@ -1,0 +1,10 @@
+* The method :meth:`~iris.cube.CubeList.extract_strict`, and the 'strict'
+  keyword to :meth:`~iris.cube.CubeList.extract` method have been removed, and
+  are replaced by the new routines :meth:`~iris.cube.CubeList.extract_cube` and
+  :meth:`~iris.cube.CubeList.extract_cubes`.
+  The new routines perform the same operation, but in a style more like other
+  Iris functions such as :meth:`iris.load_cube` and :meth:`iris.load_cubes`.
+  Unlike 'strict extraction', the type of return value is now completely
+  consistent : :meth:`~iris.cube.CubeList.extract_cube` always returns a cube,
+  and :meth:`~iris.cube.CubeList.extract_cubes` always returns a CubeList of a
+  length equal to the number of constraints.

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -428,7 +428,7 @@ def list_of_constraints(constraints):
     using :func:`as_constraint`.
 
     """
-    if not isinstance(constraints, (list, tuple)):
+    if isinstance(constraints, str) or not isinstance(constraints, Iterable):
         constraints = [constraints]
 
     return [as_constraint(constraint) for constraint in constraints]

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -355,7 +355,7 @@ class CubeList(list):
         if return_single_cube:
             if len(result) != 1:
                 # Practically this should never occur, as we now *only* request
-                # single cube results for 'extract_cube'.
+                # single cube result for 'extract_cube'.
                 msg = "Got {!s} cubes for constraints {!r}, expecting 1."
                 raise iris.exceptions.ConstraintMismatchError(
                     msg.format(len(result), constraints)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -278,9 +278,14 @@ class CubeList(list):
         **n** when filtered with **m** constraints can generate a maximum of
         **m * n** cubes.
 
+        Args:
+
+        * constraints (:class:`~iris.Constraint` or iterable of constraints):
+            A single constraint or an iterable.
+
         Keywords:
 
-        * strict - boolean
+        * strict (bool):
             If strict is True, then there must be exactly one cube which is
             filtered per constraint. Note: if a single constraint is given, a
             Cube is returned rather than a CubeList.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -268,7 +268,7 @@ class CubeList(list):
         # return our newly created XML string
         return doc.toprettyxml(indent="  ")
 
-    def extract(self, constraints, strict=False):
+    def extract(self, constraints):
         """
         Filter each of the cubes which can be filtered by the given
         constraints.
@@ -283,16 +283,9 @@ class CubeList(list):
         * constraints (:class:`~iris.Constraint` or iterable of constraints):
             A single constraint or an iterable.
 
-        Keywords:
-
-        * strict (bool):
-            If strict is True, then there must be exactly one cube which is
-            filtered per constraint. Note: if a single constraint is given, a
-            Cube is returned rather than a CubeList.
-
         """
         return self._extract_and_merge(
-            self, constraints, strict, merge_unique=None
+            self, constraints, strict=False, merge_unique=None
         )
 
     def extract_cube(self, constraint):
@@ -384,13 +377,6 @@ class CubeList(list):
             result = result[0]
 
         return result
-
-    def extract_strict(self, constraints):
-        """
-        Calls :meth:`CubeList.extract` with the strict keyword set to True.
-
-        """
-        return self.extract(constraints, strict=True)
 
     def extract_overlapping(self, coord_names):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -295,8 +295,61 @@ class CubeList(list):
             self, constraints, strict, merge_unique=None
         )
 
+    def extract_cube(self, constraint):
+        """
+        Extract a single cube from a CubeList, and return it.
+        Raise an error if the extract produces no cubes, or more than one.
+
+        Args:
+
+        * constraint (:class:`~iris.Constraint`):
+            The constraint to extract with.
+
+        .. see also::
+            :meth:`~iris.cube.CubeList.extract`
+
+        """
+        # Just validate this, so we can accept strings etc, but not multiples.
+        constraint = iris._constraints.as_constraint(constraint)
+        return self._extract_and_merge(
+            self,
+            constraint,
+            strict=True,
+            merge_unique=None,
+            return_single_as_cube=True,
+        )
+
+    def extract_cubes(self, constraints):
+        """
+        Extract specific cubes from a CubeList, one for each given constraint.
+        Each constraint must produce exactly one cube, otherwise an error is
+        raised.
+
+        Args:
+
+        * constraints (iterable of, or single, :class:`~iris.Constraint`):
+            The constraints to extract with.
+
+        .. see also::
+            :meth:`~iris.cube.CubeList.extract`
+
+        """
+        return self._extract_and_merge(
+            self,
+            constraints,
+            strict=True,
+            merge_unique=None,
+            return_single_as_cube=False,
+        )
+
     @staticmethod
-    def _extract_and_merge(cubes, constraints, strict, merge_unique=False):
+    def _extract_and_merge(
+        cubes,
+        constraints,
+        strict,
+        merge_unique=False,
+        return_single_as_cube=True,
+    ):
         # * merge_unique - if None: no merging, if false: non unique merging,
         # else unique merging (see merge)
 
@@ -327,7 +380,7 @@ class CubeList(list):
                 raise iris.exceptions.ConstraintMismatchError(msg)
             result.extend(constraint_cubes)
 
-        if strict and len(constraints) == 1:
+        if return_single_as_cube and strict and len(constraints) == 1:
             result = result[0]
 
         return result

--- a/lib/iris/tests/test_constraints.py
+++ b/lib/iris/tests/test_constraints.py
@@ -292,7 +292,7 @@ class TestCubeListStrictConstraint(StrictConstraintMixin, tests.IrisTest):
     suffix = "load_strict"
 
     def load_match(self, files, constraints):
-        cubes = iris.load(files).extract_strict(constraints)
+        cubes = iris.load(files).extract_cubes(constraints)
         return cubes
 
 
@@ -317,25 +317,25 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
 
     def test_standard_name(self):
         constraint = iris.Constraint(self.standard_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
 
     def test_long_name(self):
         constraint = iris.Constraint(self.long_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.long_name, self.long_name)
 
     def test_var_name(self):
         constraint = iris.Constraint(self.var_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.var_name, self.var_name)
 
     def test_stash(self):
         constraint = iris.Constraint(self.stash)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(str(result.attributes["STASH"]), self.stash)
 
@@ -348,7 +348,7 @@ class TestCubeExtract__names(TestMixin, tests.IrisTest):
         cube.attributes = None
         # Extract the unknown cube.
         constraint = iris.Constraint("unknown")
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.name(), "unknown")
 
@@ -380,14 +380,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
 
         # Match.
         constraint = NameConstraint(standard_name=self.standard_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
 
         # Match - callable.
         kwargs = dict(standard_name=lambda item: item.startswith("air_pot"))
         constraint = NameConstraint(**kwargs)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
 
@@ -397,7 +397,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         constraint = NameConstraint(
             standard_name=None, long_name=self.long_name
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertIsNone(result.standard_name)
         self.assertEqual(result.long_name, self.long_name)
@@ -410,7 +410,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
 
         # Match.
         constraint = NameConstraint(long_name=self.long_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.long_name, self.long_name)
 
@@ -420,7 +420,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
             and item.startswith("air pot")
         )
         constraint = NameConstraint(**kwargs)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.long_name, self.long_name)
 
@@ -430,7 +430,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         constraint = NameConstraint(
             standard_name=self.standard_name, long_name=None
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
         self.assertIsNone(result.long_name)
@@ -443,14 +443,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
 
         # Match.
         constraint = NameConstraint(var_name=self.var_name)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.var_name, self.var_name)
 
         # Match - callable.
         kwargs = dict(var_name=lambda item: item.startswith("ap"))
         constraint = NameConstraint(**kwargs)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.var_name, self.var_name)
 
@@ -460,7 +460,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         constraint = NameConstraint(
             standard_name=self.standard_name, var_name=None
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
         self.assertIsNone(result.var_name)
@@ -473,14 +473,14 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
 
         # Match.
         constraint = NameConstraint(STASH=self.stash)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(str(result.attributes["STASH"]), self.stash)
 
         # Match - callable.
         kwargs = dict(STASH=lambda stash: stash.item == 4)
         constraint = NameConstraint(**kwargs)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
 
     def test_stash__None(self):
@@ -489,7 +489,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         constraint = NameConstraint(
             standard_name=self.standard_name, STASH=None
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
         self.assertIsNone(result.attributes.get("STASH"))
@@ -499,7 +499,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         constraint = NameConstraint(
             standard_name=self.standard_name, long_name=self.long_name
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
 
@@ -518,7 +518,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
             long_name=self.long_name,
             var_name=self.var_name,
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
         self.assertEqual(result.long_name, self.long_name)
@@ -541,7 +541,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
             var_name=self.var_name,
             STASH=self.stash,
         )
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertEqual(result.standard_name, self.standard_name)
         self.assertEqual(result.long_name, self.long_name)
@@ -571,7 +571,7 @@ class TestCubeExtract__name_constraint(TestMixin, tests.IrisTest):
         cube.var_name = None
         cube.attributes = None
         constraint = NameConstraint(None, None, None, None)
-        result = self.cubes.extract(constraint, strict=True)
+        result = self.cubes.extract_cube(constraint)
         self.assertIsNotNone(result)
         self.assertIsNone(result.standard_name)
         self.assertIsNone(result.long_name)

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -79,9 +79,7 @@ class TestMultiCube(tests.IrisTest, TestMixin):
         # Load slices, decorating a coord with custom attributes
         cubes = iris.load_raw(self._data_path, callback=custom_coord_callback)
         # Merge
-        merged = iris.cube.CubeList._extract_and_merge(
-            cubes, constraints=None, strict=False, merge_unique=False
-        )
+        merged = iris.cube.CubeList(cubes).merge()
         # Check the custom attributes are in the merged cube
         for cube in merged:
             assert cube.coord("time").attributes["monty"] == "python"

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -330,10 +330,15 @@ class ExtractMixin:
             elif isinstance(expected, Cube):
                 self.assertIsInstance(result, Cube)
                 self.assertEqual(result, expected)
-            else:
-                self.assertIsInstance(expected, list)
+            elif isinstance(expected, list):
                 self.assertIsInstance(result, CubeList)
                 self.assertEqual(result, expected)
+            else:
+                msg = (
+                    'Unhandled usage in "check_extract" call: '
+                    '"expected" arg has type {}, value {}.'
+                )
+                raise ValueError(msg.format(type(expected), expected))
 
 
 class Test_extract_cube(ExtractMixin, tests.IrisTest):


### PR DESCRIPTION
Replace "cubelist.extract(..., strict=True)" and the equivalent "cubelist.extract_strict(...)" with a newer-style API.

Closes #3695
As noted there, this is more in keeping with other facilities, and also addresses the slightly quirky return-type behaviour of the old style :  The old method would return a cubelist for 0 or 2..N constraints/results, but just a cube for exactly one constraint.