### PR TITLE
Add string arguments for Cube methods

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -22,7 +22,8 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-* N/A
+* `@gcaria`_ fixed :meth:`~iris.cube.Cube.cell_measure_dims` to also accept the string name of a :class:`~iris.coords.CellMeasure`. (:pull:`3931`)
+* `@gcaria`_ fixed :meth:`~iris.cube.Cube.ancillary_variable_dims` to also accept the string name of a :class:`~iris.coords.AncillaryVariable`. (:pull:`3931`)
 
 
 💣 Incompatible Changes
@@ -53,3 +54,5 @@ This document explains the changes made to Iris for this release
 ===========
 
 * N/A
+
+.. _@gcaria: https://github.com/gcaria

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1400,10 +1400,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Returns a tuple of the data dimensions relevant to the given
         CellMeasure.
 
-        * cell_measure
-            The CellMeasure to look for.
+        * cell_measure (string or CellMeasure)
+            The (name of the) cell measure to look for.
 
         """
+        cell_measure = self.cell_measure(cell_measure)
+
         # Search for existing cell measure (object) on the cube, faster lookup
         # than equality - makes no functional difference.
         matches = [
@@ -1422,10 +1424,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Returns a tuple of the data dimensions relevant to the given
         AncillaryVariable.
 
-        * ancillary_variable
-            The AncillaryVariable to look for.
+        * ancillary_variable (string or AncillaryVariable)
+            The (name of the) AncillaryVariable to look for.
 
         """
+        ancillary_variable = self.ancillary_variable(ancillary_variable)
+
         # Search for existing ancillary variable (object) on the cube, faster
         # lookup than equality - makes no functional difference.
         matches = [

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2050,7 +2050,8 @@ class Test_remove_metadata(tests.IrisTest):
 
     def test_fail_remove_ancilliary_variable_by_name(self):
         with self.assertRaises(AncillaryVariableNotFoundError):
-            self.cube.remove_ancillary_variable("notarea")
+            self.cube.remove_ancillary_variable("notname")
+
 
 class Test__getitem_CellMeasure(tests.IrisTest):
     def setUp(self):
@@ -2153,6 +2154,16 @@ class TestAncillaryVariables(tests.IrisTest):
         with self.assertRaises(AncillaryVariableNotFoundError):
             self.cube.ancillary_variable_dims(ancillary_variable)
 
+    def test_ancillary_variable_dims_by_name(self):
+        ancill_var_dims = self.cube.ancillary_variable_dims(
+            "number_of_observations"
+        )
+        self.assertEqual(ancill_var_dims, (0, 1))
+
+    def test_fail_ancillary_variable_dims_by_name(self):
+        with self.assertRaises(AncillaryVariableNotFoundError):
+            self.cube.ancillary_variable_dims("notname")
+
 
 class TestCellMeasures(tests.IrisTest):
     def setUp(self):
@@ -2200,6 +2211,14 @@ class TestCellMeasures(tests.IrisTest):
         a_cell_measure.units = "km2"
         with self.assertRaises(CellMeasureNotFoundError):
             _ = self.cube.cell_measure_dims(a_cell_measure)
+
+    def test_cell_measure_dims_by_name(self):
+        cm_dims = self.cube.cell_measure_dims("area")
+        self.assertEqual(cm_dims, (0, 1))
+
+    def test_fail_cell_measure_dims_by_name(self):
+        with self.assertRaises(CellMeasureNotFoundError):
+            self.cube.cell_measure_dims("notname")
 
 
 class Test_transpose(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2044,6 +2044,13 @@ class Test_remove_metadata(tests.IrisTest):
         )
         self.assertEqual(self.cube._ancillary_variables_and_dims, [])
 
+    def test_remove_ancilliary_variable_by_name(self):
+        self.cube.remove_ancillary_variable("Quality of Detection")
+        self.assertEqual(self.cube._ancillary_variables_and_dims, [])
+
+    def test_fail_remove_ancilliary_variable_by_name(self):
+        with self.assertRaises(AncillaryVariableNotFoundError):
+            self.cube.remove_ancillary_variable("notarea")
 
 class Test__getitem_CellMeasure(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Resolves #3602 

I have just started to work on this, and after adding a short test I get 5 failures when testing `lib/iris/tests/unit/cube/test_Cube.py`, all `AssertionError`s similar to:
```
AssertionError: CML do not match: /home/gcaria/github/iris/lib/iris/tests/results/unit/cube/Cube/xml/checksum_ignores_masked_values.cml
```

which don't seem to be related to the test I've added. I've followed the instructions for [running the tests](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_running_tests.html) so I'm not sure what I'm missing.
