### PR TITLE
add mesh public doc-strings

### DIFF
--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1354,47 +1354,50 @@ def metadata_filter(
 ):
     """
     Filter a collection of objects by their metadata to fit the given metadata
-    criteria. Criteria can be one or both of: specific properties / other objects
-    carrying metadata to be matched.
+    criteria.
+
+    Criteria can be either specific properties or other objects with metadata
+    to be matched.
 
     Args:
 
-    * instances
+    * instances:
         One or more objects to be filtered.
 
     Kwargs:
 
-    * item
-        Either
+    * item:
+        Either,
 
-        (a) a :attr:`standard_name`, :attr:`long_name`, or
-        :attr:`var_name`. Defaults to value of `default`
-        (which itself defaults to `unknown`) as defined in
-        :class:`~iris.common.CFVariableMixin`.
+        * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+          :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+          :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is compared
+          against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
-        (b) a 'coordinate' instance with metadata equal to that of
-        the desired coordinates. Accepts either a
-        :class:`~iris.coords.DimCoord`, :class:`~iris.coords.AuxCoord`,
-        :class:`~iris.aux_factory.AuxCoordFactory`,
-        :class:`~iris.common.CoordMetadata` or
-        :class:`~iris.common.DimCoordMetadata` or
-        :class:`~iris.experimental.ugrid.ConnectivityMetadata`.
-    * standard_name
-        The CF standard name of the desired coordinate. If None, does not
-        check for standard name.
-    * long_name
-        An unconstrained description of the coordinate. If None, does not
-        check for long_name.
-    * var_name
-        The netCDF variable name of the desired coordinate. If None, does
-        not check for var_name.
-    * attributes
-        A dictionary of attributes desired on the coordinates. If None,
-        does not check for attributes.
-    * axis
-        The desired coordinate axis, see
-        :func:`~iris.util.guess_coord_axis`. If None, does not check for
-        axis. Accepts the values 'X', 'Y', 'Z' and 'T' (case-insensitive).
+        * a coordinate or metadata instance equal to that of
+          the desired coordinates e.g., :class:`~iris.coords.DimCoord`
+          or :class:`CoordMetadata`.
+
+    * standard_name:
+        The CF standard name of the desired coordinate. If ``None``, does not
+        check for ``standard_name``.
+
+    * long_name:
+        An unconstrained description of the coordinate. If ``None``, does not
+        check for ``long_name``.
+
+    * var_name:
+        The netCDF variable name of the desired coordinate. If ``None``, does
+        not check for ``var_name``.
+
+    * attributes:
+        A dictionary of attributes desired on the coordinates. If ``None``,
+        does not check for ``attributes``.
+
+    * axis:
+        The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+        If ``None``, does not check for ``axis``. Accepts the values ``X``,
+        ``Y``, ``Z`` and ``T`` (case-insensitive).
 
     Returns:
         A list of the objects supplied in the ``instances`` argument, limited

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1375,27 +1375,27 @@ def metadata_filter(
           against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
         * a coordinate or metadata instance equal to that of
-          the desired coordinates e.g., :class:`~iris.coords.DimCoord`
+          the desired objects e.g., :class:`~iris.coords.DimCoord`
           or :class:`CoordMetadata`.
 
     * standard_name:
-        The CF standard name of the desired coordinate. If ``None``, does not
+        The CF standard name of the desired object. If ``None``, does not
         check for ``standard_name``.
 
     * long_name:
-        An unconstrained description of the coordinate. If ``None``, does not
+        An unconstrained description of the object. If ``None``, does not
         check for ``long_name``.
 
     * var_name:
-        The netCDF variable name of the desired coordinate. If ``None``, does
+        The NetCDF variable name of the desired object. If ``None``, does
         not check for ``var_name``.
 
     * attributes:
-        A dictionary of attributes desired on the coordinates. If ``None``,
+        A dictionary of attributes desired on the object. If ``None``,
         does not check for ``attributes``.
 
     * axis:
-        The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+        The desired object's axis, see :func:`~iris.util.guess_coord_axis`.
         If ``None``, does not check for ``axis``. Accepts the values ``X``,
         ``Y``, ``Z`` and ``T`` (case-insensitive).
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -590,8 +590,7 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
 
         Returns:
             The :class:`xml.dom.minidom.Element` that will describe this
-            :class:`_DimensionalMetadata`, and the dictionary of attributes
-            that require to be added to this element.
+            :class:`_DimensionalMetadata`.
 
         """
         # Create the XML element as the camelCaseEquivalent of the
@@ -2271,8 +2270,7 @@ class Coord(_DimensionalMetadata):
 
         Returns:
             The :class:`xml.dom.minidom.Element` that will describe this
-            :class:`DimCoord`, and the dictionary of attributes that require
-            to be added to this element.
+            :class:`DimCoord`.
 
         """
         # Create the XML element as the camelCaseEquivalent of the

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1588,53 +1588,62 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         Kwargs:
 
-        * name_or_coord
-            Either
+        * name_or_coord:
+            Either,
 
-            (a) a :attr:`standard_name`, :attr:`long_name`, or
-            :attr:`var_name`. Defaults to value of `default`
-            (which itself defaults to `unknown`) as defined in
-            :class:`iris.common.CFVariableMixin`.
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :class:`~iris.common.mixin.CFVariableMixin.name`.
 
-            (b) a coordinate instance with metadata equal to that of
-            the desired coordinates. Accepts either a
-            :class:`iris.coords.DimCoord`, :class:`iris.coords.AuxCoord`,
-            :class:`iris.aux_factory.AuxCoordFactory`,
-            :class:`iris.common.CoordMetadata` or
-            :class:`iris.common.DimCoordMetadata`.
-        * standard_name
-            The CF standard name of the desired coordinate. If None, does not
-            check for standard name.
-        * long_name
-            An unconstrained description of the coordinate. If None, does not
-            check for long_name.
-        * var_name
-            The netCDF variable name of the desired coordinate. If None, does
-            not check for var_name.
-        * attributes
-            A dictionary of attributes desired on the coordinates. If None,
-            does not check for attributes.
-        * axis
-            The desired coordinate axis, see
-            :func:`iris.util.guess_coord_axis`. If None, does not check for
-            axis. Accepts the values 'X', 'Y', 'Z' and 'T' (case-insensitive).
-        * contains_dimension
-            The desired coordinate contains the data dimension. If None, does
+            * a coordinate or metadata instance equal to that of the desired
+              coordinate e.g., :class:`~iris.coords.DimCoord` or
+              :class:`~iris.common.metadata.CoordMetadata`.
+
+        * standard_name:
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard name``.
+
+        * long_name:
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name:
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes:
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis:
+            The desired coordinate axis, see :func:`iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * contains_dimension:
+            The desired coordinate contains the data dimension. If ``None``, does
             not check for the dimension.
-        * dimensions
+
+        * dimensions:
             The exact data dimensions of the desired coordinate. Coordinates
-            with no data dimension can be found with an empty tuple or list
-            (i.e. ``()`` or ``[]``). If None, does not check for dimensions.
-        * coord_system
-            Whether the desired coordinates have coordinate systems equal to
-            the given coordinate system. If None, no check is done.
-        * dim_coords
-            Set to True to only return coordinates that are the cube's
-            dimension coordinates. Set to False to only return coordinates
-            that are the cube's auxiliary and derived coordinates. If None,
+            with no data dimension can be found with an empty ``tuple`` or
+            ``list`` i.e., ``()`` or ``[]``. If ``None``, does not check for
+            dimensions.
+
+        * coord_system:
+            Whether the desired coordinates have a coordinate system equal to
+            the given coordinate system. If ``None``, no check is done.
+
+        * dim_coords:
+            Set to ``True`` to only return coordinates that are the cube's
+            dimension coordinates. Set to ``False`` to only return coordinates
+            that are the cube's auxiliary and derived coordinates. If ``None``,
             returns all coordinates.
 
-        See also :meth:`Cube.coord()<iris.cube.Cube.coord>`.
+        .. seealso:
+
+            The :meth:`Cube.coord` method for matching exactly one coordinate.
 
         """
         coords_and_factories = []
