### PR TITLE
set third party default logging level

### DIFF
--- a/lib/iris/etc/logging.yaml
+++ b/lib/iris/etc/logging.yaml
@@ -33,6 +33,12 @@ loggers:
     level: INFO
     handlers: [console-func]
     propagate: no
+  matplotlib:
+    level: INFO
+  PIL:
+    level: INFO
+  urllib3:
+    level: INFO
 
 root:
   level: INFO


### PR DESCRIPTION
This PR explicitly sets the `logging` level of third party dependencies that are causing `DEBUG` noise in `travis-ci`.

There may be another way of doing this, but this seems like a reasonable initial approach for now...