### PR TITLE
Updated CF saver version in User Guide and docstring

### DIFF
--- a/docs/iris/src/userguide/saving_iris_cubes.rst
+++ b/docs/iris/src/userguide/saving_iris_cubes.rst
@@ -6,7 +6,7 @@ Saving Iris cubes
 
 Iris supports the saving of cubes and cube lists to:
 
-* CF netCDF (version 1.6)
+* CF netCDF (version 1.7)
 * GRIB edition 2  (if `iris-grib  <https://github.com/SciTools/iris-grib>`_ is installed)
 * Met Office PP
 

--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -308,6 +308,8 @@ This document explains the changes made to Iris for this release
   included documentation for :ref:`metadata`, :ref:`lenient metadata`, and
   :ref:`lenient maths`. (:pull:`3890`)
 
+* `@jonseddon`_ updated the CF version of the netCDF saver in the 
+  :ref:`saving_iris_cubes` section and in the equivalent function docstring.
 
 💼 Internal
 ===========

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -9,7 +9,7 @@ according to the 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 
 References:
 
-[CF]  NetCDF Climate and Forecast (CF) Metadata conventions, Version 1.5, October, 2010.
+[CF]  NetCDF Climate and Forecast (CF) Metadata conventions.
 [NUG] NetCDF User's Guide, https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/
 
 """

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2490,7 +2490,7 @@ def save(
     """
     Save cube(s) to a netCDF file, given the cube and the filename.
 
-    * Iris will write CF 1.5 compliant NetCDF files.
+    * Iris will write CF 1.7 compliant NetCDF files.
     * The attributes dictionaries on each cube in the saved cube list
       will be compared and common attributes saved as NetCDF global
       attributes where appropriate.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -8,8 +8,7 @@ Module to support the loading of a NetCDF file into an Iris cube.
 
 See also: `netCDF4 python <http://code.google.com/p/netcdf4-python/>`_.
 
-Also refer to document 'NetCDF Climate and Forecast (CF) Metadata Conventions',
-Version 1.4, 27 February 2009.
+Also refer to document 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 
 """
 

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -13,7 +13,7 @@ dependencies:
 # Core dependencies.
   - cartopy>=0.18
   - cf-units>=2
-  - cftime
+  - cftime<1.3.0 
   - dask>=2
   - matplotlib
   - netcdf4

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -13,7 +13,7 @@ dependencies:
 # Core dependencies.
   - cartopy>=0.18
   - cf-units>=2
-  - cftime
+  - cftime<1.3.0
   - dask>=2
   - matplotlib
   - netcdf4


### PR DESCRIPTION
## 🚀 Pull Request

### Description
The User Guide and `iris.fileformats.netcdf.save()` docstring have been updated with the correct version of the CF version that netCDF files are saved with.
