### PR TITLE
whatsnew - branded section icons

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "⚙ Feature Request"
+name: "✨ Feature Request"
 about: Submit a request for a new feature in Iris
 title: ''
 labels: 'New: Feature'
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-## ⚙ Feature Request
+## ✨ Feature Request
 <!-- Provide a clear and concise description of the feature proposal -->
 
 ## Motivation

--- a/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
@@ -109,27 +109,27 @@ Contribution categories
 The structure of the what's new release note should be easy to read by
 users.  To achieve this several categories may be used.
 
-*📢 Announcements*
-  General announcements to the Iris community.
+**📢 Announcements**
+  General news and announcements to the Iris community.
 
-*✨ Features*
+**✨ Features**
   Features that are new or changed to add functionality.
 
-*🐛 Bug Fixes*
+**🐛 Bug Fixes**
   A bug fix.
 
-*💣 Incompatible Changes*
+**💣 Incompatible Changes**
   A change that causes an incompatibility with prior versions of Iris.
 
-*🔥 Deprecations*
+**🔥 Deprecations**
   Deprecations of functionality.
 
-*🔗 Dependencies*
+**🔗 Dependencies**
   Additions, removals and version changes in Iris' package dependencies.
 
-*📚 Documentation*
+**📚 Documentation**
   Changes to documentation.
 
-*💼 Internal*
+**💼 Internal**
   Changes to any internal or development related topics, such as testing,
   environment dependencies etc.

--- a/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
@@ -109,24 +109,27 @@ Contribution categories
 The structure of the what's new release note should be easy to read by
 users.  To achieve this several categories may be used.
 
-*Features*
+*📢 Announcements*
+  General announcements to the Iris community.
+
+*✨ Features*
   Features that are new or changed to add functionality.
 
-*Bug Fixes*
+*🐛 Bug Fixes*
   A bug fix.
 
-*Incompatible Changes*
+*💣 Incompatible Changes*
   A change that causes an incompatibility with prior versions of Iris.
 
-*Deprecations*
+*🔥 Deprecations*
   Deprecations of functionality.
 
-*Dependencies*
+*🔗 Dependencies*
   Additions, removals and version changes in Iris' package dependencies.
 
-*Documentation*
+*📚 Documentation*
   Changes to documentation.
 
-*Internal*
+*💼 Internal*
   Changes to any internal or development related topics, such as testing,
   environment dependencies etc.

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -10,14 +10,14 @@ This document explains the changes made to Iris for this release
    :depth: 3
 
 
-🎉 Announcements
+📢 Announcements
 ================
 
 * N/A
 
 
-⚙ Features
-==========
+✨ Features
+===========
 
 * `@MoseleyS`_ greatly enhanced  the :mod:`~iris.fileformats.nimrod`
   module to provide richer meta-data translation when loading ``Nimrod`` data
@@ -95,7 +95,7 @@ This document explains the changes made to Iris for this release
   (:pull:`3804`)
 
 
-⛔ Incompatible Changes
+💣 Incompatible Changes
 =======================
 
 * `@pp-mo`_ rationalised :class:`~iris.cube.CubeList` extraction
@@ -137,7 +137,7 @@ This document explains the changes made to Iris for this release
   duplicate coordinate errors in certain circumstances. (:pull:`3718`)
 
 
-🚫 Deprecations
+🔥 Deprecations
 ===============
 
 * `@stephenworsley`_ removed the deprecated :class:`iris.Future` flags

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -10,8 +10,14 @@ This document explains the changes made to Iris for this release
    :depth: 3
 
 
-Features
-========
+🎉 Announcements
+================
+
+* N/A
+
+
+⚙ Features
+==========
 
 * `@MoseleyS`_ greatly enhanced  the :mod:`~iris.fileformats.nimrod`
   module to provide richer meta-data translation when loading ``Nimrod`` data
@@ -35,8 +41,8 @@ Features
   :class:`~iris.analysis.AreaWeighted` regridding schemes. (:pull:`3701`)
 
 
