### PR TITLE
update docs for travis-ci to cirrus-ci

### DIFF
--- a/docs/iris/src/common_links.inc
+++ b/docs/iris/src/common_links.inc
@@ -12,8 +12,8 @@
 .. _iris-sample-data: https://github.com/SciTools/iris-sample-data
 .. _test-iris-imagehash: https://github.com/SciTools/test-iris-imagehash
 .. _readthedocs.yml: https://github.com/SciTools/iris/blob/master/requirements/ci/readthedocs.yml
-.. _travis-ci: https://travis-ci.org/github/SciTools/iris
-.. _.travis.yml: https://github.com/SciTools/iris/blob/master/.travis.yml
+.. _cirrus-ci: https://cirrus-ci.com/github/SciTools/iris
+.. _.cirrus.yml: https://github.com/SciTools/iris/blob/master/.cirrus.yml
 .. _.flake8.yml: https://github.com/SciTools/iris/blob/master/.flake8
 .. _GitHub Help Documentation: https://docs.github.com/en/github
 .. _using git: https://docs.github.com/en/github/using-git

--- a/docs/iris/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/iris/src/developers_guide/contributing_ci_tests.rst
@@ -10,7 +10,7 @@ automatically when a pull request is created, updated or merged against
 Iris **master**.  The checks performed are:
 
 * :ref:`testing_cla`
-* :ref:`testing_travis`
+* :ref:`testing_cirrus`
 
 
 .. _testing_cla:
@@ -23,23 +23,23 @@ A bot that checks the user who created the pull request has signed the
 please see https://scitools.org.uk/organisation.html#governance
 
 
-.. _testing_travis:
+.. _testing_cirrus:
 
-Travis-CI
+Cirrus-CI
 *********
 
 The unit and integration tests in Iris are an essential mechanism to ensure
 that the Iris code base is working as expected.  :ref:`developer_running_tests`
 may be run manually but to ensure the checks are performed a
-continuous integration testing tool named `travis-ci`_ is used.
+continuous integration testing tool named `cirrus-ci`_ is used.
 
-A `travis-ci`_ configuration file named `.travis.yml`_
-is in the Iris repository which tells travis-ci what commands to run.  The
+A `cirrus-ci`_ configuration file named `.cirrus.yml`_
+is in the Iris repository which tells Cirrus-CI what commands to run.  The
 commands include retrieving the Iris code base and associated test files using
-conda and then running the tests.  `travis-ci`_ allows for a matrix of tests to
+conda and then running the tests.  `cirrus-ci`_ allows for a matrix of tests to
 be performed to ensure that all expected variations test successfully.
 
-The `travis-ci`_ tests are run automatically against the `Iris`_ master
+The `cirrus-ci`_ tests are run automatically against the `Iris`_ master
 repository when a pull request is submitted, updated or merged.
 
 GitHub Checklist

--- a/docs/iris/src/developers_guide/contributing_documentation.rst
+++ b/docs/iris/src/developers_guide/contributing_documentation.rst
@@ -28,7 +28,7 @@ The build can be run from the documentation directory ``iris/docs/iris/src``.
 
 The build output for the html is found in the ``_build/html`` sub directory.
 When updating the documentation ensure the html build has *no errors* or
-*warnings* otherwise it may fail the automated `travis-ci`_  build.
+*warnings* otherwise it may fail the automated `cirrus-ci`_  build.
 
 Once the build is complete, if it is rerun it will only rebuild the impacted
 build artefacts so should take less time.
@@ -50,7 +50,7 @@ This is useful for a final test before committing your changes.
           have been promoted to be **errors** to ensure they are addressed.
           This **only** applies when ``make html`` is run.
 
-.. _travis-ci: https://travis-ci.org/github/SciTools/iris
+.. _cirrus-ci: https://cirrus-ci.com/github/SciTools/iris
 
 .. _contributing.documentation.testing:
 
@@ -99,7 +99,7 @@ or ignore the url.
     ``spelling_word_list_filename``.
 
 
-.. note:: In addition to the automated `travis-ci`_ build of all the
+.. note:: In addition to the automated `cirrus-ci`_ build of all the
           documentation build options above, the
           https://readthedocs.org/ service is also used.  The configuration
           of this held in a file in the root of the

--- a/docs/iris/src/developers_guide/contributing_graphics_tests.rst
+++ b/docs/iris/src/developers_guide/contributing_graphics_tests.rst
@@ -34,7 +34,7 @@ perceived as it may be a simple pixel shift.
 Testing Strategy
 ================
 
