### PR TITLE
var_name in AuxCoord created by trajectory.interpolate()

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -126,6 +126,11 @@ Incompatible Changes
   Prior to Iris ``3.0.0``, these cases defaulted to ``units='1'``.
   See :pull:`3795`.
 
+* `Simon Peatman <https://github.com/SimonPeatman>`_ added attribute
+  ``var_name`` to coordinates created by the
+  :func:`iris.analysis.trajectory.interpolate` function.  This prevents
+  duplicate coordinate errors in certain circumstances.  (:pull:`3718`).
+
 
 Internal
 ========

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -297,6 +297,7 @@ def interpolate(cube, sample_points, method=None):
             points = np.array([coord.points.flatten()[0]] * trajectory_size)
             new_coord = iris.coords.AuxCoord(
                 points,
+                var_name=coord.var_name,
                 standard_name=coord.standard_name,
                 long_name=coord.long_name,
                 units=coord.units,

--- a/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
+++ b/lib/iris/tests/results/trajectory/tri_polar_latitude_slice.cml
@@ -77,7 +77,7 @@
       </coord>
       <coord datadims="[2]">
         <auxCoord id="11ca7825" long_name="Latitude" points="[-78.1906, -78.1906, -78.1906, ..., 83.8392,
-		86.2794, 87.9471]" shape="(90,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+		86.2794, 87.9471]" shape="(90,)" standard_name="latitude" units="Unit('degrees')" value_type="float32" var_name="nav_lat">
           <attributes>
             <attribute name="nav_model" value="Default grid"/>
             <attribute name="valid_max" value="89.6139"/>
@@ -87,7 +87,7 @@
       </coord>
       <coord datadims="[2]">
         <auxCoord id="ee0adb2e" long_name="Longitude" points="[-84.0002, -90.0001, -90.0001, ..., -86.9366,
-		-88.8945, -100.0]" shape="(90,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+		-88.8945, -100.0]" shape="(90,)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="nav_lon">
           <attributes>
             <attribute name="nav_model" value="Default grid"/>
             <attribute name="valid_max" value="180.0"/>


### PR DESCRIPTION
When ```iris.analysis.trajectory.interpolate()``` creates AuxCoords for the coordinates interpolated along, it doesn't give them a ```var_name```.  This causes an error if the coordinates differ in var_name only, because Iris doesn't like having two identical coordinates on the same Cube.

Use case: I had a Cube which was a 2D histogram, with the two coordinates being some diagnostic on day _n_ and the same diagnostic on day _n+1_, so they were the same thing physically and therefore differed in ```var_name``` only.  When I tried to use ```trajectory.interpolate()``` it crashed with "ValueError: Duplicate coordinates are not permitted.".