### PR TITLE
whatsnew - using the author github id

### DIFF
--- a/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
@@ -66,10 +66,9 @@ first. The content should target an Iris user as the audience. The required
 content, in order, is as follows:
 
 * Names of those who contributed the change. These should be their GitHub
-  display name, or if that is not available use their GitHub user name. Link
-  the name to their GitHub profile. E.g.
-  ```Bill Little <https://github.com/bjlittle>`_ and
-  `tkknight <https://github.com/tkknight>`_ changed...``
+  user name. Link the name to their GitHub profile. E.g.
+  ```@bjlittle <https://github.com/bjlittle>`_ and
+  `@tkknight <https://github.com/tkknight>`_ changed...``
 
 * The new/changed behaviour
 
@@ -84,8 +83,8 @@ content, in order, is as follows:
 
 For example::
 
-  * `Bill Little <https://github.com/bjlittle>`_ and
-    `tkknight <https://github.com/tkknight>`_ changed changed argument ``x``
+  * `@bjlittle <https://github.com/bjlittle>`_ and
+    `@tkknight <https://github.com/tkknight>`_ changed changed argument ``x``
     to be optional in :class:`~iris.module.class` and
     :meth:`iris.module.method`. This allows greater flexibility as requested in
     :issue:`9999`. (:pull:`1111`, :pull:`9999`)

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -13,11 +13,11 @@ This document explains the changes made to Iris for this release
 Features
 ========
 
-* `Stephen Moseley`_ greatly enhanced  the :mod:`~iris.fileformats.nimrod`
+* `@MoseleyS`_ greatly enhanced  the :mod:`~iris.fileformats.nimrod`
   module to provide richer meta-data translation when loading ``Nimrod`` data
   into cubes. This covers most known operational use-cases. (:pull:`3647`)
 
-* `stephenworsley`_ improved the handling of :class:`iris.coord.CellMeasure` in
+* `@stephenworsley`_ improved the handling of :class:`iris.coord.CellMeasure` in
   the statistical operations :meth:`iris.cube.Cube.collapsed`,
   :meth:`iris.cube.Cube.aggregated_by` and
   :meth:`iris.cube.Cube.rolling_window`. These previously removed every
@@ -25,12 +25,12 @@ Features
   :class:`iris.coord.CellMeasure` will only be removed if it is associated with
   an axis over which the statistic is being run. (:pull:`3549`)
 
-* `stephenworsley`_, `Patrick Peglar`_ and `abooton`_ added support for
+* `@stephenworsley`_, `@pp-mo`_ and `@abooton`_ added support for
   `CF Ancillary Data`_ variables, which can be loaded from and saved to
   NetCDF-CF files. Support for `Quality Flags`_ is also provided to ensure they
   load and save with appropriate units. (:pull:`3800`)
 
-* `Bouwe Andela`_ implemented lazy regridding for the
+* `@bouweandela`_ implemented lazy regridding for the
   :class:`~iris.analysis.Linear`, :class:`~iris.analysis.Nearest`, and
   :class:`~iris.analysis.AreaWeighted` regridding schemes. (:pull:`3701`)
 
@@ -38,52 +38,52 @@ Features
 Bugs Fixed
 ==========
 
-* `stephenworsley`_ fixed :meth:`~iris.Cube.cube.remove_coord` to now also
+* `@stephenworsley`_ fixed :meth:`~iris.Cube.cube.remove_coord` to now also
   remove derived coordinates by removing aux_factories. (:pull:`3641`)
 
-* `Jon Seddon`_ fixed ``isinstance(cube, collections.Iterable)`` to now behave
+* `@jonseddon`_ fixed ``isinstance(cube, collections.Iterable)`` to now behave
   as expected if a :class:`~iris.cube.Cube` is iterated over, while also
   ensuring that ``TypeError`` is still raised. (Fixed by setting the
   ``__iter__()`` method in :class:`~iris.cube.Cube` to ``None``).
   (:pull:`3656`)
 
-* `stephenworsley`_ enabled cube concatenation along an axis shared by cell
+* `@stephenworsley`_ enabled cube concatenation along an axis shared by cell
   measures; these cell measures are now concatenated together in the resulting
   cube. Such a scenario would previously cause concatenation to inappropriately
   fail. (:pull:`3566`)
 
