### PR TITLE
pin cftime<1.3.0

### DIFF
--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -13,7 +13,7 @@ dependencies:
 # Core dependencies.
   - cartopy>=0.18
   - cf-units>=2
-  - cftime
+  - cftime<1.3.0
   - dask>=2
   - matplotlib
   - netcdf4

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -13,7 +13,7 @@ dependencies:
 # Core dependencies.
   - cartopy>=0.18
   - cf-units>=2
-  - cftime
+  - cftime<1.3.0
   - dask>=2
   - matplotlib
   - netcdf4

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,7 +2,7 @@
 
 cartopy>=0.18
 cf-units>=2
-cftime
+cftime<1.3.0
 dask[array]>=2
 matplotlib
 netcdf4


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR pins `cftime<1.3.0`. The `iris` tests are broken with the latest released version `1.3.0`, which pulls from [PyPI](https://pypi.org/project/cftime/).

Pinning will give us time to investigate and either fix `iris` and/or feedback to the `cftime` developers.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
