### PR TITLE
remove unused cirrus-ci variable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,6 @@ env:
 linux_task_template: &LINUX_TASK_TEMPLATE
   auto_cancellation: true
   env:
-    IRIS_REPO_DIR: ${CIRRUS_WORKING_DIR}
     PATH: ${HOME}/miniconda/bin:${PATH}
     SITE_CFG: ${CIRRUS_WORKING_DIR}/lib/iris/etc/site.cfg
   conda_cache:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR simply removes the unused `IRIS_REPO_DIR` from the `.cirrus.yml`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
