### PR TITLE
remove explicit URLs for core dev names from latest.rst

### DIFF
--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -84,18 +84,15 @@ This document explains the changes made to Iris for this release
 
 
 .. comment
-    What's new author names (@github name) in alphabetical order:
+    Whatsnew author names (@github name) in alphabetical order. Note that,
+    core dev names are automatically included by the common_links.inc:
 
-.. _@bjlittle: https://github.com/bjlittle
 .. _@gcaria: https://github.com/gcaria
 .. _@MHBalsmeier: https://github.com/MHBalsmeier
-.. _@pelson: https://github.com/pelson
-.. _@rcomer: https://github.com/rcomer
-.. _@trexfeathers: https://github.com/trexfeathers
 
 
 .. comment
-    What's new resources in alphabetical order:
+    Whatsnew resources in alphabetical order:
 
 .. _abstract base class: https://docs.python.org/3/library/abc.html
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose

--- a/docs/iris/src/whatsnew/latest.rst.template
+++ b/docs/iris/src/whatsnew/latest.rst.template
@@ -83,12 +83,13 @@ This document explains the changes made to Iris for this release
 
 
 .. comment
-    What's new author names (@github name) in alphabetical order:
+    Whatsnew author names (@github name) in alphabetical order. Note that,
+    core dev names are automatically included by the common_links.inc:
 
 
 
 
 .. comment
-    What's new resources in alphabetical order:
+    Whatsnew resources in alphabetical order:
 
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR realises the value of #3972, and removes the explicit `rst` URL references of `iris` core dev names from the `latest.rst`.

Also, tweak the `latest.rst` and `latest.rst.template` comment titles.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
