### PR TITLE
Allow CFReader to exclude given variables

### DIFF
--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -10,18 +10,16 @@ according to the 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 References:
 
 [CF]  NetCDF Climate and Forecast (CF) Metadata conventions, Version 1.5, October, 2010.
-[NUG] NetCDF User's Guide, https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/
+[NUG] NetCDF User's Guide, http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
 
 """
 
 from abc import ABCMeta, abstractmethod
 
 from collections.abc import Iterable, MutableMapping
-import os
 import re
 import warnings
 
-import netCDF4
 import numpy as np
 import numpy.ma as ma
 
@@ -1008,8 +1006,12 @@ class CFReader:
 
     """
 
-    def __init__(self, filename, warn=False, monotonic=False):
-        self._filename = os.path.expanduser(filename)
+    def __init__(
+        self, dataset, warn=False, monotonic=False, exclude_var_names=None
+    ):
+        self._dataset = dataset
+        self._filename = dataset.filepath()
+
         # All CF variable types EXCEPT for the "special cases" of
         # CFDataVariable, CFCoordinateVariable and _CFFormulaTermsVariable.
         self._variable_types = (
@@ -1025,8 +1027,6 @@ class CFReader:
         #: Collection of CF-netCDF variables associated with this netCDF file
         self.cf_group = CFGroup()
 
-        self._dataset = netCDF4.Dataset(self._filename, mode="r")
-
         # Issue load optimisation warning.
         if warn and self._dataset.file_format in [
             "NETCDF3_CLASSIC",
@@ -1039,6 +1039,7 @@ class CFReader:
 
         self._check_monotonic = monotonic
 
+        self.exclude_var_names = exclude_var_names or []
         self._translate()
         self._build_cf_groups()
         self._reset()
@@ -1049,14 +1050,20 @@ class CFReader:
     def _translate(self):
         """Classify the netCDF variables into CF-netCDF variables."""
 
-        netcdf_variable_names = list(self._dataset.variables.keys())
+        netcdf_variable_names = [
+            var_name
+            for var_name in self._dataset.variables.keys()
+            if var_name not in self.exclude_var_names
+        ]
 
         # Identify all CF coordinate variables first. This must be done
         # first as, by CF convention, the definition of a CF auxiliary
         # coordinate variable may include a scalar CF coordinate variable,
         # whereas we want these two types of variables to be mutually exclusive.
         coords = CFCoordinateVariable.identify(
-            self._dataset.variables, monotonic=self._check_monotonic
+            self._dataset.variables,
+            ignore=self.exclude_var_names,
+            monotonic=self._check_monotonic,
         )
         self.cf_group.update(coords)
         coordinate_names = list(self.cf_group.coordinates.keys())
@@ -1064,11 +1071,9 @@ class CFReader:
         # Identify all CF variables EXCEPT for the "special cases".
         for variable_type in self._variable_types:
             # Prevent grid mapping variables being mis-identified as CF coordinate variables.
-            ignore = (
-                None
-                if issubclass(variable_type, CFGridMappingVariable)
-                else coordinate_names
-            )
+            ignore = self.exclude_var_names
+            if not issubclass(variable_type, CFGridMappingVariable):
+                ignore += coordinate_names
             self.cf_group.update(
                 variable_type.identify(self._dataset.variables, ignore=ignore)
             )
@@ -1082,7 +1087,7 @@ class CFReader:
 
         # Identify and register all CF formula terms.
         formula_terms = _CFFormulaTermsVariable.identify(
-            self._dataset.variables
+            self._dataset.variables, ignore=self.exclude_var_names
         )
 
         for cf_var in formula_terms.values():
@@ -1125,10 +1130,9 @@ class CFReader:
             for variable_type in self._variable_types:
                 # Prevent grid mapping variables being mis-identified as
                 # CF coordinate variables.
-                if issubclass(variable_type, CFGridMappingVariable):
-                    ignore = None
-                else:
-                    ignore = coordinate_names
+                ignore = self.exclude_var_names
+                if not issubclass(variable_type, CFGridMappingVariable):
+                    ignore += coordinate_names
                 match = variable_type.identify(
                     self._dataset.variables,
                     ignore=ignore,
@@ -1258,11 +1262,8 @@ class CFReader:
     def _reset(self):
         """Reset the attribute touch history of each variable."""
         for nc_var_name in self._dataset.variables.keys():
-            self.cf_group[nc_var_name].cf_attrs_reset()
-
-    def __del__(self):
-        # Explicitly close dataset to prevent file remaining open.
-        self._dataset.close()
+            if nc_var_name not in self.exclude_var_names:
+                self.cf_group[nc_var_name].cf_attrs_reset()
 
 
 def _getncattr(dataset, attr, default=None):

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1265,6 +1265,10 @@ class CFReader:
             if nc_var_name not in self.exclude_var_names:
                 self.cf_group[nc_var_name].cf_attrs_reset()
 
+    def __del__(self):
+        # Explicitly close dataset to prevent file remaining open.
+        self._dataset.close()
+
 
 def _getncattr(dataset, attr, default=None):
     """

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -10,7 +10,7 @@ according to the 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 References:
 
 [CF]  NetCDF Climate and Forecast (CF) Metadata conventions, Version 1.5, October, 2010.
-[NUG] NetCDF User's Guide, http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
+[NUG] NetCDF User's Guide, https://www.unidata.ucar.edu/software/netcdf/docs/
 
 """
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -778,7 +778,9 @@ def load_cubes(filenames, callback=None):
 
     for filename in filenames:
         # Ingest the netCDF file.
-        cf = iris.fileformats.cf.CFReader(filename)
+        filename = os.path.expanduser(filename)
+        dataset = netCDF4.Dataset(filename, mode="r")
+        cf = iris.fileformats.cf.CFReader(dataset)
 
         # Process each CF data variable.
         data_variables = list(cf.cf_group.data_variables.values()) + list(

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -13,6 +13,8 @@ import iris.tests as tests
 
 from unittest import mock
 
+import netCDF4 as nc
+
 import iris
 import iris.fileformats.cf as cf
 
@@ -54,7 +56,8 @@ class TestCFReader(tests.IrisTest):
         filename = tests.get_data_path(
             ("NetCDF", "rotated", "xyt", "small_rotPole_precipitation.nc")
         )
-        self.cfr = cf.CFReader(filename)
+        ds = nc.Dataset(filename)
+        self.cfr = cf.CFReader(ds)
 
     def test_ancillary_variables_pass_0(self):
         self.assertEqual(self.cfr.cf_group.ancillary_variables, {})
@@ -328,7 +331,8 @@ class TestClimatology(tests.IrisTest):
                 "A1B-99999a-river-sep-2070-2099.nc",
             )
         )
-        self.cfr = cf.CFReader(filename)
+        ds = nc.Dataset(filename)
+        self.cfr = cf.CFReader(ds)
 
     def test_bounds(self):
         time = self.cfr.cf_group["temp_dmax_tmean_abs"].cf_group.coordinates[
@@ -353,12 +357,14 @@ class TestLabels(tests.IrisTest):
                 "A1B-99999a-river-sep-2070-2099.nc",
             )
         )
-        self.cfr_start = cf.CFReader(filename)
+        ds = nc.Dataset(filename)
+        self.cfr_start = cf.CFReader(ds)
 
         filename = tests.get_data_path(
             ("NetCDF", "label_and_climate", "small_FC_167_mon_19601101.nc")
         )
-        self.cfr_end = cf.CFReader(filename)
+        ds = nc.Dataset(filename)
+        self.cfr_end = cf.CFReader(ds)
 
     def test_label_dim_start(self):
         cf_data_var = self.cfr_start.cf_group["temp_dmax_tmean_abs"]

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -360,8 +360,7 @@ class Test_exclude_vars(tests.IrisTest):
         self.assertEqual(cf.exclude_var_names, exclude_list)
 
     def test_exclude_names_error(self):
-        expected_message = r"can only concatenate str \(not .*\) to str"
-        with self.assertRaisesRegex(TypeError, expected_message):
+        with self.assertRaises(TypeError):
             CFReader(self.dataset, exclude_var_names="not a list")
 
     def test_exclude_vars(self):

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -70,11 +70,10 @@ class Test_translate__global_attributes(tests.IrisTest):
         )
 
     def test_create_global_attributes(self):
