### PR TITLE
Update CF standard name table to v75

### DIFF
--- a/etc/cf-standard-name-table.xml
+++ b/etc/cf-standard-name-table.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <standard_name_table xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cf-standard-name-table-1.1.xsd">
-   <version_number>70</version_number>
-   <last_modified>2019-12-10T14:47:41Z</last_modified>
+   <version_number>75</version_number>
+   <last_modified>2020-09-15T14:45:31Z</last_modified>
    <institution>Centre for Environmental Data Analysis</institution>
    <contact>support@ceda.ac.uk</contact>
 
@@ -48,6 +48,13 @@
       <description>&quot;Age of surface snow&quot; means the length of time elapsed since the snow accumulated on the earth&#39;s surface. The surface called &quot;surface&quot; means the lower boundary of the atmosphere.</description>
    </entry>
   
+   <entry id="aggregate_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>This flag is an algorithmic combination of the results of all relevant quality tests run for the related ancillary parent data variable. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. The aggregate quality flag provides a summary of all quality tests performed on the data variable (both automated and manual) whether present in the dataset as independent ancillary variables to the parent data variable or not.</description>
+   </entry>
+  
    <entry id="air_density">
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
@@ -55,11 +62,25 @@
       <description></description>
    </entry>
   
+   <entry id="air_equivalent_potential_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The &quot;equivalent potential temperature&quot; is a thermodynamic quantity, with its natural logarithm proportional to the entropy of moist air, that is conserved in a reversible moist adiabatic process. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Equivalent_potential_temperature. It is the temperature of a parcel of air if all the moisture contained in it were first condensed, releasing latent heat, before moving the parcel dry adiabatically to a standard pressure, typically representative of mean sea level pressure. To specify the standard pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure.</description>
+   </entry>
+  
+   <entry id="air_equivalent_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The equivalent temperature is the temperature that an air parcel would have if all water vapor were condensed at contstant pressure and the enthalpy released from the vapor used to heat the air. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Equivalent_temperature. It is the isobaric equivalent temperature and not the adiabatic equivalent temperature, also known as pseudoequivalent temperature, which has the standard name air_pseudo_equivalent_temperature.</description>
+   </entry>
+  
    <entry id="air_potential_temperature">
       <canonical_units>K</canonical_units>
       <grib>13</grib>
       <amip>theta</amip>
-      <description>Potential temperature is the temperature a parcel of air or sea water would have if moved adiabatically to sea level pressure.</description>
+      <description>Air potential temperature is the temperature a parcel of air would have if moved dry adiabatically to a standard pressure, typically representative of mean sea level pressure. To specify the standard pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure.</description>
    </entry>
   
    <entry id="air_pressure">
@@ -123,6 +144,20 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Top of atmosphere model&quot; means the upper boundary of the top layer of an atmosphere model. Air pressure is the force per unit area which would be exerted when the moving gas molecules of which the air is composed strike a theoretical surface of any orientation.</description>
+   </entry>
+  
+   <entry id="air_pseudo_equivalent_potential_temperature">
+      <canonical_units>K</canonical_units>
+      <grib>14</grib>
+      <amip></amip>
+      <description>The pseudoequivalent potential temperature is the temperature a parcel of air would have if it is expanded by a pseudoadiabatic (irreversible moist-adiabatic) process to zero pressure and afterwards compressed by a dry-adiabatic process to a standard pressure, typically representative of mean sea level pressure. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Pseudoequivalent_potential_temperature. A pseudoadiabatic process means that the liquid water that condenses is assumed to be removed as soon as it is formed. Reference: AMS Glossary http:/glossary.ametsoc.org/wiki/Pseudoadiabatic_process. To specify the standard pressure to which the quantity applies, provide a scalar coordinate variable with the standard name reference_pressure.</description>
+   </entry>
+  
+   <entry id="air_pseudo_equivalent_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The pseudoequivalent temperature is also known as the adiabatic equivalent temperature. It is the temperature that an air parcel would have after undergoing the following process: dry-adiabatic expansion until saturated; pseudoadiabatic expansion until all moisture is precipitated out; dry-adiabatic compression to the initial pressure. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Equivalent_temperature. This quantity is distinct from the isobaric equivalent temperature, also known as equivalent temperature, which has the standard name air_equivalent_temperature.</description>
    </entry>
   
    <entry id="air_temperature">
@@ -265,6 +300,13 @@
       <description>The &quot;Angstrom exponent&quot; appears in the formula relating aerosol optical thickness to the wavelength of incident radiation: T(lambda) = T(lambda0) * [lambda/lambda0] ** (-1 * alpha) where alpha is the Angstrom exponent, lambda is the wavelength of incident radiation, lambda0 is a reference wavelength, T(lambda) and T(lambda0) are the values of aerosol optical thickness at wavelengths lambda and lambda0, respectively. &quot;Aerosol&quot; means the system of suspended liquid or solid particles in air (except cloud droplets) and their carrier gas, the air itself. &quot;Ambient_aerosol&quot; means that the aerosol is measured or modelled at the ambient state of pressure, temperature and relative humidity that exists in its immediate environment. &quot;Ambient aerosol particles&quot; are aerosol particles that have taken up ambient water through hygroscopic growth. The extent of hygroscopic growth depends on the relative humidity and the composition of the particles. To specify the relative humidity and temperature at which the quantity described by the standard name applies, provide scalar coordinate variables with standard names of &quot;relative_humidity&quot; and &quot;air_temperature&quot;.</description>
    </entry>
   
+   <entry id="apparent_air_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The quantity with standard name apparent_air_temperature is the perceived air temperature derived from either a combination of temperature and wind (which has standard name wind_chill_of_air_temperature) or temperature and humidity (which has standard name heat_index_of_air_temperature) for the hour indicated by the time coordinate variable. When the air temperature falls to 283.15 K or below, wind chill is used for the apparent_air_temperature. When the air temperature rises above 299.817 K, the heat index is used for apparent_air_temperature. For temperatures above 283.15 and below 299.817K, the apparent_air_temperature is the ambient air temperature (which has standard name air_temperature). References: https://digital.weather.gov/staticpages/definitions.php; WMO codes registry entry http://codes.wmo.int/grib2/codeflag/4.2/_0-0-21.</description>
+   </entry>
+  
    <entry id="apparent_oxygen_utilization">
       <canonical_units>mol kg-1</canonical_units>
       <grib></grib>
@@ -311,7 +353,7 @@
       <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>A variable with the standard name of area_type contains strings which indicate the nature of the surface e.g. land, sea, sea_ice. These strings are standardised.  Values must be taken from the area_type table.</description>
+      <description>A variable with the standard_name of area_type contains either strings which indicate the nature of the surface e.g. land, sea, sea_ice, or flags which can be translated to strings using flag_values and flag_meanings attributes. These strings are standardised. Values must be taken from the area_type table.</description>
    </entry>
   
    <entry id="asymmetry_factor_of_ambient_aerosol_particles">
@@ -319,13 +361,6 @@
       <grib></grib>
       <amip></amip>
       <description>The asymmetry factor is the angular integral of the aerosol scattering phase function weighted by the cosine of the angle with the incident radiation flux. The asymmetry coefficient is assumed to be an integral over all wavelengths, unless a coordinate of radiation_wavelength is included to specify the wavelength. &quot;Aerosol&quot; means the system of suspended liquid or solid particles in air (except cloud droplets) and their carrier gas, the air itself. &quot;Ambient_aerosol&quot; means that the aerosol is measured or modelled at the ambient state of pressure, temperature and relative humidity that exists in its immediate environment. &quot;Ambient aerosol particles&quot; are aerosol particles that have taken up ambient water through hygroscopic growth. The extent of hygroscopic growth depends on the relative humidity and the composition of the particles. To specify the relative humidity and temperature at which the quantity described by the standard name applies, provide scalar coordinate variables with standard names of &quot;relative_humidity&quot; and &quot;air_temperature&quot;.</description>
-   </entry>
-  
-   <entry id="atmosphere_absolute_vorticity">
-      <canonical_units>s-1</canonical_units>
-      <grib>41</grib>
-      <amip></amip>
-      <description>Absolute vorticity is the sum of relative vorticity and the upward component of vorticity due to the Earth&#39;s rotation.</description>
    </entry>
   
    <entry id="atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles">
@@ -487,6 +522,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used.</description>
+   </entry>
+  
+   <entry id="atmosphere_layer_thickness_expressed_as_geopotential_height_difference">
+      <canonical_units>m</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name atmosphere_layer_thickness_expressed_as_geopotential_height_difference is the difference of geopotential height between two atmospheric levels. &quot;Layer&quot; means any layer with upper and lower boundaries that have constant values in some vertical coordinate. There must be a vertical coordinate variable indicating the extent of the layer(s). If the layers are model layers, the vertical coordinate can be &quot;model_level_number&quot;, but it is recommended to specify a physical coordinate (in a scalar or auxiliary coordinate variable) as well. &quot;Thickness&quot; means the vertical extent of a layer. Geopotential is the sum of the specific gravitational potential energy relative to the geoid and the specific centripetal potential energy. Geopotential height is the geopotential divided by the standard acceleration due to gravity. It is numerically similar to the altitude (or geometric height) and not to the quantity with standard name &quot;height&quot;, which is relative to the surface.</description>
    </entry>
   
    <entry id="atmosphere_level_of_free_convection">
@@ -773,7 +815,7 @@
       <canonical_units>kg m-2</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used.</description>
+      <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="atmosphere_mass_content_of_clox_expressed_as_chlorine">
@@ -801,7 +843,7 @@
       <canonical_units>kg m-2</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Convective cloud is that produced by the convection schemes in an atmosphere model.  &quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used.</description>
+      <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used. Convective cloud is that produced by the convection schemes in an atmosphere model. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="atmosphere_mass_content_of_dichlorine_peroxide">
@@ -1070,6 +1112,13 @@
       <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including &quot;content_of_atmosphere_layer&quot; are used. The chemical formula for limonene is C10H16. The IUPAC name for limonene is 1-methyl-4-prop-1-en-2-ylcyclohexene. Limonene is a member of the group of hydrocarbons known as terpenes. There are standard names for the terpene group as well as for some of the individual species.</description>
    </entry>
   
+   <entry id="atmosphere_mass_content_of_liquid_precipitation">
+      <canonical_units>kg m-2</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including &quot;content_of_atmosphere_layer&quot; are used. &quot;Liquid_precipitation&quot; includes both &quot;rain&quot; and &quot;drizzle&quot;. &quot;Rain&quot; means drops of water falling through the atmosphere that have a diameter greater than 0.5 mm. &quot;Drizzle&quot; means drops of water falling through the atmosphere that have a diameter typically in the range 0.2-0.5 mm.</description>
+   </entry>
+  
    <entry id="atmosphere_mass_content_of_mercury_dry_aerosol_particles">
       <canonical_units>kg m-2</canonical_units>
       <grib></grib>
@@ -1285,6 +1334,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used. The mass is the total mass of the particles. &quot;Aerosol&quot; means the system of suspended liquid or solid particles in air (except cloud droplets) and their carrier gas, the air itself. Aerosol particles take up ambient water (a process known as hygroscopic growth) depending on the relative humidity and the composition of the particles. &quot;Dry aerosol particles&quot; means aerosol particles without any water uptake. &quot;Secondary particulate organic matter &quot; means particulate organic matter formed within the atmosphere from gaseous precursors. The sum of primary_particulate_organic_matter_dry_aerosol and secondary_particulate_organic_matter_dry_aerosol is particulate_organic_matter_dry_aerosol.</description>
+   </entry>
+  
+   <entry id="atmosphere_mass_content_of_snow">
+      <canonical_units>kg m-2</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including &quot;content_of_atmosphere_layer&quot; are used. &quot;Snow&quot; refers to the precipitating part of snow in the atmosphere – the cloud snow content is excluded.</description>
    </entry>
   
    <entry id="atmosphere_mass_content_of_sulfate">
@@ -2246,13 +2302,6 @@
       <description>&quot;Content&quot; indicates a quantity per unit area. The &quot;atmosphere content&quot; of a quantity refers to the vertical integral from the surface to the top of the atmosphere. For the content between specified levels in the atmosphere, standard names including content_of_atmosphere_layer are used. Potential energy is the sum of the gravitational potential energy relative to the geoid and the centripetal potential energy. (The geopotential is the specific potential energy.)</description>
    </entry>
   
-   <entry id="atmosphere_relative_vorticity">
-      <canonical_units>s-1</canonical_units>
-      <grib>43 E138</grib>
-      <amip></amip>
-      <description>Relative vorticity is the upward component of the vorticity vector i.e. the component which arises from horizontal velocity.</description>
-   </entry>
-  
    <entry id="atmosphere_sigma_coordinate">
       <canonical_units>1</canonical_units>
       <grib></grib>
@@ -2300,6 +2349,27 @@
       <grib></grib>
       <amip></amip>
       <description>The atmosphere convective mass flux is the vertical transport of mass for a field of cumulus clouds or thermals, given by the product of air density and vertical velocity. For an area-average, cell_methods should specify whether the average is over all the area or the area of updrafts and/or downdrafts only. &quot;Updraft&quot; means that the flux is positive in the updward direction (negative downward). upward. In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics.</description>
