### PR TITLE
Ugrid version

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -106,7 +106,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.0.dev0"
+__version__ = "3.0.0ugrid1"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
Label the "ugrid" feature branch with a custom version string.
This string is chosen to suit the forthcoming "iris-ugrid regrid demo" which we want to build, as we want to include a version of the iris branch in that