### PR TITLE
Clarify behaviour of "wrapper" objects derived from CFVariable.

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -559,7 +559,7 @@ def _get_cf_var_data(cf_var, filename):
 
     # Create cube with deferred data, but no metadata
     fill_value = getattr(
-        cf_var.cf_data,
+        cf_var.nc_variable,
         "_FillValue",
         netCDF4.default_fillvals[cf_var.dtype.str[1:]],
     )
@@ -568,7 +568,7 @@ def _get_cf_var_data(cf_var, filename):
     )
     # Get the chunking specified for the variable : this is either a shape, or
     # maybe the string "contiguous".
-    chunks = cf_var.cf_data.chunking()
+    chunks = cf_var.nc_variable.chunking()
     # In the "contiguous" case, pass chunks=None to 'as_lazy_data'.
     if chunks == "contiguous":
         chunks = None

--- a/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__get_cf_var_data.py
@@ -26,12 +26,12 @@ class Test__get_cf_var_data(tests.IrisTest):
         self.expected_chunks = _optimum_chunksize(self.shape, self.shape)
 
     def _make(self, chunksizes):
-        cf_data = mock.Mock(_FillValue=None)
-        cf_data.chunking = mock.MagicMock(return_value=chunksizes)
+        nc_variable = mock.Mock(_FillValue=None)
+        nc_variable.chunking = mock.MagicMock(return_value=chunksizes)
         cf_var = mock.MagicMock(
             spec=iris.fileformats.cf.CFVariable,
             dtype=np.dtype("i4"),
-            cf_data=cf_data,
+            nc_variable=nc_variable,
             cf_name="DUMMY_VAR",
             shape=self.shape,
         )

--- a/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__load_cube.py
@@ -51,12 +51,12 @@ class TestCoordAttributes(tests.IrisTest):
             cf_group[name] = mock.Mock(cf_attrs_unused=cf_attrs_unused)
         cf = mock.Mock(cf_group=cf_group)
 
-        cf_data = mock.Mock(_FillValue=None)
-        cf_data.chunking = mock.MagicMock(return_value=shape)
+        nc_variable = mock.Mock(_FillValue=None)
+        nc_variable.chunking = mock.MagicMock(return_value=shape)
         cf_var = mock.MagicMock(
             spec=iris.fileformats.cf.CFVariable,
             dtype=np.dtype("i4"),
-            cf_data=cf_data,
+            nc_variable=nc_variable,
             cf_name="DUMMY_VAR",
             cf_group=coords,
             shape=shape,
@@ -129,12 +129,12 @@ class TestCubeAttributes(tests.IrisTest):
     def _make(self, attrs):
         shape = (1,)
         cf_attrs_unused = mock.Mock(return_value=attrs)
-        cf_data = mock.Mock(_FillValue=None)
-        cf_data.chunking = mock.MagicMock(return_value=shape)
+        nc_variable = mock.Mock(_FillValue=None)
+        nc_variable.chunking = mock.MagicMock(return_value=shape)
         cf_var = mock.MagicMock(
             spec=iris.fileformats.cf.CFVariable,
             dtype=np.dtype("i4"),
-            cf_data=cf_data,
+            nc_variable=nc_variable,
             cf_name="DUMMY_VAR",
             cf_group=mock.Mock(),
             cf_attrs_unused=cf_attrs_unused,


### PR DESCRIPTION
I spent ages trying to fully understand this, and especially what was introduced in #213
(all that time ago!)
I think there is an excess of subtlety here, and I would have liked to remove some, but that is quite complicated !

So instead, here is an attempt to make the mechanisms clearer :  Mainly, just renaming a few things, and adding a few choice comments which I wish I'd had to go on.

Frankly, I'd like to go further and ditch the "wrapper" implementation, which allows us to use a "cf_var" (of a CFVariable-derived type) as a proxy for the underlying netcdf variable object.
( "cf_var.cf_data" -- or as I'm now calling it, "cf_var.nc_variable" ).
Unfortunately there is a lot of other code using that, in both Pyke rules ([example](https://github.com/SciTools/iris/blob/v2.4.0/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb#L1852)) and netcdf.py ([example](https://github.com/SciTools/iris/blob/v2.4.0/lib/iris/fileformats/netcdf.py#L497)), so I think that change is just too big to include with this.