### PR TITLE
Add abstract cube summary

### DIFF
--- a/lib/iris/_representation.py
+++ b/lib/iris/_representation.py
@@ -1,0 +1,273 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Provides objects describing cube summaries.
+"""
+
+import iris.util
+
+
+class DimensionHeader:
+    def __init__(self, cube):
+        if cube.shape == ():
+            self.scalar = True
+            self.dim_names = []
+            self.shape = []
+            self.contents = ["scalar cube"]
+        else:
+            self.scalar = False
+            self.dim_names = []
+            for dim in range(len(cube.shape)):
+                dim_coords = cube.coords(
+                    contains_dimension=dim, dim_coords=True
+                )
+                if dim_coords:
+                    self.dim_names.append(dim_coords[0].name())
+                else:
+                    self.dim_names.append("-- ")
+            self.shape = list(cube.shape)
+            self.contents = [
+                name + ": %d" % dim_len
+                for name, dim_len in zip(self.dim_names, self.shape)
+            ]
+
+
+class FullHeader:
+    def __init__(self, cube, name_padding=35):
+        self.name = cube.name()
+        self.unit = cube.units
+        self.nameunit = "{name} / ({units})".format(
+            name=self.name, units=self.unit
+        )
+        self.name_padding = name_padding
+        self.dimension_header = DimensionHeader(cube)
+
+
+class CoordSummary:
+    def _summary_coord_extra(self, cube, coord):
+        # Returns the text needed to ensure this coordinate can be
+        # distinguished from all others with the same name.
+        extra = ""
+        similar_coords = cube.coords(coord.name())
+        if len(similar_coords) > 1:
+            # Find all the attribute keys
+            keys = set()
+            for similar_coord in similar_coords:
+                keys.update(similar_coord.attributes.keys())
+            # Look for any attributes that vary
+            vary = set()
+            attributes = {}
+            for key in keys:
+                for similar_coord in similar_coords:
+                    if key not in similar_coord.attributes:
+                        vary.add(key)
+                        break
+                    value = similar_coord.attributes[key]
+                    if attributes.setdefault(key, value) != value:
+                        vary.add(key)
+                        break
+            keys = sorted(vary & set(coord.attributes.keys()))
+            bits = [
+                "{}={!r}".format(key, coord.attributes[key]) for key in keys
+            ]
+            if bits:
+                extra = ", ".join(bits)
+        return extra
+
+
+class VectorSummary(CoordSummary):
+    def __init__(self, cube, vector, iscoord):
+        self.name = iris.util.clip_string(vector.name())
+        dims = vector.cube_dims(cube)
+        self.dim_chars = [
+            "x" if dim in dims else "-" for dim in range(len(cube.shape))
+        ]
+        if iscoord:
+            extra = self._summary_coord_extra(cube, vector)
+            self.extra = iris.util.clip_string(extra)
+        else:
+            self.extra = ""
+
+
+class ScalarSummary(CoordSummary):
+    def __init__(self, cube, coord):
+        self.name = coord.name()
+        if (
+            coord.units in ["1", "no_unit", "unknown"]
+            or coord.units.is_time_reference()
+        ):
+            self.unit = ""
+        else:
+            self.unit = " {!s}".format(coord.units)
+        coord_cell = coord.cell(0)
+        if isinstance(coord_cell.point, str):
+            self.string_type = True
+            self.lines = [
+                iris.util.clip_string(str(item))
+                for item in coord_cell.point.split("\n")
+            ]
+            self.point = None
+            self.bound = None
+            self.content = "\n".join(self.lines)
+        else:
+            self.string_type = False
+            self.lines = None
+            self.point = "{!s}".format(coord_cell.point)
+            coord_cell_cbound = coord_cell.bound
+            if coord_cell_cbound is not None:
+                self.bound = "({})".format(
+                    ", ".join(str(val) for val in coord_cell_cbound)
+                )
+                self.content = "{}{}, bound={}{}".format(
+                    self.point, self.unit, self.bound, self.unit
+                )
+            else:
+                self.bound = None
+                self.content = "{}{}".format(self.point, self.unit)
+        extra = self._summary_coord_extra(cube, coord)
+        self.extra = iris.util.clip_string(extra)
+
+
+class Section:
+    def _init_(self):
+        self.contents = []
+
+    def is_empty(self):
+        return self.contents == []
+
+
+class VectorSection(Section):
+    def __init__(self, title, cube, vectors, iscoord):
+        self.title = title
+        self.contents = [
+            VectorSummary(cube, vector, iscoord) for vector in vectors
+        ]
+
+
+class ScalarSection(Section):
+    def __init__(self, title, cube, scalars):
+        self.title = title
+        self.contents = [ScalarSummary(cube, scalar) for scalar in scalars]
+
+
+class ScalarCellMeasureSection(Section):
+    def __init__(self, title, cell_measures):
+        self.title = title
+        self.contents = [cm.name() for cm in cell_measures]
+
+
+class AttributeSection(Section):
+    def __init__(self, title, attributes):
+        self.title = title
+        self.names = []
+        self.values = []
+        self.contents = []
+        for name, value in sorted(attributes.items()):
+            value = iris.util.clip_string(str(value))
+            self.names.append(name)
+            self.values.append(value)
+            content = "{}: {}".format(name, value)
+            self.contents.append(content)
+
+
+class CellMethodSection(Section):
+    def __init__(self, title, cell_methods):
+        self.title = title
+        self.contents = [str(cm) for cm in cell_methods]
+
+
+class CubeSummary:
+    def __init__(self, cube, shorten=False, name_padding=35):
+        self.section_indent = 5
+        self.item_indent = 10
+        self.extra_indent = 13
+        self.shorten = shorten
+        self.header = FullHeader(cube, name_padding)
+
+        # Cache the derived coords so we can rely on consistent
+        # object IDs.
+        derived_coords = cube.derived_coords
+        # Determine the cube coordinates that are scalar (single-valued)
+        # AND non-dimensioned.
+        dim_coords = cube.dim_coords
+        aux_coords = cube.aux_coords
+        all_coords = dim_coords + aux_coords + derived_coords
+        scalar_coords = [
+            coord
+            for coord in all_coords
+            if not cube.coord_dims(coord) and coord.shape == (1,)
+        ]
+        # Determine the cube coordinates that are not scalar BUT
+        # dimensioned.
+        scalar_coord_ids = set(map(id, scalar_coords))
+        vector_dim_coords = [
+            coord for coord in dim_coords if id(coord) not in scalar_coord_ids
+        ]
+        vector_aux_coords = [
+            coord for coord in aux_coords if id(coord) not in scalar_coord_ids
+        ]
+        vector_derived_coords = [
+            coord
+            for coord in derived_coords
+            if id(coord) not in scalar_coord_ids
+        ]
+
+        # cell measures
+        vector_cell_measures = [
+            cm for cm in cube.cell_measures() if cm.shape != (1,)
+        ]
+
+        # Ancillary Variables
+        vector_ancillary_variables = [av for av in cube.ancillary_variables()]
+
+        # Sort scalar coordinates by name.
+        scalar_coords.sort(key=lambda coord: coord.name())
+        # Sort vector coordinates by data dimension and name.
+        vector_dim_coords.sort(
+            key=lambda coord: (cube.coord_dims(coord), coord.name())
+        )
+        vector_aux_coords.sort(
+            key=lambda coord: (cube.coord_dims(coord), coord.name())
+        )
+        vector_derived_coords.sort(
+            key=lambda coord: (cube.coord_dims(coord), coord.name())
+        )
+        scalar_cell_measures = [
+            cm for cm in cube.cell_measures() if cm.shape == (1,)
+        ]
+
+        self.vector_sections = {}
+
+        def add_vector_section(title, contents, iscoord=True):
+            self.vector_sections[title] = VectorSection(
+                title, cube, contents, iscoord
+            )
+
+        add_vector_section("Dimension coordinates:", vector_dim_coords)
+        add_vector_section("Auxiliary coordinates:", vector_aux_coords)
+        add_vector_section("Derived coordinates:", vector_derived_coords)
+        add_vector_section("Cell Measures:", vector_cell_measures, False)
+        add_vector_section(
+            "Ancillary Variables:", vector_ancillary_variables, False
+        )
+
+        self.scalar_sections = {}
+
+        def add_scalar_section(section_class, title, *args):
+            self.scalar_sections[title] = section_class(title, *args)
+
+        add_scalar_section(
+            ScalarSection, "Scalar Coordinates:", cube, scalar_coords
+        )
+        add_scalar_section(
+            ScalarCellMeasureSection,
+            "Scalar cell measures:",
+            scalar_cell_measures,
+        )
+        add_scalar_section(AttributeSection, "Attributes:", cube.attributes)
+        add_scalar_section(
+            CellMethodSection, "Cell methods:", cube.cell_methods
+        )

--- a/lib/iris/tests/unit/representation/__init__.py
+++ b/lib/iris/tests/unit/representation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris._representation` module."""

