### PR TITLE
Documentation homepage, use of panels for visibility to users

### DIFF
--- a/docs/iris/src/common_links.inc
+++ b/docs/iris/src/common_links.inc
@@ -24,3 +24,4 @@
 .. _conda: https://docs.conda.io/en/latest/
 .. _sphinx: https://www.sphinx-doc.org/en/master/
 .. _napolean: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html
+.. _legacy documentation: https://scitools.org.uk/iris/docs/v2.4.0/

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -115,6 +115,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinx.ext.napoleon",
+    "sphinx_panels",
     # TODO: Spelling extension disabled until the dependencies can be included
     # "sphinxcontrib.spelling",
     "sphinx_gallery.gen_gallery",
@@ -125,6 +126,9 @@ extensions = [
     "custom_data_autodoc",
     "generate_package_rst",
 ]
+
+# -- panels extension ---------------------------------------------------------
+# See https://sphinx-panels.readthedocs.io/en/latest/
 
 # -- Napoleon extension -------------------------------------------------------
 # See https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html

--- a/docs/iris/src/developers_guide/contributing_getting_involved.rst
+++ b/docs/iris/src/developers_guide/contributing_getting_involved.rst
@@ -1,6 +1,6 @@
-.. _development_where_to_start:
-
 .. include:: ../common_links.inc
+
+.. _development_where_to_start:
 
 Getting Involved
 ----------------

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -1,9 +1,3 @@
-.. note:: For **Iris 2.4** and earlier documentation please see the
-          `legacy documentation`_
-
-.. _legacy documentation: https://scitools.org.uk/iris/docs/v2.4.0/
-
-
 Iris Documentation
 ==================
 
@@ -44,158 +38,61 @@ Interoperability with packages from the wider scientific Python ecosystem comes
 from Iris' use of standard NumPy/dask arrays as its underlying data storage.
 
 Iris is part of SciTools, for more information see https://scitools.org.uk/.
+For **Iris 2.4** and earlier documentation please see the
+:link-badge:`https://scitools.org.uk/iris/docs/v2.4.0/,"legacy documentation",cls=badge-info text-white`.
 
-
-Panel Experiment
-~~~~~~~~~~~~~~~~
-
-https://sphinx-panels.readthedocs.io/en/latest/
-
-
-Play #1
-"""""""
-
-.. panels::
-
-    .. link-button:: Iris
-        :type: ref
-        :text: Iris API 1
-
-    ---
-
-    A package for handling multi-dimensional data and associated metadata.
-
-    +++
-
-    .. link-button:: Iris
-        :type: ref
-        :text: Iris API 2
-        :classes: btn-outline-primary btn-block stretched-link
-
-
-Play #2
-"""""""
-
-and more....
 
 .. panels::
     :container: container-lg pb-3
     :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
 
-    this is some text
-
-    .. link-button:: generated/api/iris.html
-        :text: Iris API 1
-        :classes: btn-outline-primary
-    ---
-    .. link-button:: generated/api/iris.html
-        :text: Iris API 2
-        :classes: btn-outline-primary btn-block btn-sm
-    ---
-    .. link-button:: generated/api/iris.html
-        :text: Iris API 3
-        :classes: btn-outline-info stretched-link font-weight-bold btn-lg
-    ---
-    :column: col-lg-12 p-2
-    panel4
-
-
-Play #3
-"""""""
-
-More links....
-
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
-
-    Find out what's new in Iris
-
-    +++
-
-    .. link-button:: Iris
-        :type: ref
-        :text: Iris API
-        :classes: btn-outline-primary
-    ---
-
-    Find out what has recently been added to Iris, or what is soon about to be.
-
-    +++
-
-    .. link-button:: iris_whatsnew
-        :type: ref
-        :text: What's new
-        :classes: btn-outline-primary
-    ---
-
-    As a developer you can contribute to Iris
-
-    +++
-
-    .. link-button::_development_where_to_start
-        :type: ref
-        :text: Getting Involved
-        :classes: btn-outline-primary
-    ---
-
-
-
-Play #4
-"""""""
-
-More consistent layout, showing some button variations.
-
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
-
-    Install to use Iris or for develeopment.
+    Install Iris to use ir for development.
     +++
     .. link-button:: installing_iris
         :type: ref
         :text: Installing Iris
