### PR TITLE
Lazy Percentile Aggregator

### DIFF
--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -34,6 +34,8 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ added support for ``false_easting`` and ``false_northing`` to
    :class:`~iris.coord_system.Mercator`. (:issue:`3107`, :pull:`4524`)
 
+#. `@rcomer`_ implemented lazy aggregation for the
+   :obj:`iris.analysis.PERCENTILE` aggregator. (:pull:`3901`)
 
 🐛 Bugs Fixed
 =============

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -359,7 +359,7 @@ def map_complete_blocks(src, func, dims, out_sizes):
 
     Args:
 
-    * src (:class:`~iris.cube.Cube`):
+    * src (:class:`~iris.cube.Cube` or lazy array):
         Source cube that function is applied to.
     * func:
         Function to apply.
@@ -369,10 +369,12 @@ def map_complete_blocks(src, func, dims, out_sizes):
         Output size of dimensions that cannot be chunked.
 
     """
-    if not src.has_lazy_data():
+    if is_lazy_data(src):
+        data = src
+    elif not src.has_lazy_data():
         return func(src.data)
-
-    data = src.lazy_data()
+    else:
+        data = src.lazy_data()
 
     # Ensure dims are not chunked
     in_chunks = list(data.chunks)

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -359,7 +359,7 @@ def map_complete_blocks(src, func, dims, out_sizes):
 
     Args:
 
-    * src (:class:`~iris.cube.Cube` or lazy array):
+    * src (:class:`~iris.cube.Cube` or array-like):
         Source cube that function is applied to.
     * func:
         Function to apply.
@@ -371,6 +371,9 @@ def map_complete_blocks(src, func, dims, out_sizes):
     """
     if is_lazy_data(src):
         data = src
