### PR TITLE
Docs warning to error

### DIFF
--- a/docs/iris/src/Makefile
+++ b/docs/iris/src/Makefile
@@ -2,11 +2,14 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = 
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 SRCDIR        = .
+
+# See https://www.sphinx-doc.org/en/master/man/sphinx-build.html?highlight=--keep-going#cmdoption-sphinx-build-W
+WARNING_TO_ERROR = -W --keep-going
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -39,7 +42,7 @@ clean:
 	-rm -rf $(SRCDIR)/generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) $(WARNING_TO_ERROR) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html"
 

--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -46,9 +46,6 @@ If you wish to run a clean build you can run::
 
 This is useful for a final test before committing your changes.
 
-.. todo:: warning to errors just for ``make html``?? what about ``doctest``,
-          ``gallerytest``, ``linkcheck``, ``html-noplot``?
-
 .. note:: In order to preserve a clean build for the html, all **warnings**
           have been promoted to be **errors** to ensure they are addressed.
           This check is only applied when ``make html`` is run.

--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -48,7 +48,7 @@ This is useful for a final test before committing your changes.
 
 .. note:: In order to preserve a clean build for the html, all **warnings**
           have been promoted to be **errors** to ensure they are addressed.
-          This is **only** applied when ``make html`` is run.
+          This **only** applies when ``make html`` is run.
 
 .. _travis-ci: https://travis-ci.org/github/SciTools/iris
 

--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -48,7 +48,7 @@ This is useful for a final test before committing your changes.
 
 .. note:: In order to preserve a clean build for the html, all **warnings**
           have been promoted to be **errors** to ensure they are addressed.
-          This check is only applied when ``make html`` is run.
+          This is **only** applied when ``make html`` is run.
 
 .. _travis-ci: https://travis-ci.org/github/SciTools/iris
 

--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -49,11 +49,12 @@ If you wish to run a clean build you can run::
 
 This is useful for a final test before committing your changes.
 
-.. note:: In addition to the automated `travis-ci`_  build of the documentation,
-          the https://readthedocs.org/ service is also used.  The configuration
-          of this held in a file in the root of the
-          `github Iris project <https://github.com/SciTools/iris>`_  named
-          ``.readthedocs.yml``.
+.. todo:: warning to errors just for ``make html``?? what about ``doctest``,
+          ``gallerytest``, ``linkcheck``, ``html-noplot``?
+
+.. note:: In order to preserve a clean build for the html, all **warnings**
+          have been promoted to be **errors** to ensure they are addressed.
+          This check is only applied when ``make html`` is run.
 
 .. _travis-ci: https://travis-ci.org/github/SciTools/iris
 
@@ -104,8 +105,13 @@ or ignore the url.
     ``spelling_word_list_filename``.
 
 
-.. note:: All of the above tests are automatically run as part of the
-          `travis-ci`_  automated build.
+.. note:: In addition to the automated `travis-ci`_ build of all the
+          documentation build options above, the
+          https://readthedocs.org/ service is also used.  The configuration
+          of this held in a file in the root of the
+          `github Iris project <https://github.com/SciTools/iris>`_  named
+          ``.readthedocs.yml``.
+
 
 .. _conf.py: https://github.com/SciTools/iris/blob/master/docs/iris/src/conf.py
 

--- a/docs/iris/src/userguide/real_and_lazy_data.rst
+++ b/docs/iris/src/userguide/real_and_lazy_data.rst
@@ -220,7 +220,6 @@ coordinates' lazy points and bounds:
     True
     >>> print(derived_coord.has_lazy_bounds())
     True
-    foo
 
 .. note::
     Printing a lazy :class:`~iris.coords.AuxCoord` will realise its points and bounds arrays!

--- a/docs/iris/src/userguide/real_and_lazy_data.rst
+++ b/docs/iris/src/userguide/real_and_lazy_data.rst
@@ -220,6 +220,7 @@ coordinates' lazy points and bounds:
     True
     >>> print(derived_coord.has_lazy_bounds())
     True
+    foo
 
 .. note::
     Printing a lazy :class:`~iris.coords.AuxCoord` will realise its points and bounds arrays!


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Configured **sphinx-build** to promote **warnings to errors** when building the documentation via ``make html``.

Updated the **Makefile** to use two new arguments:

- ``-W``. Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
- ``--keep-going``. With -W option, keep going processing when getting warnings to the end of build, and sphinx-build exits with exit status 1.

Also updated the ``contributing to the documentation`` in the Iris docs to state that warnings are promoted to errors.

For more info see https://www.sphinx-doc.org/en/master/man/sphinx-build.html?highlight=--keep-going#cmdoption-sphinx-build-W

### Why do this?

Before the overhaul of the Iris docs (https://github.com/SciTools/iris/pull/3752), there were many warnings in the build but were not actively fixed as no error was raised and the travis task completed ok.

### Why not promote all warnings to errors?

I believe the Travis jobs (of a task) will currently fail correctly for the following:

- ``make gallerytest``
- ``make doctest``
- ``make linkcheck``

For ``make html-noplot`` (skip the gallery creation) it could be applied but this is usually used as a quick way to build the docs and the ``make html`` that is part of the travis jobs (and can be run manually) will capture any issues anyway.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
