### PR TITLE
Connectivity Class (AVD-1595)

### DIFF
--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -182,9 +182,10 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
                     return result
 
                 # Note that, for strict we use "_fields" not "_members".
-                # The "circular" member does not participate in strict equivalence.
+                # The "circular" and "src_dim" members do not participate in strict equivalence.
                 fields = filter(
-                    lambda field: field != "circular", self._fields
+                    lambda field: field not in ("circular", "src_dim"),
+                    self._fields,
                 )
                 result = all([func(field) for field in fields])
 
@@ -882,6 +883,8 @@ class ConnectivityMetadata(BaseMetadata):
 
     """
 
+    # The "src_dim" member is stateful only, and does not participate in
+    # lenient/strict equivalence.
     _members = ("cf_role", "start_index", "src_dim")
 
     __slots__ = ()
@@ -933,11 +936,15 @@ class ConnectivityMetadata(BaseMetadata):
             Boolean.
 
         """
-        # Perform "strict" comparison for "cf_role", "start_index", "src_dim".
+        # Perform "strict" comparison for "cf_role", "start_index".
+        # The "src_dim" member is not part of lenient equivalence.
+        members = filter(
+            lambda member: member != "src_dim", ConnectivityMetadata._members
+        )
         result = all(
             [
                 getattr(self, field) == getattr(other, field)
-                for field in ConnectivityMetadata._members
+                for field in members
             ]
         )
         if result:

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -34,10 +34,10 @@ __all__ = [
     "AncillaryVariableMetadata",
     "BaseMetadata",
     "CellMeasureMetadata",
+    "ConnectivityMetadata",
     "CoordMetadata",
     "CubeMetadata",
     "DimCoordMetadata",
-    "ConnectivityMetadata",
     "metadata_manager_factory",
 ]
 
@@ -876,6 +876,120 @@ class CellMeasureMetadata(BaseMetadata):
         return super().equal(other, lenient=lenient)
 
 
+class ConnectivityMetadata(BaseMetadata):
+    """
+    Metadata container for a :class:`~iris.coords.Connectivity`.
+
+    """
+
+    _members = ("cf_role", "start_index", "element_dim")
+
+    __slots__ = ()
+
+    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
+    @lenient_service
+    def __eq__(self, other):
+        return super().__eq__(other)
+
+    def _combine_lenient(self, other):
+        """
+        Perform lenient combination of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            combination.
+
+        Returns:
+            A list of combined metadata member values.
+
+        """
+        # Perform "strict" combination for "cf_role", "start_index", "element_dim".
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return left if left == right else None
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in ConnectivityMetadata._members]
+        # Perform lenient combination of the other parent members.
+        result = super()._combine_lenient(other)
+        result.extend(values)
+
+        return result
+
+    def _compare_lenient(self, other):
+        """
+        Perform lenient equality of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            comparison.
+
+        Returns:
+            Boolean.
+
+        """
+        # Perform "strict" comparison for "cf_role", "start_index", "element_dim".
+        result = all(
+            [
+                getattr(self, field) == getattr(other, field)
+                for field in ConnectivityMetadata._members
+            ]
+        )
+        if result:
+            # Perform lenient comparison of the other parent members.
+            result = super()._compare_lenient(other)
+
+        return result
+
+    def _difference_lenient(self, other):
+        """
+        Perform lenient difference of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            difference.
+
+        Returns:
+            A list of difference metadata member values.
+
+        """
+        # Perform "strict" difference for "cf_role", "start_index", "element_dim".
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return None if left == right else (left, right)
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in ConnectivityMetadata._members]
+        # Perform lenient difference of the other parent members.
+        result = super()._difference_lenient(other)
+        result.extend(values)
+
+        return result
+
+    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
+    @lenient_service
+    def combine(self, other, lenient=None):
+        return super().combine(other, lenient=lenient)
+
+    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
+    @lenient_service
+    def difference(self, other, lenient=None):
+        return super().difference(other, lenient=lenient)
+
+    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
+    @lenient_service
+    def equal(self, other, lenient=None):
+        return super().equal(other, lenient=lenient)
+
+
 class CoordMetadata(BaseMetadata):
     """
     Metadata container for a :class:`~iris.coords.Coord`.
@@ -1317,120 +1431,6 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
-class ConnectivityMetadata(BaseMetadata):
-    """
-    Metadata container for a :class:`~iris.coords.Connectivity`.
-
-    """
-
-    _members = ("cf_role", "start_index", "element_dim")
-
-    __slots__ = ()
-
-    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
-    @lenient_service
-    def __eq__(self, other):
-        return super().__eq__(other)
-
-    def _combine_lenient(self, other):
-        """
-        Perform lenient combination of metadata members for connectivities.
-
-        Args:
-
-        * other (ConnectivityMetadata):
-            The other connectivity metadata participating in the lenient
-            combination.
-
-        Returns:
-            A list of combined metadata member values.
-
-        """
-        # Perform "strict" combination for "cf_role", "start_index", "element_dim".
-        def func(field):
-            left = getattr(self, field)
-            right = getattr(other, field)
-            return left if left == right else None
-
-        # Note that, we use "_members" not "_fields".
-        values = [func(field) for field in ConnectivityMetadata._members]
-        # Perform lenient combination of the other parent members.
-        result = super()._combine_lenient(other)
-        result.extend(values)
-
-        return result
-
-    def _compare_lenient(self, other):
-        """
-        Perform lenient equality of metadata members for connectivities.
-
-        Args:
-
-        * other (ConnectivityMetadata):
-            The other connectivity metadata participating in the lenient
-            comparison.
-
-        Returns:
-            Boolean.
-
-        """
-        # Perform "strict" comparison for "cf_role", "start_index", "element_dim".
-        result = all(
-            [
-                getattr(self, field) == getattr(other, field)
-                for field in ConnectivityMetadata._members
-            ]
-        )
-        if result:
-            # Perform lenient comparison of the other parent members.
-            result = super()._compare_lenient(other)
-
-        return result
-
-    def _difference_lenient(self, other):
-        """
-        Perform lenient difference of metadata members for connectivities.
-
-        Args:
-
-        * other (ConnectivityMetadata):
-            The other connectivity metadata participating in the lenient
-            difference.
-
-        Returns:
-            A list of difference metadata member values.
-
-        """
-        # Perform "strict" difference for "cf_role", "start_index", "element_dim".
-        def func(field):
-            left = getattr(self, field)
-            right = getattr(other, field)
-            return None if left == right else (left, right)
-
-        # Note that, we use "_members" not "_fields".
-        values = [func(field) for field in ConnectivityMetadata._members]
-        # Perform lenient difference of the other parent members.
-        result = super()._difference_lenient(other)
-        result.extend(values)
-
-        return result
-
-    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
-    @lenient_service
-    def combine(self, other, lenient=None):
-        return super().combine(other, lenient=lenient)
-
-    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
-    @lenient_service
-    def difference(self, other, lenient=None):
-        return super().difference(other, lenient=lenient)
-
-    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
-    @lenient_service
-    def equal(self, other, lenient=None):
-        return super().equal(other, lenient=lenient)
-
-
 def metadata_manager_factory(cls, **kwargs):
     """
     A class instance factory function responsible for manufacturing
@@ -1574,10 +1574,10 @@ SERVICES_COMBINE = (
     AncillaryVariableMetadata.combine,
     BaseMetadata.combine,
     CellMeasureMetadata.combine,
+    ConnectivityMetadata.combine,
     CoordMetadata.combine,
     CubeMetadata.combine,
     DimCoordMetadata.combine,
-    ConnectivityMetadata.combine,
 )
 
 
