### PR TITLE
Iris py38

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,6 +121,8 @@ linux_task:
       PY_VER: 3.6
     env:
       PY_VER: 3.7
+    env:
+      PY_VER: 3.8
   name: "${CIRRUS_OS}: py${PY_VER} tests (full)"
   container:
     image: gcc:latest
@@ -148,9 +150,7 @@ linux_task:
 gallery_task:
   matrix:
     env:
-      PY_VER: 3.6
-    env:
-      PY_VER: 3.7
+      PY_VER: 3.8
   name: "${CIRRUS_OS}: py${PY_VER} doc tests (gallery)"
   container:
     image: gcc:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,6 +98,8 @@ linux_minimal_task:
       PY_VER: 3.6
     env:
       PY_VER: 3.7
+    env:
+      PY_VER: 3.8
   name: "${CIRRUS_OS}: py${PY_VER} tests (minimal)"
   container:
     image: gcc:latest
@@ -176,7 +178,7 @@ gallery_task:
 doctest_task:
   matrix:
     env:
-      PY_VER: 3.7
+      PY_VER: 3.8
   name: "${CIRRUS_OS}: py${PY_VER} doc tests"
   container:
     image: gcc:latest
@@ -210,7 +212,7 @@ doctest_task:
 link_task:
   matrix:
     env:
-      PY_VER: 3.7
+      PY_VER: 3.8
   name: "${CIRRUS_OS}: py${PY_VER} doc link check"
   container:
     image: gcc:latest

--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -1,6 +1,7 @@
 .. comment
     Common resources in alphabetical order:
 
+.. _black: https://black.readthedocs.io/en/stable/
 .. _.cirrus.yml: https://github.com/SciTools/iris/blob/master/.cirrus.yml
 .. _.flake8.yml: https://github.com/SciTools/iris/blob/master/.flake8
 .. _cirrus-ci: https://cirrus-ci.com/github/SciTools/iris
@@ -19,6 +20,7 @@
 .. _legacy documentation: https://scitools.org.uk/iris/docs/v2.4.0/
 .. _matplotlib: https://matplotlib.org/
 .. _napolean: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html
+.. _nox: https://nox.thea.codes/en/stable/
 .. _New Issue: https://github.com/scitools/iris/issues/new/choose
 .. _pull request: https://github.com/SciTools/iris/pulls
 .. _pull requests: https://github.com/SciTools/iris/pulls

--- a/docs/src/developers_guide/contributing_running_tests.rst
+++ b/docs/src/developers_guide/contributing_running_tests.rst
@@ -186,8 +186,6 @@ For further `nox`_ command-line options::
 .. note:: `nox`_ will cache its testing environments in the `.nox` root ``iris`` project directory.
 
 
-.. _black: https://black.readthedocs.io/en/stable/
-.. _nox: https://nox.thea.codes/en/latest/
 .. _setuptools: https://setuptools.readthedocs.io/en/latest/
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _virtualenv: https://virtualenv.pypa.io/en/latest/

--- a/docs/src/further_topics/metadata.rst
+++ b/docs/src/further_topics/metadata.rst
@@ -258,12 +258,12 @@ create a **new** instance directly from the metadata class itself,
     >>> DimCoordMetadata._make(values)
     DimCoordMetadata(standard_name=1, long_name=2, var_name=3, units=4, attributes=5, coord_system=6, climatological=7, circular=8)
 
-It is also possible to easily convert ``metadata`` to an `OrderedDict`_
+It is also possible to easily convert ``metadata`` to an `dict`_
 using the `namedtuple._asdict`_ method. This can be particularly handy when a
 standard Python built-in container is required to represent your ``metadata``,
 
     >>> metadata._asdict()
