### PR TITLE
pin matplotlib<3.3 for readthedocs conda

### DIFF
--- a/ci/requirements/readthedocs.yml
+++ b/ci/requirements/readthedocs.yml
@@ -17,9 +17,9 @@ dependencies:
   - cartopy>=0.12
   - proj4<6
   - cf-units>=2
-  - cftime==1.1.3
+  - cftime
   - dask>=2
-  - matplotlib
+  - matplotlib<3.3
   - netcdf4
   - numpy>=1.14
   - scipy


### PR DESCRIPTION
Temp fix for the read the docs build to pass.

Once merged the build should pass, see https://readthedocs.org/projects/scitools-iris/builds/

Relates to #3760 