### PR TITLE
cirrus-ci credits for non-master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,7 +88,7 @@ linux_task_template: &LINUX_TASK_TEMPLATE
 #
 compute_credits_template: &CREDITS_TEMPLATE
   # Only use credits for non-DRAFT pull-requests to SciTools/iris master branch by collaborators
-  use_compute_credits: ${CIRRUS_REPO_FULL_NAME} == "SciTools/iris" && ${CIRRUS_USER_COLLABORATOR} == "true" && ${CIRRUS_PR_DRAFT} == "false" && ${CIRRUS_BASE_BRANCH} == "master" && ${CIRRUS_PR} != ""
+  use_compute_credits: ${CIRRUS_REPO_FULL_NAME} == "SciTools/iris" && ${CIRRUS_USER_COLLABORATOR} == "true" && ${CIRRUS_PR_DRAFT} == "false" && ${CIRRUS_PR} != ""
 
 
 #


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR relaxes the criteria for our use of `cirrus-ci` compute credits i.e., allow then to be spent also on non-`master` branches.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
