### PR TITLE
enabled pdf creation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,3 +17,4 @@ python:
 
 formats:
     - htmlzip
+    - pdf

--- a/docs/iris/Makefile
+++ b/docs/iris/Makefile
@@ -5,19 +5,6 @@ html:
         echo "make html in $$i..."; \
         (cd $$i; $(MAKE) $(MFLAGS) $(MYMAKEFLAGS) html); done
 
-pdf:
-	@for i in $(SUBDIRS); do\
-		echo "make latex in $$i.."; \
-		(cd $$i; $(MAKE) $(MFLAGS) $(MYMAKEFLAGS) latex); done
-		echo "\def\sphinxdocclass{MO_report}" > build/latex/docs.tex
-		echo "\documentclass[letterpaper,10pt,english]{MO_report}" >> build/latex/docs.tex
-		tail -n +4 build/latex/Iris.tex >> build/latex/docs.tex
-		sed 's/\\tableofcontents/\\tableofcontents\n\\pagenumbering\{arabic\}/' build/latex/docs.tex > build/latex/docs2.tex
-		sed 's/subsection{/section{/' build/latex/docs2.tex > build/latex/documentation.tex
-		(cd build/latex; pdflatex -interaction=scrollmode documentation.tex)
-		# call latex again to get page numbers right...
-		(cd build/latex; pdflatex -interaction=scrollmode documentation.tex);
-
 all:
 	@for i in $(SUBDIRS); do \
 		echo "make all in $$i..."; \

--- a/docs/iris/Makefile
+++ b/docs/iris/Makefile
@@ -7,16 +7,16 @@ html:
 
 pdf:
 	@for i in $(SUBDIRS); do\
-	echo "make latex in $$i.."; \
-	(cd $$i; $(MAKE) $(MFLAGS) $(MYMAKEFLAGS) latex); done
-	echo "\def\sphinxdocclass{MO_report}" > build/latex/docs.tex
-	echo "\documentclass[letterpaper,10pt,english]{MO_report}" >> build/latex/docs.tex
-	tail -n +4 build/latex/Iris.tex >> build/latex/docs.tex
-	sed 's/\\tableofcontents/\\tableofcontents\n\\pagenumbering\{arabic\}/' build/latex/docs.tex > build/latex/docs2.tex
-	sed 's/subsection{/section{/' build/latex/docs2.tex > build/latex/documentation.tex
-	(cd build/latex; pdflatex -interaction=scrollmode documentation.tex)
-	# call latex again to get page numbers right...
-	(cd build/latex; pdflatex -interaction=scrollmode documentation.tex);
+		echo "make latex in $$i.."; \
+		(cd $$i; $(MAKE) $(MFLAGS) $(MYMAKEFLAGS) latex); done
+		echo "\def\sphinxdocclass{MO_report}" > build/latex/docs.tex
+		echo "\documentclass[letterpaper,10pt,english]{MO_report}" >> build/latex/docs.tex
+		tail -n +4 build/latex/Iris.tex >> build/latex/docs.tex
+		sed 's/\\tableofcontents/\\tableofcontents\n\\pagenumbering\{arabic\}/' build/latex/docs.tex > build/latex/docs2.tex
+		sed 's/subsection{/section{/' build/latex/docs2.tex > build/latex/documentation.tex
+		(cd build/latex; pdflatex -interaction=scrollmode documentation.tex)
+		# call latex again to get page numbers right...
+		(cd build/latex; pdflatex -interaction=scrollmode documentation.tex);
 
 all:
 	@for i in $(SUBDIRS); do \

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -62,8 +62,8 @@ project = "Iris"
 # define the copyright information for latex builds. Note, for html builds,
 # the copyright exists directly inside "_templates/layout.html"
 upper_copy_year = datetime.datetime.now().year
-copyright = "Iris contributors"
-_authors = "Iris developers"
+copyright = "Iris Contributors"
+author = "Iris Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -242,54 +242,3 @@ warnings.filterwarnings(
     message="Matplotlib is currently using agg, which is a"
     " non-GUI backend, so cannot show the figure.",
 )
-
-# -- Options for LaTeX output --------------------------------------------------
-
-# The paper size ('letter' or 'a4').
-# latex_paper_size = 'letter'
-
-# The font size ('10pt', '11pt' or '12pt').
-# latex_font_size = '10pt'
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual]).
-# latex_documents = [
-#    (
-#        "contents",
-#        "Iris.tex",
-#        "Iris Documentation",
-#        " \\and ".join(_authors),
-#        "manual",
-#    ),
-# ]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-# latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-# latex_use_parts = False
-
-# If true, show page references after internal links.
-# latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-# latex_show_urls = False
-
-# Additional stuff for the LaTeX preamble.
-# latex_preamble = ''
-
-# Documents to append as an appendix to all manuals.
-# latex_appendices = []
-
-# If false, no module index is generated.
-# latex_domain_indices = True
-# latex_elements = {}
-# latex_elements["docclass"] = "MO_report"
-
-# -- Options for manual page output --------------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-# man_pages = [("index", "iris", "Iris Documentation", _authors, 1)]


### PR DESCRIPTION
**Enabled the pdf creation on** the Read The Docs (RTD) service.

Note that we cannot create a pdf locally as RTD does some magic to do this.  We should not need to as the PDF is based upon the same source as the built html, which we can build locally to check.

Every time RTD creates a new version of the html it should also create a PDF one too.

This PR also covers:

- Fixing indention on a Makefile for pdf creation (not used at this time) - could be removed
- Purging all latex/man options in the **conf.py**

When his PR is merged if you view the documentation via https://scitools-iris.readthedocs.io/en/latest/, if you click on the **current version at the bottom of the sidebar** you will have an option to view the PDF for the active version.