### PR TITLE
Explicitly set coords in nimrod load to have units "1"

### DIFF
--- a/lib/iris/fileformats/nimrod_load_rules.py
+++ b/lib/iris/fileformats/nimrod_load_rules.py
@@ -301,7 +301,9 @@ def experiment(cube, field):
     """Add an 'experiment number' to the cube, if present in the field."""
     if not is_missing(field, field.experiment_num):
         cube.add_aux_coord(
-            DimCoord(field.experiment_num, long_name="experiment_number")
+            DimCoord(
+                field.experiment_num, long_name="experiment_number", units="1"
+            )
         )
 
 
@@ -592,7 +594,9 @@ def ensemble_member(cube, field):
     if not is_missing(field, ensemble_member_value):
         cube.add_aux_coord(
             DimCoord(
-                np.array(ensemble_member_value, dtype=np.int32), "realization"
+                np.array(ensemble_member_value, dtype=np.int32),
+                "realization",
+                units="1",
             )
         )
 


### PR DESCRIPTION
This should fix one of the failing tests in #3731 which would change the behaviour of nimrod loading due to a change in default units upon coord creation.