+    elif not hasattr(src, "has_lazy_data"):
+        # Not a lazy array and not a cube.  So treat as ordinary numpy array.
+        return func(src)
     elif not src.has_lazy_data():
         return func(src.data)
     else:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1278,7 +1278,6 @@ def _percentile(
 
     """
     if not isinstance(percent, Iterable):
-        scalar_percent = True
         percent = [percent]
     percent = np.array(percent)
 
@@ -1304,7 +1303,7 @@ def _percentile(
 
     # Check whether to reduce to a scalar result, as per the behaviour
     # of other aggregators.
-    if result.shape == (1,) and scalar_percent:
+    if result.shape == (1,):
         result = np.squeeze(result)
 
     return result

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1267,12 +1267,24 @@ def _percentile(data, percent, fast_percentile_method=False, **kwargs):
     If a new additive dimension is formed, then it will always be the last
     dimension of the resulting percentile data payload.
 
+    Args:
+
+    * data (array-like)
+        array from which percentiles are to be calculated
+    * axis (int or tuple of int)
+        Axis or axes along which the percentiles are computed
+        (handled by decorator)
+
     Kwargs:
 
-    * fast_percentile_method (boolean) :
+    * fast_percentile_method (boolean)
         When set to True, uses the numpy.percentiles method as a faster
         alternative to the scipy.mstats.mquantiles method. Does not handle
         masked arrays.
+
+    **kwargs
+        passed to scipy.stats.mstats.mquantiles if fast_percentile_method is
+        False
 
     """
     if not isinstance(percent, Iterable):

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1241,7 +1241,7 @@ def _percentile(
     # Check whether to reduce to a scalar result, as per the behaviour
     # of other aggregators.
     if result.shape == (1,) and scalar_percent:
-        result = result[0]
+        result = np.squeeze(result)
 
     return result
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1245,21 +1245,17 @@ def _percentile(
         masked arrays.
 
     """
-    # Express axis as list of non-negative integers.
-    if not isinstance(axis, Iterable):
-        axis = [axis % data.ndim]
-    else:
-        axis = sorted([dim % data.ndim for dim in axis])
-
     # Get data as a 1D or 2D view with the target axis as the trailing one.
-    end_size = np.prod([data.shape[dim] for dim in axis])
-    untouched_dims = [dim for dim in range(data.ndim) if dim not in axis]
-    shape = [data.shape[dim] for dim in untouched_dims]
+    if not isinstance(axis, Iterable):
+        axis = (axis,)
+    end = range(-len(axis), 0)
 
-    data = data.transpose(untouched_dims + axis)
-
-    if shape or len(axis) > 1:
-        data = data.reshape([np.prod(shape), end_size])
+    data = np.moveaxis(data, axis, end)
+    shape = data.shape[: -len(axis)]
+    if shape:
+        data = data.reshape(np.prod(shape), -1)
+    else:
+        data = data.flatten()
 
     if not isinstance(percent, Iterable):
         scalar_percent = True

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1250,8 +1250,7 @@ def _percentile(
 
     data = data.transpose(untouched_dims + axis)
 
-    # Flatten any leading dimensions.
-    if shape:
+    if shape or len(axis) > 1:
         data = data.reshape([np.prod(shape), end_size])
 
     if not isinstance(percent, Iterable):

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -792,7 +792,7 @@ class PercentileAggregator(_Aggregator):
             function.
 
         Returns:
-            A lazy array representing the aggregation operation
+            A lazy array representing the result of the aggregation operation
             (:class:`dask.array.Array`).
 
         """

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1271,9 +1271,6 @@ def _percentile(data, percent, fast_percentile_method=False, **kwargs):
 
     * data (array-like)
         array from which percentiles are to be calculated
-    * axis (int or tuple of int)
-        Axis or axes along which the percentiles are computed
-        (handled by decorator)
 
     Kwargs:
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1830,9 +1830,10 @@ This aggregator handles masked data.
 
 PERCENTILE = PercentileAggregator(alphap=1, betap=1)
 """
-An :class:`~iris.analysis.PercentileAggregator` instance that calculates the
+A :class:`~iris.analysis.PercentileAggregator` instance that calculates the
 percentile over a :class:`~iris.cube.Cube`, as computed by
-:func:`scipy.stats.mstats.mquantiles`.
+:func:`scipy.stats.mstats.mquantiles` (default) or :func:`numpy.percentile` (if
+fast_percentile_method is True).
 
 **Required** kwargs associated with the use of this aggregator:
 
@@ -1847,6 +1848,11 @@ Additional kwargs associated with the use of this aggregator:
 * betap (float):
     Plotting positions parameter, see :func:`scipy.stats.mstats.mquantiles`.
     Defaults to 1.
+* fast_percentile_method (boolean):
+    When set to True, uses :func:`numpy.percentile` method as a faster
+    alternative to the :func:`scipy.stats.mstats.mquantiles` method.  alphap and
+    betap are ignored. An exception is raised if the data are masked.
+    Defaults to False.
 
 **For example**:
 
@@ -1854,7 +1860,14 @@ To compute the 10th and 90th percentile over *time*::
 
     result = cube.collapsed('time', iris.analysis.PERCENTILE, percent=[10, 90])
 
-This aggregator handles masked data.
+This aggregator handles masked data and lazy data.
+
+.. note::
+    Performance of this aggregator on lazy data is particularly sensitive to
+    the dask array chunking, so it may be useful to test with various chunk
+    sizes for a given application.  Any chunking along the dimensions to be
+    aggregated is removed by the aggregator prior to calculating the
+    percentiles.
 
 """
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1875,6 +1875,7 @@ To compute the 10th and 90th percentile over *time*::
 This aggregator handles masked data and lazy data.
 
 .. note::
+
     Performance of this aggregator on lazy data is particularly sensitive to
     the dask array chunking, so it may be useful to test with various chunk
     sizes for a given application.  Any chunking along the dimensions to be

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1159,7 +1159,7 @@ def _build_dask_mdtol_function(dask_stats_function):
 
 def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
     """
-    Calculate percentiles along the 2nd axis of a 2D array.
+    Calculate percentiles along the trailing axis of a 1D or 2D array.
 
     """
     if fast_percentile_method:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -697,11 +697,6 @@ class PercentileAggregator(_Aggregator):
             Returns an :class:`cf_units.Unit`, or a
             value that can be made into one.
 
-        * lazy_func (callable or None):
-            An alternative to :data:`call_func` implementing a lazy
-            aggregation. Note that, it need not support all features of the
-            main operation, but should raise an error in unhandled cases.
-
         Additional kwargs::
             Passed through to :data:`call_func` and :data:`lazy_func`.
 
@@ -717,7 +712,7 @@ class PercentileAggregator(_Aggregator):
         _Aggregator.__init__(
             self,
             None,
-            functools.partial(_percentile, lazy=False),
+            _real_percentile,
             units_func=units_func,
             lazy_func=_lazy_percentile,
             **kwargs,
@@ -1314,6 +1309,8 @@ def _percentile(
 
     return result
 
+
+_real_percentile = functools.partial(_percentile, lazy=False)
 
 _lazy_percentile = _build_dask_mdtol_function(
     functools.partial(_percentile, lazy=True)

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -226,6 +226,8 @@ class MultiAxisMixin:
 
 
 class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin, MultiAxisMixin):
+    """Tests for fast aggregation on lazy data."""
+
     def setUp(self):
         self.fast = True
         self.lazy = True
@@ -247,6 +249,8 @@ class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin, MultiAxisMixin):
 class Test_lazy_aggregate(
     tests.IrisTest, CalcMixin, MaskedCalcMixin, MultiAxisMixin
 ):
+    """Tests for standard aggregation on lazy data."""
+
     def setUp(self):
         self.fast = False
         self.lazy = True

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -239,7 +239,9 @@ class Test_lazy_aggregate(tests.IrisTest):
         data[1] = ma.masked
         data = as_lazy_data(data)
         percent = np.array([10, 50, 70, 80])
-        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=percent)
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=percent, mdtol=0.1
+        )
         self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
         self.assertTrue(is_lazy_data(actual))
         expected = np.tile(np.arange(shape[-1]), percent.size)

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -154,7 +154,7 @@ class MaskedAggregateMixin:
         axis = 0
         self.agg_method(data, axis=axis, percent=percent)
         for key in ["alphap", "betap"]:
-            assert mocked_mquantiles.call_args.kwargs[key] == 1
+            self.assertEqual(mocked_mquantiles.call_args.kwargs[key], 1)
 
     @mock.patch("scipy.stats.mstats.mquantiles")
     def test_chosen_kwargs_passed(self, mocked_mquantiles):
@@ -165,7 +165,7 @@ class MaskedAggregateMixin:
             data, axis=axis, percent=percent, alphap=0.6, betap=0.5
         )
         for key, val in zip(["alphap", "betap"], [0.6, 0.5]):
-            assert mocked_mquantiles.call_args.kwargs[key] == val
+            self.assertEqual(mocked_mquantiles.call_args.kwargs[key], val)
 
 
 class Test_aggregate(tests.IrisTest, AggregateMixin, MaskedAggregateMixin):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -169,7 +169,10 @@ class MultiAxisMixin:
         lazy_data = as_lazy_data(data)
         percent = 30
         actual = PERCENTILE.lazy_aggregate(
-            lazy_data, axis=collapse_axes, percent=percent
+            lazy_data,
+            axis=collapse_axes,
+            percent=percent,
+            fast_percentile_method=self.fast,
         )
         self.assertTrue(is_lazy_data(actual))
         result = as_concrete_data(actual)
@@ -186,7 +189,10 @@ class MultiAxisMixin:
         lazy_data = as_lazy_data(data)
         percent = [20, 30, 50, 70, 80]
         actual = PERCENTILE.lazy_aggregate(
-            lazy_data, axis=collapse_axes, percent=percent
+            lazy_data,
+            axis=collapse_axes,
+            percent=percent,
+            fast_percentile_method=self.fast,
         )
         self.assertTrue(is_lazy_data(actual))
         result = as_concrete_data(actual)
@@ -198,7 +204,7 @@ class MultiAxisMixin:
             )
 
 
