### PR TITLE
Relax setup.py setup requirements

### DIFF
--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -1,6 +1,4 @@
 # Dependencies necessary to run setup.py of iris
 # ----------------------------------------------
 
-scitools-pyke
 setuptools>=40.8.0
-wheel


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR targets the `v3.0.x` release branch, and relaxes the requirements used by `setup.py`.

This is the result of `conda build` issues for `iris` as is. The building of `pyke` is performed as part of `PEP517` and `PEP518` using the PyPI proxy package `scitools-pyke`, as per the `pyproject.toml`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
