### PR TITLE
Add template collapsible markdown sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -29,3 +29,12 @@ Steps to reproduce the behaviour:
 
 ## Additional context
 <!-- Provide any further information to help us understand -->
+<details>
+<summary>Click to expand <b>this section...</b></summary>
+
+```
+Add additional verbose information in a collapsible section.
+```
+See [here](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab) for further details.
+</details>
+

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -16,3 +16,12 @@ assignees: ''
 
 ## Additional context
 <!-- Provide any further information to help us understand -->
+<details>
+<summary>Click to expand <b>this section...</b></summary>
+
+```
+Add additional verbose information in a collapsible section.
+```
+See [here](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab) for further details.
+</details>
+


### PR DESCRIPTION
This PR adds a collapsible markdown section to the **Additional context** section of the **Bug Report** and **Feature Request** issue templates.

Having collapsible markdown sections is particularly handy for user issues that have verbose content, e.g., see the **Additional context** section of https://github.com/SciTools/iris/issues/3821, which inspired this PR.

For further details on collapsible markdown sections, see [here](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab).

Also, see [here](https://github.com/bjlittle/iris/issues/new/choose) for how this PR change is rendered in markdown, on my own forked `master` branch.