### PR TITLE
Stop using deprecated aliases of builtin types

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -112,11 +112,15 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ enabled `cirrus-ci`_ compute credits for non-draft pull-requests
    from collaborators targeting the Iris ``master`` branch. (:pull:`4007`)
 
+#. `@akuhnregnier`_ replaced `deprecated numpy 1.20 aliases for builtin types`_.
+   (:pull:`3997`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
+.. _@akuhnregnier: https://github.com/akuhnregnier
 .. _@gcaria: https://github.com/gcaria
 .. _@MHBalsmeier: https://github.com/MHBalsmeier
 
@@ -125,6 +129,7 @@ This document explains the changes made to Iris for this release
     Whatsnew resources in alphabetical order:
 
 .. _abstract base class: https://docs.python.org/3/library/abc.html
+.. _deprecated numpy 1.20 aliases for builtin types: https://numpy.org/doc/1.20/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _Met Office: https://www.metoffice.gov.uk/
 .. _numpy: https://numpy.org/doc/stable/release/1.20.0-notes.html

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -294,7 +294,7 @@ class _CoordConstraint:
             except TypeError:
                 try_quick = False
         if try_quick:
-            r = np.zeros(coord.shape, dtype=np.bool)
+            r = np.zeros(coord.shape, dtype=np.bool_)
             if coord.cell(i) == self._coord_thing:
                 r[i] = True
         else:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1454,7 +1454,7 @@ def _peak(array, **kwargs):
     slices[-1] = endslice
     slices = tuple(slices)  # Numpy>=1.16 : index with tuple, *not* list.
 
-    if isinstance(array.dtype, np.float):
+    if isinstance(array.dtype, np.float64):
         data = array[slices]
     else:
         # Cast non-float data type.

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -696,7 +696,7 @@ class RectilinearRegridder:
 
         if ma.isMaskedArray(src_data):
             data = ma.empty(shape, dtype=dtype)
-            data.mask = np.zeros(data.shape, dtype=np.bool)
+            data.mask = np.zeros(data.shape, dtype=np.bool_)
         else:
             data = np.empty(shape, dtype=dtype)
 

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -498,9 +498,9 @@ def _regrid_area_weighted_array(src_data, x_dim, y_dim, weights_info, mdtol=0):
     # Flag to indicate whether the original data was a masked array.
     src_masked = src_data.mask.any() if ma.isMaskedArray(src_data) else False
     if src_masked:
-        src_area_masks = np.full(src_areas_shape, True, dtype=np.bool)
+        src_area_masks = np.full(src_areas_shape, True, dtype=np.bool_)
     else:
-        new_data_mask = np.full(new_shape, False, dtype=np.bool)
+        new_data_mask = np.full(new_shape, False, dtype=np.bool_)
 
     # Axes of data over which the weighted mean is calculated.
     axis = (y_dim, x_dim)

--- a/lib/iris/fileformats/_ff.py
+++ b/lib/iris/fileformats/_ff.py
@@ -816,7 +816,7 @@ class FF2PP:
         return pp._interpret_fields(self._extract_field())
 
 
-def _parse_binary_stream(file_like, dtype=np.float, count=-1):
+def _parse_binary_stream(file_like, dtype=np.float64, count=-1):
     """
     Replacement :func:`numpy.fromfile` due to python3 performance issues.
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -752,7 +752,7 @@ def _data_bytes_to_shaped_array(
             # However, we still mask any MDI values in the array (below).
             pass
         else:
-            land_mask = mask.data.astype(np.bool)
+            land_mask = mask.data.astype(np.bool_)
             sea_mask = ~land_mask
             new_data = np.ma.masked_all(land_mask.shape)
             new_data.fill_value = mdi

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -580,7 +580,7 @@ def _epoch_date_hours(epoch_hours_unit, datetime):
     # numpy.float64.  The behaviour of round is to recast this to an
     # int, which is not the desired behaviour for PP files.
     # So, cast the answer to numpy.float_ to be safe.
-    epoch_hours = np.float_(epoch_hours_unit.date2num(datetime))
+    epoch_hours = np.float64(epoch_hours_unit.date2num(datetime))
 
     if days_offset is not None:
         # Correct for any modifications to achieve a valid date.

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -483,26 +483,26 @@ class IrisTest_nometa(unittest.TestCase):
                         stats.get("max", 0.0),
                         stats.get("min", 0.0),
                     ),
-                    dtype=np.float_,
+                    dtype=np.float64,
                 )
                 if math.isnan(stats.get("mean", 0.0)):
                     self.assertTrue(math.isnan(data.mean()))
                 else:
                     data_stats = np.array(
                         (data.mean(), data.std(), data.max(), data.min()),
-                        dtype=np.float_,
+                        dtype=np.float64,
                     )
                     self.assertArrayAllClose(nstats, data_stats, **kwargs)
         else:
             self._ensure_folder(reference_path)
             stats = collections.OrderedDict(
                 [
-                    ("std", np.float_(data.std())),
-                    ("min", np.float_(data.min())),
-                    ("max", np.float_(data.max())),
+                    ("std", np.float64(data.std())),
+                    ("min", np.float64(data.min())),
+                    ("max", np.float64(data.max())),
                     ("shape", data.shape),
                     ("masked", ma.is_masked(data)),
-                    ("mean", np.float_(data.mean())),
+                    ("mean", np.float64(data.mean())),
                 ]
             )
             with open(reference_path, "w") as reference_file:

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -675,7 +675,7 @@ class TestConservativeRegrid(tests.IrisTest):
                 [100, 100, 100, 100, 100, 100, 100, 100, 100],
                 [100, 100, 100, 100, 100, 100, 100, 100, 100],
             ],
-            dtype=np.float,
+            dtype=np.float64,
         )
 
         c1_areasum = _cube_area_sum(c1)
@@ -715,7 +715,7 @@ class TestConservativeRegrid(tests.IrisTest):
                 [100, 100, 199, 199, 100],
                 [100, 100, 199, 199, 199],
             ],
-            dtype=np.float,
+            dtype=np.float64,
         )
         c2_areasum = _cube_area_sum(c2)
 
@@ -770,7 +770,7 @@ class TestConservativeRegrid(tests.IrisTest):
                     [100, 100, 100, 100, 100, 100, 100, 100, 100],
                     [100, 100, 100, 100, 100, 100, 100, 100, 100],
                 ],
-                dtype=np.float,
+                dtype=np.float64,
             )
 
             if do_add_missing:

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -130,7 +130,7 @@ class TestCells(tests.IrisTest):
         self.assertEqual(self.d.__ne__(Terry()), NotImplemented)
 
     def test_numpy_int_equality(self):
-        dtypes = (np.int, np.int16, np.int32, np.int64)
+        dtypes = (int, np.int16, np.int32, np.int64)
         for dtype in dtypes:
             val = dtype(3)
             cell = iris.coords.Cell(val, None)
@@ -138,7 +138,7 @@ class TestCells(tests.IrisTest):
 
     def test_numpy_float_equality(self):
         dtypes = (
-            np.float,
+            float,
             np.float16,
             np.float32,
             np.float64,

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -138,7 +138,7 @@ class TestCells(tests.IrisTest):
 
     def test_numpy_float_equality(self):
         dtypes = (
-            float,
+            np.float_,
             np.float16,
             np.float32,
             np.float64,

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -130,7 +130,7 @@ class TestCells(tests.IrisTest):
         self.assertEqual(self.d.__ne__(Terry()), NotImplemented)
 
     def test_numpy_int_equality(self):
-        dtypes = (int, np.int16, np.int32, np.int64)
+        dtypes = (np.int_, np.int16, np.int32, np.int64)
         for dtype in dtypes:
             val = dtype(3)
             cell = iris.coords.Cell(val, None)

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -415,7 +415,7 @@ class Test2D(tests.IrisTest):
         self.assertEqual(result[0].shape, (2, 4))
         mask = np.array(
             [[True, False, False, True], [False, True, True, False]],
-            dtype=np.bool,
+            dtype=np.bool_,
         )
         self.assertArrayEqual(result[0].data.mask, mask)
 
@@ -436,7 +436,7 @@ class Test2D(tests.IrisTest):
         self.assertEqual(result[0].shape, (4, 2))
         mask = np.array(
             [[True, False], [False, True], [False, True], [True, False]],
-            dtype=np.bool,
+            dtype=np.bool_,
         )
         self.assertArrayEqual(result[0].data.mask, mask)
 
@@ -458,7 +458,7 @@ class Test2D(tests.IrisTest):
         self.assertEqual(result[0].shape, (4, 2))
         mask = np.array(
             [[True, False], [False, True], [False, True], [True, False]],
-            dtype=np.bool,
+            dtype=np.bool_,
         )
         self.assertArrayEqual(result[0].data.mask, mask)
 
@@ -480,7 +480,7 @@ class Test2D(tests.IrisTest):
         self.assertEqual(result[0].shape, (4, 2))
         mask = np.array(
             [[True, False], [False, True], [False, True], [True, False]],
-            dtype=np.bool,
+            dtype=np.bool_,
         )
         self.assertArrayEqual(result[0].data.mask, mask)
 

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -468,7 +468,7 @@ class TestCombination(tests.IrisTest):
         )
 
         for name, value in zip(["a", "b", "c", "d"], [a, b, c, d]):
-            dtype = np.str if isinstance(value, str) else np.float32
+            dtype = np.str_ if isinstance(value, str) else np.float32
             cube.add_aux_coord(
                 AuxCoord(
                     np.array([value], dtype=dtype), long_name=name, units="1"
@@ -613,7 +613,7 @@ class TestDimSelection(tests.IrisTest):
         )
 
         for name, value, dim in zip(["a", "b"], [a, b], [a_dim, b_dim]):
-            dtype = np.str if isinstance(value, str) else np.float32
+            dtype = np.str_ if isinstance(value, str) else np.float32
             ctype = DimCoord if dim else AuxCoord
             coord = ctype(
                 np.array([value], dtype=dtype), long_name=name, units="1"

--- a/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
@@ -431,7 +431,7 @@ class TestMasking(tests.IrisTest):
                 [1, 1, 1, 1, 1, 0, 0, 1, 1, 1],
                 [1, 1, 1, 1, 1, 0, 0, 1, 1, 1],
             ],
-            np.bool,
+            np.bool_,
         )
         self.assertArrayEqual(expected_mask, ut.data.mask)
         self.assertArrayEqual(expected_mask, vt.data.mask)

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -266,7 +266,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
     def test_default_ndarray(self):
         # NaN           -> NaN
         # Extrapolated  -> NaN
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method)
@@ -278,7 +278,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked
         # Masked        -> Masked
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -293,7 +293,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked
         # Masked        -> N/A
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method)
@@ -307,7 +307,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked
         # Masked        -> N/A
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         # Make sure the mask has been expanded
         data.mask = False
         data[0, 0] = np.nan
@@ -322,7 +322,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
     def test_method_ndarray(self):
         # NaN           -> NaN
         # Extrapolated  -> linear
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method, "extrapolate")
@@ -334,7 +334,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> linear
         # Masked        -> Masked
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -348,7 +348,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
     def test_nan_ndarray(self):
         # NaN           -> NaN
         # Extrapolated  -> NaN
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method, "nan")
@@ -360,7 +360,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> NaN
         # Masked        -> Masked
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -373,7 +373,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
 
     def test_error_ndarray(self):
         # Values irrelevant - the function raises an error.
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             with self.assertRaisesRegex(ValueError, "out of bounds"):
@@ -381,7 +381,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
 
     def test_error_maskedarray(self):
         # Values irrelevant - the function raises an error.
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -392,7 +392,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked (this is different from all the other
         #                          modes)
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method, "mask")
@@ -406,7 +406,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked
         # Masked        -> Masked
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -420,7 +420,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
     def test_nanmask_ndarray(self):
         # NaN           -> NaN
         # Extrapolated  -> NaN
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         for method in self.methods:
             result = self._regrid(data, method, "nanmask")
@@ -432,7 +432,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
         # NaN           -> NaN
         # Extrapolated  -> Masked
         # Masked        -> Masked
-        data = ma.arange(12, dtype=np.float).reshape(3, 4)
+        data = ma.arange(12, dtype=np.float64).reshape(3, 4)
         data[0, 0] = np.nan
         data[2, 3] = ma.masked
         for method in self.methods:
@@ -444,7 +444,7 @@ class Test__regrid__extrapolation_modes(tests.IrisTest):
             self.assertMaskedArrayEqual(result, expected)
 
     def test_invalid(self):
-        data = np.arange(12, dtype=np.float).reshape(3, 4)
+        data = np.arange(12, dtype=np.float64).reshape(3, 4)
         emsg = "Invalid extrapolation mode"
         for method in self.methods:
             with self.assertRaisesRegex(ValueError, emsg):

--- a/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSFactory.py
@@ -195,12 +195,12 @@ class Test_make_coord(tests.IrisTest):
             np.arange(-0.975, 0, 0.05, dtype=float), units="1", long_name="s"
         )
         self.eta = AuxCoord(
-            np.arange(-1, 3, dtype=np.float).reshape(2, 2),
+            np.arange(-1, 3, dtype=np.float64).reshape(2, 2),
             long_name="eta",
             units="m",
         )
         self.depth = AuxCoord(
-            np.arange(4, dtype=np.float).reshape(2, 2) * 1e3,
+            np.arange(4, dtype=np.float64).reshape(2, 2) * 1e3,
             long_name="depth",
             units="m",
         )

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg1Factory.py
@@ -179,12 +179,12 @@ class Test_make_coord(tests.IrisTest):
             np.linspace(-0.959, -0.001, 36), units="1", long_name="c"
         )
         self.eta = AuxCoord(
-            np.arange(-1, 3, dtype=np.float).reshape(2, 2),
+            np.arange(-1, 3, dtype=np.float64).reshape(2, 2),
             long_name="eta",
             units="m",
         )
         self.depth = AuxCoord(
-            np.array([[5, 200], [1000, 4000]], dtype=np.float),
+            np.array([[5, 200], [1000, 4000]], dtype=np.float64),
             long_name="depth",
             units="m",
         )

--- a/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSg2Factory.py
@@ -179,12 +179,12 @@ class Test_make_coord(tests.IrisTest):
             np.linspace(-0.959, -0.001, 36), units="1", long_name="c"
         )
         self.eta = AuxCoord(
-            np.arange(-1, 3, dtype=np.float).reshape(2, 2),
+            np.arange(-1, 3, dtype=np.float64).reshape(2, 2),
             long_name="eta",
             units="m",
         )
         self.depth = AuxCoord(
-            np.array([[5, 200], [1000, 4000]], dtype=np.float),
+            np.array([[5, 200], [1000, 4000]], dtype=np.float64),
             long_name="depth",
             units="m",
         )

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaFactory.py
@@ -102,12 +102,12 @@ class Test_make_coord(tests.IrisTest):
             np.linspace(-0.05, -1, 5), long_name="sigma", units="1"
         )
         self.eta = AuxCoord(
-            np.arange(-1, 3, dtype=np.float).reshape(2, 2),
+            np.arange(-1, 3, dtype=np.float64).reshape(2, 2),
             long_name="eta",
             units="m",
         )
         self.depth = AuxCoord(
-            np.arange(4, dtype=np.float).reshape(2, 2) * 1e3,
+            np.arange(4, dtype=np.float64).reshape(2, 2) * 1e3,
             long_name="depth",
             units="m",
         )

--- a/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_OceanSigmaZFactory.py
@@ -199,22 +199,22 @@ class Test_make_coord(tests.IrisTest):
 
     def setUp(self):
         self.sigma = DimCoord(
-            np.arange(5, dtype=np.float) * 10, long_name="sigma", units="1"
+            np.arange(5, dtype=np.float64) * 10, long_name="sigma", units="1"
         )
         self.eta = AuxCoord(
-            np.arange(4, dtype=np.float).reshape(2, 2),
+            np.arange(4, dtype=np.float64).reshape(2, 2),
             long_name="eta",
             units="m",
         )
         self.depth = AuxCoord(
-            np.arange(4, dtype=np.float).reshape(2, 2) * 10,
+            np.arange(4, dtype=np.float64).reshape(2, 2) * 10,
             long_name="depth",
             units="m",
         )
         self.depth_c = AuxCoord([15], long_name="depth_c", units="m")
         self.nsigma = AuxCoord([3], long_name="nsigma")
         self.zlev = DimCoord(
-            np.arange(5, dtype=np.float) * 10, long_name="zlev", units="m"
+            np.arange(5, dtype=np.float64) * 10, long_name="zlev", units="m"
         )
         self.kwargs = dict(
             sigma=self.sigma,

--- a/lib/iris/tests/unit/common/metadata/test_BaseMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_BaseMetadata.py
@@ -1074,8 +1074,8 @@ class Test__difference_lenient_attributes(tests.IrisTest):
         self.values = OrderedDict(
             one=sentinel.one,
             two=sentinel.two,
-            three=np.float(3.14),
-            four=np.arange(10, dtype=np.float),
+            three=np.float64(3.14),
+            four=np.arange(10, dtype=np.float64),
             five=ma.arange(10, dtype=np.int16),
         )
         self.cls = BaseMetadata

--- a/lib/iris/tests/unit/common/metadata/test__hexdigest.py
+++ b/lib/iris/tests/unit/common/metadata/test__hexdigest.py
@@ -49,18 +49,18 @@ class TestBytesLikeObject(tests.IrisTest):
         self.assertEqual(expected, hexdigest(value))
 
     def test_numpy_array_int(self):
-        value = np.arange(10, dtype=np.int)
+        value = np.arange(10, dtype=np.int_)
         expected = self._ndarray(value)
         self.assertEqual(expected, hexdigest(value))
 
     def test_numpy_array_float(self):
-        value = np.arange(10, dtype=np.float)
+        value = np.arange(10, dtype=np.float64)
         expected = self._ndarray(value)
         self.assertEqual(expected, hexdigest(value))
 
     def test_numpy_array_float_not_int(self):
-        ivalue = np.arange(10, dtype=np.int)
-        fvalue = np.arange(10, dtype=np.float)
+        ivalue = np.arange(10, dtype=np.int_)
+        fvalue = np.arange(10, dtype=np.float64)
         expected = self._ndarray(ivalue)
         self.assertNotEqual(expected, hexdigest(fvalue))
 
@@ -75,7 +75,7 @@ class TestBytesLikeObject(tests.IrisTest):
         self.assertNotEqual(expected, hexdigest(value.flatten()))
 
     def test_masked_array_int(self):
-        value = ma.arange(10, dtype=np.int)
+        value = ma.arange(10, dtype=np.int_)
         expected = self._masked(value)
         self.assertEqual(expected, hexdigest(value))
 
@@ -85,7 +85,7 @@ class TestBytesLikeObject(tests.IrisTest):
         self.assertEqual(expected, hexdigest(value))
 
     def test_masked_array_float(self):
-        value = ma.arange(10, dtype=np.float)
+        value = ma.arange(10, dtype=np.float64)
         expected = self._masked(value)
         self.assertEqual(expected, hexdigest(value))
 
@@ -95,8 +95,8 @@ class TestBytesLikeObject(tests.IrisTest):
         self.assertEqual(expected, hexdigest(value))
 
     def test_masked_array_float_not_int(self):
-        ivalue = ma.arange(10, dtype=np.int)
-        fvalue = ma.arange(10, dtype=np.float)
+        ivalue = ma.arange(10, dtype=np.int_)
+        fvalue = ma.arange(10, dtype=np.float64)
         expected = self._masked(ivalue)
         self.assertNotEqual(expected, hexdigest(fvalue))
 
@@ -127,7 +127,7 @@ class TestNotBytesLikeObject(tests.IrisTest):
         self.assertEqual(expected, hexdigest(value))
 
     def test_numpy_int(self):
-        value = np.int(123)
+        value = int(123)
         expected = self._expected(value)
         self.assertEqual(expected, hexdigest(value))
 
@@ -137,7 +137,7 @@ class TestNotBytesLikeObject(tests.IrisTest):
         self.assertEqual(expected, hexdigest(value))
 
     def test_numpy_float(self):
-        value = np.float(123.4)
+        value = float(123.4)
         expected = self._expected(value)
         self.assertEqual(expected, hexdigest(value))
 

--- a/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
+++ b/lib/iris/tests/unit/experimental/regrid/test_regrid_weighted_curvilinear_to_rectilinear.py
@@ -37,7 +37,7 @@ class Test(tests.IrisTest):
         # Source cube.
         self.test_src_name = "air_temperature"
         self.test_src_units = "K"
-        self.test_src_data = ma.arange(1, 13, dtype=np.float).reshape(3, 4)
+        self.test_src_data = ma.arange(1, 13, dtype=np.float64).reshape(3, 4)
         self.test_src_attributes = dict(wibble="wobble")
         self.test_scalar_coord = iris.coords.DimCoord(
             [1], long_name="test_scalar_coord"
@@ -135,7 +135,7 @@ class Test(tests.IrisTest):
         )
 
     def _weighted_mean(self, points):
-        points = np.asarray(points, dtype=np.float)
+        points = np.asarray(points, dtype=np.float64)
         weights = points * self.weight_factor
         numerator = denominator = 0
         for point, weight in zip(points, weights):

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -59,7 +59,7 @@ def netcdf_variable(
 
 class Test_translate__global_attributes(tests.IrisTest):
     def setUp(self):
-        ncvar = netcdf_variable("ncvar", "height", np.float)
+        ncvar = netcdf_variable("ncvar", "height", np.float64)
         ncattrs = mock.Mock(return_value=["dimensions"])
         getncattr = mock.Mock(return_value="something something_else")
         self.dataset = mock.Mock(
@@ -80,24 +80,24 @@ class Test_translate__global_attributes(tests.IrisTest):
 class Test_translate__formula_terms(tests.IrisTest):
     def setUp(self):
         self.delta = netcdf_variable(
-            "delta", "height", np.float, bounds="delta_bnds"
+            "delta", "height", np.float64, bounds="delta_bnds"
         )
         self.delta_bnds = netcdf_variable(
             "delta_bnds", "height bnds", np.float
         )
         self.sigma = netcdf_variable(
-            "sigma", "height", np.float, bounds="sigma_bnds"
+            "sigma", "height", np.float64, bounds="sigma_bnds"
         )
         self.sigma_bnds = netcdf_variable(
             "sigma_bnds", "height bnds", np.float
         )
-        self.orography = netcdf_variable("orography", "lat lon", np.float)
+        self.orography = netcdf_variable("orography", "lat lon", np.float64)
         formula_terms = "a: delta b: sigma orog: orography"
         standard_name = "atmosphere_hybrid_height_coordinate"
         self.height = netcdf_variable(
             "height",
             "height",
-            np.float,
+            np.float64,
             formula_terms=formula_terms,
             bounds="height_bnds",
             standard_name=standard_name,
@@ -106,13 +106,16 @@ class Test_translate__formula_terms(tests.IrisTest):
         # which will be ignored by the cf loader.
         formula_terms = "a: delta_bnds b: sigma_bnds orog: orography"
         self.height_bnds = netcdf_variable(
-            "height_bnds", "height bnds", np.float, formula_terms=formula_terms
+            "height_bnds",
+            "height bnds",
+            np.float64,
+            formula_terms=formula_terms,
         )
-        self.lat = netcdf_variable("lat", "lat", np.float)
-        self.lon = netcdf_variable("lon", "lon", np.float)
+        self.lat = netcdf_variable("lat", "lat", np.float64)
+        self.lon = netcdf_variable("lon", "lon", np.float64)
         # Note that, only lat and lon are explicitly associated as coordinates.
         self.temp = netcdf_variable(
-            "temp", "height lat lon", np.float, coordinates="lat lon"
+            "temp", "height lat lon", np.float64, coordinates="lat lon"
         )
 
         self.variables = dict(
@@ -179,24 +182,24 @@ class Test_translate__formula_terms(tests.IrisTest):
 class Test_build_cf_groups__formula_terms(tests.IrisTest):
     def setUp(self):
         self.delta = netcdf_variable(
-            "delta", "height", np.float, bounds="delta_bnds"
+            "delta", "height", np.float64, bounds="delta_bnds"
         )
         self.delta_bnds = netcdf_variable(
             "delta_bnds", "height bnds", np.float
         )
         self.sigma = netcdf_variable(
-            "sigma", "height", np.float, bounds="sigma_bnds"
+            "sigma", "height", np.float64, bounds="sigma_bnds"
         )
         self.sigma_bnds = netcdf_variable(
             "sigma_bnds", "height bnds", np.float
         )
-        self.orography = netcdf_variable("orography", "lat lon", np.float)
+        self.orography = netcdf_variable("orography", "lat lon", np.float64)
         formula_terms = "a: delta b: sigma orog: orography"
         standard_name = "atmosphere_hybrid_height_coordinate"
         self.height = netcdf_variable(
             "height",
             "height",
-            np.float,
+            np.float64,
             formula_terms=formula_terms,
             bounds="height_bnds",
             standard_name=standard_name,
@@ -205,15 +208,18 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
         # which will be ignored by the cf loader.
         formula_terms = "a: delta_bnds b: sigma_bnds orog: orography"
         self.height_bnds = netcdf_variable(
-            "height_bnds", "height bnds", np.float, formula_terms=formula_terms
+            "height_bnds",
+            "height bnds",
+            np.float64,
+            formula_terms=formula_terms,
         )
-        self.lat = netcdf_variable("lat", "lat", np.float)
-        self.lon = netcdf_variable("lon", "lon", np.float)
-        self.x = netcdf_variable("x", "lat lon", np.float)
-        self.y = netcdf_variable("y", "lat lon", np.float)
+        self.lat = netcdf_variable("lat", "lat", np.float64)
+        self.lon = netcdf_variable("lon", "lon", np.float64)
+        self.x = netcdf_variable("x", "lat lon", np.float64)
+        self.y = netcdf_variable("y", "lat lon", np.float64)
         # Note that, only lat and lon are explicitly associated as coordinates.
         self.temp = netcdf_variable(
-            "temp", "height lat lon", np.float, coordinates="x y"
+            "temp", "height lat lon", np.float64, coordinates="x y"
         )
 
         self.variables = dict(
@@ -332,7 +338,7 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
             self.assertEqual(warn.call_count, 1)
 
     def test_promoted_auxiliary_ignore(self):
-        self.wibble = netcdf_variable("wibble", "lat wibble", np.float)
+        self.wibble = netcdf_variable("wibble", "lat wibble", np.float64)
         self.variables["wibble"] = self.wibble
         self.orography.coordinates = "wibble"
         with mock.patch(

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -199,8 +199,8 @@ class Test_coord_system(tests.IrisTest):
 
 class Test__init__(tests.IrisTest):
     def setUp(self):
-        header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
-        header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+        header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int_)
+        header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float64)
         self.header = list(header_longs) + list(header_floats)
 
     def test_no_headers(self):
@@ -232,8 +232,8 @@ class Test__init__(tests.IrisTest):
 
 class Test__getattr__(tests.IrisTest):
     def setUp(self):
-        header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int)
-        header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float)
+        header_longs = np.zeros(pp.NUM_LONG_HEADERS, dtype=np.int_)
+        header_floats = np.zeros(pp.NUM_FLOAT_HEADERS, dtype=np.float64)
         self.header = list(header_longs) + list(header_floats)
 
     def test_attr_singular_long(self):

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -32,7 +32,7 @@ class Test__data_bytes_to_shaped_array__lateral_boundary_compression(
         decompressed = np.arange(data_len).reshape(*self.data_shape)
         decompressed *= np.arange(self.data_shape[1]) % 3 + 1
 
-        decompressed_mask = np.zeros(self.data_shape, np.bool)
+        decompressed_mask = np.zeros(self.data_shape, np.bool_)
         decompressed_mask[
             y_halo + rim : -(y_halo + rim), x_halo + rim : -(x_halo + rim)
         ] = True
@@ -81,7 +81,7 @@ class Test__data_bytes_to_shaped_array__land_packed(tests.IrisTest):
         self.land = np.array(
             [[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]], dtype=np.float64
         )
-        sea = ~self.land.astype(np.bool)
+        sea = ~self.land.astype(np.bool_)
         self.land_masked_data = np.array([1, 3, 4.5])
         self.sea_masked_data = np.array([1, 3, 4.5, -4, 5, 0, 1, 2, 3])
 

--- a/lib/iris/tests/unit/lazy_data/test_lazy_elementwise.py
+++ b/lib/iris/tests/unit/lazy_data/test_lazy_elementwise.py
@@ -44,7 +44,7 @@ class Test_lazy_elementwise(tests.IrisTest):
         lazy_array = as_lazy_data(concrete_array)
         wrapped = lazy_elementwise(lazy_array, _test_elementwise_op)
         self.assertTrue(is_lazy_data(wrapped))
-        self.assertEqual(wrapped.dtype, np.int)
+        self.assertEqual(wrapped.dtype, np.int_)
         self.assertEqual(wrapped.compute().dtype, wrapped.dtype)
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR removes deprecated NumPy aliases of builtin types, which is required to avoid warnings starting with NumPy 1.20.0.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