+   </entry>
+  
+   <entry id="atmosphere_upward_absolute_vorticity">
+      <canonical_units>s-1</canonical_units>
+      <grib>41</grib>
+      <amip></amip>
+      <description>Atmosphere upward absolute vorticity is the sum of the atmosphere upward relative vorticity and the vertical component of vorticity due to the Earth’s rotation. In contrast, the quantity with standard name atmosphere_upward_relative_vorticity excludes the Earth&#39;s rotation. Vorticity is a vector quantity. &quot;Upward&quot; indicates a vector component which is positive when directed upward (negative downward). A positive value of atmosphere_upward_absolute_vorticity indicates anticlockwise rotation when viewed from above.</description>
+   </entry>
+  
+   <entry id="atmosphere_upward_relative_vorticity">
+      <canonical_units>s-1</canonical_units>
+      <grib>43 E138</grib>
+      <amip></amip>
+      <description>Atmosphere upward relative vorticity is the vertical component of the 3D air vorticity vector. The vertical component arises from horizontal velocity only. &quot;Relative&quot; in this context means the vorticity of the air relative to the rotating solid earth reference frame, i.e. excluding the Earth&#39;s own rotation. In contrast, the quantity with standard name atmosphere_upward_absolute_vorticity includes the Earth&#39;s rotation. &quot;Upward&quot; indicates a vector component which is positive when directed upward (negative downward). A positive value of atmosphere_upward_relative_vorticity indicates anticlockwise rotation when viewed from above.</description>
+   </entry>
+  
+   <entry id="attenuated_signal_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Attenuated Signal test, which checks for near-flat-line conditions using a range or standard deviation. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
    </entry>
   
    <entry id="automated_tropical_cyclone_forecasting_system_storm_identifier">
@@ -2379,6 +2449,13 @@
       <description>&quot;Baseflow&quot; is subsurface runoff which takes place below the level of the water table. Runoff is the liquid water which drains from land. &quot;Amount&quot; means mass per unit area.</description>
    </entry>
   
+   <entry id="beam_consistency_indicator_from_multibeam_acoustic_doppler_velocity_profiler_in_sea_water">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The &quot;beam_consistency_indicator&quot; is the degree to which the magnitudes of a collection (ensemble) of acoustic signals from multiple underwater acoustic transceivers relate to each other. It is used as a data quality assessment parameter in ADCP (acoustic doppler current profiler) instruments and is frequently referred to as &quot;correlation magnitude&quot;. Convention is that the larger the value, the higher the signal to noise ratio and therefore the better the quality of the current vector measurements; the maximum value of the indicator is 128.</description>
+   </entry>
+  
    <entry id="beaufort_wind_force">
       <canonical_units>1</canonical_units>
       <grib></grib>
@@ -2390,14 +2467,28 @@
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice or ocean water.</description>
+      <description>Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice, ocean water or soil.</description>
    </entry>
   
    <entry id="bedrock_altitude_change_due_to_isostatic_adjustment">
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice or ocean water. The zero of bedrock altitude change is arbitrary. Isostatic adjustment is the vertical movement of the lithosphere due to changing surface ice and water loads.</description>
+      <description>The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice, ocean water or soil. The zero of bedrock altitude change is arbitrary. Isostatic adjustment is the vertical movement of the lithosphere due to changing surface ice and water loads.</description>
+   </entry>
+  
+   <entry id="biological_taxon_identifier">
+      <canonical_units></canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. The quantity with standard name biological_taxon_identifier is the machine-readable identifier for the taxon registration in either WoRMS (the AphiaID) or ITIS (the taxonomic serial number or TSN), including namespace. The namespace strings are &#39;aphia:&#39; or &#39;tsn:&#39;. For example, Calanus finmarchicus is encoded as either &#39;aphia:104464&#39; or &#39;tsn:85272&#39;. For the marine domain WoRMS has more complete coverage and so aphia Ids are preferred. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
+   <entry id="biological_taxon_name">
+      <canonical_units></canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. The quantity with standard name biological_taxon_name is the human-readable label for the taxon such as Calanus finmarchicus. The label should be registered in either WoRMS (http://www.marinespecies.org) or ITIS (https://www.itis.gov/) and spelled exactly as registered. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
    </entry>
   
    <entry id="bioluminescent_photon_rate_in_sea_water">
@@ -2670,7 +2761,7 @@
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Potential density is the density a parcel of air or sea water would have if moved adiabatically to a reference pressure, by default assumed to be sea level pressure.  For sea water potential density, if 1000 kg m-3 is subtracted, the standard name &quot;sea_water_sigma_theta&quot; should be chosen instead. &quot;change_over_time_in_X&quot; means change in a quantity X over a time-interval, which should be defined by the bounds of the time coordinate.</description>
+      <description>The phrase &quot;change_over_time_in_X&quot; means change in a quantity X over a time interval, which should be defined by the bounds of the time coordinate. Sea water potential density is the density a parcel of sea water would have if moved adiabatically to a reference pressure, by default assumed to be sea level pressure. To specify the reference pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure. The density of a substance is its mass per unit volume. For sea water potential density, if 1000 kg m-3 is subtracted, the standard name &quot;sea_water_sigma_theta&quot; should be chosen instead.</description>
    </entry>
   
    <entry id="change_over_time_in_sea_water_potential_temperature">
@@ -2750,6 +2841,13 @@
       <description>&quot;Area fraction&quot; is the fraction of a grid cell&#39;s horizontal area that has some characteristic of interest. It is evaluated as the area of interest divided by the grid cell area. It may be expressed as a fraction, a percentage, or any other dimensionless representation of a fraction. The clear_sky area fraction is for the whole atmosphere column, as seen from the surface or the top of the atmosphere. &quot;Clear sky&quot; means in the absence of clouds.</description>
    </entry>
   
+   <entry id="climatology_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Climatology test, which checks that values are within reasonable range bounds for a given time and location. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="cloud_albedo">
       <canonical_units>1</canonical_units>
       <grib></grib>
@@ -2796,7 +2894,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Cloud liquid water mixing ratio of a parcel of air is the ratio of the mass of liquid water to the mass of dry air.</description>
+      <description>Cloud liquid water mixing ratio of a parcel of air is the ratio of the mass of liquid water to the mass of dry air. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="cloud_top_altitude">
@@ -2804,6 +2902,13 @@
       <grib></grib>
       <amip></amip>
       <description>cloud_top refers to the top of the highest cloud. Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level.</description>
+   </entry>
+  
+   <entry id="colony_forming_unit_number_concentration_of_biological_taxon_in_sea_water">
+      <canonical_units>m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Colony forming unit&quot; means an estimate of the viable bacterial or fungal numbers determined by counting colonies grown from a sample. &quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
    </entry>
   
    <entry id="compressive_strength_of_sea_ice">
@@ -3048,7 +3153,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The term &quot;Exner function&quot; is applied to various quantities in the literature. &quot;Dimensionless Exner function&quot; is the standard name of (p/p0)^(R/Cp), where p is pressure, p0 a reference pressure, R the gas constant and Cp the specific heat at constant pressure. This quantity is also the ratio of in-situ to potential temperature. Standard names for other variants can be defined on request.</description>
+      <description>The term &quot;Exner function&quot; is applied to various quantities in the literature. &quot;Dimensionless Exner function&quot; is the standard name of (p/p0)^(R/Cp), where p is pressure, p0 a reference pressure, R the gas constant and Cp the specific heat at constant pressure. This quantity is also the ratio of in-situ to potential temperature. Standard names for other variants can be defined on request. To specify the reference pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure.</description>
    </entry>
   
    <entry id="direct_downwelling_shortwave_flux_in_air">
@@ -3562,11 +3667,32 @@
       <description>&quot;Eastward&quot; indicates a vector component which is positive when directed eastward (negative westward). Transport across_unit_distance means expressed per unit distance normal to the direction of transport.</description>
    </entry>
   
+   <entry id="eastward_derivative_of_eastward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name eastward_derivative_of_eastward_wind is the derivative of the eastward component of wind with respect to distance in the eastward direction for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
    <entry id="eastward_derivative_of_northward_sea_ice_velocity">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>A velocity is a vector quantity. &quot;Eastward&quot; indicates a vector component which is positive when directed eastward (negative westward). &quot;Northward&quot; indicates a vector component which is positive when directed northward (negative southward). Sea ice velocity is defined as a two-dimensional vector, with no vertical component. &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be northward, southward, eastward, westward, x or y. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. The named quantity is a component of the strain rate tensor for sea ice. &quot;Sea ice&quot; means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.</description>
+   </entry>
+  
+   <entry id="eastward_derivative_of_northward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name eastward_derivative_of_northward_wind is the derivative of the northward component of wind with respect to distance in the eastward direction for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
+   <entry id="eastward_derivative_of_wind_from_direction">
+      <canonical_units>degree m-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name eastward_derivative_of_wind_from_direction is the derivative of wind from_direction with respect to the change in eastward lateral position for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. In meteorological reports, the direction of the wind vector is usually (but not always) given as the direction from which it is blowing (&quot;wind_from_direction&quot;) (westerly, northerly, etc.). In other contexts, such as atmospheric modelling, it is often natural to give the direction in the usual manner of vectors as the heading or the direction to which it is blowing (&quot;wind_to_direction&quot;) (eastward, southward, etc.). Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
    </entry>
   
    <entry id="eastward_flood_water_velocity">
@@ -3692,14 +3818,14 @@
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution.</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="effective_radius_of_cloud_liquid_water_particles_at_liquid_water_cloud_top">
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. The phrase &quot;cloud_top&quot; refers to the top of the highest cloud.</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution.  &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The phrase &quot;cloud_top&quot; refers to the top of the highest cloud.</description>
    </entry>
   
    <entry id="effective_radius_of_convective_cloud_ice_particles">
@@ -3713,14 +3839,14 @@
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. Convective cloud is that produced by the convection schemes in an atmosphere model.</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. Convective cloud is that produced by the convection schemes in an atmosphere model. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="effective_radius_of_convective_cloud_liquid_water_particles_at_convective_liquid_water_cloud_top">
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. The phrase &quot;convective_liquid_water_cloud_top&quot; refers to the top of the highest convective liquid water cloud. Convective cloud is that produced by the convection schemes in an atmosphere model.</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. The phrase &quot;convective_liquid_water_cloud_top&quot; refers to the top of the highest convective liquid water cloud. Convective cloud is that produced by the convection schemes in an atmosphere model. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="effective_radius_of_convective_cloud_rain_particles">
@@ -3755,14 +3881,14 @@
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="effective_radius_of_stratiform_cloud_liquid_water_particles_at_stratiform_liquid_water_cloud_top">
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. The phrase &quot;stratiform_liquid_water_cloud_top&quot; refers to the top of the highest stratiform liquid water cloud. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).</description>
+      <description>The effective radius of a size distribution of particles, such as aerosols, cloud droplets or ice crystals, is the area weighted mean radius of particle size. It is calculated as the ratio of the third to the second moment of the particle size distribution. The phrase &quot;stratiform_liquid_water_cloud_top&quot; refers to the top of the highest stratiform liquid water cloud. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="effective_radius_of_stratiform_cloud_rain_particles">
@@ -3807,13 +3933,6 @@
       <description>Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. The equilibrium line is the locus of points on a land ice surface at which ice accumulation balances ice ablation over the year.</description>
    </entry>
   
-   <entry id="equivalent_potential_temperature">
-      <canonical_units>K</canonical_units>
-      <grib></grib>
-      <amip></amip>
-      <description>Potential temperature is the temperature a parcel of air or sea water would have if moved adiabatically to sea level pressure.</description>
-   </entry>
-  
    <entry id="equivalent_pressure_of_atmosphere_ozone_content">
       <canonical_units>Pa</canonical_units>
       <grib></grib>
@@ -3828,13 +3947,6 @@
       <description>&quot;Equivalent reflectivity factor&quot;  is the radar reflectivity factor that is calculated from the measured radar return power assuming the target is composed of liquid water droplets whose diameter is less than one tenth of the radar wavelength, i.e., treating the droplets as Rayleigh scatterers.  The actual radar reflectivity factor would depend on the size distribution and composition of the particles within the target volume and these are  often unknown.</description>
    </entry>
   
-   <entry id="equivalent_temperature">
-      <canonical_units>K</canonical_units>
-      <grib></grib>
-      <amip></amip>
-      <description></description>
-   </entry>
-  
    <entry id="equivalent_thickness_at_stp_of_atmosphere_ozone_content">
       <canonical_units>m</canonical_units>
       <grib>10</grib>
@@ -3846,7 +3958,7 @@
       <canonical_units>K m2 kg-1 s-1</canonical_units>
       <grib></grib>
       <amip>vorpot</amip>
