### PR TITLE
normalise version to implicit development release number

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -106,7 +106,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.1.0dev0"
+__version__ = "3.1.dev0"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR normalises the `__version__` to the expected [PEP-0440 implicit development release number](https://www.python.org/dev/peps/pep-0440/#implicit-development-release-number) i.e., we can drop the implied `0` point release part - which makes sense as point releases equate to patch releases from a release feature branch e.g., `v3.0.x`

It also avoids `setuptools` issuing the following warning:
```shell
> python setup.py build
<snip>/lib/python3.7/site-packages/setuptools/dist.py:458: UserWarning: Normalizing '3.1.0dev0' to '3.1.0.dev0'
```


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
