### PR TITLE
Extended the installation description

### DIFF
--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -41,11 +41,39 @@ need the Iris sample data. This can also be installed using conda::
 Further documentation on using conda and the features it provides can be found
 at https://conda.io/en/latest/index.html.
 
+.. _installing_from_source_without_conda:
 
-.. _installing_from_source:
+Installing from source without conda on Debian-based Linux distros (devs)
+-------------------------------------------------------------------------
 
-Installing from source (devs)
------------------------------
+Iris can also be installed without a conda environment. The instructions in
+this section are valid for Debian-based Linux distributions (Debian, Ubuntu, Kubuntu, etc.).
+
+Iris and its dependencies need some shared libraries in order to work properly. These can be installed
+with apt:
+
+  sudo apt-get install python3-pip python3-tk libudunits2-dev libproj-dev proj-bin libgeos-dev libcunit1-dev
+  
+Consider executing
+
+  sudo apt-get update
+  
+before and after installation of Debian packages.
+
+The rest can be done with pip. Begin with numpy:
+
+  pip3 install numpy
+
+Finally, Iris and its Python dependencies can be installed with the following command:
+
+  pip3 install astropy tqdm oktopus bs4 setuptools nc_time_axis cython cfunits cf-units cf-python pandas stratify pyugrid scitools-pyke black imagehash nose asv scitools-iris
+
+This procedure was tested on a Ubuntu 20.04 system on the 26th of January, 2021. Be aware that through updates of the involved Debian and/or Python packages, dependency conflicts might arise or the procedure might have to modified.
+
+.. _installing_from_source_with_conda:
+
+Installing from source with conda (devs)
+----------------------------------------
 
 The latest Iris source release is available from
 https://github.com/SciTools/iris.

--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -70,7 +70,7 @@ Finally, Iris and its Python dependencies can be installed with the following co
 
 This procedure was tested on a Ubuntu 20.04 system on the 26th of January, 2021. Be aware that through updates of the involved Debian and/or Python packages, dependency conflicts might arise or the procedure might have to modified.
 
-.. _installing_from_source_with_conda:
+.. _installing_from_source:
 
 Installing from source with conda (devs)
 ----------------------------------------

--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -50,21 +50,21 @@ Iris can also be installed without a conda environment. The instructions in
 this section are valid for Debian-based Linux distributions (Debian, Ubuntu, Kubuntu, etc.).
 
 Iris and its dependencies need some shared libraries in order to work properly. These can be installed
-with apt:
+with apt::
 
   sudo apt-get install python3-pip python3-tk libudunits2-dev libproj-dev proj-bin libgeos-dev libcunit1-dev
   
-Consider executing
+Consider executing::
 
   sudo apt-get update
   
 before and after installation of Debian packages.
 
-The rest can be done with pip. Begin with numpy:
+The rest can be done with pip. Begin with numpy::
 
   pip3 install numpy
 
-Finally, Iris and its Python dependencies can be installed with the following command:
+Finally, Iris and its Python dependencies can be installed with the following command::
 
   pip3 install astropy tqdm oktopus bs4 setuptools nc_time_axis cython cfunits cf-units cf-python pandas stratify pyugrid scitools-pyke black imagehash nose asv scitools-iris
 

--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -47,9 +47,11 @@ Installing from source without conda on Debian-based Linux distros (devs)
 -------------------------------------------------------------------------
 
 Iris can also be installed without a conda environment. The instructions in
-this section are valid for Debian-based Linux distributions (Debian, Ubuntu, Kubuntu, etc.).
+this section are valid for Debian-based Linux distributions (Debian, Ubuntu,
+Kubuntu, etc.).
 
-Iris and its dependencies need some shared libraries in order to work properly. These can be installed
+Iris and its dependencies need some shared libraries in order to work properly.
+These can be installed
 with apt::
 
   sudo apt-get install python3-pip python3-tk libudunits2-dev libproj-dev proj-bin libgeos-dev libcunit1-dev
