### PR TITLE
metadata string reduction

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -48,6 +48,9 @@ This document explains the changes made to Iris for this release
    representation of the 64-bit non-cryptographic hash of the object using the
    extremely fast `xxhash`_ hashing algorithm. (:pull:`4020`)
 
+#. `@rcomer`_ implemented a string method for metadata classes, so printing
+   these objects skips metadata elements that are set to None. (:pull:`4040`)
+
 
 🐛 Bugs Fixed
 =============

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -48,8 +48,9 @@ This document explains the changes made to Iris for this release
    representation of the 64-bit non-cryptographic hash of the object using the
    extremely fast `xxhash`_ hashing algorithm. (:pull:`4020`)
 
-#. `@rcomer`_ implemented a string method for metadata classes, so printing
-   these objects skips metadata elements that are set to None. (:pull:`4040`)
+#. `@rcomer`_ implemented a ``__str__`` method for metadata classes, so
+   printing these objects skips metadata elements that are set to None or an
+   empty string or dictionary. (:pull:`4040`)
 
 
 🐛 Bugs Fixed

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -231,8 +231,9 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
         field_strings = []
         for field in self._fields:
             value = getattr(self, field)
-            if value is not None:
-                field_strings.append(f"{field}={value}")
+            if value is None or isinstance(value, (str, dict)) and not value:
+                continue
+            field_strings.append(f"{field}={value}")
 
         return f"{type(self).__name__}({', '.join(field_strings)})"
 

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -227,6 +227,15 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
 
         return result
 
+    def __str__(self):
+        field_strings = []
+        for field in self._fields:
+            value = getattr(self, field)
+            if value is not None:
+                field_strings.append(f"{field}={value}")
+
+        return f"{type(self).__name__}({', '.join(field_strings)})"
+
     def _api_common(
         self, other, func_service, func_operation, action, lenient=None
     ):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Suppose I make, for example, a coordinate, and print it

```python
coord = iris.coords.DimCoord(range(3), long_name='foo', units='m')
print(coord)
```
I get info about what it contains:
```
DimCoord(array([0, 1, 2]), standard_name=None, units=Unit('m'), long_name='foo')
```

However, if I just print the metadata,
```python
print(coord.metadata)
```
I see all the unset stuff too, which I'm not really interested in:
```
DimCoordMetadata(standard_name=None, long_name='foo', var_name=None, units=Unit('m'), attributes={}, coord_system=None, climatological=False, circular=False)
```
For differences, it's hard to see at a glance what is actually different:
```python
coord2 = iris.coords.DimCoord(range(3), long_name='foo', units='m', attributes=dict(bar=1), var_name='wibble')
print(coord2.metadata.difference(coord.metadata))
```
```
DimCoordMetadata(standard_name=None, long_name=None, var_name=('wibble', None), units=None, attributes=({'bar': 1}, {}), coord_system=None, climatological=None, circular=None)
```
With my branch, these outputs become:
```
DimCoordMetadata(long_name=foo, units=m, attributes={}, climatological=False, circular=False)
DimCoordMetadata(var_name=('wibble', None), attributes=({'bar': 1}, {}))
```
Note that, if you do want to see all the unset metadata, you can still use the `repr`.  We could potentially also skip empty attributes dictionaries for the `str`.

Does something like this need tests?  I had a peek at the [coord string tests](https://github.com/SciTools/iris/blob/cbaa95524649378779f148cf5897611f208c76fb/lib/iris/tests/unit/coords/test_Coord.py#L882), but they seem to be focussed on getting date formats right.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
