### PR TITLE
drop stickler references in docs

### DIFF
--- a/docs/iris/src/common_links.inc
+++ b/docs/iris/src/common_links.inc
@@ -14,7 +14,6 @@
 .. _readthedocs.yml: https://github.com/SciTools/iris/blob/master/requirements/ci/readthedocs.yml
 .. _travis-ci: https://travis-ci.org/github/SciTools/iris
 .. _.travis.yml: https://github.com/SciTools/iris/blob/master/.travis.yml
-.. _.stickler.yml: https://github.com/SciTools/iris/blob/master/.stickler.yml
 .. _.flake8.yml: https://github.com/SciTools/iris/blob/master/.flake8
 .. _GitHub Help Documentation: https://docs.github.com/en/github
 .. _using git: https://docs.github.com/en/github/using-git

--- a/docs/iris/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/iris/src/developers_guide/contributing_ci_tests.rst
@@ -11,7 +11,6 @@ Iris **master**.  The checks performed are:
 
 * :ref:`testing_cla`
 * :ref:`testing_travis`
-* :ref:`testing_stickler`
 
 
 .. _testing_cla:
@@ -22,16 +21,6 @@ SciTools CLA Checker
 A bot that checks the user who created the pull request has signed the
 **Contributor's License Agreement (CLA)**.  For more information on this this
 please see https://scitools.org.uk/organisation.html#governance
-
-
-.. _testing_stickler:
-
-Stickler CI
-***********
-
-Automatically enforces coding standards.  The configuration file named
-`.stickler.yml`_ is in the Iris_ root directory.  For more information see
-https://stickler-ci.com/.
 
 
 .. _testing_travis:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Remove references to `stickler-ci` in the documentation.

See #3928, where `sticker-ci` was dropped as a service, and replaced by use of a dedicated `nox` session.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