-        with mock.patch("netCDF4.Dataset", return_value=self.dataset):
-            global_attrs = CFReader("dummy").cf_group.global_attributes
-            self.assertEqual(
-                global_attrs["dimensions"], "something something_else"
-            )
+        global_attrs = CFReader(self.dataset).cf_group.global_attributes
+        self.assertEqual(
+            global_attrs["dimensions"], "something something_else"
+        )
 
 
 class Test_translate__formula_terms(tests.IrisTest):
@@ -142,38 +141,37 @@ class Test_translate__formula_terms(tests.IrisTest):
         self.addCleanup(reset_patch.stop)
 
     def test_create_formula_terms(self):
-        with mock.patch("netCDF4.Dataset", return_value=self.dataset):
-            cf_group = CFReader("dummy").cf_group
-            self.assertEqual(len(cf_group), len(self.variables))
-            # Check there is a singular data variable.
-            group = cf_group.data_variables
-            self.assertEqual(len(group), 1)
-            self.assertEqual(list(group.keys()), ["temp"])
-            self.assertIs(group["temp"].cf_data, self.temp)
-            # Check there are three coordinates.
-            group = cf_group.coordinates
-            self.assertEqual(len(group), 3)
-            coordinates = ["height", "lat", "lon"]
-            self.assertEqual(set(group.keys()), set(coordinates))
-            for name in coordinates:
-                self.assertIs(group[name].cf_data, getattr(self, name))
-            # Check there are three auxiliary coordinates.
-            group = cf_group.auxiliary_coordinates
-            self.assertEqual(len(group), 3)
-            aux_coordinates = ["delta", "sigma", "orography"]
-            self.assertEqual(set(group.keys()), set(aux_coordinates))
-            for name in aux_coordinates:
-                self.assertIs(group[name].cf_data, getattr(self, name))
-            # Check all the auxiliary coordinates are formula terms.
-            formula_terms = cf_group.formula_terms
-            self.assertEqual(set(group.items()), set(formula_terms.items()))
-            # Check there are three bounds.
-            group = cf_group.bounds
-            self.assertEqual(len(group), 3)
-            bounds = ["height_bnds", "delta_bnds", "sigma_bnds"]
-            self.assertEqual(set(group.keys()), set(bounds))
-            for name in bounds:
-                self.assertEqual(group[name].cf_data, getattr(self, name))
+        cf_group = CFReader(self.dataset).cf_group
+        self.assertEqual(len(cf_group), len(self.variables))
+        # Check there is a singular data variable.
+        group = cf_group.data_variables
+        self.assertEqual(len(group), 1)
+        self.assertEqual(list(group.keys()), ["temp"])
+        self.assertIs(group["temp"].cf_data, self.temp)
+        # Check there are three coordinates.
+        group = cf_group.coordinates
+        self.assertEqual(len(group), 3)
+        coordinates = ["height", "lat", "lon"]
+        self.assertEqual(set(group.keys()), set(coordinates))
+        for name in coordinates:
+            self.assertIs(group[name].cf_data, getattr(self, name))
+        # Check there are three auxiliary coordinates.
+        group = cf_group.auxiliary_coordinates
+        self.assertEqual(len(group), 3)
+        aux_coordinates = ["delta", "sigma", "orography"]
+        self.assertEqual(set(group.keys()), set(aux_coordinates))
+        for name in aux_coordinates:
+            self.assertIs(group[name].cf_data, getattr(self, name))
+        # Check all the auxiliary coordinates are formula terms.
+        formula_terms = cf_group.formula_terms
+        self.assertEqual(set(group.items()), set(formula_terms.items()))
+        # Check there are three bounds.
+        group = cf_group.bounds
+        self.assertEqual(len(group), 3)
+        bounds = ["height_bnds", "delta_bnds", "sigma_bnds"]
+        self.assertEqual(set(group.keys()), set(bounds))
+        for name in bounds:
+            self.assertEqual(group[name].cf_data, getattr(self, name))
 
 
 class Test_build_cf_groups__formula_terms(tests.IrisTest):
