### PR TITLE
Remove all local table of contents

### DIFF
--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -11,9 +11,6 @@ improve the documentation for all users.
 Any change to the Iris project whether it is a bugfix, new feature or
 documentation update must use the :ref:`development-workflow`.
 
-.. contents:: Contents:
-      :local:
-
 
 Requirements
 ~~~~~~~~~~~~

--- a/docs/iris/src/whatsnew/1.0.rst
+++ b/docs/iris/src/whatsnew/1.0.rst
@@ -4,12 +4,6 @@ v1.0 (17 Oct 2012)
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
-
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 With the release of Iris 1.0, we have broadly completed the transition
 to the CF data model, and established a stable foundation for future
 work. Following this release we plan to deliver significant performance

--- a/docs/iris/src/whatsnew/1.1.rst
+++ b/docs/iris/src/whatsnew/1.1.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.10.rst
+++ b/docs/iris/src/whatsnew/1.10.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.11.rst
+++ b/docs/iris/src/whatsnew/1.11.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.12.rst
+++ b/docs/iris/src/whatsnew/1.12.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.13.rst
+++ b/docs/iris/src/whatsnew/1.13.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.2.rst
+++ b/docs/iris/src/whatsnew/1.2.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.3.rst
+++ b/docs/iris/src/whatsnew/1.3.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.4.rst
+++ b/docs/iris/src/whatsnew/1.4.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.5.rst
+++ b/docs/iris/src/whatsnew/1.5.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.6.rst
+++ b/docs/iris/src/whatsnew/1.6.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.7.rst
+++ b/docs/iris/src/whatsnew/1.7.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.8.rst
+++ b/docs/iris/src/whatsnew/1.8.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/1.9.rst
+++ b/docs/iris/src/whatsnew/1.9.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/2.0.rst
+++ b/docs/iris/src/whatsnew/2.0.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/2.1.rst
+++ b/docs/iris/src/whatsnew/2.1.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/2.2.rst
+++ b/docs/iris/src/whatsnew/2.2.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/2.3.rst
+++ b/docs/iris/src/whatsnew/2.3.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 

--- a/docs/iris/src/whatsnew/2.4.rst
+++ b/docs/iris/src/whatsnew/2.4.rst
@@ -5,11 +5,6 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. contents:: Skip to section:
-   :local:
-   :depth: 3
-
-
 Features
 ========
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Remove all **local table of contents** in the documentation.  This aligns with the `latest.rst` approach.  Users can use the **side bar** for navigation instead.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
