### PR TITLE
automate docs discovery of iris and python versions

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -96,7 +96,7 @@ autolog("Iris Release = {}".format(release))
 # Create a variable that can be inserted in the rst "|copyright_years|".
 # You can add more variables here if needed.
 rst_epilog = f"""
-.. |copyright_years| replace:: {2010 - upper_copy_year}
+.. |copyright_years| replace:: 2010 - {upper_copy_year}
 .. |python_version| replace:: {'.'.join([str(i) for i in sys.version_info[:3]])}
 .. |iris_version| replace:: v{version}
 .. |build_date| replace:: ({datetime.datetime.now().strftime('%d %b %Y')})

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -99,10 +99,12 @@ rst_epilog = """
 .. |copyright_years| replace:: {year_range}
 .. |python_version| replace:: {python_version}
 .. |iris_version| replace:: {iris_version}
+.. |build_date| replace:: {build_date}
 """.format(
     year_range=f"2010 - {upper_copy_year}",
     python_version=".".join([str(i) for i in sys.version_info[:3]]),
     iris_version=f"v{version}",
+    build_date=f"({datetime.datetime.now().strftime('%d %b %Y')})",
 )
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,6 +43,7 @@ if on_rtd:
     for item, value in os.environ.items():
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -92,12 +93,16 @@ autolog("Iris Release = {}".format(release))
 
 # -- General configuration ---------------------------------------------------
 
-# Create a variable that can be insterted in the rst "|copyright_years|".
-# You can add more vairables here if needed
+# Create a variable that can be inserted in the rst "|copyright_years|".
+# You can add more variables here if needed.
 rst_epilog = """
 .. |copyright_years| replace:: {year_range}
