### PR TITLE
Add support for 1-d weights in collapse.

### DIFF
--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -113,6 +113,12 @@ This document explains the changes made to Iris for this release
   and preservation of common metadata and coordinates during cube math operations.
   Resolves :issue:`1887`, :issue:`2765`, and :issue:`3478`. (:pull:`3785`)
 
+* `@pp-mo`_ and `@TomekTrzeciak`_ enhanced :meth:`~iris.cube.Cube.collapse` to allow a 1-D weights array when
+  collapsing over a single dimension.
+  Previously, the weights had to be the same shape as the whole cube, which could cost a lot of memory in some cases.
+  The 1-D form is supported by most weighted array statistics (such as :meth:`np.average`), so this now works
+  with the corresponding Iris schemes (in that case, :const:`~iris.analysis.MEAN`).  (:pull:`3943`)
+
 
 🐛 Bugs Fixed
 =============
@@ -472,6 +478,7 @@ This document explains the changes made to Iris for this release
 .. _@tkknight: https://github.com/tkknight
 .. _@lbdreyer: https://github.com/lbdreyer
 .. _@SimonPeatman: https://github.com/SimonPeatman
+.. _@TomekTrzeciak: https://github.com/TomekTrzeciak
 .. _@rcomer: https://github.com/rcomer
 .. _@jvegasbsc: https://github.com/jvegasbsc
 .. _@zklaus: https://github.com/zklaus

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -340,6 +340,7 @@ class Test_collapsed__multidim_weighted(tests.IrisTest):
     def setUp(self):
         self.data = np.arange(6.0).reshape((2, 3))
         self.lazydata = as_lazy_data(self.data)
+        # Test cubes wth (same-valued) real and lazy data
         cube_real = Cube(self.data)
         for i_dim, name in enumerate(("y", "x")):
             npts = cube_real.shape[i_dim]
@@ -347,41 +348,94 @@ class Test_collapsed__multidim_weighted(tests.IrisTest):
             cube_real.add_dim_coord(coord, i_dim)
         self.cube_real = cube_real
         self.cube_lazy = cube_real.copy(data=self.lazydata)
+        # Test weights and expected result for a y-collapse
         self.y_weights = np.array([0.3, 0.5])
-        self.full_weights = np.broadcast_to(
+        self.full_weights_y = np.broadcast_to(
             self.y_weights.reshape((2, 1)), cube_real.shape
         )
-        self.expected_result = np.array([1.875, 2.875, 3.875])
+        self.expected_result_y = np.array([1.875, 2.875, 3.875])
+        # Test weights and expected result for an x-collapse
+        self.x_weights = np.array([0.7, 0.4, 0.6])
+        self.full_weights_x = np.broadcast_to(
+            self.x_weights.reshape((1, 3)), cube_real.shape
+        )
+        self.expected_result_x = np.array([0.941176, 3.941176])
 
-    def test_weighted_fullweights_real(self):
+    def test_weighted_fullweights_real_y(self):
         # Supplying full-shape weights for collapsing over a single dimension.
         cube_collapsed = self.cube_real.collapsed(
-            "y", MEAN, weights=self.full_weights
+            "y", MEAN, weights=self.full_weights_y
         )
-        self.assertArrayAlmostEqual(cube_collapsed.data, self.expected_result)
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_y
+        )
 
-    def test_weighted_fullweights_lazy(self):
-        # Full-shape weights, single dimension, lazy cube :  Check lazy result, same values as real calc.
+    def test_weighted_fullweights_lazy_y(self):
+        # Full-shape weights, lazy data :  Check lazy result, same values as real calc.
         cube_collapsed = self.cube_lazy.collapsed(
-            "y", MEAN, weights=self.full_weights
+            "y", MEAN, weights=self.full_weights_y
         )
         self.assertTrue(cube_collapsed.has_lazy_data())
-        self.assertArrayAlmostEqual(cube_collapsed.data, self.expected_result)
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_y
+        )
 
-    def test_weighted_1dweights_real(self):
-        # 1-D weights, single dimension, real cube :  Check same results as full-shape.
+    def test_weighted_1dweights_real_y(self):
+        # 1-D weights, real data :  Check same results as full-shape.
         cube_collapsed = self.cube_real.collapsed(
             "y", MEAN, weights=self.y_weights
         )
-        self.assertArrayAlmostEqual(cube_collapsed.data, self.expected_result)
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_y
+        )
 
-    def test_weighted_1dweights_lazy(self):
-        # 1-D weights, single dimension, lazy cube :  Check lazy result, same values as real calc.
+    def test_weighted_1dweights_lazy_y(self):
+        # 1-D weights, lazy data :  Check lazy result, same values as real calc.
         cube_collapsed = self.cube_lazy.collapsed(
             "y", MEAN, weights=self.y_weights
         )
         self.assertTrue(cube_collapsed.has_lazy_data())
-        self.assertArrayAlmostEqual(cube_collapsed.data, self.expected_result)
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_y
+        )
+
+    def test_weighted_fullweights_real_x(self):
+        # Full weights, real data, ** collapse X ** :  as for 'y' case above
+        cube_collapsed = self.cube_real.collapsed(
+            "x", MEAN, weights=self.full_weights_x
+        )
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_x
+        )
+
+    def test_weighted_fullweights_lazy_x(self):
+        # Full weights, lazy data, ** collapse X ** :  as for 'y' case above
+        cube_collapsed = self.cube_lazy.collapsed(
+            "x", MEAN, weights=self.full_weights_x
+        )
+        self.assertTrue(cube_collapsed.has_lazy_data())
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_x
+        )
+
+    def test_weighted_1dweights_real_x(self):
+        # 1-D weights, real data, ** collapse X ** :  as for 'y' case above
+        cube_collapsed = self.cube_real.collapsed(
+            "x", MEAN, weights=self.x_weights
+        )
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_x
+        )
+
+    def test_weighted_1dweights_lazy_x(self):
+        # 1-D weights, lazy data, ** collapse X ** :  as for 'y' case above
+        cube_collapsed = self.cube_lazy.collapsed(
+            "x", MEAN, weights=self.x_weights
+        )
+        self.assertTrue(cube_collapsed.has_lazy_data())
+        self.assertArrayAlmostEqual(
+            cube_collapsed.data, self.expected_result_x
+        )
 
 
 class Test_collapsed__cellmeasure_ancils(tests.IrisTest):


### PR DESCRIPTION
## 🚀 Pull Request

Stop Cube.collapse from re-forming a weights array when it is 1-dimensional.
This allows to pass a 1-D weights array relating to a (single) collapse dimension, instead of the weights always having to be the 
shape of the whole cube.
This is supported by the API of functions like `np.average` (and `da.average`), so this provides access to those features.

(N.B. to make this work as expected with **_lazy_** data, we also need to pass a simple integer as the axis. instead of a "list of one axis", because the underlying numpy  + dask  functions require this when passing a 1D weights array.)

Closes #3707 