### PR TITLE
Deprecate iris.util.as_compatible_shape

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -165,6 +165,10 @@ This document explains the changes made to Iris for this release
   ``int``. The deprecated attributes ``flag1``, ``flag2`` etc. have been
   removed from it. (:pull:`3461`)
 
+* `@bjlittle`_ deprecated :func:`~iris.util.as_compatible_shape` in preference
+  for :class:`~iris.common.resolve.Resolve`. The :func:`~iris.util.as_compatible_shape`
+  function will be removed in a future release of Iris.
+
 
 🔗 Dependencies
 ===============

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -166,8 +166,9 @@ This document explains the changes made to Iris for this release
   removed from it. (:pull:`3461`)
 
 * `@bjlittle`_ deprecated :func:`~iris.util.as_compatible_shape` in preference
-  for :class:`~iris.common.resolve.Resolve`. The :func:`~iris.util.as_compatible_shape`
-  function will be removed in a future release of Iris.
+  for :class:`~iris.common.resolve.Resolve` e.g., ``Resolve(src, tgt)(tgt.core_data())``.
+  The :func:`~iris.util.as_compatible_shape` function will be removed in a future
+  release of Iris. (:pull:`3892`)
 
 
 🔗 Dependencies

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -24,6 +24,7 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
+from iris._deprecation import warn_deprecated
 import iris.coords
 import iris.exceptions
 import iris.cube
@@ -1222,6 +1223,8 @@ def as_compatible_shape(src_cube, target_cube):
 
     .. note:: This function will load and copy the data payload of `src_cube`.
 
+    .. deprecated:: 3.0.0
+
     Args:
 
     * src_cube:
@@ -1236,6 +1239,12 @@ def as_compatible_shape(src_cube, target_cube):
         suitably reshaped to fit.
 
     """
+    wmsg = (
+        "iris.util.as_compatible_shape has been deprecated and will be "
+        "removed, please use iris.common.resolve.Resolve instead."
+    )
+    warn_deprecated(wmsg)
+
     dim_mapping = {}
     for coord in target_cube.aux_coords + target_cube.dim_coords:
         dims = target_cube.coord_dims(coord)

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1225,6 +1225,10 @@ def as_compatible_shape(src_cube, target_cube):
 
     .. deprecated:: 3.0.0
 
+       Instead use :class:`~iris.common.resolve.Resolve`. For example, rather
+       than calling ``as_compatible_shape(src_cube, target_cube)`` replace
+       with ``Resolve(src_cube, target_cube)(target_cube.core_data())``.
+
     Args:
 
     * src_cube:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
The PR marks the `iris.util.as_compatible_shape` function for deprecation from `iris` in a future release, in preference for using an instance of the `iris.common.resolve.Resolve` class.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
