### PR TITLE
Resolve test coverage

### DIFF
--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -270,6 +270,7 @@ linkcheck_ignore = [
     "http://scitools.github.com/cartopy",
     "http://www.wmo.int/pages/prog/www/DPFS/documents/485_Vol_I_en_colour.pdf",
     "https://software.ac.uk/how-cite-software",
+    "http://www.esrl.noaa.gov/psd/data/gridded/conventions/cdc_netcdf_standard.shtml",
 ]
 
 # list of sources to exclude from the build.

--- a/docs/iris/src/conf.py
+++ b/docs/iris/src/conf.py
@@ -269,6 +269,7 @@ linkcheck_ignore = [
     "http://schacon.github.com/git",
     "http://scitools.github.com/cartopy",
     "http://www.wmo.int/pages/prog/www/DPFS/documents/485_Vol_I_en_colour.pdf",
+    "https://software.ac.uk/how-cite-software",
 ]
 
 # list of sources to exclude from the build.

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -294,6 +294,25 @@ class Resolve:
             self(lhs, rhs)
 
     def __call__(self, lhs, rhs):
+        """
+        Resolve the ``lhs`` :class:`~iris.cube.Cube` operand and ``rhs``
+        :class:`~iris.cube.Cube` operand metadata.
+
+        Involves determining all the common coordinate metadata shared between
+        the operands, and the metadata that is local to each operand. Given
+        the common metadata, the broadcast shape of the resultant resolved
+        :class:`~iris.cube.Cube`, which may be auto-transposed, can be
+        determined.
+
+        Args:
+
+        * lhs:
+            The left-hand-side :class:`~iris.cube.Cube` operand.
+
+        * rhs:
+            The right-hand-side :class:`~iris.cube.Cube` operand.
+
+        """
         from iris.cube import Cube
 
         emsg = (
@@ -430,6 +449,40 @@ class Resolve:
         common_aux_metadata,
         common_scalar_metadata,
     ):
+        """
+        Determine the dimensions covered by each of the local and common
+        auxiliary coordinates of the provided :class:`~iris.cube.Cube`.
+
+        The cube dimensions not covered by any of the auxiliary coordinates is
+        also determined; these are known as `free` dimensions.
+
+        The scalar coordinates local to the cube are also determined.
+
+        Args:
+
+        * cube:
+            The :class:`~iris.cube.Cube` to be analysed for coverage.
+
+        * cube_items_aux:
+            The list of associated :class:`~iris.common.resolve._Item` metadata
+            for each auxiliary coordinate owned by the cube.
+
+        * cube_items_scalar:
+            The list of associated :class:`~iris.common.resolve._Item` metadata
+            for each scalar coordinate owned by the cube.
+
+        * common_aux_metadata:
+            The list of common auxiliary coordinate metadata shared by both
+            the LHS and RHS cube operands being resolved.
+
+        * common_scalar_metadata:
+            The list of common scalar coordinate metadata shared by both
+            the LHS and RHS cube operands being resolved.
+
+        Returns:
+            :class:`~iris.common.resolve._AuxCoverage`
+
+        """
         common_items_aux = []
         common_items_scalar = []
         local_items_aux = []
@@ -507,6 +560,22 @@ class Resolve:
 
     @staticmethod
     def _categorise_items(cube):
+        """
+        Inspect the provided :class:`~iris.cube.Cube` and group its
+        coordinates and associated metadata into dimension, auxiliary and
+        scalar categories.
+
+        Args:
+
+        * cube:
+            The :class:`~iris.cube.Cube` that will have its coordinates and
+            metadata grouped into their associated dimension, auxiliary and
+            scalar categories.
+
+        Returns:
+            :class:`~iris.common.resolve._CategoryItems`
+
+        """
         category = _CategoryItems(items_dim=[], items_aux=[], items_scalar=[])
 
         # Categorise the dim coordinates of the cube.
@@ -573,6 +642,30 @@ class Resolve:
 
     @staticmethod
     def _dim_coverage(cube, cube_items_dim, common_dim_metadata):
+        """
+        Determine the dimensions covered by each of the local and common
+        dimension coordinates of the provided :class:`~iris.cube.Cube`.
+
+        The cube dimensions not covered by any of the dimension coordinates is
+        also determined; these are known as `free` dimensions.
+
+        Args:
+
+        * cube:
+            The :class:`~iris.cube.Cube` to be analysed for coverage.
+
+        * cube_items_dim:
+            The list of associated :class:`~iris.common.resolve._Item` metadata
+            for each dimension coordinate owned by the cube.
+
+        * common_dim_metadata:
+            The list of common dimension coordinate metadata shared by both
+            the LHS and RHS cube operands being resolved.
+
+        Returns:
+            :class:`~iris.common.resolve._DimCoverage`
+
+        """
         ndim = cube.ndim
         metadata = [None] * ndim
         coords = [None] * ndim
@@ -758,6 +851,17 @@ class Resolve:
         logger.debug(f"mapping free dimensions gives, mapping={self.mapping}")
 
     def _metadata_coverage(self):
+        """
+        Using the pre-categorised metadata of the cubes, determine the dimensions
+        covered by their associated dimension and auxiliary coordinates, and which
+        dimensions are free of metadata coverage.
+
+        This coverage analysis clarifies how the dimensions covered by common
+        metadata are related, thus establishing a dimensional mapping between
+        the cubes. It also identifies the dimensions covered by metadata that
+        is local to each cube, and indeed which dimensions are free of metadata.
+
+        """
         # Determine the common dim coordinate metadata coverage.
         common_dim_metadata = [
             item.metadata for item in self.category_common.items_dim

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -357,10 +357,30 @@ class Resolve:
         return self
 
     def _as_compatible_cubes(self):
+        """
+        Determine whether the ``src`` and ``tgt`` :class:`~iris.cube.Cube` can
+        be transposed and/or broadcast successfully together.
+
+        If compatible, the ``_broadcast_shape`` is calculated of the resultant
+        resolved cube, and the ``_src_cube_resolved`` (transposed/broadcast ``src``
+        cube) and ``_tgt_cube_resolved`` (same as the ``tgt`` cube) are
+        calculated.
+
+        An exception will be raised if the ``src`` and ``tgt`` cannot be
+        broadcast, even after a suitable transpose has been performed.
+
+        .. note::
+
+            Requires that **all** ``src`` cube dimensions have been mapped
+            successfully to an appropriate ``tgt`` cube dimension.
+
+        """
         from iris.cube import Cube
 
         src_cube = self._src_cube
         tgt_cube = self._tgt_cube
+
+        assert src_cube.ndim == len(self.mapping)
 
         # Use the mapping to calculate the new src cube shape.
         new_src_shape = [1] * tgt_cube.ndim

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1386,6 +1386,30 @@ class Resolve:
     def _prepare_common_dim_payload(
         self, src_coverage, tgt_coverage, ignore_mismatch=None
     ):
+        """
+        Populate the ``items_dim`` member of :attr:`~iris.common.resolve.Resolve.prepared_category_items`
+        with a :class:`~iris.common.resolve._PreparedItem` containing the necessary metadata for
+        each :class:`~iris.coords.DimCoord` to be constructed and attached to the resulting resolved
+        :class:`~iris.cube.Cube`.
+
+        Args:
+
+        * src_coverage:
+            The :class:`~iris.common.resolve._DimCoverage` metadata for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_coverage:
+            The :class:`~iris.common.resolve._DimCoverage` metadata for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        Kwargs:
+
+        * ignore_mismatch:
+            When ``False``, an exception will be raised if a difference is detected between corresponding
+            ``src`` and ``tgt`` :class:`~iris.coords.DimCoord` ``points`` and/or ``bounds``.
+            When ``True``, the coverage metadata is ignored i.e., a :class:`~iris.coords.DimCoord` will not
+            be constructed and added to the resulting resolved :class:`~iris.cube.Cube`.
+            Defaults to ``False``.
+
+        """
         from iris.coords import DimCoord
 
         if ignore_mismatch is None:

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1518,10 +1518,42 @@ class Resolve:
         self, metadata, category_local, from_src=True, from_local=False
     ):
         """
-        TBD
+        Find the :attr:`~iris.common.resolve._PreparedItem` from the
+        :attr:`~iris.common.resolve.Resolve.prepared_category` that matches the provided ``metadata``.
+
+        Alternatively, the ``category_local`` is searched to find a :class:`~iris.common.resolve._Item`
+        with matching ``metadata`` from either the local ``src`` or ``tgt`` :class:`~iris.cube.Cube`.
+        If a match is found, then a new `~iris.common.resolve._PreparedItem` is created and added to
+        :attr:`~iris.common.resolve.Resolve.prepared_category` and returned. See ``from_local``.
+
+        Args:
+
+        * metadata:
+            The target metadata of the prepared (or local) item to retrieve.
+
+        * category_local:
+            The :class:`~iris.common.resolve._CategoryItems` containing the
+            local metadata of either the ``src`` or ``tgt`` :class:`~iris.cube.Cube`.
+            See ``from_local``.
+
+        Kwargs:
+
+        * from_src:
+            Boolean stating whether the ``metadata`` is from the ``src`` (``True``)
+            or ``tgt`` :class:`~iris.cube.Cube`.
+            Defaults to ``True``.
+
+        * from_local:
+            Boolean controlling whether the ``metadata`` is used to search the
+            ``category_local`` (``True``) or the :attr:`~iris.common.resolve.Resolve.prepared_category`.
+            Defaults to ``False``.
+
+        Returns:
+            The :class:`~iris.common.resolve._PreparedItem` matching the provided ``metadata``.
 
         """
         result = None
+
         if from_local:
             category = category_local
             match = lambda item: item.metadata == metadata
@@ -1531,6 +1563,7 @@ class Resolve:
                 match = lambda item: item.metadata.src == metadata
             else:
                 match = lambda item: item.metadata.tgt == metadata