-        :classes: btn-outline-primary
+        :classes: btn-outline-primary btn-block
     ---
-    View the gallery with python code used to create it.
+    View the gallery that includes python code used to create it.
     +++
     .. link-button:: sphx_glr_generated_gallery
         :type: ref
         :text: Gallery
-        :classes: btn-primary
+        :classes: btn-outline-primary btn-block
     ---
-    Find out what has recently, or soon to be added to Iris.
+    Find out what has recently been added to Iris, or soon will be.
     +++
     .. link-button:: iris_whatsnew
         :type: ref
         :text: What's new
-        :classes: btn-outline-success
+        :classes: btn-outline-primary btn-block
     ---
     Learn how to use Iris.
     +++
     .. link-button:: user_guide_index
         :type: ref
         :text: User Guide
-        :classes: btn-outline-info btn-block
+        :classes: btn-outline-primary btn-block
     ---
     Extensive programming API documentation.
     +++
     .. link-button:: Iris
         :type: ref
         :text: Iris API
-        :classes: btn-info btn-block
+        :classes: btn-outline-primary btn-block
     ---
     As a developer you can contribute to Iris.
     +++
     .. link-button:: development_where_to_start
         :type: ref
         :text: Getting Involved
-        :classes: btn-success btn-block
+        :classes: btn-outline-primary btn-block
 
 
 .. toctree::
    :maxdepth: 1
    :caption: Getting started
+   :hidden:
 
    installing
    generated/gallery/index
@@ -205,6 +102,7 @@ More consistent layout, showing some button variations.
    :maxdepth: 1
    :caption: User Guide
    :name: userguide_index
+   :hidden:
 
    userguide/index
    userguide/iris_cubes
@@ -228,6 +126,7 @@ More consistent layout, showing some button variations.
    :maxdepth: 1
    :caption: Developers Guide
    :name: development_index
+   :hidden:
 
    developers_guide/contributing_getting_involved
    developers_guide/gitwash/index
@@ -235,13 +134,14 @@ More consistent layout, showing some button variations.
    developers_guide/contributing_codebase_index
    developers_guide/contributing_changes
    developers_guide/release
-   generated/api/iris
 
 
 .. toctree::
    :maxdepth: 1
    :caption: Reference
+   :hidden:
 
+   generated/api/iris
    whatsnew/index
    techpapers/index
    copyright

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -51,6 +51,10 @@ Panel Experiment
 
 https://sphinx-panels.readthedocs.io/en/latest/
 
+
+Play #1
+"""""""
+
 .. panels::
 
     .. link-button:: Iris
@@ -67,6 +71,10 @@ https://sphinx-panels.readthedocs.io/en/latest/
         :type: ref
         :text: Iris API 2
         :classes: btn-outline-primary btn-block stretched-link
+
+
+Play #2
+"""""""
 
 and more....
 
@@ -91,6 +99,9 @@ and more....
     :column: col-lg-12 p-2
     panel4
 
+
+Play #3
+"""""""
 
 More links....
 
@@ -129,51 +140,57 @@ More links....
     ---
 
 
-Lets try the toc as buttons instead.......
+
+Play #4
+"""""""
+
+More consistent layout, showing some button variations.
 
 .. panels::
     :container: container-lg pb-3
     :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
 
+    Install to use Iris or for develeopment.
+    +++
     .. link-button:: installing_iris
         :type: ref
-        :text: Getting Started
+        :text: Installing Iris
         :classes: btn-outline-primary
     ---
