### PR TITLE
whatsnew - remove contents directive

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 📢 Announcements
 ================
 

--- a/docs/iris/src/whatsnew/latest.rst.template
+++ b/docs/iris/src/whatsnew/latest.rst.template
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 📢 Announcements
 ================
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR removes the `sphinx` `contents` directive from the `whatsnew`, as its unnecessary to have these section page links rendered.

Users can navigate using the section page links in the LHS sidebar instead.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/pulls.html#the-iris-check-list)
