### PR TITLE
align mesh api with cube

### DIFF
--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -1410,7 +1410,7 @@ class Mesh(CFVariableMixin):
             that matched the given criteria.
 
         """
-        return self._connectivity_manager.filters(
+        result = self._connectivity_manager.filters(
             item=item,
             standard_name=standard_name,
             long_name=long_name,
@@ -1421,6 +1421,7 @@ class Mesh(CFVariableMixin):
             contains_edge=contains_edge,
             contains_face=contains_face,
         )
+        return list(result.values())
 
     def connectivity(
         self,
@@ -1502,7 +1503,7 @@ class Mesh(CFVariableMixin):
 
         """
 
-        return self._connectivity_manager.filter(
+        result = self._connectivity_manager.filter(
             item=item,
             standard_name=standard_name,
             long_name=long_name,
@@ -1513,6 +1514,7 @@ class Mesh(CFVariableMixin):
             contains_edge=contains_edge,
             contains_face=contains_face,
         )
+        return list(result.values())[0]
 
     def coord(
         self,
@@ -1591,7 +1593,7 @@ class Mesh(CFVariableMixin):
             that matched the given criteria.
 
         """
-        return self._coord_manager.filter(
+        result = self._coord_manager.filter(
             item=item,
             standard_name=standard_name,
             long_name=long_name,
@@ -1602,6 +1604,7 @@ class Mesh(CFVariableMixin):
             include_edges=include_edges,
             include_faces=include_faces,
         )
+        return list(result.values())[0]
 
     def coords(
         self,
@@ -1675,7 +1678,7 @@ class Mesh(CFVariableMixin):
             :class:`Mesh` that matched the given criteria.
 
         """
-        return self._coord_manager.filters(
+        result = self._coord_manager.filters(
             item=item,
             standard_name=standard_name,
             long_name=long_name,
@@ -1686,6 +1689,7 @@ class Mesh(CFVariableMixin):
             include_edges=include_edges,
             include_faces=include_faces,
         )
+        return list(result.values())
 
     def remove_connectivities(
         self,
@@ -2769,8 +2773,7 @@ class MeshCoord(AuxCoord):
 
         # Get the 'coord identity' metadata from the relevant node-coordinate.
         # N.B. mesh.coord returns a dict
-        node_coords = self.mesh.coord(include_nodes=True, axis=self.axis)
-        (node_coord,) = list(node_coords.values())
+        node_coord = self.mesh.coord(include_nodes=True, axis=self.axis)
         # Call parent constructor to handle the common constructor args.
         super().__init__(
             points,
@@ -2911,23 +2914,17 @@ class MeshCoord(AuxCoord):
         # TODO: cheat for now : correct calculations, but not dynamic.
         # TODO: replace wth fully dynamic lazy calcs (slightly more complex).
         mesh, location, axis = self.mesh, self.location, self.axis
-        # N.B. mesh.coord returns a dict
-        node_coords = self.mesh.coord(include_nodes=True, axis=axis)
-        (node_coord,) = list(node_coords.values())
+        node_coord = self.mesh.coord(include_nodes=True, axis=axis)
         if location == "node":
             points = node_coord.core_points()
             bounds = None
         elif location == "edge":
-            # N.B. mesh.coord returns a dict
-            edge_coords = self.mesh.coord(include_edges=True, axis=self.axis)
-            (edge_coord,) = list(edge_coords.values())
+            edge_coord = self.mesh.coord(include_edges=True, axis=self.axis)
             points = edge_coord.core_points()
             inds = mesh.edge_node_connectivity.core_indices()
             bounds = node_coord.core_points()[inds]
         elif location == "face":
-            # N.B. mesh.coord returns a dict
-            face_coords = self.mesh.coord(include_faces=True, axis=self.axis)
-            (face_coord,) = list(face_coords.values())
+            face_coord = self.mesh.coord(include_faces=True, axis=self.axis)
             points = face_coord.core_points()  # For now, this always exists
             inds = mesh.face_node_connectivity.core_indices()
             bounds = node_coord.core_points()[inds]

--- a/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
@@ -168,11 +168,9 @@ class TestProperties1D(TestMeshCommon):
 
         func = self.mesh.connectivities
         for kwargs in positive_kwargs:
-            self.assertEqual(
-                self.EDGE_NODE, func(**kwargs)["edge_node_connectivity"]
-            )
+            self.assertEqual([self.EDGE_NODE], func(**kwargs))
         for kwargs in negative_kwargs:
-            self.assertNotIn("edge_node_connectivity", func(**kwargs))
+            self.assertEqual([], func(**kwargs))
 
     def test_connectivities_locations(self):
         # topology_dimension-specific results. Method intended to be overridden.
@@ -188,15 +186,14 @@ class TestProperties1D(TestMeshCommon):
             {"contains_edge": False, "contains_node": False},
         )
 
-        expected = {self.EDGE_NODE.cf_role: self.EDGE_NODE}
         func = self.mesh.connectivities
         for kwargs in positive_kwargs:
-            self.assertEqual(expected, func(**kwargs))
+            self.assertEqual([self.EDGE_NODE], func(**kwargs))
         for kwargs in negative_kwargs:
-            self.assertEqual({}, func(**kwargs))
+            self.assertEqual([], func(**kwargs))
 
         with self.assertLogs(ugrid.logger, level="DEBUG") as log:
-            self.assertEqual({}, func(contains_face=True))
+            self.assertEqual([], func(contains_face=True))
             self.assertIn("filter for non-existent", log.output[0])
 
     def test_coord(self):
@@ -231,9 +228,9 @@ class TestProperties1D(TestMeshCommon):
 
         func = self.mesh.coords
         for kwargs in positive_kwargs:
-            self.assertEqual(self.NODE_LON, func(**kwargs)["node_x"])
+            self.assertIn(self.NODE_LON, func(**kwargs))
         for kwargs in negative_kwargs:
-            self.assertNotIn("node_x", func(**kwargs))
+            self.assertNotIn(self.NODE_LON, func(**kwargs))
 
     def test_coords_locations(self):
         # topology_dimension-specific results. Method intended to be overridden.
@@ -264,13 +261,11 @@ class TestProperties1D(TestMeshCommon):
 
         func = self.mesh.coords
         for kwargs, expected in kwargs_expected:
-            expected = {
-                k: all_expected[k] for k in expected if k in all_expected
-            }
+            expected = [all_expected[k] for k in expected if k in all_expected]
             self.assertEqual(expected, func(**kwargs))
 
         with self.assertLogs(ugrid.logger, level="DEBUG") as log:
-            self.assertEqual({}, func(include_faces=True))
+            self.assertEqual([], func(include_faces=True))
             self.assertIn("filter non-existent", log.output[0])
 
     def test_edge_dimension(self):
@@ -472,8 +467,10 @@ class TestProperties2D(TestProperties1D):
         )
         func = self.mesh.connectivities
         for kwargs, expected in kwargs_expected:
-            expected = {c.cf_role: c for c in expected}
-            self.assertEqual(expected, func(**kwargs))
+            result = func(**kwargs)
+            self.assertEqual(len(expected), len(result))
+            for item in expected:
+                self.assertIn(item, result)
 
     def test_coords_locations(self):
         all_expected = {
@@ -518,9 +515,7 @@ class TestProperties2D(TestProperties1D):
 
         func = self.mesh.coords
         for kwargs, expected in kwargs_expected:
-            expected = {
-                k: all_expected[k] for k in expected if k in all_expected
-            }
+            expected = [all_expected[k] for k in expected if k in all_expected]
             self.assertEqual(expected, func(**kwargs))
 
     def test_edge_face(self):

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -122,8 +122,7 @@ class Test___init__(tests.IrisTest):
         for axis in Mesh.AXES:
             meshcoord = _create_test_meshcoord(axis=axis)
             # N.B.
-            node_x_coords = meshcoord.mesh.coord(include_nodes=True, axis=axis)
-            (node_x_coord,) = list(node_x_coords.values())
+            node_x_coord = meshcoord.mesh.coord(include_nodes=True, axis=axis)
             for key in node_x_coord.metadata._fields:
                 meshval = getattr(meshcoord, key)
                 if key == "var_name":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A minor refactor of the `Mesh.coord`, `Mesh.coords`, `Mesh.connectivity`, and `Mesh.connectivities` API to align with `Cube.coord` and `Cube.coords`, in that a single instance or a `list` containing zero or more instances is returned, rather than a `dict`. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
