### PR TITLE
Gallery: don't support mpl v1.2

### DIFF
--- a/docs/gallery_code/meteorology/plot_deriving_phenomena.py
+++ b/docs/gallery_code/meteorology/plot_deriving_phenomena.py
@@ -26,14 +26,7 @@ def limit_colorbar_ticks(contour_object):
     number of ticks on the colorbar to 4.
 
     """
-    # Under Matplotlib v1.2.x the colorbar attribute of a contour object is
-    # a tuple containing the colorbar and an axes object, whereas under
-    # Matplotlib v1.3.x it is simply the colorbar.
-    try:
-        colorbar = contour_object.colorbar[0]
-    except (AttributeError, TypeError):
-        colorbar = contour_object.colorbar
-
+    colorbar = contour_object.colorbar
     colorbar.locator = matplotlib.ticker.MaxNLocator(4)
     colorbar.update_ticks()
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A simple one:  I think the days of worrying about Matplotlib v1.2.x should be over.

Given how minor this change is, I'm unconvinced it warrants a whatsnew.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