-      <description></description>
+      <description>The Ertel potential vorticity is the scalar product of the atmospheric absolute vorticity vector and the gradient of potential temperature. It is a conserved quantity in the absence of friction and heat sources [AMS Glossary, http://glossary.ametsoc.org/wiki/Ertel_potential_vorticity]. A frequently used simplification of the general Ertel potential vorticity considers the Earth rotation vector to have only a vertical component. Then, only the vertical contribution of the scalar product is calculated.</description>
    </entry>
   
    <entry id="fast_soil_pool_mass_content_of_carbon">
@@ -3882,6 +3994,13 @@
       <grib></grib>
       <amip></amip>
       <description>The overall temperature of a fire area due to contributions from smoldering and flaming biomass. A data variable containing the area affected by fire should be given the standard name fire_area.</description>
+   </entry>
+  
+   <entry id="flat_line_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Flat Line test, which checks for consecutively repeated values within a tolerance. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
    </entry>
   
    <entry id="floating_ice_shelf_area">
@@ -4001,6 +4120,13 @@
       <grib></grib>
       <amip></amip>
       <description>The fugacity is the measured pressure (or partial pressure) of a real gas corrected for the intermolecular forces of that gas, which allows that corrected quantity to be treated like the pressure of an ideal gas in the ideal gas equation PV = nRT. The partial pressure of a dissolved gas in sea water is the partial pressure in air with which it would be in equilibrium. The partial pressure of a gaseous constituent of air is the pressure that it would exert if all other gaseous constituents were removed, assuming the volume, the temperature, and its number of moles remain unchanged. The chemical formula for carbon dioxide is CO2.</description>
+   </entry>
+  
+   <entry id="gap_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Timing/Gap test, which checks that data have been received within the expected time window and have the correct time stamp. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
    </entry>
   
    <entry id="geoid_height_above_reference_ellipsoid">
@@ -4157,6 +4283,13 @@
       <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Gross primary production is the rate of synthesis of biomass from inorganic precursors by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton. The producers also respire some of this biomass and the difference is &quot;net_primary_production&quot;. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A.</description>
    </entry>
   
+   <entry id="gross_range_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Gross Range test, which checks that values are within reasonable range bounds. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="gross_rate_of_decrease_in_area_fraction">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
@@ -4206,11 +4339,11 @@
       <description>Diatoms are phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Irradiance&quot; means the power per unit area (called radiative flux in other standard names), the area being normal to the direction of flow of the radiant energy. Solar irradiance is essential to the photosynthesis reaction and its presence promotes the growth of phytoplankton populations. &quot;Growth limitation due to solar irradiance&quot; means the ratio of the growth rate of a species population in the environment (where the amount of sunlight reaching a location may be limited) to the theoretical growth rate if there were no such limit on solar irradiance.</description>
    </entry>
   
-   <entry id="growth_limitation_of_diazotrophs_due_to_solar_irradiance">
+   <entry id="growth_limitation_of_diazotrophic_phytoplankton_due_to_solar_irradiance">
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Irradiance&quot; means the power per unit area (called radiative flux in other standard names), the area being normal to the direction of flow of the radiant energy. Solar irradiance is essential to the photosynthesis reaction and its presence promotes the growth of phytoplankton populations. &quot;Growth limitation due to solar irradiance&quot; means the ratio of the growth rate of a species population in the environment (where the amount of sunlight reaching a location may be limited) to the theoretical growth rate if there were no such limit on solar irradiance.</description>
+      <description>&quot;Growth limitation due to solar irradiance&quot; means the ratio of the growth rate of a biological population in the environment (where the amount of sunlight reaching a location may be limited) to the theoretical growth rate if there were no such limit on solar irradiance. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Irradiance&quot; means the power per unit area (called radiative flux in other standard names), the area being normal to the direction of flow of the radiant energy. Solar irradiance is essential to the photosynthesis reaction and its presence promotes the growth of phytoplankton populations. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="growth_limitation_of_miscellaneous_phytoplankton_due_to_solar_irradiance">
@@ -4302,6 +4435,13 @@
       <grib></grib>
       <amip></amip>
       <description>In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics.  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;Snow thermodynamics&quot; refers to the addition or subtraction of mass due to surface and basal fluxes, i.e., due to melting, sublimation and fusion.</description>
+   </entry>
+  
+   <entry id="heat_index_of_air_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The quantity with standard name heat_index_of_air_temperature is the perceived air temperature when relative humidity is taken into consideration (which makes it feel hotter than the actual air temperature). Heat index is only defined when the ambient air temperature is at or above 299.817 K. References: https://www.weather.gov/safety/heat-index; WMO codes registry entry http://codes.wmo.int/grib2/codeflag/4.2/_0-0-12.</description>
    </entry>
   
    <entry id="height">
@@ -4421,6 +4561,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Water&quot; means water in all phases. &quot;River&quot; refers to water in the fluvial system (stream and floodplain).</description>
+   </entry>
+  
+   <entry id="indicative_error_from_multibeam_acoustic_doppler_velocity_profiler_in_sea_water">
+      <canonical_units>m s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>Sea water velocity is a vector quantity that is the speed at which water travels in a specified direction. The &quot;indicative error&quot; is an estimate of the quality of a sea water velocity profile measured using an ADCP (acoustic doppler current profiler). It is determined by differencing duplicate error velocity measurements made using different pairs of beams. The parameter is frequently referred to as the &quot;error velocity&quot;.</description>
    </entry>
   
    <entry id="institution">
@@ -7139,11 +7286,11 @@
       <description>Diatoms are phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. &quot;Iron growth limitation&quot; means the ratio of the growth rate of a species population in the environment (where there is a finite availability of iron) to the theoretical growth rate if there were no such limit on iron availability.</description>
    </entry>
   
-   <entry id="iron_growth_limitation_of_diazotrophs">
+   <entry id="iron_growth_limitation_of_diazotrophic_phytoplankton">
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. &quot;Iron growth limitation&quot; means the ratio of the growth rate of a species population in the environment (where there is a finite availability of iron) to the theoretical growth rate if there were no such limit on iron availability.</description>
+      <description>&quot;Iron growth limitation&quot; means the ratio of the growth rate of a biological population in the environment (where there is a finite availability of iron) to the theoretical growth rate if there were no such limit on iron availability. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="iron_growth_limitation_of_miscellaneous_phytoplankton">
@@ -7248,7 +7395,7 @@
       <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>A variable with the standard name of land_cover_sccs contains strings which indicate the nature of the surface, e.g. cropland_..., tree_... . These strings are standardised. Values must be combinations of classifiers from the Land Cover Classification System (LCCS; Di Gregorio A., 2005, UN Land Cover Classification System (LCCS) - Classification concepts and user manual for Software version 2; available at www.fao.org/DOCREP/003/X0596E/X0596e00.htm).</description>
+      <description>A variable with the standard name of land_cover_lccs contains strings which indicate the nature of the surface, e.g. cropland_..., tree_... . Each string should represent a land cover class constructed using the Land Cover Classification System (LCCS; Di Gregorio A., 2005, UN Land Cover Classification System (LCCS) - Classification concepts and user manual for Software version 2; available at www.fao.org/DOCREP/003/X0596E/X0596e00.htm). String values should represent the classifiers used to define each class.</description>
    </entry>
   
    <entry id="land_ice_area_fraction">
@@ -7580,6 +7727,13 @@
       <description>&quot;Content&quot; indicates a quantity per unit area. &quot;Litter&quot; is dead plant material in or above the soil. It is distinct from coarse wood debris. The precise distinction between &quot;fine&quot; and &quot;coarse&quot; is model dependent. The sum of the quantities with standard names surface_litter_mass_content_of_nitrogen and subsurface_litter_mass_content_of_nitrogen has the standard name litter_mass_content_of_nitrogen.</description>
    </entry>
   
+   <entry id="location_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Location test, which checks that a location is within reasonable bounds. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="log10_size_interval_based_number_size_distribution_of_cloud_condensation_nuclei_at_stp_in_air">
       <canonical_units>m-3</canonical_units>
       <grib></grib>
@@ -7895,6 +8049,27 @@
       <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;nmvoc&quot; means non methane volatile organic compounds; &quot;nmvoc&quot; is the term used in standard names to describe the group of chemical species having this classification that are represented within a given model. The list of individual species that are included in a quantity having a group chemical standard name can vary between models. Where possible, the data variable should be accompanied by a complete description of the species represented, for example, by using a comment attribute. &quot;Biogenic&quot; means influenced, caused, or created by natural processes.</description>
    </entry>
   
+   <entry id="mass_concentration_of_biological_taxon_expressed_as_carbon_in_sea_water">
+      <canonical_units>kg m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Mass concentration of biota expressed as carbon is also referred to as &quot;carbon biomass&quot;. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
+   <entry id="mass_concentration_of_biological_taxon_expressed_as_chlorophyll_in_sea_water">
+      <canonical_units>kg m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables. Chlorophylls are the green pigments found in most plants, algae and cyanobacteria; their presence is essential for photosynthesis to take place. There are several different forms of chlorophyll that occur naturally. All contain a chlorin ring (chemical formula C20H16N4) which gives the green pigment and a side chain whose structure varies. The naturally occurring forms of chlorophyll contain between 35 and 55 carbon atoms.</description>
+   </entry>
+  
+   <entry id="mass_concentration_of_biological_taxon_expressed_as_nitrogen_in_sea_water">
+      <canonical_units>kg m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Mass concentration of biota expressed as nitrogen is also referred to as &quot;nitrogen biomass&quot;. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
    <entry id="mass_concentration_of_biomass_burning_dry_aerosol_particles_in_air">
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
@@ -8039,15 +8214,14 @@
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y.  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Chlorophylls are the green pigments found in most plants, algae and cyanobacteria; their presence is essential for photosynthesis to take place. There are several different forms of chlorophyll that occur naturally. All contain a chlorin ring (chemical formula C20H16N4) which gives the green pigment and a side chain whose structure varies. The naturally occurring forms of chlorophyll contain between 35 and 55 carbon atoms.
-</description>
+      <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y.  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Chlorophylls are the green pigments found in most plants, algae and cyanobacteria; their presence is essential for photosynthesis to take place. There are several different forms of chlorophyll that occur naturally. All contain a chlorin ring (chemical formula C20H16N4) which gives the green pigment and a side chain whose structure varies. The naturally occurring forms of chlorophyll contain between 35 and 55 carbon atoms.</description>
    </entry>
   
    <entry id="mass_concentration_of_cloud_liquid_water_in_air">
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass concentration means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. Cloud droplets are spherical and typically a few micrometers to a few tens of micrometers in diameter. An upper limit of 0.2 mm diameter is sometimes used to distinguish between cloud droplets and drizzle drops, but in active cumulus clouds strong updrafts can maintain much larger cloud droplets.</description>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="mass_concentration_of_clox_expressed_as_chlorine_in_air">
@@ -8092,11 +8266,18 @@
       <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Diatoms are single-celled phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
    </entry>
   
-   <entry id="mass_concentration_of_diazotrophs_expressed_as_chlorophyll_in_sea_water">
+   <entry id="mass_concentration_of_diazotrophic_phytoplankton_expressed_as_carbon_in_sea_water">
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Chlorophylls are the green pigments found in most plants, algae and cyanobacteria; their presence is essential for photosynthesis to take place. There are several different forms of chlorophyll that occur naturally. All contain a chlorin ring (chemical formula C20H16N4) which gives the green pigment and a side chain whose structure varies. The naturally occurring forms of chlorophyll contain between 35 and 55 carbon atoms. In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
+   </entry>
+  
+   <entry id="mass_concentration_of_diazotrophic_phytoplankton_expressed_as_chlorophyll_in_sea_water">
+      <canonical_units>kg m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Chlorophylls are the green pigments found in most plants, algae and cyanobacteria; their presence is essential for photosynthesis to take place. There are several different forms of chlorophyll that occur naturally. All contain a chlorin ring (chemical formula C20H16N4) which gives the green pigment and a side chain whose structure varies. The naturally occurring forms of chlorophyll contain between 35 and 55 carbon atoms. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="mass_concentration_of_dichlorine_peroxide_in_air">
@@ -8792,6 +8973,13 @@
       <description>Mass concentration means mass per unit volume and is used in the construction mass_concentration_of_X_in_Y, where X is a material constituent of Y.  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. The chemical formula for xylene is C6H4C2H6. In chemistry, xylene is a generic term for a group of three isomers of dimethylbenzene. The IUPAC names for the isomers are 1,2-dimethylbenzene, 1,3-dimethylbenzene and 1,4-dimethylbenzene. Xylene is an aromatic hydrocarbon. There are standard names that refer to aromatic_compounds as a group, as well as those for individual species.</description>
    </entry>
   
+   <entry id="mass_concentration_of_zooplankton_expressed_as_carbon_in_sea_water">
+      <canonical_units>kg m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass concentration&quot; means mass per unit volume and is used in the construction &quot;mass_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;Zooplankton&quot; means the total zooplankton population, with components such as mesozooplankton, microzooplankton and miscellaneous zooplankton.</description>
+   </entry>
+  
    <entry id="mass_content_of_13C_in_vegetation_and_litter_and_soil_and_forestry_and_agricultural_products">
       <canonical_units>kg m-2</canonical_units>
       <grib></grib>
@@ -8831,7 +9019,7 @@
       <canonical_units>kg m-2</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Content&quot; indicates a quantity per unit area. &quot;Layer&quot; means any layer with upper and lower boundaries that have constant values in some vertical coordinate. There must be a vertical coordinate variable indicating the extent of the layer(s). If the layers are model layers, the vertical coordinate can be model_level_number, but it is recommended to specify a physical coordinate (in a scalar or auxiliary coordinate variable) as well.</description>
+      <description>The &quot;content_of_X_in_atmosphere_layer&quot; refers to the vertical integral between two specified levels in the atmosphere. &quot;Content&quot; indicates a quantity per unit area. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. &quot;Layer&quot; means any layer with upper and lower boundaries that have constant values in some vertical coordinate. There must be a vertical coordinate variable indicating the extent of the layer(s). If the layers are model layers, the vertical coordinate can be model_level_number, but it is recommended to specify a physical coordinate (in a scalar or auxiliary coordinate variable) as well.</description>
    </entry>
   
    <entry id="mass_content_of_nitrogen_in_vegetation_and_litter_and_soil_and_forestry_and_agricultural_products">
@@ -9237,7 +9425,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip>clw</amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
+      <description>&quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="mass_fraction_of_clox_expressed_as_chlorine_in_air">
@@ -9265,7 +9453,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). Convective cloud is that produced by the convection schemes in an atmosphere model.</description>
+      <description>&quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. Convective cloud is that produced by the convection schemes in an atmosphere model. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="mass_fraction_of_dichlorine_peroxide_in_air">
@@ -9539,6 +9727,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The chemical formula for limonene is C10H16. The IUPAC name for limonene is 1-methyl-4-prop-1-en-2-ylcyclohexene. Limonene is a member of the group of hydrocarbons known as terpenes. There are standard names for the terpene group as well as for some of the individual species.</description>
+   </entry>
+  
+   <entry id="mass_fraction_of_liquid_precipitation_in_air">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Liquid_precipitation&quot; includes both &quot;rain&quot; and &quot;drizzle&quot;. &quot;Rain&quot; means drops of water falling through the atmosphere that have a diameter greater than 0.5 mm. &quot;Drizzle&quot; means drops of water falling through the atmosphere that have a diameter typically in the range 0.2-0.5 mm.</description>
    </entry>
   
    <entry id="mass_fraction_of_mercury_dry_aerosol_particles_in_air">