+
         for member in category._fields:
             category_items = getattr(category, member)
             matched_items = tuple(filter(match, category_items))

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -230,7 +230,7 @@ class Resolve:
 
         """
         #: The ``lhs`` operand to be resolved into the resultant :class:`~iris.cube.Cube`.
-        self.lhs_cube = None  # set in _call__
+        self.lhs_cube = None  # set in __call__
         #: The ``rhs`` operand to be resolved into the resultant :class:`~iris.cube.Cube`.
         self.rhs_cube = None  # set in __call__
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -825,8 +825,9 @@ class Resolve:
 
         .. note::
 
-            A local dimension cannot be mapped to a local dimension, by definition,
-            otherwise this dimension would be classed as a common dimension.
+            A local dimension cannot be mapped to another local dimension,
+            by definition, otherwise this dimension would be classed as a
+            common dimension.
 
         """
         src_cube = src_dim_coverage.cube
@@ -1013,10 +1014,6 @@ class Resolve:
         )
 
     def _metadata_mapping(self):
-        """
-        TBD
-
-        """
         # Initialise the state.
         self.mapping = {}
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1727,6 +1727,47 @@ class Resolve:
     def _prepare_points_and_bounds(
         self, src_coord, tgt_coord, src_dims, tgt_dims, ignore_mismatch=None
     ):
+        """
+        Compare the points and bounds of the ``src`` and ``tgt`` coordinates to ensure
+        that they are equivalent, taking into account broadcasting when appropriate.
+
+        .. note::
+
+            An exception will be raised if the ``src`` and ``tgt`` coordinates cannot
+            be broadcast.
+
+        .. note::
+
+            An exception will be raised if either the points or bounds are different,
+            however appropriate lenient behaviour concessions are applied.
+
+        Args:
+
+        * src_coord:
+            The ``src`` :class:`~iris.cube.Cube` coordinate with metadata matching
+            the ``tgt_coord``.
+
+        * tgt_coord:
+            The ``tgt`` :class`~iris.cube.Cube` coordinate with metadata matching
+            the ``src_coord``.
+
+        * src_dims:
+            The dimension/s of the ``src_coord`` attached to the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_dims:
+            The dimension/s of the ``tgt_coord`` attached to the ``tgt`` :class:`~iris.cube.Cube`.
+
+        Kwargs:
+
+        * ignore_mismatch:
+            For lenient behaviour only, don't raise an exception if there is a difference between
+            the ``src`` and ``tgt`` coordinate points or bounds.
+            Defaults to ``False``.
+
+        Returns:
+            Tuple of equivalent ``points`` and ``bounds``, otherwise ``None``.
+
+        """
         from iris.util import array_equal
 
         if ignore_mismatch is None:
@@ -1773,6 +1814,7 @@ class Resolve:
             tgt_broadcasting = tgt_shape != tgt_shape_broadcast
 
             if src_broadcasting and tgt_broadcasting:
+                # TDB: Extend capability to support attempting to broadcast two-way multi-dimensional coordinates.
                 emsg = (
                     f"Cannot broadcast the coordinate {src_coord.name()!r} on "
                     f"{self._src_cube_position} cube {self._src_cube.name()!r} and "

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1685,7 +1685,7 @@ class Resolve:
             In general, a local coordinate will only be added if there is no other metadata competing
             to describe the same dimension/s on the ``tgt`` :class:`~iris.cube.Cube`. Lenient behaviour
             is more liberal, whereas strict behaviour will only add a local ``tgt`` coordinate covering
-            an unmapped "extra" ``tgt`` dimension.
+            an unmapped "extra" ``tgt`` dimension/s.
 
         Args:
 
@@ -1757,6 +1757,29 @@ class Resolve:
     def _prepare_local_payload_scalar(
         self, src_aux_coverage, tgt_aux_coverage
     ):
+        """
+        Populate the ``items_scalar`` member of :attr:`~iris.common.resolve.Resolve.prepared_category_items`
+        with a :class:`~iris.common.resolve._PreparedItem` containing the necessary metadata for each
+        ``src`` or ``tgt`` local scalar coordinate to be constructed and attached to the resulting
+        resolved :class:`~iris.cube.Cube`.
+
+        .. note::
+
+            In general, lenient behaviour subscribes to the philosophy that it is easier to remove
+            metadata than it is to find then add metadata. To those ends, lenient behaviour supports
+            metadata richness by adding both local ``src`` and ``tgt`` scalar coordinates.
+            Alternatively, strict behaviour will only add a ``tgt`` local scalar coordinate when the
+            ``src`` is a scalar :class:`~iris.cube.Cube` with no local scalar coordinates.
+
+        Args:
+
+        * src_aux_coverage:
+            The :class:`~iris.common.resolve.Resolve._AuxCoverage` for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_aux_coverage:
+            The :class:~iris.common.resolve.Resolve._AuxCoverage` for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        """
         # Add all local tgt scalar coordinates iff the src cube is a
         # scalar cube with no local src scalar coordinates.
         # Only for strict maths.

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -361,8 +361,8 @@ class Resolve:
         Determine whether the ``src`` and ``tgt`` :class:`~iris.cube.Cube` can
         be transposed and/or broadcast successfully together.
 
-        If compatible, the ``_broadcast_shape`` is calculated of the resultant
-        resolved cube, and the ``_src_cube_resolved`` (transposed/broadcast ``src``
+        If compatible, the ``_broadcast_shape`` of the resultant resolved cube is
+        calculated, and the ``_src_cube_resolved`` (transposed/broadcast ``src``
         cube) and ``_tgt_cube_resolved`` (same as the ``tgt`` cube) are
         calculated.
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1182,6 +1182,12 @@ class Resolve:
             self._as_compatible_cubes()
 
     def _metadata_prepare(self):
+        """
+        Populate the :attr:`~iris.common.resolve.Resolve.prepared_category` and
+        :attr:`~iris.common.resolve.Resolve.prepared_factories` with the necessary metadata to be constructed
+        and attached to the resulting resolved :class:`~iris.cube.Cube`.
+
+        """
         # Initialise the state.
         self.prepared_category = _CategoryItems(
             items_dim=[], items_aux=[], items_scalar=[]

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1034,6 +1034,37 @@ class Resolve:
         )
 
     def _metadata_mapping(self):
+        """
+        Ensure that each ``src`` :class:`~iris.cube.Cube` dimension is mapped to an associated
+        ``tgt`` :class:`~iris.cube.Cube` dimension using the common dim and aux coordinate metadata.
+
+        If the common metadata does not result in a full mapping of ``src`` to ``tgt`` dimensions
+        then free dimensions are analysed to determine whether the mapping can be completed.
+
+        Once the ``src`` has been mapped to the ``tgt``, the cubes are checked to ensure that they
+        will successfully broadcast, and the ``src`` :class:`~iris.cube.Cube` is transposed appropriately,
+        if necessary.
+
+        The :attr:`~iris.common.resolve.Resolve._broadcast_shape` is set, along with the
+        :attr:`~iris.common.resolve.Resolve._src_cube_resolved` and :attr:`~iris.common.resolve.Resolve._tgt_cube_resolved`,
+        which are the broadcast/transposed ``src`` and ``tgt``.
+
+        .. note::
+
+            An exception will be raised if a ``src`` dimension cannot be mapped to a ``tgt`` dimension.
+
+        .. note::
+
+            An exception will be raised if the full mapped ``src`` :class:`~iris.cube.Cube` cannot be
+            broadcast or transposed with the ``tgt`` :class:`~iris.cube.Cube`.
+
+        .. note::
+
+            The ``src`` and ``tgt`` may  be swapped in the case where they both have equal dimensionality and
+            the ``tgt`` does have the same shape as the resolved broadcast shape (and the ``src`` does) or
+            the ``tgt`` has more free dimensions than the ``src``.
+
+        """
         # Initialise the state.
         self.mapping = {}
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1811,6 +1811,27 @@ class Resolve:
         tgt_dim_coverage,
         tgt_aux_coverage,
     ):
+        """
+        Populate the :attr:`~iris.common.resolve.Resolve.prepared_category_items` with a
+        :class:`~iris.common.resolve._PreparedItem` containing the necessary metadata from the ``src``
+        and/or ``tgt`` :class:`~iris.cube.Cube` for each coordinate to be constructed and attached
+        to the resulting resolved :class:`~iris.cube.Cube`.
+
+        Args:
+
+        * src_dim_coverage:
+            The :class:`~iris.common.resolve.Resolve._DimCoverage` for the ``src`` :class:`~iris.cube.Cube`.
+
+        * src_aux_coverage:
+            The :class:`~iris.common.resolve.Resolve._AuxCoverage` for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_dim_coverage:
+            The :class:`~iris.common.resolve.Resolve._DimCoverage` for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        * tgt_aux_coverage:
+            The :class:~iris.common.resolve.Resolve._AuxCoverage` for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        """
         # Add local src/tgt dim coordinates.
         self._prepare_local_payload_dim(src_dim_coverage, tgt_dim_coverage)
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1601,6 +1601,29 @@ class Resolve:
                 logger.debug(dmsg)
 
     def _prepare_local_payload_aux(self, src_aux_coverage, tgt_aux_coverage):
+        """
+        Populate the ``items_aux`` member of :attr:`~iris.common.resolve.Resolve.prepared_category_items`
+        with a :class:`~iris.common.resolve._PreparedItem` containing the necessary metadata for each
+        ``src`` or ``tgt`` local auxiliary coordinate to be constructed and attached to the resulting
+        resolved :class:`~iris.cube.Cube`.
+
+        .. note::
+
+            In general, lenient behaviour subscribes to the philosophy that it is easier to remove
+            metadata than it is to find then add metadata. To those ends, lenient behaviour supports
+            metadata richness by adding both local ``src`` and ``tgt`` auxiliary coordinates.
+            Alternatively, strict behaviour will only add a ``tgt`` local auxiliary coordinate that
+            spans dimensions not mapped to by the ``src`` e.g., extra ``tgt`` dimensions.
+
+        Args:
+
+        * src_aux_coverage:
+            The :class:`~iris.common.resolve.Resolve._AuxCoverage` for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_aux_coverage:
+            The :class:~iris.common.resolve.Resolve._AuxCoverage` for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        """
         # Determine whether there are tgt dimensions not mapped to by an
         # associated src dimension, and thus may be covered by any local
         # tgt aux coordinates.
@@ -1653,7 +1676,7 @@ class Resolve:
     def _prepare_local_payload_dim(self, src_dim_coverage, tgt_dim_coverage):
         """
         Populate the ``items_dim`` member of :attr:`~iris.common.resolve.Resolve.prepared_category_items`
-        with a :class:``~iris.common.resolve._PreparedItem` containing the necessary metadata for each
+        with a :class:`~iris.common.resolve._PreparedItem` containing the necessary metadata for each
         ``src`` or ``tgt`` local :class:`~iris.coords.DimCoord` to be constructed and attached to the
         resulting resolved :class:`~iris.cube.Cube`.
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -646,15 +646,40 @@ class Resolve:
         return category
 
     @staticmethod
-    def _create_prepared_item(coord, dims, src=None, tgt=None):
-        if src is not None and tgt is not None:
-            combined = src.combine(tgt)
+    def _create_prepared_item(
+        coord, dims, src_metadata=None, tgt_metadata=None
+    ):
+        """
+        Convenience method that creates a :class:`~iris.common.resolve._PreparedItem`
+        containing the data and metadata required to construct and attach a coordinate
+        to the resultant resolved cube.
+
+        Args:
+
+        * coord:
+            The coordinate with the ``points`` and ``bounds`` to be extracted.
+
+        * dims:
+            The dimensions that the ``coord`` spans on the resulting resolved :class:`~iris.cube.Cube`.
+
+        * src_metadata:
+            The coordinate metadata from the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_metadata:
+            The coordinate metadata from the ``tgt`` :class:`~iris.cube.Cube`.
+
+        Returns:
+            The :class:`~iris.common.resolve._PreparedItem`.
+
+        """
+        if src_metadata is not None and tgt_metadata is not None:
+            combined = src_metadata.combine(tgt_metadata)
         else:
-            combined = src or tgt
+            combined = src_metadata or tgt_metadata
         if not isinstance(dims, Iterable):
             dims = (dims,)
         prepared_metadata = _PreparedMetadata(
-            combined=combined, src=src, tgt=tgt
+            combined=combined, src=src_metadata, tgt=tgt_metadata
         )
         bounds = coord.bounds
         result = _PreparedItem(
@@ -1518,7 +1543,10 @@ class Resolve:
                                 tgt = item.metadata
                                 dims = item.dims
                             result = self._create_prepared_item(
-                                item.coord, dims, src=src, tgt=tgt
+                                item.coord,
+                                dims,
+                                src_metadata=src,
+                                tgt_metadata=tgt,
                             )
                             getattr(self.prepared_category, member).append(
                                 result
@@ -1589,7 +1617,7 @@ class Resolve:
                 if all([dim in mapped_src_dims for dim in item.dims]):
                     tgt_dims = tuple([self.mapping[dim] for dim in item.dims])
                     prepared_item = self._create_prepared_item(
-                        item.coord, tgt_dims, src=item.metadata
+                        item.coord, tgt_dims, src_metadata=item.metadata
                     )
                     self.prepared_category.items_aux.append(prepared_item)
                 else:
@@ -1611,7 +1639,7 @@ class Resolve:
                 [dim in extra_tgt_dims for dim in tgt_dims]
             ):
                 prepared_item = self._create_prepared_item(
-                    item.coord, tgt_dims, tgt=item.metadata
+                    item.coord, tgt_dims, tgt_metadata=item.metadata
                 )
                 self.prepared_category.items_aux.append(prepared_item)
             else:
@@ -1644,7 +1672,7 @@ class Resolve:
                     metadata = src_dim_coverage.metadata[src_dim]
                     coord = src_dim_coverage.coords[src_dim]
                     prepared_item = self._create_prepared_item(
-                        coord, tgt_dim, src=metadata
+                        coord, tgt_dim, src_metadata=metadata
                     )
                     self.prepared_category.items_dim.append(prepared_item)
                 else:
@@ -1677,7 +1705,7 @@ class Resolve:
                 if metadata is not None:
                     coord = tgt_dim_coverage.coords[tgt_dim]
                     prepared_item = self._create_prepared_item(
-                        coord, tgt_dim, tgt=metadata
+                        coord, tgt_dim, tgt_metadata=metadata
                     )
                     self.prepared_category.items_dim.append(prepared_item)
 
@@ -1697,14 +1725,14 @@ class Resolve:
             # Add any local src scalar coordinates, if available.
             for item in src_aux_coverage.local_items_scalar:
                 prepared_item = self._create_prepared_item(
-                    item.coord, item.dims, src=item.metadata
+                    item.coord, item.dims, src_metadata=item.metadata
                 )
                 self.prepared_category.items_scalar.append(prepared_item)
 
             # Add any local tgt scalar coordinates, if available.
             for item in tgt_aux_coverage.local_items_scalar:
                 prepared_item = self._create_prepared_item(
-                    item.coord, item.dims, tgt=item.metadata
+                    item.coord, item.dims, tgt_metadata=item.metadata
                 )
                 self.prepared_category.items_scalar.append(prepared_item)
 

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1324,6 +1324,41 @@ class Resolve:
         prepared_items,
         ignore_mismatch=None,
     ):
+        """
+        Populate the ``prepared_items`` with a :class:`~iris.common.resolve._PreparedItem` containing
+        the necessary metadata for each auxiliary coordinate to be constructed and attached to the
+        resulting resolved :class:`~iris.cube.Cube`.
+
+        .. note::
+
+            For mixed ``src`` and ``tgt`` coordinate types with matching metadata, an
+            :class:`~iris.coords.AuxCoord` will be nominated for construction.
+
+        Args:
+
+        * src_common_items:
+            The list of :attr:`~iris.common.resolve._AuxCoverage.common_items_aux` metadata
+            for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_common_items:
+            The list of :attr:`~iris.common.resolve._AuxCoverage.common_items_aux` metadata
+            for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        * prepared_items:
+            The list of :class:`~iris.common.resolve._PreparedItem` metadata that will be used
+            to construct the auxiliary coordinates that will be attached to the resulting
+            resolved :class:`~iris.cube.Cube`.
+
+        Kwargs:
+
+        * ignore_mismatch:
+            When ``False``, an exception will be raised if a difference is detected between corresponding
+            ``src`` and ``tgt`` coordinate ``points`` and/or ``bounds``.
+            When ``True``, the coverage metadata is ignored i.e., a coordinate will not be constructed and
+            added to the resulting resolved :class:`~iris.cube.Cube`.
+            Defaults to ``False``.
+
+        """
         from iris.coords import AuxCoord
 
         if ignore_mismatch is None:

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -1651,6 +1651,28 @@ class Resolve:
                 logger.debug(dmsg)
 
     def _prepare_local_payload_dim(self, src_dim_coverage, tgt_dim_coverage):
+        """
+        Populate the ``items_dim`` member of :attr:`~iris.common.resolve.Resolve.prepared_category_items`
+        with a :class:``~iris.common.resolve._PreparedItem` containing the necessary metadata for each
+        ``src`` or ``tgt`` local :class:`~iris.coords.DimCoord` to be constructed and attached to the
+        resulting resolved :class:`~iris.cube.Cube`.
+
+        .. note::
+
+            In general, a local coordinate will only be added if there is no other metadata competing
+            to describe the same dimension/s on the ``tgt`` :class:`~iris.cube.Cube`. Lenient behaviour
+            is more liberal, whereas strict behaviour will only add a local ``tgt`` coordinate covering
+            an unmapped "extra" ``tgt`` dimension.
+
+        Args:
+
+        * src_dim_coverage:
+            The :class:`~iris.common.resolve.Resolve._DimCoverage` for the ``src`` :class:`~iris.cube.Cube`.
+
+        * tgt_dim_coverage:
+            The :class:`~iris.common.resolve.Resolve._DimCoverage` for the ``tgt`` :class:`~iris.cube.Cube`.
+
+        """
         mapped_tgt_dims = self.mapping.values()
 
         # Determine whether there are tgt dimensions not mapped to by an

--- a/lib/iris/tests/unit/common/resolve/__init__.py
+++ b/lib/iris/tests/unit/common/resolve/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris.common.resolve` package."""

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -3497,5 +3497,329 @@ class Test__prepare_local_payload_aux(tests.IrisTest):
         self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
 
 
+class Test__prepare_local_payload_scalar(tests.IrisTest):
+    def setUp(self):
+        self.Cube = namedtuple("Cube", ["ndim"])
+        self.resolve = Resolve()
+        self.resolve.prepared_category = _CategoryItems(
+            items_dim=[], items_aux=[], items_scalar=[]
+        )
+        self.src_coverage = dict(
+            cube=None,
+            common_items_aux=None,
+            common_items_scalar=None,
+            local_items_aux=None,
+            local_items_scalar=[],
+            dims_common=None,
+            dims_local=[],
+            dims_free=None,
+        )
+        self.tgt_coverage = deepcopy(self.src_coverage)
+        self.src_prepared_item = sentinel.src_prepared_item
+        self.tgt_prepared_item = sentinel.tgt_prepared_item
+        self.m_create_prepared_item = self.patch(
+            "iris.common.resolve.Resolve._create_prepared_item",
+            side_effect=(self.src_prepared_item, self.tgt_prepared_item),
+        )
+        self.src_dims = ()
+        self.tgt_dims = ()
+
+    def test_src_no_local_with_tgt_no_local(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_no_local_with_tgt_no_local__strict(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_no_local_with_tgt_no_local__src_scalar_cube(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_no_local_with_tgt_no_local__src_scalar_cube_strict(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_local_with_tgt_no_local(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(1, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.src_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(src_coord, self.src_dims, src_metadata=src_metadata)
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_local_with_tgt_no_local__strict(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_local_with_tgt_no_local__src_scalar_cube(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(1, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.src_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(src_coord, self.src_dims, src_metadata=src_metadata)
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_local_with_tgt_no_local__src_scalar_cube_strict(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_no_local_with_tgt_local(self):
+        self.m_create_prepared_item.side_effect = (self.tgt_prepared_item,)
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(1, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.tgt_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(tgt_coord, self.tgt_dims, tgt_metadata=tgt_metadata)
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_no_local_with_tgt_local__strict(self):
+        self.m_create_prepared_item.side_effect = (self.tgt_prepared_item,)
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_no_local_with_tgt_local__src_scalar_cube(self):
+        self.m_create_prepared_item.side_effect = (self.tgt_prepared_item,)
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(1, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.tgt_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(tgt_coord, self.tgt_dims, tgt_metadata=tgt_metadata)
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_no_local_with_tgt_local__src_scalar_cube_strict(self):
+        self.m_create_prepared_item.side_effect = (self.tgt_prepared_item,)
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(1, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.tgt_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(tgt_coord, self.tgt_dims, tgt_metadata=tgt_metadata)
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_local_with_tgt_local(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(2, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.src_prepared_item, self.tgt_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(src_coord, self.src_dims, src_metadata=src_metadata),
+            mock.call(tgt_coord, self.tgt_dims, tgt_metadata=tgt_metadata),
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_local_with_tgt_local__strict(self):
+        ndim = 2
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+    def test_src_local_with_tgt_local__src_scalar_cube(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        self.resolve._prepare_local_payload_scalar(src_coverage, tgt_coverage)
+        self.assertEqual(2, len(self.resolve.prepared_category.items_scalar))
+        expected = [self.src_prepared_item, self.tgt_prepared_item]
+        self.assertEqual(expected, self.resolve.prepared_category.items_scalar)
+        expected = [
+            mock.call(src_coord, self.src_dims, src_metadata=src_metadata),
+            mock.call(tgt_coord, self.tgt_dims, tgt_metadata=tgt_metadata),
+        ]
+        self.assertEqual(expected, self.m_create_prepared_item.call_args_list)
+
+    def test_src_local_with_tgt_local__src_scalar_cube_strict(self):
+        ndim = 0
+        self.src_coverage["cube"] = self.Cube(ndim=ndim)
+        src_metadata = sentinel.src_metadata
+        src_coord = sentinel.src_coord
+        src_item = _Item(
+            metadata=src_metadata, coord=src_coord, dims=self.src_dims
+        )
+        self.src_coverage["local_items_scalar"].append(src_item)
+        src_coverage = _AuxCoverage(**self.src_coverage)
+        tgt_metadata = sentinel.tgt_metadata
+        tgt_coord = sentinel.tgt_coord
+        tgt_item = _Item(
+            metadata=tgt_metadata, coord=tgt_coord, dims=self.tgt_dims
+        )
+        self.tgt_coverage["local_items_scalar"].append(tgt_item)
+        tgt_coverage = _AuxCoverage(**self.tgt_coverage)
+        with LENIENT.context(maths=False):
+            self.resolve._prepare_local_payload_scalar(
+                src_coverage, tgt_coverage
+            )
+        self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -1465,11 +1465,11 @@ class Test__tgt_cube_position(tests.IrisTest):
 
     def test_rhs_cube(self):
         self.resolve.map_rhs_to_lhs = False
-        self.assertEqual("LHS", self.resolve._tgt_cube_position)
+        self.assertEqual("RHS", self.resolve._tgt_cube_position)
 
     def test_lhs_cube(self):
         self.resolve.map_rhs_to_lhs = True
-        self.assertEqual("RHS", self.resolve._tgt_cube_position)
+        self.assertEqual("LHS", self.resolve._tgt_cube_position)
 
     def test_fail__no_map_rhs_to_lhs(self):
         with self.assertRaises(AssertionError):

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -1,0 +1,129 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for the :class:`iris.common.resolve.Resolve`.
+
+"""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import unittest.mock as mock
+from unittest.mock import sentinel
+
+from iris.common.resolve import Resolve
+from iris.cube import Cube
+
+
+class Test___init__(tests.IrisTest):
+    def setUp(self):
+        target = "iris.common.resolve.Resolve.__call__"
+        self.mcall = mock.MagicMock(return_value=sentinel.return_value)
+        _ = self.patch(target, new=self.mcall)
+
+    def _assert_members_none(self, resolve):
+        self.assertIsNone(resolve.lhs_cube_resolved)
+        self.assertIsNone(resolve.rhs_cube_resolved)
+        self.assertIsNone(resolve.lhs_cube_category)
+        self.assertIsNone(resolve.rhs_cube_category)
+        self.assertIsNone(resolve.lhs_cube_category_local)
+        self.assertIsNone(resolve.rhs_cube_category_local)
+        self.assertIsNone(resolve.category_common)
+        self.assertIsNone(resolve.lhs_cube_dim_coverage)
+        self.assertIsNone(resolve.lhs_cube_aux_coverage)
+        self.assertIsNone(resolve.rhs_cube_dim_coverage)
+        self.assertIsNone(resolve.rhs_cube_aux_coverage)
+        self.assertIsNone(resolve.map_rhs_to_lhs)
+        self.assertIsNone(resolve.mapping)
+        self.assertIsNone(resolve.prepared_category)
+        self.assertIsNone(resolve.prepared_factories)
+        self.assertIsNone(resolve._broadcast_shape)
+
+    def test_lhs_rhs_default(self):
+        resolve = Resolve()
+        self.assertIsNone(resolve.lhs_cube)
+        self.assertIsNone(resolve.rhs_cube)
+        self._assert_members_none(resolve)
+        self.assertEqual(self.mcall.call_count, 0)
+
+    def test_lhs_rhs_provided(self):
+        lhs = sentinel.lhs
+        rhs = sentinel.rhs
+        resolve = Resolve(lhs=lhs, rhs=rhs)
+        self.assertIsNone(resolve.lhs_cube)
+        self.assertIsNone(resolve.rhs_cube)
+        self._assert_members_none(resolve)
+        self.assertEqual(self.mcall.call_count, 1)
+        call_args = mock.call(lhs, rhs)
+        self.assertEqual(self.mcall.call_args, call_args)
+
+
+class Test___call__(tests.IrisTest):
+    def setUp(self):
+        self.lhs = mock.MagicMock(spec=Cube)
+        self.rhs = mock.MagicMock(spec=Cube)
+        target = "iris.common.resolve.Resolve.{method}"
+        method = target.format(method="_metadata_resolve")
+        self.metadata_resolve = self.patch(method)
+        method = target.format(method="_metadata_coverage")
+        self.metadata_coverage = self.patch(method)
+        method = target.format(method="_metadata_mapping")
+        self.metadata_mapping = self.patch(method)
+        method = target.format(method="_metadata_prepare")
+        self.metadata_prepare = self.patch(method)
+
+    def test_lhs_not_cube(self):
+        emsg = "'LHS' argument to be a 'Cube'"
+        with self.assertRaisesRegex(TypeError, emsg):
+            _ = Resolve(rhs=self.rhs)
+
+    def test_rhs_not_cube(self):
+        emsg = "'RHS' argument to be a 'Cube'"
+        with self.assertRaisesRegex(TypeError, emsg):
+            _ = Resolve(lhs=self.lhs)
+
+    def _assert_called_metadata_methods(self):
+        call_args = mock.call()
+        self.assertEqual(self.metadata_resolve.call_count, 1)
+        self.assertEqual(self.metadata_resolve.call_args, call_args)
+        self.assertEqual(self.metadata_coverage.call_count, 1)
+        self.assertEqual(self.metadata_coverage.call_args, call_args)
+        self.assertEqual(self.metadata_mapping.call_count, 1)
+        self.assertEqual(self.metadata_mapping.call_args, call_args)
+        self.assertEqual(self.metadata_prepare.call_count, 1)
+        self.assertEqual(self.metadata_prepare.call_args, call_args)
+
+    def test_map_rhs_to_lhs__less_than(self):
+        self.lhs.ndim = 2
+        self.rhs.ndim = 1
+        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
+        self.assertEqual(resolve.lhs_cube, self.lhs)
+        self.assertEqual(resolve.rhs_cube, self.rhs)
+        self.assertTrue(resolve.map_rhs_to_lhs)
+        self._assert_called_metadata_methods()
+
+    def test_map_rhs_to_lhs__equal(self):
+        self.lhs.ndim = 2
+        self.rhs.ndim = 2
+        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
+        self.assertEqual(resolve.lhs_cube, self.lhs)
+        self.assertEqual(resolve.rhs_cube, self.rhs)
+        self.assertTrue(resolve.map_rhs_to_lhs)
+        self._assert_called_metadata_methods()
+
+    def test_map_lhs_to_rhs__equal(self):
+        self.lhs.ndim = 2
+        self.rhs.ndim = 3
+        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
+        self.assertEqual(resolve.lhs_cube, self.lhs)
+        self.assertEqual(resolve.rhs_cube, self.rhs)
+        self.assertFalse(resolve.map_rhs_to_lhs)
+        self._assert_called_metadata_methods()
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -1516,6 +1516,19 @@ class Test__tgt_cube_resolved__setter(tests.IrisTest):
             self.resolve._tgt_cube_resolved = self.expected
 
 
+class Test_shape(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+
+    def test_no_shape(self):
+        self.assertIsNone(self.resolve.shape)
+
+    def test_shape(self):
+        expected = sentinel.shape
+        self.resolve._broadcast_shape = expected
+        self.assertEqual(expected, self.resolve.shape)
+
+
 class Test__as_compatible_cubes(tests.IrisTest):
     pass
 

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -1362,5 +1362,163 @@ class Test__free_mapping(tests.IrisTest):
             self.resolve._free_mapping(**args)
 
 
+class Test__src_cube(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve.rhs_cube = self.expected
+        self.assertEqual(self.expected, self.resolve._src_cube)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve.lhs_cube = self.expected
+        self.assertEqual(self.expected, self.resolve._src_cube)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._src_cube
+
+
+class Test__src_cube_position(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.assertEqual("RHS", self.resolve._src_cube_position)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.assertEqual("LHS", self.resolve._src_cube_position)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._src_cube_position
+
+
+class Test__src_cube_resolved__getter(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve.rhs_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve._src_cube_resolved)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve.lhs_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve._src_cube_resolved)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._src_cube_resolved
+
+
+class Test__src_cube_resolved__setter(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve._src_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve.rhs_cube_resolved)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve._src_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve.lhs_cube_resolved)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._src_cube_resolved = self.expected
+
+
+class Test__tgt_cube(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve.rhs_cube = self.expected
+        self.assertEqual(self.expected, self.resolve._tgt_cube)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve.lhs_cube = self.expected
+        self.assertEqual(self.expected, self.resolve._tgt_cube)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._tgt_cube
+
+
+class Test__tgt_cube_position(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.assertEqual("LHS", self.resolve._tgt_cube_position)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.assertEqual("RHS", self.resolve._tgt_cube_position)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._tgt_cube_position
+
+
+class Test__tgt_cube_resolved__getter(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve.rhs_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve._tgt_cube_resolved)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve.lhs_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve._tgt_cube_resolved)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._tgt_cube_resolved
+
+
+class Test__tgt_cube_resolved__setter(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.expected = sentinel.cube
+
+    def test_rhs_cube(self):
+        self.resolve.map_rhs_to_lhs = False
+        self.resolve._tgt_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve.rhs_cube_resolved)
+
+    def test_lhs_cube(self):
+        self.resolve.map_rhs_to_lhs = True
+        self.resolve._tgt_cube_resolved = self.expected
+        self.assertEqual(self.expected, self.resolve.lhs_cube_resolved)
+
+    def test_fail__no_map_rhs_to_lhs(self):
+        with self.assertRaises(AssertionError):
+            self.resolve._tgt_cube_resolved = self.expected
+
+
+class Test__as_compatible_cubes(tests.IrisTest):
+    pass
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -1520,5 +1520,9 @@ class Test__as_compatible_cubes(tests.IrisTest):
     pass
 
 
+class Test__metadata_mapping(tests.IrisTest):
+    pass
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -15,15 +15,21 @@ import iris.tests as tests
 import unittest.mock as mock
 from unittest.mock import sentinel
 
-from iris.common.resolve import Resolve
+from iris.common.resolve import (
+    Resolve,
+    _AuxCoverage,
+    _CategoryItems,
+    _DimCoverage,
+    _Item,
+)
 from iris.cube import Cube
 
 
 class Test___init__(tests.IrisTest):
     def setUp(self):
         target = "iris.common.resolve.Resolve.__call__"
-        self.mcall = mock.MagicMock(return_value=sentinel.return_value)
-        _ = self.patch(target, new=self.mcall)
+        self.m_call = mock.MagicMock(return_value=sentinel.return_value)
+        _ = self.patch(target, new=self.m_call)
 
     def _assert_members_none(self, resolve):
         self.assertIsNone(resolve.lhs_cube_resolved)
@@ -48,81 +54,656 @@ class Test___init__(tests.IrisTest):
         self.assertIsNone(resolve.lhs_cube)
         self.assertIsNone(resolve.rhs_cube)
         self._assert_members_none(resolve)
-        self.assertEqual(self.mcall.call_count, 0)
+        self.assertEqual(0, self.m_call.call_count)
 
     def test_lhs_rhs_provided(self):
-        lhs = sentinel.lhs
-        rhs = sentinel.rhs
-        resolve = Resolve(lhs=lhs, rhs=rhs)
+        m_lhs = sentinel.lhs
+        m_rhs = sentinel.rhs
+        resolve = Resolve(lhs=m_lhs, rhs=m_rhs)
+        # The lhs_cube and rhs_cube are only None due
+        # to __call__ being mocked. See Test___call__
+        # for appropriate test coverage.
         self.assertIsNone(resolve.lhs_cube)
         self.assertIsNone(resolve.rhs_cube)
         self._assert_members_none(resolve)
-        self.assertEqual(self.mcall.call_count, 1)
-        call_args = mock.call(lhs, rhs)
-        self.assertEqual(self.mcall.call_args, call_args)
+        self.assertEqual(1, self.m_call.call_count)
+        call_args = mock.call(m_lhs, m_rhs)
+        self.assertEqual(call_args, self.m_call.call_args)
 
 
 class Test___call__(tests.IrisTest):
     def setUp(self):
-        self.lhs = mock.MagicMock(spec=Cube)
-        self.rhs = mock.MagicMock(spec=Cube)
+        self.m_lhs = mock.MagicMock(spec=Cube)
+        self.m_rhs = mock.MagicMock(spec=Cube)
         target = "iris.common.resolve.Resolve.{method}"
         method = target.format(method="_metadata_resolve")
-        self.metadata_resolve = self.patch(method)
+        self.m_metadata_resolve = self.patch(method)
         method = target.format(method="_metadata_coverage")
-        self.metadata_coverage = self.patch(method)
+        self.m_metadata_coverage = self.patch(method)
         method = target.format(method="_metadata_mapping")
-        self.metadata_mapping = self.patch(method)
+        self.m_metadata_mapping = self.patch(method)
         method = target.format(method="_metadata_prepare")
-        self.metadata_prepare = self.patch(method)
+        self.m_metadata_prepare = self.patch(method)
 
     def test_lhs_not_cube(self):
         emsg = "'LHS' argument to be a 'Cube'"
         with self.assertRaisesRegex(TypeError, emsg):
-            _ = Resolve(rhs=self.rhs)
+            _ = Resolve(rhs=self.m_rhs)
 
     def test_rhs_not_cube(self):
         emsg = "'RHS' argument to be a 'Cube'"
         with self.assertRaisesRegex(TypeError, emsg):
-            _ = Resolve(lhs=self.lhs)
+            _ = Resolve(lhs=self.m_lhs)
 
     def _assert_called_metadata_methods(self):
         call_args = mock.call()
-        self.assertEqual(self.metadata_resolve.call_count, 1)
-        self.assertEqual(self.metadata_resolve.call_args, call_args)
-        self.assertEqual(self.metadata_coverage.call_count, 1)
-        self.assertEqual(self.metadata_coverage.call_args, call_args)
-        self.assertEqual(self.metadata_mapping.call_count, 1)
-        self.assertEqual(self.metadata_mapping.call_args, call_args)
-        self.assertEqual(self.metadata_prepare.call_count, 1)
-        self.assertEqual(self.metadata_prepare.call_args, call_args)
+        self.assertEqual(1, self.m_metadata_resolve.call_count)
+        self.assertEqual(call_args, self.m_metadata_resolve.call_args)
+        self.assertEqual(1, self.m_metadata_coverage.call_count)
+        self.assertEqual(call_args, self.m_metadata_coverage.call_args)
+        self.assertEqual(1, self.m_metadata_mapping.call_count)
+        self.assertEqual(call_args, self.m_metadata_mapping.call_args)
+        self.assertEqual(1, self.m_metadata_prepare.call_count)
+        self.assertEqual(call_args, self.m_metadata_prepare.call_args)
 
     def test_map_rhs_to_lhs__less_than(self):
-        self.lhs.ndim = 2
-        self.rhs.ndim = 1
-        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
-        self.assertEqual(resolve.lhs_cube, self.lhs)
-        self.assertEqual(resolve.rhs_cube, self.rhs)
+        self.m_lhs.ndim = 2
+        self.m_rhs.ndim = 1
+        resolve = Resolve(lhs=self.m_lhs, rhs=self.m_rhs)
+        self.assertEqual(self.m_lhs, resolve.lhs_cube)
+        self.assertEqual(self.m_rhs, resolve.rhs_cube)
         self.assertTrue(resolve.map_rhs_to_lhs)
         self._assert_called_metadata_methods()
 
     def test_map_rhs_to_lhs__equal(self):
-        self.lhs.ndim = 2
-        self.rhs.ndim = 2
-        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
-        self.assertEqual(resolve.lhs_cube, self.lhs)
-        self.assertEqual(resolve.rhs_cube, self.rhs)
+        self.m_lhs.ndim = 2
+        self.m_rhs.ndim = 2
+        resolve = Resolve(lhs=self.m_lhs, rhs=self.m_rhs)
+        self.assertEqual(self.m_lhs, resolve.lhs_cube)
+        self.assertEqual(self.m_rhs, resolve.rhs_cube)
         self.assertTrue(resolve.map_rhs_to_lhs)
         self._assert_called_metadata_methods()
 
-    def test_map_lhs_to_rhs__equal(self):
-        self.lhs.ndim = 2
-        self.rhs.ndim = 3
-        resolve = Resolve(lhs=self.lhs, rhs=self.rhs)
-        self.assertEqual(resolve.lhs_cube, self.lhs)
-        self.assertEqual(resolve.rhs_cube, self.rhs)
+    def test_map_lhs_to_rhs(self):
+        self.m_lhs.ndim = 2
+        self.m_rhs.ndim = 3
+        resolve = Resolve(lhs=self.m_lhs, rhs=self.m_rhs)
+        self.assertEqual(self.m_lhs, resolve.lhs_cube)
+        self.assertEqual(self.m_rhs, resolve.rhs_cube)
         self.assertFalse(resolve.map_rhs_to_lhs)
         self._assert_called_metadata_methods()
+
+
+class Test__categorise_items(tests.IrisTest):
+    def setUp(self):
+        self.coord_dims = {}
+        # configure dim coords
+        coord = mock.Mock(metadata=sentinel.dim_metadata1)
+        self.dim_coords = [coord]
+        self.coord_dims[coord] = sentinel.dims1
+        # configure aux and scalar coords
+        self.aux_coords = []
+        pairs = [
+            (sentinel.aux_metadata2, sentinel.dims2),
+            (sentinel.aux_metadata3, sentinel.dims3),
+            (sentinel.scalar_metadata4, None),
+            (sentinel.scalar_metadata5, None),
+            (sentinel.scalar_metadata6, None),
+        ]
+        for metadata, dims in pairs:
+            coord = mock.Mock(metadata=metadata)
+            self.aux_coords.append(coord)
+            self.coord_dims[coord] = dims
+        func = lambda coord: self.coord_dims[coord]
+        self.cube = mock.Mock(
+            aux_coords=self.aux_coords,
+            dim_coords=self.dim_coords,
+            coord_dims=func,
+        )
+
+    def test(self):
+        result = Resolve._categorise_items(self.cube)
+        self.assertIsInstance(result, _CategoryItems)
+        self.assertEqual(1, len(result.items_dim))
+        # check dim coords
+        for item in result.items_dim:
+            self.assertIsInstance(item, _Item)
+        (coord,) = self.dim_coords
+        dims = self.coord_dims[coord]
+        expected = [_Item(metadata=coord.metadata, coord=coord, dims=dims)]
+        self.assertEqual(expected, result.items_dim)
+        # check aux coords
+        self.assertEqual(2, len(result.items_aux))
+        for item in result.items_aux:
+            self.assertIsInstance(item, _Item)
+        expected_aux, expected_scalar = [], []
+        for coord in self.aux_coords:
+            dims = self.coord_dims[coord]
+            item = _Item(metadata=coord.metadata, coord=coord, dims=dims)
+            if dims:
+                expected_aux.append(item)
+            else:
+                expected_scalar.append(item)
+        self.assertEqual(expected_aux, result.items_aux)
+        # check scalar coords
+        self.assertEqual(3, len(result.items_scalar))
+        for item in result.items_scalar:
+            self.assertIsInstance(item, _Item)
+        self.assertEqual(expected_scalar, result.items_scalar)
+
+
+class Test__metadata_resolve(tests.IrisTest):
+    def setUp(self):
+        self.target = "iris.common.resolve.Resolve._categorise_items"
+        self.m_lhs_cube = sentinel.lhs_cube
+        self.m_rhs_cube = sentinel.rhs_cube
+
+    @staticmethod
+    def _create_items(pairs):
+        # this wrapper (hack) is necessary in order to support mocking
+        # the "name" method (callable) of the metadata, as "name" is already
+        # part of the mock API - this is always troublesome in mock-world.
+        from collections import namedtuple
+
+        Wrapper = namedtuple("Wrapper", ("name", "value"))
+        result = []
+        for name, dims in pairs:
+            metadata = Wrapper(name=lambda: str(name), value=name)
+            coord = mock.Mock(metadata=metadata)
+            item = _Item(metadata=metadata, coord=coord, dims=dims)
+            result.append(item)
+        return result
+
+    def test_metadata_same(self):
+        category = _CategoryItems(items_dim=[], items_aux=[], items_scalar=[])
+        # configure dim coords
+        pairs = [(sentinel.dim_metadata1, sentinel.dims1)]
+        category.items_dim.extend(self._create_items(pairs))
+        # configure aux coords
+        pairs = [
+            (sentinel.aux_metadata1, sentinel.dims2),
+            (sentinel.aux_metadata2, sentinel.dims3),
+        ]
+        category.items_aux.extend(self._create_items(pairs))
+        # configure scalar coords
+        pairs = [
+            (sentinel.scalar_metadata1, None),
+            (sentinel.scalar_metadata2, None),
+            (sentinel.scalar_metadata3, None),
+        ]
+        category.items_scalar.extend(self._create_items(pairs))
+
+        side_effect = (category, category)
+        mocker = self.patch(self.target, side_effect=side_effect)
+
+        resolve = Resolve()
+        self.assertIsNone(resolve.lhs_cube)
+        self.assertIsNone(resolve.rhs_cube)
+        self.assertIsNone(resolve.lhs_cube_category)
+        self.assertIsNone(resolve.rhs_cube_category)
+        self.assertIsNone(resolve.lhs_cube_category_local)
+        self.assertIsNone(resolve.rhs_cube_category_local)
+        self.assertIsNone(resolve.category_common)
+
+        # require to explicitly configure cubes
+        resolve.lhs_cube = self.m_lhs_cube
+        resolve.rhs_cube = self.m_rhs_cube
+        resolve._metadata_resolve()
+
+        self.assertEqual(mocker.call_count, 2)
+        calls = [mock.call(self.m_lhs_cube), mock.call(self.m_rhs_cube)]
+        self.assertEqual(calls, mocker.call_args_list)
+
+        self.assertEqual(category, resolve.lhs_cube_category)
+        self.assertEqual(category, resolve.rhs_cube_category)
+        expected = _CategoryItems(items_dim=[], items_aux=[], items_scalar=[])
+        self.assertEqual(expected, resolve.lhs_cube_category_local)
+        self.assertEqual(expected, resolve.rhs_cube_category_local)
+        self.assertEqual(category, resolve.category_common)
+
+    def test_metadata_overlap(self):
+        # configure the lhs cube category
+        category_lhs = _CategoryItems(
+            items_dim=[], items_aux=[], items_scalar=[]
+        )
+        # configure dim coords
+        pairs = [
+            (sentinel.dim_metadata1, sentinel.dims1),
+            (sentinel.dim_metadata2, sentinel.dims2),
+        ]
+        category_lhs.items_dim.extend(self._create_items(pairs))
+        # configure aux coords
+        pairs = [
+            (sentinel.aux_metadata1, sentinel.dims3),
+            (sentinel.aux_metadata2, sentinel.dims4),
+        ]
+        category_lhs.items_aux.extend(self._create_items(pairs))
+        # configure scalar coords
+        pairs = [
+            (sentinel.scalar_metadata1, None),
+            (sentinel.scalar_metadata2, None),
+        ]
+        category_lhs.items_scalar.extend(self._create_items(pairs))
+
+        # configure the rhs cube category
+        category_rhs = _CategoryItems(
+            items_dim=[], items_aux=[], items_scalar=[]
+        )
+        # configure dim coords
+        category_rhs.items_dim.append(category_lhs.items_dim[0])
+        pairs = [(sentinel.dim_metadata200, sentinel.dims2)]
+        category_rhs.items_dim.extend(self._create_items(pairs))
+        # configure aux coords
+        category_rhs.items_aux.append(category_lhs.items_aux[0])
+        pairs = [(sentinel.aux_metadata200, sentinel.dims4)]
+        category_rhs.items_aux.extend(self._create_items(pairs))
+        # configure scalar coords
+        category_rhs.items_scalar.append(category_lhs.items_scalar[0])
+        pairs = [(sentinel.scalar_metadata200, None)]
+        category_rhs.items_scalar.extend(self._create_items(pairs))
+
+        side_effect = (category_lhs, category_rhs)
+        mocker = self.patch(self.target, side_effect=side_effect)
+
+        resolve = Resolve()
+        self.assertIsNone(resolve.lhs_cube)
+        self.assertIsNone(resolve.rhs_cube)
+        self.assertIsNone(resolve.lhs_cube_category)
+        self.assertIsNone(resolve.rhs_cube_category)
+        self.assertIsNone(resolve.lhs_cube_category_local)
+        self.assertIsNone(resolve.rhs_cube_category_local)
+        self.assertIsNone(resolve.category_common)
+
+        # require to explicitly configure cubes
+        resolve.lhs_cube = self.m_lhs_cube
+        resolve.rhs_cube = self.m_rhs_cube
+        resolve._metadata_resolve()
+
+        self.assertEqual(2, mocker.call_count)
+        calls = [mock.call(self.m_lhs_cube), mock.call(self.m_rhs_cube)]
+        self.assertEqual(calls, mocker.call_args_list)
+
+        self.assertEqual(category_lhs, resolve.lhs_cube_category)
+        self.assertEqual(category_rhs, resolve.rhs_cube_category)
+
+        items_dim = [category_lhs.items_dim[1]]
+        items_aux = [category_lhs.items_aux[1]]
+        items_scalar = [category_lhs.items_scalar[1]]
+        expected = _CategoryItems(
+            items_dim=items_dim, items_aux=items_aux, items_scalar=items_scalar
+        )
+        self.assertEqual(expected, resolve.lhs_cube_category_local)
+
+        items_dim = [category_rhs.items_dim[1]]
+        items_aux = [category_rhs.items_aux[1]]
+        items_scalar = [category_rhs.items_scalar[1]]
+        expected = _CategoryItems(
+            items_dim=items_dim, items_aux=items_aux, items_scalar=items_scalar
+        )
+        self.assertEqual(expected, resolve.rhs_cube_category_local)
+
+        items_dim = [category_lhs.items_dim[0]]
+        items_aux = [category_lhs.items_aux[0]]
+        items_scalar = [category_lhs.items_scalar[0]]
+        expected = _CategoryItems(
+            items_dim=items_dim, items_aux=items_aux, items_scalar=items_scalar
+        )
+        self.assertEqual(expected, resolve.category_common)
+
+    def test_metadata_different(self):
+        # configure the lhs cube category
+        category_lhs = _CategoryItems(
+            items_dim=[], items_aux=[], items_scalar=[]
+        )
+        # configure dim coords
+        pairs = [
+            (sentinel.dim_metadata1, sentinel.dims1),
+            (sentinel.dim_metadata2, sentinel.dims2),
+        ]
+        category_lhs.items_dim.extend(self._create_items(pairs))
+        # configure aux coords
+        pairs = [
+            (sentinel.aux_metadata1, sentinel.dims3),
+            (sentinel.aux_metadata2, sentinel.dims4),
+        ]
+        category_lhs.items_aux.extend(self._create_items(pairs))
+        # configure scalar coords
+        pairs = [
+            (sentinel.scalar_metadata1, None),
+            (sentinel.scalar_metadata2, None),
+        ]
+        category_lhs.items_scalar.extend(self._create_items(pairs))
+
+        # configure the rhs cube category
+        category_rhs = _CategoryItems(
+            items_dim=[], items_aux=[], items_scalar=[]
+        )
+        # configure dim coords
+        pairs = [
+            (sentinel.dim_metadata100, sentinel.dims1),
+            (sentinel.dim_metadata200, sentinel.dims2),
+        ]
+        category_rhs.items_dim.extend(self._create_items(pairs))
+        # configure aux coords
+        pairs = [
+            (sentinel.aux_metadata100, sentinel.dims3),
+            (sentinel.aux_metadata200, sentinel.dims4),
+        ]
+        category_rhs.items_aux.extend(self._create_items(pairs))
+        # configure scalar coords
+        pairs = [
+            (sentinel.scalar_metadata100, None),
+            (sentinel.scalar_metadata200, None),
+        ]
+        category_rhs.items_scalar.extend(self._create_items(pairs))
+
+        side_effect = (category_lhs, category_rhs)
+        mocker = self.patch(self.target, side_effect=side_effect)
+
+        resolve = Resolve()
+        self.assertIsNone(resolve.lhs_cube)
+        self.assertIsNone(resolve.rhs_cube)
+        self.assertIsNone(resolve.lhs_cube_category)
+        self.assertIsNone(resolve.rhs_cube_category)
+        self.assertIsNone(resolve.lhs_cube_category_local)
+        self.assertIsNone(resolve.rhs_cube_category_local)
+        self.assertIsNone(resolve.category_common)
+
+        # first require to explicitly lhs/rhs configure cubes
+        resolve.lhs_cube = self.m_lhs_cube
+        resolve.rhs_cube = self.m_rhs_cube
+        resolve._metadata_resolve()
+
+        self.assertEqual(2, mocker.call_count)
+        calls = [mock.call(self.m_lhs_cube), mock.call(self.m_rhs_cube)]
+        self.assertEqual(calls, mocker.call_args_list)
+
+        self.assertEqual(category_lhs, resolve.lhs_cube_category)
+        self.assertEqual(category_rhs, resolve.rhs_cube_category)
+        self.assertEqual(category_lhs, resolve.lhs_cube_category_local)
+        self.assertEqual(category_rhs, resolve.rhs_cube_category_local)
+        expected = _CategoryItems(items_dim=[], items_aux=[], items_scalar=[])
+        self.assertEqual(expected, resolve.category_common)
+
+
+class Test__dim_coverage(tests.IrisTest):
+    def setUp(self):
+        self.ndim = 4
+        self.cube = mock.Mock(ndim=self.ndim)
+        self.items = []
+        parts = [
+            (sentinel.metadata0, sentinel.coord0, (0,)),
+            (sentinel.metadata1, sentinel.coord1, (1,)),
+            (sentinel.metadata2, sentinel.coord2, (2,)),
+            (sentinel.metadata3, sentinel.coord3, (3,)),
+        ]
+        column_parts = [x for x in zip(*parts)]
+        self.metadata, self.coords, self.dims = [list(x) for x in column_parts]
+        self.dims = [dim for dim, in self.dims]
+        for metadata, coord, dims in parts:
+            item = _Item(metadata=metadata, coord=coord, dims=dims)
+            self.items.append(item)
+
+    def test_coverage_no_local_no_common_all_free(self):
+        items = []
+        common = []
+        result = Resolve._dim_coverage(self.cube, items, common)
+        self.assertIsInstance(result, _DimCoverage)
+        self.assertEqual(self.cube, result.cube)
+        expected = [None] * self.ndim
+        self.assertEqual(expected, result.metadata)
+        self.assertEqual(expected, result.coords)
+        self.assertEqual([], result.dims_common)
+        self.assertEqual([], result.dims_local)
+        expected = list(range(self.ndim))
+        self.assertEqual(expected, result.dims_free)
+
+    def test_coverage_all_local_no_common_no_free(self):
+        common = []
+        result = Resolve._dim_coverage(self.cube, self.items, common)
+        self.assertIsInstance(result, _DimCoverage)
+        self.assertEqual(self.cube, result.cube)
+        self.assertEqual(self.metadata, result.metadata)
+        self.assertEqual(self.coords, result.coords)
+        self.assertEqual([], result.dims_common)
+        self.assertEqual(self.dims, result.dims_local)
+        self.assertEqual([], result.dims_free)
+
+    def test_coverage_no_local_all_common_no_free(self):
+        result = Resolve._dim_coverage(self.cube, self.items, self.metadata)
+        self.assertIsInstance(result, _DimCoverage)
+        self.assertEqual(self.cube, result.cube)
+        self.assertEqual(self.metadata, result.metadata)
+        self.assertEqual(self.coords, result.coords)
+        self.assertEqual(self.dims, result.dims_common)
+        self.assertEqual([], result.dims_local)
+        self.assertEqual([], result.dims_free)
+
+    def test_coverage_mixed(self):
+        common = [self.items[1].metadata, self.items[2].metadata]
+        self.items.pop(0)
+        self.items.pop(-1)
+        metadata, coord, dims = sentinel.metadata100, sentinel.coord100, (0,)
+        self.items.append(_Item(metadata=metadata, coord=coord, dims=dims))
+        result = Resolve._dim_coverage(self.cube, self.items, common)
+        self.assertIsInstance(result, _DimCoverage)
+        self.assertEqual(self.cube, result.cube)
+        expected = [
+            metadata,
+            self.items[0].metadata,
+            self.items[1].metadata,
+            None,
+        ]
+        self.assertEqual(expected, result.metadata)
+        expected = [coord, self.items[0].coord, self.items[1].coord, None]
+        self.assertEqual(expected, result.coords)
+        self.assertEqual([1, 2], result.dims_common)
+        self.assertEqual([0], result.dims_local)
+        self.assertEqual([3], result.dims_free)
+
+
+class Test__aux_coverage(tests.IrisTest):
+    def setUp(self):
+        self.ndim = 4
+        self.cube = mock.Mock(ndim=self.ndim)
+        # configure aux coords
+        self.items_aux = []
+        aux_parts = [
+            (sentinel.aux_metadata0, sentinel.aux_coord0, (0,)),
+            (sentinel.aux_metadata1, sentinel.aux_coord1, (1,)),
+            (sentinel.aux_metadata23, sentinel.aux_coord23, (2, 3)),
+        ]
+        column_aux_parts = [x for x in zip(*aux_parts)]
+        self.aux_metadata, self.aux_coords, self.aux_dims = [
+            list(x) for x in column_aux_parts
+        ]
+        for metadata, coord, dims in aux_parts:
+            item = _Item(metadata=metadata, coord=coord, dims=dims)
+            self.items_aux.append(item)
+        # configure scalar coords
+        self.items_scalar = []
+        scalar_parts = [
+            (sentinel.scalar_metadata0, sentinel.scalar_coord0, ()),
+            (sentinel.scalar_metadata1, sentinel.scalar_coord1, ()),
+            (sentinel.scalar_metadata2, sentinel.scalar_coord2, ()),
+        ]
+        column_scalar_parts = [x for x in zip(*scalar_parts)]
+        self.scalar_metadata, self.scalar_coords, self.scalar_dims = [
+            list(x) for x in column_scalar_parts
+        ]
+        for metadata, coord, dims in scalar_parts:
+            item = _Item(metadata=metadata, coord=coord, dims=dims)
+            self.items_scalar.append(item)
+
+    def test_coverage_no_local_no_common_all_free(self):
+        items_aux, items_scalar = [], []
+        common_aux, common_scalar = [], []
+        result = Resolve._aux_coverage(
+            self.cube, items_aux, items_scalar, common_aux, common_scalar
+        )
+        self.assertIsInstance(result, _AuxCoverage)
+        self.assertEqual(self.cube, result.cube)
+        self.assertEqual([], result.common_items_aux)
+        self.assertEqual([], result.common_items_scalar)
+        self.assertEqual([], result.local_items_aux)
+        self.assertEqual([], result.local_items_scalar)
+        self.assertEqual([], result.dims_common)
+        self.assertEqual([], result.dims_local)
+        expected = list(range(self.ndim))
+        self.assertEqual(expected, result.dims_free)
+
+    def test_coverage_all_local_no_common_no_free(self):
+        common_aux, common_scalar = [], []
+        result = Resolve._aux_coverage(
+            self.cube,
+            self.items_aux,
+            self.items_scalar,
+            common_aux,
+            common_scalar,
+        )
+        self.assertIsInstance(result, _AuxCoverage)
+        self.assertEqual(self.cube, result.cube)
+        expected = []
+        self.assertEqual(expected, result.common_items_aux)
+        self.assertEqual(expected, result.common_items_scalar)
+        self.assertEqual(self.items_aux, result.local_items_aux)
+        self.assertEqual(self.items_scalar, result.local_items_scalar)
+        self.assertEqual([], result.dims_common)
+        expected = list(range(self.ndim))
+        self.assertEqual(expected, result.dims_local)
+        self.assertEqual([], result.dims_free)
+
+    def test_coverage_no_local_all_common_no_free(self):
+        result = Resolve._aux_coverage(
+            self.cube,
+            self.items_aux,
+            self.items_scalar,
+            self.aux_metadata,
+            self.scalar_metadata,
+        )
+        self.assertIsInstance(result, _AuxCoverage)
+        self.assertEqual(self.cube, result.cube)
+        self.assertEqual(self.items_aux, result.common_items_aux)
+        self.assertEqual(self.items_scalar, result.common_items_scalar)
+        self.assertEqual([], result.local_items_aux)
+        self.assertEqual([], result.local_items_scalar)
+        expected = list(range(self.ndim))
+        self.assertEqual(expected, result.dims_common)
+        self.assertEqual([], result.dims_local)
+        self.assertEqual([], result.dims_free)
+
+    def test_coverage_mixed(self):
+        common_aux = [self.items_aux[-1].metadata]
+        common_scalar = [self.items_scalar[1].metadata]
+        self.items_aux.pop(1)
+        result = Resolve._aux_coverage(
+            self.cube,
+            self.items_aux,
+            self.items_scalar,
+            common_aux,
+            common_scalar,
+        )
+        self.assertIsInstance(result, _AuxCoverage)
+        self.assertEqual(self.cube, result.cube)
+        expected = [self.items_aux[-1]]
+        self.assertEqual(expected, result.common_items_aux)
+        expected = [self.items_scalar[1]]
+        self.assertEqual(expected, result.common_items_scalar)
+        expected = [self.items_aux[0]]
+        self.assertEqual(expected, result.local_items_aux)
+        expected = [self.items_scalar[0], self.items_scalar[2]]
+        self.assertEqual(expected, result.local_items_scalar)
+        self.assertEqual([2, 3], result.dims_common)
+        self.assertEqual([0], result.dims_local)
+        self.assertEqual([1], result.dims_free)
+
+
+class Test__metadata_coverage(tests.IrisTest):
+    def setUp(self):
+        self.resolve = Resolve()
+        self.m_lhs_cube = sentinel.lhs_cube
+        self.resolve.lhs_cube = self.m_lhs_cube
+        self.m_rhs_cube = sentinel.rhs_cube
+        self.resolve.rhs_cube = self.m_rhs_cube
+        self.m_items_dim_metadata = sentinel.items_dim_metadata
+        self.m_items_aux_metadata = sentinel.items_aux_metadata
+        self.m_items_scalar_metadata = sentinel.items_scalar_metadata
+        items_dim = [mock.Mock(metadata=self.m_items_dim_metadata)]
+        items_aux = [mock.Mock(metadata=self.m_items_aux_metadata)]
+        items_scalar = [mock.Mock(metadata=self.m_items_scalar_metadata)]
+        category = _CategoryItems(
+            items_dim=items_dim, items_aux=items_aux, items_scalar=items_scalar
+        )
+        self.resolve.category_common = category
+        self.m_items_dim = sentinel.items_dim
+        self.m_items_aux = sentinel.items_aux
+        self.m_items_scalar = sentinel.items_scalar
+        category = _CategoryItems(
+            items_dim=self.m_items_dim,
+            items_aux=self.m_items_aux,
+            items_scalar=self.m_items_scalar,
+        )
+        self.resolve.lhs_cube_category = category
+        self.resolve.rhs_cube_category = category
+        target = "iris.common.resolve.Resolve._dim_coverage"
+        self.m_lhs_cube_dim_coverage = sentinel.lhs_cube_dim_coverage
+        self.m_rhs_cube_dim_coverage = sentinel.rhs_cube_dim_coverage
+        side_effect = (
+            self.m_lhs_cube_dim_coverage,
+            self.m_rhs_cube_dim_coverage,
+        )
+        self.mocker_dim_coverage = self.patch(target, side_effect=side_effect)
+        target = "iris.common.resolve.Resolve._aux_coverage"
+        self.m_lhs_cube_aux_coverage = sentinel.lhs_cube_aux_coverage
+        self.m_rhs_cube_aux_coverage = sentinel.rhs_cube_aux_coverage
+        side_effect = (
+            self.m_lhs_cube_aux_coverage,
+            self.m_rhs_cube_aux_coverage,
+        )
+        self.mocker_aux_coverage = self.patch(target, side_effect=side_effect)
+
+    def test(self):
+        self.resolve._metadata_coverage()
+        self.assertEqual(2, self.mocker_dim_coverage.call_count)
+        calls = [
+            mock.call(
+                self.m_lhs_cube, self.m_items_dim, [self.m_items_dim_metadata]
+            ),
+            mock.call(
+                self.m_rhs_cube, self.m_items_dim, [self.m_items_dim_metadata]
+            ),
+        ]
+        self.assertEqual(calls, self.mocker_dim_coverage.call_args_list)
+        self.assertEqual(2, self.mocker_aux_coverage.call_count)
+        calls = [
+            mock.call(
+                self.m_lhs_cube,
+                self.m_items_aux,
+                self.m_items_scalar,
+                [self.m_items_aux_metadata],
+                [self.m_items_scalar_metadata],
+            ),
+            mock.call(
+                self.m_rhs_cube,
+                self.m_items_aux,
+                self.m_items_scalar,
+                [self.m_items_aux_metadata],
+                [self.m_items_scalar_metadata],
+            ),
+        ]
+        self.assertEqual(calls, self.mocker_aux_coverage.call_args_list)
+        self.assertEqual(
+            self.m_lhs_cube_dim_coverage, self.resolve.lhs_cube_dim_coverage
+        )
+        self.assertEqual(
+            self.m_rhs_cube_dim_coverage, self.resolve.rhs_cube_dim_coverage
+        )
+        self.assertEqual(
+            self.m_lhs_cube_aux_coverage, self.resolve.lhs_cube_aux_coverage
+        )
+        self.assertEqual(
+            self.m_rhs_cube_aux_coverage, self.resolve.rhs_cube_aux_coverage
+        )
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -817,6 +817,20 @@ class Test__aux_mapping(tests.IrisTest):
             ),
         ]
 
+    def _copy(self, items):
+        # Due to a bug in python 3.6.x, performing a deepcopy of a mock.sentinel
+        # will yield an object that is not equivalent to its parent, so this
+        # is a work-around until we drop support for python 3.6.x.
+        import sys
+
+        version = sys.version_info
+        major, minor = version.major, version.minor
+        result = deepcopy(items)
+        if major == 3 and minor <= 6:
+            for i, item in enumerate(items):
+                result[i] = result[i]._replace(metadata=item.metadata)
+        return result
+
     def test_no_mapping(self):
         result = Resolve._aux_mapping(self.src_coverage, self.tgt_coverage)
         self.assertEqual(dict(), result)
@@ -830,7 +844,7 @@ class Test__aux_mapping(tests.IrisTest):
 
     def test_transpose_mapping(self):
         self.src_coverage.common_items_aux.extend(self.items)
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         items[0].dims[0] = 2
         items[2].dims[0] = 0
         self.tgt_coverage.common_items_aux.extend(items)
@@ -841,7 +855,7 @@ class Test__aux_mapping(tests.IrisTest):
     def test_partial_mapping__transposed(self):
         _ = self.items.pop(1)
         self.src_coverage.common_items_aux.extend(self.items)
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         items[0].dims[0] = 2
         items[1].dims[0] = 0
         self.tgt_coverage.common_items_aux.extend(items)
@@ -850,7 +864,7 @@ class Test__aux_mapping(tests.IrisTest):
         self.assertEqual(expected, result)
 
     def test_mapping__match_multiple_src_metadata(self):
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         _ = self.items.pop(1)
         self.src_coverage.common_items_aux.extend(self.items)
         items[1] = items[0]
@@ -860,7 +874,7 @@ class Test__aux_mapping(tests.IrisTest):
         self.assertEqual(expected, result)
 
     def test_mapping__skip_match_multiple_src_metadata(self):
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         _ = self.items.pop(1)
         self.tgt_coverage.common_items_aux.extend(self.items)
         items[1] = items[0]._replace(dims=[1])
@@ -870,7 +884,7 @@ class Test__aux_mapping(tests.IrisTest):
         self.assertEqual(expected, result)
 
     def test_mapping__skip_different_rank(self):
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         self.src_coverage.common_items_aux.extend(self.items)
         items[2] = items[2]._replace(dims=[1, 2])
         self.tgt_coverage.common_items_aux.extend(items)
@@ -880,7 +894,7 @@ class Test__aux_mapping(tests.IrisTest):
 
     def test_bad_metadata_mapping(self):
         self.src_coverage.common_items_aux.extend(self.items)
-        items = deepcopy(self.items)
+        items = self._copy(self.items)
         items[0] = items[0]._replace(metadata=sentinel.bad)
         self.tgt_coverage.common_items_aux.extend(items)
         emsg = "Failed to map common aux coordinate metadata"

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -3821,5 +3821,43 @@ class Test__prepare_local_payload_scalar(tests.IrisTest):
         self.assertEqual(0, len(self.resolve.prepared_category.items_scalar))
 
 
+class Test__prepare_local_payload(tests.IrisTest):
+    def test(self):
+        src_dim_coverage = sentinel.src_dim_coverage
+        src_aux_coverage = sentinel.src_aux_coverage
+        tgt_dim_coverage = sentinel.tgt_dim_coverage
+        tgt_aux_coverage = sentinel.tgt_aux_coverage
+        prepared_dim = sentinel.prepared_dim
+        prepared_aux = sentinel.prepared_aux
+        prepared_scalar = sentinel.prepared_scalar
+        root = "iris.common.resolve.Resolve"
+        m_prepare_dim = self.patch(
+            f"{root}._prepare_local_payload_dim", return_value=prepared_dim
+        )
+        m_prepare_aux = self.patch(
+            f"{root}._prepare_local_payload_aux", return_value=prepared_aux
+        )
+        m_prepare_scalar = self.patch(
+            f"{root}._prepare_local_payload_scalar",
+            return_value=prepared_scalar,
+        )
+        resolve = Resolve()
+        resolve._prepare_local_payload(
+            src_dim_coverage,
+            src_aux_coverage,
+            tgt_dim_coverage,
+            tgt_aux_coverage,
+        )
+        self.assertEqual(1, m_prepare_dim.call_count)
+        expected = [mock.call(src_dim_coverage, tgt_dim_coverage)]
+        self.assertEqual(expected, m_prepare_dim.call_args_list)
+        self.assertEqual(1, m_prepare_aux.call_count)
+        expected = [mock.call(src_aux_coverage, tgt_aux_coverage)]
+        self.assertEqual(expected, m_prepare_aux.call_args_list)
+        self.assertEqual(1, m_prepare_scalar.call_count)
+        expected = [mock.call(src_aux_coverage, tgt_aux_coverage)]
+        self.assertEqual(expected, m_prepare_scalar.call_args_list)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds the missing unit test coverage for the `iris.common.resolve` module.

**To-do**

Unit test coverage is required for the following `iris.common.resolve.Resolve` methods:

- [x] `__init__`
- [x] `__call__`
- [x] `_metadata_resolve`
  - [x] `_categorise_items` 
- [x] `_metadata_coverage`
  - [x] `_dim_coverage`
  - [x] `_aux_coverage` 
- [x] `_metadata_mapping`
  - [x] `_dim_mapping`
  - [x] `_aux_mapping`
  - [x] `_free_mapping` 
  - [x] `_as_compatible_cubes`
- [x] `_metadata_prepare` 
  - [x] `_prepare_common_dim_payload`
  - [x] `_prepare_points_and_bounds`
  - [x] `_prepare_common_aux_payload` 
  - [x] `_prepare_local_payload` 
    - [x] `_create_prepared_item`
    - [x] `_prepare_local_payload_dim` 
    - [x] `_prepare_local_payload_aux` 
    - [x] `_prepare_local_payload_scalar`
  - [x] `_prepare_factory_payload` 
    - [x] `_get_prepared_item` 
- [x] `_src_cube`
- [x] `_src_cube_position`
- [x] `_src_cube_resolved`
- [x] `_tgt_cube`
- [x] `_tgt_cube_position`
- [x] `_tgt_cube_resolved`
- [x] `_tgt_cube_prepare`
- [x] `cube`
- [x] `mapped`
- [x] `shape`

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