-class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin):
+class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin, MultiAxisMixin):
     def setUp(self):
         self.fast = True
         self.lazy = True
@@ -217,7 +223,9 @@ class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin):
             as_concrete_data(actual)
 
 
-class Test_lazy_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
+class Test_lazy_aggregate(
+    tests.IrisTest, CalcMixin, MaskedCalcMixin, MultiAxisMixin
+):
     def setUp(self):
         self.fast = False
         self.lazy = True

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.ma as ma
 
 from iris.analysis import PERCENTILE
+from iris._lazy_data import as_lazy_data, as_concrete_data, is_lazy_data
 
 
 class Test_aggregate(tests.IrisTest):
@@ -95,6 +96,156 @@ class Test_aggregate(tests.IrisTest):
         expected = expected.reshape(percent.size, shape[-1]).T
         expected = expected + (percent / 10 * 2)
         self.assertArrayAlmostEqual(actual, expected)
+
+
+class Test_lazy_fast_aggregate(tests.IrisTest):
+    def test_1d_single(self):
+        data = as_lazy_data(np.arange(11))
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=50, fast_percentile_method=True
+        )
+        expected = 5
+        self.assertTupleEqual(actual.shape, ())
+        self.assertTrue(is_lazy_data(actual))
+        self.assertEqual(as_concrete_data(actual), expected)
+
+    def test_1d_multi(self):
+        data = as_lazy_data(np.arange(11))
+        percent = np.array([20, 50, 90])
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=percent, fast_percentile_method=True
+        )
+        expected = [2, 5, 9]
+        self.assertTupleEqual(actual.shape, percent.shape)
+        self.assertTrue(is_lazy_data(actual))
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_2d_single(self):
+        shape = (2, 11)
+        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=50, fast_percentile_method=True
+        )
+        self.assertTupleEqual(actual.shape, shape[-1:])
+        self.assertTrue(is_lazy_data(actual))
+        expected = np.arange(shape[-1]) + 5.5
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_2d_multi(self):
+        shape = (2, 10)
+        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        percent = np.array([10, 50, 90, 100])
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=percent, fast_percentile_method=True
+        )
+        self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
+        self.assertTrue(is_lazy_data(actual))
+        expected = np.tile(np.arange(shape[-1]), percent.size)
+        expected = expected.reshape(percent.size, shape[-1]).T + 1
+        expected = expected + (percent / 10 - 1)
+        self.assertArrayAlmostEqual(as_concrete_data(actual), expected)
+
+    def test_masked(self):
+        shape = (2, 11)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        data[1, 1::2] = ma.masked
+        data = as_lazy_data(data)
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=50, fast_percentile_method=True
+        )
+        emsg = "Cannot use fast np.percentile method with masked array."
+        with self.assertRaisesRegex(TypeError, emsg):
+            as_concrete_data(actual)
+
+
+class Test_lazy_aggregate(tests.IrisTest):
+    def test_1d_single(self):
+        data = as_lazy_data(np.arange(11))
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=50)
+        expected = 5
+        self.assertTupleEqual(actual.shape, ())
+        self.assertTrue(is_lazy_data(actual))
+        self.assertEqual(as_concrete_data(actual), expected)
+
+    def test_masked_1d_single(self):
+        data = ma.arange(11)
+        data[3:7] = ma.masked
+        data = as_lazy_data(data)
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=50)
+        expected = 7
+        self.assertTupleEqual(actual.shape, ())
+        self.assertTrue(is_lazy_data(actual))
+        self.assertEqual(as_concrete_data(actual), expected)
+
+    def test_1d_multi(self):
+        data = as_lazy_data(np.arange(11))
+        percent = np.array([20, 50, 90])
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=percent)
+        expected = [2, 5, 9]
+        self.assertTupleEqual(actual.shape, percent.shape)
+        self.assertTrue(is_lazy_data(actual))
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_masked_1d_multi(self):
+        data = ma.arange(11)
+        data[3:9] = ma.masked
+        data = as_lazy_data(data)
+        percent = np.array([25, 50, 75])
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=percent)
+        expected = [1, 2, 9]
+        self.assertTupleEqual(actual.shape, percent.shape)
+        self.assertTrue(is_lazy_data(actual))
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_2d_single(self):
+        shape = (2, 11)
+        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=50)
+        expected = np.arange(shape[-1]) + 5.5
+        self.assertTupleEqual(actual.shape, shape[-1:])
+        self.assertTrue(is_lazy_data(actual))
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_masked_2d_single(self):
+        shape = (2, 11)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        data[1, 1::2] = ma.masked
+        data = as_lazy_data(data)
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=50)
+        self.assertTupleEqual(actual.shape, shape[-1:])
+        self.assertTrue(is_lazy_data(actual))
+        expected = np.empty(shape[-1:])
+        expected[1::2] = data[0, 1::2]
+        expected[::2] = data[1, ::2]
+        self.assertArrayEqual(as_concrete_data(actual), expected)
+
+    def test_2d_multi(self):
+        shape = (2, 10)
+        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        percent = np.array([10, 50, 90, 100])
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=percent)
+        self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
+        self.assertTrue(is_lazy_data(actual))
+        expected = np.tile(np.arange(shape[-1]), percent.size)
+        expected = expected.reshape(percent.size, shape[-1]).T + 1
+        expected = expected + (percent / 10 - 1)
+        self.assertArrayAlmostEqual(as_concrete_data(actual), expected)
+
+    def test_masked_2d_multi(self):
+        shape = (3, 10)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[1] = ma.masked
+        data = as_lazy_data(data)
+        percent = np.array([10, 50, 70, 80])
+        actual = PERCENTILE.lazy_aggregate(data, axis=0, percent=percent)
+        self.assertTupleEqual(actual.shape, (shape[-1], percent.size))
+        self.assertTrue(is_lazy_data(actual))
+        expected = np.tile(np.arange(shape[-1]), percent.size)
+        expected = expected.reshape(percent.size, shape[-1]).T
+        expected = expected + (percent / 10 * 2)
+        self.assertArrayAlmostEqual(as_concrete_data(actual), expected)
 
 
 class Test_name(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -145,6 +145,8 @@ class MaskedCalcMixin:
 
 
 class Test_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
+    """Tests for standard aggregation method on real data."""
+
     def setUp(self):
         self.fast = False
         self.lazy = False
@@ -156,10 +158,29 @@ class Test_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
             PERCENTILE.aggregate("dummy", axis=0)
 
 
+class Test_fast_aggregate(tests.IrisTest, CalcMixin):
+    """Tests for fast percentile method on real data."""
+
+    def setUp(self):
+        self.fast = True
+        self.lazy = False
+        self.agg_method = PERCENTILE.aggregate
+
+    def test_masked(self):
+        shape = (2, 11)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        emsg = "Cannot use fast np.percentile method with masked array."
+        with self.assertRaisesRegex(TypeError, emsg):
+            PERCENTILE.aggregate(
+                data, axis=0, percent=50, fast_percentile_method=True
+            )
+
+
 class MultiAxisMixin:
     """
     Tests for axis passed as a tuple.  Only relevant for lazy aggregation since
-    axis is specified as int for real aggregation.
+    axis is always specified as int for real aggregation.
 
     """
 

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -163,6 +163,38 @@ class Test_lazy_fast_aggregate(tests.IrisTest, LazyMixin):
         with self.assertRaisesRegex(TypeError, emsg):
             as_concrete_data(actual)
 
+    def test_multi_axis(self):
+        data = np.arange(24.0).reshape((2, 3, 4))
+        collapse_axes = (0, 2)
+        lazy_data = as_lazy_data(data)
+        percent = 30
+        agg = PERCENTILE.lazy_aggregate(
+            lazy_data, axis=collapse_axes, percent=percent
+        )
+        result = as_concrete_data(agg)
+        self.assertTupleEqual(result.shape, (3,))
+        for num, sub_result in enumerate(result):
+            # results should be the same as percentiles calculated from slices.
+            self.assertArrayAlmostEqual(
+                sub_result, np.percentile(data[:, num, :], percent)
+            )
+
+    def test_multi_axis_multi_percent(self):
+        data = np.arange(24.0).reshape((2, 3, 4))
+        collapse_axes = (0, 2)
+        lazy_data = as_lazy_data(data)
+        percent = [20, 30, 50, 70, 80]
+        agg = PERCENTILE.lazy_aggregate(
+            lazy_data, axis=collapse_axes, percent=percent
+        )
+        result = as_concrete_data(agg)
+        self.assertTupleEqual(result.shape, (3, 5))
+        for num, sub_result in enumerate(result):
+            # results should be the same as percentiles calculated from slices.
+            self.assertArrayAlmostEqual(
+                sub_result, np.percentile(data[:, num, :], percent)
+            )
+
 
 class Test_lazy_aggregate(tests.IrisTest, LazyMixin):
     def setUp(self):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -132,14 +132,14 @@ class CalcMixin:
             self.assertArrayEqual(actual, expected)
 
     def test_1d_single(self):
-        data = as_lazy_data(np.arange(11))
+        data = np.arange(11)
         axis = 0
         percent = 50
         expected = 5
         self.check_percentile_calc(data, axis, percent, expected)
 
     def test_1d_multi(self):
-        data = as_lazy_data(np.arange(11))
+        data = np.arange(11)
         percent = np.array([20, 50, 90])
         axis = 0
         expected = [2, 5, 9]
@@ -147,7 +147,7 @@ class CalcMixin:
 
     def test_2d_single(self):
         shape = (2, 11)
-        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        data = np.arange(np.prod(shape)).reshape(shape)
         axis = 0
         percent = 50
         expected = np.arange(shape[-1]) + 5.5
@@ -155,7 +155,7 @@ class CalcMixin:
 
     def test_2d_multi(self):
         shape = (2, 10)
-        data = as_lazy_data(np.arange(np.prod(shape)).reshape(shape))
+        data = np.arange(np.prod(shape)).reshape(shape)
         axis = 0
         percent = np.array([10, 50, 90, 100])
         expected = np.tile(np.arange(shape[-1]), percent.size)

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -9,6 +9,8 @@
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
+from unittest import mock
+
 import numpy as np
 import numpy.ma as ma
 
@@ -144,6 +146,26 @@ class MaskedAggregateMixin:
         self.check_percentile_calc(
             data, axis, percent, expected, mdtol=mdtol, approx=True
         )
+
+    @mock.patch("scipy.stats.mstats.mquantiles")
+    def test_default_kwargs_passed(self, mocked_mquantiles):
+        data = np.arange(5)
+        percent = 50
+        axis = 0
+        self.agg_method(data, axis=axis, percent=percent)
+        for key in ["alphap", "betap"]:
+            assert mocked_mquantiles.call_args.kwargs[key] == 1
+
+    @mock.patch("scipy.stats.mstats.mquantiles")
+    def test_chosen_kwargs_passed(self, mocked_mquantiles):
+        data = np.arange(5)
+        percent = 50
+        axis = 0
+        self.agg_method(
+            data, axis=axis, percent=percent, alphap=0.6, betap=0.5
+        )
+        for key, val in zip(["alphap", "betap"], [0.6, 0.5]):
+            assert mocked_mquantiles.call_args.kwargs[key] == val
 
 
 class Test_aggregate(tests.IrisTest, AggregateMixin, MaskedAggregateMixin):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -156,23 +156,12 @@ class Test_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
             PERCENTILE.aggregate("dummy", axis=0)
 
 
-class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin):
-    def setUp(self):
-        self.fast = True
-        self.lazy = True
-        self.agg_method = PERCENTILE.lazy_aggregate
+class MultiAxisMixin:
+    """
+    Tests for axis passed as a tuple.  Only relevant for lazy aggregation since
+    axis is specified as int for real aggregation.
 
-    def test_masked(self):
-        shape = (2, 11)
-        data = ma.arange(np.prod(shape)).reshape(shape)
-        data[0, ::2] = ma.masked
-        data = as_lazy_data(data)
-        actual = PERCENTILE.lazy_aggregate(
-            data, axis=0, percent=50, fast_percentile_method=True
-        )
-        emsg = "Cannot use fast np.percentile method with masked array."
-        with self.assertRaisesRegex(TypeError, emsg):
-            as_concrete_data(actual)
+    """
 
     def test_multi_axis(self):
         data = np.arange(24).reshape((2, 3, 4))