+.. |python_version| replace:: {python_version}
+.. |iris_version| replace:: {iris_version}
 """.format(
-    year_range="2010 - {}".format(upper_copy_year)
+    year_range=f"2010 - {upper_copy_year}",
+    python_version=".".join([str(i) for i in sys.version_info[:3]]),
+    iris_version=f"v{version}",
 )
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -95,17 +95,12 @@ autolog("Iris Release = {}".format(release))
 
 # Create a variable that can be inserted in the rst "|copyright_years|".
 # You can add more variables here if needed.
-rst_epilog = """
-.. |copyright_years| replace:: {year_range}
-.. |python_version| replace:: {python_version}
-.. |iris_version| replace:: {iris_version}
-.. |build_date| replace:: {build_date}
-""".format(
-    year_range=f"2010 - {upper_copy_year}",
-    python_version=".".join([str(i) for i in sys.version_info[:3]]),
-    iris_version=f"v{version}",
-    build_date=f"({datetime.datetime.now().strftime('%d %b %Y')})",
-)
+rst_epilog = f"""
+.. |copyright_years| replace:: {2010 - upper_copy_year}
+.. |python_version| replace:: {'.'.join([str(i) for i in sys.version_info[:3]])}
+.. |iris_version| replace:: v{version}
+.. |build_date| replace:: ({datetime.datetime.now().strftime('%d %b %Y')})
+"""
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -126,9 +126,8 @@ These steps assume a release for ``v1.9`` is to be created.
 Release Steps
 ~~~~~~~~~~~~~
 
-#. Create the branch ``1.9.x`` on the main repo, not in a forked repo, for the
-   release candidate or release.  The only exception is for a point/bugfix
-   release as it should already exist
+#. Create the release feature branch ``1.9.x`` on `SciTools/iris`_.
+   The only exception is for a point/bugfix release, as it should already exist
 #. Update the ``iris.__init__.py`` version string e.g., to ``1.9.0``
 #. Update the what's new for the release:
 
@@ -175,4 +174,5 @@ Post Release Steps
 
 
 .. _Read The Docs: https://readthedocs.org/projects/scitools-iris/builds/
+.. _SciTools/iris: https://github.com/SciTools/iris
 .. _tag on the SciTools/Iris: https://github.com/SciTools/iris/releases

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -121,7 +121,7 @@ release process is to be followed, including the merge back of changes into
 Maintainer Steps
 ----------------
 
-These steps assume a release for ``v1.9`` is to be created
+These steps assume a release for ``v1.9`` is to be created.
 
 Release Steps
 ~~~~~~~~~~~~~
@@ -131,25 +131,26 @@ Release Steps
    release as it should already exist
 #. Update the what's new for the release:
 
-    * Copy ``docs/src/whatsnew/latest.rst`` to a file named
-      ``v1.9.rst``
-    * Delete the ``docs/src/whatsnew/latest.rst`` file so it will not
-      cause an issue in the build
+    * Use git to rename ``docs/src/whatsnew/latest.rst`` to the release
+      version file ``v1.9.rst``
+    * Use git to delete the ``docs/src/whatsnew/latest.rst.template`` file
     * In ``v1.9.rst`` update the page title (first line of the file) to show
-      the date and version in the format of ``v1.9 (DD MMM YYYY)``.  For
-      example ``v1.9 (03 Aug 2020)``
+      the release date in the format of ``v1.9 (DD MMM YYYY)``.  For
+      example ``v1.9 (03 Aug 2020)``. Note that, the release version in the
+      title is updated automatically
     * Review the file for correctness
-    * Work with the development team to create a 'highlights' section at the
-      top of the file, providing extra detail on notable changes
-    * Add ``v1.9.rst`` to git and commit all changes, including removal of
-      ``latest.rst``
+    * Work with the development team to populate the ``Release Highlights``
+      dropdown at the top of the file, which provides extra detail on notable
+      changes
+    * Use git to add and commit all changes, including removal of
+      ``latest.rst.template``
 
 #. Update the what's new index ``docs/src/whatsnew/index.rst``
 
-   * Temporarily remove reference to ``latest.rst``
+   * Remove the reference to ``latest.rst``
    * Add a reference to ``v1.9.rst`` to the top of the list
 
-#. Update the ``Iris.__init__.py`` version string, to ``1.9.0``
+#. Update the ``iris.__init__.py`` version string e.g., to ``1.9.0``
 #. Check your changes by building the documentation and viewing the changes
 #. Once all the above steps are complete, the release is cut, using
    the :guilabel:`Draft a new release` button on the

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -129,15 +129,15 @@ Release Steps
 #. Create the branch ``1.9.x`` on the main repo, not in a forked repo, for the
    release candidate or release.  The only exception is for a point/bugfix
    release as it should already exist
+#. Update the ``iris.__init__.py`` version string e.g., to ``1.9.0``
 #. Update the what's new for the release:
 
     * Use git to rename ``docs/src/whatsnew/latest.rst`` to the release
       version file ``v1.9.rst``
     * Use git to delete the ``docs/src/whatsnew/latest.rst.template`` file
-    * In ``v1.9.rst`` update the page title (first line of the file) to show
-      the release date in the format of ``v1.9 (DD MMM YYYY)``.  For
-      example ``v1.9 (03 Aug 2020)``. Note that, the release version in the
-      title is updated automatically
+    * In ``v1.9.rst`` remove the ``[unreleased]`` caption from the page title.
+      Note that, the Iris version and release date are updated automatically
+      when the documentation is built
     * Review the file for correctness
     * Work with the development team to populate the ``Release Highlights``
       dropdown at the top of the file, which provides extra detail on notable
@@ -150,8 +150,7 @@ Release Steps
    * Remove the reference to ``latest.rst``
    * Add a reference to ``v1.9.rst`` to the top of the list
 
-#. Update the ``iris.__init__.py`` version string e.g., to ``1.9.0``
-#. Check your changes by building the documentation and viewing the changes
+#. Check your changes by building the documentation and reviewing
 #. Once all the above steps are complete, the release is cut, using
    the :guilabel:`Draft a new release` button on the
    `Iris release page <https://github.com/SciTools/iris/releases>`_
@@ -171,7 +170,7 @@ Post Release Steps
    new headings
 #. Add back in the reference to ``latest.rst`` to the what's new index
    ``docs/src/whatsnew/index.rst``
-#. Update ``Iris.__init__.py`` version string to show as ``1.10.dev0``
+#. Update ``iris.__init__.py`` version string to show as ``1.10.dev0``
 #. Merge back to master
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -77,8 +77,11 @@ This document explains the changes made to Iris for this release
    (:pull:`3958`)
 
 #. `@bjlittle`_ clarified in the doc-string that :class:`~iris.coords.Coord`
-   is now an `abstract base class`_ of coordinates since Iris ``3.0.0``, and
-   it is **not** possible to create an instance of it. (:pull:`3971`)
+   is now an `abstract base class`_ since Iris ``3.0.0``, and it is **not**
+   possible to create an instance of it. (:pull:`3971`)
+
+#. `@bjlittle`_ added automated Iris version discovery for the ``latest.rst``
+   in the ``whatsnew`` documentation. (:pull:`3981`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -1,7 +1,7 @@
 .. include:: ../common_links.inc
 
-|iris_version| (unreleased)
-***************************
+|iris_version| |build_date| [unreleased]
+****************************************
 
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -1,7 +1,7 @@
 .. include:: ../common_links.inc
 
-<unreleased>
-************
+|iris_version| (unreleased)
+***************************
 
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -1,7 +1,7 @@
 .. include:: ../common_links.inc
 
-|iris_version| (unreleased)
-***************************
+|iris_version| |build_date| [unreleased]
+****************************************
 
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -1,7 +1,7 @@
 .. include:: ../common_links.inc
 
-<unreleased>
-************
+|iris_version| (unreleased)
+***************************
 
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR automates the discovery of the `iris` version for the `whatsnew`, and also the `python` version used to build the documentation via the `sphinx` [rst_epilog](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_epilog).

These are available in all `rst` files via `|iris_version|` and `|python_version|` directives.

The rendered version of the `whatsnew` generated by this PR is available [here](https://bjlittle-iris.readthedocs.io/en/latest/whatsnew/latest.html).

The rendered version of the `release` documentation changes from this PR are available [here](https://bjlittle-iris.readthedocs.io/en/latest/developers_guide/release.html#release-steps).

P.S. the `|build_date|` directive is now also available to automate the `whatsnew` release/build date.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
