### PR TITLE
Remove pin on eccodes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,10 +102,9 @@ install:
 
   # TODO : remove when iris doesn't do an integration test requiring iris-grib.
   # test against the latest version of python-eccodes.
-  # Conda-forge versioning is out of order (0.9.* is later than 2.12.*).
   - >
     if [[ "${TEST_MINIMAL}" != true ]]; then
-        conda install --quiet -n ${ENV_NAME} python-eccodes">=0.9.1, <2";
+        conda install --quiet -n ${ENV_NAME} python-eccodes;
         conda install --quiet -n ${ENV_NAME} --no-deps iris-grib;
     fi
 


### PR DESCRIPTION
**WIP - do not merge**
Closes #3723 (?we hope?)
We should now be able to test with the latest python-eccodes.
We shall see what this attempts to install, and whether it functions !