-    OrderedDict([('standard_name', 'longitude'), ('long_name', None), ('var_name', 'longitude'), ('units', Unit('degrees')), ('attributes', {'grinning face': '🙃'}), ('coord_system', GeogCS(6371229.0)), ('climatological', False), ('circular', False)])
+    {'standard_name': 'longitude', 'long_name': None, 'var_name': 'longitude', 'units': Unit('degrees'), 'attributes': {'grinning face': '🙃'}, 'coord_system': GeogCS(6371229.0), 'climatological': False, 'circular': False}
 
 Using the `namedtuple._replace`_ method allows you to create a new metadata
 class instance, but replacing specified members with **new** associated values,
@@ -943,7 +943,7 @@ such as a `dict`_,
 
     >>> mapping = latitude.metadata._asdict()
     >>> mapping
-    OrderedDict([('standard_name', 'latitude'), ('long_name', None), ('var_name', 'latitude'), ('units', Unit('degrees')), ('attributes', {}), ('coord_system', GeogCS(6371229.0)), ('climatological', False), ('circular', False)])
+    {'standard_name': 'latitude', 'long_name': None, 'var_name': 'latitude', 'units': Unit('degrees'), 'attributes': {}, 'coord_system': GeogCS(6371229.0), 'climatological': False, 'circular': False}
     >>> longitude.metadata = mapping
     >>> longitude.metadata
     DimCoordMetadata(standard_name='latitude', long_name=None, var_name='latitude', units=Unit('degrees'), attributes={}, coord_system=GeogCS(6371229.0), climatological=False, circular=False)
@@ -1000,7 +1000,6 @@ values. All other metadata members will be left unaltered.
 .. _NetCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _NetCDF CF Metadata Conventions: https://cfconventions.org/
 .. _NumPy: https://github.com/numpy/numpy
-.. _OrderedDict: https://docs.python.org/3/library/collections.html#collections.OrderedDict
 .. _Parametric Vertical Coordinate: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#parametric-vertical-coordinate
 .. _rich comparison: https://www.python.org/dev/peps/pep-0207/
 .. _SciTools/iris: https://github.com/SciTools/iris

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -16,8 +16,8 @@ any WSL_ distributions.
 
 .. _WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 
-.. note:: Iris currently supports and is tested against **Python 3.6** and
-          **Python 3.7**.  
+.. note:: Iris is currently supported and tested against Python ``3.6``,
+          ``3.7``, and ``3.8``.
           
 .. note:: This documentation was built using Python |python_version|.
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,8 +97,8 @@ This document explains the changes made to Iris for this release
 
 #. `@jamesp`_ updated a test for `numpy`_ ``1.20.0``. (:pull:`3977`)
 
-#. `@bjlittle`_ extended the `cirrus-ci`_ testing and `nox`_ testing
-   automation to support `Python 3.8`_. (:pull:`3976`)
+#. `@bjlittle`_ and `@jamesp`_ extended the `cirrus-ci`_ testing and `nox`_
+   testing automation to support `Python 3.8`_. (:pull:`3976`)
 
 #. `@bjlittle`_ rationalised the ``noxfile.py``, and added the ability for
    each ``nox`` session to list its ``conda`` environment packages and

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -12,7 +12,6 @@ This document explains the changes made to Iris for this release
    :title: text-primary text-center font-weight-bold
    :body: bg-light
    :animate: fade-in
-   :open:
 
    The highlights for this major/minor release of Iris include:
 
@@ -96,7 +95,10 @@ This document explains the changes made to Iris for this release
 #. `@tkknight`_ moved the ``docs/iris`` directory to be in the parent
    directory ``docs``.  (:pull:`3975`)
 
-#. `@jamesp`_ updated a test to the latest numpy version (:pull:`3977`)
+#. `@jamesp`_ updated a test for `numpy`_ ``1.20.0``. (:pull:`3977`)
+
+#. `@bjlittle`_ extended the `cirrus-ci`_ testing and `nox`_ testing
+   automation to support `Python 3.8`_. (:pull:`3976`)
 
 #. `@bjlittle`_ rationalised the ``noxfile.py``, and added the ability for
    each ``nox`` session to list its ``conda`` environment packages and
