### PR TITLE
Capitilise installation heading

### DIFF
--- a/docs/iris/src/installing.rst
+++ b/docs/iris/src/installing.rst
@@ -43,8 +43,8 @@ at https://conda.io/en/latest/index.html.
 
 .. _installing_from_source_without_conda:
 
-Installing from source without conda on Debian-based Linux distros (devs)
--------------------------------------------------------------------------
+Installing from Source Without Conda on Debian-Based Linux Distros (Developers)
+-------------------------------------------------------------------------------
 
 Iris can also be installed without a conda environment. The instructions in
 this section are valid for Debian-based Linux distributions (Debian, Ubuntu,
@@ -55,11 +55,11 @@ These can be installed
 with apt::
 
   sudo apt-get install python3-pip python3-tk libudunits2-dev libproj-dev proj-bin libgeos-dev libcunit1-dev
-  
+
 Consider executing::
 
   sudo apt-get update
-  
+
 before and after installation of Debian packages.
 
 The rest can be done with pip. Begin with numpy::


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This is a simple change to capitalise a heading in the Iris installation instructions - aligning the content of #3958 with the changes in #3940 (they are misaligned due to the merge-back timing).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
