### PR TITLE
[FB] [PI-3478] Fix resolve free flip of src/tgt mapping

### DIFF
--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -666,6 +666,7 @@ class Resolve:
 
         # Given the resultant broadcast shape, determine whether the
         # mapping requires to be reversed.
+        # Only applies to equal src/tgt dimensionality.
         broadcast_flip = (
             src_cube.ndim == tgt_cube.ndim
             and self._tgt_cube_resolved.shape != self.shape
@@ -674,13 +675,16 @@ class Resolve:
 
         # Given the number of free dimensions, determine whether the
         # mapping requires to be reversed.
+        # Only applies to equal src/tgt dimensionality.
         src_free = set(src_dim_coverage.dims_free) & set(
             src_aux_coverage.dims_free
         )
         tgt_free = set(tgt_dim_coverage.dims_free) & set(
             tgt_aux_coverage.dims_free
         )
-        free_flip = len(tgt_free) > len(src_free)
+        free_flip = src_cube.ndim == tgt_cube.ndim and len(tgt_free) > len(
+            src_free
+        )
 
         # Reverse the mapping direction.
         if broadcast_flip or free_flip:


### PR DESCRIPTION
This PR fixes the case where free dimension flipping of the src to tgt mapping was not constrained to the case of src and tgt cubes of equal dimensionality.

Testing will follow as a separate task, as per all new code introduced for the cube arithmetic over-haul.