### PR TITLE
whatsnew for coord default units

### DIFF
--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -205,6 +205,9 @@ This document explains the changes made to Iris for this release
   :func:`iris.experimental.concatenate.concatenate` function raised an
   exception. (:pull:`3523`)
 
+* `@stephenworsley`_ changed the default units of :class:`~iris.coords.DimCoord` 
+  and :class:`~iris.coords.AuxCoord` from `"1"` to `"unknown"`.  (:pull:`3795`)
+
 * `@stephenworsley`_ changed Iris objects loaded from NetCDF-CF files to have
   ``units='unknown'`` where the corresponding NetCDF variable has no ``units``
   property. Previously these cases defaulted to ``units='1'``.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Having inserted `units=1` all over my user code where I'd created coordinates from scratch, I realised I couldn't see this change in the whatsnew.  Obviously it was the same change as the NetCDF loading behaviour, but a user doesn't need to be loading NetCDF to trip over it.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
