### PR TITLE
Mesh tests

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -848,124 +848,6 @@ class MeshMetadata(BaseMetadata):
         return super().equal(other, lenient=lenient)
 
 
-class MeshCoordMetadata(BaseMetadata):
-    """
-    Metadata container for a :class:`~iris.coords.MeshCoord`.
-    """
-
-    _members = ("location", "axis")
-    # NOTE: in future, we may add 'mesh' as part of this metadata,
-    # as the Mesh seems part of the 'identity' of a MeshCoord.
-    # For now we omit it, particularly as we don't yet implement Mesh.__eq__.
-    #
-    # Thus, for now, the MeshCoord class will need to handle 'mesh' explicitly
-    # in identity / comparison, but in future that may be simplified.
-
-    __slots__ = ()
-
-    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
-    @lenient_service
-    def __eq__(self, other):
-        return super().__eq__(other)
-
-    def _combine_lenient(self, other):
-        """
-        Perform lenient combination of metadata members for MeshCoord.
-
-        Args:
-
-        * other (MeshCoordMetadata):
-            The other metadata participating in the lenient combination.
-
-        Returns:
-            A list of combined metadata member values.
-
-        """
-        # It is actually "strict" : return None except where members are equal.
-        def func(field):
-            left = getattr(self, field)
-            right = getattr(other, field)
-            return left if left == right else None
-
-        # Note that, we use "_members" not "_fields".
-        values = [func(field) for field in self._members]
-        # Perform lenient combination of the other parent members.
-        result = super()._combine_lenient(other)
-        result.extend(values)
-
-        return result
-
-    def _compare_lenient(self, other):
-        """
-        Perform lenient equality of metadata members for MeshCoord.
-
-        Args:
-
-        * other (MeshCoordMetadata):
-            The other metadata participating in the lenient comparison.
-
-        Returns:
-            Boolean.
-
-        """
-        # Perform "strict" comparison for the MeshCoord specific members
-        # 'location', 'axis' : for equality, they must all match.
-        result = all(
-            [
-                getattr(self, field) == getattr(other, field)
-                for field in self._members
-            ]
-        )
-        if result:
-            # Perform lenient comparison of the other parent members.
-            result = super()._compare_lenient(other)
-
-        return result
-
-    def _difference_lenient(self, other):
-        """
-        Perform lenient difference of metadata members for MeshCoord.
-
-        Args:
-
-        * other (MeshCoordMetadata):
-            The other MeshCoord metadata participating in the lenient
-            difference.
-
-        Returns:
-            A list of different metadata member values.
-
-        """
-        # Perform "strict" difference for location / axis.
-        def func(field):
-            left = getattr(self, field)
-            right = getattr(other, field)
-            return None if left == right else (left, right)
-
-        # Note that, we use "_members" not "_fields".
-        values = [func(field) for field in self._members]
-        # Perform lenient difference of the other parent members.
-        result = super()._difference_lenient(other)
-        result.extend(values)
-
-        return result
-
-    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
-    @lenient_service
-    def combine(self, other, lenient=None):
-        return super().combine(other, lenient=lenient)
-
-    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
-    @lenient_service
-    def difference(self, other, lenient=None):
-        return super().difference(other, lenient=lenient)
-
-    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
-    @lenient_service
-    def equal(self, other, lenient=None):
-        return super().equal(other, lenient=lenient)
-
-
 class Mesh(CFVariableMixin):
     """
 
@@ -2264,6 +2146,124 @@ class _Mesh2DConnectivityManager(_MeshConnectivityManagerBase):
     @property
     def face_node(self):
         return self._members["face_node_connectivity"]
+
+
+class MeshCoordMetadata(BaseMetadata):
+    """
+    Metadata container for a :class:`~iris.coords.MeshCoord`.
+    """
+
+    _members = ("location", "axis")
+    # NOTE: in future, we may add 'mesh' as part of this metadata,
+    # as the Mesh seems part of the 'identity' of a MeshCoord.
+    # For now we omit it, particularly as we don't yet implement Mesh.__eq__.
+    #
+    # Thus, for now, the MeshCoord class will need to handle 'mesh' explicitly
+    # in identity / comparison, but in future that may be simplified.
+
+    __slots__ = ()
+
+    @wraps(BaseMetadata.__eq__, assigned=("__doc__",), updated=())
+    @lenient_service
+    def __eq__(self, other):
+        return super().__eq__(other)
+
+    def _combine_lenient(self, other):
+        """
+        Perform lenient combination of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other metadata participating in the lenient combination.
+
+        Returns:
+            A list of combined metadata member values.
+
+        """
+        # It is actually "strict" : return None except where members are equal.
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return left if left == right else None
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in self._members]
+        # Perform lenient combination of the other parent members.
+        result = super()._combine_lenient(other)
+        result.extend(values)
+
+        return result
+
+    def _compare_lenient(self, other):
+        """
+        Perform lenient equality of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other metadata participating in the lenient comparison.
+
+        Returns:
+            Boolean.
+
+        """
+        # Perform "strict" comparison for the MeshCoord specific members
+        # 'location', 'axis' : for equality, they must all match.
+        result = all(
+            [
+                getattr(self, field) == getattr(other, field)
+                for field in self._members
+            ]
+        )
+        if result:
+            # Perform lenient comparison of the other parent members.
+            result = super()._compare_lenient(other)
+
+        return result
+
+    def _difference_lenient(self, other):
+        """
+        Perform lenient difference of metadata members for MeshCoord.
+
+        Args:
+
+        * other (MeshCoordMetadata):
+            The other MeshCoord metadata participating in the lenient
+            difference.
+
+        Returns:
+            A list of different metadata member values.
+
+        """
+        # Perform "strict" difference for location / axis.
+        def func(field):
+            left = getattr(self, field)
+            right = getattr(other, field)
+            return None if left == right else (left, right)
+
+        # Note that, we use "_members" not "_fields".
+        values = [func(field) for field in self._members]
+        # Perform lenient difference of the other parent members.
+        result = super()._difference_lenient(other)
+        result.extend(values)
+
+        return result
+
+    @wraps(BaseMetadata.combine, assigned=("__doc__",), updated=())
+    @lenient_service
+    def combine(self, other, lenient=None):
+        return super().combine(other, lenient=lenient)
+
+    @wraps(BaseMetadata.difference, assigned=("__doc__",), updated=())
+    @lenient_service
+    def difference(self, other, lenient=None):
+        return super().difference(other, lenient=lenient)
+
+    @wraps(BaseMetadata.equal, assigned=("__doc__",), updated=())
+    @lenient_service
+    def equal(self, other, lenient=None):
+        return super().equal(other, lenient=lenient)
 
 
 # Add our new optional metadata operations into the 'convenience collections'

--- a/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
@@ -245,12 +245,12 @@ class TestProperties1D(TestMeshCommon):
         }
 
         kwargs_expected = (
-            ({"axis": "x"}, ("node_x", "edge_x")),
-            ({"axis": "y"}, ("node_y", "edge_y")),
-            ({"include_nodes": True}, ("node_x", "node_y")),
-            ({"include_edges": True}, ("edge_x", "edge_y")),
-            ({"include_nodes": False}, ("edge_x", "edge_y")),
-            ({"include_edges": False}, ("node_x", "node_y")),
+            ({"axis": "x"}, ["node_x", "edge_x"]),
+            ({"axis": "y"}, ["node_y", "edge_y"]),
+            ({"include_nodes": True}, ["node_x", "node_y"]),
+            ({"include_edges": True}, ["edge_x", "edge_y"]),
+            ({"include_nodes": False}, ["edge_x", "edge_y"]),
+            ({"include_edges": False}, ["node_x", "node_y"]),
             (
                 {"include_nodes": True, "include_edges": True},
                 ["node_x", "node_y", "edge_x", "edge_y"],
@@ -258,7 +258,7 @@ class TestProperties1D(TestMeshCommon):
             ({"include_nodes": False, "include_edges": False}, []),
             (
                 {"include_nodes": False, "include_edges": True},
-                ("edge_x", "edge_y"),
+                ["edge_x", "edge_y"],
             ),
         )
 
@@ -425,41 +425,41 @@ class TestProperties2D(TestProperties1D):
         kwargs_expected = (
             (
                 {"contains_node": True},
-                (self.EDGE_NODE, self.FACE_NODE, self.BOUNDARY_NODE),
+                [self.EDGE_NODE, self.FACE_NODE, self.BOUNDARY_NODE],
             ),
             (
                 {"contains_edge": True},
-                (self.EDGE_NODE, self.FACE_EDGE, self.EDGE_FACE),
+                [self.EDGE_NODE, self.FACE_EDGE, self.EDGE_FACE],
             ),
             (
                 {"contains_face": True},
-                (
+                [
                     self.FACE_NODE,
                     self.FACE_EDGE,
                     self.FACE_FACE,
                     self.EDGE_FACE,
-                ),
+                ],
             ),
             (
                 {"contains_node": False},
-                (self.FACE_EDGE, self.EDGE_FACE, self.FACE_FACE),
+                [self.FACE_EDGE, self.EDGE_FACE, self.FACE_FACE],
             ),
             (
                 {"contains_edge": False},
-                (self.FACE_NODE, self.BOUNDARY_NODE, self.FACE_FACE),
+                [self.FACE_NODE, self.BOUNDARY_NODE, self.FACE_FACE],
             ),
-            ({"contains_face": False}, (self.EDGE_NODE, self.BOUNDARY_NODE)),
+            ({"contains_face": False}, [self.EDGE_NODE, self.BOUNDARY_NODE]),
             (
                 {"contains_edge": True, "contains_face": True},
-                (self.FACE_EDGE, self.EDGE_FACE),
+                [self.FACE_EDGE, self.EDGE_FACE],
             ),
             (
                 {"contains_node": False, "contains_edge": False},
-                (self.FACE_FACE,),
+                [self.FACE_FACE],
             ),
             (
                 {"contains_node": True, "contains_edge": False},
-                (self.FACE_NODE, self.BOUNDARY_NODE),
+                [self.FACE_NODE, self.BOUNDARY_NODE],
             ),
             (
                 {
@@ -486,33 +486,33 @@ class TestProperties2D(TestProperties1D):
         }
 
         kwargs_expected = (
-            ({"axis": "x"}, ("node_x", "edge_x", "face_x")),
-            ({"axis": "y"}, ("node_y", "edge_y", "face_y")),
-            ({"include_nodes": True}, ("node_x", "node_y")),
-            ({"include_edges": True}, ("edge_x", "edge_y")),
+            ({"axis": "x"}, ["node_x", "edge_x", "face_x"]),
+            ({"axis": "y"}, ["node_y", "edge_y", "face_y"]),
+            ({"include_nodes": True}, ["node_x", "node_y"]),
+            ({"include_edges": True}, ["edge_x", "edge_y"]),
             (
                 {"include_nodes": False},
-                ("edge_x", "edge_y", "face_x", "face_y"),
+                ["edge_x", "edge_y", "face_x", "face_y"],
             ),
             (
                 {"include_edges": False},
-                ("node_x", "node_y", "face_x", "face_y"),
+                ["node_x", "node_y", "face_x", "face_y"],
             ),
             (
                 {"include_faces": False},
-                ("node_x", "node_y", "edge_x", "edge_y"),
+                ["node_x", "node_y", "edge_x", "edge_y"],
             ),
             (
                 {"include_faces": True, "include_edges": True},
-                ("edge_x", "edge_y", "face_x", "face_y"),
+                ["edge_x", "edge_y", "face_x", "face_y"],
             ),
             (
                 {"include_faces": False, "include_edges": False},
-                ("node_x", "node_y"),
+                ["node_x", "node_y"],
             ),
             (
                 {"include_faces": False, "include_edges": True},
-                ("edge_x", "edge_y"),
+                ["edge_x", "edge_y"],
             ),
         )
 

--- a/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
@@ -88,6 +88,25 @@ class TestProperties1D(tests.IrisTest):
         )
         self.assertEqual(expected, self.mesh.__getstate__())
 
+    def test___repr__(self):
+        expected = (
+            "Mesh(topology_dimension=1, node_coords_and_axes=[(AuxCoord("
+            "array([0, 2, 1]), standard_name='longitude', units=Unit("
+            "'unknown'), long_name='long_name', var_name='node_lon', "
+            "attributes={'test': 1}), 'x'), (AuxCoord(array([0, 0, 1]), "
+            "standard_name='latitude', units=Unit('unknown'), "
+            "var_name='node_lat'), 'y')], connectivities=Connectivity("
+            "cf_role='edge_node_connectivity', start_index=0), "
+            "edge_coords_and_axes=[(AuxCoord(array([1. , 1.5, 0.5]), "
+            "standard_name='longitude', units=Unit('unknown'), "
+            "var_name='edge_lon'), 'x'), (AuxCoord(array([0. , 0.5, 0.5]), "
+            "standard_name='latitude', units=Unit('unknown'), "
+            "var_name='edge_lat'), 'y')], long_name='my_topology_mesh', "
+            "var_name='mesh', attributes={'notes': 'this is a test'}, "
+            "node_dimension='NodeDim', edge_dimension='EdgeDim')"
+        )
+        self.assertEqual(expected, self.mesh.__repr__())
+
     def test_all_connectivities(self):
         expected = ugrid.Mesh1DConnectivities(EDGE_NODE)
         self.assertEqual(expected, self.mesh.all_connectivities)
@@ -298,6 +317,35 @@ class TestProperties2D(TestProperties1D):
         cls.KWARGS["face_dimension"] = "FaceDim"
         cls.KWARGS["face_coords_and_axes"] = ((FACE_LON, "x"), (FACE_LAT, "y"))
         super().setUpClass()
+
+    def test___repr__(self):
+        expected = (
+            "Mesh(topology_dimension=2, node_coords_and_axes=[(AuxCoord("
+            "array([0, 2, 1]), standard_name='longitude', units=Unit("
+            "'unknown'), long_name='long_name', var_name='node_lon', "
+            "attributes={'test': 1}), 'x'), (AuxCoord(array([0, 0, 1]), "
+            "standard_name='latitude', units=Unit('unknown'), "
+            "var_name='node_lat'), 'y')], connectivities=[Connectivity("
+            "cf_role='face_node_connectivity', start_index=0), Connectivity("
+            "cf_role='edge_node_connectivity', start_index=0), Connectivity("
+            "cf_role='face_edge_connectivity', start_index=0), Connectivity("
+            "cf_role='face_face_connectivity', start_index=0), Connectivity("
+            "cf_role='edge_face_connectivity', start_index=0), Connectivity("
+            "cf_role='boundary_node_connectivity', start_index=0)], "
+            "edge_coords_and_axes=[(AuxCoord(array([1. , 1.5, 0.5]), "
+            "standard_name='longitude', units=Unit('unknown'), "
+            "var_name='edge_lon'), 'x'), (AuxCoord(array([0. , 0.5, 0.5]), "
+            "standard_name='latitude', units=Unit('unknown'), "
+            "var_name='edge_lat'), 'y')], face_coords_and_axes=[(AuxCoord("
+            "array([0.5]), standard_name='longitude', units=Unit('unknown'), "
+            "var_name='face_lon'), 'x'), (AuxCoord(array([0.5]), "
+            "standard_name='latitude', units=Unit('unknown'), "
+            "var_name='face_lat'), 'y')], long_name='my_topology_mesh', "
+            "var_name='mesh', attributes={'notes': 'this is a test'}, "
+            "node_dimension='NodeDim', edge_dimension='EdgeDim', "
+            "face_dimension='FaceDim')"
+        )
+        self.assertEqual(expected, self.mesh.__repr__())
 
     def test_all_connectivities(self):
         expected = ugrid.Mesh2DConnectivities(

--- a/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
@@ -19,10 +19,8 @@ from iris.experimental import ugrid
 class TestMeshCommon(tests.IrisTest):
     @classmethod
     def setUpClass(cls):
-        # A collection of minimal coords and connectivities describing an equilateral triangle.
-        # Re-used in most/all of the test classes, hence globals.
-        # global NODE_LON, NODE_LAT, EDGE_LON, EDGE_LAT, FACE_LON, FACE_LAT, EDGE_NODE, FACE_NODE, FACE_EDGE, FACE_FACE, EDGE_FACE, BOUNDARY_NODE
-
+        # A collection of minimal coords and connectivities describing an
+        # equilateral triangle.
         cls.NODE_LON = AuxCoord(
             [0, 2, 1],
             standard_name="longitude",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adds a suite of tests for the `Mesh` class.

---

### Test Style

In agreement with @bjlittle (and with tentative support from @pp-mo), these tests are written in a different style that is unit-esque, but focuses on being easier to write and read. You might call them **"pragmatic tests"** or some-such. The basic idea:

* Write tests that look more similar to how a user/developer would use the functionality in the real world.
* Avoid the difficult process of abstracting every test to definitely only test one thing.
* Consider re-using objects for multiple assertions in one test.
    * May achieve more readable, concise testing.
    * Reduces possible resource-bloat caused by the reduced abstraction.

Cons

* Less granular information on failures.
  So an error takes more investigation.
  But not much more, and errors always need some investigation anyway. 

Pros

* Greatly reduced use of `mock`, which is known to be difficult.
  Plenty of stories of `mock` making testing take longer than the functionality.
* Can write more intuitively - faster and less difficult.
* A single test can achieve the same coverage as many unit tests.
  I.e. more coverage for less thinking/writing.

With this style, I was able to write the `Mesh` tests - ~800 lines, ~80 tests, >100 assertions - pretty much fluidly without having to  stop and work out __how__ to write a test. This definitely hasn't been true in the past when trying to achieve proper unit test abstraction.

The amount of time it takes to achieve good coverage with proper unit tests in my opinion often takes longer than the time they save when investigating errors.

This is of course only worth doing if it doesn't make the tests run excessively longer. For reference: testing the `Mesh` class - a fairly rich class - with reasonably good coverage takes ~100ms locally for me.

If this style causes problems / doesn't solve problems in the months ahead, I'm happy to roll back on this idea. And by all means object if you have other concerns!

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
