### PR TITLE
Ditch `if __name__ == "__main__"` in gallery examples

### DIFF
--- a/docs/iris/gallery_code/general/plot_lineplot_with_legend.py
+++ b/docs/iris/gallery_code/general/plot_lineplot_with_legend.py
@@ -11,39 +11,34 @@ import iris.plot as iplt
 import iris.quickplot as qplt
 
 
-def main():
-    fname = iris.sample_data_path("air_temp.pp")
+fname = iris.sample_data_path("air_temp.pp")
 
-    # Load exactly one cube from the given file.
-    temperature = iris.load_cube(fname)
+# Load exactly one cube from the given file.
+temperature = iris.load_cube(fname)
 
-    # We only want a small number of latitudes, so filter some out
-    # using "extract".
-    temperature = temperature.extract(
-        iris.Constraint(latitude=lambda cell: 68 <= cell < 78)
-    )
+# We only want a small number of latitudes, so filter some out
+# using "extract".
+temperature = temperature.extract(
+    iris.Constraint(latitude=lambda cell: 68 <= cell < 78)
+)
 
-    for cube in temperature.slices("longitude"):
+for cube in temperature.slices("longitude"):
 
-        # Create a string label to identify this cube (i.e. latitude: value).
-        cube_label = "latitude: %s" % cube.coord("latitude").points[0]
+    # Create a string label to identify this cube (i.e. latitude: value).
+    cube_label = "latitude: %s" % cube.coord("latitude").points[0]
 
-        # Plot the cube, and associate it with a label.
-        qplt.plot(cube, label=cube_label)
+    # Plot the cube, and associate it with a label.
+    qplt.plot(cube, label=cube_label)
 
-    # Add the legend with 2 columns.
-    plt.legend(ncol=2)
+# Add the legend with 2 columns.
+plt.legend(ncol=2)
 
-    # Put a grid on the plot.
-    plt.grid(True)
+# Put a grid on the plot.
+plt.grid(True)
 
-    # Tell matplotlib not to extend the plot axes range to nicely
-    # rounded numbers.
-    plt.axis("tight")
+# Tell matplotlib not to extend the plot axes range to nicely
+# rounded numbers.
+plt.axis("tight")
 
-    # Finally, show it.
-    iplt.show()
-
-
-if __name__ == "__main__":
-    main()
+# Finally, show it.
+iplt.show()

--- a/docs/iris/gallery_tests/test_plot_lineplot_with_legend.py
+++ b/docs/iris/gallery_tests/test_plot_lineplot_with_legend.py
@@ -8,6 +8,8 @@
 # importing anything else.
 import iris.tests as tests
 
+import runpy
+
 from .gallerytest_util import (
     add_gallery_to_path,
     show_replaced_by_check_graphic,
@@ -21,9 +23,8 @@ class TestLineplotWithLegend(tests.GraphicsTest):
     def test_plot_lineplot_with_legend(self):
         with fail_any_deprecation_warnings():
             with add_gallery_to_path():
-                import plot_lineplot_with_legend
-            with show_replaced_by_check_graphic(self):
-                plot_lineplot_with_legend.main()
+                with show_replaced_by_check_graphic(self):
+                    runpy.run_module("plot_lineplot_with_legend")
 
 
 if __name__ == "__main__":

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -263,7 +263,6 @@ html_style = "theme_override.css"
 linkcheck_ignore = [
     "http://cfconventions.org",
     "http://code.google.com/p/msysgit/downloads/list",
-    "http://effbot.org",
     "https://github.com",
     "http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html",
     "http://schacon.github.com/git",

--- a/docs/iris/src/userguide/plotting_a_cube.rst
+++ b/docs/iris/src/userguide/plotting_a_cube.rst
@@ -195,21 +195,7 @@ function can be called to indicate that a legend is desired:
 
 This example of consecutive ``qplt.plot`` calls coupled with the 
 :func:`Cube.slices() <iris.cube.Cube.slices>` method on a cube shows 
-the temperature at some latitude cross-sections. 
-
-.. note::
-
-    The previous example uses the ``if __name__ == "__main__"`` style to run 
-    the desired code if and only if the script is run from the command line.
-
-    This is a good habit to get into when writing scripts in Python as it means 
-    that any useful functions or variables defined within the script can be 
-    imported into other scripts without running all of the code and thus 
-    creating an unwanted plot. This is discussed in more detail at 
-    `<http://effbot.org/pyfaq/tutor-what-is-if-name-main-for.htm>`_.
-
-    In order to run this example, you will need to copy the code into a file 
-    and run it using ``python my_file.py``.
+the temperature at some latitude cross-sections.
 
 
 Plotting 2-dimensional cubes


### PR DESCRIPTION
## 🚀 Pull Request

### Description
All our gallery examples are currently set out as scripts, with a `main` function and `if __name__ == "__main__"` loop.  We now have the option to [download the examples as Jupyter notebooks](https://scitools-iris.readthedocs.io/en/latest/_downloads/76212d3ad65134e03284d4129976c811/plot_polar_stereo.ipynb) and I think the `if __name__ == "__main__"` layout looks somewhat odd in that context.  I clicked on a few examples in the Matplotlib gallery, and those do not have this layout (Cartopy gallery examples do though).

As a proof of concept, I've modified the `plot_lineplot_with_legend.py` example.  This also required modifying the gallery test, as it relied on running the `main` function.  I've never been near those tests before so happy to take advice on a better way to do them!  I've established that I still get the image comparison failure if I e.g. change the legend labels.

This particular gallery example is also included in the User Guide and is, I think, the only User Guide example that has the `if __name__ == "__main__"` layout.  I speculate that the note here may have been a response to users asking "why is this example different".  However, I think advice about general python script structure is out of scope for the Iris User Guide, so removing that note is an added bonus of modifying the example.  This note is the only place our docs link to `effbot.org`, so we no longer need to explicitly skip that in the linkchecks.

If I get a thumbs up, I will go ahead and modify the other gallery examples.

### Question

How do you do that thing of making temporary builds of the docs for review?  I think it might be useful here...

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
