### PR TITLE
Parse with packaging version

### DIFF
--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -13,8 +13,10 @@ See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 
 """
 
+from packaging import version
+
 import cf_units
-from matplotlib import __version__ as mpl_version
+from matplotlib import __version__ as _mpl_version
 import matplotlib.pyplot as plt
 
 import iris.config
@@ -49,7 +51,7 @@ def _title(cube_or_coord, with_units):
                 units = units.symbol
             if units.is_time_reference():
                 # iris.plot uses matplotlib.dates.date2num, which is fixed to the below unit.
-                if mpl_version >= "3.3":
+                if version.parse(_mpl_version) >= version.parse("3.3"):
                     days_since = "1970-01-01"
                 else:
                     days_since = "0001-01-01"


### PR DESCRIPTION
This PR uses `packaging.version` to safely parse version strings.

See here for a [fuller](https://stackoverflow.com/questions/11887762/how-do-i-compare-version-numbers-in-python) (opinionated) discussion.