@@ -1715,18 +1724,16 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dim_coords=None,
     ):
         """
-        Return a single coord given the same arguments as :meth:`Cube.coords`.
+        Return a single coordinate given the same arguments as :meth:`Cube.coords`.
 
         .. note::
 
-            If the arguments given do not result in precisely 1 coordinate
-            being matched, an :class:`iris.exceptions.CoordinateNotFoundError`
-            is raised.
+            If the arguments given do not result in **precisely one** coordinate,
+            then a :class:`~iris.exceptions.CoordinateNotFoundError` is raised.
 
         .. seealso::
 
-            :meth:`Cube.coords()<iris.cube.Cube.coords>` for full keyword
-            documentation.
+            :meth:`Cube.coords()` for full keyword documentation.
 
         """
         coords = self.coords(

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -848,7 +848,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         * long_name
             An unconstrained description of the cube.
         * var_name
-            The netCDF variable name for the cube.
+            The NetCDF variable name for the cube.
         * units
             The unit of the cube, e.g. ``"m s-1"`` or ``"kelvin"``.
         * attributes
@@ -905,7 +905,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         #: The "long name" for the Cube's phenomenon.
         self.long_name = long_name
 
-        #: The netCDF variable name for the Cube.
+        #: The NetCDF variable name for the Cube.
         self.var_name = var_name
 
         self.cell_methods = cell_methods
@@ -1514,7 +1514,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             An unconstrained description of the coordinate factory.
             If None, does not check for long_name.
         * var_name
-            The netCDF variable name of the desired coordinate factory.
+            The NetCDF variable name of the desired coordinate factory.
             If None, does not check for var_name.
 
         .. note::
@@ -1584,7 +1584,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dim_coords=None,
     ):
         """
-        Return a list of coordinates in this cube fitting the given criteria.
+        Return a list of coordinates from the :class:`Cube` that match the
+        provided criteria.
+
+        .. seealso::
+
+            :meth:`Cube.coord` for matching exactly one coordinate.
 
         Kwargs:
 
@@ -1594,7 +1599,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
               :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
               :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
-              compared against the :class:`~iris.common.mixin.CFVariableMixin.name`.
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
             * a coordinate or metadata instance equal to that of the desired
               coordinate e.g., :class:`~iris.coords.DimCoord` or
@@ -1609,7 +1614,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             check for ``long_name``.
 
         * var_name:
-            The netCDF variable name of the desired coordinate. If ``None``, does
+            The NetCDF variable name of the desired coordinate. If ``None``, does
             not check for ``var_name``.
 
         * attributes:
@@ -1641,9 +1646,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             that are the cube's auxiliary and derived coordinates. If ``None``,
             returns all coordinates.
 
-        .. seealso:
-
-            The :meth:`Cube.coord` method for matching exactly one coordinate.
+        Returns:
+            A list containing zero or more coordinates matching the provided
+            criteria.
 
         """
         coords_and_factories = []
@@ -1724,7 +1729,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dim_coords=None,
     ):
         """
-        Return a single coordinate given the same arguments as :meth:`Cube.coords`.
+        Return a single coordinate from the :class:`Cube` that matches the
+        provided criteria.
 
         .. note::
 
@@ -1733,7 +1739,65 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         .. seealso::
 
-            :meth:`Cube.coords()` for full keyword documentation.
+            :meth:`Cube.coords` for matching zero or more coordinates.
+
+        Kwargs:
+
+        * name_or_coord:
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of the desired
+              coordinate e.g., :class:`~iris.coords.DimCoord` or
+              :class:`~iris.common.metadata.CoordMetadata`.
+
+        * standard_name:
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard name``.
+
+        * long_name:
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name:
+            The NetCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes:
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis:
+            The desired coordinate axis, see :func:`iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * contains_dimension:
+            The desired coordinate contains the data dimension. If ``None``, does
+            not check for the dimension.
+
+        * dimensions:
+            The exact data dimensions of the desired coordinate. Coordinates
+            with no data dimension can be found with an empty ``tuple`` or
+            ``list`` i.e., ``()`` or ``[]``. If ``None``, does not check for
+            dimensions.
+
+        * coord_system:
+            Whether the desired coordinates have a coordinate system equal to
+            the given coordinate system. If ``None``, no check is done.
+
+        * dim_coords:
+            Set to ``True`` to only return coordinates that are the cube's
+            dimension coordinates. Set to ``False`` to only return coordinates
+            that are the cube's auxiliary and derived coordinates. If ``None``,
+            returns all coordinates.
+
+        Returns:
+            The coordinate that matches the provided criteria.
 
         """
         coords = self.coords(
@@ -1750,23 +1814,22 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         )
 
         if len(coords) > 1:
