### PR TITLE
MeshCoordMetadata [AVD-1629]

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -46,6 +46,7 @@ __all__ = [
     "MeshFaceCoords",
     "MeshNodeCoords",
     "MeshMetadata",
+    "MeshCoordMetadata",
 ]
 
 
@@ -1989,32 +1990,11 @@ class _Mesh2DConnectivityManager(_MeshConnectivityManagerBase):
         return self._members["face_node_connectivity"]
 
 
-#: Convenience collection of lenient metadata combine services.
-_services = [ConnectivityMetadata.combine, MeshMetadata.combine]
-SERVICES_COMBINE.extend(_services)
-SERVICES.extend(_services)
-#: Convenience collection of lenient metadata difference services.
-_services = [ConnectivityMetadata.difference, MeshMetadata.difference]
-SERVICES_DIFFERENCE.extend(_services)
-SERVICES.extend(_services)
-
-#: Convenience collection of lenient metadata equality services.
-_services = [
-    ConnectivityMetadata.__eq__,
-    ConnectivityMetadata.equal,
-    MeshMetadata.__eq__,
-    MeshMetadata.equal,
-]
-SERVICES_EQUAL.extend(_services)
-SERVICES.extend(_services)
-
-del _services
-
-
 class MeshCoordMetadata(BaseMetadata):
     """
     Metadata container for a :class:`~iris.coords.MeshCoord`.
     """
+
     _members = ("location", "axis")
     # NOTE: in future, we may add 'mesh' as part of this metadata,
     # as the Mesh seems part of the 'identity' of a MeshCoord.
@@ -2137,8 +2117,18 @@ _op_names_and_service_collections = [
     ("__eq__", SERVICES_EQUAL),
     ("equal", SERVICES_EQUAL),
 ]
-for _cls in (ConnectivityMetadata, MeshCoordMetadata):
+_metadata_classes = [ConnectivityMetadata, MeshMetadata, MeshCoordMetadata]
+for _cls in _metadata_classes:
     for _name, _service_collection in _op_names_and_service_collections:
         _method = getattr(_cls, _name)
         _service_collection.append(_method)
         SERVICES.append(_method)
+
+del (
+    _op_names_and_service_collections,
+    _metadata_classes,
+    _cls,
+    _name,
+    _service_collection,
+    _method,
+)

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -1993,8 +1993,6 @@ class _Mesh2DConnectivityManager(_MeshConnectivityManagerBase):
 _services = [ConnectivityMetadata.combine, MeshMetadata.combine]
 SERVICES_COMBINE.extend(_services)
 SERVICES.extend(_services)
-
-
 #: Convenience collection of lenient metadata difference services.
 _services = [ConnectivityMetadata.difference, MeshMetadata.difference]
 SERVICES_DIFFERENCE.extend(_services)
@@ -2011,3 +2009,130 @@ SERVICES_EQUAL.extend(_services)
 SERVICES.extend(_services)
 
 del _services
