### PR TITLE
Better calculations for MeshCoord lazy/real points and bounds. [AVD-1590]

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2933,6 +2933,8 @@ class MeshCoord(AuxCoord):
             # Bounds are calculated from a connectivity and the node points.
             # Data can be real or lazy, so operations must work in Dask, too.
             indices = bounds_connectivity.core_indices()
+            # Normalise indices dimension order to [faces/edges, bounds]
+            indices = bounds_connectivity.indices_by_src(indices)
             node_points = node_coord.core_points()
             lazy = hasattr(indices, "compute") or hasattr(
                 node_points, "compute"

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2935,6 +2935,9 @@ class MeshCoord(AuxCoord):
             indices = bounds_connectivity.core_indices()
             # Normalise indices dimension order to [faces/edges, bounds]
             indices = bounds_connectivity.indices_by_src(indices)
+            # Normalise the start index
+            indices = indices - bounds_connectivity.start_index
+
             node_points = node_coord.core_points()
             lazy = hasattr(indices, "compute") or hasattr(
                 node_points, "compute"
@@ -2945,14 +2948,17 @@ class MeshCoord(AuxCoord):
             # must flatten it and restore the shape later.
             flat_inds = indices.flatten()
             # NOTE: the connectivity array can have masked points, but we can't
-            # effectively index with those.  So we must post-mask the results.
-            # We also mask any places where the index is out of range.
-            missing_inds = array.logical_or(
-                flat_inds < 0,
-                flat_inds >= n_nodes,
-                array.ma.getmaskarray(flat_inds),
+            # effectively index with those.  So use a non-masked index array
+            # with "safe" index values, and post-mask the results.
+            flat_inds_mask = array.ma.getmaskarray(flat_inds)
+            flat_inds_nomask = array.ma.filled(flat_inds, 0)
+            # Note: *also* mask any places where the index is out of range.
+            bad_inds = array.logical_or(
+                flat_inds_nomask < 0, flat_inds_nomask >= n_nodes
             )
-            flat_inds_safe = array.where(missing_inds, 0, flat_inds)
+            # NB "OR" of 3 arrays in 2 steps, as Dask does not provide 'reduce'.
+            missing_inds = array.logical_or(flat_inds_mask, bad_inds)
+            flat_inds_safe = array.where(missing_inds, 0, flat_inds_nomask)
             # Here's the core indexing operation.
             # The comma applies all inds-array values to the *first* dimension.
             bounds = node_points[

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2950,14 +2950,11 @@ class MeshCoord(AuxCoord):
             # NOTE: the connectivity array can have masked points, but we can't
             # effectively index with those.  So use a non-masked index array
             # with "safe" index values, and post-mask the results.
-            flat_inds_mask = al.ma.getmaskarray(flat_inds)
-            flat_inds_nomask = al.ma.filled(flat_inds, 0)
+            flat_inds_nomask = al.ma.filled(flat_inds, -1)
             # Note: *also* mask any places where the index is out of range.
-            bad_inds = al.logical_or(
-                flat_inds_nomask < 0, flat_inds_nomask >= n_nodes
+            missing_inds = (flat_inds_nomask < 0) | (
+                flat_inds_nomask >= n_nodes
             )
-            # NB "OR" of 3 arrays in 2 steps, as Dask does not provide 'reduce'.
-            missing_inds = al.logical_or(flat_inds_mask, bad_inds)
             flat_inds_safe = al.where(missing_inds, 0, flat_inds_nomask)
             # Here's the core indexing operation.
             # The comma applies all inds-array values to the *first* dimension.

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2914,10 +2914,9 @@ class MeshCoord(AuxCoord):
         mesh, location, axis = self.mesh, self.location, self.axis
         node_coord = self.mesh.coord(include_nodes=True, axis=axis)
 
-        points_coord = None
-        bounds_connectivity = None
         if location == "node":
             points_coord = node_coord
+            bounds_connectivity = None
         elif location == "edge":
             points_coord = self.mesh.coord(include_edges=True, axis=axis)
             bounds_connectivity = mesh.edge_node_connectivity

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -18,11 +18,7 @@ import unittest.mock as mock
 from iris.coords import AuxCoord, Coord
 from iris.common.metadata import BaseMetadata
 from iris.cube import Cube
-from iris.experimental.ugrid import (
-    Connectivity,
-    Mesh,
-    _one_meshcoord as one_mesh_coord,
-)
+from iris.experimental.ugrid import Connectivity, Mesh
 
 from iris.experimental.ugrid import MeshCoord
 
@@ -637,8 +633,8 @@ class Test_MeshCoord__dataviews(tests.IrisTest):
         # Fetch the relevant source objects from the mesh.
         def fetch_sources_from_mesh():
             return (
-                one_mesh_coord(mesh.coord(include_nodes=True, axis="x")),
-                one_mesh_coord(mesh.coord(include_faces=True, axis="x")),
+                mesh.coord(include_nodes=True, axis="x"),
+                mesh.coord(include_faces=True, axis="x"),
                 mesh.face_node_connectivity,
             )
 

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -11,13 +11,18 @@ Unit tests for the :class:`iris.experimental.ugrid.MeshCoord`.
 # importing anything else.
 import iris.tests as tests
 
+import dask.array as da
 import numpy as np
 import unittest.mock as mock
 
 from iris.coords import AuxCoord, Coord
 from iris.common.metadata import BaseMetadata
 from iris.cube import Cube
-from iris.experimental.ugrid import Connectivity, Mesh
+from iris.experimental.ugrid import (
+    Connectivity,
+    Mesh,
+    _one_meshcoord as one_mesh_coord,
+)
 
 from iris.experimental.ugrid import MeshCoord
 
@@ -208,13 +213,10 @@ class Test__inherited_properties(tests.IrisTest):
 
 
 class Test__points_and_bounds(tests.IrisTest):
-    # TODO: expand tests for the calculated results, their properties and
-    #  dynamic behaviour, when we implement dynamic calculations.
-    # TODO: test with missing optional mesh elements, i.e. face/edge locations,
-    #  when we support that.
+    # Basic method testing only, for 3 locations with simple array values.
+    # See Test_MeshCoord__dataviews for more detailed checks.
     def test_node(self):
         meshcoord = _create_test_meshcoord(location="node")
-        self.assertFalse(meshcoord.has_lazy_points())
         self.assertIsNone(meshcoord.core_bounds())
         self.assertArrayAllClose(
             meshcoord.points, 1100 + np.arange(_TEST_N_NODES)
@@ -222,8 +224,6 @@ class Test__points_and_bounds(tests.IrisTest):
 
     def test_edge(self):
         meshcoord = _create_test_meshcoord(location="edge")
-        self.assertFalse(meshcoord.has_lazy_points())
-        self.assertFalse(meshcoord.has_lazy_bounds())
         points, bounds = meshcoord.core_points(), meshcoord.core_bounds()
         self.assertEqual(points.shape, meshcoord.shape)
         self.assertEqual(bounds.shape, meshcoord.shape + (2,))
@@ -243,8 +243,6 @@ class Test__points_and_bounds(tests.IrisTest):
 
     def test_face(self):
         meshcoord = _create_test_meshcoord(location="face")
-        self.assertFalse(meshcoord.has_lazy_points())
-        self.assertFalse(meshcoord.has_lazy_bounds())
         points, bounds = meshcoord.core_points(), meshcoord.core_bounds()
         self.assertEqual(points.shape, meshcoord.shape)
         self.assertEqual(bounds.shape, meshcoord.shape + (4,))
@@ -429,6 +427,166 @@ class Test_auxcoord_conversion(tests.IrisTest):
         # Also check array content.
         self.assertArrayAllClose(auxcoord.points, meshcoord.points)
         self.assertArrayAllClose(auxcoord.bounds, meshcoord.bounds)
+
+
+class Test_MeshCoord__dataviews(tests.IrisTest):
+    """
+    Fuller testing of points and bounds calculations and behaviour.
+    Including connectivity missing-points (non-square faces).
+
+    """
+
+    def setUp(self):
+        self._make_test_meshcoord()
+
+    def _make_test_meshcoord(self, lazy_sources=False):
+        # Construct a miniature face+nodes mesh for testing.
+        face_nodes_array = np.array(
+            [
+                [0, 2, 1, 3],
+                [1, 3, 10, 13],
+                [2, 7, 9, 19],
+                [
+                    3,
+                    4,
+                    7,
+                    -1,
+                ],  # This one has a "missing" point (it's a triangle)
+                [8, 1, 7, 2],
+            ]
+        )
+        # Connectivity uses *masked* for missing points.
+        face_nodes_array = np.ma.masked_less(face_nodes_array, 0)
+        n_faces = face_nodes_array.shape[0]
+        n_nodes = int(face_nodes_array.max() + 1)
+        face_xs = 500.0 + np.arange(n_faces)
+        node_xs = 100.0 + np.arange(n_nodes)
+
+        # Record all these for re-use in tests
+        self.n_faces = n_faces
+        self.n_nodes = n_nodes
+        self.face_xs = face_xs
+        self.node_xs = node_xs
+        self.face_nodes_array = face_nodes_array
+
+        # convert source data to Dask arrays if asked.
+        if lazy_sources:
+
+            def lazify(arr):
+                return da.from_array(arr, chunks=-1, meta=np.ndarray)
+
+            node_xs = lazify(node_xs)
+            face_xs = lazify(face_xs)
+            face_nodes_array = lazify(face_nodes_array)
+
+        # Build a mesh with this info stored in it.
+        co_nodex = AuxCoord(
+            node_xs, standard_name="longitude", long_name="node_x", units=1
+        )
+        co_facex = AuxCoord(
+            face_xs, standard_name="longitude", long_name="face_x", units=1
+        )
+        # N.B. the Mesh requires 'Y's as well.
+        co_nodey = co_nodex.copy()
+        co_nodey.rename("latitude")
+        co_nodey.long_name = "node_y"
+        co_facey = co_facex.copy()
+        co_facey.rename("latitude")
+        co_facey.long_name = "face_y"
+
+        face_node_conn = Connectivity(
+            face_nodes_array,
+            cf_role="face_node_connectivity",
+            long_name="face_nodes",
+        )
+
+        self.mesh = Mesh(
+            topology_dimension=2,
+            node_coords_and_axes=[(co_nodex, "x"), (co_nodey, "y")],
+            connectivities=[face_node_conn],
+            face_coords_and_axes=[(co_facex, "x"), (co_facey, "y")],
+        )
+
+        # Construct a test meshcoord.
+        meshcoord = MeshCoord(mesh=self.mesh, location="face", axis="x")
+        self.meshcoord = meshcoord
+
+    def _check_expected_points_values(self):
+        # The points are just the face_x-s
+        meshcoord = self.meshcoord
+        self.assertArrayAllClose(meshcoord.points, self.face_xs)
+
+    def _check_expected_bounds_values(self):
+        mesh_coord = self.meshcoord
+        # The bounds are selected node_x-s :  all == node_number + 100.0
+        result = mesh_coord.bounds
+        # N.B. result should be masked where the masked indices are.
+        expected = 100.0 + self.face_nodes_array
+        # Check there are *some* masked points.
+        self.assertTrue(np.count_nonzero(expected.mask) > 0)
+        # Check results match, *including* location of masked points.
+        self.assertMaskedArrayAlmostEqual(result, expected)
+
+    def test_points_values(self):
+        """Basic points content check, on real data."""
+        meshcoord = self.meshcoord
+        self.assertFalse(meshcoord.has_lazy_points())
+        self.assertFalse(meshcoord.has_lazy_points())
+        self._check_expected_points_values()
+
+    def test_bounds_values(self):
+        """Basic bounds contents check."""
+        meshcoord = self.meshcoord
+        self.assertFalse(meshcoord.has_lazy_points())
+        self.assertFalse(meshcoord.has_lazy_bounds())
+        self._check_expected_bounds_values()
+
+    def test_lazy_points_values(self):
+        """Check lazy points calculation on lazy inputs."""
+        # Remake the test data with lazy source coords.
+        self._make_test_meshcoord(lazy_sources=True)
+        meshcoord = self.meshcoord
+        self.assertTrue(meshcoord.has_lazy_points())
+        self.assertTrue(meshcoord.has_lazy_bounds())
+        # Check values, as previous.
+        self._check_expected_points_values()
+
+    def test_lazy_bounds_values(self):
+        self._make_test_meshcoord(lazy_sources=True)
+        meshcoord = self.meshcoord
+        self.assertTrue(meshcoord.has_lazy_points())
+        self.assertTrue(meshcoord.has_lazy_bounds())
+        # Check values, as previous.
+        self._check_expected_bounds_values()
+
+    def test_meshcoord_leaves_originals_lazy(self):
+        self._make_test_meshcoord(lazy_sources=True)
+        mesh = self.mesh
+        meshcoord = self.meshcoord
+
+        # Fetch the relevant source objects from the mesh.
+        def fetch_sources_from_mesh():
+            return (
+                one_mesh_coord(mesh.coord(include_nodes=True, axis="x")),
+                one_mesh_coord(mesh.coord(include_faces=True, axis="x")),
+                mesh.face_node_connectivity,
+            )
+
+        # Check all the source coords are lazy.
+        for coord in fetch_sources_from_mesh():
+            self.assertTrue(hasattr(coord._core_values(), "compute"))
+
+        # Calculate both points + bounds of the meshcoord
+        self.assertTrue(meshcoord.has_lazy_points())
+        self.assertTrue(meshcoord.has_lazy_bounds())
+        meshcoord.points
+        meshcoord.bounds
+        self.assertFalse(meshcoord.has_lazy_points())
+        self.assertFalse(meshcoord.has_lazy_bounds())
+
+        # Check all the source coords are still lazy.
+        for coord in fetch_sources_from_mesh():
+            self.assertTrue(hasattr(coord._core_values(), "compute"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Functional lazy calculations for lazy points+bounds of MeshCoord

These calcs contain snapshots of the data content of the relevant Mesh components when the MeshCoord is created, but are not able to dynamically track Mesh contents, as originally envisaged.
However they should work with either real or lazy data content.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
