### PR TITLE
update intersphinx mapping and matplotlib urls

### DIFF
--- a/docs/gallery_code/general/plot_anomaly_log_colouring.py
+++ b/docs/gallery_code/general/plot_anomaly_log_colouring.py
@@ -12,15 +12,15 @@ magnitude may be considered "not significant", so we put these into a separate
 "zero band" which is plotted in white.
 
 To do this, we create a custom value mapping function (normalization) using
-the matplotlib Norm class :doc:`matplotlib:api/_as_gen/matplotlib.colors.SymLogNorm`.
+the matplotlib Norm class :obj:`matplotlib.colors.SymLogNorm`.
 We use this to make a cell-filled pseudocolor plot with a colorbar.
 
 NOTE: By "pseudocolour", we mean that each data point is drawn as a "cell"
 region on the plot, coloured according to its data value.
 This is provided in Iris by the functions :meth:`iris.plot.pcolor` and
 :meth:`iris.plot.pcolormesh`, which call the underlying matplotlib
-functions of the same names (i.e., :doc:`matplotlib:api/_as_gen/matplotlib.pyplot.pcolor`
-and  :doc:`matplotlib:api/_as_gen/matplotlib.pyplot.pcolormesh`).
+functions of the same names (i.e., :obj:`matplotlib.pyplot.pcolor`
+and :obj:`matplotlib.pyplot.pcolormesh`).
 See also: http://en.wikipedia.org/wiki/False_color#Pseudocolor.
 
 """

--- a/docs/gallery_code/general/plot_anomaly_log_colouring.py
+++ b/docs/gallery_code/general/plot_anomaly_log_colouring.py
@@ -62,7 +62,7 @@ def main():
 
     # Use a standard colour map which varies blue-white-red.
     # For suitable options, see the 'Diverging colormaps' section in:
-    # http://matplotlib.org/stable/gallery/color/colormaps_reference.html
+    # http://matplotlib.org/stable/gallery/color/colormap_reference.html
     anom_cmap = "bwr"
 
     # Create a 'logarithmic' data normalization.

--- a/docs/gallery_code/general/plot_anomaly_log_colouring.py
+++ b/docs/gallery_code/general/plot_anomaly_log_colouring.py
@@ -13,7 +13,7 @@ magnitude may be considered "not significant", so we put these into a separate
 
 To do this, we create a custom value mapping function (normalization) using
 the matplotlib Norm class `matplotlib.colours.SymLogNorm
-<https://matplotlib.org/api/_as_gen/matplotlib.colors.SymLogNorm.html#matplotlib.colors.SymLogNorm>`_.
+<https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.SymLogNorm.html>`_.
 We use this to make a cell-filled pseudocolour plot with a colorbar.
 
 NOTE: By "pseudocolour", we mean that each data point is drawn as a "cell"
@@ -21,9 +21,9 @@ region on the plot, coloured according to its data value.
 This is provided in Iris by the functions :meth:`iris.plot.pcolor` and
 :meth:`iris.plot.pcolormesh`, which call the underlying matplotlib
 functions of the same names (i.e. `matplotlib.pyplot.pcolor
-<http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.pcolor>`_
+<http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolor>`_
 and  `matplotlib.pyplot.pcolormesh
-<http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.pcolormesh>`_).
+<http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolormesh>`_).
 See also: http://en.wikipedia.org/wiki/False_color#Pseudocolor.
 
 """
@@ -65,7 +65,7 @@ def main():
 
     # Use a standard colour map which varies blue-white-red.
     # For suitable options, see the 'Diverging colormaps' section in:
-    # http://matplotlib.org/examples/color/colormaps_reference.html
+    # http://matplotlib.org/stable/gallery/color/colormaps_reference.html
     anom_cmap = "bwr"
 
     # Create a 'logarithmic' data normalization.

--- a/docs/gallery_code/general/plot_anomaly_log_colouring.py
+++ b/docs/gallery_code/general/plot_anomaly_log_colouring.py
@@ -12,18 +12,15 @@ magnitude may be considered "not significant", so we put these into a separate
 "zero band" which is plotted in white.
 
 To do this, we create a custom value mapping function (normalization) using
