### PR TITLE
MeshCoord class [AVD-1591]

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2687,7 +2687,7 @@ class MeshCoord(AuxCoord):
     """
     Geographic coordinate values of data on an unstructured mesh.
 
-    A MeshCoord contains a `~iris.experiomental.ugrid.Mesh`.
+    A MeshCoord references a `~iris.experiomental.ugrid.Mesh`.
     When contained in a `~iris.cube.Cube` it connects the cube to the Mesh,
     and records (a) which cube dimension is mapped to the mesh, and (b) on
     which mesh location (e.g. 'face' or 'node') the cube data exists.
@@ -2702,11 +2702,11 @@ class MeshCoord(AuxCoord):
 
     The points and bounds contain coordinate values for the mesh elements,
     which depends on location.
-    For 'node', the ".points" contains node locations.
-    For 'edge', the ".bounds" contains edge endpoints, and the points contain
+    For 'node', the ``.points`` contains node locations.
+    For 'edge', the ``.bounds`` contains edge endpoints, and the ``.points`` contain
     edge locations (typically centres), if the Mesh contains them (optional).
-    For 'face', the bounds contain the face corners, and the points contain the
-    face location (optionally).
+    For 'face', the ``.bounds`` contain the face corners, and the ``.points`` contain the
+    face locations (typically centres), if the Mesh contains them (optional).
 
     .. note::
         As described above, it is possible for a MeshCoord to have bounds but

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2773,7 +2773,7 @@ class MeshCoord(AuxCoord):
 
         # Get the 'coord identity' metadata from the relevant node-coordinate.
         # N.B. mesh.coord returns a dict
-        node_coords = self.mesh.coord(node=True, axis=self.axis)
+        node_coords = self.mesh.coord(include_nodes=True, axis=self.axis)
         (node_coord,) = list(node_coords.values())
         # Call parent constructor to handle the common constructor args.
         super().__init__(
@@ -2911,21 +2911,21 @@ class MeshCoord(AuxCoord):
         # TODO: replace wth fully dynamic lazy calcs (slightly more complex).
         mesh, location, axis = self.mesh, self.location, self.axis
         # N.B. mesh.coord returns a dict
-        node_coords = self.mesh.coord(node=True, axis=axis)
+        node_coords = self.mesh.coord(include_nodes=True, axis=axis)
         (node_coord,) = list(node_coords.values())
         if location == "node":
             points = node_coord.core_points()
             bounds = None
         elif location == "edge":
             # N.B. mesh.coord returns a dict
-            edge_coords = self.mesh.coord(edge=True, axis=self.axis)
+            edge_coords = self.mesh.coord(include_edges=True, axis=self.axis)
             (edge_coord,) = list(edge_coords.values())
             points = edge_coord.core_points()
             inds = mesh.edge_node_connectivity.core_indices()
             bounds = node_coord.core_points()[inds]
         elif location == "face":
             # N.B. mesh.coord returns a dict
-            face_coords = self.mesh.coord(face=True, axis=self.axis)
+            face_coords = self.mesh.coord(include_faces=True, axis=self.axis)
             (face_coord,) = list(face_coords.values())
             points = face_coord.core_points()  # For now, this always exists
             inds = mesh.face_node_connectivity.core_indices()

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2890,7 +2890,7 @@ class MeshCoord(AuxCoord):
             eq = self.mesh == other.mesh  # N.B. 'mesh' not in metadata.
             if eq is not NotImplemented and eq:
                 # Compare rest of metadata, but not points/bounds.
-                eq = eq and self.metadata == other.metadata
+                eq = self.metadata == other.metadata
 
         return eq
 

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -50,8 +50,8 @@ __all__ = [
     "MeshFaceCoords",
     "MeshNodeCoords",
     "MeshMetadata",
-    "MeshCoordMetadata",
     "MeshCoord",
+    "MeshCoordMetadata",
 ]
 
 
@@ -2687,10 +2687,11 @@ class MeshCoord(AuxCoord):
     """
     Geographic coordinate values of data on an unstructured mesh.
 
-    A MeshCoord references a `~iris.experiomental.ugrid.Mesh`.
-    When contained in a `~iris.cube.Cube` it connects the cube to the Mesh,
-    and records (a) which cube dimension is mapped to the mesh, and (b) on
-    which mesh location (e.g. 'face' or 'node') the cube data exists.
+    A MeshCoord references a `~iris.experimental.ugrid.Mesh`.
+    When contained in a `~iris.cube.Cube` it connects the cube to the Mesh.
+    It records (a) which 1-D cube dimension represents the unstructured mesh,
+    and (b) which  mesh 'location' the cube data is mapped to -- i.e. is it
+    data on 'face's, 'edge's or 'node's.
 
     A MeshCoord also specifies its 'axis' : 'x' or 'y'.  Its values are then,
     accordingly, longitudes or latitudes.  The values are taken from the