@@ -9954,13 +10149,6 @@
       <description>The quantity with standard name mass_fraction_of_rainfall_falling_onto_surface_snow is the mass of rainfall falling onto snow as a fraction of the mass of rainfall falling within the area of interest. The phrase &quot;surface_snow&quot; means snow lying on the surface. Unless indicated in the cell_methods attribute, a quantity is assumed to apply to the whole area of each horizontal grid box.</description>
    </entry>
   
-   <entry id="mass_fraction_of_rain_in_air">
-      <canonical_units>1</canonical_units>
-      <grib></grib>
-      <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
-   </entry>
-  
    <entry id="mass_fraction_of_sea_salt_dry_aerosol_particles_expressed_as_cations_in_air">
       <canonical_units>1</canonical_units>
       <grib></grib>
@@ -9986,7 +10174,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
+      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). &quot;Snow&quot; refers to the precipitating part of snow in the atmosphere – the cloud snow content is excluded.</description>
    </entry>
   
    <entry id="mass_fraction_of_solid_precipitation_falling_onto_surface_snow">
@@ -10007,7 +10195,7 @@
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).</description>
+      <description>&quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="mass_fraction_of_sulfate_dry_aerosol_particles_in_air">
@@ -10514,6 +10702,20 @@
       <description>Mole concentration means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction mole_concentration_of_X_in_Y, where X is a material constituent of Y.  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;nmvoc&quot; means non methane volatile organic compounds; &quot;nmvoc&quot; is the term used in standard names to describe the group of chemical species having this classification that are represented within a given model. The list of individual species that are included in a quantity having a group chemical standard name can vary between models. Where possible, the data variable should be accompanied by a complete description of the species represented, for example, by using a comment attribute. &quot;Biogenic&quot; means influenced, caused, or created by natural processes.</description>
    </entry>
   
+   <entry id="mole_concentration_of_biological_taxon_expressed_as_carbon_in_sea_water">
+      <canonical_units>mol m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
+   <entry id="mole_concentration_of_biological_taxon_expressed_as_nitrogen_in_sea_water">
+      <canonical_units>mol m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
    <entry id="mole_concentration_of_bromine_chloride_in_air">
       <canonical_units>mol m-3</canonical_units>
       <grib></grib>
@@ -10724,11 +10926,11 @@
       <description>Mole concentration means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction mole_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated in terms of B alone, neglecting all other chemical constituents of A. Diatoms are phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
    </entry>
   
-   <entry id="mole_concentration_of_diazotrophs_expressed_as_carbon_in_sea_water">
+   <entry id="mole_concentration_of_diazotrophic_phytoplankton_expressed_as_carbon_in_sea_water">
       <canonical_units>mol m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mole concentration means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction mole_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
+      <description>&quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y.  A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="mole_concentration_of_dichlorine_peroxide_in_air">
@@ -10855,6 +11057,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&#39; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Organic carbon&quot; describes a family of chemical species and is the term used in standard names for all species belonging to the family that are represented within a given model. The list of individual species that are included in a quantity having a group chemical standard name can vary between models. Where possible, the data variable should be accompanied by a complete description of the species represented, for example, by using a comment attribute.</description>
+   </entry>
+  
+   <entry id="mole_concentration_of_dissolved_organic_nitrogen_in_sea_water">
+      <canonical_units>mol/m3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Dissolved organic nitrogen&quot; describes the nitrogen held in carbon compounds in solution. These are mostly generated by plankton excretion and decay.</description>
    </entry>
   
    <entry id="mole_concentration_of_ethane_in_air">
@@ -12432,6 +12641,20 @@
       <description>moles_of_X_per_unit_mass_inY is also called &quot;molality&quot; of X in Y, where X is a material constituent of Y.</description>
    </entry>
   
+   <entry id="multi_variate_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Multi-variate test, which checks that values are reasonable when compared with related variables. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
+   <entry id="neighbor_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Neighbor test, which checks that values are reasonable when compared with nearby measurements. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="net_downward_longwave_flux_in_air">
       <canonical_units>W m-2</canonical_units>
       <grib></grib>
@@ -12488,11 +12711,11 @@
       <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Diatoms are single-celled phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
    </entry>
   
-   <entry id="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophs">
+   <entry id="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophic_phytoplankton">
       <canonical_units>mol m-2 s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
+      <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_miscellaneous_phytoplankton">
@@ -12541,7 +12764,7 @@
       <canonical_units>kg m-2 s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. </description>
+      <description>&quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. &quot;Productivity&quot; means production per unit area. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A.</description>
    </entry>
   
    <entry id="net_primary_productivity_of_biomass_expressed_as_carbon_accumulated_in_miscellaneous_living_matter">
@@ -12635,11 +12858,11 @@
       <description>Diatoms are phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. &quot;Nitrogen growth limitation&quot; means the ratio of the growth rate of a species population in the environment (where there is a finite availability of nitrogen) to the theoretical growth rate if there were no such limit on nitrogen availability.</description>
    </entry>
   
-   <entry id="nitrogen_growth_limitation_of_diazotrophs">
+   <entry id="nitrogen_growth_limitation_of_diazotrophic_phytoplankton">
       <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. &quot;Nitrogen growth limitation&quot; means the ratio of the growth rate of a species population in the environment (where there is a finite availability of nitrogen) to the theoretical growth rate if there were no such limit on nitrogen availability.</description>
+      <description>&quot;Nitrogen growth limitation&quot; means the ratio of the growth rate of a biological population in the environment (where there is a finite availability of nitrogen) to the theoretical growth rate if there were no such limit on nitrogen availability. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="nitrogen_growth_limitation_of_miscellaneous_phytoplankton">
@@ -12720,7 +12943,7 @@
    </entry>
   
    <entry id="northward_atmosphere_water_transport_across_unit_distance">
-      <canonical_units>kg s-1 m-1</canonical_units>
+      <canonical_units>kg m-1 s-1</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>&quot;Water&quot; means water in all phases. &quot;Northward&quot; indicates a vector component which is positive when directed northward (negative southward). Transport across_unit_distance means expressed per unit distance normal to the direction of transport.</description>
@@ -12738,6 +12961,27 @@
       <grib></grib>
       <amip></amip>
       <description>A velocity is a vector quantity. &quot;Eastward&quot; indicates a vector component which is positive when directed eastward (negative westward). &quot;Northward&quot; indicates a vector component which is positive when directed northward (negative southward). Sea ice velocity is defined as a two-dimensional vector, with no vertical component. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be northward, southward, eastward, westward, x or y. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. The named quantity is a component of the strain rate tensor for sea ice. &quot;Sea ice&quot; means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.</description>
+   </entry>
+  
+   <entry id="northward_derivative_of_eastward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name northward_derivative_of_eastward_wind is the derivative of the eastward component of the wind with respect to distance in the northward direction for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
+   <entry id="northward_derivative_of_northward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name northward_derivative_of_northward_wind is the derivative of the northward component of wind with respect to distance in the northward direction for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
+   <entry id="northward_derivative_of_wind_from_direction">
+      <canonical_units>degree m-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name northward_derivative_of_wind_from_direction is the derivative of wind from_direction with respect to the change in northward lateral position for a given atmospheric level. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. In meteorological reports, the direction of the wind vector is usually (but not always) given as the direction from which it is blowing (&quot;wind_from_direction&quot;) (westerly, northerly, etc.). In other contexts, such as atmospheric modelling, it is often natural to give the direction in the usual manner of vectors as the heading or the direction to which it is blowing (&quot;wind_to_direction&quot;) (eastward, southward, etc.). Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
    </entry>
   
    <entry id="northward_eliassen_palm_flux_in_air">
@@ -13041,6 +13285,13 @@
       <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. &quot;Aerosol&quot; means the system of suspended liquid or solid particles in air (except cloud droplets) and their carrier gas, the air itself. &quot;Ambient_aerosol&quot; means that the aerosol is measured or modelled at the ambient state of pressure, temperature and relative humidity that exists in its immediate environment. &quot;Ambient aerosol particles&quot; are aerosol particles that have taken up ambient water through hygroscopic growth. The extent of hygroscopic growth depends on the relative humidity and the composition of the particles.</description>
    </entry>
   
+   <entry id="number_concentration_of_biological_taxon_in_sea_water">
+      <canonical_units>m-3</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. &quot;Biological taxon&quot; is a name or other label identifying an organism or a group of organisms as belonging to a unit of classification in a hierarchical taxonomy. There must be an auxiliary coordinate variable with standard name biological_taxon_name to identify the taxon in human readable format and optionally an auxiliary coordinate variable with standard name biological_taxon_identifier to provide a  machine-readable identifier. See Section 6.1.2 of the CF convention (version 1.8 or later) for information about biological taxon auxiliary coordinate variables.</description>
+   </entry>
+  
    <entry id="number_concentration_of_cloud_condensation_nuclei_at_stp_in_air">
       <canonical_units>m-3</canonical_units>
       <grib></grib>
@@ -13052,14 +13303,14 @@
       <canonical_units>m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume.</description>
+      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="number_concentration_of_cloud_liquid_water_particles_in_air_at_liquid_water_cloud_top">
       <canonical_units>m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. cloud_top refers to the top of the highest cloud.</description>
+      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. cloud_top refers to the top of the highest cloud.</description>
    </entry>
   
    <entry id="number_concentration_of_coarse_mode_ambient_aerosol_particles_in_air">
@@ -13073,7 +13324,7 @@
       <canonical_units>m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. The phrase &quot;convective_liquid_water_cloud_top&quot; refers to the top of the highest convective liquid water cloud. Convective cloud is that produced by the convection schemes in an atmosphere model.</description>
+      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. The phrase &quot;convective_liquid_water_cloud_top&quot; refers to the top of the highest convective liquid water cloud. Convective cloud is that produced by the convection schemes in an atmosphere model.  &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="number_concentration_of_ice_crystals_in_air">
@@ -13122,7 +13373,7 @@
       <canonical_units>m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. The phrase &quot;stratiform_liquid_water_cloud_top&quot; refers to the top of the highest stratiform liquid water cloud. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).</description>
+      <description>&quot;Number concentration&quot; means the number of particles or other specified objects per unit volume. The phrase &quot;stratiform_liquid_water_cloud_top&quot; refers to the top of the highest stratiform liquid water cloud. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="number_of_days_with_air_temperature_above_threshold">
@@ -13675,7 +13926,7 @@
       <canonical_units>m3 s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;y&quot; indicates a vector component along the grid y-axis, positive with increasing y. </description>
+      <description>&quot;y&quot; indicates a vector component along the grid y-axis, positive with increasing y.</description>
    </entry>
   
    <entry id="ocean_y_overturning_mass_streamfunction">
@@ -13753,6 +14004,20 @@
       <grib></grib>
       <amip></amip>
       <description>The partial pressure of a dissolved gas in sea water is the partial pressure in air with which it would be in equilibrium. The partial pressure of a gaseous constituent of air is the pressure that it would exert if all other gaseous constituents were removed, assuming the volume, the temperature, and its number of moles remain unchanged. The chemical formula for methane is CH4.</description>
+   </entry>
+  
+   <entry id="permafrost_active_layer_thickness">
+      <canonical_units>m</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name permafrost_active_layer_thickness is the thickness of the layer of the ground that is subject to annual thawing and freezing in areas underlain by permafrost. &quot;Thickness&quot; means the vertical extent of a layer. Permafrost is soil or rock that has remained at a temperature at or below zero degrees Celsius throughout the seasonal cycle for two or more years.</description>
+   </entry>
+  
+   <entry id="permafrost_area_fraction">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Area fraction&quot; is the fraction of a grid cell&#39;s horizontal area that has some characteristic of interest. It is evaluated as the area of interest divided by the grid cell area. It may be expressed as a fraction, a percentage, or any other dimensionless representation of a fraction. Permafrost is soil or rock that has remained at a temperature at or below zero degrees Celsius throughout the seasonal cycle for two or more years.</description>
    </entry>
   
    <entry id="permafrost_layer_thickness">
@@ -14189,11 +14454,25 @@
       <description>&quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics. Unless indicated in the cell_methods attribute, a quantity is assumed to apply to the whole area of each horizontal grid box. Previously, the qualifier where_type was used to specify that the quantity applies only to the part of the grid box of the named type. Names containing the where_type qualifier are deprecated and newly created data should use the cell_methods attribute to indicate the horizontal area to which the quantity applies. &quot;Canopy&quot; means the vegetative covering over a surface. The canopy is often considered to be the outer surfaces of the vegetation. Plant height and the distribution, orientation and shape of plant leaves within a canopy influence the atmospheric environment and many plant processes within the canopy. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Canopy.</description>
    </entry>
   
+   <entry id="predominant_precipitation_type_at_surface">
+      <canonical_units></canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A variable with the standard name predominant_precipitation_type_at_surface contains strings which indicate the character of the predominant precipitating hydrometeor at a location or grid cell. These strings have not yet been standardised. Alternatively, the data variable may contain integers which can be translated to strings using flag_values and flag_meanings attributes. &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. The surface called &quot;surface&quot; means the lower boundary of the atmosphere.</description>
+   </entry>
+  
    <entry id="pressure_at_effective_cloud_top_defined_by_infrared_radiation">
       <canonical_units>Pa</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>The &quot;effective cloud top defined by infrared radiation&quot; is (approximately) the geometric height above the surface that is one optical depth at infrared wavelengths (in the region of 11 micrometers) below the cloud top that would be detected by visible and lidar techniques. Reference: Minnis, P. et al 2011 CERES Edition-2 Cloud Property Retrievals Using TRMM VIRS and Terra and Aqua MODIS Data x2014; Part I: Algorithms IEEE Transactions on Geoscience and Remote Sensing, 49(11), 4374-4400. doi: http://dx.doi.org/10.1109/TGRS.2011.2144601.</description>