@@ -1586,10 +1586,10 @@ SERVICES_DIFFERENCE = (
     AncillaryVariableMetadata.difference,
     BaseMetadata.difference,
     CellMeasureMetadata.difference,
+    ConnectivityMetadata.difference,
     CoordMetadata.difference,
     CubeMetadata.difference,
     DimCoordMetadata.difference,
-    ConnectivityMetadata.difference,
 )
 
 
@@ -1601,14 +1601,14 @@ SERVICES_EQUAL = (
     BaseMetadata.equal,
     CellMeasureMetadata.__eq__,
     CellMeasureMetadata.equal,
+    ConnectivityMetadata.__eq__,
+    ConnectivityMetadata.equal,
     CoordMetadata.__eq__,
     CoordMetadata.equal,
     CubeMetadata.__eq__,
     CubeMetadata.equal,
     DimCoordMetadata.__eq__,
     DimCoordMetadata.equal,
-    ConnectivityMetadata.__eq__,
-    ConnectivityMetadata.equal,
 )
 
 

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -882,7 +882,7 @@ class ConnectivityMetadata(BaseMetadata):
 
     """
 
-    _members = ("cf_role", "start_index", "element_dim")
+    _members = ("cf_role", "start_index", "src_dim")
 
     __slots__ = ()
 
@@ -905,7 +905,7 @@ class ConnectivityMetadata(BaseMetadata):
             A list of combined metadata member values.
 
         """
-        # Perform "strict" combination for "cf_role", "start_index", "element_dim".
+        # Perform "strict" combination for "cf_role", "start_index", "src_dim".
         def func(field):
             left = getattr(self, field)
             right = getattr(other, field)
@@ -933,7 +933,7 @@ class ConnectivityMetadata(BaseMetadata):
             Boolean.
 
         """
-        # Perform "strict" comparison for "cf_role", "start_index", "element_dim".
+        # Perform "strict" comparison for "cf_role", "start_index", "src_dim".
         result = all(
             [
                 getattr(self, field) == getattr(other, field)
@@ -960,7 +960,7 @@ class ConnectivityMetadata(BaseMetadata):
             A list of difference metadata member values.
 
         """
-        # Perform "strict" difference for "cf_role", "start_index", "element_dim".
+        # Perform "strict" difference for "cf_role", "start_index", "src_dim".
         def func(field):
             left = getattr(self, field)
             right = getattr(other, field)

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -37,6 +37,7 @@ __all__ = [
     "CoordMetadata",
     "CubeMetadata",
     "DimCoordMetadata",
+    "ConnectivityMetadata",
     "metadata_manager_factory",
 ]
 
@@ -1316,6 +1317,120 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
+class ConnectivityMetadata(BaseMetadata):
+    """
+    Metadata container for a :class:`~iris.coords.Connectivity`.
+
+    """
+
+    _members = ("cf_role", "start_index", "element_dim")
+
+    __slots__ = ()
+
+    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
+    @lenient_service
+    def __eq__(self, other):
+        return super().__eq__(other)
+
+    def _combine_lenient(self, other):
+        """
+        Perform lenient combination of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            combination.
+
+        Returns:
+            A list of combined metadata member values.
+
+        """
+        # Perform "strict" combination for "cf_role", "start_index", "element_dim".
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return left if left == right else None
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in ConnectivityMetadata._members]
+        # Perform lenient combination of the other parent members.
+        result = super()._combine_lenient(other)
+        result.extend(values)
+
+        return result
+
+    def _compare_lenient(self, other):
+        """
+        Perform lenient equality of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            comparison.
+
+        Returns:
+            Boolean.
+
+        """
+        # Perform "strict" comparison for "cf_role", "start_index", "element_dim".
+        result = all(
+            [
+                getattr(self, field) == getattr(other, field)
+                for field in ConnectivityMetadata._members
+            ]
+        )
+        if result:
+            # Perform lenient comparison of the other parent members.
+            result = super()._compare_lenient(other)
+
+        return result
+
+    def _difference_lenient(self, other):
+        """
+        Perform lenient difference of metadata members for connectivities.
+
+        Args:
+
+        * other (ConnectivityMetadata):
+            The other connectivity metadata participating in the lenient
+            difference.
+
+        Returns:
+            A list of difference metadata member values.
+
+        """
+        # Perform "strict" difference for "cf_role", "start_index", "element_dim".
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return None if left == right else (left, right)
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in ConnectivityMetadata._members]
+        # Perform lenient difference of the other parent members.
+        result = super()._difference_lenient(other)
+        result.extend(values)
+
+        return result
+
+    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
+    @lenient_service
+    def combine(self, other, lenient=None):
+        return super().combine(other, lenient=lenient)
+
+    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
+    @lenient_service
+    def difference(self, other, lenient=None):
+        return super().difference(other, lenient=lenient)
+
+    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
+    @lenient_service
+    def equal(self, other, lenient=None):
+        return super().equal(other, lenient=lenient)
+
+
 def metadata_manager_factory(cls, **kwargs):
     """
     A class instance factory function responsible for manufacturing
@@ -1462,6 +1577,7 @@ SERVICES_COMBINE = (
     CoordMetadata.combine,
     CubeMetadata.combine,
     DimCoordMetadata.combine,
+    ConnectivityMetadata.combine,
 )
 
 
@@ -1473,6 +1589,7 @@ SERVICES_DIFFERENCE = (
     CoordMetadata.difference,
     CubeMetadata.difference,
     DimCoordMetadata.difference,
+    ConnectivityMetadata.difference,
 )
 
 
@@ -1490,6 +1607,8 @@ SERVICES_EQUAL = (
     CubeMetadata.equal,
     DimCoordMetadata.__eq__,
     DimCoordMetadata.equal,
+    ConnectivityMetadata.__eq__,
+    ConnectivityMetadata.equal,
 )
 
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -31,9 +31,9 @@ from iris.common import (
     BaseMetadata,
     CFVariableMixin,
     CellMeasureMetadata,
+    ConnectivityMetadata,
     CoordMetadata,
     DimCoordMetadata,
-    ConnectivityMetadata,
     metadata_manager_factory,
 )
 import iris.exceptions

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2850,14 +2850,14 @@ class Connectivity(_DimensionalMetadata):
         * attributes (dict):
             A dictionary containing other cf and user-defined attributes.
         * start_index (int):
-            Either ``0`` or ``1``. Denotes whether :attr:`indices` uses 0-based
-            or 1-based indexing (allows support for Fortran and legacy NetCDF
-            files).
+            Either ``0`` or ``1``. Default is ``0``. Denotes whether
+            :attr:`indices` uses 0-based or 1-based indexing (allows support
+            for Fortran and legacy NetCDF files).
         * src_dim (int):
-            Either ``0`` or ``1``. Denotes which dimension of :attr:`indices`
-            varies over the :attr:`src_location`s (the alternate dimension
-            therefore varying within individual :attr:`src_location`s).
-            (This parameter allows support for fastest varying index being
+            Either ``0`` or ``1``. Default is ``0``. Denotes which dimension
+            of :attr:`indices` varies over the :attr:`src_location`s (the
+            alternate dimension therefore varying within individual
+            :attr:`src_location`s). (This parameter allows support for fastest varying index being
             either first or last).
             E.g. for ``face_node_connectivity``, for 10 faces:
             ``indices.shape[src_dim] = 10``.
@@ -3010,7 +3010,7 @@ class Connectivity(_DimensionalMetadata):
         Kwargs:
         * indices (array):
             The array on which to operate. If ``None``, will operate on
-            :attr:`indices`.
+            :attr:`indices`. Default is ``None``.
 
         Returns:
             A view of the indices array transposed - if necessary - to put

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -3135,19 +3135,6 @@ class Connectivity(_DimensionalMetadata):
         """
         return super()._has_lazy_values()
 