--- a/lib/iris/tests/unit/representation/test_representation.py
+++ b/lib/iris/tests/unit/representation/test_representation.py
@@ -1,0 +1,187 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris._representation` module."""
+
+import numpy as np
+import iris.tests as tests
+import iris._representation
+from iris.cube import Cube
+from iris.coords import (
+    DimCoord,
+    AuxCoord,
+    CellMeasure,
+    AncillaryVariable,
+    CellMethod,
+)
+
+
+def example_cube():
+    cube = Cube(
+        np.arange(6).reshape([3, 2]),
+        standard_name="air_temperature",
+        long_name="screen_air_temp",
+        var_name="airtemp",
+        units="K",
+    )
+    lat = DimCoord([0, 1, 2], standard_name="latitude", units="degrees")
+    cube.add_dim_coord(lat, 0)
+    return cube
+
+
+class Test_CubeSummary(tests.IrisTest):
+    def setUp(self):
+        self.cube = example_cube()
+
+    def test_header(self):
+        rep = iris._representation.CubeSummary(self.cube)
+        header_left = rep.header.nameunit
+        header_right = rep.header.dimension_header.contents
+
+        self.assertEqual(header_left, "air_temperature / (K)")
+        self.assertEqual(header_right, ["latitude: 3", "-- : 2"])
+
+    def test_blank_cube(self):
+        cube = Cube([1, 2])
+        rep = iris._representation.CubeSummary(cube)
+
+        self.assertEqual(rep.header.nameunit, "unknown / (unknown)")
+        self.assertEqual(rep.header.dimension_header.contents, ["-- : 2"])
+
+        expected_vector_sections = [
+            "Dimension coordinates:",
+            "Auxiliary coordinates:",
+            "Derived coordinates:",
+            "Cell Measures:",
+            "Ancillary Variables:",
+        ]
+        self.assertEqual(
+            list(rep.vector_sections.keys()), expected_vector_sections
+        )
+        for title in expected_vector_sections:
+            vector_section = rep.vector_sections[title]
+            self.assertEqual(vector_section.contents, [])
+            self.assertTrue(vector_section.is_empty())
+
+        expected_scalar_sections = [
+            "Scalar Coordinates:",
+            "Scalar cell measures:",
+            "Attributes:",
+            "Cell methods:",
+        ]
+
+        self.assertEqual(
+            list(rep.scalar_sections.keys()), expected_scalar_sections
+        )
+        for title in expected_scalar_sections:
+            scalar_section = rep.scalar_sections[title]
+            self.assertEqual(scalar_section.contents, [])
+            self.assertTrue(scalar_section.is_empty())
+
+    def test_vector_coord(self):
+        rep = iris._representation.CubeSummary(self.cube)
+        dim_section = rep.vector_sections["Dimension coordinates:"]
+
+        self.assertEqual(len(dim_section.contents), 1)
+        self.assertFalse(dim_section.is_empty())
+
+        dim_summary = dim_section.contents[0]
+
+        name = dim_summary.name
+        dim_chars = dim_summary.dim_chars
+        extra = dim_summary.extra
+
+        self.assertEqual(name, "latitude")
+        self.assertEqual(dim_chars, ["x", "-"])
+        self.assertEqual(extra, "")
+
+    def test_scalar_coord(self):
+        cube = self.cube
+        scalar_coord_no_bounds = AuxCoord([10], long_name="bar", units="K")
+        scalar_coord_with_bounds = AuxCoord(
+            [10], long_name="foo", units="K", bounds=[(5, 15)]
+        )
+        scalar_coord_text = AuxCoord(
+            ["a\nb\nc"], long_name="foo", attributes={"key": "value"}
+        )
+        cube.add_aux_coord(scalar_coord_no_bounds)
+        cube.add_aux_coord(scalar_coord_with_bounds)
+        cube.add_aux_coord(scalar_coord_text)
+        rep = iris._representation.CubeSummary(cube)
+
+        scalar_section = rep.scalar_sections["Scalar Coordinates:"]
+
+        self.assertEqual(len(scalar_section.contents), 3)
+
+        no_bounds_summary = scalar_section.contents[0]
+        bounds_summary = scalar_section.contents[1]
+        text_summary = scalar_section.contents[2]
+
+        self.assertEqual(no_bounds_summary.name, "bar")
+        self.assertEqual(no_bounds_summary.content, "10 K")
+        self.assertEqual(no_bounds_summary.extra, "")
+
+        self.assertEqual(bounds_summary.name, "foo")
+        self.assertEqual(bounds_summary.content, "10 K, bound=(5, 15) K")
+        self.assertEqual(bounds_summary.extra, "")
+
+        self.assertEqual(text_summary.name, "foo")
+        self.assertEqual(text_summary.content, "a\nb\nc")
+        self.assertEqual(text_summary.extra, "key='value'")
+
+    def test_cell_measure(self):
+        cube = self.cube
+        cell_measure = CellMeasure([1, 2, 3], long_name="foo")
+        cube.add_cell_measure(cell_measure, 0)
+        rep = iris._representation.CubeSummary(cube)
+
+        cm_section = rep.vector_sections["Cell Measures:"]
+        self.assertEqual(len(cm_section.contents), 1)
+
+        cm_summary = cm_section.contents[0]
+        self.assertEqual(cm_summary.name, "foo")
+        self.assertEqual(cm_summary.dim_chars, ["x", "-"])
+
+    def test_ancillary_variable(self):
+        cube = self.cube
+        cell_measure = AncillaryVariable([1, 2, 3], long_name="foo")
+        cube.add_ancillary_variable(cell_measure, 0)
+        rep = iris._representation.CubeSummary(cube)
+
+        av_section = rep.vector_sections["Ancillary Variables:"]
+        self.assertEqual(len(av_section.contents), 1)
+
+        av_summary = av_section.contents[0]
+        self.assertEqual(av_summary.name, "foo")
+        self.assertEqual(av_summary.dim_chars, ["x", "-"])
+
+    def test_attributes(self):
+        cube = self.cube
+        cube.attributes = {"a": 1, "b": "two"}
+        rep = iris._representation.CubeSummary(cube)
+
+        attribute_section = rep.scalar_sections["Attributes:"]
+        attribute_contents = attribute_section.contents
+        expected_contents = ["a: 1", "b: two"]
+
+        self.assertEqual(attribute_contents, expected_contents)
+
+    def test_cell_methods(self):
+        cube = self.cube
+        x = AuxCoord(1, long_name="x")
+        y = AuxCoord(1, long_name="y")
+        cell_method_xy = CellMethod("mean", [x, y])
+        cell_method_x = CellMethod("mean", x)
+        cube.add_cell_method(cell_method_xy)
+        cube.add_cell_method(cell_method_x)
+
+        rep = iris._representation.CubeSummary(cube)
+        cell_method_section = rep.scalar_sections["Cell methods:"]
+        expected_contents = ["mean: x, y", "mean: x"]
+        self.assertEqual(cell_method_section.contents, expected_contents)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A simple replacement for #3952
 * now based on current "master"
 * commits squashed

With this, I'm intending to bank what is now on #3952.
I still think there are some small improvements outstanding, but we can fix those later, along with adding my new cube summary code -- all in subsequent PRs.
So I'm now intending to **put this onto master** (as originally suggested by @bjlittle), 

Future plans... 
Subsequently when adding my new cube-summary code, I will find a quick way not to break the existing `_repr_html_` implementation.
I **think** I can make the string summary close enough in form that I can also make the existing `_repr_html_` code work with minimal changes.  If not, I will leave the existing cube summary code in place, under a different name, until we find time to fix it properly  -- which would be messy, but means we can get on.
So, **given that approach, I think we can still target master here**


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
