### PR TITLE
drop __unicode__ method usage

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2652,9 +2652,6 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def __str__(self):
         return self.summary()
 
-    def __unicode__(self):
-        return self.summary()
-
     def __repr__(self):
         return "<iris 'Cube' of %s>" % self.summary(
             shorten=True, name_padding=1


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR drops the use of the Python2 `__unicode__` method.

This method is no longer required in Python3, and since `iris` is no longer supported on Python2, it's time to purge it

This method was only present on `iris.cube.Cube.__unicode__`.




---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