+
+
+class MeshCoordMetadata(BaseMetadata):
+    """
+    Metadata container for a :class:`~iris.coords.MeshCoord`.
+    """
+    _members = ("mesh", "location", "axis")
+
+    __slots__ = ()
+
+    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
+    @lenient_service
+    def __eq__(self, other):
+        return super().__eq__(other)
+
+    def _combine_lenient(self, other):
+        """
+        Perform lenient combination of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other metadata participating in the lenient combination.
+
+        Returns:
+            A list of combined metadata member values.
+
+        """
+        # It is actually "strict" : return None except where members are equal.
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return left if left == right else None
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in self._members]
+        # Perform lenient combination of the other parent members.
+        result = super()._combine_lenient(other)
+        result.extend(values)
+
+        return result
+
+    def _compare_lenient(self, other):
+        """
+        Perform lenient equality of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other metadata participating in the lenient comparison.
+
+        Returns:
+            Boolean.
+
+        """
+        # Perform "strict" comparison for the MeshCoord specific members
+        # (i.e. mesh, location, axis) : for equality, they must all match.
+        result = all(
+            [
+                getattr(self, field) == getattr(other, field)
+                for field in self._members
+            ]
+        )
+        if result:
+            # Perform lenient comparison of the other parent members.
+            result = super()._compare_lenient(other)
+
+        return result
+
+    def _difference_lenient(self, other):
+        """
+        Perform lenient difference of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other MeshCoord metadata participating in the lenient
+            difference.
+
+        Returns:
+            A list of different metadata member values.
+
+        """
+        # Perform "strict" difference for "cf_role", "start_index", "src_dim".
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return None if left == right else (left, right)
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in self._members]
+        # Perform lenient difference of the other parent members.
+        result = super()._difference_lenient(other)
+        result.extend(values)
+
+        return result
+
+    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
+    @lenient_service
+    def combine(self, other, lenient=None):
+        return super().combine(other, lenient=lenient)
+
+    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
+    @lenient_service
+    def difference(self, other, lenient=None):
+        return super().difference(other, lenient=lenient)
+
+    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
+    @lenient_service
+    def equal(self, other, lenient=None):
+        return super().equal(other, lenient=lenient)
+
+
+# Add our new optional metadata operations into the 'convenience collections'
+# of lenient metadata services.
+# TODO: when included in 'iris.common.metadata', install each one directly ?
+for cls in (ConnectivityMetadata, MeshCoordMetadata):
+    op_names_and_collections = {
+        "combine": SERVICES_COMBINE,
+        "difference": SERVICES_DIFFERENCE,
+        "__eq__": SERVICES_EQUAL,
+        "equal": SERVICES_EQUAL,
+    }
+    for name, collection in op_names_and_collections.items():
+        method = getattr(cls, name)
+        collection.append(method)
+        SERVICES.append(method)

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2015,7 +2015,13 @@ class MeshCoordMetadata(BaseMetadata):
     """
     Metadata container for a :class:`~iris.coords.MeshCoord`.
     """
-    _members = ("mesh", "location", "axis")
+    _members = ("location", "axis")
+    # NOTE: in future, we may add 'mesh' as part of this metadata,
+    # as the Mesh seems part of the 'identity' of a MeshCoord.
+    # For now we omit it, particularly as we don't yet implement Mesh.__eq__.
+    #
+    # Thus, for now, the MeshCoord class will need to handle 'mesh' explicitly
+    # in identity / comparison, but in future that may be simplified.
 
     __slots__ = ()
 
@@ -2065,7 +2071,7 @@ class MeshCoordMetadata(BaseMetadata):
 
         """
         # Perform "strict" comparison for the MeshCoord specific members
-        # (i.e. mesh, location, axis) : for equality, they must all match.
+        # 'location', 'axis' : for equality, they must all match.
         result = all(
             [
                 getattr(self, field) == getattr(other, field)
@@ -2092,7 +2098,7 @@ class MeshCoordMetadata(BaseMetadata):
             A list of different metadata member values.
 
         """
-        # Perform "strict" difference for mesh / location / axis.
+        # Perform "strict" difference for location / axis.
         def func(field):
             left = getattr(self, field)
             right = getattr(other, field)

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2125,14 +2125,14 @@ class MeshCoordMetadata(BaseMetadata):
 # Add our new optional metadata operations into the 'convenience collections'
 # of lenient metadata services.
 # TODO: when included in 'iris.common.metadata', install each one directly ?
