### PR TITLE
move whatsnew contributions

### DIFF
--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -219,6 +219,8 @@ The result could now be plotted using the guidance provided in the
     A very similar example to this can be found in the examples section, 
     with the title "Deriving Exner Pressure and Air Temperature".
 
+.. _cube_maths_combining_units:
+
 Combining units
 ---------------
 

--- a/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/bugfix_2019-Nov-21_cell_measure_attributes.txt
@@ -1,2 +1,0 @@
-* Fixed a bug where the attributes of cell measures in netcdf-CF files were discarded on
-  loading.  They now appear on the CellMeasure in the loaded cube.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Aug-25_clarify_unit_handling.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/docchange_2020-Aug-25_clarify_unit_handling.txt
@@ -1,1 +1,0 @@
-* Added an explanation to the user guide of how units are handled by cube arithmetic.

--- a/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/incompatiblechange_2020-May-15_change_default_unit_loading.txt
@@ -1,1 +1,0 @@
-* When loading data from netcdf-CF files, where a variable has no "units" property, the corresponding Iris object will have "units='unknown'". Prior to Iris 3.0, these cases defaulted to "units='1'".

--- a/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Nov-21_netcdf_ancillary_data.txt
+++ b/docs/iris/src/whatsnew/contributions_3.0.0/newfeature_2019-Nov-21_netcdf_ancillary_data.txt
@@ -1,2 +1,0 @@
-* CF Ancillary Variables are now loaded from and saved to netcdf-CF files. Support for `quality flags <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags>`_ is also provided to ensure they load and save with appropriate units.
-

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -27,7 +27,9 @@ Features
   dependency on `matplotlib`_ at ``v2.x``.  Now that ``Python2`` support has
   been dropped, ``Iris`` is free to use the latest version of `matplotlib`_.
 
-* `CF Ancillary Data`_ variables are now supported.
+* `CF Ancillary Data`_ variables are now supported, and can be loaded from and
+  saved to NetCDF-CF files. Support for `Quality Flags`_ is also provided to
+  ensure they load and save with appropriate units.
 
 
 Dependency Updates
@@ -80,6 +82,10 @@ Bugs Fixed
   (previously would take the unit from a time coordinate, if present, even
   though the coordinate's value had been changed via ``date2num``).
 
+* Attributes of cell measures in NetCDF-CF files were being discarded during
+  loading. They are now available on the :class:`~iris.coords.CellMeasure` in
+  the loaded :class:`~iris.cube.Cube`.
+
 
 Incompatible Changes
 ====================
@@ -108,6 +114,11 @@ Incompatible Changes
   :meth:`iris.cube.CubeList.concatenate` method.  Since then, calling the
   :func:`iris.experimental.concatenate.concatenate` function raised an
   exception.
+
+* When loading data from NetCDF-CF files, where a variable has no ``units``
+  property, the corresponding Iris object will have ``units='unknown'``.
+  Prior to Iris ``3.0.0``, these cases defaulted to ``units='1'``.
+
 
 Internal
 ========
@@ -176,6 +187,10 @@ Documentation
 * Added a warning to the :func:`iris.analysis.cartography.project` function
   regarding its behaviour on projections with non-rectangular boundaries.
 
+* Added an explanation to the user guide of how ``Units`` are handled during
+  cube arithmetic.
+
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
 .. _matplotlib: https://matplotlib.org/
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
+.. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -29,7 +29,7 @@ Features
 
 * `CF Ancillary Data`_ variables are now supported, and can be loaded from and
   saved to NetCDF-CF files. Support for `Quality Flags`_ is also provided to
-  ensure they load and save with appropriate units.
+  ensure they load and save with appropriate units. See :pull:`3800`.
 
 
 Dependency Updates
@@ -84,7 +84,7 @@ Bugs Fixed
 
 * Attributes of cell measures in NetCDF-CF files were being discarded during
   loading. They are now available on the :class:`~iris.coords.CellMeasure` in
-  the loaded :class:`~iris.cube.Cube`.
+  the loaded :class:`~iris.cube.Cube`. See :pull:`3800`.
 
 
 Incompatible Changes
@@ -118,6 +118,7 @@ Incompatible Changes
 * When loading data from NetCDF-CF files, where a variable has no ``units``
   property, the corresponding Iris object will have ``units='unknown'``.
   Prior to Iris ``3.0.0``, these cases defaulted to ``units='1'``.
+  See :pull:`3795`.
 
 
 Internal
@@ -187,8 +188,8 @@ Documentation
 * Added a warning to the :func:`iris.analysis.cartography.project` function
   regarding its behaviour on projections with non-rectangular boundaries.
 
-* Added an explanation to the user guide of how ``Units`` are handled during
-  cube arithmetic.
+* Added the :ref:`cube_maths_combining_units` section to the user guide to
+  clarify how ``Units`` are handled during cube arithmetic.
 
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
 .. _matplotlib: https://matplotlib.org/


### PR DESCRIPTION
This PR tidies some valid `whatsnew/contrabutions` entries from the legacy and semi-automated mechanism, into the current and manual `whatsnew/latest`:

- bug-fix contribution from #3800
- doc-change contribution from #3803 
- incompatible-change contribution from #3795 
- new-feature contribution from #3800, #3801 

These contributions are from older feature branches using the then valid legacy approach to documenting `whatsnew` entries, which were then merged to `master`. 