-            msg = (
-                "Expected to find exactly 1 coordinate, but found %s. "
-                "They were: %s."
-                % (len(coords), ", ".join(coord.name() for coord in coords))
+            emsg = (
+                f"Expected to find exactly 1 coordinate, but found {len(coords)}. "
+                f"They were: {', '.join(coord.name() for coord in coords)}."
             )
-            raise iris.exceptions.CoordinateNotFoundError(msg)
+            raise iris.exceptions.CoordinateNotFoundError(emsg)
         elif len(coords) == 0:
             _name = name_or_coord
             if name_or_coord is not None:
                 if not isinstance(name_or_coord, str):
                     _name = name_or_coord.name()
             bad_name = _name or standard_name or long_name or ""
-            msg = (
-                "Expected to find exactly 1 %s coordinate, but found "
-                "none." % bad_name
+            emsg = (
+                f"Expected to find exactly 1 {bad_name!r} coordinate, "
+                "but found none."
             )
-            raise iris.exceptions.CoordinateNotFoundError(msg)
+            raise iris.exceptions.CoordinateNotFoundError(emsg)
 
         return coords[0]
 
@@ -2067,7 +2130,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         .. note::
 
-            Cubes obtained from netCDF, PP, and FieldsFile files will only
+            Cubes obtained from NetCDF, PP, and FieldsFile files will only
             populate this attribute on its first use.
 
             To obtain the shape of the data without causing it to be loaded,

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -67,9 +67,9 @@ logger = get_logger(__name__, fmt="[%(cls)s.%(funcName)s]")
 # Mesh dimension names namedtuples.
 #
 
-#: Namedtuple for 1D mesh topology netCDF variable dimension names.
+#: Namedtuple for 1D mesh topology NetCDF variable dimension names.
 Mesh1DNames = namedtuple("Mesh1DNames", ["node_dimension", "edge_dimension"])
-#: Namedtuple for 2D mesh topology netCDF variable dimension names.
+#: Namedtuple for 2D mesh topology NetCDF variable dimension names.
 Mesh2DNames = namedtuple(
     "Mesh2DNames", ["node_dimension", "edge_dimension", "face_dimension"]
 )
@@ -177,7 +177,7 @@ class Connectivity(_DimensionalMetadata):
         * long_name (str):
             Descriptive name of the connectivity.
         * var_name (str):
-            The netCDF variable name for the connectivity.
+            The NetCDF variable name for the connectivity.
         * units (cf_units.Unit):
             The :class:`~cf_units.Unit` of the connectivity's values.
             Can be a string, which will be converted to a Unit object.
@@ -188,7 +188,7 @@ class Connectivity(_DimensionalMetadata):
         * start_index (int):
             Either ``0`` or ``1``. Default is ``0``. Denotes whether
             :attr:`indices` uses 0-based or 1-based indexing (allows support
-            for Fortran and legacy netCDF files).
+            for Fortran and legacy NetCDF files).
         * src_dim (int):
             Either ``0`` or ``1``. Default is ``0``. Denotes which dimension
             of :attr:`indices` varies over the :attr:`src_location`'s (the
@@ -873,12 +873,12 @@ class Mesh(CFVariableMixin):
     A container representing the UGRID ``cf_role`` ``mesh_topology``, supporting
     1D network, 2D triangular, and 2D flexible mesh topologies.
 
-    .. note:
+    .. note::
 
         The 3D layered and fully 3D unstructured mesh topologies are not supported
         at this time.
 
-    .. seealso:
+    .. seealso::
 
         The UGRID Conventions, https://ugrid-conventions.github.io/ugrid-conventions/
 
@@ -910,7 +910,7 @@ class Mesh(CFVariableMixin):
         .. note::
 
             The purpose of the :attr:`node_dimension`, :attr:`edge_dimension` and
-            :attr:`face_dimension` properties are to preserve the original netCDF
+            :attr:`face_dimension` properties are to preserve the original NetCDF
             variable dimension names. Note that, only :attr:`edge_dimension` and
             :attr:`face_dimension` are UGRID attributes, and are only present for
             :attr:`topology_dimension` ``>=2``.
@@ -1153,7 +1153,7 @@ class Mesh(CFVariableMixin):
     @property
     def edge_dimension(self):
         """
-        The *optionally required* UGRID netCDF variable name for the ``edge``
+        The *optionally required* UGRID NetCDF variable name for the ``edge``
         dimension.
 
         """
@@ -1179,8 +1179,10 @@ class Mesh(CFVariableMixin):
     @property
     def edge_node_connectivity(self):
         """
-        The *optionally required* UGRID ``edge_node_connectivity``
-        :class:`Connectivity` coordinate of the :class:`Mesh`.
+        The UGRID ``edge_node_connectivity`` :class:`Connectivity` coordinate
+        of the :class:`Mesh`, which is **required** for
+        :attr:`Mesh.topology_dimension` of ``1``, and *optionally required* for
+        :attr:`Mesh.topology_dimension` ``>=2``.
 
         """
         return self._connectivity_manager.edge_node
@@ -1197,7 +1199,7 @@ class Mesh(CFVariableMixin):
     @property
     def face_dimension(self):
         """
-        The *optionally required* UGRID netCDF variable name for the ``face``
+        The *optionally required* UGRID NetCDF variable name for the ``face``
         dimension.
 
         """
@@ -1242,8 +1244,10 @@ class Mesh(CFVariableMixin):
     @property
     def face_node_connectivity(self):
         """
-        The **required** UGRID ``face_node_connectivity`` :class:`Connectivity`
-        coordinate of the :class:`Mesh`.
+        The UGRID ``face_node_connectivity`` :class:`Connectivity` coordinate
+        of the :class:`Mesh`, which is **required** for
+        :attr:`Mesh.topology_dimension` of ``2``, and *optionally required* for
+        :attr:`Mesh.topology_dimension` of ``3``.
 
         """
         return self._connectivity_manager.face_node
@@ -1259,7 +1263,7 @@ class Mesh(CFVariableMixin):
 
     @property
     def node_dimension(self):
-        """The netCDF variable name for the ``node`` dimension."""
+        """The NetCDF variable name for the ``node`` dimension."""
         return self._metadata_manager.node_dimension
 
     @node_dimension.setter
@@ -1343,11 +1347,15 @@ class Mesh(CFVariableMixin):
         contains_face=None,
     ):
         """
-        Return all :class:`Connectivity` coordinates from the :class:`Mesh`
-        that match the provided criteria.
+        Return all :class:`Connectivity` instances from the :class:`Mesh` that
+        match the provided criteria.
 
         Criteria can be either specific properties or other objects with
         metadata to be matched.
+
+        .. seealso::
+
+            :meth:`Mesh.connectivity` for matching exactly one connectivity.
 
         Kwargs:
 
@@ -1359,30 +1367,28 @@ class Mesh(CFVariableMixin):
               :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
               compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
-            * a coordinate or metadata instance equal to that of
-              the desired coordinates e.g., :class:`Connectivity` or
+            * a connectivity or metadata instance equal to that of
+              the desired objectss e.g., :class:`Connectivity` or
               :class:`ConnectivityMetadata`.
 
         * standard_name (str):
-            The CF standard name of the desired coordinate. If ``None``, does not
-            check for ``standard_name``.
+            The CF standard name of the desired :class:`Connectibity`. If
+            ``None``, does not check for ``standard_name``.
 
         * long_name (str):
-            An unconstrained description of the coordinate. If ``None``, does not
-            check for ``long_name``.
+            An unconstrained description of the :class:`Connectivity`. If
+            ``None``, does not check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
-            not check for ``var_name``.
+            The NetCDF variable name of the desired :class:`Connectivity`. If
+            ``None``, does not check for ``var_name``.
 
         * attributes (dict):
-            A dictionary of attributes desired on the coordinates. If ``None``,
-            does not check for ``attributes``.
+            A dictionary of attributes desired on the :class:`Connectivity`. If
+            ``None``, does not check for ``attributes``.
 
-        * axis (str):
-            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
-            If ``None``, does not check for ``axis``. Accepts the values ``X``,
-            ``Y``, ``Z`` and ``T`` (case-insensitive).
+        * cf_role (str):
+            The UGRID ``cf_role`` of the desired :class:`Connectivity`.
 
         * contains_node (bool):
             Contains the ``node`` location as part of the
@@ -1397,7 +1403,7 @@ class Mesh(CFVariableMixin):
             :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
 
         Returns:
-            A list of :class:`Connectivity` coordinates from the :class:`Mesh`
+            A list of :class:`Connectivity` instances from the :class:`Mesh`
             that matched the given criteria.
 
         """