@@ -2719,11 +2720,6 @@ class MeshCoord(AuxCoord):
 
     """
 
-    # Note: the valid mesh locations are effectively part of the Mesh api, but
-    # it doesn't provide them in a simple form, so we define our own here.
-    # TODO: make this a public item of the Mesh class ?
-    VALID_MESH_LOCATIONS = ("face", "edge", "node")
-
     def __init__(
         self,
         mesh,
@@ -2745,10 +2741,10 @@ class MeshCoord(AuxCoord):
         # NOTE: currently *not* included in metadata. In future it might be.
         self._mesh = mesh
 
-        if location not in self.VALID_MESH_LOCATIONS:
+        if location not in Mesh.LOCATIONS:
             msg = (
                 f"'location' of {location} is not a valid Mesh location', "
-                f"must be one of {self.VALID_MESH_LOCATIONS}."
+                f"must be one of {Mesh.LOCATIONS}."
             )
             raise ValueError(msg)
         # Held in metadata, readable as self.location, but cannot set it.

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2694,8 +2694,8 @@ class MeshCoord(AuxCoord):
 
     A MeshCoord also specifies its 'axis' : 'x' or 'y'.  Its values are then,
     accordingly, longitudes or latitudes.  The values are taken from the
-    appropriate element coordinates and connectivities in the Mesh, determined
-    by its 'location' and 'axis'.
+    appropriate coordinates and connectivities in the Mesh, determined by its
+    'location' and 'axis'.
 
     Any cube with data on a mesh will have a MeshCoord for each axis,
     i.e. an 'X' and a 'Y'.
@@ -2710,7 +2710,8 @@ class MeshCoord(AuxCoord):
 
     .. note::
         As described above, it is possible for a MeshCoord to have bounds but
-        no points.  This is not possible for a regular AuxCoord or DimCoord.
+        no points.  This is not possible for a regular
+        :class:`~iris.coords.AuxCoord` or :class:`~iris.coords.DimCoord`.
 
     .. note::
         A MeshCoord can not yet actually be created with bounds but no points.
@@ -2718,9 +2719,9 @@ class MeshCoord(AuxCoord):
 
     """
 
