### PR TITLE
pin cftime

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -6,7 +6,7 @@
 cartopy>=0.12
 #conda: proj4<6
 cf-units>=2
-cftime
+cftime==1.1.3
 dask[array]>=2  #conda: dask>=2
 matplotlib
 netcdf4


### PR DESCRIPTION
This PR temporarily pins back `cftime`, which is causing some unit test failures due to its most recent release, moving from `v1.1.3` to `v1.2.0`, see the [Unidata/cftime changelog](https://github.com/Unidata/cftime/blob/master/Changelog).

The following `iris.tests.unit.fileformats.pp_load_rules.test__epoch_date_hours.TestEpochHours__gregorian` unit tests fail, all of which deal with our workaround for handling dates with a year of `0` (pretty much), and all of which are now 48hrs out using `v1.2.0` of `cftime` :confused::
- `test_year_0`
- `test_ymd_0_0_0`
- `test_ymd_preserves_timeofday`
- `test_ymd_1_1_1`