-the matplotlib Norm class `matplotlib.colours.SymLogNorm
-<https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.SymLogNorm.html>`_.
-We use this to make a cell-filled pseudocolour plot with a colorbar.
+the matplotlib Norm class :doc:`matplotlib:api/_as_gen/matplotlib.colors.SymLogNorm`.
+We use this to make a cell-filled pseudocolor plot with a colorbar.
 
 NOTE: By "pseudocolour", we mean that each data point is drawn as a "cell"
 region on the plot, coloured according to its data value.
 This is provided in Iris by the functions :meth:`iris.plot.pcolor` and
 :meth:`iris.plot.pcolormesh`, which call the underlying matplotlib
-functions of the same names (i.e. `matplotlib.pyplot.pcolor
-<http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolor>`_
-and  `matplotlib.pyplot.pcolormesh
-<http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolormesh>`_).
+functions of the same names (i.e., :doc:`matplotlib:api/_as_gen/matplotlib.pyplot.pcolor`
+and  :doc:`matplotlib:api/_as_gen/matplotlib.pyplot.pcolormesh`).
 See also: http://en.wikipedia.org/wiki/False_color#Pseudocolor.
 
 """

--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -18,7 +18,7 @@
 .. _issue: https://github.com/SciTools/iris/issues
 .. _issues: https://github.com/SciTools/iris/issues
 .. _legacy documentation: https://scitools.org.uk/iris/docs/v2.4.0/
-.. _matplotlib: https://matplotlib.org/
+.. _matplotlib: https://matplotlib.org/stable/
 .. _napolean: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html
 .. _nox: https://nox.thea.codes/en/stable/
 .. _New Issue: https://github.com/scitools/iris/issues/new/choose

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -184,18 +184,18 @@ templates_path = ["_templates"]
 # -- intersphinx extension ----------------------------------------------------
 # See https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 intersphinx_mapping = {
-    "cartopy": ("http://scitools.org.uk/cartopy/docs/latest/", None),
-    "matplotlib": ("http://matplotlib.org/", None),
-    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
-    "python": ("http://docs.python.org/2.7", None),
-    "scipy": ("http://docs.scipy.org/doc/scipy/reference/", None),
+    "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
 }
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
 # -- plot_directive extension -------------------------------------------------
-# See https://matplotlib.org/3.1.3/devel/plot_directive.html#options
+# See https://matplotlib.org/stable/api/sphinxext_plot_directive_api.html#options
 plot_formats = [
     ("png", 100),
 ]

--- a/docs/src/whatsnew/3.0.1.rst
+++ b/docs/src/whatsnew/3.0.1.rst
@@ -470,7 +470,7 @@ This document explains the changes made to Iris for this release
    with `flake8`_ and `black`_. (:pull:`3928`)
 
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
-.. _Matplotlib: https://matplotlib.org/
+.. _Matplotlib: https://matplotlib.org/stable/
 .. _CF units rules: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#units
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
@@ -480,7 +480,7 @@ This document explains the changes made to Iris for this release
 .. _Cartopy#1105: https://github.com/SciTools/cartopy/pull/1105
 .. _Cartopy#1117: https://github.com/SciTools/cartopy/pull/1117
 .. _Dask: https://github.com/dask/dask
-.. _matplotlib.dates.date2num: https://matplotlib.org/api/dates_api.html#matplotlib.dates.date2num
+.. _matplotlib.dates.date2num: https://matplotlib.org/stable/api/dates_api.html#matplotlib.dates.date2num
 .. _Proj: https://github.com/OSGeo/PROJ
 .. _black: https://black.readthedocs.io/en/stable/
 .. _Proj#1292: https://github.com/OSGeo/PROJ/pull/1292
@@ -510,7 +510,7 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/3.1.1/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
+.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/3.0.1.rst
+++ b/docs/src/whatsnew/3.0.1.rst
@@ -189,7 +189,7 @@ This document explains the changes made to Iris for this release
 
 #. `@stephenworsley`_ changed the way tick labels are assigned from string coords.
    Previously, the first tick label would occasionally be duplicated. This also
-   removes the use of Matplotlib's deprecated ``IndexFormatter``. (:pull:`3857`)
+   removes the use of the deprecated `matplotlib`_ ``IndexFormatter``. (:pull:`3857`)
 
 #. `@znicholls`_ fixed :meth:`~iris.quickplot._title` to only check
    ``units.is_time_reference`` if the ``units`` symbol is not used. (:pull:`3902`)
@@ -295,11 +295,11 @@ This document explains the changes made to Iris for this release
 
 #. `@stephenworsley`_ and `@trexfeathers`_ pinned Iris to require
    `Cartopy`_ ``>=0.18``, in order to remain compatible with the latest version
-   of `Matplotlib`_. (:pull:`3762`)
+   of `matplotlib`_. (:pull:`3762`)
 
-#. `@bjlittle`_ unpinned Iris to use the latest version of `Matplotlib`_.
+#. `@bjlittle`_ unpinned Iris to use the latest version of `matplotlib`_.
    Supporting ``Iris`` for both ``Python2`` and ``Python3`` had resulted in
-   pinning our dependency on `Matplotlib`_ at ``v2.x``.  But this is no longer
+   pinning our dependency on `matplotlib`_ at ``v2.x``.  But this is no longer
    necessary now that ``Python2`` support has been dropped. (:pull:`3468`)
 
 #. `@stephenworsley`_ and `@trexfeathers`_ unpinned Iris to use the latest version
@@ -422,10 +422,10 @@ This document explains the changes made to Iris for this release
    grid-line spacing in `Cartopy`_. (:pull:`3762`) (see also `Cartopy#1117`_)
 
 #. `@trexfeathers`_ added additional acceptable graphics test targets to account
-   for very minor changes in `Matplotlib`_ version ``3.3`` (colormaps, fonts and
+   for very minor changes in `matplotlib`_ version ``3.3`` (colormaps, fonts and
    axes borders). (:pull:`3762`)
 
-#. `@rcomer`_ corrected the Matplotlib backend in Iris tests to ignore
+#. `@rcomer`_ corrected the `matplotlib`_ backend in Iris tests to ignore
    `matplotlib.rcdefaults`_, instead the tests will **always** use ``agg``.
    (:pull:`3846`)
 
@@ -470,7 +470,6 @@ This document explains the changes made to Iris for this release
    with `flake8`_ and `black`_. (:pull:`3928`)
 
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
-.. _Matplotlib: https://matplotlib.org/stable/
 .. _CF units rules: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#units
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
@@ -510,7 +509,7 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
+.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/3.0.1.rst
+++ b/docs/src/whatsnew/3.0.1.rst
@@ -167,12 +167,12 @@ This document explains the changes made to Iris for this release
    ``volume`` are the only accepted values. (:pull:`3533`)
 
 #. `@trexfeathers`_ set **all** plot types in :mod:`iris.plot` to now use
-   `matplotlib.dates.date2num`_ to format date/time coordinates for use on a plot
+   :obj:`matplotlib.dates.date2num` to format date/time coordinates for use on a plot
    axis (previously :meth:`~iris.plot.pcolor` and :meth:`~iris.plot.pcolormesh`
    did not include this behaviour). (:pull:`3762`)
 
 #. `@trexfeathers`_ changed date/time axis labels in :mod:`iris.quickplot` to
-   now **always** be based on the ``epoch`` used in `matplotlib.dates.date2num`_
+   now **always** be based on the ``epoch`` used in :obj:`matplotlib.dates.date2num`
    (previously would take the unit from a time coordinate, if present, even
    though the coordinate's value had been changed via ``date2num``).
    (:pull:`3762`)
@@ -426,7 +426,7 @@ This document explains the changes made to Iris for this release
    axes borders). (:pull:`3762`)
 
 #. `@rcomer`_ corrected the `matplotlib`_ backend in Iris tests to ignore
-   `matplotlib.rcdefaults`_, instead the tests will **always** use ``agg``.
+   :obj:`matplotlib.rcdefaults`, instead the tests will **always** use ``agg``.
    (:pull:`3846`)
 
 #. `@bjlittle`_ migrated the `black`_ support from ``19.10b0`` to ``20.8b1``.
@@ -479,7 +479,6 @@ This document explains the changes made to Iris for this release
 .. _Cartopy#1105: https://github.com/SciTools/cartopy/pull/1105
 .. _Cartopy#1117: https://github.com/SciTools/cartopy/pull/1117
 .. _Dask: https://github.com/dask/dask
-.. _matplotlib.dates.date2num: https://matplotlib.org/stable/api/dates_api.html#matplotlib.dates.date2num
 .. _Proj: https://github.com/OSGeo/PROJ
 .. _black: https://black.readthedocs.io/en/stable/
 .. _Proj#1292: https://github.com/OSGeo/PROJ/pull/1292
@@ -509,7 +508,6 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/3.0.rst
+++ b/docs/src/whatsnew/3.0.rst
@@ -150,12 +150,12 @@ This document explains the changes made to Iris for this release
    ``volume`` are the only accepted values. (:pull:`3533`)
 
 #. `@trexfeathers`_ set **all** plot types in :mod:`iris.plot` to now use
-   `matplotlib.dates.date2num`_ to format date/time coordinates for use on a plot
+   :obj:`matplotlib.dates.date2num` to format date/time coordinates for use on a plot
    axis (previously :meth:`~iris.plot.pcolor` and :meth:`~iris.plot.pcolormesh`
    did not include this behaviour). (:pull:`3762`)
 
 #. `@trexfeathers`_ changed date/time axis labels in :mod:`iris.quickplot` to
-   now **always** be based on the ``epoch`` used in `matplotlib.dates.date2num`_
+   now **always** be based on the ``epoch`` used in :obj:`matplotlib.dates.date2num`
    (previously would take the unit from a time coordinate, if present, even
    though the coordinate's value had been changed via ``date2num``).
    (:pull:`3762`)
@@ -409,7 +409,7 @@ This document explains the changes made to Iris for this release
    axes borders). (:pull:`3762`)
 
 #. `@rcomer`_ corrected the `matplotlib`_ backend in Iris tests to ignore
-   `matplotlib.rcdefaults`_, instead the tests will **always** use ``agg``.
+   :obj:`matplotlib.rcdefaults`, instead the tests will **always** use ``agg``.
    (:pull:`3846`)
 
 #. `@bjlittle`_ migrated the `black`_ support from ``19.10b0`` to ``20.8b1``.
@@ -462,7 +462,6 @@ This document explains the changes made to Iris for this release
 .. _Cartopy#1105: https://github.com/SciTools/cartopy/pull/1105
 .. _Cartopy#1117: https://github.com/SciTools/cartopy/pull/1117
 .. _Dask: https://github.com/dask/dask
-.. _matplotlib.dates.date2num: https://matplotlib.org/stable/api/dates_api.html#matplotlib.dates.date2num
 .. _Proj: https://github.com/OSGeo/PROJ
 .. _black: https://black.readthedocs.io/en/stable/
 .. _Proj#1292: https://github.com/OSGeo/PROJ/pull/1292
@@ -492,7 +491,6 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/3.0.rst
+++ b/docs/src/whatsnew/3.0.rst
@@ -172,7 +172,7 @@ This document explains the changes made to Iris for this release
 
 #. `@stephenworsley`_ changed the way tick labels are assigned from string coords.
    Previously, the first tick label would occasionally be duplicated. This also
-   removes the use of Matplotlib's deprecated ``IndexFormatter``. (:pull:`3857`)
+   removes the use of the deprecated `matplotlib`_ ``IndexFormatter``. (:pull:`3857`)
 
 #. `@znicholls`_ fixed :meth:`~iris.quickplot._title` to only check
    ``units.is_time_reference`` if the ``units`` symbol is not used. (:pull:`3902`)
@@ -278,11 +278,11 @@ This document explains the changes made to Iris for this release
 
 #. `@stephenworsley`_ and `@trexfeathers`_ pinned Iris to require
    `Cartopy`_ ``>=0.18``, in order to remain compatible with the latest version
-   of `Matplotlib`_. (:pull:`3762`)
+   of `matplotlib`_. (:pull:`3762`)
 
-#. `@bjlittle`_ unpinned Iris to use the latest version of `Matplotlib`_.
+#. `@bjlittle`_ unpinned Iris to use the latest version of `matplotlib`_.
    Supporting ``Iris`` for both ``Python2`` and ``Python3`` had resulted in
-   pinning our dependency on `Matplotlib`_ at ``v2.x``.  But this is no longer
+   pinning our dependency on `matplotlib`_ at ``v2.x``.  But this is no longer
    necessary now that ``Python2`` support has been dropped. (:pull:`3468`)
 
 #. `@stephenworsley`_ and `@trexfeathers`_ unpinned Iris to use the latest version
@@ -405,10 +405,10 @@ This document explains the changes made to Iris for this release
    grid-line spacing in `Cartopy`_. (:pull:`3762`) (see also `Cartopy#1117`_)
 
 #. `@trexfeathers`_ added additional acceptable graphics test targets to account
-   for very minor changes in `Matplotlib`_ version ``3.3`` (colormaps, fonts and
+   for very minor changes in `matplotlib`_ version ``3.3`` (colormaps, fonts and
    axes borders). (:pull:`3762`)
 
-#. `@rcomer`_ corrected the Matplotlib backend in Iris tests to ignore
+#. `@rcomer`_ corrected the `matplotlib`_ backend in Iris tests to ignore
    `matplotlib.rcdefaults`_, instead the tests will **always** use ``agg``.
    (:pull:`3846`)
 
@@ -453,7 +453,6 @@ This document explains the changes made to Iris for this release
    with `flake8`_ and `black`_. (:pull:`3928`)
 
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
-.. _Matplotlib: https://matplotlib.org/stable/
 .. _CF units rules: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#units
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
@@ -493,7 +492,7 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
+.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/3.0.rst
+++ b/docs/src/whatsnew/3.0.rst
@@ -453,7 +453,7 @@ This document explains the changes made to Iris for this release
    with `flake8`_ and `black`_. (:pull:`3928`)
 
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
-.. _Matplotlib: https://matplotlib.org/
+.. _Matplotlib: https://matplotlib.org/stable/
 .. _CF units rules: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#units
 .. _CF Ancillary Data: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#ancillary-data
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
@@ -463,7 +463,7 @@ This document explains the changes made to Iris for this release
 .. _Cartopy#1105: https://github.com/SciTools/cartopy/pull/1105
 .. _Cartopy#1117: https://github.com/SciTools/cartopy/pull/1117
 .. _Dask: https://github.com/dask/dask
-.. _matplotlib.dates.date2num: https://matplotlib.org/api/dates_api.html#matplotlib.dates.date2num
+.. _matplotlib.dates.date2num: https://matplotlib.org/stable/api/dates_api.html#matplotlib.dates.date2num
 .. _Proj: https://github.com/OSGeo/PROJ
 .. _black: https://black.readthedocs.io/en/stable/
 .. _Proj#1292: https://github.com/OSGeo/PROJ/pull/1292
@@ -493,7 +493,7 @@ This document explains the changes made to Iris for this release
 .. _numpy: https://github.com/numpy/numpy
 .. _xxHash: https://github.com/Cyan4973/xxHash
 .. _PyKE: https://pypi.org/project/scitools-pyke/
-.. _matplotlib.rcdefaults: https://matplotlib.org/3.1.1/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
+.. _matplotlib.rcdefaults: https://matplotlib.org/stable/api/matplotlib_configuration_api.html?highlight=rcdefaults#matplotlib.rcdefaults
 .. _@owena11: https://github.com/owena11
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _readthedocs: https://readthedocs.org/

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,8 +86,8 @@ This document explains the changes made to Iris for this release
    on :ref:`installing_iris` and to the footer of all pages.  Also added the
    copyright years to the footer. (:pull:`3989`)
 
-#. `@bjlittle`_ updated the ``intersphinx_mapping`` and fixed redirected the
-   documentation to use ``stable`` URLs for `matplotlib`_. (:pull:`4003`)
+#. `@bjlittle`_ updated the ``intersphinx_mapping`` and fixed documentation
+   to use ``stable`` URLs for `matplotlib`_. (:pull:`4003`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,6 +86,9 @@ This document explains the changes made to Iris for this release
    on :ref:`installing_iris` and to the footer of all pages.  Also added the
    copyright years to the footer. (:pull:`3989`)
 
+#. `@bjlittle`_ updated the ``intersphinx_mapping`` and fixed redirected the
+   documentation to use ``stable`` URLs for `matplotlib`_. (:pull:`4003`)
+
 
 💼 Internal
 ===========


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the documentation `intersphinx_mapping` and addresses `matplotlib` URL issues that were causing the documentation `linkcheck` to fail.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