@@ -241,78 +239,73 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
         self.addCleanup(patcher.stop)
 
     def test_associate_formula_terms_with_data_variable(self):
-        with mock.patch("netCDF4.Dataset", return_value=self.dataset):
-            cf_group = CFReader("dummy").cf_group
-            self.assertEqual(len(cf_group), len(self.variables))
-            # Check the cf-group associated with the data variable.
-            temp_cf_group = cf_group["temp"].cf_group
-            # Check the data variable is associated with eight variables.
-            self.assertEqual(len(temp_cf_group), 8)
-            # Check there are three coordinates.
-            group = temp_cf_group.coordinates
-            self.assertEqual(len(group), 3)
-            coordinates = ["height", "lat", "lon"]
-            self.assertEqual(set(group.keys()), set(coordinates))
-            for name in coordinates:
-                self.assertIs(group[name].cf_data, getattr(self, name))
-            # Check the height coordinate is bounded.
-            group = group["height"].cf_group
-            self.assertEqual(len(group.bounds), 1)
-            self.assertIn("height_bnds", group.bounds)
-            self.assertIs(group["height_bnds"].cf_data, self.height_bnds)
-            # Check there are five auxiliary coordinates.
-            group = temp_cf_group.auxiliary_coordinates
-            self.assertEqual(len(group), 5)
-            aux_coordinates = ["delta", "sigma", "orography", "x", "y"]
-            self.assertEqual(set(group.keys()), set(aux_coordinates))
-            for name in aux_coordinates:
-                self.assertIs(group[name].cf_data, getattr(self, name))
-            # Check all the auxiliary coordinates are formula terms.
-            formula_terms = cf_group.formula_terms
-            self.assertTrue(
-                set(formula_terms.items()).issubset(list(group.items()))
+        cf_group = CFReader(self.dataset).cf_group
+        self.assertEqual(len(cf_group), len(self.variables))
+        # Check the cf-group associated with the data variable.
+        temp_cf_group = cf_group["temp"].cf_group
+        # Check the data variable is associated with eight variables.
+        self.assertEqual(len(temp_cf_group), 8)
+        # Check there are three coordinates.
+        group = temp_cf_group.coordinates
+        self.assertEqual(len(group), 3)
+        coordinates = ["height", "lat", "lon"]
+        self.assertEqual(set(group.keys()), set(coordinates))
+        for name in coordinates:
+            self.assertIs(group[name].cf_data, getattr(self, name))
+        # Check the height coordinate is bounded.
+        group = group["height"].cf_group
+        self.assertEqual(len(group.bounds), 1)
+        self.assertIn("height_bnds", group.bounds)
+        self.assertIs(group["height_bnds"].cf_data, self.height_bnds)
+        # Check there are five auxiliary coordinates.
+        group = temp_cf_group.auxiliary_coordinates
+        self.assertEqual(len(group), 5)
+        aux_coordinates = ["delta", "sigma", "orography", "x", "y"]
+        self.assertEqual(set(group.keys()), set(aux_coordinates))
+        for name in aux_coordinates:
+            self.assertIs(group[name].cf_data, getattr(self, name))
+        # Check all the auxiliary coordinates are formula terms.
+        formula_terms = cf_group.formula_terms
+        self.assertTrue(
+            set(formula_terms.items()).issubset(list(group.items()))
+        )
+        # Check the terms by root.
+        for name, term in zip(aux_coordinates, ["a", "b", "orog"]):
+            self.assertEqual(
+                formula_terms[name].cf_terms_by_root, dict(height=term)
             )
-            # Check the terms by root.
-            for name, term in zip(aux_coordinates, ["a", "b", "orog"]):
-                self.assertEqual(
-                    formula_terms[name].cf_terms_by_root, dict(height=term)
-                )
-            # Check the bounded auxiliary coordinates.
-            for name, name_bnds in zip(
-                ["delta", "sigma"], ["delta_bnds", "sigma_bnds"]
-            ):
-                aux_coord_group = group[name].cf_group
-                self.assertEqual(len(aux_coord_group.bounds), 1)
-                self.assertIn(name_bnds, aux_coord_group.bounds)
-                self.assertIs(
-                    aux_coord_group[name_bnds].cf_data,
-                    getattr(self, name_bnds),
-                )
+        # Check the bounded auxiliary coordinates.
+        for name, name_bnds in zip(
+            ["delta", "sigma"], ["delta_bnds", "sigma_bnds"]
+        ):
+            aux_coord_group = group[name].cf_group
+            self.assertEqual(len(aux_coord_group.bounds), 1)
+            self.assertIn(name_bnds, aux_coord_group.bounds)
+            self.assertIs(
+                aux_coord_group[name_bnds].cf_data, getattr(self, name_bnds),
+            )
 
     def test_promote_reference(self):
-        with mock.patch("netCDF4.Dataset", return_value=self.dataset):
-            cf_group = CFReader("dummy").cf_group
-            self.assertEqual(len(cf_group), len(self.variables))
-            # Check the number of data variables.
-            self.assertEqual(len(cf_group.data_variables), 1)
-            self.assertEqual(list(cf_group.data_variables.keys()), ["temp"])
-            # Check the number of promoted variables.
-            self.assertEqual(len(cf_group.promoted), 1)
-            self.assertEqual(list(cf_group.promoted.keys()), ["orography"])
-            # Check the promoted variable dependencies.
-            group = cf_group.promoted["orography"].cf_group.coordinates
-            self.assertEqual(len(group), 2)
-            coordinates = ("lat", "lon")
-            self.assertEqual(set(group.keys()), set(coordinates))
-            for name in coordinates:
-                self.assertIs(group[name].cf_data, getattr(self, name))
+        cf_group = CFReader(self.dataset).cf_group
+        self.assertEqual(len(cf_group), len(self.variables))
+        # Check the number of data variables.
+        self.assertEqual(len(cf_group.data_variables), 1)
+        self.assertEqual(list(cf_group.data_variables.keys()), ["temp"])
+        # Check the number of promoted variables.
+        self.assertEqual(len(cf_group.promoted), 1)
+        self.assertEqual(list(cf_group.promoted.keys()), ["orography"])
+        # Check the promoted variable dependencies.
+        group = cf_group.promoted["orography"].cf_group.coordinates
+        self.assertEqual(len(group), 2)
+        coordinates = ("lat", "lon")
+        self.assertEqual(set(group.keys()), set(coordinates))
+        for name in coordinates:
+            self.assertIs(group[name].cf_data, getattr(self, name))
 
     def test_formula_terms_ignore(self):
         self.orography.dimensions = ["lat", "wibble"]
-        with mock.patch(
-            "netCDF4.Dataset", return_value=self.dataset
-        ), mock.patch("warnings.warn") as warn:
-            cf_group = CFReader("dummy").cf_group
+        with mock.patch("warnings.warn") as warn:
+            cf_group = CFReader(self.dataset).cf_group
             group = cf_group.promoted
             self.assertEqual(list(group.keys()), ["orography"])
             self.assertIs(group["orography"].cf_data, self.orography)
@@ -320,10 +313,8 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
 
     def test_auxiliary_ignore(self):
         self.x.dimensions = ["lat", "wibble"]
-        with mock.patch(
-            "netCDF4.Dataset", return_value=self.dataset
-        ), mock.patch("warnings.warn") as warn:
-            cf_group = CFReader("dummy").cf_group
+        with mock.patch("warnings.warn") as warn:
+            cf_group = CFReader(self.dataset).cf_group
             promoted = ["x", "orography"]
             group = cf_group.promoted
             self.assertEqual(set(group.keys()), set(promoted))
@@ -335,10 +326,8 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
         self.wibble = netcdf_variable("wibble", "lat wibble", np.float)
         self.variables["wibble"] = self.wibble
         self.orography.coordinates = "wibble"
-        with mock.patch(
-            "netCDF4.Dataset", return_value=self.dataset
-        ), mock.patch("warnings.warn") as warn:
-            cf_group = CFReader("dummy").cf_group.promoted
+        with mock.patch("warnings.warn") as warn:
+            cf_group = CFReader(self.dataset).cf_group.promoted
             promoted = ["wibble", "orography"]
             self.assertEqual(set(cf_group.keys()), set(promoted))
             for name in promoted:


### PR DESCRIPTION
**Replaces #3767** 

This PR adds flexibility to the CFReader so that variable names can be specified for exclusion.

Also refactors so that the dataset must be extracted from a file before passing to CFReader, which will allow more efficient code in situations where the excluded var names are being read by opening the file ahead of instantiating CFReader.

(initial purpose is to enable an adapted CF reader in SciTools-incubator/iris-ugrid#4)