### PR TITLE
update readme logo img src and href

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
-  <a href="https://scitools.org.uk/iris/docs/latest/">
-   <img src="docs/src/_static/iris-logo-title.png" alt="Iris" width="300"></a><br>
+  <a href="https://scitools-iris.readthedocs.io/en/latest/">
+   <img src="https://scitools-iris.readthedocs.io/en/latest/_static/iris-logo-title.png" alt="Iris" width="300"></a><br>
 </h1>
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the `README.md` logo `href` to link directly to `readthedocs`, rather than indirectly via `scitools.org.uk`.

More importantly, the Iris logo image is sourced from `readthedocs`, which means that it will render correctly on `PyPI` instead of the `alt`ernative text which is displayed at present i.e.,

<img width="690" alt="iris-pypi" src="https://user-images.githubusercontent.com/2051656/107866027-932e4480-6e64-11eb-86b1-6a5990f17be7.PNG">



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
