### PR TITLE
Cube._summary_coord_extra: efficiency and bugfix

### DIFF
--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -168,7 +168,11 @@ This document explains the changes made to Iris for this release
   Previously, the first tick label would occasionally be duplicated. This also
   removes the use of Matplotlib's deprecated ``IndexFormatter``. (:pull:`3857`)
 
-* `@znicholls`_ fixed :meth:`~iris.quickplot._title` to only check ``units.is_time_reference`` if the ``units`` symbol is not used. (:pull:`3902`)
+* `@znicholls`_ fixed :meth:`~iris.quickplot._title` to only check 
+  ``units.is_time_reference`` if the ``units`` symbol is not used. (:pull:`3902`)
+
+* `@rcomer`_ fixed a bug whereby numpy array type attributes on a cube's 
+  coordinates could prevent printing it.  See :issue:`3921`.  (:pull:`3922`)
 
 .. _whatsnew 3.0 changes:
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2189,11 +2189,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     if key not in similar_coord.attributes:
                         vary.add(key)
                         break
-                    if similar_coord.attributes[key] != value:
+                    if not np.array_equal(
+                        similar_coord.attributes[key], value
+                    ):
                         vary.add(key)
                         break
+            keys = sorted(vary)
             bits = [
-                "{}={!r}".format(key, coord.attributes[key]) for key in vary
+                "{}={!r}".format(key, coord.attributes[key]) for key in keys
             ]
             if bits:
                 extra = indent + ", ".join(bits)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2182,25 +2182,18 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         extra = ""
         similar_coords = self.coords(coord.name())
         if len(similar_coords) > 1:
-            # Find all the attribute keys
-            keys = set()
-            for similar_coord in similar_coords:
-                keys.update(similar_coord.attributes.keys())
-            # Look for any attributes that vary
+            # Look for any attributes that vary.
             vary = set()
-            attributes = {}
-            for key in keys:
+            for key, value in coord.attributes.items():
                 for similar_coord in similar_coords:
                     if key not in similar_coord.attributes:
                         vary.add(key)
                         break
-                    value = similar_coord.attributes[key]
-                    if attributes.setdefault(key, value) != value:
+                    if similar_coord.attributes[key] != value:
                         vary.add(key)
                         break
-            keys = sorted(vary & set(coord.attributes.keys()))
             bits = [
-                "{}={!r}".format(key, coord.attributes[key]) for key in keys
+                "{}={!r}".format(key, coord.attributes[key]) for key in vary
             ]
             if bits:
                 extra = indent + ", ".join(bits)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2182,6 +2182,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         extra = ""
         similar_coords = self.coords(coord.name())
         if len(similar_coords) > 1:
+            similar_coords.remove(coord)
             # Look for any attributes that vary.
             vary = set()
             for key, value in coord.attributes.items():

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -484,6 +484,16 @@ class Test_summary(tests.IrisTest):
         )
         self.assertEqual(cube.summary(), expected_summary)
 
+    def test_similar_coords(self):
+        coord1 = AuxCoord(
+            42, long_name="foo", attributes=dict(bar=np.array([2, 5]))
+        )
+        coord2 = coord1.copy()
+        coord2.attributes = dict(bar="baz")
+        for coord in [coord1, coord2]:
+            self.cube.add_aux_coord(coord)
+        self.assertIn("baz", self.cube.summary())
+
 
 class Test_is_compatible(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
I started looking at this method with a view to fixing #3921, but once I looked couldn't ignore the fact that this method seemed a bit inefficient: we ultimately only want the elements of `vary` that exist as keys in `coord`'s attributes dictionary, so I think we should only loop through those keys to begin with.

I've added one simple test for the #3921 case.  Note there is also one existing test for this method in the [legacy tests](https://github.com/SciTools/iris/blob/v3.0.x/lib/iris/tests/test_cdm.py#L329).

I'd like to get this into Iris v3 if possible, as I believe lenient cube arithmetic will increase the prevalence of Frankencubes*.  So this method will get called more often.  And the change is only small :innocent: 

Closes #3921.

---
***Frankencube** _noun_: a cube with multiple coordinates that have the same name.  Coined at https://github.com/ESMValGroup/ESMValCore/issues/373