### PR TITLE
CI requirements drop pip packages

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -164,7 +164,7 @@ def tests(session):
         cache_venv(session)
 
     cache_cartopy(session)
-    session.run("python", "setup.py", "develop")
+    session.install("--no-deps", "--editable", ".")
     session.run(
         "python",
         "-m",
@@ -207,7 +207,7 @@ def gallery(session):
         cache_venv(session)
 
     cache_cartopy(session)
-    session.run("python", "setup.py", "develop")
+    session.install("--no-deps", "--editable", ".")
     session.run(
         "python",
         "-m",
@@ -249,7 +249,7 @@ def doctest(session):
         cache_venv(session)
 
     cache_cartopy(session)
-    session.run("python", "setup.py", "develop")
+    session.install("--no-deps", "--editable", ".")
     session.cd("docs/iris")
     session.run(
         "make",
@@ -297,7 +297,7 @@ def linkcheck(session):
         cache_venv(session)
 
     cache_cartopy(session)
-    session.run("python", "setup.py", "develop")
+    session.install("--no-deps", "--editable", ".")
     session.cd("docs/iris")
     session.run(
         "make",

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ nox.options.reuse_existing_virtualenvs = True
 PACKAGE = str("lib" / Path("iris"))
 
 #: Cirrus-CI environment variable hook.
-PY_VER = os.environ.get("PY_VER", "3.7")
+PY_VER = os.environ.get("PY_VER", ["3.6", "3.7"])
 
 #: Default cartopy cache directory.
 CARTOPY_CACHE_DIR = os.environ.get("HOME") / Path(".local/share/cartopy")
@@ -41,7 +41,7 @@ def venv_cached(session):
 
     """
     result = False
-    yml = Path(f"requirements/ci/py{PY_VER.replace('.', '')}.yml")
+    yml = Path(f"requirements/ci/py{session.python.replace('.', '')}.yml")
     tmp_dir = Path(session.create_tmp())
     cache = tmp_dir / yml.name
     if cache.is_file():
@@ -66,7 +66,7 @@ def cache_venv(session):
         A `nox.sessions.Session` object.
 
     """
-    yml = Path(f"requirements/ci/py{PY_VER.replace('.', '')}.yml")
+    yml = Path(f"requirements/ci/py{session.python.replace('.', '')}.yml")
     with open(yml, "rb") as fi:
         hexdigest = hashlib.sha256(fi.read()).hexdigest()
     tmp_dir = Path(session.create_tmp())
@@ -131,7 +131,7 @@ def black(session):
     session.run("black", "--check", __file__)
 
 
-@nox.session(python=[PY_VER], venv_backend="conda")
+@nox.session(python=PY_VER, venv_backend="conda")
 def tests(session):
     """
     Perform iris system, integration and unit tests.
@@ -150,7 +150,7 @@ def tests(session):
     """
     if not venv_cached(session):
         # Determine the conda requirements yaml file.
-        fname = f"requirements/ci/py{PY_VER.replace('.', '')}.yml"
+        fname = f"requirements/ci/py{session.python.replace('.', '')}.yml"
         # Back-door approach to force nox to use "conda env update".
         command = (
             "conda",
@@ -174,7 +174,7 @@ def tests(session):
     )
 
 
-@nox.session(python=[PY_VER], venv_backend="conda")
+@nox.session(python=PY_VER, venv_backend="conda")
 def gallery(session):
     """
     Perform iris gallery doc-tests.
@@ -193,7 +193,7 @@ def gallery(session):
     """
     if not venv_cached(session):
         # Determine the conda requirements yaml file.
-        fname = f"requirements/ci/py{PY_VER.replace('.', '')}.yml"
+        fname = f"requirements/ci/py{session.python.replace('.', '')}.yml"
         # Back-door approach to force nox to use "conda env update".
         command = (
             "conda",
@@ -216,7 +216,7 @@ def gallery(session):
     )
 
 
-@nox.session(python=[PY_VER], venv_backend="conda")
+@nox.session(python=PY_VER, venv_backend="conda")
 def doctest(session):
     """
     Perform iris doc-tests.
@@ -235,7 +235,7 @@ def doctest(session):
     """
     if not venv_cached(session):
         # Determine the conda requirements yaml file.
-        fname = f"requirements/ci/py{PY_VER.replace('.', '')}.yml"
+        fname = f"requirements/ci/py{session.python.replace('.', '')}.yml"
         # Back-door approach to force nox to use "conda env update".
         command = (
             "conda",
@@ -264,7 +264,7 @@ def doctest(session):
     )
 
 
-@nox.session(python=[PY_VER], venv_backend="conda")
+@nox.session(python=PY_VER, venv_backend="conda")
 def linkcheck(session):
     """
     Perform iris doc link check.
@@ -283,7 +283,7 @@ def linkcheck(session):
     """
     if not venv_cached(session):
         # Determine the conda requirements yaml file.
-        fname = f"requirements/ci/py{PY_VER.replace('.', '')}.yml"
+        fname = f"requirements/ci/py{session.python.replace('.', '')}.yml"
         # Back-door approach to force nox to use "conda env update".
         command = (
             "conda",

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -44,11 +44,8 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx
+  - sphinxcontrib-napoleon
   - sphinx-copybutton
   - sphinx-gallery
+  - sphinx-panels
   - sphinx_rtd_theme
-  - pip
-  - pip:
-    - sphinxcontrib-napoleon
-    - sphinx-panels
-

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -44,10 +44,8 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx
+  - sphinxcontrib-napoleon
   - sphinx-copybutton
   - sphinx-gallery
+  - sphinx-panels
   - sphinx_rtd_theme
-  - pip
-  - pip:
-    - sphinxcontrib-napoleon
-    - sphinx-panels


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR drops the use of `pip` packages from the `conda` CI requirements and uses the `conda` equivalent packages instead.

This PR also extends `nox` to offer `python` sessions for both `3.6` and `3.7`, and opting to use `pip install --editable .` for `iris` instead of `python setup.py develop`, but with `--no-deps` (as all the package dependencies are satisfied by `conda` and therefore not required to be checked by `pip`)


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
