### PR TITLE
update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@
 <img src="https://img.shields.io/badge/code%20style-black-000000.svg"
      alt="black" /></a>
 <a href="https://twitter.com/scitools_iris">
-<img src="https://img.shields.io/twitter/follow/scitools_iris?style=social"
-     alt="twitter" /></a>
+<img src="https://img.shields.io/twitter/follow/scitools_iris?color=yellow&label=twitter%7Cscitools_iris&logo=twitter&style=plastic"
+     alt="twitter scitools_iris" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -13,18 +13,24 @@
 <a href="https://cirrus-ci.com/github/SciTools/iris">
 <img src="https://api.cirrus-ci.com/github/SciTools/iris.svg?branch=master"
      alt="Cirrus-CI" /></a>
-<a href='https://scitools-iris.readthedocs.io/en/latest/?badge=latest'>
-<img src='https://readthedocs.org/projects/scitools-iris/badge/?version=latest'
-     alt='Documentation Status' /></a>
+<a href="https://scitools-iris.readthedocs.io/en/latest/?badge=latest">
+<img src="https://readthedocs.org/projects/scitools-iris/badge/?version=latest"
+     alt="Documentation Status" /></a>
 <a href="https://anaconda.org/conda-forge/iris">
 <img src="https://img.shields.io/conda/dn/conda-forge/iris.svg"
      alt="conda-forge downloads" /></a>
 <a href="https://github.com/SciTools/iris/graphs/contributors">
 <img src="https://img.shields.io/github/contributors/SciTools/iris.svg"
      alt="# contributors" /></a>
+<a href="https://anaconda.org/conda-forge/iris">
+<img src="https://img.shields.io/conda/v/conda-forge/iris?color=orange&label=conda-forge%7Ciris"
+     alt="conda-forge" /></a>
+<a href="https://pypi.org/project/scitools-iris">
+<img src="https://img.shields.io/pypi/v/scitools-iris?color=orange&label=pypi%7Cscitools-iris"
+     alt="pypi" /></a>
 <a href="https://github.com/SciTools/iris/releases">
-<img src="https://img.shields.io/github/tag/SciTools/iris.svg"
-     alt="Latest version" /></a>
+<img src="https://img.shields.io/github/v/release/scitools/iris"
+     alt="latest release" /></a>
 <a href="https://github.com/SciTools/iris/commits/master">
 <img src="https://img.shields.io/github/commits-since/SciTools/iris/latest.svg"
      alt="Commits since last release" /></a>

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -89,6 +89,8 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ updated the ``intersphinx_mapping`` and fixed documentation
    to use ``stable`` URLs for `matplotlib`_. (:pull:`4003`)
 
+#. `@bjlittle`_ added the |PyPI|_ badge to the `README.md`_. (:pull:`4004`)
+
 
 💼 Internal
 ===========
@@ -123,4 +125,7 @@ This document explains the changes made to Iris for this release
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _Met Office: https://www.metoffice.gov.uk/
 .. _numpy: https://numpy.org/doc/stable/release/1.20.0-notes.html
+.. |PyPI| image:: https://img.shields.io/pypi/v/scitools-iris?color=orange&label=pypi%7Cscitools-iris
+.. _PyPI: https://pypi.org/project/scitools-iris/
 .. _Python 3.8: https://www.python.org/downloads/release/python-380/
+.. _README.md: https://github.com/SciTools/iris#-----


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds the `pypi` version badge ![PyPI](https://img.shields.io/pypi/v/scitools-iris?color=orange&label=pypi%7Cscitools-iris) to the `README.md`.

It unifies the colour of the `conda-forge` version badge ![Conda](https://img.shields.io/conda/v/conda-forge/iris?color=orange&label=conda-forge%7Ciris) with that of the `pypi` version badge, but also highlights the different package name of Iris from each package distribution.

It also exchanges the `tag` github badge ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/scitools/iris) for the `release` github badge ![GitHub release (latest by date)](https://img.shields.io/github/v/release/scitools/iris).

Also branded the `twitter` badge ![Twitter Follow](https://img.shields.io/twitter/follow/scitools_iris?color=yellow&label=twitter%7Cscitools_iris&logo=twitter&style=plastic) in keeping with the style of `conda-forge` and `pypi` badges, to keep things consistent.

See this [README.md](https://github.com/bjlittle/iris/tree/readme-badges#-----) for how the badges render.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