@@ -207,6 +196,25 @@ class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin):
             self.assertArrayAlmostEqual(
                 sub_result, np.percentile(data[:, num, :], percent)
             )
+
+
+class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin):
+    def setUp(self):
+        self.fast = True
+        self.lazy = True
+        self.agg_method = PERCENTILE.lazy_aggregate
+
+    def test_masked(self):
+        shape = (2, 11)
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        data = as_lazy_data(data)
+        actual = PERCENTILE.lazy_aggregate(
+            data, axis=0, percent=50, fast_percentile_method=True
+        )
+        emsg = "Cannot use fast np.percentile method with masked array."
+        with self.assertRaisesRegex(TypeError, emsg):
+            as_concrete_data(actual)
 
 
 class Test_lazy_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -16,10 +16,10 @@ from iris._lazy_data import as_concrete_data, as_lazy_data, is_lazy_data
 from iris.analysis import PERCENTILE
 
 
-class CalcMixin:
+class AggregateMixin:
     """
-    Tests for both numpy and scipy methods within lazy and real percentile
-    aggregation.
+    Percentile aggregation tests for both numpy and scipy methods within lazy
+    and real percentile aggregation.
 
     """
 
@@ -30,6 +30,7 @@ class CalcMixin:
             data = as_lazy_data(data)
 
         expected = np.array(expected)
