### PR TITLE
update links

### DIFF
--- a/docs/iris/src/userguide/citation.rst
+++ b/docs/iris/src/userguide/citation.rst
@@ -48,7 +48,7 @@ For example::
 
  Iris. Met Office. git@github.com:SciTools/iris.git 06-03-2013
 
-.. _How to cite and describe software: http://software.ac.uk/so-exactly-what-software-did-you-use
+.. _How to cite and describe software: http://software.ac.uk/how-cite-software
 
 
 Reference: [Jackson]_.

--- a/docs/iris/src/userguide/citation.rst
+++ b/docs/iris/src/userguide/citation.rst
@@ -48,7 +48,7 @@ For example::
 
  Iris. Met Office. git@github.com:SciTools/iris.git 06-03-2013
 
-.. _How to cite and describe software: http://software.ac.uk/how-cite-software
+.. _How to cite and describe software: https://software.ac.uk/how-cite-software
 
 
 Reference: [Jackson]_.

--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -243,7 +243,7 @@ unit (if ``a`` had units ``'m2'`` then ``a ** 0.5`` would result in a cube
 with units ``'m'``).
 
 Iris inherits units from `cf_units <https://scitools.org.uk/cf-units/docs/latest/>`_
-which in turn inherits from `UDUNITS <https://www.unidata.ucar.edu/software/udunits/udunits-current/doc/udunits/udunits2.html>`_.
+which in turn inherits from `UDUNITS <https://www.unidata.ucar.edu/software/udunits/udunits-current/udunits2.html>`_.
 As well as the units UDUNITS provides, cf units also provides the units
 ``'no-unit'`` and ``'unknown'``. A unit of ``'no-unit'`` means that the
 associated data is not suitable for describing with a unit, cf units


### PR DESCRIPTION
## 🚀 Pull Request

### Description
At #3941 the link check failed with two broken links:
* The udunits docs appear genuinely to have moved.
* The `software.ac.uk` link worked when I tried it manually, but it redirected to `https://software.ac.uk/how-cite-software`.  It seems plausible to me that going straight there might be more robust.
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