-    def __str__(self):
-        result = repr(self)
-        return result
-
-    def __repr__(self):
-        cls = type(self).__name__
-        result = (
-            f"{cls}({self.indices}), cf_role="
-            f"'{self.cf_role}', start_index={self.start_index}, "
-            f"src_dim={self.src_dim}{self._repr_other_metadata()})"
-        )
-        return result
-
     def cube_dims(self, cube):
         """Not available on :class:`Connectivity`."""
         raise NotImplementedError

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2789,6 +2789,19 @@ class Connectivity(_DimensionalMetadata):
 
     """
 
+    UGRID_CF_ROLES = [
+        "edge_node_connectivity",
+        "face_node_connectivity",
+        "face_edge_connectivity",
+        "face_face_connectivity",
+        "edge_face_connectivity",
+        "boundary_node_connectivity",
+        "volume_node_connectivity",
+        "volume_edge_connectivity",
+        "volume_face_connectivity",
+        "volume_volume_connectivity",
+    ]
+
     def __init__(
         self,
         indices,
@@ -2857,20 +2870,9 @@ class Connectivity(_DimensionalMetadata):
         self._validate_arg_vs_list("start_index", start_index, [0, 1])
         # indices array will be 2-dimensional, so must be either 0 or 1.
         self._validate_arg_vs_list("src_dim", src_dim, [0, 1])
-        # TODO: find a better 'common' location to store valid cf_roles.
-        valid_cf_roles = [
-            "edge_node_connectivity",
-            "face_node_connectivity",
-            "face_edge_connectivity",
-            "face_face_connectivity",
-            "edge_face_connectivity",
-            "boundary_node_connectivity",
-            "volume_node_connectivity",
-            "volume_edge_connectivity",
-            "volume_face_connectivity",
-            "volume_volume_connectivity",
-        ]
-        self._validate_arg_vs_list("cf_role", cf_role, valid_cf_roles)
+        self._validate_arg_vs_list(
+            "cf_role", cf_role, Connectivity.UGRID_CF_ROLES
+        )
 
         self._metadata_manager.start_index = start_index
         self._metadata_manager.src_dim = src_dim

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -3003,7 +3003,7 @@ class Connectivity(_DimensionalMetadata):
 
     def _validate_indices(self, indices):
         def indices_error(message):
-            raise ValueError("Invalid indeces provided. " + message)
+            raise ValueError("Invalid indices provided. " + message)
 
         indices = self._sanitise_array(indices, 0)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2864,15 +2864,22 @@ class Connectivity(_DimensionalMetadata):
             ``indices.shape[src_dim] = 10``.
 
         """
+
+        def validate_arg_vs_list(arg_name, arg, valid_list):
+            if arg not in valid_list:
+                error_msg = (
+                    f"Invalid {arg_name} . Got: {arg} . Must be one of: "
+                    f"{valid_list} ."
+                )
+                raise ValueError(error_msg)
+
         # Configure the metadata manager.
         self._metadata_manager = metadata_manager_factory(ConnectivityMetadata)
 
-        self._validate_arg_vs_list("start_index", start_index, [0, 1])
+        validate_arg_vs_list("start_index", start_index, [0, 1])
         # indices array will be 2-dimensional, so must be either 0 or 1.
-        self._validate_arg_vs_list("src_dim", src_dim, [0, 1])
-        self._validate_arg_vs_list(
-            "cf_role", cf_role, Connectivity.UGRID_CF_ROLES
-        )
+        validate_arg_vs_list("src_dim", src_dim, [0, 1])
+        validate_arg_vs_list("cf_role", cf_role, Connectivity.UGRID_CF_ROLES)
 
         self._metadata_manager.start_index = start_index
         self._metadata_manager.src_dim = src_dim
@@ -2889,15 +2896,6 @@ class Connectivity(_DimensionalMetadata):
             units=units,
             attributes=attributes,
         )
-
-    @staticmethod
-    def _validate_arg_vs_list(arg_name, arg, list):
-        if arg not in list:
-            error_msg = (
-                f"Invalid {arg_name} . Got: {arg} . Must be one of: "
-                f"{list} ."
-            )
-            raise ValueError(error_msg)
 
     @staticmethod
     def _lazy_src_lengths(array, src_dim):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2834,7 +2834,7 @@ class Connectivity(_DimensionalMetadata):
 
         Kwargs:
 
-        * standard_name(str):
+        * standard_name (str):
             CF standard name of the connectivity.
             (NOTE: this is not expected by the UGRID conventions, but will be
             handled in Iris' standard way if provided).
@@ -2855,9 +2855,9 @@ class Connectivity(_DimensionalMetadata):
             for Fortran and legacy NetCDF files).
         * src_dim (int):
             Either ``0`` or ``1``. Default is ``0``. Denotes which dimension
-            of :attr:`indices` varies over the :attr:`src_location`s (the
+            of :attr:`indices` varies over the :attr:`src_location`'s (the
             alternate dimension therefore varying within individual
-            :attr:`src_location`s). (This parameter allows support for fastest varying index being
+            :attr:`src_location`'s). (This parameter allows support for fastest varying index being
             either first or last).
             E.g. for ``face_node_connectivity``, for 10 faces:
             ``indices.shape[src_dim] = 10``.
@@ -2964,7 +2964,7 @@ class Connectivity(_DimensionalMetadata):
     def src_dim(self):
         """
         The dimension of the connectivity's :attr:`indices` array that varies
-        over the connectivity's :attr:`src_location`s. Either ``0`` or ``1``.
+        over the connectivity's :attr:`src_location`'s. Either ``0`` or ``1``.
         **Read-only** - validity of :attr:`indices` is dependent on
         :attr:`src_dim`. Use :meth:`transpose` to create a new, transposed
         :class:`Connectivity` if a different :attr:`src_dim` is needed.
@@ -2978,7 +2978,7 @@ class Connectivity(_DimensionalMetadata):
         Derived as the alternate value of :attr:`src_dim` - each must equal
         either ``0`` or ``1``.
         The dimension of the connectivity's :attr:`indices` array that varies
-        within the connectivity's individual :attr:`src_location`s.
+        within the connectivity's individual :attr:`src_location`'s.
 
         """
         # Computed (rather than stored) property necessary since a new
@@ -3008,12 +3008,13 @@ class Connectivity(_DimensionalMetadata):
         output from :meth:`core_indices` or :meth:`lazy_indices`).
 
         Kwargs:
+
         * indices (array):
             The array on which to operate. If ``None``, will operate on
             :attr:`indices`. Default is ``None``.
 
         Returns:
-            A view of the indices array transposed - if necessary - to put
+            A view of the indices array, transposed - if necessary - to put
             :attr:`src_dim` first.
 
         """
@@ -3099,14 +3100,16 @@ class Connectivity(_DimensionalMetadata):
         """
         Perform a thorough validity check of this connectivity's
         :attr:`indices`. Includes checking the sizes of individual
-        :attr:`src_location`s (specified using masks on the
+        :attr:`src_location`'s (specified using masks on the
         :attr:`indices` array) against the :attr:`cf_role`.
 
         Raises a ``ValueError`` if any problems are encountered, otherwise
         passes silently.
 
