### PR TITLE
Cube arithmetic array type handling

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -128,6 +128,10 @@ This document explains the changes made to Iris for this release
    code comments, this was supposedly already the case, but there were several bugs
    and loopholes. (:issue:`1897`, :pull:`4767`)
 
+#. `@rcomer`_ modified cube arithmetic to handle mismatches in the cube's data
+   array type.  This prevents masks being lost in some cases and therefore
+   resolves :issue:`2987`.  (:pull:`3790`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -128,8 +128,9 @@ This document explains the changes made to Iris for this release
    code comments, this was supposedly already the case, but there were several bugs
    and loopholes. (:issue:`1897`, :pull:`4767`)
 
-#. `@rcomer`_ modified in place cube arithmetic to handle mismatches in the cube's
-   data array type.  This prevents masks being lost in some cases.  (:pull:`3790`)
+#. `@rcomer`_ modified cube arithmetic to handle mismatches in the cube's data
+   array type.  This prevents masks being lost in some cases and therefore
+   resolves :issue:`2987`.  (:pull:`3790`)
 
 
 💣 Incompatible Changes

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -128,9 +128,8 @@ This document explains the changes made to Iris for this release
    code comments, this was supposedly already the case, but there were several bugs
    and loopholes. (:issue:`1897`, :pull:`4767`)
 
-#. `@rcomer`_ modified cube arithmetic to handle mismatches in the cube's data
-   array type.  This prevents masks being lost in some cases and therefore
-   resolves :issue:`2987`.  (:pull:`3790`)
+#. `@rcomer`_ modified in place cube arithmetic to handle mismatches in the cube's
+   data array type.  This prevents masks being lost in some cases.  (:pull:`3790`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -845,7 +845,7 @@ def _binary_op_common(
         new_dtype=new_dtype,
         in_place=in_place,
         skeleton_cube=skeleton_cube,
-        force_lazy=iris._lazy_data.is_lazy_data(rhs)
+        force_lazy=iris._lazy_data.is_lazy_data(rhs),
     )
 
     if isinstance(other, Cube):

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -967,7 +967,7 @@ def _math_op_common(
         if skeleton_cube:
             # Simply wrap the resultant data in a cube, as no
             # cube metadata is required by the caller.
-            new_cube = iris.cube.Cube(data)
+            new_cube = Cube(data)
         else:
             new_cube = cube.copy(data)
 

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -848,8 +848,7 @@ def _binary_op_common(
     elif isinstance(
         cube.core_data(), ma.MaskedArray
     ) and iris._lazy_data.is_lazy_data(rhs):
-        # Temporary workaround for #2987.  numpy#16022 may provide a permanent
-        # fix.
+        # Workaround for #2987.  numpy#15200 discusses the general problem.
         cube = cube.copy(cube.lazy_data())
 
     result = _math_op_common(

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -845,6 +845,13 @@ def _binary_op_common(
         elif ma.is_masked(rhs) and not isinstance(cube.data, ma.MaskedArray):
             cube.data = ma.array(cube.data)
 
+    elif isinstance(
+        cube.core_data(), ma.MaskedArray
+    ) and iris._lazy_data.is_lazy_data(rhs):
+        # Temporary workaround for #2987.  numpy#16022 may provide a permanent
+        # fix.
+        cube = cube.copy(cube.lazy_data())
+
     result = _math_op_common(
         cube,
         unary_func,

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -845,13 +845,6 @@ def _binary_op_common(
         elif ma.is_masked(rhs) and not isinstance(cube.data, ma.MaskedArray):
             cube.data = ma.array(cube.data)
 
-    elif isinstance(
-        cube.core_data(), ma.MaskedArray
-    ) and iris._lazy_data.is_lazy_data(rhs):
-        # Temporary workaround for #2987.  numpy#16022 may provide a permanent
-        # fix.
-        cube = cube.copy(cube.lazy_data())
-
     result = _math_op_common(
         cube,
         unary_func,

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -687,12 +687,12 @@ class TestMathOperations(tests.IrisTest):
         self.data_1u = np.array([[9, 9, 9], [8, 8, 8]], dtype=np.uint64)
         self.data_2u = np.array([[3, 3, 3], [2, 2, 2]], dtype=np.uint64)
 
-        self.cube_1f = Cube(self.data_1f)
-        self.cube_2f = Cube(self.data_2f)
-        self.cube_1i = Cube(self.data_1i)
-        self.cube_2i = Cube(self.data_2i)
-        self.cube_1u = Cube(self.data_1u)
-        self.cube_2u = Cube(self.data_2u)
+        self.cube_1f = Cube(self.data_1f.copy())
+        self.cube_2f = Cube(self.data_2f.copy())
+        self.cube_1i = Cube(self.data_1i.copy())
+        self.cube_2i = Cube(self.data_2i.copy())
+        self.cube_1u = Cube(self.data_1u.copy())
+        self.cube_2u = Cube(self.data_2u.copy())
 
         self.ops = (operator.add, operator.sub, operator.mul, operator.truediv)
         self.iops = (

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -229,19 +229,34 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
     def test_partial_mask_second_lazy_in_place(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(True, second_lazy=True)
-        self.assertMaskedArrayEqual(com, res.data)
+        self.assertMaskedArrayEqual(com, res.data, strict=True)
+        self.assertIs(res, orig_cube)
 
     def test_partial_mask_not_in_place(self):
         # Cube arithmetic not an in_place operation.
         com, res, orig_cube = self._test_partial_mask(False)
 
-        self.assertMaskedArrayEqual(com, res.data)
+        self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIsNot(res, orig_cube)
 
     def test_partial_mask_second_lazy_not_in_place(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(False, second_lazy=True)
-        self.assertMaskedArrayEqual(com, res.data)
+        self.assertMaskedArrayEqual(com, res.data, strict=True)
+        self.assertIsNot(res, orig_cube)
+
+    def test_in_place_introduces_mask(self):
+        # If second cube is masked, result should also be masked.
+        data1 = np.arange(4, dtype=np.float)
+        data2 = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 1, 0, 0])
+        cube1 = Cube(data1)
+        cube2 = Cube(data2)
+
+        com = self.data_op(data1, data2)
+        res = self.cube_func(cube1, cube2, in_place=True)
+
+        self.assertMaskedArrayEqual(com, res.data, strict=True)
+        self.assertIs(res, cube1)
 
 
 class CubeArithmeticCoordsTest(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -15,6 +15,7 @@ import operator
 import dask.array as da
 import numpy as np
 from numpy import ma
+import pytest
 
 from iris.analysis import MEAN
 from iris.analysis.maths import add
@@ -239,6 +240,10 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIsNot(res, orig_cube)
 
+    @pytest.mark.xfail(
+        condition=np.__version__ < "1.24",
+        reason="numpy#21977 implemented NEP13 for masked arrays for v1.24",
+    )
     def test_partial_mask_second_lazy_not_in_place(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(False, second_lazy=True)

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -211,7 +211,7 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
             cube_a = Cube(da.from_array(dat_a))
         else:
             cube_a = Cube(dat_a)
-            
+
         if lazy == "first":
             cube_b = Cube(da.from_array(dat_b))
         else:

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -202,65 +202,33 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         # I.E. 'iris.analysis.maths.xx'.
         pass
 
-    def _test_partial_mask(self, in_place, lazy=None, other_cube=True):
+    def _test_partial_mask(self, in_place, second_lazy=False):
         # Helper method for masked data tests.
         dat_a = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 0, 1, 0])
         dat_b = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 1, 0, 0])
 
-        if lazy == "second":
-            other_a = da.from_array(dat_a)
+        if second_lazy:
+            cube_a = Cube(da.from_array(dat_a))
         else:
-            other_a = dat_a
+            cube_a = Cube(dat_a)
 
-        if other_cube:
-            other_a = Cube(dat_a)
-
-        if lazy == "first":
-            cube_b = Cube(da.from_array(dat_b))
-        else:
-            cube_b = Cube(dat_b)
+        cube_b = Cube(dat_b)
 
         com = self.data_op(dat_b, dat_a)
-        res = self.cube_func(cube_b, other_a, in_place=in_place)
+        res = self.cube_func(cube_b, cube_a, in_place=in_place)
 
         return com, res, cube_b
 
-    def test_partial_mask_in_place_2_cubes(self):
+    def test_partial_mask_in_place(self):
         # Cube in_place arithmetic operation.
         com, res, orig_cube = self._test_partial_mask(True)
 
         self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIs(res, orig_cube)
 
-    def test_partial_mask_first_lazy_in_place_2_cubes(self):
-        # Only first cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(True, lazy="first")
-        self.assertMaskedArrayEqual(com, res.data)
-
-    def test_partial_mask_second_lazy_in_place_2_cubes(self):
+    def test_partial_mask_second_lazy_in_place(self):
         # Only second cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(True, lazy="second")
-        self.assertMaskedArrayEqual(com, res.data)
-
-    def test_partial_mask_in_place_cube_array(self):
-        # Cube in_place arithmetic operation.
-        com, res, orig_cube = self._test_partial_mask(True, other_cube=False)
-
-        self.assertMaskedArrayEqual(com, res.data, strict=True)
-        self.assertIs(res, orig_cube)
-
-    def test_partial_mask_first_lazy_in_place_cube_array(self):
-        # Only first cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(
-            True, lazy="first", other_cube=False
-        )
-        self.assertMaskedArrayEqual(com, res.data)
-
-    def test_partial_mask_second_lazy_in_place_cube_array(self):
-        # Only second cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(
-            True, lazy="second", other_cube=False
-        )
+        com, res, orig_cube = self._test_partial_mask(True, second_lazy=True)
         self.assertMaskedArrayEqual(com, res.data)
 
     def test_partial_mask_not_in_place(self):
@@ -270,14 +238,9 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(com, res.data)
         self.assertIsNot(res, orig_cube)
 
-    def test_partial_mask_first_lazy_not_in_place(self):
-        # Only first cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(False, lazy="first")
-        self.assertMaskedArrayEqual(com, res.data)
-
     def test_partial_mask_second_lazy_not_in_place(self):
         # Only second cube has lazy data.
-        com, res, orig_cube = self._test_partial_mask(False, lazy="second")
+        com, res, orig_cube = self._test_partial_mask(False, second_lazy=True)
         self.assertMaskedArrayEqual(com, res.data)
 
 

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -229,6 +229,16 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIs(res, orig_cube)
 
+    def test_partial_mask_first_lazy_in_place(self):
+        # Only first cube has lazy data.
+        com, res, orig_cube = self._test_partial_mask(True, lazy="first")
+        self.assertMaskedArrayEqual(com, res.data)
+
+    def test_partial_mask_second_lazy_in_place(self):
+        # Only second cube has lazy data.
+        com, res, orig_cube = self._test_partial_mask(True, lazy="second")
+        self.assertMaskedArrayEqual(com, res.data)
+
     def test_partial_mask_not_in_place(self):
         # Cube arithmetic not an in_place operation.
         com, res, orig_cube = self._test_partial_mask(False)
@@ -236,16 +246,14 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(com, res.data)
         self.assertIsNot(res, orig_cube)
 
-    def test_partial_mask_first_lazy(self):
+    def test_partial_mask_first_lazy_not_in_place(self):
         # Only first cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(False, lazy="first")
-
         self.assertMaskedArrayEqual(com, res.data)
 
-    def test_partial_mask_second_lazy(self):
+    def test_partial_mask_second_lazy_not_in_place(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(False, lazy="second")
-
         self.assertMaskedArrayEqual(com, res.data)
 
 

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -15,7 +15,6 @@ import operator
 import dask.array as da
 import numpy as np
 from numpy import ma
-import pytest
 
 from iris.analysis import MEAN
 from iris.analysis.maths import add
@@ -240,10 +239,6 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIsNot(res, orig_cube)
 
-    @pytest.mark.xfail(
-        condition=np.__version__ < "1.24",
-        reason="numpy#21977 implemented NEP13 for masked arrays for v1.24",
-    )
     def test_partial_mask_second_lazy_not_in_place(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(False, second_lazy=True)

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -12,9 +12,9 @@ import iris.tests as tests  # isort:skip
 from abc import ABCMeta, abstractmethod
 import operator
 
+import dask.array as da
 import numpy as np
 from numpy import ma
-import dask.array as da
 
 from iris.analysis import MEAN
 from iris.analysis.maths import add

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -208,16 +208,16 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         dat_b = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 1, 0, 0])
 
         if second_lazy:
-            cube_a = Cube(da.from_array(dat_a))
+            cube_b = Cube(da.from_array(dat_b))
         else:
-            cube_a = Cube(dat_a)
+            cube_b = Cube(dat_b)
 
-        cube_b = Cube(dat_b)
+        cube_a = Cube(dat_a)
 
-        com = self.data_op(dat_b, dat_a)
-        res = self.cube_func(cube_b, cube_a, in_place=in_place)
+        com = self.data_op(dat_a, dat_b)
+        res = self.cube_func(cube_a, cube_b, in_place=in_place)
 
-        return com, res, cube_b
+        return com, res, cube_a
 
     def test_partial_mask_in_place(self):
         # Cube in_place arithmetic operation.

--- a/lib/iris/tests/unit/analysis/maths/__init__.py
+++ b/lib/iris/tests/unit/analysis/maths/__init__.py
@@ -202,15 +202,18 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
         # I.E. 'iris.analysis.maths.xx'.
         pass
 
-    def _test_partial_mask(self, in_place, lazy=None):
+    def _test_partial_mask(self, in_place, lazy=None, other_cube=True):
         # Helper method for masked data tests.
         dat_a = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 0, 1, 0])
         dat_b = ma.array([2.0, 2.0, 2.0, 2.0], mask=[1, 1, 0, 0])
 
         if lazy == "second":
-            cube_a = Cube(da.from_array(dat_a))
+            other_a = da.from_array(dat_a)
         else:
-            cube_a = Cube(dat_a)
+            other_a = dat_a
+
+        if other_cube:
+            other_a = Cube(dat_a)
 
         if lazy == "first":
             cube_b = Cube(da.from_array(dat_b))
@@ -218,25 +221,46 @@ class CubeArithmeticMaskingTestMixin(metaclass=ABCMeta):
             cube_b = Cube(dat_b)
 
         com = self.data_op(dat_b, dat_a)
-        res = self.cube_func(cube_b, cube_a, in_place=in_place)
+        res = self.cube_func(cube_b, other_a, in_place=in_place)
 
         return com, res, cube_b
 
-    def test_partial_mask_in_place(self):
+    def test_partial_mask_in_place_2_cubes(self):
         # Cube in_place arithmetic operation.
         com, res, orig_cube = self._test_partial_mask(True)
 
         self.assertMaskedArrayEqual(com, res.data, strict=True)
         self.assertIs(res, orig_cube)
 
-    def test_partial_mask_first_lazy_in_place(self):
+    def test_partial_mask_first_lazy_in_place_2_cubes(self):
         # Only first cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(True, lazy="first")
         self.assertMaskedArrayEqual(com, res.data)
 
-    def test_partial_mask_second_lazy_in_place(self):
+    def test_partial_mask_second_lazy_in_place_2_cubes(self):
         # Only second cube has lazy data.
         com, res, orig_cube = self._test_partial_mask(True, lazy="second")
+        self.assertMaskedArrayEqual(com, res.data)
+
+    def test_partial_mask_in_place_cube_array(self):
+        # Cube in_place arithmetic operation.
+        com, res, orig_cube = self._test_partial_mask(True, other_cube=False)
+
+        self.assertMaskedArrayEqual(com, res.data, strict=True)
+        self.assertIs(res, orig_cube)
+
+    def test_partial_mask_first_lazy_in_place_cube_array(self):
+        # Only first cube has lazy data.
+        com, res, orig_cube = self._test_partial_mask(
+            True, lazy="first", other_cube=False
+        )
+        self.assertMaskedArrayEqual(com, res.data)
+
+    def test_partial_mask_second_lazy_in_place_cube_array(self):
+        # Only second cube has lazy data.
+        com, res, orig_cube = self._test_partial_mask(
+            True, lazy="second", other_cube=False
+        )
         self.assertMaskedArrayEqual(com, res.data)
 
     def test_partial_mask_not_in_place(self):


### PR DESCRIPTION
Edit 20/07/22:

Closes #2987. During the discussion below we also established there are problems for the in-place case when the rhs object is more complex (i.e. masked or lazy) than the lhs cube’s data array.  So the current change also addresses that.

~This relates to #2987 but that issue is now fixed in numpy (see https://github.com/SciTools/iris/pull/3790#issuecomment-1184495096).  During the discussion below we also established there are problems for the in-place case when the rhs object is more complex (i.e. masked or lazy) than the lhs cube’s data array.  So the current change addresses that.  Also adds a test for the #2987 case, marked xfail until numpy 1.24 is released.~

~Although I'm targetting cube arithmetic here, this change will also have some effect on `apply_ufunc` and `IFunc`, for which it probably doesn't make sense: `apply_ufunc` would, I think, always expect numpy arrays, `IFunc` may be the same given that the function is user-determined.  I *think* the worst that will happen here is an inefficiency caused by converting a numpy array to a dask array and back again before the operation happens.  Does this inefficiency matter?  If so, the new behaviour could become an option in `_binary_op_common` that is explicitly chosen by the arithmetic functions.  For now, I've just gone for the simple approach.~

~I've yet to add a whatsnew as I'm not sure where it should go at the moment.   Might become more obvious once the Iris 3 release dust has settled...~