### PR TITLE
Fix test_incompatible_dimensions test

### DIFF
--- a/docs/iris/src/common_links.inc
+++ b/docs/iris/src/common_links.inc
@@ -42,6 +42,7 @@
 .. _@djkirkham: https://github.com/djkirkham
 .. _@DPeterK: https://github.com/DPeterK
 .. _@esc24: https://github.com/esc24
+.. _@jamesp: https://github.com/jamesp
 .. _@jonseddon: https://github.com/jonseddon
 .. _@jvegasbsc: https://github.com/jvegasbsc
 .. _@lbdreyer: https://github.com/lbdreyer

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -82,7 +82,7 @@ This document explains the changes made to Iris for this release
 
 #. `@rcomer`_ removed an old unused test file. (:pull:`3913`)
 
-#. `@jamesp`_ updated a test to the latest numpy version (:pull: `3977`)
+#. `@jamesp`_ updated a test to the latest numpy version (:pull:`3977`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -81,7 +81,7 @@ This document explains the changes made to Iris for this release
 ===========
 
 #. `@rcomer`_ removed an old unused test file. (:pull:`3913`)
-
+#. `@jamesp`_ updated a test to the latest numpy version (:pull: `3977`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/iris/src/whatsnew/latest.rst
+++ b/docs/iris/src/whatsnew/latest.rst
@@ -81,6 +81,7 @@ This document explains the changes made to Iris for this release
 ===========
 
 #. `@rcomer`_ removed an old unused test file. (:pull:`3913`)
+
 #. `@jamesp`_ updated a test to the latest numpy version (:pull: `3977`)
 
 .. comment

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -853,7 +853,7 @@ class TestMaskedArrays(tests.IrisTest):
 
     def test_incompatible_dimensions(self):
         data3 = ma.MaskedArray(
-            [[3, 3, 3, 4], [2, 2, 2]], mask=[[0, 1, 0, 0], [0, 1, 1]]
+            [[3, 3, 3, 4], [2, 2, 2, 2]], mask=[[0, 1, 0, 0], [0, 1, 1, 1]]
         )
         with self.assertRaises(ValueError):
             # Incompatible dimensions.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
test_incompatible_dimensions used a ragged array for the test, which has been deprecated in numpy, and now fails if dtype is anything other than object.  This test appears to be checking that the addition of a [2x4] masked array to a [2x3] masked cube, iris should raise a ValueError. This commit fixes the creation of `data3` object to be a [2x4] non-ragged array, preventing the *different* ValueError raised by numpy!


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