@@ -117,3 +119,5 @@ This document explains the changes made to Iris for this release
 .. _abstract base class: https://docs.python.org/3/library/abc.html
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _Met Office: https://www.metoffice.gov.uk/
+.. _numpy: https://numpy.org/doc/stable/release/1.20.0-notes.html
+.. _Python 3.8: https://www.python.org/downloads/release/python-380/

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2275,9 +2275,7 @@ class Coord(_DimensionalMetadata):
         # class name
         element = super().xml_element(doc=doc)
 
-        element.setAttribute("points", self._xml_array_repr(self.points))
-
-        # Add bounds handling
+        # Add bounds, points are handled by the parent class.
         if self.has_bounds():
             element.setAttribute("bounds", self._xml_array_repr(self.bounds))
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -593,24 +593,26 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
             that require to be added to this element.
 
         """
-        # Create the XML element as the camelCaseEquivalent of the class name.
+        # Create the XML element as the camelCaseEquivalent of the
+        # class name.
         element_name = type(self).__name__
         element_name = element_name[0].lower() + element_name[1:]
         element = doc.createElement(element_name)
-        attributes = {}
 
-        attributes["id"] = self._xml_id()
+        element.setAttribute("id", self._xml_id())
 
         if self.standard_name:
-            attributes["standard_name"] = str(self.standard_name)
+            element.setAttribute("standard_name", str(self.standard_name))
         if self.long_name:
-            attributes["long_name"] = str(self.long_name)
+            element.setAttribute("long_name", str(self.long_name))
         if self.var_name:
-            attributes["var_name"] = str(self.var_name)
-        attributes["units"] = repr(self.units)
+            element.setAttribute("var_name", str(self.var_name))
+        element.setAttribute("units", repr(self.units))
         if isinstance(self, Coord):
             if self.climatological:
-                attributes["climatological"] = str(self.climatological)
+                element.setAttribute(
+                    "climatological", str(self.climatological)
+                )
 
         if self.attributes:
             attributes_element = doc.createElement("attributes")
@@ -628,18 +630,18 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
                 element.appendChild(self.coord_system.xml_element(doc))
 
         # Add the values
-        attributes["value_type"] = str(self._value_type_name())
-        attributes["shape"] = str(self.shape)
+        element.setAttribute("value_type", str(self._value_type_name()))
+        element.setAttribute("shape", str(self.shape))
 
-        # The values are referred to as "points" for a coordinate and "data"
+        # The values are referred to "points" of a coordinate and "data"
         # otherwise.
         if isinstance(self, Coord):
             values_term = "points"
         else:
             values_term = "data"
-        attributes[values_term] = self._xml_array_repr(self._values)
+        element.setAttribute(values_term, self._xml_array_repr(self._values))
 
-        return element, attributes
+        return element
 
     def _xml_id_extra(self, unique_value):
         return unique_value
@@ -789,47 +791,6 @@ class AncillaryVariable(_DimensionalMetadata):
         """
         return cube.ancillary_variable_dims(self)
 
-    def xml_element(self, doc, separated=None):
-        """
-        Create the :class:`xml.dom.minidom.Element` that describes this
-        :class:`AncillaryVariable`.
-
-        Args:
-
-        * doc:
-            The parent :class:`xml.dom.minidom.Document`.
-
-        Kwargs:
-
-        * separated:
-            Boolean determining whether a :class:`xml.dom.minidom.Element`
-            fully describing the attributes of this :class:`AncillaryVariable`
-            is returned (``False``). Otherwise, return the
-            :class:`xml.dom.minidom.Element` that will describe this
-            :class:`AncillaryVariable`, and the a dictionary of the attributes
-            to set on the element. Defaults to ``False``.
-
-        Returns:
-            The :class:`xml.dom.minidom.Element` that will describe this
-            :class:`DimCoord`, and the dictionary of attributes that require
-            to be added to this element, if ``separated`` is ``True``.
-
-        """
-        if separated is None:
-            separated = False
-
-        element, attributes = super().xml_element(doc=doc)
-
-        if separated:
-            result = element, attributes
-        else:
-            # Explicitly set the attributes in alphabetical order.
-            for key in sorted(attributes.keys()):
-                element.setAttribute(key, attributes[key])
-            result = element
-
-        return result
-
 
 class CellMeasure(AncillaryVariable):
     """
@@ -948,14 +909,12 @@ class CellMeasure(AncillaryVariable):
             :class:`CellMeasure`.
 
         """
