### PR TITLE
linkcheck ignore http://cfconventions.org

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -267,6 +267,7 @@ linkcheck_ignore = [
     "http://schacon.github.com/git",
     "https://github.com/SciTools/iris/pull",
     "https://github.com/SciTools/iris/issue",
+    "http://cfconventions.org",
 ]
 
 # list of sources to exclude from the build.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Add a linkcheck ignore for http://cfconventions.org.  This is due to the url often failing during the linkcheck.

```
(line    9) ok        http://cfconventions.org
(line   40) ok        https://scitools.org.uk/
(line   34) redirect  http://www.numpy.org/ - permanently to https://numpy.org/
(line   14) redirect  https://github.com/SciTools/cf_units - permanently to https://github.com/SciTools/cf-units
(line   40) ok        https://scitools.org.uk/iris/docs/v2.4.0/
(line   34) redirect  https://dask.pydata.org/en/latest/ - with Found to https://docs.dask.org/en/latest/
(line   14) broken    http://cfconventions.org/standard-names.html - HTTPConnectionPool(host='cfconventions.org', port=80): Max retries exceeded with url: /standard-names.html (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fa3cb21c7d0>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
