### PR TITLE
Docs unreleased banner

### DIFF
--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -26,3 +26,17 @@ table.docutils td {
     word-wrap: break-word;
 }
 
+/* Used for very strong warning */
+#slim-red-box-message {
+  background: #ff0000;
+  box-sizing: border-box;
+  color: #ffffff;
+  font-weight: normal;
+  padding: 0.5em;
+  width: 100%;
+}
+
+#slim-red-box-message a {
+  color: #ffffff;
+  text-decoration:underline;
+}

--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -33,10 +33,10 @@ table.docutils td {
   color: #ffffff;
   font-weight: normal;
   padding: 0.5em;
-  width: 100%;
 }
 
 #slim-red-box-message a {
   color: #ffffff;
+  font-weight: normal;  
   text-decoration:underline;
 }

--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -26,3 +26,17 @@ table.docutils td {
     word-wrap: break-word;
 }
 
+/* Used for very strong warning */
+#slim-red-box-message {
+  background: #ff0000;
+  box-sizing: border-box;
+  color: #ffffff;
+  font-weight: normal;
+  padding: 0.5em;
+}
+
+#slim-red-box-message a {
+  color: #ffffff;
+  font-weight: normal;  
+  text-decoration:underline;
+}

--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -26,17 +26,3 @@ table.docutils td {
     word-wrap: break-word;
 }
 
-/* Used for very strong warning */
-#slim-red-box-message {
-  background: #ff0000;
-  box-sizing: border-box;
-  color: #ffffff;
-  font-weight: normal;
-  padding: 0.5em;
-}
-
-#slim-red-box-message a {
-  color: #ffffff;
-  font-weight: normal;  
-  text-decoration:underline;
-}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -7,6 +7,10 @@
 /*---------------------------------------------------------------------------*/
 
 {%- block document %}
+    DEBUG:
+    readthedocs.v1.vcs.type = {{ readthedocs.v1.vcs.type }}
+    readthedocs.v1 = {{ readthedocs.v1 }}
+
     {% if rtd_version == 'latest' %}
     <div class="admonition warning">
         <p class="admonition-title">Warning</p>

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -6,30 +6,25 @@
 
 /*---------------------------------------------------------------------------*/
 
-{%- block sidebartitle  %}
-    {{ super() }}
-
-    FOO!
-{%- endblock %}
-
-/*---------------------------------------------------------------------------*/
-
 {%- block document %}
-    DEBUG:
-    {% if readthedocs %}
-        readthedocs.v1.vcs.type = {{ readthedocs.v1.vcs.type }}
-        readthedocs.v1 = {{ readthedocs.v1 }}
-    {%- endif %}
 
     {% if rtd_version == 'latest' %}
-    <div class="admonition warning">
-        <p class="admonition-title">Warning</p>
+        <div id="slim-red-box-message">
             You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.
-    </div>
-    <p></p>
+        </div>
+        <p></p>
+        
+        <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+                You a viewing the <b>latest</b> unreleased documentation
+                <b>v{{ version }}</b>.  You may prefer a 
+                <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
+                version.
+        </div>
+        <p></p>
     {%- endif %}
 
     {{ super() }}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -14,7 +14,6 @@
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.
-        <p>
     </div>
     <p></p>
     {%- endif %}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -7,7 +7,6 @@
 /*---------------------------------------------------------------------------*/
 
 {%- block document %}
-
     {% if rtd_version == 'latest' %}
         <div id="slim-red-box-message">
             You a viewing the <b>latest</b> unreleased documentation

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -15,15 +15,6 @@
             version.
         </div>
         <p></p>
-        
-        <div class="admonition warning">
-            <p class="admonition-title">Warning</p>
-                You are viewing the <b>latest</b> unreleased documentation
-                <b>v{{ version }}</b>.  You may prefer a 
-                <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
-                version.
-        </div>
-        <p></p>
     {%- endif %}
 
     {{ super() }}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -7,7 +7,7 @@
 /*---------------------------------------------------------------------------*/
 
 {%- block document %}
