### PR TITLE
update setuptools description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ setup(
     author="UK Met Office",
     author_email="scitools-iris-dev@googlegroups.com",
     description="A powerful, format-agnostic, community-driven Python "
-    "library for analysing and visualising Earth science data",
+    "package for analysing and visualising Earth science data",
     long_description=long_description(),
     long_description_content_type="text/markdown",
     packages=find_package_tree("lib/iris", "iris"),


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the `setuptools` `description` to keep it inline with our migration from using the word `library` -> `package` in the Iris tag line.

This is most notable on PyPI for `scitools_iris`:

<img width="689" alt="iris-pypi-package" src="https://user-images.githubusercontent.com/2051656/107875393-7a9b4a00-6eb7-11eb-894d-202832437819.PNG">



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