+
         actual = self.agg_method(
             data,
             axis=axis,
@@ -42,8 +43,8 @@ class CalcMixin:
         is_lazy = is_lazy_data(actual)
 
         if self.lazy:
-            actual = as_concrete_data(actual)
             self.assertTrue(is_lazy)
+            actual = as_concrete_data(actual)
         else:
             self.assertFalse(is_lazy)
 
@@ -85,9 +86,10 @@ class CalcMixin:
         self.check_percentile_calc(data, axis, percent, expected, approx=True)
 
 
-class MaskedCalcMixin:
+class MaskedAggregateMixin:
     """
-    Tests for calculations on masked data.  Will only work if using the scipy
+    Tests for calculations on masked data.  Will only work if using the standard
+    (scipy) method.  Needs to be used with AggregateMixin, as these tests re-use its
     method.
 
     """
@@ -144,7 +146,7 @@ class MaskedCalcMixin:
         )
 
 
-class Test_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
+class Test_aggregate(tests.IrisTest, AggregateMixin, MaskedAggregateMixin):
     """Tests for standard aggregation method on real data."""
 
     def setUp(self):
@@ -158,7 +160,7 @@ class Test_aggregate(tests.IrisTest, CalcMixin, MaskedCalcMixin):
             PERCENTILE.aggregate("dummy", axis=0)
 
 
-class Test_fast_aggregate(tests.IrisTest, CalcMixin):
+class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
     """Tests for fast percentile method on real data."""
 
     def setUp(self):
@@ -225,7 +227,7 @@ class MultiAxisMixin:
             )
 
 
-class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin, MultiAxisMixin):
+class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
     """Tests for fast aggregation on lazy data."""
 
     def setUp(self):
@@ -247,7 +249,7 @@ class Test_lazy_fast_aggregate(tests.IrisTest, CalcMixin, MultiAxisMixin):
 
 
 class Test_lazy_aggregate(
-    tests.IrisTest, CalcMixin, MaskedCalcMixin, MultiAxisMixin
+    tests.IrisTest, AggregateMixin, MaskedAggregateMixin, MultiAxisMixin
 ):
     """Tests for standard aggregation on lazy data."""
 

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -81,7 +81,7 @@ class Test_post_process(tests.IrisTest):
             self.cube_simple, data, coords, **kwargs
         )
         self.assertEqual(actual.shape, percent.shape + self.cube_simple.shape)
-        expected = np.rollaxis(data, -1)
+        expected = data.T
         self.assertArrayEqual(actual.data, expected)
         name = "percentile_over_time"
         coord = actual.coord(name)