-* `stephenworsley`_ newly included :class:`~iris.coords.CellMeasure`s in
+* `@stephenworsley`_ newly included :class:`~iris.coords.CellMeasure`s in
   :class:`~iris.cube.Cube` copy operations. Previously copying a
   :class:`~iris.cube.Cube` would ignore any attached
   :class:`~iris.coords.CellMeasure`. (:pull:`3546`)
 
-* `Bill Little`_ set a :class:`~iris.coords.CellMeasure`'s
+* `@bjlittle`_ set a :class:`~iris.coords.CellMeasure`'s
   ``measure`` attribute to have a default value of ``area``.
   Previously, the ``measure`` was provided as a keyword argument to
   :class:`~iris.coords.CellMeasure` with a default value of ``None``, which
   caused a ``TypeError`` when no ``measure`` was provided, since ``area`` or
   ``volume`` are the only accepted values. (:pull:`3533`)
 
-* `Martin Yeo`_ set **all** plot types in `iris.plot` to now use
+* `@trexfeathers`_ set **all** plot types in `iris.plot` to now use
   `matplotlib.dates.date2num
   <https://matplotlib.org/api/dates_api.html#matplotlib.dates.date2num>`_
   to format date/time coordinates for use on a plot axis (previously
   :meth:`~iris.plot.pcolor` and :meth:`~iris.plot.pcolormesh` did not include
   this behaviour). (:pull:`3762`)
 
