### PR TITLE
Added link to scitools.org.uk on the main index.

### DIFF
--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -43,6 +43,8 @@ single-machine workflows right through to multi-core clusters and HPC.
 Interoperability with packages from the wider scientific Python ecosystem comes
 from Iris' use of standard NumPy/dask arrays as its underlying data storage.
 
+Iris is part of SciTools, for more information see https://scitools.org.uk/.
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
**SciTools** is never mentioned in the docs apart from the Iris gituhb url https://github.com/SciTools/iris.

A link has been added in the landing page for the documentation.