@@ -1426,7 +1432,7 @@ class Mesh(CFVariableMixin):
         contains_face=None,
     ):
         """
-        Return a single :class:`Connectivity` coordinate from the :class:`Mesh` that
+        Return a single :class:`Connectivity` from the :class:`Mesh` that
         matches the provided criteria.
 
         Criteria can be either specific properties or other objects with
@@ -1434,8 +1440,13 @@ class Mesh(CFVariableMixin):
 
         .. note::
 
-            If the given criteria do not return **precisely one** coordinate,
-            then a :class:`~iris.exceptions.ConnectivityNotFoundError` is raised.
+            If the given criteria do not return **precisely one**
+            :class:`Connectivity`, then a
+            :class:`~iris.exceptions.ConnectivityNotFoundError` is raised.
+
+        .. seealso::
+
+            :meth:`Cube.connectivities` for matching zero or more connectivities.
 
         Kwargs:
 
@@ -1447,30 +1458,28 @@ class Mesh(CFVariableMixin):
               :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
               compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
-            * a coordinate or metadata instance equal to that of
-              the desired coordinate e.g., :class:`Connectivity` or
+            * a connectivity or metadata instance equal to that of
+              the desired object e.g., :class:`Connectivity` or
               :class:`ConnectivityMetadata`.
 
         * standard_name (str):
-            The CF standard name of the desired coordinate. If ``None``, does not
-            check for ``standard_name``.
+            The CF standard name of the desired :class:`Connectivity`. If
+            ``None``, does not check for ``standard_name``.
 
         * long_name (str):
-            An unconstrained description of the coordinate. If ``None``, does not
-            check for ``long_name``.
+            An unconstrained description of the :class:`Connectivity`. If
+            ``None``, does not check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
-            not check for ``var_name``.
+            The NetCDF variable name of the desired :class:`Connectivity`. If
+            ``None``, does not check for ``var_name``.
 
         * attributes (dict):
-            A dictionary of attributes desired on the coordinates. If ``None``,
-            does not check for ``attributes``.
+            A dictionary of attributes desired on the :class:`Connectivity`. If
+            ``None``, does not check for ``attributes``.
 
-        * axis (str):
-            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
-            If ``None``, does not check for ``axis``. Accepts the values ``X``,
-            ``Y``, ``Z`` and ``T`` (case-insensitive).
+        * cf_role (str):
+            The UGRID ``cf_role`` of the desired :class:`Connectivity`.
 
         * contains_node (bool):
             Contains the ``node`` location as part of the
@@ -1485,8 +1494,8 @@ class Mesh(CFVariableMixin):
             :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
 
         Returns:
-            The :class:`Connectivity` coordinate from the :class:`Mesh` that matched
-            the given criteria.
+            The :class:`Connectivity` from the :class:`Mesh` that matched the
+            given criteria.
 
         """
 
@@ -1526,6 +1535,10 @@ class Mesh(CFVariableMixin):
             If the given criteria do not return **precisely one** coordinate,
             then a :class:`~iris.exceptions.CoordinateNotFoundError` is raised.
 
+        .. seealso::
+
+            :meth:`Cube.coords` for matching zero or more coordinates.
+
         Kwargs:
 
         * item (str or object):
@@ -1549,7 +1562,7 @@ class Mesh(CFVariableMixin):
             check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
+            The NetCDF variable name of the desired coordinate. If ``None``, does
             not check for ``var_name``.
 
         * attributes (dict):
@@ -1606,6 +1619,10 @@ class Mesh(CFVariableMixin):
         Criteria can be either specific properties or other objects with
         metadata to be matched.
 
+        .. seealso::
+
+            :meth:`Mesh.coord` for matching exactly one coordinate.
+
         Kwargs:
 
         * item (str or object):
@@ -1629,7 +1646,7 @@ class Mesh(CFVariableMixin):
             check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
+            The NetCDF variable name of the desired coordinate. If ``None``, does
             not check for ``var_name``.
 
         * attributes (dict):
@@ -1709,17 +1726,15 @@ class Mesh(CFVariableMixin):
             check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
+            The NetCDF variable name of the desired coordinate. If ``None``, does
             not check for ``var_name``.
 
         * attributes (dict):
             A dictionary of attributes desired on the coordinates. If ``None``,
             does not check for ``attributes``.
 
-        * axis (str):
-            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
-            If ``None``, does not check for ``axis``. Accepts the values ``X``,
-            ``Y``, ``Z`` and ``T`` (case-insensitive).
+        * cf_role (str):
+            The UGRID ``cf_role`` of the desired :class:`Connectivity`.
 
         * contains_node (bool):
             Contains the ``node`` location as part of the
@@ -1795,7 +1810,7 @@ class Mesh(CFVariableMixin):
             check for ``long_name``.
 
         * var_name (str):
-            The netCDF variable name of the desired coordinate. If ``None``, does
+            The NetCDF variable name of the desired coordinate. If ``None``, does
             not check for ``var_name``.
 
         * attributes (dict):
@@ -1884,22 +1899,21 @@ class Mesh(CFVariableMixin):
 
     def dimension_names_reset(self, node=False, edge=False, face=False):
         """
-        Clear the current assigned name to be used for the netCDF variable
-        representing the ``node``, ``edge`` and ``face`` dimension to
-        ``None``.
+        Reset the name used for the NetCDF variable representing the ``node``,
+        ``edge`` and/or ``face`` dimension to ``None``.
 
         Kwargs:
 
         * node (bool):
-            Clear the name of the ``node`` dimension if ``True``. Default
+            Reset the name of the ``node`` dimension if ``True``. Default
             is ``False``.
 
         * edge (bool):
-            Clear the name of the ``edge`` dimension if ``True``. Default
+            Reset the name of the ``edge`` dimension if ``True``. Default
             is ``False``.
 
         * face (bool):
-            Clear the name of the ``face`` dimension if ``True``. Default
+            Reset the name of the ``face`` dimension if ``True``. Default
             is ``False``.
 
         """
@@ -1907,7 +1921,7 @@ class Mesh(CFVariableMixin):
 
     def dimension_names(self, node=None, edge=None, face=None):
         """
-        Assign the name to be used for the netCDF variable representing
+        Assign the name to be used for the NetCDF variable representing
         the ``node``, ``edge`` and ``face`` dimension.
 
         The default value of ``None`` will not be assigned to clear the
@@ -1917,15 +1931,15 @@ class Mesh(CFVariableMixin):
         Kwargs:
 
         * node (str):
-            The name to be used for the netCDF variable representing the
+            The name to be used for the NetCDF variable representing the
             ``node`` dimension.
 
         * edge (str):
-            The name to be used for the netCDF variable representing the
+            The name to be used for the NetCDF variable representing the
             ``edge`` dimension.
 
         * face (str):
-            The name to be used for the netCDF variable representing the
+            The name to be used for the NetCDF variable representing the
             ``face`` dimension.
 
         """
@@ -1933,7 +1947,7 @@ class Mesh(CFVariableMixin):
 
     @property
     def cf_role(self):
-        """The UGRID ``cf_role`` attribute of a mesh."""
+        """The UGRID ``cf_role`` attribute of the :class:`Mesh`."""
         return "mesh_topology"
 
     @property

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -98,9 +98,9 @@ MeshFaceCoords = namedtuple("MeshFaceCoords", ["face_x", "face_y"])
 # Mesh connectivity manager namedtuples.
 #
 
-#: Namedtuple for 1D mesh :class:`Connectivity` coordinates.
+#: Namedtuple for 1D mesh :class:`Connectivity` instances.
 Mesh1DConnectivities = namedtuple("Mesh1DConnectivities", ["edge_node"])