-        element, attributes = super().xml_element(doc=doc, separated=True)
+        # Create the XML element as the camelCaseEquivalent of the
+        # class name
+        element = super().xml_element(doc=doc)
 
         # Add the 'measure' property
-        attributes["measure"] = self.measure
-
-        # Explicitly set the attributes in alphabetical order.
-        for key in sorted(attributes.keys()):
-            element.setAttribute(key, attributes[key])
+        element.setAttribute("measure", self.measure)
 
         return element
 
@@ -2312,13 +2271,17 @@ class Coord(_DimensionalMetadata):
             to be added to this element.
 
         """
-        element, attributes = super().xml_element(doc=doc)
+        # Create the XML element as the camelCaseEquivalent of the
+        # class name
+        element = super().xml_element(doc=doc)
 
-        # Add bounds, points are handled by the parent class.
+        element.setAttribute("points", self._xml_array_repr(self.points))
+
+        # Add bounds handling
         if self.has_bounds():
-            attributes["bounds"] = self._xml_array_repr(self.bounds)
+            element.setAttribute("bounds", self._xml_array_repr(self.bounds))
 
-        return element, attributes
+        return element
 
     def _xml_id_extra(self, unique_value):
         """Coord specific stuff for the xml id"""
@@ -2707,15 +2670,9 @@ class DimCoord(Coord):
             :class:`DimCoord`.
 
         """
-        element, attributes = super().xml_element(doc=doc)
-
+        element = super().xml_element(doc)
         if self.circular:
-            attributes["circular"] = str(self.circular)
-
-        # Explicitly set the attributes in alphabetical order.
-        for key in sorted(attributes.keys()):
-            element.setAttribute(key, attributes[key])
-
+            element.setAttribute("circular", str(self.circular))
         return element
 
 
@@ -2773,28 +2730,12 @@ class AuxCoord(Coord):
         """
         super().__init__(*args, **kwargs)
 
-    def xml_element(self, doc):
-        """
-        Create the :class:`xml.dom.minidom.Element` that describes this
-        :class:`AuxCoord`.
-
-        Args:
-
-        * doc:
-            The parent :class:`xml.dom.minidom.Document`.
-
-        Returns:
-            The :class:`xml.dom.minidom.Element` that describes this
-            :class:`AuxCoord`.
-
-        """
-        element, attributes = super().xml_element(doc=doc)
-
-        # Explicitly set the attributes in alphabetical order.
-        for key in sorted(attributes.keys()):
-            element.setAttribute(key, attributes[key])
-
-        return element
+    # Logically, :class:`Coord` is an abstract class and all actual coords must
+    # be members of some concrete subclass, i.e. an :class:`AuxCoord` or
+    # a :class:`DimCoord`.
+    # So we retain :class:`AuxCoord` as a distinct concrete subclass.
+    # This provides clarity, backwards compatibility, and so we can add
+    # AuxCoord-specific code if needed in future.
 
 
 class CellMethod(iris.util._OrderedHashable):
@@ -2922,24 +2863,19 @@ class CellMethod(iris.util._OrderedHashable):
 
         """
         cellMethod_xml_element = doc.createElement("cellMethod")