-
+    View the gallery with python code used to create it.
+    +++
+    .. link-button:: sphx_glr_generated_gallery
+        :type: ref
+        :text: Gallery
+        :classes: btn-primary
+    ---
+    Find out what has recently, or soon to be added to Iris.
+    +++
+    .. link-button:: iris_whatsnew
+        :type: ref
+        :text: What's new
+        :classes: btn-outline-success
+    ---
+    Learn how to use Iris.
+    +++
     .. link-button:: user_guide_index
         :type: ref
         :text: User Guide
-        :classes: btn-outline-primary
+        :classes: btn-outline-info
     ---
-
-    .. link-button::_development_where_to_start
-        :type: ref
-        :text: Developers Guideeeeeeeeeee
-        :classes: btn-outline-primary
-    ---
-
-    .. link-button:: iris_whatsnew
-        :type: ref
-        :text: Reference
-        :classes: btn-outline-primary
-    ---
-
+    Extensive programming API documentation.
+    +++
     .. link-button:: Iris
         :type: ref
         :text: Iris API
-        :classes: btn-outline-primary
+        :classes: btn-info
     ---
-
-What do we want to show using buttons?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* :fa:`question` Iris API
-* :fa:`question-circle` Installing Iris
-* User Guide
-* Dev Guide - Getting Started
-* Whats New
-
+    As a developer you can contribute to Iris.
+    +++
+    .. link-button:: development_where_to_start
+        :type: ref
+        :text: Getting Involved
+        :classes: btn-success
 
 
 .. toctree::

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -49,6 +49,8 @@ Iris is part of SciTools, for more information see https://scitools.org.uk/.
 Panel Experiment
 ~~~~~~~~~~~~~~~~
 
+https://sphinx-panels.readthedocs.io/en/latest/
+
 .. panels::
 
     .. link-button:: Iris

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -53,18 +53,18 @@ For **Iris 2.4** and earlier documentation please see the
         :text: Installing Iris
         :classes: btn-outline-primary btn-block
     ---
-    View the gallery that includes python code used to create it.
+    Example code to create a variety of plots.
     +++
     .. link-button:: sphx_glr_generated_gallery
         :type: ref
         :text: Gallery
         :classes: btn-outline-primary btn-block
     ---
-    Find out what has recently been added to Iris, or soon will be.
+    Find out what has recently changed in Iris.
     +++
     .. link-button:: iris_whatsnew
         :type: ref
-        :text: What's new
+        :text: What's New
         :classes: btn-outline-primary btn-block
     ---
     Learn how to use Iris.
@@ -74,7 +74,7 @@ For **Iris 2.4** and earlier documentation please see the
         :text: User Guide
         :classes: btn-outline-primary btn-block
     ---
-    Documentation for the Iris Application Programming Interface.
+    Browse full Iris functionality by module.
     +++
     .. link-button:: Iris
         :type: ref

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -46,7 +46,7 @@ For **Iris 2.4** and earlier documentation please see the
     :container: container-lg pb-3
     :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
 
-    Install Iris to use ir for development.
+    Install Iris to use or for development.
     +++
     .. link-button:: installing_iris
         :type: ref
@@ -74,7 +74,7 @@ For **Iris 2.4** and earlier documentation please see the
         :text: User Guide
         :classes: btn-outline-primary btn-block
     ---
-    Extensive programming API documentation.
+    Documentation for the Iris Application Programming Interface.
     +++
     .. link-button:: Iris
         :type: ref

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -46,6 +46,134 @@ from Iris' use of standard NumPy/dask arrays as its underlying data storage.
 Iris is part of SciTools, for more information see https://scitools.org.uk/.
 
 
