### PR TITLE
Replace deprecated IndexFormatter

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -97,6 +97,10 @@ This document explains the changes made to Iris for this release
   which was previously failing for some coordinate systems. See :issue:`3629`.
   (:pull:`3804`)
 
+* `@stephenworsley`_ changed the way tick labels are assigned from string coords.
+  Previously, the first tick label would occasionally be duplicated. This also
+  removes the use of Matplotlib's deprecated ``IndexFormatter``. (:pull:`3857`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -260,6 +260,7 @@ def _string_coord_axis_tick_labels(string_axes, axes=None):
             label_dict = dict(zip(tick_locations, labels))
             label = label_dict.get(x, "")
             return label
+
         formatter = mpl_ticker.FuncFormatter(ticker_func)
         locator = mpl_ticker.MaxNLocator(integer=True)
         this_axis = getattr(ax, axis)

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -249,16 +249,14 @@ def _string_coord_axis_tick_labels(string_axes, axes=None):
 
     ax = axes if axes else plt.gca()
     for axis, ticks in string_axes.items():
-        # Define a tick formatter, this replaces the now deprecated
-        # mpl_ticker.IndexFormatter. Note that this formatter behaves
-        # differently to IndexFormatter and will only assign labels to
-        # ticks which are located precisely on integers in
-        # range(len(ticks)).
-        def ticker_func(x, _):
+        # Define a tick formatter. This will assign a label to all ticks
+        # located precisely on  an integer in range(len(ticks)) and assign
+        # an empty string to any other ticks.
+        def ticker_func(tick_location, _):
             tick_locations = range(len(ticks))
             labels = ticks
             label_dict = dict(zip(tick_locations, labels))
-            label = label_dict.get(x, "")
+            label = label_dict.get(tick_location, "")
             return label
 
         formatter = mpl_ticker.FuncFormatter(ticker_func)

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -249,7 +249,18 @@ def _string_coord_axis_tick_labels(string_axes, axes=None):
 
     ax = axes if axes else plt.gca()
     for axis, ticks in string_axes.items():
-        formatter = mpl_ticker.IndexFormatter(ticks)
+        # Define a tick formatter, this replaces the now deprecated
+        # mpl_ticker.IndexFormatter. Note that this formatter behaves
+        # differently to IndexFormatter and will only assign labels to
+        # ticks which are located precisely on integers in
+        # range(len(ticks)).
+        def ticker_func(x, _):
+            tick_locations = range(len(ticks))
+            labels = ticks
+            label_dict = dict(zip(tick_locations, labels))
+            label = label_dict.get(x, "")
+            return label
+        formatter = mpl_ticker.FuncFormatter(ticker_func)
         locator = mpl_ticker.MaxNLocator(integer=True)
         this_axis = getattr(ax, axis)
         this_axis.set_major_formatter(formatter)

--- a/lib/iris/tests/unit/plot/__init__.py
+++ b/lib/iris/tests/unit/plot/__init__.py
@@ -44,7 +44,7 @@ class TestGraphicStringCoord(tests.GraphicsTest):
     def assertBoundsTickLabels(self, axis, axes=None):
         actual = self.tick_loc_and_label(axis, axes)
         expected = [
-            (-1.0, "a"),
+            (-1.0, ""),
             (0.0, "a"),
             (1.0, "b"),
             (2.0, "c"),


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Addresses #3848 (and the duplicate issue #3821).

The replacement formatter is not designed to be an exact copy of IndexFormatter since it seems that IndexFormatter can be considered bugged. Specifically, IndexFormatter would add a duplicate of the label at the 0 tick to the -1 tick. This behaviour was being accounted for by our tests, which have been changed to reflect the new behaviour. The new behaviour also relies on ticks being located precisely on integers (the IndexFormatter would perform some rudimentary rounding operations). This should always be the case since the locator is `MaxNLocator(integer=True)`.
