### PR TITLE
Dummy PR: demonstrate unit test failures

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -107,6 +107,7 @@ except ImportError:
 
 # Iris revision.
 __version__ = "3.1.dev0"
+foo = "wibble"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
As raised on the [Google Group](https://groups.google.com/g/scitools-iris/c/M1J6gV4Y_cM), cftime v1.3 was released this week and is unforgiving about what kind of datetimes you can have.  Iris tests now produce a raft of errors of the form 
```
ValueError: invalid year provided in cftime.datetime(0, 0, 0, 0, 0, 0, 0, calendar='gregorian')
```
While demonstrating this locally, I saw a bunch of other failures that aren't _obviously_ about cftime.  So I figured the easiest way to raise this was to create a PR and let Travis show them!

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
