### PR TITLE
tidy issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,7 +25,7 @@ Steps to reproduce the behaviour:
 
 ## Environment 
  - OS & Version: [e.g., Ubuntu 20.04 LTS]
- - Iris Version.  [e.g., From the command line run `python -c "import iris; print(iris.__version__)"`]
+ - Iris Version: [e.g., From the command line run `python -c "import iris; print(iris.__version__)"`]
 
 ## Additional context
 <!-- Provide any further information to help us understand -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## 🐛 Bug Report
-<!-- a clear description of what the bug is -->
+<!-- Provide a clear description of what the bug is -->
 
 ## How To Reproduce
 Steps to reproduce the behaviour:
@@ -21,11 +21,11 @@ Steps to reproduce the behaviour:
 <!-- A clear and concise description of what you expected to happen -->
 
 ## Screenshots
-<!-- If applicable, add screenshots to help explain your problem. -->
+<!-- If applicable, add screenshots to help explain your problem -->
 
 ## Environment 
- - OS & Version: [e.g. Ubuntu 20.04 LTS]
- - Iris Version.  [e.g. From the command line run `python -c "import iris; print(iris.__version__)"`]
+ - OS & Version: [e.g., Ubuntu 20.04 LTS]
+ - Iris Version.  [e.g., From the command line run `python -c "import iris; print(iris.__version__)"`]
 
 ## Additional context
-<!--  Add any other context about the problem here. -->
+<!-- Provide any further information to help us understand -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# reference: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,5 +8,5 @@ assignees: ''
 ---
 
 ## 📚 Documentation
-<!--  https://scitools-iris.readthedocs.io/en/latest/ -->
-<!-- Describe an issue or suggestion for improving the documentation -->
+<!-- See https://scitools-iris.readthedocs.io/en/latest/ -->
+<!-- Describe the issue or provide a suggestion for improving the Iris documentation -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "⚙Feature Request"
+name: "⚙ Feature Request"
 about: Submit a request for a new feature in Iris
 title: ''
 labels: 'New: Feature'
@@ -7,12 +7,12 @@ assignees: ''
 
 ---
 
-##  ⚙Feature Request
-<!-- A clear and concise description of the feature proposal -->
+## ⚙ Feature Request
+<!-- Provide a clear and concise description of the feature proposal -->
 
 ## Motivation
 <!-- Is your feature request related to an existing issue? -->
 <!-- I'm always frustrated when ... -->
 
 ## Additional context
-<!-- any other useful information -->
+<!-- Provide any further information to help us understand -->

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F4F0 Custom Issue"
+about: Submit a generic issue to help us improve Iris
+title: ''
+labels: 'New: Issue'
+assignees: ''
+
+---
+
+## 📰 Custom Issue
+<!-- Provide a clear description of what the issue is, and we'll try our best to help 😀 -->


### PR DESCRIPTION
This PR performs some minor tidying of the repo GitHub `Issues` templates. 

Changes include...

Renaming the template files to remove leading dashes, which cause major headaches. Just for reference, I used the following command to do this e.g.,
```shell
> git mv -- `---bug-report.md` bug-report.md
```
For reference, the following [resource](https://www.cyberciti.biz/faq/linuxunix-move-file-starting-with-a-dash/) was pretty useful.

Changed and aligned some of the spacing and wording for the bug, feature and documentation templates.

Added a new `config.yml` to turn-off blank issues, and force users to use the new `issue.md` template, which adds the `New: Issue` label to the issue - so now **all** issues raised by the community will have a `New` label, which makes it easier for core developers to identify new issues that require ownership and servicing.

See [here](https://github.com/bjlittle/iris/issues/new/choose) for an example of these changes.