@@ -115,7 +115,7 @@ class Test_post_process(tests.IrisTest):
             self.cube_multi, data, coords, **kwargs
         )
         self.assertEqual(actual.shape, percent.shape + self.cube_multi.shape)
-        expected = np.rollaxis(data, -1)
+        expected = np.moveaxis(data, -1, 0)
         self.assertArrayEqual(actual.data, expected)
         name = "percentile_over_time"
         coord = actual.coord(name)
@@ -135,7 +135,7 @@ class Test_post_process(tests.IrisTest):
         )
         self.assertEqual(actual.shape, percent.shape + self.cube_multi.shape)
         self.assertTrue(actual.has_lazy_data())
-        expected = np.rollaxis(as_concrete_data(data), -1)
+        expected = np.moveaxis(as_concrete_data(data), -1, 0)
         self.assertArrayEqual(actual.data, expected)
 
 

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -15,25 +15,22 @@ import iris.tests as tests  # isort:skip
 from unittest import mock
 
 import numpy as np
+import dask.array as da
 
-from iris.analysis import PercentileAggregator, _percentile
+from iris.analysis import PercentileAggregator
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
+from iris._lazy_data import as_lazy_data
+from iris._lazy_data import as_concrete_data
 
 
 class Test(tests.IrisTest):
     def test_init(self):
         name = "percentile"
-        call_func = _percentile
         units_func = mock.sentinel.units_func
-        lazy_func = mock.sentinel.lazy_func
-        aggregator = PercentileAggregator(
-            units_func=units_func, lazy_func=lazy_func
-        )
+        aggregator = PercentileAggregator(units_func=units_func)
         self.assertEqual(aggregator.name(), name)
-        self.assertIs(aggregator.call_func, call_func)
         self.assertIs(aggregator.units_func, units_func)
-        self.assertIs(aggregator.lazy_func, lazy_func)
         self.assertIsNone(aggregator.cell_method)
 
 
@@ -125,6 +122,80 @@ class Test_post_process(tests.IrisTest):
         coord = actual.coord(name)
         expected = AuxCoord(percent, long_name=name, units="percent")
         self.assertEqual(coord, expected)
+
+
+class Test_lazy_post_process(tests.IrisTest):
+    def setUp(self):
+        shape = (2, 5)
+        data = as_lazy_data(np.arange(np.prod(shape)))
+
+        self.coord_simple = DimCoord(data, "time")
+        self.cube_simple = Cube(data)
+        self.cube_simple.add_dim_coord(self.coord_simple, 0)
+
+        self.coord_multi_0 = DimCoord(np.arange(shape[0]), "time")
+        self.coord_multi_1 = DimCoord(np.arange(shape[1]), "height")
+        self.cube_multi = Cube(data.reshape(shape))
+        self.cube_multi.add_dim_coord(self.coord_multi_0, 0)
+        self.cube_multi.add_dim_coord(self.coord_multi_1, 1)
+
+    def test_simple_single_point(self):
+        aggregator = PercentileAggregator()
+        percent = 50
+        kwargs = dict(percent=percent)
+        shape = self.cube_simple.shape
+        data = da.arange(np.prod(shape)).reshape(shape)
+        coords = [self.coord_simple]
+        actual = aggregator.post_process(
+            self.cube_simple, data, coords, **kwargs
+        )
+        self.assertEqual(actual.shape, self.cube_simple.shape)
+        self.assertTrue(actual.has_lazy_data())
+        self.assertIs(actual.lazy_data(), data)
+
+    def test_simple_multiple_points(self):
+        aggregator = PercentileAggregator()
+        percent = np.array([10, 20, 50, 90])
+        kwargs = dict(percent=percent)
+        shape = self.cube_simple.shape + percent.shape
+        data = da.arange(np.prod(shape)).reshape(shape)
+        coords = [self.coord_simple]
+        actual = aggregator.post_process(
+            self.cube_simple, data, coords, **kwargs
+        )
+        self.assertEqual(actual.shape, percent.shape + self.cube_simple.shape)
+        self.assertTrue(actual.has_lazy_data())
+        expected = np.rollaxis(as_concrete_data(data), -1)
+        self.assertArrayEqual(actual.data, expected)
+
+    def test_multi_single_point(self):
+        aggregator = PercentileAggregator()
+        percent = 70
+        kwargs = dict(percent=percent)
+        shape = self.cube_multi.shape
+        data = da.arange(np.prod(shape)).reshape(shape)
+        coords = [self.coord_multi_0]
+        actual = aggregator.post_process(
+            self.cube_multi, data, coords, **kwargs
+        )
+        self.assertEqual(actual.shape, self.cube_multi.shape)
+        self.assertTrue(actual.has_lazy_data())
+        self.assertIs(actual.lazy_data(), data)
+
+    def test_multi_multiple_points(self):
+        aggregator = PercentileAggregator()
+        percent = np.array([17, 29, 81])
+        kwargs = dict(percent=percent)
+        shape = self.cube_multi.shape + percent.shape
+        data = da.arange(np.prod(shape)).reshape(shape)
+        coords = [self.coord_multi_0]
+        actual = aggregator.post_process(
+            self.cube_multi, data, coords, **kwargs
+        )
+        self.assertEqual(actual.shape, percent.shape + self.cube_multi.shape)
+        self.assertTrue(actual.has_lazy_data())
+        expected = np.rollaxis(as_concrete_data(data), -1)
+        self.assertArrayEqual(actual.data, expected)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -14,14 +14,13 @@ import iris.tests as tests  # isort:skip
 
 from unittest import mock
 
-import numpy as np
 import dask.array as da
+import numpy as np
 
