### PR TITLE
Modify parsing of ff headers to avoid numpy.fromfile.

### DIFF
--- a/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_FF2PP.py
@@ -87,9 +87,11 @@ class Test__extract_field__LBC_format(tests.IrisTest):
         ff2pp._ff_header.grid = mock.Mock(return_value=grid)
 
         open_func = "builtins.open"
-        with mock.patch("numpy.fromfile", return_value=[0]), mock.patch(
-            open_func
-        ), mock.patch("struct.unpack_from", return_value=[4]), mock.patch(
+        with mock.patch(
+            "iris.fileformats._ff._parse_binary_stream", return_value=[0]
+        ), mock.patch(open_func), mock.patch(
+            "struct.unpack_from", return_value=[4]
+        ), mock.patch(
             "iris.fileformats.pp.make_pp_field", side_effect=fields
         ), mock.patch(
             "iris.fileformats._ff.FF2PP._payload", return_value=(0, 0)


### PR DESCRIPTION
Recently noticed that fieldsfile loading was causing a bottleneck in our iris usage with iris running under python3, profiling seemed to show that half of our runtime was being spent in parsing fieldsfile headers. With `numpy.fromfile` being the main sink of time within the loading path (Seems to be a more widely noted issue for python3 versions of numpy, https://github.com/numpy/numpy/issues/13319),

Created a rough timing script to show for some basic timing loading a specific field from a file 1000 times:
```python
# An quick timing script to show the effect of removing fromfile.
import iris
import time
import os

f_size = os.path.getsize('big_fields_file')
print(f"File 'big_fields_file size': {f_size/1024**3:.2f}GB")

total_time = 0
count = 1000

for i in range(count):
    if i % 100 == 0:
        print(f'Run: {i}')
    s_time = time.time()
    # Load soil temp, just happened to be the data to hand!
    cube = iris.load('big_fields_file', iris.AttributeConstraint(STASH='m01s08i223'))
    r_time = time.time() - s_time
    total_time += r_time

print(f'==========================================================')
print(f'Total time: {total_time}, Average time: {total_time/count}')
print(f'==========================================================')
```

With output when running on master vs this branch

Branch
```
(iris-dev) [aowen@vld588:/data/users/aowen/iris_timings]$ python -m cProfile -o branch.pstat  timing_script.py 
File 'big_fields_file size': 5.04GB
Run: 0
Run: 100
Run: 200
Run: 300
Run: 400
Run: 500
Run: 600
Run: 700
Run: 800
Run: 900
==========================================================
Total time: 443.8917579650879, Average time: 0.4438917579650879
==========================================================
``` 

Master
```
(iris-dev) [aowen@vld588:/data/users/aowen/iris_timings]$ python -m cProfile -o master.pstat  timing_script.py 
File 'big_fields_file size': 5.04GB
Run: 0
Run: 100
Run: 200
Run: 300
Run: 400
Run: 500
Run: 600
Run: 700
Run: 800
Run: 900
==========================================================
Total time: 520.458238363266, Average time: 0.520458238363266
==========================================================
```

In this scenario we're seeing roughly 15% improvement with this change to the load pipeline, but it seems highly variable dependant on the file system being read from. I'd expect the improvement to be much higher on lustre based file systems where the initial issue was spotted, where we saw an overall reduction of around 45% in total  runtime.