### PR TITLE
linkcheck ignore for iris pull and issue url

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -244,6 +244,8 @@ linkcheck_ignore = [
     "http://www.wmo.int/pages/prog/www/DPFS/documents/485_Vol_I_en_colour.pdf",
     "http://code.google.com/p/msysgit/downloads/list",
     "http://schacon.github.com/git",
+    "https://github.com/SciTools/iris/pull",
+    "https://github.com/SciTools/iris/issue",
 ]
 
 # list of sources to exclude from the build.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Added 2 urls to be **ignored** when running the **linkcheck** to avoid spamming github when running a **linkcheck**.

Since we have started to use the pull and issue directives:

```
:issue:`9999`
:pull:`9999`
```

... in the **what's new** that is later substituted for a full url, when running the **linkcheck** from **travis** the host (github) may **refuse the connection** as it is essentially being hit frequently from many different travis jobs.  This will show as a **warning/error** and fail the linkcheck travis task.

The ignore urls only covers Iris **pull** and **issue**, it will still check links to **blobs** (source code).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