+Panel Experiment
+~~~~~~~~~~~~~~~~
+
+.. panels::
+
+    .. link-button:: Iris
+        :type: ref
+        :text: Iris API 1
+
+    ---
+
+    A package for handling multi-dimensional data and associated metadata.
+
+    +++
+
+    .. link-button:: Iris
+        :type: ref
+        :text: Iris API 2
+        :classes: btn-outline-primary btn-block stretched-link
+
+and more....
+
+.. panels::
+    :container: container-lg pb-3
+    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+
+    this is some text
+
+    .. link-button:: generated/api/iris.html
+        :text: Iris API 1
+        :classes: btn-outline-primary
+    ---
+    .. link-button:: generated/api/iris.html
+        :text: Iris API 2
+        :classes: btn-outline-primary btn-block btn-sm
+    ---
+    .. link-button:: generated/api/iris.html
+        :text: Iris API 3
+        :classes: btn-outline-info stretched-link font-weight-bold btn-lg
+    ---
+    :column: col-lg-12 p-2
+    panel4
+
+
+More links....
+
+.. panels::
+    :container: container-lg pb-3
+    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+
+    Find out what's new in Iris
+
+    +++
+
+    .. link-button:: Iris
+        :type: ref
+        :text: Iris API
+        :classes: btn-outline-primary
+    ---
+
+    Find out what has recently been added to Iris, or what is soon about to be.
+
+    +++
+
+    .. link-button:: iris_whatsnew
+        :type: ref
+        :text: What's new
+        :classes: btn-outline-primary
+    ---
+
+    As a developer you can contribute to Iris
+
+    +++
+
+    .. link-button::_development_where_to_start
+        :type: ref
+        :text: Getting Involved
+        :classes: btn-outline-primary
+    ---
+
+
+Lets try the toc as buttons instead.......
+
+.. panels::
+    :container: container-lg pb-3
+    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+
+    .. link-button:: installing_iris
+        :type: ref
+        :text: Getting Started
+        :classes: btn-outline-primary
+    ---
+
+    .. link-button:: user_guide_index
+        :type: ref
+        :text: User Guide
+        :classes: btn-outline-primary
+    ---
+
+    .. link-button::_development_where_to_start
+        :type: ref
+        :text: Developers Guideeeeeeeeeee
+        :classes: btn-outline-primary
+    ---
+
+    .. link-button:: iris_whatsnew
+        :type: ref
+        :text: Reference
+        :classes: btn-outline-primary
+    ---
+
+    .. link-button:: Iris
+        :type: ref
+        :text: Iris API
+        :classes: btn-outline-primary
+    ---
+
+What do we want to show using buttons?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* :fa:`question` Iris API
+* :fa:`question-circle` Installing Iris
+* User Guide
+* Dev Guide - Getting Started
+* Whats New
+
+
+
 .. toctree::
    :maxdepth: 1
    :caption: Getting started

--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -176,21 +176,21 @@ More consistent layout, showing some button variations.
     .. link-button:: user_guide_index
         :type: ref
         :text: User Guide
-        :classes: btn-outline-info
+        :classes: btn-outline-info btn-block
     ---
     Extensive programming API documentation.
     +++
     .. link-button:: Iris
         :type: ref
         :text: Iris API
-        :classes: btn-info
+        :classes: btn-info btn-block
     ---
     As a developer you can contribute to Iris.
     +++
     .. link-button:: development_where_to_start
         :type: ref
         :text: Getting Involved
-        :classes: btn-success
+        :classes: btn-success btn-block
 
 
 .. toctree::

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -49,3 +49,5 @@ dependencies:
   - pip
   - pip:
     - sphinxcontrib-napoleon
+    - sphinx-panels
+

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -49,3 +49,4 @@ dependencies:
   - pip
   - pip:
     - sphinxcontrib-napoleon
+    - sphinx-panels

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,3 +5,4 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_rtd_theme
 sphinxcontrib-napoleon
+sphinx-panels


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Added some panels and use of badges on the documentation index, in order to make it more visible to users.

- The link to the legacy docs was in a note, now moved to lower on the page and uses a badge link instead.
- Added panels using the [sphinx-panels](https://sphinx-panels.readthedocs.io/en/latest/) extension.
- Made the index on the main body hidden, now it only appears in the sidebar.
- Added the dependency for `sphinx-panels`.
- Moved the `Iris API` link in the sidebar to the Reference section

You can view all rendered changes at https://iris-test-doc.readthedocs.io/en/latest/ for the lifetime of this PR.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
