### PR TITLE
ignore url for doc link check

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -263,6 +263,7 @@ html_style = "theme_override.css"
 linkcheck_ignore = [
     "http://cfconventions.org",
     "http://code.google.com/p/msysgit/downloads/list",
+    "http://effbot.org",
     "https://github.com",
     "http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html",
     "http://schacon.github.com/git",

--- a/docs/iris/src/userguide/plotting_a_cube.rst
+++ b/docs/iris/src/userguide/plotting_a_cube.rst
@@ -209,7 +209,7 @@ the temperature at some latitude cross-sections.
     `<http://effbot.org/pyfaq/tutor-what-is-if-name-main-for.htm>`_.
 
     In order to run this example, you will need to copy the code into a file 
-    and run it using ``python2.7 my_file.py``.
+    and run it using ``python my_file.py``.
 
 
 Plotting 2-dimensional cubes


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Add `http://effbot.org` to the list of URLs to ignore during documentation link checking, as its service availability is variable and caused sporadic CI link check failures.

Also removed `python2.7` reference in User Guide, thanks to @rcomer :eyes: ([great spot](https://github.com/SciTools/iris/pull/3924#issuecomment-733634993))


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