-#: Namedtuple for 2D mesh :class:`Connectivity` coordinates.
+#: Namedtuple for 2D mesh :class:`Connectivity` instances.
 Mesh2DConnectivities = namedtuple(
     "Mesh2DConnectivities",
     [
@@ -1372,7 +1372,7 @@ class Mesh(CFVariableMixin):
               :class:`ConnectivityMetadata`.
 
         * standard_name (str):
-            The CF standard name of the desired :class:`Connectibity`. If
+            The CF standard name of the desired :class:`Connectivity`. If
             ``None``, does not check for ``standard_name``.
 
         * long_name (str):
@@ -1446,7 +1446,7 @@ class Mesh(CFVariableMixin):
 
         .. seealso::
 
-            :meth:`Cube.connectivities` for matching zero or more connectivities.
+            :meth:`Mesh.connectivities` for matching zero or more connectivities.
 
         Kwargs:
 
@@ -1537,7 +1537,7 @@ class Mesh(CFVariableMixin):
 
         .. seealso::
 
-            :meth:`Cube.coords` for matching zero or more coordinates.
+            :meth:`Mesh.coords` for matching zero or more coordinates.
 
         Kwargs:
 
@@ -1713,25 +1713,25 @@ class Mesh(CFVariableMixin):
               :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
               compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
-            * a coordinate or metadata instance equal to that of
-              the desired coordinates e.g., :class:`Connectivity` or
+            * a connectivity or metadata instance equal to that of
+              the desired objects e.g., :class:`Connectivity` or
               :class:`ConnectivityMetadata`.
 
         * standard_name (str):
-            The CF standard name of the desired coordinate. If ``None``, does not
-            check for ``standard_name``.
+            The CF standard name of the desired :class:`Connectivity`. If
+            ``None``, does not check for ``standard_name``.
 
         * long_name (str):
-            An unconstrained description of the coordinate. If ``None``, does not
-            check for ``long_name``.
+            An unconstrained description of the :class:`Connectivity. If
+            ``None``, does not check for ``long_name``.
 
         * var_name (str):
-            The NetCDF variable name of the desired coordinate. If ``None``, does
-            not check for ``var_name``.
+            The NetCDF variable name of the desired :class:`Connectivity`. If
+            ``None``, does not check for ``var_name``.
 
         * attributes (dict):
-            A dictionary of attributes desired on the coordinates. If ``None``,
-            does not check for ``attributes``.
+            A dictionary of attributes desired on the :class:`Connectivity`. If
+            ``None``, does not check for ``attributes``.
 
         * cf_role (str):
             The UGRID ``cf_role`` of the desired :class:`Connectivity`.

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -39,10 +39,13 @@ from ..util import guess_coord_axis
 __all__ = [
     "Connectivity",
     "ConnectivityMetadata",
+    "Mesh",
     "Mesh1DConnectivities",
     "Mesh1DCoords",
+    "Mesh1DNames",
     "Mesh2DConnectivities",
     "Mesh2DCoords",
+    "Mesh2DNames",
     "MeshEdgeCoords",
     "MeshFaceCoords",
     "MeshNodeCoords",
@@ -60,27 +63,44 @@ NP_PRINTOPTIONS_EDGEITEMS = 2
 # Configure the logger.
 logger = get_logger(__name__, fmt="[%(cls)s.%(funcName)s]")
 
-
+#
 # Mesh dimension names namedtuples.
+#
+
+#: Namedtuple for 1D mesh topology netCDF variable dimension names.
 Mesh1DNames = namedtuple("Mesh1DNames", ["node_dimension", "edge_dimension"])
+#: Namedtuple for 2D mesh topology netCDF variable dimension names.
 Mesh2DNames = namedtuple(
     "Mesh2DNames", ["node_dimension", "edge_dimension", "face_dimension"]
 )
 
+#
 # Mesh coordinate manager namedtuples.
+#
+
+#: Namedtuple for 1D mesh :class:`~iris.coords.AuxCoord` coordinates.
 Mesh1DCoords = namedtuple(
     "Mesh1DCoords", ["node_x", "node_y", "edge_x", "edge_y"]
 )
+#: Namedtuple for 2D mesh :class:`~iris.coords.AuxCoord` coordinates.
 Mesh2DCoords = namedtuple(
     "Mesh2DCoords",
     ["node_x", "node_y", "edge_x", "edge_y", "face_x", "face_y"],
 )
+#: Namedtuple for ``node`` :class:`~iris.coords.AuxCoord` coordinates.
 MeshNodeCoords = namedtuple("MeshNodeCoords", ["node_x", "node_y"])
+#: Namedtuple for ``edge`` :class:`~iris.coords.AuxCoord` coordinates.
 MeshEdgeCoords = namedtuple("MeshEdgeCoords", ["edge_x", "edge_y"])
+#: Namedtuple for ``face`` :class:`~iris.coords.AuxCoord` coordinates.
 MeshFaceCoords = namedtuple("MeshFaceCoords", ["face_x", "face_y"])
 
+#
 # Mesh connectivity manager namedtuples.
+#
+
+#: Namedtuple for 1D mesh :class:`Connectivity` coordinates.
 Mesh1DConnectivities = namedtuple("Mesh1DConnectivities", ["edge_node"])
+#: Namedtuple for 2D mesh :class:`Connectivity` coordinates.
 Mesh2DConnectivities = namedtuple(
     "Mesh2DConnectivities",
     [
@@ -168,7 +188,7 @@ class Connectivity(_DimensionalMetadata):
         * start_index (int):
             Either ``0`` or ``1``. Default is ``0``. Denotes whether
             :attr:`indices` uses 0-based or 1-based indexing (allows support
-            for Fortran and legacy NetCDF files).
+            for Fortran and legacy netCDF files).
         * src_dim (int):
             Either ``0`` or ``1``. Default is ``0``. Denotes which dimension
             of :attr:`indices` varies over the :attr:`src_location`'s (the
@@ -850,41 +870,24 @@ class MeshMetadata(BaseMetadata):
 
 class Mesh(CFVariableMixin):
     """
+    A container representing the UGRID ``cf_role`` ``mesh_topology``, supporting
+    1D network, 2D triangular, and 2D flexible mesh topologies.
 
-    .. todo::
+    .. note:
 
-    .. questions::
+        The 3D layered and fully 3D unstructured mesh topologies are not supported
+        at this time.
 
-        - decide on the verbose/succinct version of __str__ vs __repr__
+    .. seealso:
 
-    .. notes::
-
-        - the mesh is location agnostic
-
-        - no need to support volume at mesh level, yet
-
-        - topology_dimension
-            - use for fast equality between Mesh instances
-            - checking connectivity dimensionality, specifically the highest dimensonality of the
-              "geometric element" being added i.e., reference the src_location/tgt_location
-            - used to honour and enforce the minimum UGRID connectivity contract
-
-        - support pickling
-
-        - copy is off the table!!
-
-        - MeshCoord.guess_points()
-        - MeshCoord.to_AuxCoord()
-
-        - don't provide public methods to return the coordinate and connectivity
-          managers
-
-        - validate both managers contents e.g., shape? more...?
+        The UGRID Conventions, https://ugrid-conventions.github.io/ugrid-conventions/
 
     """
 
     # TBD: for volume and/or z-axis support include axis "z" and/or dimension "3"
+    #: The supported mesh axes.
     AXES = ("x", "y")
+    #: Valid range of values for ``topology_dimension``.
     TOPOLOGY_DIMENSIONS = (1, 2)
 
     def __init__(
@@ -906,12 +909,10 @@ class Mesh(CFVariableMixin):
         """
         .. note::
 
-            :attr:`node_dimension`, :attr:`edge_dimension` and
-            :attr:`face_dimension` are stored to help round-tripping of UGRID
-            files. As such their presence in :class:`Mesh` is not a direct
-            mirror of that written in the UGRID specification, where
-            :attr:`node_dimension` is not mentioned, while
-            :attr:`edge_dimension` is only present for
+            The purpose of the :attr:`node_dimension`, :attr:`edge_dimension` and
+            :attr:`face_dimension` properties are to preserve the original netCDF
+            variable dimension names. Note that, only :attr:`edge_dimension` and
+            :attr:`face_dimension` are UGRID attributes, and are only present for
             :attr:`topology_dimension` ``>=2``.
 
         """
@@ -926,7 +927,6 @@ class Mesh(CFVariableMixin):
             raise ValueError(emsg)
         self._metadata_manager.topology_dimension = topology_dimension
 
-        # TBD: these are strings, if None is provided then assign the default string.
         self.node_dimension = node_dimension
         self.edge_dimension = edge_dimension
         self.face_dimension = face_dimension
@@ -1117,11 +1117,46 @@ class Mesh(CFVariableMixin):
         return result
 
     @property
+    def all_connectivities(self):
+        """
+        All the :class:`Connectivity` coordinates of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.all_members
+
+    @property
     def all_coords(self):
+        """
+        All the :class:`~iris.coords.AuxCoord` coordinates of the :class:`Mesh`.
+
+        """
         return self._coord_manager.all_members
 
     @property
+    def boundary_node_connectivity(self):
+        """
+        The *optional* UGRID ``boundary_node_connectivity`` :class:`Connectivity`
+        coordinate of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.boundary_node
+
+    @property
+    def edge_coords(self):
+        """
+        The *optional* UGRID ``edge`` :class:`~iris.coords.AuxCoord` coordinates
+        of the :class:`Mesh`.
+
+        """
+        return self._coord_manager.edge_coords
+
+    @property
     def edge_dimension(self):
+        """
+        The *optionally required* UGRID netCDF variable name for the ``edge``
+        dimension.
+
+        """
         return self._metadata_manager.edge_dimension
 
     @edge_dimension.setter
@@ -1133,11 +1168,39 @@ class Mesh(CFVariableMixin):
         self._metadata_manager.edge_dimension = edge_dimension
 
     @property
-    def edge_coords(self):
-        return self._coord_manager.edge_coords
+    def edge_face_connectivity(self):
+        """
+        The *optional* UGRID ``edge_face_connectivity`` :class:`Connectivity`
+        coordinate of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.edge_face
+
+    @property
+    def edge_node_connectivity(self):
+        """
+        The *optionally required* UGRID ``edge_node_connectivity``
+        :class:`Connectivity` coordinate of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.edge_node
+
+    @property
+    def face_coords(self):
+        """
+        The *optional* UGRID ``face`` :class:`~iris.coords.AuxCoord` coordinates
+        of the :class:`Mesh`.
+
+        """
+        return self._coord_manager.face_coords
 
     @property
     def face_dimension(self):
+        """
+        The *optionally required* UGRID netCDF variable name for the ``face``
+        dimension.
+
+        """
         return self._metadata_manager.face_dimension
 
     @face_dimension.setter
@@ -1158,11 +1221,45 @@ class Mesh(CFVariableMixin):
         self._metadata_manager.face_dimension = face_dimension
 
     @property
-    def face_coords(self):
-        return self._coord_manager.face_coords
+    def face_edge_connectivity(self):
+        """
+        The *optional* UGRID ``face_edge_connectivity`` :class:`Connectivity`
+        coordinate of the :class:`Mesh`.
+
+        """
+        # optional
+        return self._connectivity_manager.face_edge
+
+    @property
+    def face_face_connectivity(self):
+        """
+        The *optional* UGRID ``face_face_connectivity`` :class:`Connectivity`
+        coordinate of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.face_face
+
+    @property
+    def face_node_connectivity(self):
+        """
+        The **required** UGRID ``face_node_connectivity`` :class:`Connectivity`
+        coordinate of the :class:`Mesh`.
+
+        """
+        return self._connectivity_manager.face_node
+
+    @property
+    def node_coords(self):
+        """
+        The **required** UGRID ``node`` :class:`~iris.coords.AuxCoord` coordinates
+        of the :class:`Mesh`.
+
+        """
+        return self._coord_manager.node_coords
 
     @property
     def node_dimension(self):
+        """The netCDF variable name for the ``node`` dimension."""
         return self._metadata_manager.node_dimension
 
     @node_dimension.setter
@@ -1173,43 +1270,18 @@ class Mesh(CFVariableMixin):
             node_dimension = name
         self._metadata_manager.node_dimension = node_dimension
 
-    @property
-    def node_coords(self):
-        return self._coord_manager.node_coords
+    def add_connectivities(self, *connectivities):
+        """
+        Add one or more :class:`Connectivity` coordinates to the :class:`Mesh`.
 
-    @property
-    def all_connectivities(self):
-        return self._connectivity_manager.all_members
+        Args:
 
-    @property
-    def face_node_connectivity(self):
-        # required
-        return self._connectivity_manager.face_node
+        * connectivities (iterable of object):
+            A collection of one or more :class:`Connectivity` coordinates to
+            add to the :class:`Mesh`.
 
-    @property
-    def edge_node_connectivity(self):
-        # optionally required
-        return self._connectivity_manager.edge_node
-
-    @property
-    def face_edge_connectivity(self):
-        # optional
-        return self._connectivity_manager.face_edge
-
-    @property
-    def face_face_connectivity(self):
-        # optional
-        return self._connectivity_manager.face_face
-
-    @property
-    def edge_face_connectivity(self):
-        # optional
-        return self._connectivity_manager.edge_face
-
-    @property
-    def boundary_node_connectivity(self):
-        # optional
-        return self._connectivity_manager.boundary_node
+        """
+        self._connectivity_manager.add(*connectivities)
 
     def add_coords(
         self,
@@ -1220,6 +1292,30 @@ class Mesh(CFVariableMixin):
         face_x=None,
         face_y=None,
     ):
+        """
+        Add one or more :class:`~iris.coords.AuxCoord` coordinates to the :class:`Mesh`.
+
+        Kwargs:
+
+        * node_x (object):
+            The ``x-axis`` like ``node`` :class:`~iris.coords.AuxCoord`.
+
+        * node_y (object):
+            The ``y-axis`` like ``node`` :class:`~iris.coords.AuxCoord`.
+
+        * edge_x (object):
+            The ``x-axis`` like ``edge`` :class:`~iris.coords.AuxCoord`.
+
+        * edge_y (object):
+            The ``y-axis`` like ``edge`` :class:`~iris.coords.AuxCoord`.
+
+        * face_x (object):
+            The ``x-axis`` like ``face`` :class:`~iris.coords.AuxCoord`.
+
+        * face_y (object):
+            The ``y-axis`` like ``face`` :class:`~iris.coords.AuxCoord`.
+
+        """
         # Filter out absent arguments - only expecting face coords sometimes,
         # same will be true of volumes in future.
         kwargs = {
@@ -1234,9 +1330,6 @@ class Mesh(CFVariableMixin):
 
         self._coord_manager.add(**kwargs)
 
-    def add_connectivities(self, *connectivities):
-        self._connectivity_manager.add(*connectivities)
-
     def connectivities(
         self,
         item=None,
@@ -1249,6 +1342,65 @@ class Mesh(CFVariableMixin):
         contains_edge=None,
         contains_face=None,
     ):
+        """
+        Return all :class:`Connectivity` coordinates from the :class:`Mesh`
+        that match the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinates e.g., :class:`Connectivity` or
+              :class:`ConnectivityMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * contains_node (bool):
+            Contains the ``node`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        * contains_edge (bool):
+            Contains the ``edge`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        * contains_face (bool):
+            Contains the ``face`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        Returns:
+            A list of :class:`Connectivity` coordinates from the :class:`Mesh`
+            that matched the given criteria.
+
+        """
         return self._connectivity_manager.filters(
             item=item,
             standard_name=standard_name,
@@ -1273,6 +1425,71 @@ class Mesh(CFVariableMixin):
         contains_edge=None,
         contains_face=None,
     ):
+        """
+        Return a single :class:`Connectivity` coordinate from the :class:`Mesh` that
+        matches the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        .. note::
+
+            If the given criteria do not return **precisely one** coordinate,
+            then a :class:`~iris.exceptions.ConnectivityNotFoundError` is raised.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinate e.g., :class:`Connectivity` or
+              :class:`ConnectivityMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * contains_node (bool):
+            Contains the ``node`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        * contains_edge (bool):
+            Contains the ``edge`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        * contains_face (bool):
+            Contains the ``face`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched.
+
+        Returns:
+            The :class:`Connectivity` coordinate from the :class:`Mesh` that matched
+            the given criteria.
+
+        """
+
         return self._connectivity_manager.filter(
             item=item,
             standard_name=standard_name,
@@ -1297,6 +1514,67 @@ class Mesh(CFVariableMixin):
         include_edges=None,
         include_faces=None,
     ):
+        """
+        Return a single :class:`~iris.coords.AuxCoord` coordinate from the
+        :class:`Mesh` that matches the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        .. note::
+
+            If the given criteria do not return **precisely one** coordinate,
+            then a :class:`~iris.exceptions.CoordinateNotFoundError` is raised.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinate e.g., :class:`~iris.coords.AuxCoord` or
+              :class:`~iris.common.metadata.CoordMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * include_node (bool):
+            Include all ``node`` coordinates in the list of objects to be matched.
+
+        * include_edge (bool):
+            Include all ``edge`` coordinates in the list of objects to be matched.
+
+        * include_face (bool):
+            Include all ``face`` coordinates in the list of objects to be matched.
+
+        Returns:
+            The :class:`~iris.coords.AuxCoord` coordinate from the :class:`Mesh`
+            that matched the given criteria.
+
+        """
         return self._coord_manager.filter(
             item=item,
             standard_name=standard_name,
@@ -1321,6 +1599,62 @@ class Mesh(CFVariableMixin):
         include_edges=None,
         include_faces=None,
     ):
+        """
+        Return all :class:`~iris.coords.AuxCoord` coordinates from the :class:`Mesh` that
+        match the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinates e.g., :class:`~iris.coords.AuxCoord` or
+              :class:`~iris.common.metadata.CoordMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * include_node (bool):
+            Include all ``node`` coordinates in the list of objects to be matched.
+
+        * include_edge (bool):
+            Include all ``edge`` coordinates in the list of objects to be matched.
+
+        * include_face (bool):
+            Include all ``face`` coordinates in the list of objects to be matched.
+
+        Returns:
+            A list of :class:`~iris.coords.AuxCoord` coordinates from the
+            :class:`Mesh` that matched the given criteria.
+
+        """
         return self._coord_manager.filters(
             item=item,
             standard_name=standard_name,
@@ -1345,6 +1679,68 @@ class Mesh(CFVariableMixin):
         contains_edge=None,
         contains_face=None,
     ):
+        """
+        Remove one or more :class:`Connectivity` from the :class:`Mesh` that
+        match the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinates e.g., :class:`Connectivity` or
+              :class:`ConnectivityMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * contains_node (bool):
+            Contains the ``node`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched
+            for potential removal.
+
+        * contains_edge (bool):
+            Contains the ``edge`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched
+            for potential removal.
+
+        * contains_face (bool):
+            Contains the ``face`` location as part of the
+            :attr:`ConnectivityMetadata.cf_role` in the list of objects to be matched
+            for potential removal.
+
+        Returns:
+            A list of :class:`Connectivity` coordinates removed from the :class:`Mesh`
+            that matched the given criteria.
+
+        """
         return self._connectivity_manager.remove(
             item=item,
             standard_name=standard_name,
@@ -1369,6 +1765,65 @@ class Mesh(CFVariableMixin):
         include_edges=None,
         include_faces=None,
     ):
+        """
+        Remove one or more :class:`~iris.coords.AuxCoord` from the :class:`Mesh`
+        that match the provided criteria.
+
+        Criteria can be either specific properties or other objects with
+        metadata to be matched.
+
+        Kwargs:
+
+        * item (str or object):
+            Either,
+
+            * a :attr:`~iris.common.mixin.CFVariableMixin.standard_name`,
+              :attr:`~iris.common.mixin.CFVariableMixin.long_name`, or
+              :attr:`~iris.common.mixin.CFVariableMixin.var_name` which is
+              compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
+
+            * a coordinate or metadata instance equal to that of
+              the desired coordinates e.g., :class:`~iris.coords.AuxCoord` or
+              :class:`~iris.common.metadata.CoordMetadata`.
+
+        * standard_name (str):
+            The CF standard name of the desired coordinate. If ``None``, does not
+            check for ``standard_name``.
+
+        * long_name (str):
+            An unconstrained description of the coordinate. If ``None``, does not
+            check for ``long_name``.
+
+        * var_name (str):
+            The netCDF variable name of the desired coordinate. If ``None``, does
+            not check for ``var_name``.
+
+        * attributes (dict):
+            A dictionary of attributes desired on the coordinates. If ``None``,
+            does not check for ``attributes``.
+
+        * axis (str):
+            The desired coordinate axis, see :func:`~iris.util.guess_coord_axis`.
+            If ``None``, does not check for ``axis``. Accepts the values ``X``,
+            ``Y``, ``Z`` and ``T`` (case-insensitive).
+
+        * include_node (bool):
+            Include all ``node`` coordinates in the list of objects to be matched
+            for potential removal.
+
+        * include_edge (bool):
+            Include all ``edge`` coordinates in the list of objects to be matched
+            for potential removal.
+
+        * include_face (bool):
+            Include all ``face`` coordinates in the list of objects to be matched
+            for potential removal.
+
+        Returns:
+            A list of :class:`~iris.coords.AuxCoord` coordinates removed from
+            the :class:`Mesh` that matched the given criteria.
+
+        """
         # Filter out absent arguments - only expecting face coords sometimes,
         # same will be true of volumes in future.
         kwargs = {
@@ -1386,8 +1841,22 @@ class Mesh(CFVariableMixin):
 
         return self._coord_manager.remove(**kwargs)
 
-    def xml_element(self):
-        # TBD
+    def xml_element(self, doc):
+        """
+        Create the :class:`xml.dom.minidom.Element` that describes this
+        :class:`Mesh`.
+
+        Args:
+
+        * doc (object):
+            The parent :class:`xml.dom.minidom.Document`.
+
+        Returns:
+            The :class:`xml.dom.minidom.Element` that will describe this
+            :class:`Mesh`, and the dictionary of attributes that require
+            to be added to this element.
+
+        """
         pass
 
     # the MeshCoord will always have bounds, perhaps points. However the MeshCoord.guess_points() may
@@ -1414,17 +1883,67 @@ class Mesh(CFVariableMixin):
     #     # use Connectivity.indices_by_src for fetching indices, passing in the lazy_indices() result as an argument.
 
     def dimension_names_reset(self, node=False, edge=False, face=False):
+        """
+        Clear the current assigned name to be used for the netCDF variable
+        representing the ``node``, ``edge`` and ``face`` dimension to
+        ``None``.
+
+        Kwargs:
+
+        * node (bool):
+            Clear the name of the ``node`` dimension if ``True``. Default
+            is ``False``.
+
+        * edge (bool):
+            Clear the name of the ``edge`` dimension if ``True``. Default
+            is ``False``.
+
+        * face (bool):
+            Clear the name of the ``face`` dimension if ``True``. Default
+            is ``False``.
+
+        """
         return self._set_dimension_names(node, edge, face, reset=True)
 
     def dimension_names(self, node=None, edge=None, face=None):
+        """
+        Assign the name to be used for the netCDF variable representing
+        the ``node``, ``edge`` and ``face`` dimension.
+
+        The default value of ``None`` will not be assigned to clear the
+        associated ``node``, ``edge`` or ``face``. Instead use
+        :meth:`Mesh.dimension_names_reset`.
+
+        Kwargs:
+
+        * node (str):
+            The name to be used for the netCDF variable representing the
+            ``node`` dimension.
+
+        * edge (str):
+            The name to be used for the netCDF variable representing the
+            ``edge`` dimension.
+
+        * face (str):
+            The name to be used for the netCDF variable representing the
+            ``face`` dimension.
+
+        """
         return self._set_dimension_names(node, edge, face, reset=False)
 
     @property
     def cf_role(self):
+        """The UGRID ``cf_role`` attribute of a mesh."""
         return "mesh_topology"
 
     @property
     def topology_dimension(self):
+        """
+        The UGRID ``topology_dimension`` attribute represents the highest
+        dimensionality of all the geometric elements (node, edge, face) represented
+        within the :class:`Mesh`.
+
+        """
         return self._metadata_manager.topology_dimension
 
 

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -1119,7 +1119,7 @@ class Mesh(CFVariableMixin):
     @property
     def all_connectivities(self):
         """
-        All the :class:`Connectivity` coordinates of the :class:`Mesh`.
+        All the :class:`Connectivity` instances of the :class:`Mesh`.
 
         """
         return self._connectivity_manager.all_members
@@ -1136,7 +1136,7 @@ class Mesh(CFVariableMixin):
     def boundary_node_connectivity(self):
         """
         The *optional* UGRID ``boundary_node_connectivity`` :class:`Connectivity`
-        coordinate of the :class:`Mesh`.
+        of the :class:`Mesh`.
 
         """
         return self._connectivity_manager.boundary_node
@@ -1171,7 +1171,7 @@ class Mesh(CFVariableMixin):
     def edge_face_connectivity(self):
         """
         The *optional* UGRID ``edge_face_connectivity`` :class:`Connectivity`
-        coordinate of the :class:`Mesh`.
+        of the :class:`Mesh`.
 
         """
         return self._connectivity_manager.edge_face
@@ -1179,9 +1179,9 @@ class Mesh(CFVariableMixin):
     @property
     def edge_node_connectivity(self):
         """
-        The UGRID ``edge_node_connectivity`` :class:`Connectivity` coordinate
-        of the :class:`Mesh`, which is **required** for
-        :attr:`Mesh.topology_dimension` of ``1``, and *optionally required* for
+        The UGRID ``edge_node_connectivity`` :class:`Connectivity` of the
+        :class:`Mesh`, which is **required** for :attr:`Mesh.topology_dimension`
+        of ``1``, and *optionally required* for
         :attr:`Mesh.topology_dimension` ``>=2``.
 
         """
@@ -1226,7 +1226,7 @@ class Mesh(CFVariableMixin):
     def face_edge_connectivity(self):
         """
         The *optional* UGRID ``face_edge_connectivity`` :class:`Connectivity`
-        coordinate of the :class:`Mesh`.
+        of the :class:`Mesh`.
 
         """
         # optional
@@ -1236,7 +1236,7 @@ class Mesh(CFVariableMixin):
     def face_face_connectivity(self):
         """
         The *optional* UGRID ``face_face_connectivity`` :class:`Connectivity`
-        coordinate of the :class:`Mesh`.
+        of the :class:`Mesh`.
 
         """
         return self._connectivity_manager.face_face
@@ -1244,10 +1244,10 @@ class Mesh(CFVariableMixin):
     @property
     def face_node_connectivity(self):
         """
-        The UGRID ``face_node_connectivity`` :class:`Connectivity` coordinate
-        of the :class:`Mesh`, which is **required** for
-        :attr:`Mesh.topology_dimension` of ``2``, and *optionally required* for
-        :attr:`Mesh.topology_dimension` of ``3``.
+        The UGRID ``face_node_connectivity`` :class:`Connectivity` of the
+        :class:`Mesh`, which is **required** for :attr:`Mesh.topology_dimension`
+        of ``2``, and *optionally required* for :attr:`Mesh.topology_dimension`
+        of ``3``.
 
         """
         return self._connectivity_manager.face_node
@@ -1276,12 +1276,12 @@ class Mesh(CFVariableMixin):
 
     def add_connectivities(self, *connectivities):
         """
-        Add one or more :class:`Connectivity` coordinates to the :class:`Mesh`.
+        Add one or more :class:`Connectivity` instances to the :class:`Mesh`.
 
         Args:
 
         * connectivities (iterable of object):
-            A collection of one or more :class:`Connectivity` coordinates to
+            A collection of one or more :class:`Connectivity` instances to
             add to the :class:`Mesh`.
 
         """
@@ -1368,7 +1368,7 @@ class Mesh(CFVariableMixin):
               compared against the :meth:`~iris.common.mixin.CFVariableMixin.name`.
 
             * a connectivity or metadata instance equal to that of
-              the desired objectss e.g., :class:`Connectivity` or
+              the desired objects e.g., :class:`Connectivity` or
               :class:`ConnectivityMetadata`.
 
         * standard_name (str):
@@ -1752,7 +1752,7 @@ class Mesh(CFVariableMixin):
             for potential removal.
 
         Returns:
-            A list of :class:`Connectivity` coordinates removed from the :class:`Mesh`
+            A list of :class:`Connectivity` instances removed from the :class:`Mesh`
             that matched the given criteria.
 
         """

--- a/lib/iris/tests/unit/util/test_reverse.py
+++ b/lib/iris/tests/unit/util/test_reverse.py
@@ -172,7 +172,9 @@ class Test_cube(tests.IrisTest):
             cube1_reverse_spanning.coord("spanning").points,
         )
 
-        msg = "Expected to find exactly 1 latitude coordinate, but found none."
+        msg = (
+            "Expected to find exactly 1 'latitude' coordinate, but found none."
+        )
         with self.assertRaisesRegex(
             iris.exceptions.CoordinateNotFoundError, msg
         ):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds the doc-strings to the public API methods of the class `iris.experimental.ugrid.Mesh` et al.

To view the rendered doc-strings for this pull-request, see [here](https://bjlittle-iris.readthedocs.io/en/latest/generated/api/iris/experimental/ugrid.html).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
