### PR TITLE
Numpy rounding fix

### DIFF
--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -627,7 +627,7 @@ def _convert_time_coords(
     def date2hours(t):
         epoch_hours = _epoch_date_hours(epoch_hours_unit, t)
         if t.minute == 0 and t.second == 0:
-            epoch_hours = round(epoch_hours)
+            epoch_hours = np.around(epoch_hours)
         return epoch_hours
 
     def date2year(t_in):

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -8,7 +8,7 @@ cartopy>=0.12
 cf-units>=2
 cftime==1.1.3
 dask[array]>=2  #conda: dask>=2
-matplotlib==1.2.2
+matplotlib<1.3
 netcdf4
 numpy>=1.14
 scipy

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -8,7 +8,7 @@ cartopy>=0.12
 cf-units>=2
 cftime==1.1.3
 dask[array]>=2  #conda: dask>=2
-matplotlib
+matplotlib==1.2.2
 netcdf4
 numpy>=1.14
 scipy

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -8,7 +8,7 @@ cartopy>=0.12
 cf-units>=2
 cftime==1.1.3
 dask[array]>=2  #conda: dask>=2
-matplotlib<1.3
+matplotlib<3.3
 netcdf4
 numpy>=1.14
 scipy


### PR DESCRIPTION
As mentioned in #3757, there is a test currently failing due to a number being rounded to an `int` rather than a `float`. It turns out this is not due to a change in cftime as previously thought, but due to a [change in numpy](https://numpy.org/doc/stable/release/1.19.0-notes.html#change-output-of-round-on-scalars-to-be-consistent-with-python).
Matplotlib is also being pinned here to get a separate test to pass.