-        attributes = {"method": self.method}
+        cellMethod_xml_element.setAttribute("method", self.method)
 
         for coord_name, interval, comment in zip_longest(
             self.coord_names, self.intervals, self.comments
         ):
             coord_xml_element = doc.createElement("coord")
             if coord_name is not None:
-                # Add attributes in alphabetical order.
-                if comment is not None:
-                    coord_xml_element.setAttribute("comment", comment)
+                coord_xml_element.setAttribute("name", coord_name)
                 if interval is not None:
                     coord_xml_element.setAttribute("interval", interval)
-                coord_xml_element.setAttribute("name", coord_name)
+                if comment is not None:
+                    coord_xml_element.setAttribute("comment", comment)
                 cellMethod_xml_element.appendChild(coord_xml_element)
-
-        # Explicitly set the attributes in alphabetical order.
-        for key in sorted(attributes.keys()):
-            cellMethod_xml_element.setAttribute(key, attributes[key])
 
         return cellMethod_xml_element
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -578,7 +578,21 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
         return self._values_dm.shape
 
     def xml_element(self, doc):
-        """Return a DOM element describing this metadata and a dictionary of its attributes."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`_DimensionalMetadata`.
+
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that will describe this
+            :class:`_DimensionalMetadata`, and the dictionary of attributes
+            that require to be added to this element.
+
+        """
         # Create the XML element as the camelCaseEquivalent of the class name.
         element_name = type(self).__name__
         element_name = element_name[0].lower() + element_name[1:]
@@ -775,15 +789,38 @@ class AncillaryVariable(_DimensionalMetadata):
         """
         return cube.ancillary_variable_dims(self)
 
-    def xml_element(self, doc, split=None):
-        """Return DOM element describing this :class:`AncillaryVariable`."""
+    def xml_element(self, doc, separated=None):
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`AncillaryVariable`.
 
-        if split is None:
-            split = False
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Kwargs:
+
+        * separated:
+            Boolean determining whether a :class:`xml.dom.minidom.Element`
+            fully describing the attributes of this :class:`AncillaryVariable`
+            is returned (``False``). Otherwise, return the
+            :class:`xml.dom.minidom.Element` that will describe this
+            :class:`AncillaryVariable`, and the a dictionary of the attributes
+            to set on the element. Defaults to ``False``.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that will describe this
+            :class:`DimCoord`, and the dictionary of attributes that require
+            to be added to this element, if ``separated`` is ``True``.
+
+        """
+        if separated is None:
+            separated = False
 
         element, attributes = super().xml_element(doc=doc)
 
-        if split:
+        if separated:
             result = element, attributes
         else:
             # Explicitly set the attributes in alphabetical order.
@@ -897,9 +934,21 @@ class CellMeasure(AncillaryVariable):
         return cube.cell_measure_dims(self)
 
     def xml_element(self, doc):
-        """Return DOM element describing this :class:`CellMeasure`."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`CellMeasure`.
 
-        element, attributes = super().xml_element(doc=doc, split=True)
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that describes this
+            :class:`CellMeasure`.
+
+        """
+        element, attributes = super().xml_element(doc=doc, separated=True)
 
         # Add the 'measure' property
         attributes["measure"] = self.measure
@@ -2248,7 +2297,21 @@ class Coord(_DimensionalMetadata):
         return result_index
 
     def xml_element(self, doc):
-        """Return a DOM element describing this :class:`Coord` and a dictionary of its attributes."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`Coord`.
+
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that will describe this
+            :class:`DimCoord`, and the dictionary of attributes that require
+            to be added to this element.
+
+        """
         element, attributes = super().xml_element(doc=doc)
 
         # Add bounds, points are handled by the parent class.
@@ -2630,7 +2693,20 @@ class DimCoord(Coord):
         return True
 
     def xml_element(self, doc):
