### PR TITLE
add pre-commit.ci badge and doc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 <a href="https://scitools-iris.readthedocs.io/en/latest/?badge=latest">
 <img src="https://readthedocs.org/projects/scitools-iris/badge/?version=latest"
      alt="Documentation Status" /></a>
+<a src="https://results.pre-commit.ci/latest/github/SciTools/iris/master">
+<img src="https://results.pre-commit.ci/badge/github/SciTools/iris/master.svg"
+     alt="pre-commit.ci status" /></a>
 <a href="https://anaconda.org/conda-forge/iris">
 <img src="https://img.shields.io/conda/dn/conda-forge/iris.svg"
      alt="conda-forge downloads" /></a>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <a href="https://scitools-iris.readthedocs.io/en/latest/?badge=latest">
 <img src="https://readthedocs.org/projects/scitools-iris/badge/?version=latest"
      alt="Documentation Status" /></a>
-<a src="https://results.pre-commit.ci/latest/github/SciTools/iris/master">
+<a href="https://results.pre-commit.ci/latest/github/SciTools/iris/master">
 <img src="https://results.pre-commit.ci/badge/github/SciTools/iris/master.svg"
      alt="pre-commit.ci status" /></a>
 <a href="https://anaconda.org/conda-forge/iris">

--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -23,6 +23,7 @@
 .. _napolean: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html
 .. _nox: https://nox.thea.codes/en/stable/
 .. _New Issue: https://github.com/scitools/iris/issues/new/choose
+.. _pre-commit: https://pre-commit.com/
 .. _pull request: https://github.com/SciTools/iris/pulls
 .. _pull requests: https://github.com/SciTools/iris/pulls
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/

--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -6,21 +6,12 @@ Continuous Integration (CI) Testing
 ===================================
 
 The `Iris`_ GitHub repository is configured to run checks against all its
-branches automatically whenever a pull request is created, updated or merged.
+branches automatically whenever a pull-request is created, updated or merged.
 The checks performed are:
 
-* :ref:`testing_cla`
 * :ref:`testing_cirrus`
-
-
-.. _testing_cla:
-
-SciTools CLA Checker
-********************
-
-A bot which checks that the GitHub author of the pull request has signed the
-**SciTools Contributor's License Agreement (CLA)**.  For more information on
-this please see https://scitools.org.uk/organisation.html#governance.
+* :ref:`testing_cla`
+* :ref:`pre_commit_ci`
 
 
 .. _testing_cirrus:
@@ -44,7 +35,7 @@ refer to the `Cirrus-CI Documentation`_. The tasks performed during CI include:
 * checking all URL references within the code base and documentation are valid
 
 The above `cirrus-ci`_ tasks are run automatically against all `Iris`_ branches
-on GitHub whenever a pull request is submitted, updated or merged. See the
+on GitHub whenever a pull-request is submitted, updated or merged. See the
 `Cirrus-CI Dashboard`_ for details of recent past and active Iris jobs.
 
 .. _skipping Cirrus-CI tasks:
@@ -79,17 +70,41 @@ e.g., to skip the linting task, the following are all equivalent::
 
 
 GitHub Checklist
-****************
+----------------
 
-An example snapshot from a successful GitHub pull request shows all tests
+An example snapshot from a successful GitHub pull-request shows all tests
 passing:
 
 .. image:: ci_checks.png
 
-If any CI tasks fail, then the pull request is unlikely to be merged to the
+If any CI tasks fail, then the pull-request is unlikely to be merged to the
 Iris target branch by a core developer.
+
+
+.. _testing_cla:
+
+SciTools CLA Checker
+********************
+
+A bot which checks that the GitHub author of the pull-request has signed the
+**SciTools Contributor's License Agreement (CLA)**.  For more information on
+this please see https://scitools.org.uk/organisation.html#governance.
+
+
+.. _pre_commit_ci:
+
+pre-commit CI
+*************
+
+A CI service for the `pre-commit`_ framework that checks and auto fixes all
+pull-requests given the `Iris`_ GitHub repository `.pre-commit-config.yaml`_.
+
+See the `pre-commit.ci dashboard`_ for details of recent past and active Iris jobs.
+
 
 
 .. _Cirrus-CI Dashboard: https://cirrus-ci.com/github/SciTools/iris
 .. _Cirrus-CI Documentation: https://cirrus-ci.org/guide/writing-tasks/
+.. _.pre-commit-config.yaml: https://github.com/SciTools/iris/blob/master/.pre-commit-config.yaml
+.. _pre-commit.ci dashboard: https://results.pre-commit.ci/repo/github/5312648
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -113,6 +113,9 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ added post-release instructions on how to :ref:`update_pypi`
    with `scitools-iris`_. (:pull:`4038`)
 
+#. `@bjlittle`_ added the |pre-commit.ci|_ badge to the `README.md`_.
+   See :ref:`pre_commit_ci` for further details. (:pull:`4061`)
+
 
 💼 Internal
 ===========
@@ -159,6 +162,8 @@ This document explains the changes made to Iris for this release
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _Met Office: https://www.metoffice.gov.uk/
 .. _numpy: https://numpy.org/doc/stable/release/1.20.0-notes.html
+.. |pre-commit.ci| image:: https://results.pre-commit.ci/badge/github/SciTools/iris/master.svg
+.. _pre-commit.ci: https://results.pre-commit.ci/latest/github/SciTools/iris/master
 .. |PyPI| image:: https://img.shields.io/pypi/v/scitools-iris?color=orange&label=pypi%7Cscitools-iris
 .. _PyPI: https://pypi.org/project/scitools-iris/
 .. _Python 3.8: https://www.python.org/downloads/release/python-380/


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds the `pre-commit.ci` badge to the `README.md` and also adds some docs support to highlight the service to `iris` developers.

The documentation changes associated with this PR are rendered [here](https://bjlittle-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#pre-commit-ci).

Also, see [here](https://github.com/bjlittle/iris/tree/add-pre-commit-ci-badge) for a preview of the new `README.md` with the badge.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