@@ -64,11 +66,15 @@ The rest can be done with pip. Begin with numpy::
 
   pip3 install numpy
 
-Finally, Iris and its Python dependencies can be installed with the following command::
+Finally, Iris and its Python dependencies can be installed with the following
+command::
 
   pip3 install astropy tqdm oktopus bs4 setuptools nc_time_axis cython cfunits cf-units cf-python pandas stratify pyugrid scitools-pyke black imagehash nose asv scitools-iris
 
-This procedure was tested on a Ubuntu 20.04 system on the 26th of January, 2021. Be aware that through updates of the involved Debian and/or Python packages, dependency conflicts might arise or the procedure might have to modified.
+This procedure was tested on a Ubuntu 20.04 system on the
+26th of January, 2021.
+Be aware that through updates of the involved Debian and/or Python packages,
+dependency conflicts might arise or the procedure might have to modified.
 
 .. _installing_from_source:
 

--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -69,10 +69,10 @@ The rest can be done with pip. Begin with numpy::
 Finally, Iris and its Python dependencies can be installed with the following
 command::
 
-  pip3 install astropy tqdm oktopus bs4 setuptools nc_time_axis cython cfunits cf-units cf-python pandas stratify pyugrid scitools-pyke black imagehash nose asv scitools-iris
+  pip3 install setuptools cftime==1.2.1 cf-units scitools-pyke scitools-iris
 
 This procedure was tested on a Ubuntu 20.04 system on the
-26th of January, 2021.
+27th of January, 2021.
 Be aware that through updates of the involved Debian and/or Python packages,
 dependency conflicts might arise or the procedure might have to modified.
 

--- a/docs/iris/src/userguide/citation.rst
+++ b/docs/iris/src/userguide/citation.rst
@@ -48,7 +48,7 @@ For example::
 
  Iris. Met Office. git@github.com:SciTools/iris.git 06-03-2013
 
-.. _How to cite and describe software: http://software.ac.uk/so-exactly-what-software-did-you-use
+.. _How to cite and describe software: https://software.ac.uk/how-cite-software
 
 
 Reference: [Jackson]_.

--- a/docs/iris/src/userguide/cube_maths.rst
+++ b/docs/iris/src/userguide/cube_maths.rst
@@ -243,7 +243,7 @@ unit (if ``a`` had units ``'m2'`` then ``a ** 0.5`` would result in a cube
 with units ``'m'``).
 
 Iris inherits units from `cf_units <https://scitools.org.uk/cf-units/docs/latest/>`_
-which in turn inherits from `UDUNITS <https://www.unidata.ucar.edu/software/udunits/udunits-current/doc/udunits/udunits2.html>`_.
+which in turn inherits from `UDUNITS <https://www.unidata.ucar.edu/software/udunits/udunits-current/udunits2.html>`_.
 As well as the units UDUNITS provides, cf units also provides the units
 ``'no-unit'`` and ``'unknown'``. A unit of ``'no-unit'`` means that the
 associated data is not suitable for describing with a unit, cf units

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -68,3 +68,4 @@ This document explains the changes made to Iris for this release
 .. _@trexfeathers: https://github.com/trexfeathers
 .. _@gcaria: https://github.com/gcaria
 .. _@rcomer: https://github.com/rcomer
+.. _@MHBalsmeier: https://github.com/MHBalsmeier

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -53,6 +53,8 @@ This document explains the changes made to Iris for this release
 
 * `@rcomer`_ updated the "Seasonal ensemble model plots" Gallery example.
   (:pull:`3933`)
+* `@MHBalsmeier`_ Described non-conda installation on Debian-based distros.
+  (:pull:`3958`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
As mentioned in Issue 3949, installation of Iris on Ubuntu was very difficult. I described an easy way to install Iris on Ubuntu without conda in the installation file in the documentation.