+   </entry>
+  
+   <entry id="probability_distribution_of_wind_from_direction_over_time">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The construction &quot;probability_distribution_of_X_over_Z&quot; means that the data variable is a number in the range 0.0-1.0 for each range of X, where X varies over Z. The data variable should have an axis for X. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;). The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. In meteorological reports, the direction of the wind vector is usually (but not always) given as the direction from which it is blowing (&quot;wind_from_direction&quot;) (westerly, northerly, etc.). In other contexts, such as atmospheric modelling, it is often natural to give the direction in the usual manner of vectors as the heading or the direction to which it is blowing (&quot;wind_to_direction&quot;) (eastward, southward, etc.).</description>
    </entry>
   
    <entry id="product_of_air_temperature_and_specific_humidity">
@@ -14343,11 +14622,25 @@
       <description>&quot;product_of_X_and_Y&quot; means X*Y. &quot;specific&quot; means per unit mass. A velocity is a vector quantity. &quot;Upward&quot; indicates a vector component which is positive when directed upward (negative downward). Specific humidity is the mass fraction of water vapor in (moist) air. Upward air velocity is the vertical component of the 3D air velocity vector.</description>
    </entry>
   
+   <entry id="projection_x_angular_coordinate">
+      <canonical_units>radian</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;x&quot; indicates a vector component along the grid x-axis, when this is not true longitude, positive with increasing x. Angular projection coordinates are angular distances in the x- and y-directions on a plane onto which the surface of the Earth has been projected according to a map projection. The relationship between the angular projection coordinates and latitude and longitude is described by the grid_mapping.</description>
+   </entry>
+  
    <entry id="projection_x_coordinate">
       <canonical_units>m</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>&quot;x&quot; indicates a vector component along the grid x-axis, when this is not true longitude, positive with increasing x. Projection coordinates are distances in the x- and y-directions on a plane onto which the surface of the Earth has been projected according to a map projection. The relationship between the projection coordinates and latitude and longitude is described by the grid_mapping.</description>
+   </entry>
+  
+   <entry id="projection_y_angular_coordinate">
+      <canonical_units>radian</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;y&quot; indicates a vector component along the grid y-axis, when this is not true latitude, positive with increasing y. Angular projection coordinates are angular distances in the x- and y-directions on a plane onto which the surface of the Earth has been projected according to a map projection. The relationship between the angular projection coordinates and latitude and longitude is described by the grid_mapping.</description>
    </entry>
   
    <entry id="projection_y_coordinate">
@@ -14357,18 +14650,11 @@
       <description>&quot;y&quot; indicates a vector component along the grid y-axis, when this is not true latitude, positive with increasing y. Projection coordinates are distances in the x- and y-directions on a plane onto which the surface of the Earth has been projected according to a map projection. The relationship between the projection coordinates and latitude and longitude is described by the grid_mapping.</description>
    </entry>
   
-   <entry id="pseudo_equivalent_potential_temperature">
-      <canonical_units>K</canonical_units>
-      <grib>14</grib>
-      <amip></amip>
-      <description>Potential temperature is the temperature a parcel of air or sea water would have if moved adiabatically to sea level pressure.</description>
-   </entry>
-  
-   <entry id="pseudo_equivalent_temperature">
-      <canonical_units>K</canonical_units>
+   <entry id="proportion_of_acceptable_signal_returns_from_acoustic_instrument_in_sea_water">
+      <canonical_units>1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description></description>
+      <description>The phrase &quot;proportion_of_acceptable_signal_returns&quot; means the fraction of a collection (ensemble) of returned signal transmissions that have passed a set of automatic quality control criteria. For an ADCP (acoustic doppler current profiler) the rejection criteria include low correlation, large error velocity and fish detection. The dimensionless proportion is often but not exclusively expressed as a percentage, when it is referred to as &quot;percent good&quot;.</description>
    </entry>
   
    <entry id="quality_flag">
@@ -17003,6 +17289,13 @@
       <description></description>
    </entry>
   
+   <entry id="rate_of_change_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Rate of Change test, which checks that the first order difference of a series of values is within reasonable bounds. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="rate_of_hydroxyl_radical_destruction_due_to_reaction_with_nmvoc">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
@@ -17052,6 +17345,13 @@
       <description>For models using a dimensionless vertical coordinate, for example, sigma, hybrid sigma-pressure or eta, the values of the vertical coordinate at the model levels are calculated relative to a reference level. &quot;Reference air pressure&quot; is the air pressure at the model reference level. It is a model-dependent constant.</description>
    </entry>
   
+   <entry id="reference_pressure">
+      <canonical_units>Pa</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A constant pressure value, typically representative of mean sea level pressure, which can be used in defining coordinates or functions of state.</description>
+   </entry>
+  
    <entry id="reference_sea_water_density_for_boussinesq_approximation">
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
@@ -17063,7 +17363,7 @@
       <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>A variable with the standard name of region contains strings which indicate geographical regions. These strings must be chosen from the standard region list.</description>
+      <description>A variable with the standard name of region contains either strings which indicate a geographical region or flags which can be translated to strings using flag_values and flag_meanings attributes. These strings are standardised. Values must be taken from the CF standard region list.</description>
    </entry>
   
    <entry id="relative_humidity">
@@ -17298,7 +17598,7 @@
    </entry>
   
    <entry id="sea_ice_classification">
-      <canonical_units>1</canonical_units>
+      <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
       <description>A variable with the standard name of sea_ice_classification contains strings which indicate the character of the ice surface e.g. open_ice, or first_year_ice. These strings have not yet been standardised. However, and whenever possible, they should follow the terminology defined in the WMO Standard Nomenclature for Sea Ice Classification. Alternatively, the data variable may contain integers which can be translated to strings using flag_values and flag_meanings attributes. &quot;Sea ice&quot; means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.</description>
@@ -17626,6 +17926,13 @@
       <description>The quantity with standard name sea_surface_primary_swell_wave_from_direction is the direction from which the most energetic swell waves are coming. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The primary swell wave is the most energetic swell wave. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north.</description>
    </entry>
   
+   <entry id="sea_surface_primary_swell_wave_from_direction_at_variance_spectral_density_maximum">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_primary_swell_wave_from_direction_at_variance_spectral_density_maximum is the direction from which the most energetic waves are coming in the primary swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The primary swell wave is the most energetic swell wave in the low frequency portion of a bimodal wave frequency spectrum. The spectral peak is the most energetic wave in the wave spectrum partition. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. The wave directional spectrum can be written as a five dimensional function S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. S has the standard name sea_surface_wave_directional_variance_spectral_density. S can be integrated over direction to give S1= integral(S dtheta) and this quantity has the standard name sea_surface_wave_variance_spectral_density.</description>
+   </entry>
+  
    <entry id="sea_surface_primary_swell_wave_mean_period">
       <canonical_units>s</canonical_units>
       <grib></grib>
@@ -17675,6 +17982,13 @@
       <description>The quantity with standard name sea_surface_secondary_swell_wave_from_direction is the direction from which the second most energetic swell waves are coming. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The secondary swell wave is the second most energetic wave in the low frequency portion of a bimodal wave frequency spectrum. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north.</description>
    </entry>
   
+   <entry id="sea_surface_secondary_swell_wave_from_direction_at_variance_spectral_density_maximum">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_secondary_swell_wave_from_direction_at_variance_spectral_density_maximum is the direction from which the most energetic waves are coming in the secondary swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The secondary swell wave is the second most energetic wave in the low frequency portion of a bimodal wave frequency spectrum. The spectral peak is the most energetic wave in the wave spectrum partition. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. The wave directional spectrum can be written as a five dimensional function S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. S has the standard name sea_surface_wave_directional_variance_spectral_density. S can be integrated over direction to give S1= integral(S dtheta) and this quantity has the standard name sea_surface_wave_variance_spectral_density.</description>
+   </entry>
+  
    <entry id="sea_surface_secondary_swell_wave_mean_period">
       <canonical_units>s</canonical_units>
       <grib></grib>
@@ -17710,11 +18024,25 @@
       <description>The sea surface subskin temperature is the temperature at the base of the conductive laminar sub-layer of the ocean surface, that is, at a depth of approximately 1 - 1.5 millimeters below the air-sea interface. For practical purposes, this quantity can be well approximated to the measurement of surface temperature by a microwave radiometer operating in the 6 - 11 gigahertz frequency range, but the relationship is neither direct nor invariant to changing physical conditions or to the specific geometry of the microwave measurements. Measurements of this quantity are subject to a large potential diurnal cycle due to thermal stratification of the upper ocean layer in low wind speed high solar irradiance conditions.</description>
    </entry>
   
+   <entry id="sea_surface_swell_wave_directional_spread">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_swell_wave_directional_spread is the directional width of the swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. Directional spread is the (one-sided) directional width within a given sub-domain of the wave directional spectrum, S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. For a given mean wave (beam) direction the quantity approximates half the root mean square width about the beam axis, as derived either directly from circular moments or via the Fourier components of the wave directional spectrum.</description>
+   </entry>
+  
    <entry id="sea_surface_swell_wave_from_direction">
       <canonical_units>degree</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north.</description>
+   </entry>
+  
+   <entry id="sea_surface_swell_wave_from_direction_at_variance_spectral_density_maximum">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_swell_wave_from_direction_at_variance_spectral_density_maximum is the direction from which the most energetic waves are coming in the swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The spectral peak is the most energetic wave in the wave spectrum partition. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. The swell wave directional spectrum can be written as a five dimensional function S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. S has the standard name sea_surface_wave_directional_variance_spectral_density. S can be integrated over direction to give S1= integral(S dtheta) and this quantity has the standard name sea_surface_wave_variance_spectral_density.</description>
    </entry>
   
    <entry id="sea_surface_swell_wave_mean_period">
@@ -17750,6 +18078,13 @@
       <grib>106</grib>
       <amip></amip>
       <description>A period is an interval of time, or the time-period of an oscillation. Swell waves are waves on the ocean surface.</description>
+   </entry>
+  
+   <entry id="sea_surface_swell_wave_period_at_variance_spectral_density_maximum">
+      <canonical_units>s</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_swell_wave_period_at_variance_spectral_density_maximum is the period of the most energetic waves within the swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. A period is an interval of time, or the time-period of an oscillation. Wave period is the interval of time between repeated features on the waveform such as crests, troughs or upward passes through the mean level. The phrase &quot;wave_period_at_variance_spectral_density_maximum&quot;, sometimes called peak wave period, describes the period of the most energetic waves within a given sub-domain of the wave spectrum.</description>
    </entry>
   
    <entry id="sea_surface_swell_wave_significant_height">
@@ -17792,6 +18127,13 @@
       <grib></grib>
       <amip></amip>
       <description>The quantity with standard name sea_surface_tertiary_swell_wave_from_direction is the direction from which the third most energetic swell waves are coming. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The tertiary swell wave is the third most energetic swell wave. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north.</description>
+   </entry>
+  
+   <entry id="sea_surface_tertiary_swell_wave_from_direction_at_variance_spectral_density_maximum">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_tertiary_swell_wave_from_direction_at_variance_spectral_density_maximum is the direction from which the most energetic waves are coming in the tertiary swell wave component of a sea. Swell waves are waves on the ocean surface and are the low frequency portion of a bimodal wave frequency spectrum. The tertiary swell wave is the third most energetic swell wave in the low frequency portion of a bimodal wave frequency spectrum. The spectral peak is the most energetic wave in the wave spectrum partition. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. The wave directional spectrum can be written as a five dimensional function S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. S has the standard name sea_surface_wave_directional_variance_spectral_density. S can be integrated over direction to give S1= integral(S dtheta) and this quantity has the standard name sea_surface_wave_variance_spectral_density.</description>
    </entry>
   
    <entry id="sea_surface_tertiary_swell_wave_mean_period">
@@ -18067,6 +18409,13 @@
       <description>Wind waves are waves on the ocean surface and are the high frequency portion of a bimodal wave frequency spectrum. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north.</description>
    </entry>
   
+   <entry id="sea_surface_wind_wave_from_direction_at_variance_spectral_density_maximum">
+      <canonical_units>degree</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name sea_surface_wind_wave_from_direction_at_variance_spectral_density_maximum is the direction from which the most energetic waves are coming in the wind wave component of a sea. Wind waves are waves on the ocean surface and are the high frequency portion of a bimodal wave frequency spectrum. The spectral peak is the most energetic wave in the wave spectrum partition. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. The wave directional spectrum can be written as a five dimensional function S(t,x,y,f,theta) where t is time, x and y are horizontal coordinates (such as longitude and latitude), f is frequency and theta is direction. S has the standard name sea_surface_wave_directional_variance_spectral_density. S can be integrated over direction to give S1= integral(S dtheta) and this quantity has the standard name sea_surface_wave_variance_spectral_density.</description>
+   </entry>
+  
    <entry id="sea_surface_wind_wave_mean_period">
       <canonical_units>s</canonical_units>
       <grib></grib>
@@ -18253,14 +18602,14 @@
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Potential density is the density a parcel of air or sea water would have if moved adiabatically to a reference pressure, by default assumed to be sea level pressure. For sea water potential density, if 1000 kg m-3 is subtracted, the standard name sea_water_sigma_theta should be chosen instead.</description>
+      <description>Sea water potential density is the density a parcel of sea water would have if moved adiabatically to a reference pressure, by default assumed to be sea level pressure. To specify the reference pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure. The density of a substance is its mass per unit volume. For sea water potential density, if 1000 kg m-3 is subtracted, the standard name sea_water_sigma_theta should be chosen instead.</description>
    </entry>
   
    <entry id="sea_water_potential_temperature">
       <canonical_units>K</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Potential temperature is the temperature a parcel of air or sea water would have if moved adiabatically to sea level pressure.</description>
