### PR TITLE
Automate pull request labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,8 @@
-"New: Contribution":
+"New: Pull Request":
   - "**"
 
 "Type: Documentation":
   - docs/**/*
-
-"Type: Infrastructure":
-  - any["./*", ".github/**/*", "etc/**/*", "lib/iris/etc/**/*", "requirements/**/*", "tools/**/*"]
 
 "Type: Testing":
   - lib/iris/tests/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+"New: Contribution":
+  - "**"
+
+"Type: Documentation":
+  - docs/**/*
+
+"Type: Infrastructure":
+  - any["./*", ".github/**/*", "etc/**/*", "lib/iris/etc/**/*", "requirements/**/*", "tools/**/*"]
+
+"Type: Testing":
+  - lib/iris/tests/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler.yml


### PR DESCRIPTION
This PR uses the GitHub [actions/labeler](https://github.com/actions/labeler) to automate the process of labelling pull-requests.

For further information and reference material, also see:
- `actions/labeler` [example](https://selleo.com/til/posts/iumvmfrkhn-automate-pull-request-labels-via-github-actions)
- GitHub [Configuring and managing workflows](https://docs.github.com/en/actions/configuring-and-managing-workflows)
- [A curated list of awesome things related to GitHub Actions](https://github.com/sdras/awesome-actions)