-    # Note: effectively this list of valid mesh locations is determined by
-    # the Mesh api, but it doesn't expose those choices in a generic form, so
-    # we will just define our own here.
+    # Note: the valid mesh locations are effectively part of the Mesh api, but
+    # it doesn't provide them in a simple form, so we define our own here.
+    # TODO: make this a public item of the Mesh class ?
     VALID_MESH_LOCATIONS = ("face", "edge", "node")
 
     def __init__(
@@ -2735,7 +2736,8 @@ class MeshCoord(AuxCoord):
         # Validate and record the class-specific constructor args.
         if not isinstance(mesh, Mesh):
             msg = (
-                "'mesh' must be an iris.experimental.ugrid.Mesh, "
+                "'mesh' must be an "
+                f"{Mesh.__module__}.{Mesh.__name__}, "
                 f"got {mesh}."
             )
             raise ValueError(msg)
@@ -2791,33 +2793,18 @@ class MeshCoord(AuxCoord):
     def mesh(self):
         return self._mesh
 
-    @mesh.setter
-    def mesh(self, value):
-        msg = "Cannot set the 'mesh' of a MeshCoord."
-        raise ValueError(msg)
-
     @property
     def location(self):
         return self._metadata_manager.location
-
-    @location.setter
-    def location(self, value):
-        msg = "Cannot set the 'location' of a MeshCoord."
-        raise ValueError(msg)
 
     @property
     def axis(self):
         return self._metadata_manager.axis
 
-    @axis.setter
-    def axis(self, value):
-        msg = "Cannot set the 'axis' of a MeshCoord."
-        raise ValueError(msg)
-
     # Provide overrides to mimic the Coord-specific properties that are not
-    # supported by MeshCoord, i.e. "coord_sytem" and "climatological".
-    # These mimic the Coord properties, but always return fixed 'null' values,
-    # and cannot be set.
+    # supported by MeshCoord, i.e. "coord_system" and "climatological".
+    # These mimic the Coord properties, but always return fixed 'null' values.
+    # They can be set, to the 'null' value only, for the inherited init code.
 
     @property
     def coord_system(self):

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2884,20 +2884,13 @@ class MeshCoord(AuxCoord):
     def __eq__(self, other):
         eq = NotImplemented
         if isinstance(other, MeshCoord):
-            # We compare only our defining properties: mesh/location/axis.
-            # This is not in fact *quite* reliable, as although our other
-            # properties all come from the Mesh object, they are copied at
-            # create time and it could in theory have changed since.
-            # TODO: we could close this loophole, either by implementing a
-            # strictly immutable Mesh, or making the MeshCoord derived
-            # properties *dynamically* reflect the Mesh state.
+            # *Don't* use the parent (_DimensionalMetadata) __eq__, as that
+            # will try to compare points and bounds arrays.
+            # Just compare the mesh, and the (other) metadata.
             eq = self.mesh == other.mesh  # N.B. 'mesh' not in metadata.
             if eq is not NotImplemented and eq:
-                eq = (
-                    eq
-                    and self.location == other.location
-                    and self.axis == other.axis
-                )
+                # Compare rest of metadata, but not points/bounds.
+                eq = eq and self.metadata == other.metadata
 
         return eq
 

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -1,0 +1,279 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for the :class:`iris.experimental.ugrid.MeshCoord`.
+
+"""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import unittest.mock as mock
+
+import numpy as np
+
+from iris.cube import Cube
+from iris.coords import AuxCoord, Coord
+from iris.experimental.ugrid import Connectivity, Mesh
+
+from iris.experimental.ugrid import MeshCoord
+
+# Default test object creation controls
+_TEST_N_FACES = 3
+_TEST_N_BOUNDS = 4
+
+# Default actual points + bounds.
+_TEST_POINTS = np.arange(_TEST_N_FACES)
+_TEST_BOUNDS = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS)
+_TEST_BOUNDS = _TEST_BOUNDS.reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
+
+
+def _default_create_args():
+    # Produce a minimal set of default constructor args
+    kwargs = {
+        "standard_name": "longitude",
+        "long_name": "long-name",
+        "var_name": "var",
+        "units": "degrees",
+        "attributes": {"a": 1, "b": 2},
+        "location": "face",
+        "axis": "x",
+        "mesh": mock.Mock(spec=Mesh),  # Dummy Mesh for default
+        "points": _TEST_POINTS,
+        "bounds": _TEST_BOUNDS,
+    }
+    # NOTE: *don't* include coord_system or climatology.
+    # We expect to only set those (non-default) explicitly.
+    return kwargs
+
+
+def _create_test_meshcoord(**override_kwargs):
+    kwargs = _default_create_args()
+    # Apply requested overrides and additions.
+    kwargs.update(override_kwargs)
+    # Create and return the test coord.
+    result = MeshCoord(**kwargs)
+    return result
+
+
+class Test___init__(tests.IrisTest):
+    def setUp(self):
+        self.meshcoord = _create_test_meshcoord()
+
+    def test_basic(self):
+        kwargs = _default_create_args()
+        meshcoord = _create_test_meshcoord(**kwargs)
+        for key, val in kwargs.items():
+            if hasattr(val, "dtype"):
+                self.assertArrayAllClose(getattr(meshcoord, key), val)
+            else:
+                self.assertEqual(getattr(meshcoord, key), val)
+        self.assertIsInstance(meshcoord, MeshCoord)
+        self.assertIsInstance(meshcoord, Coord)
+
+    def test_fail_bad_mesh(self):
+        with self.assertRaisesRegex(ValueError, "must be a.*Mesh"):
+            _create_test_meshcoord(mesh=mock.sentinel.odd)
+
+    def test_valid_locations(self):
+        for loc in ("face", "edge", "node"):
+            meshcoord = _create_test_meshcoord(location=loc)
+            self.assertEqual(meshcoord.location, loc)
+
+    def test_fail_bad_location(self):
+        with self.assertRaisesRegex(ValueError, "not a valid Mesh location"):
+            _create_test_meshcoord(location="bad")
+
+    def test_valid_axes(self):
+        for axis in ("x", "y"):
+            meshcoord = _create_test_meshcoord(axis=axis)
+            self.assertEqual(meshcoord.axis, axis)
+
+    def test_fail_bad_axis(self):
+        with self.assertRaisesRegex(ValueError, "not a valid Mesh axis"):
+            _create_test_meshcoord(axis="q")
+
+    def test_fail_bounds_no_points(self):
+        # An specific error, *not* a signature mismatch (TypeError).
+        # In future, this may actually be possible.
+        with self.assertRaisesRegex(ValueError, "Cannot.*without points"):
+            _create_test_meshcoord(points=None)
+
+
+class Test__readonly_properties(tests.IrisTest):
+    def setUp(self):
+        self.meshcoord = _create_test_meshcoord()
+
+    def test_fixed_metadata(self):
+        # Check that you cannot set any of these on an existing MeshCoord.
+        meshcoord = self.meshcoord
+        props = ("mesh", "location", "axis", "coord_system", "climatological")
+        msg = "Cannot set"
+        for prop in props:
+            with self.assertRaisesRegex(ValueError, msg):
+                setattr(meshcoord, prop, mock.sentinel.odd)
+
+    def test_coord_system(self):
+        self.assertIsNone(self.meshcoord.coord_system)
+
+    def test_fail_create_with_coord_system(self):
+        # Check that you can't specify a non-None coord_system even at creation.
+        with self.assertRaisesRegex(ValueError, "Cannot set"):
+            _create_test_meshcoord(coord_system=mock.sentinel.odd)
+
+    def test_climatological(self):
+        self.assertFalse(self.meshcoord.climatological)
+
+    def test_fail_create_with_climatological(self):
+        # Check that you can't set 'climatological', even at creation.
+        with self.assertRaisesRegex(ValueError, "Cannot set"):
+            _create_test_meshcoord(climatological=True)
+
+
+class Test__copy(tests.IrisTest):
+    def test_basic(self):
+        meshcoord = _create_test_meshcoord()
+        meshcoord2 = meshcoord.copy()
+        self.assertIsNot(meshcoord2, meshcoord)
+        self.assertEqual(meshcoord2, meshcoord)
+        # In this case, we should *NOT* copy the linked Mesh object.
+        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
+
+    def test_points_no_bounds(self):
+        meshcoord = _create_test_meshcoord()
+        meshcoord2 = meshcoord.copy(points=meshcoord.core_points())
+        points1, points2 = meshcoord.core_points(), meshcoord2.core_points()
+        self.assertIsNot(points2, points1)
+        self.assertArrayAllClose(points2, points1)
+        self.assertIsNone(meshcoord2.bounds)
+        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
+
+    def test_fail_bounds_no_points(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "Cannot.*without points"):
+            meshcoord.copy(bounds=meshcoord.core_bounds())
+
+    def test_fail_points_bounds_mismatch(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "shape must be compatible"):
+            meshcoord.copy(
+                points=meshcoord.core_points(),
+                bounds=meshcoord.core_bounds()[:-1],
+            )
+
+
+def _create_test_mesh():
+    xco = AuxCoord(np.zeros(_TEST_N_FACES), standard_name="longitude")
+    yco = AuxCoord(np.zeros(_TEST_N_FACES), standard_name="latitude")
+    face_nodes = Connectivity(
+        np.zeros((_TEST_N_FACES, _TEST_N_BOUNDS), dtype=int),
+        cf_role="face_node_connectivity",
+    )
+    mesh = Mesh(
+        topology_dimension=2,
+        node_coords_and_axes=[(xco, "x"), (yco, "y")],
+        connectivities=[face_nodes],
+    )
+    return mesh
+
+
+class Test___eq__(tests.IrisTest):
+    # We must do this test with *actual* Mesh objects.
+    def setUp(self):
+        self.mesh = _create_test_mesh()
+
+    def _create_common_mesh(self, **kwargs):
+        return _create_test_meshcoord(mesh=self.mesh, **kwargs)
+
+    def test_same_mesh(self):
+        meshcoord1 = self._create_common_mesh()
+        meshcoord2 = self._create_common_mesh()
+        self.assertEqual(meshcoord2, meshcoord1)
+
+    def test_different_identical_mesh(self):
+        # For equality, must have the SAME mesh (at present).
+        mesh1 = _create_test_mesh()
+        mesh2 = _create_test_mesh()  # Presumably identical, but not the same
+        meshcoord1 = _create_test_meshcoord(mesh=mesh1)
+        meshcoord2 = _create_test_meshcoord(mesh=mesh2)
+        # These should NOT compare, because the Meshes are not identical : at
+        # present, Mesh equality is not implemented (i.e. limited to identity)
+        self.assertNotEqual(
+            meshcoord2, meshcoord1
+        )  # NOTE: this assumes Mesh equality
+
+    def test_different_location(self):
+        meshcoord = self._create_common_mesh()
+        meshcoord2 = self._create_common_mesh(location="node")
+        self.assertNotEqual(meshcoord2, meshcoord)
+
+    def test_different_axis(self):
+        meshcoord = self._create_common_mesh()
+        meshcoord2 = self._create_common_mesh(axis="y")
+        self.assertNotEqual(meshcoord2, meshcoord)
+
+    def test_different_common_metadata(self):
+        # Actually handled by parent class, but maybe worth checking.
+        meshcoord = self._create_common_mesh()
+        meshcoord2 = self._create_common_mesh(long_name="blurb")
+        self.assertNotEqual(meshcoord2, meshcoord)
+
+    def test_different_points(self):
+        # Actually handled by parent class, but maybe worth checking.
+        meshcoord = self._create_common_mesh()
+        points = meshcoord.core_points() + 1.0
+        bounds = meshcoord.core_bounds()
+        meshcoord2 = self._create_common_mesh(points=points, bounds=bounds)
+        self.assertNotEqual(meshcoord2, meshcoord)
+
+
+class Test_cube_containment(tests.IrisTest):
+    # Check that we can put a MeshCoord into a cube, and have it behave just
+    # like a regular AuxCoord
+    def setUp(self):
+        meshcoord = _create_test_meshcoord()
+        data_shape = (2,) + _TEST_POINTS.shape
+        cube = Cube(np.zeros(data_shape))
+        cube.add_aux_coord(meshcoord, 1)
+        self.meshcoord = meshcoord
+        self.cube = cube
+
+    def test_added_to_cube(self):
+        meshcoord = self.meshcoord
+        cube = self.cube
+        self.assertIn(meshcoord, cube.coords())
+
+    def test_cube_dims(self):
+        meshcoord = self.meshcoord
+        cube = self.cube
+        self.assertEqual(meshcoord.cube_dims(cube), (1,))
+        self.assertEqual(cube.coord_dims(meshcoord), (1,))
+
+    def test_find_by_name(self):
+        meshcoord = self.meshcoord
+        cube = self.cube
+        self.assertIs(cube.coord(standard_name="longitude"), meshcoord)
+        self.assertIs(cube.coord(long_name="long-name"), meshcoord)
+        self.assertIs(cube.coord(var_name="var"), meshcoord)
+
+    def test_find_by_axis(self):
+        meshcoord = self.meshcoord
+        cube = self.cube
+        self.assertIs(cube.coord(axis="x"), meshcoord)
+        self.assertEqual(cube.coords(axis="y"), [])
+
+        # NOTE: the meshcoord.axis takes precedence over the older
+        # "guessed axis" approach.  So the standard_name does not control it.
+        cube.remove_coord(meshcoord)
+        meshcoord = _create_test_meshcoord(standard_name="longitude", axis="y")
+        cube.add_aux_coord(meshcoord, (1,))
+        self.assertIs(cube.coord(axis="y"), meshcoord)
+        self.assertEqual(cube.coords(axis="x"), [])
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -145,19 +145,25 @@ class Test__readonly_properties(tests.IrisTest):
     def test_fixed_metadata(self):
         # Check that you cannot set any of these on an existing MeshCoord.
         meshcoord = self.meshcoord
-        props = ("mesh", "location", "axis", "coord_system", "climatological")
-        msg = "Cannot set"
-        for prop in props:
-            with self.assertRaisesRegex(ValueError, msg):
+        for prop in ("mesh", "location", "axis"):
+            with self.assertRaisesRegex(AttributeError, "can't set"):
                 setattr(meshcoord, prop, mock.sentinel.odd)
 
     def test_coord_system(self):
-        # The property exists as a 'null' value.
+        # The property exists, =None, can set to None, can not set otherwise.
+        self.assertTrue(hasattr(self.meshcoord, "coord_system"))
         self.assertIsNone(self.meshcoord.coord_system)
+        self.meshcoord.coord_system = None
+        with self.assertRaisesRegex(ValueError, "Cannot set.* MeshCoord"):
+            self.meshcoord.coord_system = 1
 
-    def test_climatological(self):
-        # The property exists as a 'null' value.
+    def test_set_climatological(self):
+        # The property exists, =False, can set to False, can not set otherwise.
+        self.assertTrue(hasattr(self.meshcoord, "climatological"))
         self.assertFalse(self.meshcoord.climatological)
+        self.meshcoord.climatological = False
+        with self.assertRaisesRegex(ValueError, "Cannot set.* MeshCoord"):
+            self.meshcoord.climatological = True
 
 
 class Test___eq__(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -12,9 +12,8 @@ Unit tests for the :class:`iris.experimental.ugrid.MeshCoord`.
 # importing anything else.
 import iris.tests as tests
 
-import unittest.mock as mock
-
 import numpy as np
+import unittest.mock as mock
 
 from iris.cube import Cube
 from iris.coords import AuxCoord, Coord
@@ -23,7 +22,9 @@ from iris.experimental.ugrid import Connectivity, Mesh
 from iris.experimental.ugrid import MeshCoord
 
 # Default test object creation controls
+_TEST_N_NODES = 15
 _TEST_N_FACES = 3
+_TEST_N_EDGES = 5
 _TEST_N_BOUNDS = 4
 
 # Default actual points + bounds.
@@ -32,20 +33,50 @@ _TEST_BOUNDS = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS)
 _TEST_BOUNDS = _TEST_BOUNDS.reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
 
 
+def _create_test_mesh():
+    node_x = AuxCoord(
+        1100 + np.arange(_TEST_N_NODES),
+        standard_name="longitude",
+        long_name="long-name",
+        var_name="var",
+    )
+    node_y = AuxCoord(
+        1200 + np.arange(_TEST_N_NODES), standard_name="latitude"
+    )
+
+    conns = np.arange(_TEST_N_EDGES * 2, dtype=int)
+    conns = ((conns + 5) % _TEST_N_NODES).reshape((_TEST_N_EDGES, 2))
+    edge_nodes = Connectivity(conns, cf_role="edge_node_connectivity")
+    edge_x = AuxCoord(
+        2100 + np.arange(_TEST_N_EDGES), standard_name="longitude"
+    )
+    edge_y = AuxCoord(
+        2200 + np.arange(_TEST_N_EDGES), standard_name="latitude"
+    )
+
+    conns = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS, dtype=int)
+    conns = (conns % _TEST_N_NODES).reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
+    face_nodes = Connectivity(conns, cf_role="face_node_connectivity")
+    face_x = AuxCoord(
+        3100 + np.arange(_TEST_N_FACES), standard_name="longitude"
+    )
+    face_y = AuxCoord(
+        3200 + np.arange(_TEST_N_FACES), standard_name="latitude"
+    )
+
+    mesh = Mesh(
+        topology_dimension=2,
+        node_coords_and_axes=[(node_x, "x"), (node_y, "y")],
+        connectivities=[face_nodes, edge_nodes],
+        edge_coords_and_axes=[(edge_x, "x"), (edge_y, "y")],
+        face_coords_and_axes=[(face_x, "x"), (face_y, "y")],
+    )
+    return mesh
+
+
 def _default_create_args():
     # Produce a minimal set of default constructor args
-    kwargs = {
-        "standard_name": "longitude",
-        "long_name": "long-name",
-        "var_name": "var",
-        "units": "degrees",
-        "attributes": {"a": 1, "b": 2},
-        "location": "face",
-        "axis": "x",
-        "mesh": mock.Mock(spec=Mesh),  # Dummy Mesh for default
-        "points": _TEST_POINTS,
-        "bounds": _TEST_BOUNDS,
-    }
+    kwargs = {"location": "face", "axis": "x", "mesh": _create_test_mesh()}
     # NOTE: *don't* include coord_system or climatology.
     # We expect to only set those (non-default) explicitly.
     return kwargs
@@ -68,12 +99,26 @@ class Test___init__(tests.IrisTest):
         kwargs = _default_create_args()
         meshcoord = _create_test_meshcoord(**kwargs)
         for key, val in kwargs.items():
-            if hasattr(val, "dtype"):
-                self.assertArrayAllClose(getattr(meshcoord, key), val)
-            else:
-                self.assertEqual(getattr(meshcoord, key), val)
+            self.assertEqual(getattr(meshcoord, key), val)
         self.assertIsInstance(meshcoord, MeshCoord)
         self.assertIsInstance(meshcoord, Coord)
+
+    def test_derived_properties(self):
+        # Check the derived properties of the meshcoord against the correct
+        # underlying mesh coordinate.
+        for axis in ("x", "y"):
+            meshcoord = _create_test_meshcoord(axis=axis)
+            # N.B.
+            node_x_coords = meshcoord.mesh.coord(node=True, axis=axis)
+            (node_x_coord,) = list(node_x_coords.values())
+            for key in node_x_coord.metadata._fields:
+                meshval = getattr(meshcoord, key)
+                if key == "var_name":
+                    # var_name is unused.
+                    self.assertIsNone(meshval)
+                else:
+                    # names, units and attributes are derived from the node coord.
+                    self.assertEqual(meshval, getattr(node_x_coord, key))
 
     def test_fail_bad_mesh(self):
         with self.assertRaisesRegex(ValueError, "must be a.*Mesh"):
@@ -88,20 +133,9 @@ class Test___init__(tests.IrisTest):
         with self.assertRaisesRegex(ValueError, "not a valid Mesh location"):
             _create_test_meshcoord(location="bad")
 
-    def test_valid_axes(self):
-        for axis in ("x", "y"):
-            meshcoord = _create_test_meshcoord(axis=axis)
-            self.assertEqual(meshcoord.axis, axis)
-
     def test_fail_bad_axis(self):
         with self.assertRaisesRegex(ValueError, "not a valid Mesh axis"):
             _create_test_meshcoord(axis="q")
-
-    def test_fail_bounds_no_points(self):
-        # An specific error, *not* a signature mismatch (TypeError).
-        # In future, this may actually be possible.
-        with self.assertRaisesRegex(ValueError, "Cannot.*without points"):
-            _create_test_meshcoord(points=None)
 
 
 class Test__readonly_properties(tests.IrisTest):
@@ -118,67 +152,12 @@ class Test__readonly_properties(tests.IrisTest):
                 setattr(meshcoord, prop, mock.sentinel.odd)
 
     def test_coord_system(self):
+        # The property exists as a 'null' value.
         self.assertIsNone(self.meshcoord.coord_system)
 
-    def test_fail_create_with_coord_system(self):
-        # Check that you can't specify a non-None coord_system even at creation.
-        with self.assertRaisesRegex(ValueError, "Cannot set"):
-            _create_test_meshcoord(coord_system=mock.sentinel.odd)
-
     def test_climatological(self):
+        # The property exists as a 'null' value.
         self.assertFalse(self.meshcoord.climatological)
-
-    def test_fail_create_with_climatological(self):
-        # Check that you can't set 'climatological', even at creation.
-        with self.assertRaisesRegex(ValueError, "Cannot set"):
-            _create_test_meshcoord(climatological=True)
-
-
-class Test__copy(tests.IrisTest):
-    def test_basic(self):
-        meshcoord = _create_test_meshcoord()
-        meshcoord2 = meshcoord.copy()
-        self.assertIsNot(meshcoord2, meshcoord)
-        self.assertEqual(meshcoord2, meshcoord)
-        # In this case, we should *NOT* copy the linked Mesh object.
-        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
-
-    def test_points_no_bounds(self):
-        meshcoord = _create_test_meshcoord()
-        meshcoord2 = meshcoord.copy(points=meshcoord.core_points())
-        points1, points2 = meshcoord.core_points(), meshcoord2.core_points()
-        self.assertIsNot(points2, points1)
-        self.assertArrayAllClose(points2, points1)
-        self.assertIsNone(meshcoord2.bounds)
-        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
-
-    def test_fail_bounds_no_points(self):
-        meshcoord = _create_test_meshcoord()
-        with self.assertRaisesRegex(ValueError, "Cannot.*without points"):
-            meshcoord.copy(bounds=meshcoord.core_bounds())
-
-    def test_fail_points_bounds_mismatch(self):
-        meshcoord = _create_test_meshcoord()
-        with self.assertRaisesRegex(ValueError, "shape must be compatible"):
-            meshcoord.copy(
-                points=meshcoord.core_points(),
-                bounds=meshcoord.core_bounds()[:-1],
-            )
-
-
-def _create_test_mesh():
-    xco = AuxCoord(np.zeros(_TEST_N_FACES), standard_name="longitude")
-    yco = AuxCoord(np.zeros(_TEST_N_FACES), standard_name="latitude")
-    face_nodes = Connectivity(
-        np.zeros((_TEST_N_FACES, _TEST_N_BOUNDS), dtype=int),
-        cf_role="face_node_connectivity",
-    )
-    mesh = Mesh(
-        topology_dimension=2,
-        node_coords_and_axes=[(xco, "x"), (yco, "y")],
-        connectivities=[face_nodes],
-    )
-    return mesh
 
 
 class Test___eq__(tests.IrisTest):
@@ -202,9 +181,7 @@ class Test___eq__(tests.IrisTest):
         meshcoord2 = _create_test_meshcoord(mesh=mesh2)
         # These should NOT compare, because the Meshes are not identical : at
         # present, Mesh equality is not implemented (i.e. limited to identity)
-        self.assertNotEqual(
-            meshcoord2, meshcoord1
-        )  # NOTE: this assumes Mesh equality
+        self.assertNotEqual(meshcoord2, meshcoord1)
 
     def test_different_location(self):
         meshcoord = self._create_common_mesh()
@@ -216,24 +193,60 @@ class Test___eq__(tests.IrisTest):
         meshcoord2 = self._create_common_mesh(axis="y")
         self.assertNotEqual(meshcoord2, meshcoord)
 
-    def test_different_common_metadata(self):
-        # Actually handled by parent class, but maybe worth checking.
-        meshcoord = self._create_common_mesh()
-        meshcoord2 = self._create_common_mesh(long_name="blurb")
-        self.assertNotEqual(meshcoord2, meshcoord)
 
-    def test_different_points(self):
-        # Actually handled by parent class, but maybe worth checking.
-        meshcoord = self._create_common_mesh()
-        points = meshcoord.core_points() + 1.0
-        bounds = meshcoord.core_bounds()
-        meshcoord2 = self._create_common_mesh(points=points, bounds=bounds)
-        self.assertNotEqual(meshcoord2, meshcoord)
+class Test__copy(tests.IrisTest):
+    def test_basic(self):
+        meshcoord = _create_test_meshcoord()
+        meshcoord2 = meshcoord.copy()
+        self.assertIsNot(meshcoord2, meshcoord)
+        self.assertEqual(meshcoord2, meshcoord)
+        # In this case, they should share *NOT* copy the Mesh object.
+        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
+
+    def test_copy__newdata_whole(self):
+        # This is equivalent to a plain copy.
+        # It is required to make [:] the same as copy, so we can slice cubes.
+        meshcoord = _create_test_meshcoord()
+        meshcoord2 = meshcoord.copy(
+            points=np.zeros(meshcoord.shape),
+            bounds=np.zeros(meshcoord._bounds_dm.shape),
+        )
+        self.assertEqual(meshcoord2, meshcoord)
+
+    def test_fail_copy_pointsonly(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "Cannot change the content"):
+            meshcoord.copy(points=np.zeros(meshcoord.shape))
+
+    def test_fail_copy_boundsonly(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "Cannot change the content"):
+            meshcoord.copy(bounds=np.zeros(meshcoord._bounds_dm.shape))
+
+    def test_fail_copy_shapechange(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "Cannot change the content"):
+            meshcoord.copy(points=np.zeros((7,)), bounds=np.zeros((7, 4)))
+
+
+class Test__getitem__(tests.IrisTest):
+    def test_slice_whole(self):
+        meshcoord = _create_test_meshcoord()
+        meshcoord2 = meshcoord[:]
+        self.assertIsNot(meshcoord2, meshcoord)
+        self.assertEqual(meshcoord2, meshcoord)
+        # In this case, we should *NOT* copy the linked Mesh object.
+        self.assertIs(meshcoord2.mesh, meshcoord.mesh)
+
+    def test_fail_slice_part(self):
+        meshcoord = _create_test_meshcoord()
+        with self.assertRaisesRegex(ValueError, "Cannot change the content"):
+            meshcoord[:1]
 
 
 class Test_cube_containment(tests.IrisTest):
     # Check that we can put a MeshCoord into a cube, and have it behave just
-    # like a regular AuxCoord
+    # like a regular AuxCoord.
     def setUp(self):
         meshcoord = _create_test_meshcoord()
         data_shape = (2,) + _TEST_POINTS.shape
@@ -258,7 +271,7 @@ class Test_cube_containment(tests.IrisTest):
         cube = self.cube
         self.assertIs(cube.coord(standard_name="longitude"), meshcoord)
         self.assertIs(cube.coord(long_name="long-name"), meshcoord)
-        self.assertIs(cube.coord(var_name="var"), meshcoord)
+        # self.assertIs(cube.coord(var_name="var"), meshcoord)
 
     def test_find_by_axis(self):
         meshcoord = self.meshcoord
@@ -268,11 +281,63 @@ class Test_cube_containment(tests.IrisTest):
 
         # NOTE: the meshcoord.axis takes precedence over the older
         # "guessed axis" approach.  So the standard_name does not control it.
-        cube.remove_coord(meshcoord)
-        meshcoord = _create_test_meshcoord(standard_name="longitude", axis="y")
-        cube.add_aux_coord(meshcoord, (1,))
-        self.assertIs(cube.coord(axis="y"), meshcoord)
-        self.assertEqual(cube.coords(axis="x"), [])
+        meshcoord.rename("latitude")
+        self.assertIs(cube.coord(axis="x"), meshcoord)
+        self.assertEqual(cube.coords(axis="y"), [])
+
+    def test_cube_copy(self):
+        # Check that we can copy a cube, and get a MeshCoord == the original.
+        # Note: currently must have the *same* mesh, as for MeshCoord.copy().
+        meshcoord = self.meshcoord
+        cube = self.cube
+        cube2 = cube.copy()
+        meshco2 = cube2.coord(meshcoord)
+        self.assertIsNot(meshco2, meshcoord)
+        self.assertEqual(meshco2, meshcoord)
+
+    def test_cube_nonmesh_slice(self):
+        # Check that we can slice a cube on a non-mesh dimension, and get a
+        # meshcoord == original.
+        # Note: currently this must have the *same* mesh, as for .copy().
+        meshcoord = self.meshcoord
+        cube = self.cube
+        cube2 = cube[:1]  # Make a reduced copy, slicing the non-mesh dim
+        meshco2 = cube2.coord(meshcoord)
+        self.assertIsNot(meshco2, meshcoord)
+        self.assertEqual(meshco2, meshcoord)
+
+    def test_cube_mesh_partslice(self):
+        # Check that we can *not* get a partial MeshCoord slice, as the
+        # MeshCoord refuses to be sliced.
+        # Instead, you get an AuxCoord created from the MeshCoord.
+        meshcoord = self.meshcoord
+        cube = self.cube
+        cube2 = cube[:, :1]  # Make a reduced copy, slicing the mesh dim
+
+        # The resulting coord can not be identified with the original.
+        # (i.e. metadata does not match)
+        co_matches = cube2.coords(meshcoord)
+        self.assertEqual(co_matches, [])
+
+        # The resulting coord is an AuxCoord instead of a MeshCoord, but the
+        # values match.
+        co2 = cube2.coord(meshcoord.name())
+        self.assertFalse(isinstance(co2, MeshCoord))
+        self.assertIsInstance(co2, AuxCoord)
+        self.assertArrayAllClose(co2.points, meshcoord.points[:1])
+        self.assertArrayAllClose(co2.bounds, meshcoord.bounds[:1])
+
+
+class Test_auxcoord_conversion(tests.IrisTest):
+    def test_basic(self):
+        meshcoord = _create_test_meshcoord()
+        auxcoord = AuxCoord.from_coord(meshcoord)
+        for propname, auxval in auxcoord.metadata._asdict().items():
+            meshval = getattr(meshcoord, propname)
+            self.assertEqual(auxval, meshval)
+        # Also check array content.
+        self.assertArrayAllClose(auxcoord.points, meshcoord.points)
+        self.assertArrayAllClose(auxcoord.bounds, meshcoord.bounds)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -108,7 +108,7 @@ class Test___init__(tests.IrisTest):
         for axis in ("x", "y"):
             meshcoord = _create_test_meshcoord(axis=axis)
             # N.B.
-            node_x_coords = meshcoord.mesh.coord(node=True, axis=axis)
+            node_x_coords = meshcoord.mesh.coord(include_nodes=True, axis=axis)
             (node_x_coord,) = list(node_x_coords.values())
             for key in node_x_coord.metadata._fields:
                 meshval = getattr(meshcoord, key)

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -124,7 +124,7 @@ class Test___init__(tests.IrisTest):
             _create_test_meshcoord(mesh=mock.sentinel.odd)
 
     def test_valid_locations(self):
-        for loc in ("face", "edge", "node"):
+        for loc in Mesh.LOCATIONS:
             meshcoord = _create_test_meshcoord(location=loc)
             self.assertEqual(meshcoord.location, loc)
 
@@ -321,7 +321,6 @@ class Test_cube_containment(tests.IrisTest):
         cube = self.cube
         self.assertIs(cube.coord(standard_name="longitude"), meshcoord)
         self.assertIs(cube.coord(long_name="long-name"), meshcoord)
-        # self.assertIs(cube.coord(var_name="var"), meshcoord)
 
     def test_find_by_axis(self):
         meshcoord = self.meshcoord


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Adding MeshCoord.

Notes: 
  1. the characteristic points and bounds indexing calculations are **_not_** yet implemented here.
I have other code prototyped for that, but this PR is simpler if I leave it out for now.
  2. the implementation isn't quite minimal, but I have chosen to control copying and slicing to make it a 'good citizen' within a cube (i.e. not blocking cube copy or slicing).
  3. there is as yet no sensible `__str__` or `__repr__`.  We have another task pending to address that.
  
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