+from iris._lazy_data import as_concrete_data, as_lazy_data
 from iris.analysis import PercentileAggregator
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
-from iris._lazy_data import as_lazy_data
-from iris._lazy_data import as_concrete_data
 
 
 class Test(tests.IrisTest):

--- a/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
+++ b/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
@@ -27,7 +27,7 @@ class TestInputReshape(tests.IrisTest):
     def check_input(self, data, axis, expected):
         wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
         wrapped_stat_func(data, axis=axis)
-        self.assertArrayEqual(self.stat_func.call_args.args[0], expected)
+        self.assertArrayEqual(self.stat_func.call_args[0][0], expected)
 
     def test_1d_input(self):
         # Trailing axis chosen, so array should be unchanged.
@@ -84,9 +84,9 @@ class TestInputReshape(tests.IrisTest):
 
         wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
         wrapped_stat_func(lazy_data, axis=axis)
-        self.assertTrue(is_lazy_data(self.stat_func.call_args.args[0]))
+        self.assertTrue(is_lazy_data(self.stat_func.call_args[0][0]))
         self.assertArrayEqual(
-            as_concrete_data(self.stat_func.call_args.args[0]), expected
+            as_concrete_data(self.stat_func.call_args[0][0]), expected
         )
 
 

--- a/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
+++ b/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
@@ -34,7 +34,7 @@ class TestInputReshape(tests.IrisTest):
         wrapped_stat_func(data, axis=axis)
         # Can't use Mock.assert_called_with because array equality is ambiguous
         # get hold of the first arg instead.
-        self.assertArrayEqual(self.stat_func.call_args[0][0], expected)
+        self.assertArrayEqual(self.stat_func.call_args.args[0], expected)
 
     def test_1d_input(self):
         # Trailing axis chosen, so array should be unchanged.
@@ -91,9 +91,9 @@ class TestInputReshape(tests.IrisTest):
 
         wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
         wrapped_stat_func(lazy_data, axis=axis)
-        self.assertTrue(is_lazy_data(self.stat_func.call_args[0][0]))
+        self.assertTrue(is_lazy_data(self.stat_func.call_args.args[0]))
         self.assertArrayEqual(
-            as_concrete_data(self.stat_func.call_args[0][0]), expected
+            as_concrete_data(self.stat_func.call_args.args[0]), expected
         )
 
 

--- a/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
+++ b/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
@@ -25,8 +25,15 @@ class TestInputReshape(tests.IrisTest):
         self.stat_func = mock.Mock()
 
     def check_input(self, data, axis, expected):
+        """
+        Given data and axis passed to the wrapped function, check that expected
+        array is passed to the inner function.
+
+        """
         wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
         wrapped_stat_func(data, axis=axis)
+        # Can't use Mock.assert_called_with because array equality is ambiguous
+        # get hold of the first arg instead.
         self.assertArrayEqual(self.stat_func.call_args[0][0], expected)
 
     def test_1d_input(self):