+      <description>Sea water potential temperature is the temperature a parcel of sea water would have if moved adiabatically to sea level pressure.</description>
    </entry>
   
    <entry id="sea_water_potential_temperature_at_sea_floor">
@@ -18379,7 +18728,7 @@
       <canonical_units>kg m-3</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Sigma-theta of sea water is the potential density (i.e. the density when moved adiabatically to a reference pressure) of water having the same temperature and salinity, minus 1000 kg m-3. Note that sea water sigma is not the same quantity as the dimensionless ocean sigma coordinate (see Appendix D of the CF convention), for which there is another standard name.</description>
+      <description>Sigma-theta of sea water is the potential density (i.e. the density when moved adiabatically to a reference pressure) of water having the same temperature and salinity, minus 1000 kg m-3. Note that sea water sigma is not the same quantity as the dimensionless ocean sigma coordinate (see Appendix D of the CF convention), for which there is another standard name. To specify the reference pressure to which the quantity applies, provide a scalar coordinate variable with standard name reference_pressure.</description>
    </entry>
   
    <entry id="sea_water_sigma_theta_difference">
@@ -18592,6 +18941,13 @@
       <description>Convective precipitation is that produced by the convection schemes in an atmosphere model. Some atmosphere models differentiate between shallow and deep convection. &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics.</description>
    </entry>
   
+   <entry id="signal_intensity_from_multibeam_acoustic_doppler_velocity_sensor_in_sea_water">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The magnitude of an acoustic signal emitted by the instrument toward a reflecting surface and received again by the instrument.</description>
+   </entry>
+  
    <entry id="single_scattering_albedo_in_air_due_to_ambient_aerosol_particles">
       <canonical_units>1</canonical_units>
       <grib></grib>
@@ -18799,7 +19155,7 @@
       <canonical_units>K</canonical_units>
       <grib>85</grib>
       <amip></amip>
-      <description>Soil temperature is the bulk temperature of the soil, not the surface (skin) temperature.</description>
+      <description>Soil temperature is the bulk temperature of the soil, not the surface (skin) temperature. &quot;Soil&quot; means the near-surface layer where plants sink their roots. For subsurface temperatures that extend beneath the soil layer or in areas where there is no surface soil layer, the standard name solid_earth_subsurface_temperature should be used.</description>
    </entry>
   
    <entry id="soil_thermal_capacity">
@@ -18817,7 +19173,7 @@
    </entry>
   
    <entry id="soil_type">
-      <canonical_units>1</canonical_units>
+      <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
       <description>A variable with the standard name of soil_type contains strings which indicate the character of the soil e.g. clay. These strings have not yet been standardised. Alternatively, the data variable may contain integers which can be translated to strings using flag_values and flag_meanings attributes.</description>
@@ -18856,6 +19212,13 @@
       <grib></grib>
       <amip></amip>
       <description>Solar zenith angle is the the angle between the line of sight to the sun and the local vertical.</description>
+   </entry>
+  
+   <entry id="solid_earth_subsurface_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name solid_earth_subsurface_temperature is the temperature at any depth (or in a layer) of the &quot;solid&quot; earth, excluding surficial snow and ice (but not permafrost or soil). For temperatures in surface lying snow and ice, the more specific standard names temperature_in_surface_snow and land_ice_temperature should be used. For temperatures measured or modelled specifically in the soil layer (the near-surface layer where plants sink their roots) the standard name soil_temperature should be used.</description>
    </entry>
   
    <entry id="solid_precipitation_flux">
@@ -19059,6 +19422,13 @@
       <grib></grib>
       <amip></amip>
       <description>&quot;Amount&quot; means mass per unit area. &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases.The construction lwe_thickness_of_X_amount or _content means the vertical extent of a layer of liquid water having the same mass per unit area. The abbreviation &quot;lwe&quot; means liquid water equivalent. A spell is the number of consecutive days on which the condition X_below|above_threshold is satisfied.  A variable whose standard name has the form spell_length_of_days_with_X_below|above_threshold must have a coordinate variable or scalar coordinate variable with the a standard name of X to supply the threshold(s). It must have a climatological time variable, and a cell_method entry for within days which describes the processing of quantity X before the threshold is applied. A spell_length_of_days is an intensive quantity in time, and the cell_methods entry for over days can be any of the methods listed in Appendix E appropriate for intensive quantities e.g. &quot;maximum&quot;, &quot;minimum&quot; or &quot;mean&quot;.</description>
+   </entry>
+  
+   <entry id="spike_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Spike test, which checks that the difference between two points in a series of values is within reasonable bounds. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
    </entry>
   
    <entry id="square_of_air_temperature">
@@ -19446,6 +19816,13 @@
       <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Diffuse&quot; radiation is radiation that has been scattered by gas molecules in the atmosphere and by particles such as cloud droplets and aerosols. The term &quot;shortwave&quot; means shortwave radiation. Hemispherical reflectance is the ratio of the energy of the reflected to the incident radiation. This term gives the fraction of the surface_diffuse_downwelling_shortwave_flux_in_air which is reflected. If the diffuse radiation is isotropic, this term is equivalent to the integral of surface_bidirectional_reflectance over all incident angles and over all outgoing angles in the hemisphere above the surface. A coordinate variable of radiation_wavelength or radiation_frequency can be used to specify the wavelength or frequency, respectively, of the radiation. Shortwave hemispherical reflectance is related to albedo, but albedo is defined in terms of the fraction of the full spectrum of incident solar radiation which is reflected. It is related to the hemispherical reflectance averaged over all wavelengths using a weighting proportional to the incident radiative flux.</description>
    </entry>
   
+   <entry id="surface_direct_along_beam_shortwave_flux_in_air">
+      <canonical_units>W m-2</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Direct&quot; (also known as &quot;beam&quot;) radiation is radiation that has followed a direct path from the sun and is alternatively known as &quot;direct insolation&quot;. The phrase &quot;along_beam&quot; refers to direct radiation on a plane perpendicular to the direction of the sun. This is in contrast to standard names such as direct_downwelling_shortwave_flux_in_air, where the radiation falls on a horizontal plane at the earth surface. The term &quot;shortwave&quot; means shortwave radiation. In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics. The quantity with standard name surface_direct_along_beam_shortwave_flux_in_air is also called Direct Normal Irradiance (DNI) in the solar energy industry.</description>
+   </entry>
+  
    <entry id="surface_direct_downwelling_shortwave_flux_in_air">
       <canonical_units>W m-2</canonical_units>
       <grib></grib>
@@ -19471,7 +19848,7 @@
       <canonical_units>Pa</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Downward&quot; indicates a vector component which is positive when directed downward (negative upward). &quot;Eastward&quot; indicates a vector component which is positive when directed eastward (negative westward). &quot;Downward eastward&quot; indicates the ZX component of a tensor. A downward eastward stress is a downward flux of eastward momentum, which accelerates the lower medium eastward and the upper medium westward. The surface downward stress is the wind stress on the surface. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Downward&quot; indicates a vector component which is positive when directed downward (negative upward). &quot;Eastward&quot; indicates a vector component which is positive when directed eastward (negative westward). &quot;Downward eastward&quot; indicates the ZX component of a tensor. A downward eastward stress is a downward flux of eastward momentum, which accelerates the lower medium eastward and the upper medium westward. The surface downward stress is the wind stress on the surface. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="surface_downward_heat_flux_in_air">
@@ -19611,7 +19988,7 @@
       <canonical_units>Pa</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Downward&quot; indicates a vector component which is positive when directed downward (negative upward). &quot;Northward&quot; indicates a vector component which is positive when directed northward (negative southward). Downward northward&quot; indicates the ZY component of a tensor. A downward northward stress is a downward flux of northward momentum, which accelerates the lower medium northward and the upper medium southward. The surface downward stress is the wind stress on the surface. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Downward&quot; indicates a vector component which is positive when directed downward (negative upward). &quot;Northward&quot; indicates a vector component which is positive when directed northward (negative southward). Downward northward&quot; indicates the ZY component of a tensor. A downward northward stress is a downward flux of northward momentum, which accelerates the lower medium northward and the upper medium southward. The surface downward stress is the wind stress on the surface. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="surface_downward_sensible_heat_flux">
@@ -20161,7 +20538,7 @@
    </entry>
   
    <entry id="surface_radioactivity_content">
-      <canonical_units></canonical_units>
+      <canonical_units>Bq m-2</canonical_units>
       <grib></grib>
       <amip></amip>
       <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Content&quot; indicates a quantity per unit area. &quot;Radioactivity&quot; means the number of radioactive decays of a material per second.</description>
@@ -23275,6 +23652,13 @@
       <description>The surface called &quot;surface&quot; means the lower boundary of the atmosphere. &quot;Water&quot; means water in all phases, including frozen i.e. ice and snow. Evaporation is the conversion of liquid or solid into vapor. (The conversion of solid alone into vapor is called &quot;sublimation&quot;). The quantity with standard name surface_water_evaporation_flux does not include transpiration from vegetation. In accordance with common usage in geophysical disciplines, &quot;flux&quot; implies per unit area, called &quot;flux density&quot; in physics. Unless indicated in the cell_methods attribute, a quantity is assumed to apply to the whole area of each horizontal grid box. Previously, the qualifier where_type was used to specify that the quantity applies only to the part of the grid box of the named type. Names containing the where_type qualifier are deprecated and newly created data should use the cell_methods attribute to indicate the horizontal area to which the quantity applies.</description>
    </entry>
   
+   <entry id="syntax_test_quality_flag">
+      <canonical_units>1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>A quality flag that reports the result of the Syntax test, which checks that the data contain no indicators of flawed transmission. The linkage between the data variable and this variable is achieved using the ancillary_variables attribute. There are standard names for other specific quality tests which take the form of X_quality_flag. Quality information that does not match any of the specific quantities should be given the more general standard name of quality_flag.</description>
+   </entry>
+  
    <entry id="temperature_at_base_of_ice_sheet_model">
       <canonical_units>K</canonical_units>
       <grib></grib>
@@ -23293,10 +23677,7 @@
       <canonical_units>K</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>This quantity is defined as the temperature difference between a parcel of air lifted adiabatically from a starting air pressure to a finishing air pressure in the troposphere and the ambient air temperature at the finishing air pressure in the troposphere. It is 
-often called the lifted index (LI) and provides a measure of the instability of the atmosphere. The air parcel is &quot;lifted&quot; by moving the air parcel from the starting air pressure to the Lifting Condensation Level (dry adiabatically) and then from the Lifting Condensation Level to the finishing air pressure (wet adiabatically). Air temperature is 
-the bulk temperature of the air. Coordinate variables of original_air_pressure_of_lifted_parcel and 
-final_air_pressure_of_lifted_parcel should be specified to indicate the specific air pressures at which the parcel lifting starts (starting air pressure) and the temperature difference is calculated at (finishing air pressure), respectively.</description>
+      <description>This quantity is defined as the temperature difference between a parcel of air lifted adiabatically from a starting air pressure to a finishing air pressure in the troposphere and the ambient air temperature at the finishing air pressure in the troposphere. It is often called the lifted index (LI) and provides a measure of the instability of the atmosphere. The air parcel is &quot;lifted&quot; by moving the air parcel from the starting air pressure to the Lifting Condensation Level (dry adiabatically) and then from the Lifting Condensation Level to the finishing air pressure (wet adiabatically). Air temperature is the bulk temperature of the air. Coordinate variables of original_air_pressure_of_lifted_parcel and final_air_pressure_of_lifted_parcel should be specified to indicate the specific air pressures at which the parcel lifting starts (starting air pressure) and the temperature difference is calculated at (finishing air pressure), respectively.</description>
    </entry>
   
    <entry id="temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface">
@@ -23332,6 +23713,13 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <grib>E238</grib>
       <amip></amip>
       <description>&quot;Temperature in surface snow&quot; is the bulk temperature of the snow, not the surface (skin) temperature.  The surface called &quot;surface&quot; means the lower boundary of the atmosphere.</description>
+   </entry>
+  
+   <entry id="temperature_of_analysis_of_sea_water">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The temperature_of_analysis_of_sea_water is the reference temperature for the effects of temperature on the measurement of another variable. This temperature should be measured, but may have been calculated, or assumed. For example, the temperature of the sample when measuring pH, or the temperature of equilibration in the case of dissolved gases. The linkage between the data variable and the variable with a standard_name of temperature_of_analysis_of_sea_water is achieved using the ancillary_variables attribute on the data variable.</description>
    </entry>
   
    <entry id="temperature_of_sensor_for_oxygen_in_sea_water">
@@ -23373,7 +23761,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>K s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_air_temperature_due_to_convection">
@@ -23492,7 +23880,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>K s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity named by omitting the phrase. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity named by omitting the phrase. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_air_temperature_due_to_stratiform_precipitation">
@@ -27433,7 +27821,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>m s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;tendency_of_X&quot; means derivative of X with respect to time. Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice or ocean water.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Altitude is the (geometric) height above the geoid, which is the reference geopotential surface. The geoid is similar to mean sea level. &quot;Bedrock&quot; is the solid Earth surface beneath land ice, ocean water or soil.</description>
    </entry>
   
    <entry id="tendency_of_canopy_water_amount_due_to_evaporation_of_intercepted_precipitation">
