### PR TITLE
Use napolean extension in docs to handle numpy docstrings too

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -114,6 +114,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
+    "sphinx.ext.napoleon",
     # TODO: Spelling extension disabled until the dependencies can be included
     # "sphinxcontrib.spelling",
     "sphinx_gallery.gen_gallery",
@@ -124,6 +125,20 @@ extensions = [
     "custom_data_autodoc",
     "generate_package_rst",
 ]
+
+# -- Napoleon extension -------------------------------------------------------
+# See https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
 
 # -- spellingextension --------------------------------------------------------
 # See https://sphinxcontrib-spelling.readthedocs.io/en/latest/customize.html

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -132,13 +132,15 @@ napoleon_google_docstring = True
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
+napoleon_include_special_with_doc = True  # includes dunders in api doc
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False
 napoleon_use_ivar = False
 napoleon_use_param = True
 napoleon_use_rtype = True
+napoleon_use_keyword = True
+napoleon_custom_sections = None
 
 # -- spellingextension --------------------------------------------------------
 # See https://sphinxcontrib-spelling.readthedocs.io/en/latest/customize.html

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -1098,7 +1098,7 @@ class IFunc:
             Dimension along which to apply `other` if it's a coordinate that is
             not found in `cube`
 
-        * **kwargs_data_func:
+        * kwargs_data_func:
             Keyword arguments that get passed on to the data_func.
 
         Returns:

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -351,24 +351,27 @@ def save(source, target, saver=None, **kwargs):
 
     Args:
 
-        * source    - A :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
-                      sequence of cubes.
-        * target    - A filename (or writeable, depending on file format).
-                      When given a filename or file, Iris can determine the
-                      file format.
+    * source:
+        :class:`iris.cube.Cube`, :class:`iris.cube.CubeList` or
+        sequence of cubes.
+    * target:
+        A filename (or writeable, depending on file format).
+        When given a filename or file, Iris can determine the
+        file format.
 
     Kwargs:
 
-        * saver     - Optional. Specifies the file format to save.
-                      If omitted, Iris will attempt to determine the format.
+    * saver:
+        Optional. Specifies the file format to save.
+        If omitted, Iris will attempt to determine the format.
 
-                      If a string, this is the recognised filename extension
-                      (where the actual filename may not have it).
-                      Otherwise the value is a saver function, of the form:
-                      ``my_saver(cube, target)`` plus any custom keywords. It
-                      is assumed that a saver will accept an ``append`` keyword
-                      if it's file format can handle multiple cubes. See also
-                      :func:`iris.io.add_saver`.
+        If a string, this is the recognised filename extension
+        (where the actual filename may not have it).
+        Otherwise the value is a saver function, of the form:
+        ``my_saver(cube, target)`` plus any custom keywords. It
+        is assumed that a saver will accept an ``append`` keyword
+        if it's file format can handle multiple cubes. See also
+        :func:`iris.io.add_saver`.
 
     All other keywords are passed through to the saver function; see the
     relevant saver documentation for more information on keyword arguments.

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -287,8 +287,8 @@ def add_saver(file_extension, new_saver):
 
     Args:
 
-        * file_extension - A string such as "pp" or "my_format".
-        * new_saver      - A function of the form ``my_saver(cube, target)``.
+    * file_extension: A string such as "pp" or "my_format".
+    * new_saver:      A function of the form ``my_saver(cube, target)``.
 
     See also :func:`iris.io.save`
 

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -46,3 +46,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - sphinx_rtd_theme
+  - pip
+  - pip:
+    - sphinxcontrib-napoleon

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -46,3 +46,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - sphinx_rtd_theme
+  - pip
+  - pip:
+    - sphinxcontrib-napoleon

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,3 +4,4 @@ sphinx
 sphinx-copybutton
 sphinx-gallery
 sphinx_rtd_theme
+sphinxcontrib-napoleon


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR **enables adoption** (but does not force) of **numpy docstrings**.  This solves  https://github.com/SciTools/iris/issues/3841

Enabling [napolean ](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html) sphinx extension to allow for **google style docstrings** and now also **numpy style docstrings**.

Just by enabling this extension causes build warnings due to existing incorrectly formatted docstrings.  A couple of files needed to be updated to allow for a clean build.  

- `lib/iris/io/__init__.py` - Correct formatting is now applied when rendered.  
  - Live: https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/io.html#iris.io.save
  - This PR: https://iris-test-doc.readthedocs.io/en/latest/generated/api/iris/io.html#iris.io.save
- `lib/iris/analysis/maths.py` - Fix build warning

The `requirements/ci/py37.yml` and `py36.yml` have been updated to include the new dependency for this extension.

Note that the documentation now will also include all **dunders**, you can search for dunders via:

- Live: https://scitools-iris.readthedocs.io/en/latest/search.html?q=__&check_keywords=yes&area=default (none in search)
- This PR: https://iris-test-doc.readthedocs.io/en/latest/search.html?q=__&check_keywords=yes&area=default (lots in search)

The setting named **napoleon_include_special_with_doc** can change this (currently set to **True)** in `conf.py`.

Note that the links to the **This PR** is only valid for the lifetime of this PR.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