-The `Iris Travis matrix`_ defines multiple test runs that use
+The `Iris Cirrus-CI matrix`_ defines multiple test runs that use
 different versions of Python to ensure Iris is working as expected.
 
 To make this manageable, the ``iris.tests.IrisTest_nometa.check_graphic`` test
@@ -155,7 +155,7 @@ To add your changes to Iris, you need to make two pull requests (PR).
 
 .. important::
 
-  The Iris pull-request will not test successfully in Travis until the
+  The Iris pull-request will not test successfully in Cirrus-CI until the
   ``test-iris-imagehash`` pull request has been merged.  This is because there
   is an Iris_ test which ensures the existence of the reference images (uris)
   for all the targets in the image results database.  It will also fail
@@ -163,4 +163,4 @@ To add your changes to Iris, you need to make two pull requests (PR).
   image-listing file in ``test-iris-imagehash``.
 
 
-.. _Iris travis matrix: https://github.com/scitools/iris/blob/master/.travis.yml#L15
+.. _Iris Cirrus-CI matrix: https://github.com/scitools/iris/blob/master/.cirrus.yml

--- a/docs/iris/src/developers_guide/contributing_pull_request_checklist.rst
+++ b/docs/iris/src/developers_guide/contributing_pull_request_checklist.rst
@@ -38,7 +38,7 @@ is merged.  Before submitting a pull request please consider this list.
 #. **Check the documentation builds without warnings or errors**.  See
    :ref:`contributing.documentation.building`
 
-#. **Check for any new dependencies in the** `.travis.yml`_ **config file.**
+#. **Check for any new dependencies in the** `.cirrus.yml`_ **config file.**
 
 #. **Check for any new dependencies in the** `readthedocs.yml`_ **file**.  This
    file is used to build the documentation that is served from

--- a/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/iris/src/developers_guide/documenting/whats_new_contributions.rst
@@ -38,7 +38,7 @@ situation is thought likely (large PR, high repo activity etc.):
 * PR author: create the "What's New" pull request
 
 * PR reviewer: once the "What's New" PR is created, **merge the main PR**.
-  (this will fix any `travis-ci`_ linkcheck errors where the links in the
+  (this will fix any `cirrus-ci`_ linkcheck errors where the links in the
   "What's New" PR reference new features introduced in the main PR)
 
 * PR reviewer: review the "What's New" PR, merge once acceptable
@@ -96,11 +96,11 @@ examine past what's :ref:`iris_whatsnew` entries.
 
 .. note:: The reStructuredText syntax will be checked as part of building
           the documentation.  Any warnings should be corrected.
-          `travis-ci`_ will automatically build the documentation when
+          `cirrus-ci`_ will automatically build the documentation when
           creating a pull request, however you can also manually
           :ref:`build <contributing.documentation.building>` the documentation.
 
-.. _travis-ci: https://travis-ci.org/github/SciTools/iris
+.. _cirrus-ci: https://cirrus-ci.com/github/SciTools/iris
 
 
 Contribution Categories

--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -498,3 +498,4 @@ This document explains the changes made to Iris for this release
 .. _flake8: https://flake8.pycqa.org/en/stable/
 .. _nox: https://nox.thea.codes/en/stable/
 .. _Title Case Capitalization: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case
+.. _travis-ci: https://travis-ci.org/github/SciTools/iris

--- a/docs/iris/src/whatsnew/3.0.rst
+++ b/docs/iris/src/whatsnew/3.0.rst
@@ -442,7 +442,7 @@ This document explains the changes made to Iris for this release
 
 * `@znicholls`_ made :func:`~iris.tests.idiff.step_over_diffs` robust to hyphens (``-``) in the input path (i.e. the ``result_dir`` argument) (:pull:`3902`).
 
-* `@bjlittle`_ migrated the CIaaS from `travis-ci`_ to `cirrus-ci`_. (:pull:`3928`)
+* `@bjlittle`_ migrated the CIaaS from `travis-ci`_ to `cirrus-ci`_, and removed `stickler-ci`_ support. (:pull:`3928`)
 
 * `@bjlittle`_ introduced `nox`_ as a common and easy entry-point for test automation.
   It can be used both from `cirrus-ci`_ in the cloud, and locally by the developer to
@@ -499,3 +499,4 @@ This document explains the changes made to Iris for this release
 .. _nox: https://nox.thea.codes/en/stable/
 .. _Title Case Capitalization: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case
 .. _travis-ci: https://travis-ci.org/github/SciTools/iris
+.. _stickler-ci: https://stickler-ci.com/


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Update the documentation to replace `travis-ci` references with `cirrus-ci`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