@@ -27692,21 +28080,21 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time.  &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_cloud_liquid_water_in_air_due_to_advection">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_cloud_liquid_water_in_air_due_to_diffusion">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_condensed_water_in_air">
@@ -27741,7 +28129,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. The phrase &quot;condensed_water&quot; means liquid and ice. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. The phrase &quot;condensed_water&quot; means liquid and ice. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_condensed_water_in_air_due_to_cloud_microphysics">
@@ -27804,7 +28192,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_cloud_microphysics">
@@ -27839,7 +28227,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Heterogeneous nucleation occurs when a small particle of a substance other than water acts as a freezing or condensation nucleus.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;.  In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Heterogeneous nucleation occurs when a small particle of a substance other than water acts as a freezing or condensation nucleus. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_heterogeneous_nucleation_from_water_vapor">
@@ -27867,7 +28255,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a  single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_melting_to_rain">
@@ -27881,7 +28269,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Riming is the rapid freezing of supercooled water onto a surface. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a  single term in a sum of terms which together compose the general quantity named by omitting the phrase. Riming is the rapid freezing of supercooled water onto a surface.  &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_riming_from_rain">
@@ -27895,140 +28283,140 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_accretion_to_rain">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Accretion is the growth of a hydrometeor by collision with cloud droplets or ice crystals. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Accretion is the growth of a hydrometeor by collision with cloud droplets or ice crystals. &quot;Rain&quot; means drops of water falling through the atmosphere that have a diameter greater than 0.5 mm.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_accretion_to_snow">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Accretion is the growth of a hydrometeor by collision with cloud droplets or ice crystals. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot; where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Accretion is the growth of a hydrometeor by collision with cloud droplets or ice crystals.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_advection">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_autoconversion">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Autoconversion is the process of collision and coalescence which results in the formation of precipitation particles from cloud water droplets or ice crystals. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Autoconversion is the process of collision and coalescence which results in the formation of precipitation particles from cloud water droplets or ice crystals.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_bergeron_findeisen_process_to_cloud_ice">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&#39;Mass fraction&#39; is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical or biological species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;.  In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase. The Bergeron-Findeisen process is the conversion of cloud liquid water to cloud ice arising from the fact that water vapor has a lower equilibrium vapor pressure with respect to ice than it has with respect to liquid water at the same subfreezing temperature. &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. The Bergeron-Findeisen process is the conversion of cloud liquid water to cloud ice arising from the fact that water vapor has a lower equilibrium vapor pressure with respect to ice than it has with respect to liquid water at the same subfreezing temperature.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_boundary_layer_mixing">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_cloud_microphysics">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Cloud microphysics&quot; is the sum of many cloud processes such as condensation, evaporation, homogeneous nucleation, heterogeneous nucleation, deposition, sublimation, the Bergeron-Findeisen process, riming, accretion, aggregation and icefall. The precise list of processes that are included in &quot;cloud microphysics&quot; can vary between models. Where possible, the data variable should be accompanied by a complete description of the processes included, for example, by using a comment attribute. Standard names also exist to describe the tendencies due to the separate processes.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Cloud microphysics&quot; is the sum of many cloud processes such as condensation, evaporation, homogeneous nucleation, heterogeneous nucleation, deposition, sublimation, the Bergeron-Findeisen process, riming, accretion, aggregation and icefall. The precise list of processes that are included in &quot;cloud microphysics&quot; can vary between models. Where possible, the data variable should be accompanied by a complete description of the processes included, for example, by using a comment attribute. Standard names also exist to describe the tendencies due to the separate processes.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor. Condensation is the conversion of vapor into liquid. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_boundary_layer_mixing">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a  single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_convection">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor. Condensation is the conversion of vapor into liquid. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_longwave_heating">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor. Condensation is the conversion of vapor into liquid. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.  &quot;longwave&quot; means longwave radiation.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor. The term &quot;longwave&quot; means longwave radiation.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_pressure_change">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor. Condensation is the conversion of vapor into liquid. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_shortwave_heating">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor.  In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.  &quot;shortwave&quot; means shortwave radiation.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor. The term &quot;shortwave&quot; means shortwave radiation.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_condensation_and_evaporation_from_turbulence">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Evaporation is the conversion of liquid or solid into vapor. Condensation is the conversion of vapor into liquid. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Condensation is the conversion of vapor into liquid. Evaporation is the conversion of liquid or solid into vapor.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_convective_detrainment">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_heterogeneous_nucleation">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Heterogeneous nucleation occurs when a small particle of a substance other than water acts as a freezing or condensation nucleus.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Heterogeneous nucleation occurs when a small particle of a substance other than water acts as a freezing or condensation nucleus.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_homogeneous_nucleation">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Homogeneous nucleation occurs when a small number of water molecules combine to form a freezing or condensation nucleus.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X). A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Homogeneous nucleation occurs when a small number of water molecules combine to form a freezing or condensation nucleus.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_melting_from_cloud_ice">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase.</description>
    </entry>
   
    <entry id="tendency_of_mass_fraction_of_stratiform_cloud_liquid_water_in_air_due_to_riming">
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>Mass fraction is used in the construction mass_fraction_of_X_in_Y, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &#39;nitrogen&#39; or a phrase such as &#39;nox_expressed_as_nitrogen&#39;. Riming is the rapid freezing of supercooled water onto a surface. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes).  The specification of a physical process by the phrase due_to_process means that the quantity named is a  single term in a sum of terms which together compose the general quantity  named by omitting the phrase.  &quot;tendency_of_X&quot; means derivative of X with respect to time.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mass fraction&quot; is used in the construction &quot;mass_fraction_of_X_in_Y&quot;, where X is a material constituent of Y. It means the ratio of the mass of X to the mass of Y (including X).  A chemical species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Cloud liquid water&quot; refers to the liquid phase of cloud water. A diameter of 0.2 mm has been suggested as an upper limit to the size of drops that shall be regarded as cloud drops; larger drops fall rapidly enough so that only very strong updrafts can sustain them. Any such division is somewhat arbitrary, and active cumulus clouds sometimes contain cloud drops much larger than this. Reference: AMS Glossary http://glossary.ametsoc.org/wiki/Cloud_drop. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Riming is the rapid freezing of supercooled water onto a surface.</description>
    </entry>
   
    <entry id="tendency_of_middle_atmosphere_moles_of_carbon_monoxide">