-    {% if rtd_version == 'latest' %}
+    {% if READTHEDOCS and rtd_version == 'latest' %}
         <div id="slim-red-box-message">
             You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -7,27 +7,45 @@
 /*---------------------------------------------------------------------------*/
 
 {%- block document %}
+{% if theme_display_version %}
+{%- set nav_version = version %}
+{% if READTHEDOCS and current_version %}
+  {%- set nav_version = current_version %}
+{% endif %}
+{% if nav_version %}
+  <div class="version">
+    {{ nav_version }}
+  </div>
+{% endif %}
+{% endif %}
 
-    DEBUG: version is <b>{{ version }}</b>.  Below are two different presentations
-    on showing a warning message.
 
-    {%- if (("dev" in version) or ("rc" in version)) %}
-    <div id="slim-red-box-message">
-        You a viewing the <b>latest</b> unreleased documentation.
-        Please see the 
-        <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
-        version.
-    </div>
-    <p></p>
+DEBUG: theme_display_version = {{ theme_display_version }}<br>
+    DEBUG: current_version = {{ current_version }}<br>
+    DEBUG: nav_version = {{ nav_version }}<br>
+    DEBUG: version = {{ version }}<br>
 
+    {%- if "dev" in version %}
+        <div id="slim-red-box-message">
+            You a viewing the <b>latest</b> unreleased documentation
+            <b>v{{ version }}</b>.  You may prefer a 
+            <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
+            version.
+        </div>
+        <p></p>
+    {%- endif %}
+
+    {%- if "dev" in version %}
     <div class="admonition warning">
         <p class="admonition-title">Warning</p>
-            You a viewing the <b>latest</b> unreleased documentation.
-            Please see the 
+            You a viewing the <b>latest</b> unreleased documentation
+            <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.
         <p>
     </div>
+
+    <p></p>
     {%- endif %}
 
     {{ super() }}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -25,7 +25,7 @@ DEBUG: theme_display_version = {{ theme_display_version }}<br>
     DEBUG: nav_version = {{ nav_version }}<br>
     DEBUG: version = {{ version }}<br>
 
-    {% if rtd_version = "latest" %}
+    {% if rtd_version == 'latest' %}
         <div id="slim-red-box-message">
             (rtd_version1) You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
@@ -35,7 +35,7 @@ DEBUG: theme_display_version = {{ theme_display_version }}<br>
         <p></p>
     {%- endif %}
 
-    {% if rtd_version = "latest" %}
+    {% if rtd_version == 'latest' %}
     <div class="admonition warning">
         <p class="admonition-title">Warning</p>
             (rtd_version2) You a viewing the <b>latest</b> unreleased documentation

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -25,9 +25,9 @@ DEBUG: theme_display_version = {{ theme_display_version }}<br>
     DEBUG: nav_version = {{ nav_version }}<br>
     DEBUG: version = {{ version }}<br>
 
-    {%- if "dev" in version %}
+    {% if rtd_version = "latest" %}
         <div id="slim-red-box-message">
-            You a viewing the <b>latest</b> unreleased documentation
+            (rtd_version1) You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.
@@ -35,10 +35,10 @@ DEBUG: theme_display_version = {{ theme_display_version }}<br>
         <p></p>
     {%- endif %}
 
-    {%- if "dev" in version %}
+    {% if rtd_version = "latest" %}
     <div class="admonition warning">
         <p class="admonition-title">Warning</p>
-            You a viewing the <b>latest</b> unreleased documentation
+            (rtd_version2) You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -8,19 +8,9 @@
 
 {%- block document %}
     {% if rtd_version == 'latest' %}
-        <div id="slim-red-box-message">
-            (rtd_version1) You a viewing the <b>latest</b> unreleased documentation
-            <b>v{{ version }}</b>.  You may prefer a 
-            <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
-            version.
-        </div>
-        <p></p>
-    {%- endif %}
-
-    {% if rtd_version == 'latest' %}
     <div class="admonition warning">
         <p class="admonition-title">Warning</p>
