### PR TITLE
hide the further topics toc

### DIFF
--- a/docs/iris/src/index.rst
+++ b/docs/iris/src/index.rst
@@ -125,6 +125,7 @@ For **Iris 2.4** and earlier documentation please see the
 .. toctree::
    :maxdepth: 1
    :caption: Further Topics
+   :hidden:
 
    further_topics/index
    further_topics/metadata


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR hides the new `Further topics` TOC from the documentation main page, but keeps it in the sidebar.

Thanks @tkknight :eyes: 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
