### PR TITLE
Cube print respin

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2318,14 +2318,13 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dim_coords = self.dim_coords
         aux_coords = self.aux_coords
         all_coords = dim_coords + aux_coords + derived_coords
-        scalar_coords = [
-            coord
+        scalar_coord_ids = [
+            id(coord)
             for coord in all_coords
             if not self.coord_dims(coord) and coord.shape == (1,)
         ]
         # Determine the cube coordinates that are not scalar BUT
         # dimensioned.
-        scalar_coord_ids = set(map(id, scalar_coords))
         vector_dim_coords = [
             coord for coord in dim_coords if id(coord) not in scalar_coord_ids
         ]
@@ -2344,20 +2343,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         ]
 
         # Ancillary Variables
-        vector_ancillary_variables = [av for av in self.ancillary_variables()]
+        vector_ancillary_variables = [
+            av for av in self.ancillary_variables() if av.shape != (1,)
+        ]
 
-        # Sort scalar coordinates by name.
-        scalar_coords.sort(key=lambda coord: coord.name())
-        # Sort vector coordinates by data dimension and name.
-        vector_dim_coords.sort(
-            key=lambda coord: (self.coord_dims(coord), coord.name())
-        )
-        vector_aux_coords.sort(
-            key=lambda coord: (self.coord_dims(coord), coord.name())
-        )
-        vector_derived_coords.sort(
-            key=lambda coord: (self.coord_dims(coord), coord.name())
-        )
+        # Sort vector coordinates by data dimension.
+        vector_dim_coords.sort(key=self.coord_dims)
+        vector_aux_coords.sort(key=self.coord_dims)
+        vector_derived_coords.sort(key=self.coord_dims)
         Spec = self._VectorSectionSpec
         section_specs = [
             Spec("Dimension coordinates", vector_dim_coords, True),

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2469,58 +2469,26 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     ),
                 )
 
-            if vector_dim_coords:
-                dim_coord_summary, cube_header = vector_summary(
-                    vector_dim_coords,
-                    cube_header,
-                    max_line_offset,
-                    add_extra_lines=True,
-                )
-                summary += "\n     Dimension coordinates:\n" + "\n".join(
-                    dim_coord_summary
-                )
-
-            if vector_aux_coords:
-                aux_coord_summary, cube_header = vector_summary(
-                    vector_aux_coords,
-                    cube_header,
-                    max_line_offset,
-                    add_extra_lines=True,
-                )
-                summary += "\n     Auxiliary coordinates:\n" + "\n".join(
-                    aux_coord_summary
-                )
-
-            if vector_derived_coords:
-                derived_coord_summary, cube_header = vector_summary(
-                    vector_derived_coords,
-                    cube_header,
-                    max_line_offset,
-                    add_extra_lines=True,
-                )
-                summary += "\n     Derived coordinates:\n" + "\n".join(
-                    derived_coord_summary
-                )
-
             #
-            # Generate summary of cube cell measures attribute
+            # Generate textual summary for each type of vector component.
             #
