### PR TITLE
Remove warning for convert_units on lazy data

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -981,10 +981,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         celsius and subtract 273.15 from each value in
         :attr:`~iris.cube.Cube.data`.
 
-        .. warning::
-            Calling this method will trigger any deferred loading, causing
-            the cube's data array to be loaded into memory.
-
         """
         # If the cube has units convert the data.
         if self.units.is_unknown():

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -981,6 +981,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         celsius and subtract 273.15 from each value in
         :attr:`~iris.cube.Cube.data`.
 
+        This operation preserves lazy data.
+
         """
         # If the cube has units convert the data.
         if self.units.is_unknown():


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Removed the warning that `Cube.convert_units` will load lazy data.  Looks like this has not been true since #2964.

```python
In [1]: import iris

In [2]: import dask.array as da

In [3]: import numpy as np

In [4]: cube = iris.cube.Cube(da.from_array(np.arange(5)), units='m')

In [5]: cube.has_lazy_data()
Out[5]: True

In [6]: cube.convert_units('feet')

In [7]: cube.has_lazy_data()
Out[7]: True
```
Since the change is tiny, I'm targeting the v3 branch.  Happy to switch to `master` though.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