-        NOTE: while this uses lazy computation, it will still be a high
-        resource demand for a large :attr:`indices` array.
+        .. note::
+
+            While this uses lazy computation, it will still be a high
+            resource demand for a large :attr:`indices` array.
 
         """
         self._validate_indices(self.indices, shapes_only=False)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2981,9 +2981,7 @@ class Connectivity(_DimensionalMetadata):
         within the connectivity's individual :attr:`src_location`'s.
 
         """
-        # Computed (rather than stored) property necessary since a new
-        # Connectivity returned by self.transpose() would have a flipped src_dim.
-        return 1 - self._metadata_manager.src_dim
+        return self._tgt_dim
 
     @property
     def indices(self):
@@ -3134,7 +3132,7 @@ class Connectivity(_DimensionalMetadata):
 
     def transpose(self):
         """
-        Create a deep copy of this :class:`Connectivity` with the
+        Create a new :class:`Connectivity`, identical to this one but with the
         :attr:`indices` array transposed and the :attr:`src_dim` value flipped.
 
         Returns:
@@ -3142,16 +3140,17 @@ class Connectivity(_DimensionalMetadata):
             the original.
 
         """
-        new_connectivity = self.copy()
-        new_src_dim = 1 - self.src_dim
-        new_indices = self.indices.transpose()
-
-        new_connectivity._metadata_manager.src_dim = new_src_dim
-        # Replace the data manager with one for the new shaped indices.
-        # This is safe to override since Connectivity is not attached to a cube
-        # dimension unlike other _DimensionalMetadata-using classes.
-        new_connectivity._values_dm = DataManager(new_indices)
-
+        new_connectivity = Connectivity(
+            indices=self.indices.transpose().copy(),
+            cf_role=self.cf_role,
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            units=self.units,
+            attributes=self.attributes,
+            start_index=self.start_index,
+            src_dim=self.tgt_dim,
+        )
         return new_connectivity
 
     def lazy_indices(self):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2793,8 +2793,10 @@ class Connectivity(_DimensionalMetadata):
         self,
         indices,
         cf_role,
+        standard_name=None,
         long_name=None,
         var_name=None,
+        units=None,
         attributes=None,
         start_index=0,
         src_dim=0,
@@ -2820,10 +2822,19 @@ class Connectivity(_DimensionalMetadata):
 
         Kwargs:
 
