### PR TITLE
Meshcoord printout [AVD-1592]

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2772,7 +2772,6 @@ class MeshCoord(AuxCoord):
             raise ValueError(msg)
 
         # Get the 'coord identity' metadata from the relevant node-coordinate.
-        # N.B. mesh.coord returns a dict
         node_coord = self.mesh.coord(include_nodes=True, axis=self.axis)
         # Call parent constructor to handle the common constructor args.
         super().__init__(
@@ -2896,6 +2895,56 @@ class MeshCoord(AuxCoord):
                 eq = self.metadata == other.metadata
 
         return eq
+
+    def _string_summary(self, repr_style):
+        # Note: bypass the immediate parent here, which is Coord, because we
+        # have no interest in reporting coord_system or climatological, or in
+        # printing out our points/bounds.
+        # We also want to list our defining properties, i.e. mesh/location/axis
+        # *first*, before names/units etc, so different from other Coord types.
+
+        # First construct a shortform text summary to identify the Mesh.
+        # IN 'str-mode', this attempts to use Mesh.name() if it is set,
+        # otherwise uses an object-id style (as also for 'repr-mode').
+        # TODO: use a suitable method provided by Mesh, e.g. something like
+        #  "Mesh.summary(shorten=True)", when it is available.
+        mesh_name = None
+        if not repr_style:
+            mesh_name = self.mesh.name()
+            if mesh_name in (None, "", "unknown"):
+                mesh_name = None
+        if mesh_name:
+            # Use a more human-readable form
+            mesh_string = f"Mesh({mesh_name!r})"
+        else:
+            # Mimic the generic object.__str__ style.
+            mesh_id = id(self.mesh)
+            mesh_string = f"<Mesh object at {hex(mesh_id)}>"
+        result = (
+            f"mesh={mesh_string}"
+            f", location={self.location!r}"
+            f", axis={self.axis!r}"
+        )
+        # Add 'other' metadata that is drawn from the underlying node-coord.
+        # But put these *afterward*, unlike other similar classes.
+        for item in ("standard_name", "units", "long_name", "attributes"):
+            # NOTE: order of these matches Coord.summary, but omit vor_name.
+            val = getattr(self, item, None)
+            if item == "attributes":
+                is_blank = len(val) == 0  # an empty dict is as good as none
+            else:
+                is_blank = val is None
+            if not is_blank:
+                result += f", {item}={val!r}"
+
+        result = f"MeshCoord({result})"
+        return result
+
+    def __str__(self):
+        return self._string_summary(repr_style=False)
+
+    def __repr__(self):
+        return self._string_summary(repr_style=True)
 
     def _construct_access_arrays(self):
         """

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2928,7 +2928,7 @@ class MeshCoord(AuxCoord):
         # Add 'other' metadata that is drawn from the underlying node-coord.
         # But put these *afterward*, unlike other similar classes.
         for item in ("standard_name", "units", "long_name", "attributes"):
-            # NOTE: order of these matches Coord.summary, but omit vor_name.
+            # NOTE: order of these matches Coord.summary, but omit var_name.
             val = getattr(self, item, None)
             if item == "attributes":
                 is_blank = len(val) == 0  # an empty dict is as good as none

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -366,21 +366,11 @@ class Test__str_repr(tests.IrisTest):
 
     def test_repr(self):
         result = repr(self.meshcoord)
-        re_expected = (
-            r"MeshCoord\(mesh=<Mesh object at .*>"
-            r", location='face', axis='x'"
-            r".*\)"
-        )
         re_expected = self._expected_elements_regexp(mesh_strstyle=False)
         self.assertRegex(result, re_expected)
 
     def test__str__(self):
         result = str(self.meshcoord)
-        re_expected = (
-            r"MeshCoord\(mesh=Mesh\('test_mesh'\)"
-            r", location='face', axis='x'"
-            r".*\)"
-        )
         re_expected = self._expected_elements_regexp(mesh_strstyle=True)
         self.assertRegex(result, re_expected)
 
@@ -391,24 +381,6 @@ class Test__str_repr(tests.IrisTest):
         result = str(meshcoord)
         re_expected = r", location='edge', axis='y'"
         self.assertRegex(result, re_expected)
-
-    def _check_str_additional(self, standard_name=True, long_name=True):
-        result = str(self.meshcoord)
-        expects = [
-            r"MeshCoord\(mesh=Mesh\('test_mesh'\)",
-            r", location='face', axis='x'",
-        ]
-        if standard_name:
-            expects += [", standard_name='longitude'"]
-        expects += [r", units=Unit\('degrees_east'\)"]
-        if long_name:
-            expects += [", long_name='long-name'"]
-        expects += r"\)"
-        re_expected = "".join(expects)
-        self.assertRegex(result, re_expected)
-
-    # def test_all_additional(self):
-    #     self._check_str_additional()
 
     def test_str_no_long_name(self):
         mesh = self.mesh
@@ -435,7 +407,7 @@ class Test__str_repr(tests.IrisTest):
 
     def test_str_no_attributes(self):
         mesh = self.mesh
-        # Remove the standard_name of the node coord in the mesh.
+        # No attributes on the node coord in the mesh.
         node_coord = mesh.coord(include_nodes=True, axis="x")
         node_coord.attributes = None
         # Make a new meshcoord, based on the modified mesh.
@@ -446,7 +418,7 @@ class Test__str_repr(tests.IrisTest):
 
     def test_str_empty_attributes(self):
         mesh = self.mesh
-        # Remove the standard_name of the node coord in the mesh.
+        # Empty attributes dict on the node coord in the mesh.
         node_coord = mesh.coord(include_nodes=True, axis="x")
         node_coord.attributes.clear()
         # Make a new meshcoord, based on the modified mesh.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Added string representations for MeshCoord

Waiting until #4053 is in :  Which this is based on.
(so it won't merge into the target branch, as yet)

I have made the str/repr versions slightly different, following discussion with @bjlittle 
I'm still a little uncertain that the results are the most useful, though:
  * if you enter a MeshCoord at the command line, you get "repr", which shows a mesh as `<Mesh object at 0x{address}>`, 
     * whereas the "str" form attempts a more human-readable account of the Mesh, as `Mesh('name')`
  * This  corresponds with the "standard" Python usage ...
  * ... **_but_**,  for a cube, the "repr" version is the *short form*, whereas print(cube) gives full details.
    * .. so making repr the "more precise and less human" is **_against_** what we do for cubes.  



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