-* `Martin Yeo`_ changed date/time axis labels in `iris.quickplot` to now
+* `@trexfeathers`_ changed date/time axis labels in `iris.quickplot` to now
   **always** be based on the ``epoch`` used in `matplotlib.dates.date2num
   <https://matplotlib.org/api/dates_api.html#matplotlib.dates.date2num>`_
   (previously would take the unit from a time coordinate, if present, even
   though the coordinate's value had been changed via ``date2num``).
   (:pull:`3762`)
 
-* `Patrick Peglar`_ newly included attributes of cell measures in NETCDF-CF
+* `@pp-mo`_ newly included attributes of cell measures in NETCDF-CF
   file loading; they were previously being discarded. They are now available on
   the :class:`~iris.coords.CellMeasure` in the loaded :class:`~iris.cube.Cube`.
   (:pull:`3800`)
 
-* `Patrick Peglar`_ fixed the netcdf loader to now handle any grid-mapping
+* `@pp-mo`_ fixed the netcdf loader to now handle any grid-mapping
   variables with missing ``false_easting`` and ``false_northing`` properties,
   which was previously failing for some coordinate systems. See :issue:`3629`.
   (:pull:`3804`)
@@ -92,7 +92,7 @@ Bugs Fixed
 Incompatible Changes
 ====================
 
-* `Patrick Peglar`_ rationalised :class:`~iris.cube.CubeList` extraction
+* `@pp-mo`_ rationalised :class:`~iris.cube.CubeList` extraction
   methods:
 
   The method :meth:`~iris.cube.CubeList.extract_strict`, and the ``strict``
@@ -107,39 +107,38 @@ Incompatible Changes
   always returns an :class:`iris.cube.CubeList` of a length equal to the
   number of constraints. (:pull:`3715`)
 
-* `Patrick Peglar`_ removed the former function
+* `@pp-mo`_ removed the former function
   ``iris.analysis.coord_comparison``. (:pull:`3562`)
 
-* `Bill Little`_ moved the
+* `@bjlittle`_ moved the
   :func:`iris.experimental.equalise_cubes.equalise_attributes` function from
   the :mod:`iris.experimental` module into the :mod:`iris.util` module.  Please
   use the :func:`iris.util.equalise_attributes` function instead.
   (:pull:`3527`)
 
-* `Bill Little`_ removed the :mod:`iris.experimental.concatenate` module. In
+* `@bjlittle`_ removed the :mod:`iris.experimental.concatenate` module. In
   ``v1.6.0`` the experimental ``concatenate`` functionality was moved to the
   :meth:`iris.cube.CubeList.concatenate` method.  Since then, calling the
   :func:`iris.experimental.concatenate.concatenate` function raised an
   exception. (:pull:`3523`)
 
-* `stephenworsley`_ changed Iris objects loaded from NetCDF-CF files to have
+* `@stephenworsley`_ changed Iris objects loaded from NetCDF-CF files to have
   ``units='unknown'`` where the corresponding NetCDF variable has no ``units``
   property. Previously these cases defaulted to ``units='1'``. (:pull:`3795`)
 
-* `Simon Peatman <https://github.com/SimonPeatman>`_ added attribute
-  ``var_name`` to coordinates created by the
+* `@SimonPeatman`_ added attribute ``var_name`` to coordinates created by the
   :func:`iris.analysis.trajectory.interpolate` function.  This prevents
-  duplicate coordinate errors in certain circumstances.  (:pull:`3718`).
+  duplicate coordinate errors in certain circumstances. (:pull:`3718`).
 
 
 Deprecations
 ============
 
-* `stephenworsley`_ removed the deprecated :class:`iris.Future` flags
+* `@stephenworsley`_ removed the deprecated :class:`iris.Future` flags
   ``cell_date_time_objects``, ``netcdf_promote``, ``netcdf_no_unlimited`` and
   ``clip_latitudes``. (:pull:`3459`)
 
-* `stephenworsley`_ changed :attr:`iris.fileformats.pp.PPField.lbproc` to be an
+* `@stephenworsley`_ changed :attr:`iris.fileformats.pp.PPField.lbproc` to be an
   ``int``. The deprecated attributes ``flag1``, ``flag2`` etc. have been
   removed from it. (:pull:`3461`).
 
@@ -148,52 +147,52 @@ Dependencies
 ============
 
 
-* `stephenworsley`_, `Martin Yeo`_ and `Bill Little`_ removed ``Python2``
+* `@stephenworsley`_, `@trexfeathers`_ and `@bjlittle`_ removed ``Python2``
   support, modernising the codebase by switching to exclusive ``Python3``
   support. (:pull:`3513`)
 
-* `Bill Little`_ improved the developer set up process. Configuring Iris and
+* `@bjlittle`_ improved the developer set up process. Configuring Iris and
   :ref:`installing_from_source` as a developer with all the required package
   dependencies is now easier with our curated conda environment YAML files.
   (:pull:`3812`)
 
-* `stephenworsley`_ pinned Iris to require Dask >= 2.0. (:pull:`3460`)
+* `@stephenworsley`_ pinned Iris to require Dask >= 2.0. (:pull:`3460`)
 
-* `stephenworsley`_ and `Martin Yeo`_ pinned Iris to require
+* `@stephenworsley`_ and `@trexfeathers`_ pinned Iris to require
   `Cartopy <https://github.com/SciTools/cartopy>`_ >= 0.18, in
   order to remain compatible with the latest version of `Matplotlib`_.
   (:pull:`3762`)
 
-* `Bill Little`_ unpinned Iris to use the latest version of `Matplotlib`_.
+* `@bjlittle`_ unpinned Iris to use the latest version of `Matplotlib`_.
   Supporting ``Iris`` for both ``Python2`` and ``Python3`` had resulted in
   pinning our dependency on `Matplotlib`_ at ``v2.x``.  But this is no longer
   necessary now that ``Python2`` support has been dropped. (:pull:`3468`)
 
-* `stephenworsley`_ and `Martin Yeo`_ unpinned Iris to use the latest version
+* `@stephenworsley`_ and `@trexfeathers`_ unpinned Iris to use the latest version
   of `Proj <https://github.com/OSGeo/PROJ>`_. (:pull:`3762`)
 
-* `stephenworsley`_ and `Martin Yeo`_ removed GDAL from the extensions
+* `@stephenworsley`_ and `@trexfeathers`_ removed GDAL from the extensions
   dependency group. We no longer consider it to be an extension. (:pull:`3762`)
 
 
 Documentation
 =============
 
-* `tkknight`_ moved the
+* `@tkknight`_ moved the
   :ref:`sphx_glr_generated_gallery_oceanography_plot_orca_projection.py`
   from the general part of the gallery to oceanography. (:pull:`3761`)
 
-* `tkknight`_ updated documentation to use a modern sphinx theme and be
+* `@tkknight`_ updated documentation to use a modern sphinx theme and be
   served from https://scitools-iris.readthedocs.io/en/latest/. (:pull:`3752`)
 
-* `Bill Little`_ added support for the
+* `@bjlittle`_ added support for the
   `black <https://black.readthedocs.io/en/stable/>`_ code formatter. This is
   now automatically checked on GitHub PRs, replacing the older, unittest-based
   "iris.tests.test_coding_standards.TestCodeFormat". Black provides automatic
   code format correction for most IDEs.  See the new developer guide section on
   :ref:`iris_code_format`. (:pull:`3518`)
 
-* `tkknight`_ and `Martin Yeo`_ refreshed the :ref:`whats_new_contributions`
+* `@tkknight`_ and `@trexfeathers`_ refreshed the :ref:`whats_new_contributions`
   for the :ref:`iris_whatsnew`. This includes always creating the ``latest``
   what's new page so it appears on the latest documentation at
   https://scitools-iris.readthedocs.io/en/latest/whatsnew. This resolves
@@ -201,16 +200,16 @@ Documentation
   :ref:`iris_development_releases_steps` to follow when making a release.
   (:pull:`3769`, :pull:`3838`, :pull:`3843`)
 
-* `tkknight`_ enabled the PDF creation of the documentation on the
+* `@tkknight`_ enabled the PDF creation of the documentation on the
   `Read the Docs`_ service. The PDF may be accessed by clicking on the version
   at the bottom of the side bar, then selecting ``PDF`` from the ``Downloads``
   section. (:pull:`3765`)
 
-* `stephenworsley`_ added a warning to the
+* `@stephenworsley`_ added a warning to the
   :func:`iris.analysis.cartography.project` function regarding its behaviour on
   projections with non-rectangular boundaries. (:pull:`3762`)
 
-* `stephenworsley`_ added the :ref:`cube_maths_combining_units` section to the
+* `@stephenworsley`_ added the :ref:`cube_maths_combining_units` section to the
   user guide to clarify how ``Units`` are handled during cube arithmetic.
   (:pull:`3803`)
 
@@ -218,45 +217,45 @@ Documentation
 Internal
 ========
 
-* `Patrick Peglar`_ and `lbdreyer`_ removed all test dependencies on
+* `@pp-mo`_ and `@lbdreyer`_ removed all test dependencies on
   `SciTools/iris-grib <https://github.com/SciTools/iris-grib>`_ by transferring
   all relevant content to the iris-grib repository. (:pull:`3662`,
   :pull:`3663`, :pull:`3664`, :pull:`3665`, :pull:`3666`, :pull:`3669`,
   :pull:`3670`, :pull:`3671`, :pull:`3672`, :pull:`3742`, :pull:`3746`)
 
-* `lbdreyer`_ and `Patrick Peglar`_ overhauled the handling of dimensional
+* `@lbdreyer`_ and `@pp-mo`_ overhauled the handling of dimensional
   metadata to remove duplication. (:pull:`3422`, :pull:`3551`)
 
-* `Martin Yeo`_ simplified the standard license header for all files, which
+* `@trexfeathers`_ simplified the standard license header for all files, which
   removes the need to repeatedly update year numbers in the header.
   (:pull:`3489`)
 
-* `stephenworsley`_ changed the numerical values in tests involving the
+* `@stephenworsley`_ changed the numerical values in tests involving the
   Robinson projection due to improvements made in
   `Proj <https://github.com/OSGeo/PROJ>`_. (:pull:`3762`) (see also
   `proj#1292 <https://github.com/OSGeo/PROJ/pull/1292>`_ and
   `proj#2151 <https://github.com/OSGeo/PROJ/pull/2151>`_)
 
-* `stephenworsley`_ changed tests to account for more detailed descriptions of
+* `@stephenworsley`_ changed tests to account for more detailed descriptions of
   projections in `GDAL <https://github.com/OSGeo/gdal>`_. (:pull:`3762`)
   (`see also GDAL#1185 <https://github.com/OSGeo/gdal/pull/1185>`_)
 
-* `stephenworsley`_ changed tests to account for
+* `@stephenworsley`_ changed tests to account for
   `GDAL <https://github.com/OSGeo/gdal>`_ now saving fill values for data
   without masked points. (:pull:`3762`)
 
-* `Martin Yeo`_ changed every graphics test that includes `Cartopy's coastlines
+* `@trexfeathers`_ changed every graphics test that includes `Cartopy's coastlines
   <https://scitools.org.uk/cartopy/docs/latest/matplotlib/
   geoaxes.html?highlight=coastlines#cartopy.mpl.geoaxes.GeoAxes.coastlines>`_
   to account for new adaptive coastline scaling. (:pull:`3762`) (`see also
   cartopy#1105 <https://github.com/SciTools/cartopy/pull/1105>`_)
 
-* `Martin Yeo`_ changed graphics tests to account for some new default
+* `@trexfeathers`_ changed graphics tests to account for some new default
   grid-line spacing in `Cartopy <https://github.com/SciTools/cartopy>`_.
   (:pull:`3762`)
   (`see also cartopy#1117 <https://github.com/SciTools/cartopy/pull/1117>`_)
 
-* `Martin Yeo`_ added additional acceptable graphics test targets to account
+* `@trexfeathers`_ added additional acceptable graphics test targets to account
   for very minor changes in `Matplotlib`_ version 3.3 (colormaps, fonts and
   axes borders). (:pull:`3762`)
 
@@ -265,13 +264,14 @@ Internal
 .. _Matplotlib: https://matplotlib.org/
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
-.. _Stephen Moseley: https://github.com/MoseleyS
-.. _stephenworsley: https://github.com/stephenworsley
-.. _Patrick Peglar: https://github.com/pp-mo
-.. _abooton: https://github.com/abooton
-.. _Bouwe Andela: https://github.com/bouweandela
-.. _Bill Little: https://github.com/bjlittle
-.. _Martin Yeo: https://github.com/trexfeathers
-.. _Jon Seddon: https://github.com/jonseddon
-.. _tkknight: https://github.com/tkknight
-.. _lbdreyer: https://github.com/lbdreyer
+.. _@MoseleyS: https://github.com/MoseleyS
+.. _@stephenworsley: https://github.com/stephenworsley
+.. _@pp-mo: https://github.com/pp-mo
+.. _@abooton: https://github.com/abooton
+.. _@bouweandela: https://github.com/bouweandela
+.. _@bjlittle: https://github.com/bjlittle
+.. _@trexfeathers: https://github.com/trexfeathers
+.. _@jonseddon: https://github.com/jonseddon
+.. _@tkknight: https://github.com/tkknight
+.. _@lbdreyer: https://github.com/lbdreyer
+.. _@SimonPeatman: https://github.com/SimonPeatman

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -128,7 +128,7 @@ Incompatible Changes
 
 * `@SimonPeatman`_ added attribute ``var_name`` to coordinates created by the
   :func:`iris.analysis.trajectory.interpolate` function.  This prevents
-  duplicate coordinate errors in certain circumstances. (:pull:`3718`).
+  duplicate coordinate errors in certain circumstances. (:pull:`3718`)
 
 
 Deprecations
@@ -140,7 +140,7 @@ Deprecations
 
 * `@stephenworsley`_ changed :attr:`iris.fileformats.pp.PPField.lbproc` to be an
   ``int``. The deprecated attributes ``flag1``, ``flag2`` etc. have been
-  removed from it. (:pull:`3461`).
+  removed from it. (:pull:`3461`)
 
 
 Dependencies


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR makes a simple change to the **latest** `whatsnew` to opt to using and citing pull-request authors using their GitHub ID.

On reflection, this might be a better long term approach as:

- It's one less step for the person writing the `whatsnew` entry, as they no longer have to "look up" the authors profile to determine whether their GitHub name matches their GitHub ID
- The GitHub ID is how people are commonly referred to within the GitHub community, so it's easy to cross-reference the GitHub ID with their work on GitHub or locally within a repo, but this is not true for the GitHub name
- We are less likely to make an error when citing the GitHub ID

A built version of this pull-request is available on `readthedocs`, to easily view the rendered changes:
- [latest whatsnew](https://my-iris.readthedocs.io/en/latest/whatsnew/latest.html)
- [Writing a whatsnew contribution](https://my-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html#writing-a-contribution)


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/pulls.html#the-iris-check-list)