-            if vector_cell_measures:
-                cell_measure_summary, cube_header = vector_summary(
-                    vector_cell_measures, cube_header, max_line_offset,
-                )
-                summary += "\n     Cell measures:\n"
-                summary += "\n".join(cell_measure_summary)
-
-            #
-            # Generate summary of cube ancillary variables attribute
-            #
-            if vector_ancillary_variables:
-                ancillary_variable_summary, cube_header = vector_summary(
-                    vector_ancillary_variables, cube_header, max_line_offset,
-                )
-                summary += "\n     Ancillary variables:\n"
-                summary += "\n".join(ancillary_variable_summary)
+            vector_summary_specs = [
+                ("Dimension coordinates", vector_dim_coords, True),
+                ("Auxiliary coordinates", vector_aux_coords, True),
+                ("Derived coordinates", vector_derived_coords, True),
+                ("Cell measures", vector_cell_measures, False),
+                ("Ancillary variables", vector_ancillary_variables, False),
+            ]
+            for title, elements, add_extra_lines in vector_summary_specs:
+                if elements:
+                    summary_lines, cube_header = vector_summary(
+                        vector_items=elements,
+                        cube_header=cube_header,
+                        max_line_offset=max_line_offset,
+                        add_extra_lines=add_extra_lines,
+                    )
+                    summary += f"\n     {title}:\n"
+                    summary += "\n".join(summary_lines)
 
             #
             # Generate textual summary of cube scalar coordinates.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2266,7 +2266,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def _summary_dim_name(self, dim):
         """
         Get the dim_coord name that labels a data dimension,
-        or "--" if there is none (i.e. dimension is anonymous).
+        or "-- " if there is none (i.e. dimension is anonymous).
 
         """
         dim_coords = self.coords(contains_dimension=dim, dim_coords=True)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2380,7 +2380,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             #
             def vector_summary(
                 vector_items,
-                dim_function,
                 cube_header,
                 max_line_offset,
                 add_extra_lines=False,
@@ -2428,8 +2427,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
                 # Generate full textual summary for each vector item
                 # - WITH dimension markers.
-                for index, coord in enumerate(vector_items):
-                    dims = dim_function(coord)
+                for index, dim_meta in enumerate(vector_items):
+                    dims = dim_meta.cube_dims(self)
 
                     for dim in range(len(self.shape)):
                         width = alignment[dim] - len(summary_lines[index])
@@ -2473,7 +2472,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if vector_dim_coords:
                 dim_coord_summary, cube_header = vector_summary(
                     vector_dim_coords,
-                    self.coord_dims,
                     cube_header,
                     max_line_offset,
                     add_extra_lines=True,
@@ -2485,7 +2483,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if vector_aux_coords:
                 aux_coord_summary, cube_header = vector_summary(
                     vector_aux_coords,
-                    self.coord_dims,
                     cube_header,
                     max_line_offset,
                     add_extra_lines=True,
@@ -2497,7 +2494,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if vector_derived_coords:
                 derived_coord_summary, cube_header = vector_summary(
                     vector_derived_coords,
-                    self.coord_dims,
                     cube_header,
                     max_line_offset,
                     add_extra_lines=True,
@@ -2511,10 +2507,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             #
             if vector_cell_measures:
                 cell_measure_summary, cube_header = vector_summary(
-                    vector_cell_measures,
-                    self.cell_measure_dims,
-                    cube_header,
-                    max_line_offset,
+                    vector_cell_measures, cube_header, max_line_offset,
                 )
                 summary += "\n     Cell measures:\n"
                 summary += "\n".join(cell_measure_summary)
@@ -2524,10 +2517,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             #
             if vector_ancillary_variables:
                 ancillary_variable_summary, cube_header = vector_summary(
-                    vector_ancillary_variables,
-                    self.ancillary_variable_dims,
-                    cube_header,
-                    max_line_offset,
+                    vector_ancillary_variables, cube_header, max_line_offset,
                 )
                 summary += "\n     Ancillary variables:\n"
                 summary += "\n".join(ancillary_variable_summary)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2395,7 +2395,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     returned with the list of strings.
 
                 """
-                vector_summary = []
+                summary_lines = []
 
                 # Identify offsets for each dimension text marker.
                 alignment = np.array(
@@ -2409,7 +2409,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 # Generate basic textual summary for each vector item
                 # - WITHOUT dimension markers.
                 for dim_meta in vector_items:
-                    vector_summary.append(
+                    summary_lines.append(
                         "%*s%s"
                         % (indent, " ", iris.util.clip_string(dim_meta.name()))
                     )
@@ -2432,23 +2432,23 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     dims = dim_function(coord)
 
                     for dim in range(len(self.shape)):
-                        width = alignment[dim] - len(vector_summary[index])
+                        width = alignment[dim] - len(summary_lines[index])
                         char = "x" if dim in dims else "-"
                         line = "{pad:{width}}{char}".format(
                             pad=" ", width=width, char=char
                         )
-                        vector_summary[index] += line
+                        summary_lines[index] += line
 
                 if add_extra_lines:
                     # Interleave any extra lines that are needed to distinguish
                     # the coordinates.
                     # TODO: This should also be done for cell measures and
                     # ancillary variables.
-                    vector_summary = self._summary_extra(
-                        vector_items, vector_summary, extra_indent
+                    summary_lines = self._summary_extra(
+                        vector_items, summary_lines, extra_indent
                     )
 
-                return vector_summary, cube_header
+                return summary_lines, cube_header
 
             # Calculate the maximum line offset.
             max_line_offset = 0

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -117,25 +117,16 @@ class CubeRepresentation:
 
     def _get_dim_names(self):
         """
-        Get dimension-describing coordinate names, or '--' if no coordinate]
-        describes the dimension.
-
-        Note: borrows from `cube.summary`.
+        Get all the dimension-describing coordinate names, as used by
+        cube.summary.
 
         """
-        # Create a set to contain the axis names for each data dimension.
-        dim_names = list(range(len(self.cube.shape)))
-
-        # Add the dim_coord names that participate in the associated data
-        # dimensions.
-        for dim in range(len(self.cube.shape)):
-            dim_coords = self.cube.coords(
-                contains_dimension=dim, dim_coords=True
-            )
-            if dim_coords:
-                dim_names[dim] = dim_coords[0].name()
-            else:
-                dim_names[dim] = "--"
+        # NOTE: use ".strip()" on these, because the name of an anonymous dim
+        # has an unwanted extra space at the end, i.e. "-- ".
+        dim_names = [
+            self.cube._summary_dim_name(dim).strip()
+            for dim in range(len(self.cube.shape))
+        ]
         return dim_names
 
     def _dim_names(self):

--- a/lib/iris/experimental/representation.py
+++ b/lib/iris/experimental/representation.py
@@ -85,24 +85,18 @@ class CubeRepresentation:
         self.cube_id = id(self.cube)
         self.cube_str = escape(str(self.cube))
 
-        self.str_headings = {
-            "Dimension coordinates:": None,
-            "Auxiliary coordinates:": None,
-            "Derived coordinates:": None,
-            "Cell measures:": None,
-            "Ancillary variables:": None,
-            "Scalar coordinates:": None,
-            "Scalar cell measures:": None,
-            "Attributes:": None,
-            "Cell methods:": None,
-        }
-        self.dim_desc_coords = [
-            "Dimension coordinates:",
-            "Auxiliary coordinates:",
-            "Derived coordinates:",
-            "Cell measures:",
-            "Ancillary variables:",
+        vector_sections = cube._summary_vector_sections_info()
+        vector_headings = [spec.title for spec in vector_sections]
+        # TODO: this list of 'scalar summary sections' should probably also be
+        # defined by the cube itself.
+        all_headings = vector_headings + [
+            "Scalar coordinates",
+            "Scalar cell measures",
+            "Attributes",
+            "Cell methods",
         ]
+        self.str_headings = {title + ":": None for title in all_headings}
+        self.dim_desc_coords = [title + ":" for title in vector_headings]
 
         self.two_cell_headers = ["Scalar coordinates:", "Attributes:"]
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2458,7 +2458,8 @@ class Test__summary_dim_name(tests.IrisTest):
         result = cube._summary_dim_name(1)
         self.assertEqual(result, "-- ")
 
-    def test_aux_named_dim(self):
+    def test_aux_mapped_dim(self):
+        # It should *not* treat an aux-coord as the name of a dim.
         cube = Cube(np.zeros((5, 3)))
         cube.add_aux_coord(
             DimCoord(np.arange(5), standard_name="longitude", units="degrees"),
@@ -2505,7 +2506,6 @@ class Test__summary_vector_sections_info(tests.IrisTest):
             AuxCoord(np.zeros((5, 4)), long_name="co2d", units=1), (1, 2),
         )
         result = cube._summary_vector_sections_info()
-        self.assertEqual(len(result), 5)
         self.assertEqual(
             [[co.name() for co in sect[1]] for sect in result],
             [
@@ -2523,7 +2523,6 @@ class Test__summary_vector_sections_info(tests.IrisTest):
             CellMeasure(np.arange(3), long_name="coeffs", units=1), 0
         )
         result = cube._summary_vector_sections_info()
-        self.assertEqual(len(result), 5)
         self.assertEqual(
             [[co.name() for co in sect[1]] for sect in result],
             [
@@ -2542,7 +2541,6 @@ class Test__summary_vector_sections_info(tests.IrisTest):
             (0, 2),
         )
         result = cube._summary_vector_sections_info()
-        self.assertEqual(len(result), 5)
         self.assertEqual(
             [[co.name() for co in sect[1]] for sect in result],
             [

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2434,5 +2434,39 @@ class Test__eq__meta(tests.IrisTest):
         self.assertTrue(cube1 == cube2)
 
 
+class Test__summary_dim_name(tests.IrisTest):
+    def test_standard_named_dim(self):
+        cube = Cube(np.zeros((5, 3)))
+        cube.add_dim_coord(
+            DimCoord(np.arange(5), standard_name="longitude", units="degrees"),
+            0,
+        )
+        result = cube._summary_dim_name(0)
+        self.assertEqual(result, "longitude")
+
+    def test_long_named_dim(self):
+        cube = Cube(np.zeros((5, 3)))
+        cube.add_dim_coord(
+            DimCoord(np.arange(5), long_name="alons", units="degrees"), 0
+        )
+        result = cube._summary_dim_name(0)
+        self.assertEqual(result, "alons")
+
+    def test_unmapped_dim(self):
+        cube = Cube(np.zeros((5, 3)))
+        cube.add_dim_coord(DimCoord(np.arange(5), long_name="x", units=1), 0)
+        result = cube._summary_dim_name(1)
+        self.assertEqual(result, "-- ")
+
+    def test_aux_named_dim(self):
+        cube = Cube(np.zeros((5, 3)))
+        cube.add_aux_coord(
+            DimCoord(np.arange(5), standard_name="longitude", units="degrees"),
+            0,
+        )
+        result = cube._summary_dim_name(0)
+        self.assertEqual(result, "-- ")
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2599,7 +2599,7 @@ class Test__summary_vector_sections_info(tests.IrisTest):
     def test_ancils(self):
         cube = Cube(np.zeros((3, 5, 4)))
         cube.add_ancillary_variable(
-            CellMeasure(np.zeros((3, 4)), long_name="category", units=1),
+            AncillaryVariable(np.zeros((3, 4)), long_name="category", units=1),
             (0, 2),
         )
         result = cube._summary_vector_sections_info()


### PR DESCRIPTION
Now with no specific reference to ugrid.

This is now an extensive refactor of the Iris Cube `summary` and `_repr_html_` methods.
Including changes needed to enable the forthcoming iris-ugrid `UCube`s to produce "extended" cube summmaries.

I have added testing for the new factored-out helper methods.  But I haven't provided any test of how modifying these can produce extended cube summaries, as its not really an "API" + the requirement is hard to generalise.
That usage will eventually get tested by the specifics in iris-ugrid.

Meanwhile, you should see that all the existing tests simply pass. :bow_and_arrow: 

Proposals for the specific use of this in iris-ugrid are here : https://github.com/SciTools-incubator/iris-ugrid/pull/26