@@ -28206,11 +28594,11 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mole concentration means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (the rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. In the oceans, carbon production per unit volume is often found at a number of depths at a given horizontal location. That quantity can then be integrated to calculate production per unit area at the location. Standard names for production per unit area use the term &quot;productivity&quot;. Diatoms are single-celled phytoplankton with an external skeleton made of silica. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
    </entry>
   
-   <entry id="tendency_of_mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water_due_to_net_primary_production_by_diazotrophs">
+   <entry id="tendency_of_mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water_due_to_net_primary_production_by_diazotrophic_phytoplankton">
       <canonical_units>mol m-3 s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Mole concentration means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction mole_concentration_of_X_in_Y, where X is a material constituent of Y. A chemical or biological species denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (the rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. In the oceans, carbon production per unit volume is often found at a number of depths at a given horizontal location. That quantity can then be integrated to calculate production per unit area at the location. Standard names for production per unit area use the term &quot;productivity&quot;. In ocean modelling, diazotrophs are phytoplankton of the phylum cyanobacteria distinct from other phytoplankton groups in their ability to fix nitrogen gas in addition to nitrate and ammonium. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis.</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Mole concentration&quot; means number of moles per unit volume, also called &quot;molarity&quot;, and is used in the construction &quot;mole_concentration_of_X_in_Y&quot;, where X is a material constituent of Y. A chemical species or biological group denoted by X may be described by a single term such as &quot;nitrogen&quot; or a phrase such as &quot;nox_expressed_as_nitrogen&quot;. The phrase &quot;expressed_as&quot; is used in the construction &quot;A_expressed_as_B&quot;, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Production of carbon&quot; means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (the rate of synthesis of biomass from inorganic precursors) by autotrophs (&quot;producers&quot;), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. In the oceans, carbon production per unit volume is often found at a number of depths at a given horizontal location. That quantity can then be integrated to calculate production per unit area at the location. Standard names for production per unit area use the term &quot;productivity&quot;. Phytoplankton are algae that grow where there is sufficient light to support photosynthesis. Diazotrophic phytoplankton are phytoplankton (predominantly from Phylum Cyanobacteria) that are able to fix molecular nitrogen (gas or solute) in addition to nitrate and ammonium.</description>
    </entry>
   
    <entry id="tendency_of_mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water_due_to_net_primary_production_by_miscellaneous_phytoplankton">
@@ -28959,7 +29347,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Specific&quot; means per unit mass. Specific humidity is the mass fraction of water vapor in (moist) air. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. &quot;Specific&quot; means per unit mass. Specific humidity is the mass fraction of water vapor in (moist) air. The specification of a physical process by the phrase &quot;due_to_&quot; process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_specific_humidity_due_to_convection">
@@ -28994,7 +29382,7 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <canonical_units>s-1</canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Specific humidity is the mass fraction of water vapor in (moist) air. The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://www.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
+      <description>The phrase &quot;tendency_of_X&quot; means derivative of X with respect to time. Specific humidity is the mass fraction of water vapor in (moist) air. The specification of a physical process by the phrase due_to_process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. In an atmosphere model, stratiform cloud is that produced by large-scale convergence (not the convection schemes). &quot;Precipitation&quot; in the earth&#39;s atmosphere means precipitation of water in all phases. &quot;Boundary layer mixing&quot; means turbulent motions that transport heat, water, momentum and chemical constituents within the atmospheric boundary layer and affect exchanges between the surface and the atmosphere. The atmospheric boundary layer is typically characterised by a well-mixed sub-cloud layer of order 500 metres, and by a more extended conditionally unstable layer with boundary-layer clouds up to 2 km. (Reference: IPCC Third Assessment Report, Working Group 1: The Scientific Basis, 7.2.2.3, https://archive.ipcc.ch/ipccreports/tar/wg1/273.htm).</description>
    </entry>
   
    <entry id="tendency_of_specific_humidity_due_to_stratiform_precipitation">
@@ -29138,10 +29526,10 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
    </entry>
   
    <entry id="thermodynamic_phase_of_cloud_water_particles_at_cloud_top">
-      <canonical_units>1</canonical_units>
+      <canonical_units></canonical_units>
       <grib></grib>
       <amip></amip>
-      <description>&quot;cloud_top&quot; refers to the top of the highest cloud. &quot;Water&quot; means water in all phases. A variable with the standard name of thermodynamic_phase_of_cloud_water_particles_at_cloud_top contains integers which can be translated to strings using flag_values and flag_meanings attributes. Alternatively, the data variable may contain strings which indicate the thermodynamic phase. These strings are standardised. Values must be chosen from the following list: liquid; ice; mixed; clear_sky; super_cooled_liquid_water; unknown.</description>
+      <description>A variable with the standard name of thermodynamic_phase_of_cloud_water_particles_at_cloud_top contains integers which can be translated to strings using flag_values and flag_meanings attributes. Alternatively, the data variable may contain strings which indicate the thermodynamic phase. These strings are standardised. Values must be chosen from the following list: liquid; ice; mixed; clear_sky; super_cooled_liquid_water; unknown. &quot;Water&quot; means water in all phases. The phrase &quot;cloud_top&quot; refers to the top of the highest cloud.</description>
    </entry>
   
    <entry id="thermosteric_change_in_mean_sea_level">
@@ -29226,6 +29614,13 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <grib></grib>
       <amip></amip>
       <description>&quot;Sea surface height&quot; is a time-varying quantity. &quot;Height_above_X&quot; means the vertical distance above the named surface X. &quot;Lowest astronomical tide&quot; describes a local vertical reference based on the lowest water level that can be expected to occur under average meteorological conditions and under any combination of astronomical conditions. The tidal component of sea surface height describes the predicted variability of the sea surface due to astronomic forcing (chiefly lunar and solar cycles) and shallow water resonance of tidal components; for example as generated based on harmonic analysis, or resulting from the application of harmonic tidal series as boundary conditions to a numerical tidal model.</description>
+   </entry>
+  
+   <entry id="tidal_sea_surface_height_above_mean_low_water_springs">
+      <canonical_units>m</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>&quot;Sea surface height&quot; is a time-varying quantity. &quot;Height_above_X&quot; means the vertical distance above the named surface X. &quot;Mean low water springs&quot; describes a local vertical reference based on the time mean of the low water levels during spring tides (the tides each lunar month with the greatest difference between high and low water that happen during full and new moons phases) expected to occur under average meteorological conditions and under any combination of astronomical conditions. The tidal component of sea surface height describes the predicted variability of the sea surface due to astronomic forcing (chiefly lunar and solar cycles) and shallow water resonance of tidal components; for example as generated based on harmonic analysis, or resulting from the application of harmonic tidal series as boundary conditions to a numerical tidal model.</description>
    </entry>
   
    <entry id="tidal_sea_surface_height_above_mean_sea_level">
@@ -29751,6 +30146,27 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <grib>40</grib>
       <amip></amip>
       <description>A velocity is a vector quantity. &quot;Upward&quot; indicates a vector component which is positive when directed upward (negative downward). Upward air velocity is the vertical component of the 3D air velocity vector. The standard name downward_air_velocity may be used for a vector component with the opposite sign convention.</description>
+   </entry>
+  
+   <entry id="upward_derivative_of_eastward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name upward_derivative_of_eastward_wind is the derivative of the eastward component of wind with respect to height. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
+   <entry id="upward_derivative_of_northward_wind">
+      <canonical_units>s-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name upward_derivative_of_northward_wind is the derivative of the northward component of wind speed with respect to height. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
+   </entry>
+  
+   <entry id="upward_derivative_of_wind_from_direction">
+      <canonical_units>degree m-1</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>The quantity with standard name upward_derivative_of_wind_from_direction is the derivative of wind from_direction with respect to height. The phrase &quot;component_derivative_of_X&quot; means derivative of X with respect to distance in the component direction, which may be &quot;northward&quot;, &quot;southward&quot;, &quot;eastward&quot;, &quot;westward&quot;, &quot;upward&quot;, &quot;downward&quot;, &quot;x&quot; or &quot;y&quot;. The last two indicate derivatives along the axes of the grid, in the case where they are not true longitude and latitude. A positive value indicates that X is increasing with distance along the positive direction of the axis. The phrase &quot;from_direction&quot; is used in the construction X_from_direction and indicates the direction from which the velocity vector of X is coming. The direction is a bearing in the usual geographical sense, measured positive clockwise from due north. In meteorological reports, the direction of the wind vector is usually (but not always) given as the direction from which it is blowing (&quot;wind_from_direction&quot;) (westerly, northerly, etc.). In other contexts, such as atmospheric modelling, it is often natural to give the direction in the usual manner of vectors as the heading or the direction to which it is blowing (&quot;wind_to_direction&quot;) (eastward, southward, etc.). Wind is defined as a two-dimensional (horizontal) air velocity vector, with no vertical component. (Vertical motion in the atmosphere has the standard name &quot;upward_air_velocity&quot;).</description>
    </entry>
   
    <entry id="upward_dry_static_energy_flux_due_to_diffusion">
@@ -30544,6 +30960,13 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
       <description></description>
    </entry>
   
+   <entry id="wind_chill_of_air_temperature">
+      <canonical_units>K</canonical_units>
+      <grib></grib>
+      <amip></amip>
+      <description>Air temperature is the bulk temperature of the air, not the surface (skin) temperature. The quantity with standard name wind_chill_of_air_temperature is the perceived air temperature when wind is factored in with the ambient air temperature (which makes it feel colder than the actual air temperature). Wind chill is based on the rate of heat loss from exposed skin caused by wind and cold. Wind chill temperature is only defined for ambient temperatures at or below 283.1 K and wind speeds above 1.34 m s-1. References: https://www.weather.gov/safety/cold-wind-chill-chart; WMO codes registry entry http://codes.wmo.int/grib2/codeflag/4.2/0-0-13.</description>
+   </entry>
+  
    <entry id="wind_from_direction">
       <canonical_units>degree</canonical_units>
       <grib>31</grib>
@@ -30899,14 +31322,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
     <entry_id>atmosphere_net_upward_convective_mass_flux</entry_id>
   </alias>
   
-  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_melting_to_cloud_liquid">
-    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_melting_to_cloud_liquid_water</entry_id>
-  </alias>
-  
-  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_riming_from_cloud_liquid">
-    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_riming_from_cloud_liquid_water</entry_id>
-  </alias>
-  
   <alias id="eastward_water_vapor_flux">
     <entry_id>eastward_water_vapor_flux_in_air</entry_id>
   </alias>
@@ -30979,16 +31394,8 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
     <entry_id>atmosphere_mass_content_of_cloud_ice</entry_id>
   </alias>
   
-  <alias id="atmosphere_cloud_liquid_water_content">
-    <entry_id>atmosphere_mass_content_of_cloud_liquid_water</entry_id>
-  </alias>
-  
   <alias id="atmosphere_convective_cloud_condensed_water_content">
     <entry_id>atmosphere_mass_content_of_convective_cloud_condensed_water</entry_id>
-  </alias>
-  
-  <alias id="atmosphere_convective_cloud_liquid_water_content">
-    <entry_id>atmosphere_mass_content_of_convective_cloud_liquid_water</entry_id>
   </alias>
   
   <alias id="atmosphere_water_vapor_content">
@@ -31029,10 +31436,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
   
   <alias id="cloud_ice_content_of_atmosphere_layer">
     <entry_id>mass_content_of_cloud_ice_in_atmosphere_layer</entry_id>
-  </alias>
-  
-  <alias id="cloud_liquid_water_content_of_atmosphere_layer">
-    <entry_id>mass_content_of_cloud_liquid_water_in_atmosphere_layer</entry_id>
   </alias>
   
   <alias id="water_content_of_atmosphere_layer">
@@ -31553,14 +31956,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
   
   <alias id="tendency_of_atmosphere_mass_content_of_particulate_organic_matter_dry_aerosol_expressed_as_carbon_due_to_emission_from_industrial_processes_and_combustion">
     <entry_id>tendency_of_atmosphere_mass_content_of_particulate_organic_matter_dry_aerosol_particles_expressed_as_carbon_due_to_emission_from_industrial_processes_and_combustion</entry_id>
-  </alias>
-  
-  <alias id="land_cover">
-    <entry_id>area_type</entry_id>
-  </alias>
-  
-  <alias id="surface_cover">
-    <entry_id>area_type</entry_id>
   </alias>
   
   <alias id="significant_height_of_swell_waves">
@@ -32459,10 +32854,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
     <entry_id>net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diatoms</entry_id>
   </alias>
   
-  <alias id="net_primary_mole_productivity_of_carbon_by_diazotrophs">
-    <entry_id>net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophs</entry_id>
-  </alias>
-  
   <alias id="net_primary_mole_productivity_of_carbon_by_phytoplankton">
     <entry_id>net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_phytoplankton</entry_id>
   </alias>
@@ -32527,10 +32918,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
     <entry_id>mole_fraction_of_methylglyoxal_in_air</entry_id>
   </alias>
   
-  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_heterogeneous_nucleation_from_cloud_liquid">
-    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_heterogeneous_nucleation_from_cloud_liquid_water</entry_id>
-  </alias>
-  
   <alias id="moles_of_carbon_tetrachloride_in_atmosphere">
     <entry_id>atmosphere_moles_of_carbon_tetrachloride</entry_id>
   </alias>
@@ -32577,38 +32964,6 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
   
   <alias id="histogram_of_backscattering_ratio_over_height_above_reference_ellipsoid">
     <entry_id>histogram_of_backscattering_ratio_in_air_over_height_above_reference_ellipsoid</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_cloud_liquid_water_particle">
-    <entry_id>effective_radius_of_cloud_liquid_water_particles</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_cloud_liquid_water_particle_at_liquid_water_cloud_top">
-    <entry_id>effective_radius_of_cloud_liquid_water_particles_at_liquid_water_cloud_top</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_convective_cloud_liquid_water_particle">
-    <entry_id>effective_radius_of_convective_cloud_liquid_water_particles</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_convective_cloud_liquid_water_particle_at_convective_liquid_water_cloud_top">
-    <entry_id>effective_radius_of_convective_cloud_liquid_water_particles_at_convective_liquid_water_cloud_top</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_stratiform_cloud_liquid_water_particle">
-    <entry_id>effective_radius_of_stratiform_cloud_liquid_water_particles</entry_id>
-  </alias>
-  
-  <alias id="effective_radius_of_stratiform_cloud_liquid_water_particle_at_stratiform_liquid_water_cloud_top">
-    <entry_id>effective_radius_of_stratiform_cloud_liquid_water_particles_at_stratiform_liquid_water_cloud_top</entry_id>
-  </alias>
-  
-  <alias id="number_concentration_of_convective_cloud_liquid_water_particle_at_convective_liquid_water_cloud_top">
-    <entry_id>number_concentration_of_convective_cloud_liquid_water_particles_at_convective_liquid_water_cloud_top</entry_id>
-  </alias>
-  
-  <alias id="number_concentration_of_stratiform_cloud_liquid_water_particle_at_stratiform_liquid_water_cloud_top">
-    <entry_id>number_concentration_of_stratiform_cloud_liquid_water_particles_at_stratiform_liquid_water_cloud_top</entry_id>
   </alias>
   
   <alias id="effective_radius_of_convective_cloud_ice_particle">
@@ -32837,6 +33192,134 @@ final_air_pressure_of_lifted_parcel should be specified to indicate the specific
   
   <alias id="sea_water_from_direction">
     <entry_id>sea_water_velocity_from_direction</entry_id>
+  </alias>
+  
+  <alias id="atmosphere_cloud_liquid_water_content">
+    <entry_id>atmosphere_mass_content_of_cloud_liquid_water</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_cloud_liquid_water_particle">
+    <entry_id>effective_radius_of_cloud_liquid_water_particles</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_convective_cloud_liquid_water_particle">
+    <entry_id>effective_radius_of_convective_cloud_liquid_water_particles</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_convective_cloud_liquid_water_particle_at_convective_liquid_water_cloud_top">
+    <entry_id>effective_radius_of_convective_cloud_liquid_water_particles_at_convective_liquid_water_cloud_top</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_stratiform_cloud_liquid_water_particle">
+    <entry_id>effective_radius_of_stratiform_cloud_liquid_water_particles</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_stratiform_cloud_liquid_water_particle_at_stratiform_liquid_water_cloud_top">
+    <entry_id>effective_radius_of_stratiform_cloud_liquid_water_particles_at_stratiform_liquid_water_cloud_top</entry_id>
+  </alias>
+  
+  <alias id="number_concentration_of_convective_cloud_liquid_water_particle_at_convective_liquid_water_cloud_top">
+    <entry_id>number_concentration_of_convective_cloud_liquid_water_particles_at_convective_liquid_water_cloud_top</entry_id>
+  </alias>
+  
+  <alias id="number_concentration_of_stratiform_cloud_liquid_water_particle_at_stratiform_liquid_water_cloud_top">
+    <entry_id>number_concentration_of_stratiform_cloud_liquid_water_particles_at_stratiform_liquid_water_cloud_top</entry_id>
+  </alias>
+  
+  <alias id="equivalent_potential_temperature">
+    <entry_id>air_equivalent_potential_temperature</entry_id>
+  </alias>
+  
+  <alias id="cloud_liquid_water_content_of_atmosphere_layer">
+    <entry_id>mass_content_of_cloud_liquid_water_in_atmosphere_layer</entry_id>
+  </alias>
+  
+  <alias id="pseudo_equivalent_temperature">
+    <entry_id>air_pseudo_equivalent_temperature</entry_id>
+  </alias>
+  
+  <alias id="equivalent_temperature">
+    <entry_id>air_equivalent_temperature</entry_id>
+  </alias>
+  
+  <alias id="effective_radius_of_cloud_liquid_water_particle_at_liquid_water_cloud_top">
+    <entry_id>effective_radius_of_cloud_liquid_water_particles_at_liquid_water_cloud_top</entry_id>
+  </alias>
+  
+  <alias id="atmosphere_convective_cloud_liquid_water_content">
+    <entry_id>atmosphere_mass_content_of_convective_cloud_liquid_water</entry_id>
+  </alias>
+  
+  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_riming_from_cloud_liquid">
+    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_riming_from_cloud_liquid_water</entry_id>
+  </alias>
+  
+  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_heterogeneous_nucleation_from_cloud_liquid">
+    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_heterogeneous_nucleation_from_cloud_liquid_water</entry_id>
+  </alias>
+  
+  <alias id="tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_melting_to_cloud_liquid">
+    <entry_id>tendency_of_mass_fraction_of_stratiform_cloud_ice_in_air_due_to_melting_to_cloud_liquid_water</entry_id>
+  </alias>
+  
+  <alias id="pseudo_equivalent_potential_temperature">
+    <entry_id>air_pseudo_equivalent_potential_temperature</entry_id>
+  </alias>
+  
+  <alias id="growth_limitation_of_diazotrophs_due_to_solar_irradiance">
+    <entry_id>growth_limitation_of_diazotrophic_phytoplankton_due_to_solar_irradiance</entry_id>
+  </alias>
+  
+  <alias id="iron_growth_limitation_of_diazotrophs">
+    <entry_id>iron_growth_limitation_of_diazotrophic_phytoplankton</entry_id>
+  </alias>
+  
+  <alias id="mass_concentration_of_diazotrophs_expressed_as_chlorophyll_in_sea_water">
+    <entry_id>mass_concentration_of_diazotrophic_phytoplankton_expressed_as_chlorophyll_in_sea_water</entry_id>
+  </alias>
+  
+  <alias id="mole_concentration_of_diazotrophs_expressed_as_carbon_in_sea_water">
+    <entry_id>mole_concentration_of_diazotrophic_phytoplankton_expressed_as_carbon_in_sea_water</entry_id>
+  </alias>
+  
+  <alias id="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophs">
+    <entry_id>net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophic_phytoplankton</entry_id>
+  </alias>
+  
+  <alias id="net_primary_mole_productivity_of_carbon_by_diazotrophs">
+    <entry_id>net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_diazotrophic_phytoplankton</entry_id>
+  </alias>
+  
+  <alias id="nitrogen_growth_limitation_of_diazotrophs">
+    <entry_id>nitrogen_growth_limitation_of_diazotrophic_phytoplankton</entry_id>
+  </alias>
+  
+  <alias id="tendency_of_mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water_due_to_net_primary_production_by_diazotrophs">
+    <entry_id>tendency_of_mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water_due_to_net_primary_production_by_diazotrophic_phytoplankton</entry_id>
+  </alias>
+  
+  <alias id="mass_fraction_of_rain_and_drizzle_in_air">
+    <entry_id>mass_fraction_of_liquid_precipitation_in_air</entry_id>
+  </alias>
+  
+  <alias id="mass_fraction_of_rain_in_air">
+    <entry_id>mass_fraction_of_liquid_precipitation_in_air</entry_id>
+  </alias>
+  
+  <alias id="land_cover">
+    <entry_id>area_type</entry_id>
+  </alias>
+  
+  <alias id="surface_cover">
+    <entry_id>area_type</entry_id>
+  </alias>
+  
+  <alias id="atmosphere_absolute_vorticity">
+    <entry_id>atmosphere_upward_absolute_vorticity</entry_id>
+  </alias>
+  
+  <alias id="atmosphere_relative_vorticity">
+    <entry_id>atmosphere_upward_relative_vorticity</entry_id>
   </alias>
  
 


### PR DESCRIPTION
As part of any release, we should ideally also update the CF standard name table to the latest version.

This PR updates the table currently available in iris (v70, released 10 December 2019) to the latest version (v75, released 15 September 2020).

The latest version was only release a couple of days ago, so I suspect that it's unlikely they will do another release before we cut the rc.