-            (rtd_version2) You a viewing the <b>latest</b> unreleased documentation
+            You a viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -1,5 +1,41 @@
 {% extends "!layout.html" %}
 
+{# This uses blocks.  See: 
+     https://www.sphinx-doc.org/en/master/templating.html
+#}
+
+/*---------------------------------------------------------------------------*/
+
+{%- block document %}
+
+    DEBUG: version is <b>{{ version }}</b>.  Below are two different presentations
+    on showing a warning message.
+
+    {%- if (("dev" in version) or ("rc" in version)) %}
+    <div id="slim-red-box-message">
+        You a viewing the <b>latest</b> unreleased documentation.
+        Please see the 
+        <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
+        version.
+    </div>
+    <p></p>
+
+    <div class="admonition warning">
+        <p class="admonition-title">Warning</p>
+            You a viewing the <b>latest</b> unreleased documentation.
+            Please see the 
+            <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
+            version.
+        <p>
+    </div>
+    {%- endif %}
+
+    {{ super() }}
+
+{%- endblock %}
+
+/*---------------------------------------------------------------------------*/
+
 {% block menu %}
     {{ super() }}
 

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -6,10 +6,20 @@
 
 /*---------------------------------------------------------------------------*/
 
+{%- block sidebartitle  %}
+    {{ super() }}
+
+    FOO!
+{%- endblock %}
+
+/*---------------------------------------------------------------------------*/
+
 {%- block document %}
     DEBUG:
-    readthedocs.v1.vcs.type = {{ readthedocs.v1.vcs.type }}
-    readthedocs.v1 = {{ readthedocs.v1 }}
+    {% if readthedocs %}
+        readthedocs.v1.vcs.type = {{ readthedocs.v1.vcs.type }}
+        readthedocs.v1 = {{ readthedocs.v1 }}
+    {%- endif %}
 
     {% if rtd_version == 'latest' %}
     <div class="admonition warning">
@@ -25,7 +35,7 @@
     {{ super() }}
 {%- endblock %}
 
-/*---------------------------------------------------------------------------*/
+/*-----------------------------------------------------z----------------------*/
 
 {% block menu %}
     {{ super() }}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -7,24 +7,6 @@
 /*---------------------------------------------------------------------------*/
 
 {%- block document %}
-{% if theme_display_version %}
-{%- set nav_version = version %}
-{% if READTHEDOCS and current_version %}
-  {%- set nav_version = current_version %}
-{% endif %}
-{% if nav_version %}
-  <div class="version">
-    {{ nav_version }}
-  </div>
-{% endif %}
-{% endif %}
-
-
-DEBUG: theme_display_version = {{ theme_display_version }}<br>
-    DEBUG: current_version = {{ current_version }}<br>
-    DEBUG: nav_version = {{ nav_version }}<br>
-    DEBUG: version = {{ version }}<br>
-
     {% if rtd_version == 'latest' %}
         <div id="slim-red-box-message">
             (rtd_version1) You a viewing the <b>latest</b> unreleased documentation
@@ -44,12 +26,10 @@ DEBUG: theme_display_version = {{ theme_display_version }}<br>
             version.
         <p>
     </div>
-
     <p></p>
     {%- endif %}
 
     {{ super() }}
-
 {%- endblock %}
 
 /*---------------------------------------------------------------------------*/

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -9,7 +9,7 @@
 {%- block document %}
     {% if READTHEDOCS and rtd_version == 'latest' %}
         <div id="slim-red-box-message">
-            You a viewing the <b>latest</b> unreleased documentation
+            You are viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>.  You may prefer a 
             <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
             version.
@@ -18,7 +18,7 @@
         
         <div class="admonition warning">
             <p class="admonition-title">Warning</p>
-                You a viewing the <b>latest</b> unreleased documentation
+                You are viewing the <b>latest</b> unreleased documentation
                 <b>v{{ version }}</b>.  You may prefer a 
                 <a href="https://scitools-iris.readthedocs.io/en/stable/">stable</a>
                 version.

--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -24,6 +24,7 @@
 .. _New Issue: https://github.com/scitools/iris/issues/new/choose
 .. _pull request: https://github.com/SciTools/iris/pulls
 .. _pull requests: https://github.com/SciTools/iris/pulls
+.. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
 .. _readthedocs.yml: https://github.com/SciTools/iris/blob/master/requirements/ci/readthedocs.yml
 .. _SciTools: https://github.com/SciTools
 .. _sphinx: https://www.sphinx-doc.org/en/master/

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,7 +43,7 @@ if on_rtd:
     for item, value in os.environ.items():
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
-# This is the version "name" rtd uses, such as: latest, stable, v3.0.1 etc
+# This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
 # -- Path setup --------------------------------------------------------------
@@ -131,8 +131,7 @@ extensions = [
     # better api documentation (custom)
     "custom_class_autodoc",
     "custom_data_autodoc",
-    # TREMTEST
-    #    "generate_package_rst",
+    "generate_package_rst",
 ]
 # -- panels extension ---------------------------------------------------------
 # See https://sphinx-panels.readthedocs.io/en/latest/

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -44,6 +44,7 @@ if on_rtd:
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
+# TREMTEST: I may not need to create a variable, see https://docs.readthedocs.io/en/stable/development/design/theme-context.html?highlight=html_
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
 # -- Path setup --------------------------------------------------------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -44,7 +44,7 @@ if on_rtd:
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
-# TREMTEST: I may not need to create a variable, see https://docs.readthedocs.io/en/stable/development/design/theme-context.html?highlight=html_
+# For testing purposes this could be explicitly set to one of the above.
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
 # -- Path setup --------------------------------------------------------------
@@ -300,7 +300,6 @@ sphinx_gallery_conf = {
     "ignore_pattern": r"__init__\.py",
 }
 
-
 # -----------------------------------------------------------------------------
 # Remove matplotlib agg warnings from generated doc when using plt.show
 warnings.filterwarnings(
@@ -309,7 +308,6 @@ warnings.filterwarnings(
     message="Matplotlib is currently using agg, which is a"
     " non-GUI backend, so cannot show the figure.",
 )
-
 
 # -- numfig options (built-in) ------------------------------------------------
 # Enable numfig.

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -80,7 +80,6 @@ author = "Iris Developers"
 import iris
 
 # The short X.Y version.
-# TREMTEST: This seems pointless now?  Is it ever true?
 if iris.__version__ == "dev":
     version = "dev"
 else:
@@ -88,7 +87,6 @@ else:
     version = ".".join(iris.__version__.split("-")[0].split(".")[:3])
 # The full version, including alpha/beta/rc tags.
 
-# TREMTEST: lets try to not define release?
 release = iris.__version__
 
 autolog("Iris Version = {}".format(version))

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -129,7 +129,8 @@ extensions = [
     # better api documentation (custom)
     "custom_class_autodoc",
     "custom_data_autodoc",
-    "generate_package_rst",
+    # TREMTEST
+    #    "generate_package_rst",
 ]
 
 # -- panels extension ---------------------------------------------------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -128,7 +128,6 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "matplotlib.sphinxext.mathmpl",
     "matplotlib.sphinxext.plot_directive",
-    "versionwarning.extension",
     # better api documentation (custom)
     "custom_class_autodoc",
     "custom_data_autodoc",

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -80,12 +80,15 @@ author = "Iris Developers"
 import iris
 
 # The short X.Y version.
+# TREMTEST: This seems pointless now?  Is it ever true?
 if iris.__version__ == "dev":
     version = "dev"
 else:
     # major.minor.patch-dev -> major.minor.patch
     version = ".".join(iris.__version__.split("-")[0].split(".")[:3])
 # The full version, including alpha/beta/rc tags.
+
+# TREMTEST: lets try to not define release?
 release = iris.__version__
 
 autolog("Iris Version = {}".format(version))
@@ -222,12 +225,13 @@ html_favicon = "_static/favicon.ico"
 html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
-    "display_version": True,
+    "display_version": False,
     "style_external_links": True,
     "logo_only": "True",
 }
 
 html_context = {
+    "version": version,
     "copyright_years": copyright_years,
     "python_version": build_python_version,
     # menu_links and menu_links_name are used in _templates/layout.html

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -86,7 +86,6 @@ else:
     # major.minor.patch-dev -> major.minor.patch
     version = ".".join(iris.__version__.split("-")[0].split(".")[:3])
 # The full version, including alpha/beta/rc tags.
-
 release = iris.__version__
 
 autolog("Iris Version = {}".format(version))

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -134,30 +134,6 @@ extensions = [
     # TREMTEST
     #    "generate_package_rst",
 ]
-
-# -- sphinx-version-warning extension------------------------------------------
-# See https://sphinx-version-warning.readthedocs.io/en/latest/index.html
-
-versionwarning_messages = {
-    "latest": (
-        "(exntesion) You a viewing the <b>latest</b> unreleased documentation "
-        "<b>v{{ version }}</b>.  You may prefer a "
-        "<a href='https://scitools-iris.readthedocs.io/en/stable/'>stable</a>"
-        "version."
-    ),
-}
-
-versionwarning_admonition_type = "tip"
-# versionwarning_banner_title = "Tip"
-# versionwarning_body_selector = 'div[itemprop="articleBody"]'
-
-# ===
-# Show warning at top of page
-# versionwarning_body_selector = "div.document"
-# versionwarning_banner_title = ""
-# For debugging locally
-versionwarning_project_version = "latest"
-
 # -- panels extension ---------------------------------------------------------
 # See https://sphinx-panels.readthedocs.io/en/latest/
 
@@ -191,7 +167,7 @@ spelling_ignore_python_builtins = True
 # See https://sphinx-copybutton.readthedocs.io/en/latest/
 copybutton_prompt_text = ">>> "
 
-# sphinx.ext.todo configuration
+# sphinx.ext.todo configuration -----------------------------------------------
 # See https://www.sphinx-doc.org/en/master/usage/extensions/todo.html
 todo_include_todos = True
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,6 +43,8 @@ if on_rtd:
     for item, value in os.environ.items():
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
+# This is the version "name" rtd uses, such as: latest, stable, v3.0.1 etc
+rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
 # -- Path setup --------------------------------------------------------------
 
@@ -147,15 +149,15 @@ versionwarning_messages = {
 }
 
 versionwarning_admonition_type = "tip"
-versionwarning_banner_title = "Tip"
-versionwarning_body_selector = 'div[itemprop="articleBody"]'
+# versionwarning_banner_title = "Tip"
+# versionwarning_body_selector = 'div[itemprop="articleBody"]'
 
 # ===
 # Show warning at top of page
 # versionwarning_body_selector = "div.document"
 # versionwarning_banner_title = ""
 # For debugging locally
-# versionwarning_project_version = "latest"
+versionwarning_project_version = "latest"
 
 # -- panels extension ---------------------------------------------------------
 # See https://sphinx-panels.readthedocs.io/en/latest/
@@ -253,6 +255,7 @@ html_theme_options = {
 }
 
 html_context = {
+    "rtd_version": rtd_version,
     "version": version,
     "copyright_years": copyright_years,
     "python_version": build_python_version,

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -126,12 +126,36 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "matplotlib.sphinxext.mathmpl",
     "matplotlib.sphinxext.plot_directive",
+    "versionwarning.extension",
     # better api documentation (custom)
     "custom_class_autodoc",
     "custom_data_autodoc",
     # TREMTEST
     #    "generate_package_rst",
 ]
+
+# -- sphinx-version-warning extension------------------------------------------
+# See https://sphinx-version-warning.readthedocs.io/en/latest/index.html
+
+versionwarning_messages = {
+    "latest": (
+        "(exntesion) You a viewing the <b>latest</b> unreleased documentation "
+        "<b>v{{ version }}</b>.  You may prefer a "
+        "<a href='https://scitools-iris.readthedocs.io/en/stable/'>stable</a>"
+        "version."
+    ),
+}
+
+versionwarning_admonition_type = "tip"
+versionwarning_banner_title = "Tip"
+versionwarning_body_selector = 'div[itemprop="articleBody"]'
+
+# ===
+# Show warning at top of page
+# versionwarning_body_selector = "div.document"
+# versionwarning_banner_title = ""
+# For debugging locally
+# versionwarning_project_version = "latest"
 
 # -- panels extension ---------------------------------------------------------
 # See https://sphinx-panels.readthedocs.io/en/latest/

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -44,7 +44,7 @@ if on_rtd:
         autolog("[READTHEDOCS] {} = {}".format(item, value))
 
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
-# For testing purposes this could be explicitly set to one of the above.
+# For local testing purposes this could be explicitly set latest or stable.
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
 # -- Path setup --------------------------------------------------------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -223,7 +223,7 @@ html_favicon = "_static/favicon.ico"
 html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
-    "display_version": False,
+    "display_version": True,
     "style_external_links": True,
     "logo_only": "True",
 }

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,6 +91,9 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ added the |PyPI|_ badge to the `README.md`_. (:pull:`4004`)
 
+#. `@tkknight`_ added a banner at the top of every page if the unreleased
+   development documentatiion is being viewed. (:pull:`3999`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,8 +91,9 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ added the |PyPI|_ badge to the `README.md`_. (:pull:`4004`)
 
-#. `@tkknight`_ added a banner at the top of every page if the unreleased
-   development documentatiion is being viewed. (:pull:`3999`)
+#. `@tkknight`_ added a banner at the top of every page of the unreleased
+   development documentation if being viewed on `Read the Docs`_.
+   (:pull:`3999`)
 
 
 💼 Internal

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -49,3 +49,5 @@ dependencies:
   - sphinx-gallery
   - sphinx-panels
   - sphinx_rtd_theme
+  - pip:
+    - sphinx-version-warning

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -49,5 +49,3 @@ dependencies:
   - sphinx-gallery
   - sphinx-panels
   - sphinx_rtd_theme
-  - pip:
-    - sphinx-version-warning


### PR DESCRIPTION
## 🚀 Pull Request

### Description

For a better user experience it would be useful for the documentation to clearly state when you are viewing the **latest** unreleased docs (from master).

This change uses the `_templates/layout.html` to add extra content, in this case to the `document` block (the "body" content of every page on the docs).

The rendered documentation for this PR: https://tkknight-iris-test-doc.readthedocs.io/en/latest/ (may change until this PR is out of draft)

This is a part solution to #3992.

### Logic that triggers showing the notice 

When the docs are built on the Read the Docs service there is a shell environment variable named  `READTHEDOCS_VERSION` that should be set to: `latest` / `stable` / `v3.0.1`/ etc.  This variable is pulled into `conf.py` and then passed into the sphinx build via the `html_context variable`.

The banner/notice will **only** be shown when rendering on the read the docs service and when using the latest (against master) docs.

### Presentation style of the notice

The logic and the banner is in the `_templates/layout.html` file, using the `document` block (see https://www.sphinx-doc.org/en/master/templating.html).   

The `document` means the banner would be added at the top of the body of **every** page on the docs.  If the user scrolls down the banner will not be visible.

I have tried variations where the banner is fixed at the top of every page but my css skills are limited and it would render over the top of the existing content, meaning the iris logo was a little overwitten - so I aborted this approach.


#### TO DO

- [x] Choose (or another option) the presentation style of the notice.  
  - [x] Option 1: Red banner (needs a little bit of css to create).  **This is the one that will be used**
  - [x] Option 2: Use a read the docs theme note/warning.  This fits with the styliing, however it may not be as visible to users as a red banner.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