--- a/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
+++ b/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
@@ -1,0 +1,143 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :data:`iris.analysis._axis_to_single_trailing` function."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+
+from iris._lazy_data import as_concrete_data, as_lazy_data, is_lazy_data
+from iris.analysis import _axis_to_single_trailing
+
+
+class TestInputReshape(tests.IrisTest):
+    """Tests to make sure correct array is passed into stat function."""
+
+    def setUp(self):
+        self.stat_func = mock.Mock()
+
+    def check_input(self, data, axis, expected):
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        wrapped_stat_func(data, axis=axis)
+        self.assertArrayEqual(self.stat_func.call_args.args[0], expected)
+
+    def test_1d_input(self):
+        # Trailing axis chosen, so array should be unchanged.
+        data = np.arange(5)
+        axis = 0
+        self.check_input(data, axis, data)
+
+    def test_2d_input_trailing(self):
+        # Trailing axis chosen, so array should be unchanged.
+        data = np.arange(6).reshape(2, 3)
+        axis = 1
+        self.stat_func.return_value = np.arange(2)
+        self.check_input(data, axis, data)
+
+    def test_2d_input_transpose(self):
+        # Leading axis chosen, so array should be transposed.
+        data = np.arange(6).reshape(2, 3)
+        axis = 0
+        self.stat_func.return_value = np.arange(3)
+        self.check_input(data, axis, data.T)
+
+    def test_3d_input_middle(self):
+        # Middle axis is chosen, should be moved to end. Other dims should be
+        # flattened.
+        data = np.arange(24).reshape(2, 3, 4)
+        axis = 1
+        self.stat_func.return_value = np.empty(8)
+        expected = np.moveaxis(data, 1, 2).reshape(8, 3)
+        self.check_input(data, axis, expected)
+
+    def test_3d_input_leading_multiple(self):
+        # First 2 axis chosen, should be flattened and moved to end.
+        data = np.arange(24).reshape(2, 3, 4)
+        axis = (0, 1)
+        self.stat_func.return_value = np.empty(4)
+        expected = np.moveaxis(data, 2, 0).reshape(4, 6)
+        self.check_input(data, axis, expected)
+
+    def test_4d_first_and_last(self):
+        data = np.arange(120).reshape(2, 3, 4, 5)
+        axis = (0, -1)
+        self.stat_func.return_value = np.empty(12)
+        expected = np.moveaxis(data, 0, 2).reshape(12, 10)
+        self.check_input(data, axis, expected)
+
+    def test_3d_input_leading_multiple_lazy(self):
+        # First 2 axis chosen, should be flattened and moved to end.  Lazy data
+        # should be preserved.
+        data = np.arange(24).reshape(2, 3, 4)
+        lazy_data = as_lazy_data(data)
+        axis = (0, 1)
+        self.stat_func.return_value = np.empty(4)
+        expected = np.moveaxis(data, 2, 0).reshape(4, 6)
+
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        wrapped_stat_func(lazy_data, axis=axis)
+        self.assertTrue(is_lazy_data(self.stat_func.call_args.args[0]))
+        self.assertArrayEqual(
+            as_concrete_data(self.stat_func.call_args.args[0]), expected
+        )
+
+
+class TestOutputReshape(tests.IrisTest):
+    """Tests to make sure array from stat function is handled correctly."""
+
+    def setUp(self):
+        self.stat_func = mock.Mock()
+
+    def test_1d_input_1d_output(self):
+        # If array is fully aggregated, result should be same as returned by stat
+        # function.
+        data = np.arange(3)
+        self.stat_func.return_value = np.arange(2)
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        result = wrapped_stat_func(data, axis=0)
+        self.assertArrayEqual(result, self.stat_func.return_value)
+
+    def test_3d_input_middle_single_stat(self):
+        # result shape should match non-aggregated input dims.
+        data = np.empty((2, 3, 4))
+        axis = 1
+        self.stat_func.return_value = np.arange(8)
+        expected = np.arange(8).reshape(2, 4)
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        result = wrapped_stat_func(data, axis=axis)
+        self.assertArrayEqual(result, expected)
+
+    def test_3d_input_middle_single_stat_lazy(self):
+        # result shape should match non-aggregated input dims.  Lazy data should
+        # be preserved.
+        data = np.empty((2, 3, 4))
+        axis = 1
+        self.stat_func.return_value = da.arange(8)
+        expected = np.arange(8).reshape(2, 4)
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        result = wrapped_stat_func(data, axis=axis)
+        self.assertTrue(is_lazy_data(result))
+        self.assertArrayEqual(as_concrete_data(result), expected)
+
+    def test_3d_input_middle_multiple_stat(self):
+        # result shape should match non-aggregated input dims, plus trailing dim
+        # with size determined by the stat function.
+        data = np.empty((2, 3, 4))
+        axis = 1
+        self.stat_func.return_value = np.arange(8 * 5)
+        expected = np.arange(40).reshape(2, 4, 5)
+        wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
+        result = wrapped_stat_func(data, axis=axis)
+        self.assertArrayEqual(result, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
+++ b/lib/iris/tests/unit/analysis/test__axis_to_single_trailing.py
@@ -46,14 +46,14 @@ class TestInputReshape(tests.IrisTest):
         # Trailing axis chosen, so array should be unchanged.
         data = np.arange(6).reshape(2, 3)
         axis = 1
-        self.stat_func.return_value = np.arange(2)
+        self.stat_func.return_value = np.empty(2)
         self.check_input(data, axis, data)
 
     def test_2d_input_transpose(self):
         # Leading axis chosen, so array should be transposed.
         data = np.arange(6).reshape(2, 3)
         axis = 0
-        self.stat_func.return_value = np.arange(3)
+        self.stat_func.return_value = np.empty(3)
         self.check_input(data, axis, data.T)
 
     def test_3d_input_middle(self):
@@ -139,7 +139,7 @@ class TestOutputReshape(tests.IrisTest):
         # with size determined by the stat function.
         data = np.empty((2, 3, 4))
         axis = 1
-        self.stat_func.return_value = np.arange(8 * 5)
+        self.stat_func.return_value = np.arange(8 * 5).reshape(8, 5)
         expected = np.arange(40).reshape(2, 4, 5)
         wrapped_stat_func = _axis_to_single_trailing(self.stat_func)
         result = wrapped_stat_func(data, axis=axis)

--- a/lib/iris/tests/unit/lazy_data/test_map_complete_blocks.py
+++ b/lib/iris/tests/unit/lazy_data/test_map_complete_blocks.py
@@ -25,6 +25,8 @@ def create_mock_cube(array):
     cube.has_lazy_data = unittest.mock.Mock(return_value=is_lazy_data(array))
     cube.lazy_data = unittest.mock.Mock(return_value=array)
     cube.shape = array.shape
+    # Remove compute so cube is not interpreted as dask array.
+    del cube.compute
     return cube, cube_data
 
 

--- a/lib/iris/tests/unit/lazy_data/test_map_complete_blocks.py
+++ b/lib/iris/tests/unit/lazy_data/test_map_complete_blocks.py
@@ -60,6 +60,14 @@ class Test_map_complete_blocks(tests.IrisTest):
         cube.lazy_data.assert_called_once()
         cube_data.assert_not_called()
 
+    def test_dask_array_input(self):
+        lazy_array = da.asarray(self.array, chunks=((1, 1), (4,)))
+        result = map_complete_blocks(
+            lazy_array, self.func, dims=(1,), out_sizes=(4,)
+        )
+        self.assertTrue(is_lazy_data(result))
+        self.assertArrayEqual(result.compute(), self.func_result)
+
     def test_rechunk(self):
         lazy_array = da.asarray(self.array, chunks=((1, 1), (2, 2)))
         cube, _ = create_mock_cube(lazy_array)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Implements lazy aggregation for the `iris.analysis.PERCENTILE` aggregator.

My experience with `dask` is minimal, so I had a look at #3701 and basically used that approach as a template for the `_percentile` function implementation.  I believe I've understood the intent of the `map_complete_blocks` function but really not how it works.  So it's possible I've missed something important there.

I note that [dask.array.percentile](https://docs.dask.org/en/latest/array-api.html#dask.array.percentile) exists for 1D arrays, but I'm not clear how we'd incorporate the check for masked data if using that.

leaving as draft for now as I have an outstanding question about code structure and associated tests (see inline comments).

### Priority
I realise you are all busy so I'm not expecting this to get attention till after the v3 final release.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