-        """Return DOM element describing this :class:`DimCoord`."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`DimCoord`.
+
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that describes this
+            :class:`DimCoord`.
+
+        """
         element, attributes = super().xml_element(doc=doc)
 
         if self.circular:
@@ -2698,7 +2774,20 @@ class AuxCoord(Coord):
         super().__init__(*args, **kwargs)
 
     def xml_element(self, doc):
-        """Return DOM element describing this :class:`AuxCoord`."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`AuxCoord`.
+
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that describes this
+            :class:`AuxCoord`.
+
+        """
         element, attributes = super().xml_element(doc=doc)
 
         # Explicitly set the attributes in alphabetical order.
@@ -2818,7 +2907,20 @@ class CellMethod(iris.util._OrderedHashable):
         raise NotImplementedError()
 
     def xml_element(self, doc):
-        """Return DOM element describing this :class:`CellMethod`."""
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`CellMethod`.
+
+        Args:
+
+        * doc:
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that describes this
+            :class:`CellMethod`.
+
+        """
         cellMethod_xml_element = doc.createElement("cellMethod")
         attributes = {"method": self.method}
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -225,6 +225,7 @@ class CubeList(list):
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """Return a string of the XML that this list of cubes represents."""
+
         doc = Document()
         cubes_xml_element = doc.createElement("cubes")
         cubes_xml_element.setAttribute("xmlns", XML_NAMESPACE_URI)
@@ -239,6 +240,7 @@ class CubeList(list):
         doc.appendChild(cubes_xml_element)
 
         # return our newly created XML string
+        doc = Cube._sort_xml_attrs(doc)
         return doc.toprettyxml(indent="  ")
 
     def extract(self, constraints):
@@ -754,6 +756,59 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     #: or lists slice along each dimension independently. This behavior
     #: is similar to Fortran or Matlab, but different than numpy.
     __orthogonal_indexing__ = True
+
+    @classmethod
+    def _sort_xml_attrs(cls, doc):
+        """
+        Takes an xml document and returns a copy with all element
+        attributes sorted in alphabetical order.
+
+        This is a private utility method required by iris to maintain
+        legacy xml behaviour beyond python 3.7.
+
+        Args:
+
+        * doc:
+            The :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Document` with sorted element
+            attributes.
+
+        """
+        from xml.dom.minidom import Document
+
+        def _walk_nodes(node):
+            """Note: _walk_nodes is called recursively on child elements."""
+
+            # we don't want to copy the children here, so take a shallow copy
+            new_node = node.cloneNode(deep=False)
+
+            # Versions of python <3.8 order attributes in alphabetical order.
+            # Python >=3.8 order attributes in insert order.  For consistent behaviour
+            # across both, we'll go with alphabetical order always.
+            # Remove all the attribute nodes, then add back in alphabetical order.
+            attrs = [
+                new_node.getAttributeNode(attr_name).cloneNode(deep=True)
+                for attr_name in sorted(node.attributes.keys())
+            ]
+            for attr in attrs:
+                new_node.removeAttributeNode(attr)
+            for attr in attrs:
+                new_node.setAttributeNode(attr)
+
+            if node.childNodes:
+                children = [_walk_nodes(x) for x in node.childNodes]
+                for c in children:
+                    new_node.appendChild(c)
+
+            return new_node
+
+        nodes = _walk_nodes(doc.documentElement)
+        new_doc = Document()
+        new_doc.appendChild(nodes)
+
+        return new_doc
 
     def __init__(
         self,
@@ -3403,25 +3458,20 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         doc.appendChild(cube_xml_element)
 
         # Print our newly created XML
+        doc = self._sort_xml_attrs(doc)
         return doc.toprettyxml(indent="  ")
 
     def _xml_element(self, doc, checksum=False, order=True, byteorder=True):
-        def set_attributes(element, attributes):
-            """Inset the attributes explicitly in alphabetical order."""
-            for key in sorted(attributes.keys()):
-                element.setAttribute(key, attributes[key])
-
         cube_xml_element = doc.createElement("cube")
-        cube_xml_element_attributes = {}
 
         if self.standard_name:
-            cube_xml_element_attributes["standard_name"] = self.standard_name
+            cube_xml_element.setAttribute("standard_name", self.standard_name)
         if self.long_name:
-            cube_xml_element_attributes["long_name"] = self.long_name
+            cube_xml_element.setAttribute("long_name", self.long_name)
         if self.var_name:
-            cube_xml_element_attributes["var_name"] = self.var_name
-        cube_xml_element_attributes["units"] = str(self.units)
-        cube_xml_element_attributes["dtype"] = self.dtype.name
+            cube_xml_element.setAttribute("var_name", self.var_name)
+        cube_xml_element.setAttribute("units", str(self.units))
+        cube_xml_element.setAttribute("dtype", self.dtype.name)
 
         if self.attributes:
             attributes_element = doc.createElement("attributes")
@@ -3446,18 +3496,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             cube_xml_element.appendChild(attributes_element)
 
-        def dimmeta_xml_element(item, typename, dimscall):
+        def dimmeta_xml_element(element, typename, dimscall):
             # Make an inner xml element for a cube DimensionalMetadata element, with a
             # 'datadims' property showing how it maps to the parent cube dims.
             xml_element = doc.createElement(typename)
-            dims = list(dimscall(item))
+            dims = list(dimscall(element))
             if dims:
                 xml_element.setAttribute("datadims", repr(dims))
-            item_element = item.xml_element(doc)
-            xml_element.appendChild(item_element)
+            xml_element.appendChild(element.xml_element(doc))
             return xml_element
 
-        # coordinates
         coords_xml_element = doc.createElement("coords")
         for coord in sorted(self.coords(), key=lambda coord: coord.name()):
             # make a "cube coordinate" element which holds the dimensions (if
@@ -3478,7 +3526,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # cell measures
         cell_measures = sorted(self.cell_measures(), key=lambda cm: cm.name())
         if cell_measures:
-            # This one is an optional sub-element.
+            # This one is an optional subelement.
             cms_xml_element = doc.createElement("cellMeasures")
             for cm in cell_measures:
                 cms_xml_element.appendChild(
@@ -3501,9 +3549,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 )
             cube_xml_element.appendChild(ancs_xml_element)
 
-        # cube data
+        # data
         data_xml_element = doc.createElement("data")
-        data_xml_element_attributes = {"shape": str(self.shape)}
+        data_xml_element.setAttribute("shape", str(self.shape))
 
         # NB. Getting a checksum triggers any deferred loading,
         # in which case it also has the side-effect of forcing the
@@ -3534,14 +3582,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     )
                 else:
                     crc = "no-masked-elements"
-                data_xml_element_attributes["mask_checksum"] = crc
+                data_xml_element.setAttribute("mask_checksum", crc)
             else:
                 crc = "0x%08x" % (zlib.crc32(normalise(data)) & 0xFFFFFFFF,)
-                data_xml_element_attributes["checksum"] = crc
+                data_xml_element.setAttribute("checksum", crc)
         elif self.has_lazy_data():
-            data_xml_element_attributes["state"] = "deferred"
+            data_xml_element.setAttribute("state", "deferred")
         else:
-            data_xml_element_attributes["state"] = "loaded"
+            data_xml_element.setAttribute("state", "loaded")
 
         # Add the dtype, and also the array and mask orders if the
         # data is loaded.
@@ -3558,7 +3606,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                 return order
 
             if order:
-                data_xml_element_attributes["order"] = _order(data)
+                data_xml_element.setAttribute("order", _order(data))
 
             # NB. dtype.byteorder can return '=', which is bad for
             # cross-platform consistency - so we use dtype.str
@@ -3566,18 +3614,15 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             if byteorder:
                 array_byteorder = {">": "big", "<": "little"}.get(dtype.str[0])
                 if array_byteorder is not None:
-                    data_xml_element_attributes["byteorder"] = array_byteorder
+                    data_xml_element.setAttribute("byteorder", array_byteorder)
 
             if order and ma.isMaskedArray(data):
-                data_xml_element_attributes["mask_order"] = _order(data.mask)
+                data_xml_element.setAttribute("mask_order", _order(data.mask))
         else:
             dtype = self.lazy_data().dtype
-        data_xml_element_attributes["dtype"] = dtype.name
+        data_xml_element.setAttribute("dtype", dtype.name)
 
-        set_attributes(data_xml_element, data_xml_element_attributes)
         cube_xml_element.appendChild(data_xml_element)
-
-        set_attributes(cube_xml_element, cube_xml_element_attributes)
 
         return cube_xml_element
 

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -573,6 +573,10 @@ class IrisTest_nometa(unittest.TestCase):
         """
         doc = xml.dom.minidom.Document()
         doc.appendChild(obj.xml_element(doc))
+        # sort the attributes on xml elements before testing against known good state.
+        # this is to be compatible with stored test output where xml attrs are stored in alphabetical order,
+        # (which was default behaviour in python <3.8, but changed to insert order in >3.8)
+        doc = iris.cube.Cube._sort_xml_attrs(doc)
         pretty_xml = doc.toprettyxml(indent="  ")
         reference_path = self.get_result_path(reference_filename)
         self._check_same(

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ nox.options.reuse_existing_virtualenvs = True
 PACKAGE = str("lib" / Path("iris"))
 
 #: Cirrus-CI environment variable hook.
-PY_VER = os.environ.get("PY_VER", ["3.6", "3.7"])
+PY_VER = os.environ.get("PY_VER", ["3.6", "3.7", "3.8"])
 
 #: Default cartopy cache directory.
 CARTOPY_CACHE_DIR = os.environ.get("HOME") / Path(".local/share/cartopy")

--- a/requirements/ci/iris.yml
+++ b/requirements/ci/iris.yml
@@ -1,1 +1,1 @@
-py37.yml
+py38.yml

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -1,0 +1,51 @@
+name: iris-dev
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.8
+
+# Setup dependencies.
+  - setuptools>=40.8.0
+  - pyke
+
+# Core dependencies.
+  - cartopy>=0.18
+  - cf-units>=2
+  - cftime<1.3.0
+  - dask>=2
+  - matplotlib
+  - netcdf4
+  - numpy>=1.14
+  - python-xxhash
+  - scipy
+
+# Optional dependencies.
+  - esmpy>=7.0
+  - graphviz
+  - iris-sample-data
+  - mo_pack
+  - nc-time-axis
+  - pandas
+  - python-stratify
+  - pyugrid
+
+# Test dependencies.
+  - asv
+  - black=20.8b1
+  - filelock
+  - flake8
+  - imagehash>=4.0
+  - nose
+  - pillow<7
+  - pre-commit
+  - requests
+
+# Documentation dependencies.
+  - sphinx
+  - sphinxcontrib-napoleon
+  - sphinx-copybutton
+  - sphinx-gallery
+  - sphinx-panels
+  - sphinx_rtd_theme


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR extends the `iris` testing to cover `python` 3.8.x.

In order to provision this testing infra-structure, work was required on `cml` generation, as [xml.dom.minidom](https://docs.python.org/3/library/xml.dom.minidom.html#module-xml.dom.minidom) has changed from 3.8 to preserve xml element attribute assignment order - most likely due to `python` dictionaries now preserving order.

In addition to this a minor fix was required for the doc-tests, as a `namedtuple._todict()` now returns a `dict` rather than an `OrderedDict`.

Note that, all the CI documentation is performed soley for `python` 3.8 i.e.,
* the documentation gallary
* the doc-tests
* the documentation link-check


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
