### PR TITLE
Image tests: set agg backend after rcdefaults

### DIFF
--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -59,7 +59,9 @@ import iris.util
 try:
     import matplotlib
 
+    # Override any user settings e.g. from matplotlibrc file.
     matplotlib.rcdefaults()
+    # Set backend *after* rcdefaults, as we don't want that overridden (#3846).
     matplotlib.use("agg")
     # Standardise the figure size across matplotlib versions.
     # This permits matplotlib png image comparison.

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -59,8 +59,8 @@ import iris.util
 try:
     import matplotlib
 
-    matplotlib.use("agg")
     matplotlib.rcdefaults()
+    matplotlib.use("agg")
     # Standardise the figure size across matplotlib versions.
     # This permits matplotlib png image comparison.
     matplotlib.rcParams["figure.figsize"] = [8.0, 6.0]


### PR DESCRIPTION
I was following @tkknight's nice new instructions for [installing and running tests](https://github.com/SciTools/iris/blob/3e9a09482658199092dbc57937d0d7de4dd4dbe5/docs/iris/src/installing.rst#running-the-tests), but got a bunch of errors and failures from `assertBoundsTickLabels` and `assertPointsTickLabels` on the [TestGraphicStringCoord](https://github.com/SciTools/iris/blob/3e9a09482658199092dbc57937d0d7de4dd4dbe5/lib/iris/tests/unit/plot/__init__.py#L18) class.  The errors look like this:

```
Traceback (most recent call last):
  File "[git-path]/iris/lib/iris/tests/unit/plot/test_plot.py", line 57, in test_xaxis_labels_with_axes
    self.assertBoundsTickLabels("xaxis", ax)
  File "[git-path]/iris/lib/iris/tests/unit/plot/__init__.py", line 45, in assertBoundsTickLabels
    actual = self.tick_loc_and_label(axis, axes)
  File "[git-path]/iris/lib/iris/tests/unit/plot/__init__.py", line 34, in tick_loc_and_label
    axes.figure.canvas.draw)
  File "[site-packages-path]/matplotlib/backends/backend_tkagg.py", line 10, in draw
    _backend_tk.blit(self._tkphoto, self.renderer._renderer, (0, 1, 2, 3))
  File "[site-packages-path]/matplotlib/backends/_backend_tk.py", line 75, in blit
    photoimage.blank()
  File "[py3-path]/tkinter/__init__.py", line 3548, in blank
    self.tk.call(self.name, 'blank')
_tkinter.TclError: invalid command name "pyimage353"
```
so it seemed the test was attempting to use TkAgg, even though the intent in `tests/__init__.py` is clearly to use Agg.  Switching the order of the backend setting and `rcdefaults` call fixed the problem.

I'm not clear why this hasn't come up for anyone else.  I do have a `matplotlibrc` file, which probably most devs don't - this file was the reason the `rcdefaults` call was originally added (#2746).