+        * standard_name(str):
+            CF standard name of the connectivity.
+            (NOTE: this is not expected by the UGRID conventions, but will be
+            handled in Iris' standard way if provided).
         * long_name (str):
             Descriptive name of the connectivity.
         * var_name (str):
             The netCDF variable name for the connectivity.
+        * units (cf_units.Unit):
+            The :class:`~cf_units.Unit` of the connectivity's values.
+            Can be a string, which will be converted to a Unit object.
+            (NOTE: this is not expected by the UGRID conventions, but will be
+            handled in Iris' standard way if provided).
         * attributes (dict):
             A dictionary containing other cf and user-defined attributes.
         * start_index (int):
@@ -2870,10 +2881,10 @@ class Connectivity(_DimensionalMetadata):
 
         super().__init__(
             values=indices,
-            standard_name=None,
+            standard_name=standard_name,
             long_name=long_name,
             var_name=var_name,
-            units="1",
+            units=units,
             attributes=attributes,
         )
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2838,8 +2838,8 @@ class Connectivity(_DimensionalMetadata):
         * attributes (dict):
             A dictionary containing other cf and user-defined attributes.
         * start_index (int):
-            Either ``0`` or ``1``. Denotes whether :attr:`indices` uses 0- or
-            1-based indexing (allows support for Fortran and legacy NetCDF
+            Either ``0`` or ``1``. Denotes whether :attr:`indices` uses 0-based
+            or 1-based indexing (allows support for Fortran and legacy NetCDF
             files).
         * src_dim (int):
             Either ``0`` or ``1``. Denotes which dimension of :attr:`indices`

--- a/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
@@ -1,0 +1,729 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for the :class:`iris.common.metadata.ConnectivityMetadata`.
+
+"""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from copy import deepcopy
+import unittest.mock as mock
+from unittest.mock import sentinel
+
+from iris.common.lenient import _LENIENT, _qualname
+from iris.common.metadata import BaseMetadata, ConnectivityMetadata
+
+
+class Test(tests.IrisTest):
+    def setUp(self):
+        self.standard_name = mock.sentinel.standard_name
+        self.long_name = mock.sentinel.long_name
+        self.var_name = mock.sentinel.var_name
+        self.units = mock.sentinel.units
+        self.attributes = mock.sentinel.attributes
+        self.cf_role = mock.sentinel.cf_role
+        self.start_index = mock.sentinel.start_index
+        self.element_dim = mock.sentinel.element_dim
+        self.cls = ConnectivityMetadata
+
+    def test_repr(self):
+        metadata = self.cls(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            units=self.units,
+            attributes=self.attributes,
+            cf_role=self.cf_role,
+            start_index=self.start_index,
+            element_dim=self.element_dim,
+        )
+        fmt = (
+            "ConnectivityMetadata(standard_name={!r}, long_name={!r}, "
+            "var_name={!r}, units={!r}, attributes={!r}, cf_role={!r}, "
+            "start_index={!r}, element_dim={!r})"
+        )
+        expected = fmt.format(
+            self.standard_name,
+            self.long_name,
+            self.var_name,
+            self.units,
+            self.attributes,
+            self.cf_role,
+            self.start_index,
+            self.element_dim,
+        )
+        self.assertEqual(expected, repr(metadata))
+
+    def test__fields(self):
+        expected = (
+            "standard_name",
+            "long_name",
+            "var_name",
+            "units",
+            "attributes",
+            "cf_role",
+            "start_index",
+            "element_dim",
+        )
+        self.assertEqual(self.cls._fields, expected)
+
+    def test_bases(self):
+        self.assertTrue(issubclass(self.cls, BaseMetadata))
+
+
+class Test__eq__(tests.IrisTest):
+    def setUp(self):
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            cf_role=sentinel.cf_role,
+            start_index=sentinel.start_index,
+            element_dim=sentinel.element_dim,
+        )
+        self.dummy = sentinel.dummy
+        self.cls = ConnectivityMetadata
+
+    def test_wraps_docstring(self):
+        self.assertEqual(BaseMetadata.__eq__.__doc__, self.cls.__eq__.__doc__)
+
+    def test_lenient_service(self):
+        qualname___eq__ = _qualname(self.cls.__eq__)
+        self.assertIn(qualname___eq__, _LENIENT)
+        self.assertTrue(_LENIENT[qualname___eq__])
+        self.assertTrue(_LENIENT[self.cls.__eq__])
+
+    def test_call(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        metadata = self.cls(*(None,) * len(self.cls._fields))
+        with mock.patch.object(
+            BaseMetadata, "__eq__", return_value=return_value
+        ) as mocker:
+            result = metadata.__eq__(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_same_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+
+class Test___lt__(tests.IrisTest):
+    def setUp(self):
+        self.cls = ConnectivityMetadata
+        self.one = self.cls(1, 1, 1, 1, 1, 1, 1, 1)
+        self.two = self.cls(1, 1, 1, 2, 1, 1, 1, 1)
+        self.none = self.cls(1, 1, 1, None, 1, 1, 1, 1)
+        self.attributes = self.cls(1, 1, 1, 1, 10, 1, 1, 1)
+
+    def test__ascending_lt(self):
+        result = self.one < self.two
+        self.assertTrue(result)
+
+    def test__descending_lt(self):
+        result = self.two < self.one
+        self.assertFalse(result)
+
+    def test__none_rhs_operand(self):
+        result = self.one < self.none
+        self.assertFalse(result)
+
+    def test__none_lhs_operand(self):
+        result = self.none < self.one
+        self.assertTrue(result)
+
+    def test__ignore_attributes(self):
+        result = self.one < self.attributes
+        self.assertFalse(result)
+        result = self.attributes < self.one
+        self.assertFalse(result)
+
+
+class Test_combine(tests.IrisTest):
+    def setUp(self):
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            cf_role=sentinel.cf_role,
+            start_index=sentinel.start_index,
+            element_dim=sentinel.element_dim,
+        )
+        self.dummy = sentinel.dummy
+        self.cls = ConnectivityMetadata
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(
+            BaseMetadata.combine.__doc__, self.cls.combine.__doc__
+        )
+
+    def test_lenient_service(self):
+        qualname_combine = _qualname(self.cls.combine)
+        self.assertIn(qualname_combine, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_combine])
+        self.assertTrue(_LENIENT[self.cls.combine])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "combine", return_value=return_value
+        ) as mocker:
+            result = self.none.combine(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "combine", return_value=return_value
+        ) as mocker:
+            result = self.none.combine(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+        expected = self.values
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_same_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+        expected = self.values
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            expected = right.copy()
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertTrue(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertTrue(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_lenient_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["units"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+        expected = self.values.copy()
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["long_name"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_strict_different_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["long_name"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+
+class Test_difference(tests.IrisTest):
+    def setUp(self):
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            cf_role=sentinel.cf_role,
+            start_index=sentinel.start_index,
+            element_dim=sentinel.element_dim,
+        )
+        self.dummy = sentinel.dummy
+        self.cls = ConnectivityMetadata
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(
+            BaseMetadata.difference.__doc__, self.cls.difference.__doc__
+        )
+
+    def test_lenient_service(self):
+        qualname_difference = _qualname(self.cls.difference)
+        self.assertIn(qualname_difference, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_difference])
+        self.assertTrue(_LENIENT[self.cls.difference])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "difference", return_value=return_value
+        ) as mocker:
+            result = self.none.difference(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "difference", return_value=return_value
+        ) as mocker:
+            result = self.none.difference(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_lenient_same_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            member_value = getattr(lmetadata, member)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (member_value, None)
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = (None, member_value)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_lenient_different(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["units"] = (left["units"], right["units"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["units"] = lexpected["units"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_strict_different(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["long_name"] = (left["long_name"], right["long_name"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["long_name"] = lexpected["long_name"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_strict_different_none(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["long_name"] = (left["long_name"], right["long_name"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["long_name"] = lexpected["long_name"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+
+class Test_equal(tests.IrisTest):
+    def setUp(self):
+        self.cls = ConnectivityMetadata
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(BaseMetadata.equal.__doc__, self.cls.equal.__doc__)
+
+    def test_lenient_service(self):
+        qualname_equal = _qualname(self.cls.equal)
+        self.assertIn(qualname_equal, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_equal])
+        self.assertTrue(_LENIENT[self.cls.equal])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "equal", return_value=return_value
+        ) as mocker:
+            result = self.none.equal(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "equal", return_value=return_value
+        ) as mocker:
+            result = self.none.equal(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
@@ -91,6 +91,11 @@ class Test__eq__(tests.IrisTest):
         )
         self.dummy = sentinel.dummy
         self.cls = ConnectivityMetadata
+        # The "src_dim" member is stateful only, and does not participate in
+        # lenient/strict equivalence.
+        self.members_no_src_dim = filter(
+            lambda member: member != "src_dim", self.cls._members
+        )
 
     def test_wraps_docstring(self):
         self.assertEqual(BaseMetadata.__eq__.__doc__, self.cls.__eq__.__doc__)
@@ -135,7 +140,7 @@ class Test__eq__(tests.IrisTest):
             self.assertTrue(rmetadata.__eq__(lmetadata))
 
     def test_op_lenient_same_members_none(self):
-        for member in self.cls._members:
+        for member in self.members_no_src_dim:
             lmetadata = self.cls(**self.values)
             right = self.values.copy()
             right[member] = None
@@ -146,6 +151,16 @@ class Test__eq__(tests.IrisTest):
             ):
                 self.assertFalse(lmetadata.__eq__(rmetadata))
                 self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_same_src_dim_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["src_dim"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
 
     def test_op_lenient_different(self):
         lmetadata = self.cls(**self.values)
@@ -158,7 +173,7 @@ class Test__eq__(tests.IrisTest):
             self.assertFalse(rmetadata.__eq__(lmetadata))
 
     def test_op_lenient_different_members(self):
-        for member in self.cls._members:
+        for member in self.members_no_src_dim:
             lmetadata = self.cls(**self.values)
             right = self.values.copy()
             right[member] = self.dummy
@@ -169,6 +184,16 @@ class Test__eq__(tests.IrisTest):
             ):
                 self.assertFalse(lmetadata.__eq__(rmetadata))
                 self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_different_src_dim(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["src_dim"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
 
     def test_op_strict_same(self):
         lmetadata = self.cls(**self.values)
@@ -189,7 +214,7 @@ class Test__eq__(tests.IrisTest):
             self.assertFalse(rmetadata.__eq__(lmetadata))
 
     def test_op_strict_different_members(self):
-        for member in self.cls._members:
+        for member in self.members_no_src_dim:
             lmetadata = self.cls(**self.values)
             right = self.values.copy()
             right[member] = self.dummy
@@ -200,6 +225,16 @@ class Test__eq__(tests.IrisTest):
             ):
                 self.assertFalse(lmetadata.__eq__(rmetadata))
                 self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_src_dim(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["src_dim"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
 
     def test_op_strict_different_none(self):
         lmetadata = self.cls(**self.values)
@@ -212,7 +247,7 @@ class Test__eq__(tests.IrisTest):
             self.assertFalse(rmetadata.__eq__(lmetadata))
 
     def test_op_strict_different_members_none(self):
-        for member in self.cls._members:
+        for member in self.members_no_src_dim:
             lmetadata = self.cls(**self.values)
             right = self.values.copy()
             right[member] = None
@@ -223,6 +258,16 @@ class Test__eq__(tests.IrisTest):
             ):
                 self.assertFalse(lmetadata.__eq__(rmetadata))
                 self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_src_dim_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["src_dim"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
 
 
 class Test___lt__(tests.IrisTest):

--- a/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_ConnectivityMetadata.py
@@ -29,7 +29,7 @@ class Test(tests.IrisTest):
         self.attributes = mock.sentinel.attributes
         self.cf_role = mock.sentinel.cf_role
         self.start_index = mock.sentinel.start_index
-        self.element_dim = mock.sentinel.element_dim
+        self.src_dim = mock.sentinel.src_dim
         self.cls = ConnectivityMetadata
 
     def test_repr(self):
@@ -41,12 +41,12 @@ class Test(tests.IrisTest):
             attributes=self.attributes,
             cf_role=self.cf_role,
             start_index=self.start_index,
-            element_dim=self.element_dim,
+            src_dim=self.src_dim,
         )
         fmt = (
             "ConnectivityMetadata(standard_name={!r}, long_name={!r}, "
             "var_name={!r}, units={!r}, attributes={!r}, cf_role={!r}, "
-            "start_index={!r}, element_dim={!r})"
+            "start_index={!r}, src_dim={!r})"
         )
         expected = fmt.format(
             self.standard_name,
@@ -56,7 +56,7 @@ class Test(tests.IrisTest):
             self.attributes,
             self.cf_role,
             self.start_index,
-            self.element_dim,
+            self.src_dim,
         )
         self.assertEqual(expected, repr(metadata))
 
@@ -69,7 +69,7 @@ class Test(tests.IrisTest):
             "attributes",
             "cf_role",
             "start_index",
-            "element_dim",
+            "src_dim",
         )
         self.assertEqual(self.cls._fields, expected)
 
@@ -87,7 +87,7 @@ class Test__eq__(tests.IrisTest):
             attributes=sentinel.attributes,
             cf_role=sentinel.cf_role,
             start_index=sentinel.start_index,
-            element_dim=sentinel.element_dim,
+            src_dim=sentinel.src_dim,
         )
         self.dummy = sentinel.dummy
         self.cls = ConnectivityMetadata
@@ -266,7 +266,7 @@ class Test_combine(tests.IrisTest):
             attributes=sentinel.attributes,
             cf_role=sentinel.cf_role,
             start_index=sentinel.start_index,
-            element_dim=sentinel.element_dim,
+            src_dim=sentinel.src_dim,
         )
         self.dummy = sentinel.dummy
         self.cls = ConnectivityMetadata
@@ -463,7 +463,7 @@ class Test_difference(tests.IrisTest):
             attributes=sentinel.attributes,
             cf_role=sentinel.cf_role,
             start_index=sentinel.start_index,
-            element_dim=sentinel.element_dim,
+            src_dim=sentinel.src_dim,
         )
         self.dummy = sentinel.dummy
         self.cls = ConnectivityMetadata

--- a/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
+++ b/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
@@ -21,6 +21,7 @@ from iris.common.metadata import (
     AncillaryVariableMetadata,
     BaseMetadata,
     CellMeasureMetadata,
+    ConnectivityMetadata,
     CoordMetadata,
     CubeMetadata,
     metadata_manager_factory,
@@ -31,6 +32,7 @@ BASES = [
     AncillaryVariableMetadata,
     BaseMetadata,
     CellMeasureMetadata,
+    ConnectivityMetadata,
     CoordMetadata,
     CubeMetadata,
 ]

--- a/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
@@ -21,6 +21,7 @@ from iris.common.metadata import (
     AncillaryVariableMetadata,
     BaseMetadata,
     CellMeasureMetadata,
+    ConnectivityMetadata,
     CoordMetadata,
     CubeMetadata,
 )
@@ -279,6 +280,21 @@ class Test__metadata_setter(tests.IrisTest):
         self.item.metadata = metadata
         expected = metadata._asdict()
         del expected["measure"]
+        self.assertEqual(self.item._metadata_manager.values, expected)
+        self.assertIsNot(
+            self.item._metadata_manager.attributes, metadata.attributes
+        )
+
+    def test_class_connectivitymetadata(self):
+        self.args.update(
+            dict(cf_role=None, start_index=None, element_dim=None)
+        )
+        metadata = ConnectivityMetadata(**self.args)
+        self.item.metadata = metadata
+        expected = metadata._asdict()
+        del expected["cf_role"]
+        del expected["start_index"]
+        del expected["element_dim"]
         self.assertEqual(self.item._metadata_manager.values, expected)
         self.assertIsNot(
             self.item._metadata_manager.attributes, metadata.attributes

--- a/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
@@ -286,15 +286,13 @@ class Test__metadata_setter(tests.IrisTest):
         )
 
     def test_class_connectivitymetadata(self):
-        self.args.update(
-            dict(cf_role=None, start_index=None, element_dim=None)
-        )
+        self.args.update(dict(cf_role=None, start_index=None, src_dim=None))
         metadata = ConnectivityMetadata(**self.args)
         self.item.metadata = metadata
         expected = metadata._asdict()
         del expected["cf_role"]
         del expected["start_index"]
-        del expected["element_dim"]
+        del expected["src_dim"]
         self.assertEqual(self.item._metadata_manager.values, expected)
         self.assertIsNot(
             self.item._metadata_manager.attributes, metadata.attributes

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -120,7 +120,20 @@ class TestStandard(tests.IrisTest):
             self.assertIn(attribute, connectivity_element.attributes)
 
     def test___eq__(self):
-        self.assertEqual(self.connectivity, self.connectivity)
+        equivalent_kwargs = self.kwargs
+        equivalent_kwargs["indices"] = self.kwargs["indices"].transpose()
+        equivalent_kwargs["src_dim"] = 1 - self.kwargs["src_dim"]
+        equivalent = Connectivity(**equivalent_kwargs)
+        self.assertFalse(
+            (equivalent.indices == self.connectivity.indices).all()
+        )
+        self.assertEqual(equivalent, self.connectivity)
+
+    def test_different(self):
+        different_kwargs = self.kwargs
+        different_kwargs["indices"] = self.kwargs["indices"].transpose()
+        different = Connectivity(**different_kwargs)
+        self.assertNotEqual(different, self.connectivity)
 
     def test_no_cube_dims(self):
         self.assertRaises(NotImplementedError, self.connectivity.cube_dims, 1)
@@ -139,6 +152,17 @@ class TestStandard(tests.IrisTest):
         new_indices = np.linspace(11, 16, 6, dtype=int).reshape((3, -1))
         copy_connectivity = self.connectivity.copy(new_indices)
         self.assertArrayEqual(new_indices, copy_connectivity.indices)
+
+    def test_indices_by_src(self):
+        expected = self.kwargs["indices"].transpose()
+        self.assertArrayEqual(expected, self.connectivity.indices_by_src())
+
+    def test_indices_by_src_input(self):
+        expected = as_lazy_data(self.kwargs["indices"].transpose())
+        by_src = self.connectivity.indices_by_src(
+            self.connectivity.lazy_indices()
+        )
+        self.assertArrayEqual(expected, by_src)
 
 
 class TestAltIndices(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -76,20 +76,12 @@ class TestStandard(tests.IrisTest):
                 1,
             )
 
-    def test_switch_start_index(self):
-        expected_index = 1 - self.kwargs["start_index"]
-        expected_change = expected_index - self.kwargs["start_index"]
-        expected_indices = self.kwargs["indices"] + expected_change
-        self.connectivity.switch_start_index()
-        self.assertEqual(expected_index, self.connectivity.start_index)
-        self.assertArrayEqual(expected_indices, self.connectivity.indices)
-
-    def test_switch_src_dim(self):
+    def test_transpose(self):
         expected_dim = 1 - self.kwargs["src_dim"]
-        expected_indices = self.kwargs["indices"].swapaxes(0, 1)
-        self.connectivity.switch_src_dim()
-        self.assertEqual(expected_dim, self.connectivity.src_dim)
-        self.assertArrayEqual(expected_indices, self.connectivity.indices)
+        expected_indices = self.kwargs["indices"].transpose()
+        new_connectivity = self.connectivity.transpose()
+        self.assertEqual(expected_dim, new_connectivity.src_dim)
+        self.assertArrayEqual(expected_indices, new_connectivity.indices)
 
     def test_lazy_indices(self):
         self.assertTrue(is_lazy_data(self.connectivity.lazy_indices()))
@@ -142,15 +134,6 @@ class TestStandard(tests.IrisTest):
     def test___getitem_(self):
         subset = self.connectivity[:, 0:1]
         self.assertArrayEqual(self.kwargs["indices"][:, 0:1], subset.indices)
-
-    def test___getitem__data_copy(self):
-        # Check that a sliced connectivity has independent data.
-        subset = self.connectivity[:, 1:2]
-        old_indices = subset.indices.copy()
-        # Change the original one.
-        self.connectivity.switch_start_index()
-        # Check the new one has not changed.
-        self.assertArrayEqual(old_indices, subset.indices)
 
     def test_copy(self):
         new_indices = np.linspace(11, 16, 6, dtype=int).reshape((3, -1))

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -1,0 +1,350 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :class:`iris.coords.Connectivity` class."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from xml.dom import minidom
+
+import numpy as np
+from numpy import ma
+
+from iris.coords import Connectivity
+from iris._lazy_data import as_lazy_data, is_lazy_data
+
+
+class TestStandard(tests.IrisTest):
+    def setUp(self):
+        # Crete an instance, with non-default arguments to allow testing of
+        # correct property setting.
+        self.kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((3, -1)),
+            "cf_role": "face_node_connectivity",
+            "long_name": "my_face_nodes",
+            "var_name": "face_nodes",
+            "attributes": {"notes": "this is a test"},
+            "start_index": 1,
+            "element_dim": 0,
+        }
+        self.connectivity = Connectivity(**self.kwargs)
+
+    def test_cf_role(self):
+        self.assertEqual(self.kwargs["cf_role"], self.connectivity.cf_role)
+
+    def test_cf_role_element(self):
+        expected = self.kwargs["cf_role"].split("_")[0]
+        self.assertEqual(expected, self.connectivity.cf_role_element)
+
+    def test_cf_role_indexed_element(self):
+        expected = self.kwargs["cf_role"].split("_")[1]
+        self.assertEqual(expected, self.connectivity.cf_role_indexed_element)
+
+    def test_start_index(self):
+        self.assertEqual(
+            self.kwargs["start_index"], self.connectivity.start_index
+        )
+
+    def test_element_dim(self):
+        self.assertEqual(
+            self.kwargs["element_dim"], self.connectivity.element_dim
+        )
+
+    def test_indices(self):
+        self.assertArrayEqual(
+            self.kwargs["indices"], self.connectivity.indices
+        )
+
+    def test_element_lengths(self):
+        expected = [3, 3, 3]
+        self.assertArrayEqual(expected, self.connectivity.element_lengths)
+
+    def test_has_equal_element_lengths(self):
+        self.assertTrue(self.connectivity.has_equal_element_lengths)
+
+    def test_read_only(self):
+        attributes = ("indices", "cf_role", "start_index", "element_dim")
+        for attribute in attributes:
+            self.assertRaisesRegex(
+                AttributeError,
+                "can't set attribute",
+                setattr,
+                self.connectivity,
+                attribute,
+                1,
+            )
+
+    def test_switch_start_index(self):
+        expected_index = 1 - self.kwargs["start_index"]
+        expected_change = expected_index - self.kwargs["start_index"]
+        expected_indices = self.kwargs["indices"] + expected_change
+        self.connectivity.switch_start_index()
+        self.assertEqual(expected_index, self.connectivity.start_index)
+        self.assertArrayEqual(expected_indices, self.connectivity.indices)
+
+    def test_switch_element_dim(self):
+        expected_dim = 1 - self.kwargs["element_dim"]
+        expected_indices = self.kwargs["indices"].swapaxes(0, 1)
+        self.connectivity.switch_element_dim()
+        self.assertEqual(expected_dim, self.connectivity.element_dim)
+        self.assertArrayEqual(expected_indices, self.connectivity.indices)
+
+    def test_lazy_indices(self):
+        self.assertTrue(is_lazy_data(self.connectivity.lazy_indices()))
+
+    def test_core_indices(self):
+        self.assertArrayEqual(
+            self.kwargs["indices"], self.connectivity.core_indices()
+        )
+
+    def test_has_lazy_indices(self):
+        self.assertFalse(self.connectivity.has_lazy_indices())
+
+    def test___str__(self):
+        expected = (
+            "Connectivity([[1 2 3]\n [4 5 6]\n [7 8 9]]), "
+            "cf_role='face_node_connectivity', start_index=1, element_dim=0, "
+            "long_name='my_face_nodes', var_name='face_nodes', "
+            "attributes={'notes': 'this is a test'})"
+        )
+        self.assertEqual(expected, self.connectivity.__str__())
+
+    def test___repr__(self):
+        expected = (
+            "Connectivity([[1 2 3]\n [4 5 6]\n [7 8 9]]), "
+            "cf_role='face_node_connectivity', start_index=1, element_dim=0, "
+            "long_name='my_face_nodes', var_name='face_nodes', "
+            "attributes={'notes': 'this is a test'})"
+        )
+        self.assertEqual(expected, self.connectivity.__repr__())
+
+    def test_xml_element(self):
+        doc = minidom.Document()
+        connectivity_element = self.connectivity.xml_element(doc)
+        self.assertEqual(connectivity_element.tagName, "connectivity")
+        for attribute in ("cf_role", "start_index", "element_dim"):
+            self.assertIn(attribute, connectivity_element.attributes)
+
+    def test___eq__(self):
+        self.assertEqual(self.connectivity, self.connectivity)
+
+    def test_no_cube_dims(self):
+        self.assertRaises(NotImplementedError, self.connectivity.cube_dims, 1)
+
+    def test_shape(self):
+        self.assertEqual(self.kwargs["indices"].shape, self.connectivity.shape)
+
+    def test_ndim(self):
+        self.assertEqual(self.kwargs["indices"].ndim, self.connectivity.ndim)
+
+    def test___getitem_(self):
+        subset = self.connectivity[:, 0:1]
+        self.assertArrayEqual(self.kwargs["indices"][:, 0:1], subset.indices)
+
+    def test___getitem__data_copy(self):
+        # Check that a sliced connectivity has independent data.
+        subset = self.connectivity[:, 1:2]
+        old_indices = subset.indices.copy()
+        # Change the original one.
+        self.connectivity.switch_start_index()
+        # Check the new one has not changed.
+        self.assertArrayEqual(old_indices, subset.indices)
+
+    def test_copy(self):
+        new_indices = np.linspace(11, 16, 6, dtype=int).reshape((3, -1))
+        copy_connectivity = self.connectivity.copy(new_indices)
+        self.assertArrayEqual(new_indices, copy_connectivity.indices)
+
+
+class TestAltIndices(tests.IrisTest):
+    def setUp(self):
+        mask = ([0, 0, 0, 0, 1] * 2) + [0, 0, 0, 1, 1]
+        data = np.linspace(1, 15, 15, dtype=int).reshape((-1, 5))
+        self.masked_indices = ma.array(data=data, mask=mask)
+        self.lazy_indices = as_lazy_data(data)
+
+    def common(self, indices):
+        connectivity = Connectivity(
+            indices=indices, cf_role="face_node_connectivity"
+        )
+        self.assertArrayEqual(indices, connectivity.indices)
+
+    def test_int32(self):
+        indices = np.linspace(1, 9, 9, dtype=np.int32).reshape((-1, 3))
+        self.common(indices)
+
+    def test_uint32(self):
+        indices = np.linspace(1, 9, 9, dtype=np.uint32).reshape((-1, 3))
+        self.common(indices)
+
+    def test_lazy(self):
+        self.common(self.lazy_indices)
+
+    def test_masked(self):
+        self.common(self.masked_indices)
+
+    def test_masked_lazy(self):
+        self.common(as_lazy_data(self.masked_indices))
+
+    def test_has_lazy_indices(self):
+        connectivity = Connectivity(
+            indices=self.lazy_indices, cf_role="face_node_connectivity"
+        )
+        self.assertTrue(connectivity.has_lazy_indices())
+
+    def test_element_lengths(self):
+        connectivity = Connectivity(
+            indices=self.masked_indices, cf_role="face_node_connectivity"
+        )
+        self.assertArrayEqual([4, 4, 3], connectivity.element_lengths)
+        self.assertFalse(connectivity.has_equal_element_lengths)
+
+
+class TestValidations(tests.IrisTest):
+    def test_start_index(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "face_node_connectivity",
+            "start_index": 2,
+        }
+        self.assertRaisesRegex(
+            ValueError, "Invalid start_index .", Connectivity, **kwargs
+        )
+
+    def test_element_dim(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "face_node_connectivity",
+            "element_dim": 2,
+        }
+        self.assertRaisesRegex(
+            ValueError, "Invalid element_dim .", Connectivity, **kwargs
+        )
+
+    def test_cf_role(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "error",
+        }
+        self.assertRaisesRegex(
+            ValueError, "Invalid cf_role .", Connectivity, **kwargs
+        )
+
+    def test_indices_int(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9).reshape((-1, 3)),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "dtype must be numpy integer subtype",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_start_index(self):
+        kwargs = {
+            "indices": np.linspace(-9, -1, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError, " < start_index", Connectivity, **kwargs
+        )
+
+    def test_indices_dims_low(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError, "Expected 2-dimensional shape,", Connectivity, **kwargs
+        )
+
+    def test_indices_dims_high(self):
+        kwargs = {
+            "indices": np.linspace(1, 12, 12, dtype=int).reshape((-1, 3, 2)),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError, "Expected 2-dimensional shape,", Connectivity, **kwargs
+        )
+
+    def test_indices_elements_edge(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "edge_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len=2",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_elements_face(self):
+        kwargs = {
+            "indices": np.linspace(1, 6, 6, dtype=int).reshape((-1, 2)),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len>=3",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_elements_volume_face(self):
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((-1, 3)),
+            "cf_role": "volume_face_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len>=4",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_elements_volume_edge(self):
+        kwargs = {
+            "indices": np.linspace(1, 12, 12, dtype=int).reshape((-1, 3)),
+            "cf_role": "volume_edge_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len>=6",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_elements_alt_dim(self):
+        """The transposed equivalent of `test_indices_elements_volume_face`."""
+        kwargs = {
+            "indices": np.linspace(1, 9, 9, dtype=int).reshape((3, -1)),
+            "cf_role": "volume_face_connectivity",
+            "element_dim": 1,
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len>=4",
+            Connectivity,
+            **kwargs,
+        )
+
+    def test_indices_elements_masked(self):
+        mask = ([0, 0, 0] * 2) + [0, 0, 1]
+        data = np.linspace(1, 9, 9, dtype=int).reshape((3, -1))
+        kwargs = {
+            "indices": ma.array(data=data, mask=mask),
+            "cf_role": "face_node_connectivity",
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            "Not all elements meet requirement: len>=3",
+            Connectivity,
+            **kwargs,
+        )

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -96,8 +96,8 @@ class TestStandard(tests.IrisTest):
 
     def test___str__(self):
         expected = (
-            "Connectivity([[1 2 3]\n [4 5 6]\n [7 8 9]]), "
-            "cf_role='face_node_connectivity', start_index=1, src_dim=1, "
+            "Connectivity(array([[1, 2, 3],\n       [4, 5, 6],\n       [7, 8, 9]]), "
+            "standard_name=None, units=Unit('unknown'), "
             "long_name='my_face_nodes', var_name='face_nodes', "
             "attributes={'notes': 'this is a test'})"
         )
@@ -105,8 +105,8 @@ class TestStandard(tests.IrisTest):
 
     def test___repr__(self):
         expected = (
-            "Connectivity([[1 2 3]\n [4 5 6]\n [7 8 9]]), "
-            "cf_role='face_node_connectivity', start_index=1, src_dim=1, "
+            "Connectivity(array([[1, 2, 3],\n       [4, 5, 6],\n       [7, 8, 9]]), "
+            "standard_name=None, units=Unit('unknown'), "
             "long_name='my_face_nodes', var_name='face_nodes', "
             "attributes={'notes': 'this is a test'})"
         )

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -57,13 +57,6 @@ class TestStandard(tests.IrisTest):
             self.kwargs["indices"], self.connectivity.indices
         )
 
-    def test_src_lengths(self):
-        expected = [3, 3, 3]
-        self.assertArrayEqual(expected, self.connectivity.src_lengths)
-
-    def test_has_equal_src_lengths(self):
-        self.assertTrue(self.connectivity.has_equal_src_lengths)
-
     def test_read_only(self):
         attributes = ("indices", "cf_role", "start_index", "src_dim")
         for attribute in attributes:
@@ -93,6 +86,13 @@ class TestStandard(tests.IrisTest):
 
     def test_has_lazy_indices(self):
         self.assertFalse(self.connectivity.has_lazy_indices())
+
+    def test_lazy_src_lengths(self):
+        self.assertTrue(is_lazy_data(self.connectivity.lazy_src_lengths()))
+
+    def test_src_lengths(self):
+        expected = [3, 3, 3]
+        self.assertArrayEqual(expected, self.connectivity.src_lengths())
 
     def test___str__(self):
         expected = (
@@ -176,13 +176,6 @@ class TestAltIndices(tests.IrisTest):
             indices=self.lazy_indices, cf_role="face_node_connectivity"
         )
         self.assertTrue(connectivity.has_lazy_indices())
-
-    def test_src_lengths(self):
-        connectivity = Connectivity(
-            indices=self.masked_indices, cf_role="face_node_connectivity"
-        )
-        self.assertArrayEqual([4, 4, 3], connectivity.src_lengths)
-        self.assertFalse(connectivity.has_equal_src_lengths)
 
 
 class TestValidations(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Connectivity.py
+++ b/lib/iris/tests/unit/coords/test_Connectivity.py
@@ -316,9 +316,11 @@ class TestValidations(tests.IrisTest):
             "indices": ma.array(data=data, mask=mask),
             "cf_role": "face_node_connectivity",
         }
+        # Validation of individual location sizes (denoted by masks) only
+        # available through explicit call of Connectivity.validate_indices().
+        connectivity = Connectivity(**kwargs)
         self.assertRaisesRegex(
             ValueError,
             "Not all src_locations meet requirement: len>=3",
-            Connectivity,
-            **kwargs,
+            connectivity.validate_indices,
         )


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adds the `Connectivity` and accompanying `ConnectivityMetadata` classes - the first of many steps to allow Iris' core data model to represent the [CF-UGRID unstructured mesh format](https://ugrid-conventions.github.io/ugrid-conventions/) in addition to the existing CF structured grid format. Note this is targeting the new [`mesh-data-model`](https://github.com/SciTools/iris/tree/mesh-data-model) feature branch.

'Connectivity' name chosen since the most faithful interpretation of the [UGRID conventions](https://ugrid-conventions.github.io/ugrid-conventions/) is that a topology is made up of one or more self-contained connectivities.

Implemented as another member of [`iris.coords`](https://github.com/SciTools/iris/blob/master/lib/iris/coords.py), since `Connectivity`  benefits from inheriting the majority of [`_DimensionalMetadata`](https://github.com/SciTools/iris/blob/master/lib/iris/coords.py#L42-L680)'s functionality. `Connectivity` deviates slightly from existing `_DimensionalMetadata` children:

* Will never be attached to a traditional cube dimension, so [`cube_dims`](https://github.com/SciTools/iris/blob/master/lib/iris/coords.py#L186-L200) is just overridden with `NotImplementedError`.
* All the additional attributes all inter-relate - changing the value of just one will often render the others meaningless.
  As such none of them have a `.setter` method, and either need a special method to modify or the user is expected to create a new `Connectivity` with their new attribute values.
* The values of the `indices` array attribute are only meaningful subject to several requirements regarding `shape` and `dtype`, so `indices` is heavily validated whenever it is set.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
