### PR TITLE
Cube.coords mesh_coords key [AVD-1662]

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -10,6 +10,7 @@ Classes for representing multi-dimensional data with metadata.
 """
 
 from collections import OrderedDict
+
 from collections.abc import (
     Iterable,
     Container,
@@ -1582,6 +1583,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dimensions=None,
         coord_system=None,
         dim_coords=None,
+        mesh_coords=None,
     ):
         """
         Return a list of coordinates from the :class:`Cube` that match the
@@ -1643,8 +1645,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         * dim_coords:
             Set to ``True`` to only return coordinates that are the cube's
             dimension coordinates. Set to ``False`` to only return coordinates
-            that are the cube's auxiliary and derived coordinates. If ``None``,
-            returns all coordinates.
+            that are the cube's auxiliary, mesh and derived coordinates.
+            If ``None``, returns all coordinates.
+
+        * mesh_coords:
+            Set to ``True`` to return only coordinates which are
+            :class:`~iris.experimental.ugrid.MeshCoord`\\ s.
+            Set to ``False`` to return only non-mesh coordinates.
+            If ``None``, returns all coordinates.
 
         Returns:
             A list containing zero or more coordinates matching the provided
@@ -1659,6 +1667,26 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         if dim_coords in [False, None]:
             coords_and_factories += list(self.aux_coords)
             coords_and_factories += list(self.aux_factories)
+
+        if mesh_coords is not None:
+            # Select on mesh or non-mesh.
+            mesh_coords = bool(mesh_coords)
+            # Use duck typing to avoid importing from iris.experimental.ugrid,
+            # which could be a circular import.
+            if mesh_coords:
+                # *only* MeshCoords
+                coords_and_factories = [
+                    item
+                    for item in coords_and_factories
+                    if hasattr(item, "mesh")
+                ]
+            else:
+                # *not* MeshCoords
+                coords_and_factories = [
+                    item
+                    for item in coords_and_factories
+                    if not hasattr(item, "mesh")
+                ]
 
         coords_and_factories = metadata_filter(
             coords_and_factories,
@@ -1727,6 +1755,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         dimensions=None,
         coord_system=None,
         dim_coords=None,
+        mesh_coords=None,
     ):
         """
         Return a single coordinate from the :class:`Cube` that matches the
@@ -1793,8 +1822,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         * dim_coords:
             Set to ``True`` to only return coordinates that are the cube's
             dimension coordinates. Set to ``False`` to only return coordinates
-            that are the cube's auxiliary and derived coordinates. If ``None``,
-            returns all coordinates.
+            that are the cube's auxiliary, mesh and derived coordinates.
+            If ``None``, returns all coordinates.
+
+        * mesh_coords:
+            Set to ``True`` to return only coordinates which are
+            :class:`~iris.experimental.ugrid.MeshCoord`\\ s.
+            Set to ``False`` to return only non-mesh coordinates.
+            If ``None``, returns all coordinates.
 
         Returns:
             The coordinate that matches the provided criteria.

--- a/lib/iris/experimental/ugrid.py
+++ b/lib/iris/experimental/ugrid.py
@@ -2896,6 +2896,10 @@ class MeshCoord(AuxCoord):
 
         return eq
 
+    # Exactly as for Coord.__hash__ :  See there for why.
+    def __hash__(self):
+        return hash(id(self))
+
     def _string_summary(self, repr_style):
         # Note: bypass the immediate parent here, which is Coord, because we
         # have no interest in reporting coord_system or climatological, or in
@@ -2927,7 +2931,13 @@ class MeshCoord(AuxCoord):
         )
         # Add 'other' metadata that is drawn from the underlying node-coord.
         # But put these *afterward*, unlike other similar classes.
-        for item in ("standard_name", "units", "long_name", "attributes"):
+        for item in (
+            "shape",
+            "standard_name",
+            "units",
+            "long_name",
+            "attributes",
+        ):
             # NOTE: order of these matches Coord.summary, but omit var_name.
             val = getattr(self, item, None)
             if item == "attributes":

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -353,7 +353,7 @@ class Test__str_repr(tests.IrisTest):
             regexp += r"Mesh\('test_mesh'\)"
         else:
             regexp += "<Mesh object at .*>"
-        regexp += ", location='face', axis='x'"
+        regexp += r", location='face', axis='x', shape=\(3,\)"
         if standard_name:
             regexp += ", standard_name='longitude'"
         regexp += r", units=Unit\('degrees_east'\)"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Adding a 'mesh_coords' keyword to Cube.coords.
Behaves mostly like the existing `dim_coords` keyword.

(This is a simple preliminary to adding the more complex cube api to come :
  * `cube.mesh` and `.location`
  * `cube.__eq__` should compare mesh and location
  * various checks that any MeshCoord-s in a cube are always compatible.
)

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
