### PR TITLE
add minimalist mesh __eq__ support

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -917,8 +917,8 @@ class Mesh(CFVariableMixin):
             raise NotImplementedError(emsg)
 
     def __eq__(self, other):
-        # TBD
-        return NotImplemented
+        # TBD: this is a minimalist implementation and requires to be revisited
+        return id(self) == id(other)
 
     def __getstate__(self):
         return (
@@ -928,8 +928,10 @@ class Mesh(CFVariableMixin):
         )
 
     def __ne__(self, other):
-        # TBD
-        return NotImplemented
+        result = self.__eq__(other)
+        if result is not NotImplemented:
+            result = not result
+        return result
 
     def __repr__(self):
         # TBD
@@ -1304,8 +1306,8 @@ class _Mesh1DCoordinateManager:
         self.edge_y = edge_y
 
     def __eq__(self, other):
-        # TBD
-        return NotImplemented
+        # TBD: this is a minimalist implementation and requires to be revisited
+        return id(self) == id(other)
 
     def __getstate__(self):
         return self._members
@@ -1315,8 +1317,10 @@ class _Mesh1DCoordinateManager:
             yield item
 
     def __ne__(self, other):
-        # TBD
-        return NotImplemented
+        result = self.__eq__(other)
+        if result is not NotImplemented:
+            result = not result
+        return result
 
     def __repr__(self):
         args = [
@@ -1706,8 +1710,8 @@ class _MeshConnectivityManagerBase(ABC):
         self.add(*connectivities)
 
     def __eq__(self, other):
-        # TBD
-        return NotImplemented
+        # TBD: this is a minimalist implementation and requires to be revisited
+        return id(self) == id(other)
 
     def __getstate__(self):
         return self._members
@@ -1717,8 +1721,10 @@ class _MeshConnectivityManagerBase(ABC):
             yield item
 
     def __ne__(self, other):
-        # TBD
-        return NotImplemented
+        result = self.__eq__(other)
+        if result is not NotImplemented:
+            result = not result
+        return result
 
     def __repr__(self):
         args = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds minimalist `__eq__` support for the `iris.experimental.ugrid.Mesh` and its container managers.

Testing and doc-strings are to follow...


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
