### PR TITLE
Allow cube-adjust to return a new cube.

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -804,7 +804,11 @@ def load_cubes(filenames, callback=None, create_reader=None):
 
             # Call a post-processing completion step for each cube, if provided.
             if hasattr(cf, "cube_completion_adjust"):
-                cf.cube_completion_adjust(cube)
+                # Either "in-place", or "replacing", like a load callback.
+                new_cube = cf.cube_completion_adjust(cube)
+                if new_cube:
+                    # If new cube returned, replace the original.
+                    cube = new_cube
 
             # Process any associated formula terms and attach
             # the corresponding AuxCoordFactory.


### PR DESCRIPTION
As mentioned : https://github.com/SciTools-incubator/iris-ugrid/pull/24#discussion_r511917499
I think this is desirable, to enable iris-ugrid to represent unstructured data with a new derived class `Ucube(Cube)`.

By allowing the post-modify action to return a new object, the iris-ugrid loader can replace Cube-s with Ucube-s, instead of [patching a cube instance](https://github.com/SciTools-incubator/iris-ugrid/blob/25ba11b03a88702fb502836cf33cfa2129cbfca3/iris_ugrid/ugrid_cf_reader.py#L214).

Apart from being cleaner, I think it will eventually prove essential for unstructured cubes to belong to a specialised subclass of `Cube`, so that we can use inheritance and overriding to efficiently extend features.
See for example #3914, which assumes we will use a `Ucube(Cube)` class to extend cube.summary().