-Bugs Fixed
-==========
+🐛 Bugs Fixed
+=============
 
 * `@stephenworsley`_ fixed :meth:`~iris.Cube.cube.remove_coord` to now also
   remove derived coordinates by removing aux_factories. (:pull:`3641`)
@@ -89,8 +95,8 @@ Bugs Fixed
   (:pull:`3804`)
 
 
-Incompatible Changes
-====================
+⛔ Incompatible Changes
+=======================
 
 * `@pp-mo`_ rationalised :class:`~iris.cube.CubeList` extraction
   methods:
@@ -131,8 +137,8 @@ Incompatible Changes
   duplicate coordinate errors in certain circumstances. (:pull:`3718`)
 
 
-Deprecations
-============
+🚫 Deprecations
+===============
 
 * `@stephenworsley`_ removed the deprecated :class:`iris.Future` flags
   ``cell_date_time_objects``, ``netcdf_promote``, ``netcdf_no_unlimited`` and
@@ -143,8 +149,8 @@ Deprecations
   removed from it. (:pull:`3461`)
 
 
-Dependencies
-============
+🔗 Dependencies
+===============
 
 
 * `@stephenworsley`_, `@trexfeathers`_ and `@bjlittle`_ removed ``Python2``
@@ -175,8 +181,8 @@ Dependencies
   dependency group. We no longer consider it to be an extension. (:pull:`3762`)
 
 
-Documentation
-=============
+📚 Documentation
+================
 
 * `@tkknight`_ moved the
   :ref:`sphx_glr_generated_gallery_oceanography_plot_orca_projection.py`
@@ -214,8 +220,8 @@ Documentation
   (:pull:`3803`)
 
 
-Internal
-========
+💼 Internal
+===========
 
 * `@pp-mo`_ and `@lbdreyer`_ removed all test dependencies on
   `SciTools/iris-grib <https://github.com/SciTools/iris-grib>`_ by transferring

--- a/docs/iris/src/whatsnew/latest.rst.template
+++ b/docs/iris/src/whatsnew/latest.rst.template
@@ -10,14 +10,14 @@ This document explains the changes made to Iris for this release
    :depth: 3
 
 
-🎉 Announcements
+📢 Announcements
 ================
 
 * N/A
 
 
-⚙ Features
-==========
+✨ Features
+===========
 
 * N/A
 
@@ -28,14 +28,14 @@ This document explains the changes made to Iris for this release
 * N/A
 
 
-⛔ Incompatible Changes
+💣 Incompatible Changes
 =======================
 
 
 * N/A
 
 
-🚫 Deprecations
+🔥 Deprecations
 ===============
 
 * N/A

--- a/docs/iris/src/whatsnew/latest.rst.template
+++ b/docs/iris/src/whatsnew/latest.rst.template
@@ -10,37 +10,50 @@ This document explains the changes made to Iris for this release
    :depth: 3
 
 
-Features
-========
+🎉 Announcements
+================
 
 * N/A
 
 
-Bugs Fixed
+⚙ Features
 ==========
 
 * N/A
 
 
-Incompatible Changes
-====================
-
-* N/A
-
-
-Dependencies
-============
-
-* N/A
-
-
-Documentation
+🐛 Bugs Fixed
 =============
 
 * N/A
 
 
-Internal
-========
+⛔ Incompatible Changes
+=======================
+
+
+* N/A
+
+
+🚫 Deprecations
+===============
+
+* N/A
+
+
+🔗 Dependencies
+===============
+
+* N/A
+
+
+📚 Documentation
+================
+
+* N/A
+
+
+💼 Internal
+===========
 
 * N/A


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds icon branding to the `whatsnew` section headers.

Some of the icons align with those already chosen for the associated [issues icon templates](https://github.com/SciTools/iris/issues/new/choose).

If and when #3850 is merged, I'll align the `Announcements` section appropriately.

To help reviewers, the rendered `readthedocs` changes of this PR are available:
- [latest whatsnew](https://my-iris.readthedocs.io/en/latest/whatsnew/latest.html).
- [Contribution categories](https://my-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html#contribution-categories)
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/pulls.html#the-iris-check-list)
