### PR TITLE
Added text to state the Python version used to build the docs.

### DIFF
--- a/docs/src/_templates/footer.html
+++ b/docs/src/_templates/footer.html
@@ -1,0 +1,5 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+   Built using Python {{ python_version }}.
+   {{ super() }}
+{% endblock %} 

--- a/docs/src/_templates/footer.html
+++ b/docs/src/_templates/footer.html
@@ -2,4 +2,4 @@
 {% block extrafooter %}
    Built using Python {{ python_version }}.
    {{ super() }}
-{% endblock %} 
+{% endblock %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -95,9 +95,12 @@ autolog("Iris Release = {}".format(release))
 
 # Create a variable that can be inserted in the rst "|copyright_years|".
 # You can add more variables here if needed.
+
+build_python_version = ".".join([str(i) for i in sys.version_info[:3]])
+
 rst_epilog = f"""
 .. |copyright_years| replace:: 2010 - {upper_copy_year}
-.. |python_version| replace:: {'.'.join([str(i) for i in sys.version_info[:3]])}
+.. |python_version| replace:: {build_python_version}
 .. |iris_version| replace:: v{version}
 .. |build_date| replace:: ({datetime.datetime.now().strftime('%d %b %Y')})
 """
@@ -226,6 +229,7 @@ html_theme_options = {
 
 html_context = {
     "copyright_years": "2010 - {}".format(upper_copy_year),
+    "python_version": build_python_version,
     # menu_links and menu_links_name are used in _templates/layout.html
     # to include some nice icons.  See http://fontawesome.io for a list of
     # icons (used in the sphinx_rtd_theme)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -69,8 +69,8 @@ project = "Iris"
 
 # define the copyright information for latex builds. Note, for html builds,
 # the copyright exists directly inside "_templates/layout.html"
-upper_copy_year = datetime.datetime.now().year
-copyright = "Iris Contributors"
+copyright_years = f"2010 - {datetime.datetime.now().year}"
+copyright = f"{copyright_years}, Iris Contributors"
 author = "Iris Developers"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -99,7 +99,7 @@ autolog("Iris Release = {}".format(release))
 build_python_version = ".".join([str(i) for i in sys.version_info[:3]])
 
 rst_epilog = f"""
-.. |copyright_years| replace:: 2010 - {upper_copy_year}
+.. |copyright_years| replace:: {copyright_years}
 .. |python_version| replace:: {build_python_version}
 .. |iris_version| replace:: v{version}
 .. |build_date| replace:: ({datetime.datetime.now().strftime('%d %b %Y')})
@@ -228,7 +228,7 @@ html_theme_options = {
 }
 
 html_context = {
-    "copyright_years": "2010 - {}".format(upper_copy_year),
+    "copyright_years": copyright_years,
     "python_version": build_python_version,
     # menu_links and menu_links_name are used in _templates/layout.html
     # to include some nice icons.  See http://fontawesome.io for a list of

--- a/docs/src/developers_guide/contributing_documentation.rst
+++ b/docs/src/developers_guide/contributing_documentation.rst
@@ -24,7 +24,7 @@ The documentation uses specific packages that need to be present.  Please see
 Building
 ~~~~~~~~
 
-This documentation is built using the latest Python version that Iris
+This documentation was built using the latest Python version that Iris
 supports.  For more information see :ref:`installing_iris`.
 
 The build can be run from the documentation directory ``docs/src``.

--- a/docs/src/developers_guide/contributing_documentation.rst
+++ b/docs/src/developers_guide/contributing_documentation.rst
@@ -24,6 +24,9 @@ The documentation uses specific packages that need to be present.  Please see
 Building
 ~~~~~~~~
 
+This documentation is built using the latest Python version that Iris
+supports.  For more information see :ref:`installing_iris`.
+
 The build can be run from the documentation directory ``docs/src``.
 
 The build output for the html is found in the ``_build/html`` sub directory.

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -17,8 +17,9 @@ any WSL_ distributions.
 .. _WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 
 .. note:: Iris currently supports and is tested against **Python 3.6** and
-          **Python 3.7**.  This documentation is built using a single
-          version of Python, version |python_version|.
+          **Python 3.7**.  
+          
+.. note:: This documentation was built using Python |python_version|.
 
 
 .. _installing_using_conda:

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -17,7 +17,8 @@ any WSL_ distributions.
 .. _WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 
 .. note:: Iris currently supports and is tested against **Python 3.6** and
-          **Python 3.7**.
+          **Python 3.7**.  This documentation is built using a single
+          version of Python, version |python_version|.
 
 
 .. _installing_using_conda:

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -83,6 +83,10 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ added automated Iris version discovery for the ``latest.rst``
    in the ``whatsnew`` documentation. (:pull:`3981`)
 
+#. `@tkknight`_ stated the Python version used to build the documentation
+   on :ref:`installing_iris` and to the footer of all pages.  Also added the
+   copyright years to the footer. (:pull:`3989`)
+
 
 💼 Internal
 ===========


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Add explicit statement of which version Python is used when building the documentation.  This includes:

* Using the Python version as defined in the variable **build_python_version**.  This builds upon the changes from #3981.
* Updating the installing page to state the Python version in the note.
* Added the **build_python_version** to the **html_context** variable in **conf.py** to allow it to be used in the templating for the **footer.html**.  

For the lifetime of this PR the docs can be seen here: https://tkknight-iris-test-doc.readthedocs.io/en/latest/index.html.  Note:

* https://tkknight-iris-test-doc.readthedocs.io/en/latest/installing.html
* https://tkknight-iris-test-doc.readthedocs.io/en/latest/developers_guide/contributing_documentation.html#building
* An updated footer on **all** pages showing the python version used


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
