### PR TITLE
Fixed typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,8 @@ script:
       python -m iris.tests.runner --default-tests --system-tests;
     fi
 
-  - if [[ "${TEST_TARGET}" == 'gallery' ]]; then
+  - >
+   if [[ "${TEST_TARGET}" == 'gallery' ]]; then
       python -m iris.tests.runner --gallery-tests;
     fi
 


### PR DESCRIPTION
This is not a bug, only a typo.

I believe the "**- >**" is used to show a collapsable output section on travis.  