-for cls in (ConnectivityMetadata, MeshCoordMetadata):
-    op_names_and_collections = {
-        "combine": SERVICES_COMBINE,
-        "difference": SERVICES_DIFFERENCE,
-        "__eq__": SERVICES_EQUAL,
-        "equal": SERVICES_EQUAL,
-    }
-    for name, collection in op_names_and_collections.items():
-        method = getattr(cls, name)
-        collection.append(method)
-        SERVICES.append(method)
+_op_names_and_service_collections = [
+    ("combine", SERVICES_COMBINE),
+    ("difference", SERVICES_DIFFERENCE),
+    ("__eq__", SERVICES_EQUAL),
+    ("equal", SERVICES_EQUAL),
+]
+for _cls in (ConnectivityMetadata, MeshCoordMetadata):
+    for _name, _service_collection in _op_names_and_service_collections:
+        _method = getattr(_cls, _name)
+        _service_collection.append(_method)
+        SERVICES.append(_method)

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2092,7 +2092,7 @@ class MeshCoordMetadata(BaseMetadata):
             A list of different metadata member values.
 
         """
-        # Perform "strict" difference for "cf_role", "start_index", "src_dim".
+        # Perform "strict" difference for mesh / location / axis.
         def func(field):
             left = getattr(self, field)
             right = getattr(other, field)

--- a/lib/iris/tests/unit/common/lenient/test_Lenient.py
+++ b/lib/iris/tests/unit/common/lenient/test_Lenient.py
@@ -39,10 +39,10 @@ class Test___contains__(tests.IrisTest):
         self.lenient = Lenient()
 
     def test_in(self):
-        self.assertTrue("maths", self.lenient)
+        self.assertIn("maths", self.lenient)
 
     def test_not_in(self):
-        self.assertTrue(("concatenate", self.lenient))
+        self.assertNotIn("concatenate", self.lenient)
 
 
 class Test___getitem__(tests.IrisTest):
@@ -180,3 +180,7 @@ class Test_context(tests.IrisTest):
         # still synchronised
         self.assertFalse(_LENIENT.enable)
         self.assertFalse(self.lenient["maths"])
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/common/metadata/test_CellMeasureMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_CellMeasureMetadata.py
@@ -315,8 +315,8 @@ class Test_combine(tests.IrisTest):
         expected = right.copy()
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
-            self.assertTrue(expected, lmetadata.combine(rmetadata)._asdict())
-            self.assertTrue(expected, rmetadata.combine(lmetadata)._asdict())
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
 
     def test_op_lenient_different(self):
         lmetadata = self.cls(**self.values)

--- a/lib/iris/tests/unit/common/metadata/test_CubeMetadata.py
+++ b/lib/iris/tests/unit/common/metadata/test_CubeMetadata.py
@@ -339,8 +339,8 @@ class Test_combine(tests.IrisTest):
         expected = right.copy()
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
-            self.assertTrue(expected, lmetadata.combine(rmetadata)._asdict())
-            self.assertTrue(expected, rmetadata.combine(lmetadata)._asdict())
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
 
     def test_op_lenient_different(self):
         lmetadata = self.cls(**self.values)

--- a/lib/iris/tests/unit/experimental/ugrid/test_ConnectivityMetadata.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_ConnectivityMetadata.py
@@ -389,10 +389,10 @@ class Test_combine(tests.IrisTest):
             with mock.patch(
                 "iris.common.metadata._LENIENT", return_value=True
             ):
-                self.assertTrue(
+                self.assertEqual(
                     expected, lmetadata.combine(rmetadata)._asdict()
                 )
-                self.assertTrue(
+                self.assertEqual(
                     expected, rmetadata.combine(lmetadata)._asdict()
                 )
 

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
@@ -1,0 +1,740 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for the :class:`iris.experimental.ugrid.MeshCoordMetadata`.
+
+"""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+from copy import deepcopy
+import unittest.mock as mock
+from unittest.mock import sentinel
+
+from iris.common.lenient import _LENIENT, _qualname
+from iris.common.metadata import BaseMetadata
+from iris.experimental.ugrid import MeshCoordMetadata
+
+
+class Test__identity(tests.IrisTest):
+    def setUp(self):
+        self.standard_name = mock.sentinel.standard_name
+        self.long_name = mock.sentinel.long_name
+        self.var_name = mock.sentinel.var_name
+        self.units = mock.sentinel.units
+        self.attributes = mock.sentinel.attributes
+        self.mesh = mock.sentinel.mesh
+        self.location = mock.sentinel.location
+        self.axis = mock.sentinel.axis
+        self.cls = MeshCoordMetadata
+
+    def test_repr(self):
+        metadata = self.cls(
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            units=self.units,
+            attributes=self.attributes,
+            mesh=self.mesh,
+            location=self.location,
+            axis=self.axis,
+        )
+        fmt = (
+            "MeshCoordMetadata(standard_name={!r}, long_name={!r}, "
+            "var_name={!r}, units={!r}, attributes={!r}, mesh={!r}, "
+            "location={!r}, axis={!r})"
+        )
+        expected = fmt.format(
+            self.standard_name,
+            self.long_name,
+            self.var_name,
+            self.units,
+            self.attributes,
+            self.mesh,
+            self.location,
+            self.axis,
+        )
+        self.assertEqual(expected, repr(metadata))
+
+    def test__fields(self):
+        expected = (
+            "standard_name",
+            "long_name",
+            "var_name",
+            "units",
+            "attributes",
+            "mesh",
+            "location",
+            "axis",
+        )
+        self.assertEqual(self.cls._fields, expected)
+
+    def test_bases(self):
+        self.assertTrue(issubclass(self.cls, BaseMetadata))
+
+
+class Test__eq__(tests.IrisTest):
+    def setUp(self):
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            mesh=sentinel.mesh,
+            location=sentinel.location,
+            axis=sentinel.axis,
+        )
+        self.dummy = sentinel.dummy
+        self.cls = MeshCoordMetadata
+
+    def test_wraps_docstring(self):
+        self.assertEqual(BaseMetadata.__eq__.__doc__, self.cls.__eq__.__doc__)
+
+    def test_lenient_service(self):
+        qualname___eq__ = _qualname(self.cls.__eq__)
+        self.assertIn(qualname___eq__, _LENIENT)
+        self.assertTrue(_LENIENT[qualname___eq__])
+        self.assertTrue(_LENIENT[self.cls.__eq__])
+
+    def test_call(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        metadata = self.cls(*(None,) * len(self.cls._fields))
+        with mock.patch.object(
+            BaseMetadata, "__eq__", return_value=return_value
+        ) as mocker:
+            result = metadata.__eq__(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_same_none_nonmember(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertTrue(lmetadata.__eq__(rmetadata))
+            self.assertTrue(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertFalse(lmetadata.__eq__(rmetadata))
+            self.assertFalse(rmetadata.__eq__(lmetadata))
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertFalse(lmetadata.__eq__(rmetadata))
+                self.assertFalse(rmetadata.__eq__(lmetadata))
+
+
+class Test___lt__(tests.IrisTest):
+    def setUp(self):
+        self.cls = MeshCoordMetadata
+        values = [1] * len(self.cls._fields)
+        self.one = self.cls(*values)
+
+        values_two = values[:]
+        values_two[2] = 2
+        self.two = self.cls(*values_two)
+
+        values_none = values[:]
+        values_none[2] = None
+        self.none = self.cls(*values_none)
+
+        values_attrs = values[:]
+        values_attrs[4] = 10
+        self.attributes = self.cls(*values_attrs)
+
+    def test__ascending_lt(self):
+        result = self.one < self.two
+        self.assertTrue(result)
+
+    def test__descending_lt(self):
+        result = self.two < self.one
+        self.assertFalse(result)
+
+    def test__none_rhs_operand(self):
+        result = self.one < self.none
+        self.assertFalse(result)
+
+    def test__none_lhs_operand(self):
+        result = self.none < self.one
+        self.assertTrue(result)
+
+    def test__ignore_attributes(self):
+        result = self.one < self.attributes
+        self.assertFalse(result)
+        result = self.attributes < self.one
+        self.assertFalse(result)
+
+
+class Test_combine(tests.IrisTest):
+    def setUp(self):
+        self.cls = MeshCoordMetadata
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            mesh=sentinel.mesh,
+            location=sentinel.location,
+            axis=sentinel.axis,
+        )
+        self.dummy = sentinel.dummy
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(
+            BaseMetadata.combine.__doc__, self.cls.combine.__doc__
+        )
+
+    def test_lenient_service(self):
+        qualname_combine = _qualname(self.cls.combine)
+        self.assertIn(qualname_combine, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_combine])
+        self.assertTrue(_LENIENT[self.cls.combine])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "combine", return_value=return_value
+        ) as mocker:
+            result = self.none.combine(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "combine", return_value=return_value
+        ) as mocker:
+            result = self.none.combine(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+        expected = self.values
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_same_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+        expected = self.values
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            expected = right.copy()
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_lenient_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["units"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+        expected = self.values.copy()
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["long_name"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+    def test_op_strict_different_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+        expected = self.values.copy()
+        expected["long_name"] = None
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
+            self.assertEqual(expected, rmetadata.combine(lmetadata)._asdict())
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            expected = self.values.copy()
+            expected[member] = None
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    expected, lmetadata.combine(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    expected, rmetadata.combine(lmetadata)._asdict()
+                )
+
+
+class Test_difference(tests.IrisTest):
+    def setUp(self):
+        self.cls = MeshCoordMetadata
+        self.values = dict(
+            standard_name=sentinel.standard_name,
+            long_name=sentinel.long_name,
+            var_name=sentinel.var_name,
+            units=sentinel.units,
+            attributes=sentinel.attributes,
+            mesh=sentinel.mesh,
+            location=sentinel.location,
+            axis=sentinel.axis,
+        )
+        self.dummy = sentinel.dummy
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(
+            BaseMetadata.difference.__doc__, self.cls.difference.__doc__
+        )
+
+    def test_lenient_service(self):
+        qualname_difference = _qualname(self.cls.difference)
+        self.assertIn(qualname_difference, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_difference])
+        self.assertTrue(_LENIENT[self.cls.difference])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "difference", return_value=return_value
+        ) as mocker:
+            result = self.none.difference(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "difference", return_value=return_value
+        ) as mocker:
+            result = self.none.difference(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+    def test_op_lenient_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_lenient_same_none(self):
+        lmetadata = self.cls(**self.values)
+        right = self.values.copy()
+        right["var_name"] = None
+        rmetadata = self.cls(**right)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_lenient_same_members_none(self):
+        for member in self.cls._members:
+            lmetadata = self.cls(**self.values)
+            member_value = getattr(lmetadata, member)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (member_value, None)
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = (None, member_value)
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_lenient_different(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["units"] = self.dummy
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["units"] = (left["units"], right["units"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["units"] = lexpected["units"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=True):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_lenient_different_members(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=True
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_strict_same(self):
+        lmetadata = self.cls(**self.values)
+        rmetadata = self.cls(**self.values)
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertIsNone(lmetadata.difference(rmetadata))
+            self.assertIsNone(rmetadata.difference(lmetadata))
+
+    def test_op_strict_different(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["long_name"] = self.dummy
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["long_name"] = (left["long_name"], right["long_name"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["long_name"] = lexpected["long_name"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_strict_different_members(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = self.dummy
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+    def test_op_strict_different_none(self):
+        left = self.values.copy()
+        lmetadata = self.cls(**left)
+        right = self.values.copy()
+        right["long_name"] = None
+        rmetadata = self.cls(**right)
+        lexpected = deepcopy(self.none)._asdict()
+        lexpected["long_name"] = (left["long_name"], right["long_name"])
+        rexpected = deepcopy(self.none)._asdict()
+        rexpected["long_name"] = lexpected["long_name"][::-1]
+
+        with mock.patch("iris.common.metadata._LENIENT", return_value=False):
+            self.assertEqual(
+                lexpected, lmetadata.difference(rmetadata)._asdict()
+            )
+            self.assertEqual(
+                rexpected, rmetadata.difference(lmetadata)._asdict()
+            )
+
+    def test_op_strict_different_members_none(self):
+        for member in self.cls._members:
+            left = self.values.copy()
+            lmetadata = self.cls(**left)
+            right = self.values.copy()
+            right[member] = None
+            rmetadata = self.cls(**right)
+            lexpected = deepcopy(self.none)._asdict()
+            lexpected[member] = (left[member], right[member])
+            rexpected = deepcopy(self.none)._asdict()
+            rexpected[member] = lexpected[member][::-1]
+
+            with mock.patch(
+                "iris.common.metadata._LENIENT", return_value=False
+            ):
+                self.assertEqual(
+                    lexpected, lmetadata.difference(rmetadata)._asdict()
+                )
+                self.assertEqual(
+                    rexpected, rmetadata.difference(lmetadata)._asdict()
+                )
+
+
+class Test_equal(tests.IrisTest):
+    def setUp(self):
+        self.cls = MeshCoordMetadata
+        self.none = self.cls(*(None,) * len(self.cls._fields))
+
+    def test_wraps_docstring(self):
+        self.assertEqual(BaseMetadata.equal.__doc__, self.cls.equal.__doc__)
+
+    def test_lenient_service(self):
+        qualname_equal = _qualname(self.cls.equal)
+        self.assertIn(qualname_equal, _LENIENT)
+        self.assertTrue(_LENIENT[qualname_equal])
+        self.assertTrue(_LENIENT[self.cls.equal])
+
+    def test_lenient_default(self):
+        other = sentinel.other
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "equal", return_value=return_value
+        ) as mocker:
+            result = self.none.equal(other)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=None), kwargs)
+
+    def test_lenient(self):
+        other = sentinel.other
+        lenient = sentinel.lenient
+        return_value = sentinel.return_value
+        with mock.patch.object(
+            BaseMetadata, "equal", return_value=return_value
+        ) as mocker:
+            result = self.none.equal(other, lenient=lenient)
+
+        self.assertEqual(return_value, result)
+        self.assertEqual(1, mocker.call_count)
+        (arg,), kwargs = mocker.call_args
+        self.assertEqual(other, arg)
+        self.assertEqual(dict(lenient=lenient), kwargs)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
@@ -28,7 +28,6 @@ class Test__identity(tests.IrisTest):
         self.var_name = mock.sentinel.var_name
         self.units = mock.sentinel.units
         self.attributes = mock.sentinel.attributes
-        self.mesh = mock.sentinel.mesh
         self.location = mock.sentinel.location
         self.axis = mock.sentinel.axis
         self.cls = MeshCoordMetadata
@@ -40,13 +39,12 @@ class Test__identity(tests.IrisTest):
             var_name=self.var_name,
             units=self.units,
             attributes=self.attributes,
-            mesh=self.mesh,
             location=self.location,
             axis=self.axis,
         )
         fmt = (
             "MeshCoordMetadata(standard_name={!r}, long_name={!r}, "
-            "var_name={!r}, units={!r}, attributes={!r}, mesh={!r}, "
+            "var_name={!r}, units={!r}, attributes={!r}, "
             "location={!r}, axis={!r})"
         )
         expected = fmt.format(
@@ -55,7 +53,6 @@ class Test__identity(tests.IrisTest):
             self.var_name,
             self.units,
             self.attributes,
-            self.mesh,
             self.location,
             self.axis,
         )
@@ -68,7 +65,6 @@ class Test__identity(tests.IrisTest):
             "var_name",
             "units",
             "attributes",
-            "mesh",
             "location",
             "axis",
         )
@@ -86,7 +82,6 @@ class Test__eq__(tests.IrisTest):
             var_name=sentinel.var_name,
             units=sentinel.units,
             attributes=sentinel.attributes,
-            mesh=sentinel.mesh,
             location=sentinel.location,
             axis=sentinel.axis,
         )
@@ -276,7 +271,6 @@ class Test_combine(tests.IrisTest):
             var_name=sentinel.var_name,
             units=sentinel.units,
             attributes=sentinel.attributes,
-            mesh=sentinel.mesh,
             location=sentinel.location,
             axis=sentinel.axis,
         )
@@ -473,7 +467,6 @@ class Test_difference(tests.IrisTest):
             var_name=sentinel.var_name,
             units=sentinel.units,
             attributes=sentinel.attributes,
-            mesh=sentinel.mesh,
             location=sentinel.location,
             axis=sentinel.axis,
         )

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py
@@ -128,7 +128,7 @@ class Test__eq__(tests.IrisTest):
     def test_op_lenient_same_none_nonmember(self):
         lmetadata = self.cls(**self.values)
         right = self.values.copy()
-        right["var_name"] = None
+        right["long_name"] = None
         rmetadata = self.cls(**right)
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
@@ -151,7 +151,7 @@ class Test__eq__(tests.IrisTest):
     def test_op_lenient_different(self):
         lmetadata = self.cls(**self.values)
         right = self.values.copy()
-        right["units"] = self.dummy
+        right["long_name"] = self.dummy
         rmetadata = self.cls(**right)
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
@@ -335,7 +335,7 @@ class Test_combine(tests.IrisTest):
     def test_op_lenient_same_none(self):
         lmetadata = self.cls(**self.values)
         right = self.values.copy()
-        right["var_name"] = None
+        right["long_name"] = None
         rmetadata = self.cls(**right)
         expected = self.values
 
@@ -364,10 +364,10 @@ class Test_combine(tests.IrisTest):
     def test_op_lenient_different(self):
         lmetadata = self.cls(**self.values)
         right = self.values.copy()
-        right["units"] = self.dummy
+        right["long_name"] = self.dummy
         rmetadata = self.cls(**right)
         expected = self.values.copy()
-        expected["units"] = None
+        expected["long_name"] = None
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
             self.assertEqual(expected, lmetadata.combine(rmetadata)._asdict())
@@ -531,7 +531,7 @@ class Test_difference(tests.IrisTest):
     def test_op_lenient_same_none(self):
         lmetadata = self.cls(**self.values)
         right = self.values.copy()
-        right["var_name"] = None
+        right["long_name"] = None
         rmetadata = self.cls(**right)
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
@@ -564,12 +564,12 @@ class Test_difference(tests.IrisTest):
         left = self.values.copy()
         lmetadata = self.cls(**left)
         right = self.values.copy()
-        right["units"] = self.dummy
+        right["long_name"] = self.dummy
         rmetadata = self.cls(**right)
         lexpected = deepcopy(self.none)._asdict()
-        lexpected["units"] = (left["units"], right["units"])
+        lexpected["long_name"] = (left["long_name"], right["long_name"])
         rexpected = deepcopy(self.none)._asdict()
-        rexpected["units"] = lexpected["units"][::-1]
+        rexpected["long_name"] = lexpected["long_name"][::-1]
 
         with mock.patch("iris.common.metadata._LENIENT", return_value=True):
             self.assertEqual(


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Adds MeshCoordMetadata class (with tests)
Preliminary to creating a MeshCoord

Note: also fixed some problems I stumbled over in existing metadata testing.
Some of which  had already been copied into other tests! ...
There **_is_** a lot of boilerplate here : 
much of the  code in `lib/iris/tests/unit/experimental/ugrid/test_MeshCoordMetadata.py` is a total copy 
of that in `lib/iris/tests/unit/experimental/ugrid/test_ConnectivityMetadata.py` (i.e. ultimately from #3968)

As we are in a hurry, we are resolved to fix that "later"... 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
