### PR TITLE
Support for cube mesh api [AVD-1663]

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1919,6 +1919,32 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return result
 
+    def mesh(self):
+        """
+        Return the unstructured :class:`~iris.experimental.ugrid.Mesh`
+        associated with the cube, or None if there is none.
+
+        """
+        result = self.coords(mesh_coords=True)
+        if len(result) == 0:
+            result = None
+        else:
+            result = result[0].mesh
+        return result
+
+    def location(self):
+        """
+        Return the mesh location of the cube, if the cube has an unstructured
+        :class:`~iris.experimental.ugrid.Mesh`, or None if there is none.
+
+        """
+        result = self.coords(mesh_coords=True)
+        if len(result) == 0:
+            result = None
+        else:
+            result = result[0].location
+        return result
+
     def cell_measures(self, name_or_cell_measure=None):
         """
         Return a list of cell measures in this cube fitting the given criteria.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1134,7 +1134,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def _add_unique_aux_coord(self, coord, data_dims):
         data_dims = self._check_multi_dim_metadata(coord, data_dims)
         if hasattr(coord, "mesh"):
-            mesh = self.mesh()
+            mesh = self.mesh
             if mesh:
                 msg = (
                     "{item} of Meshcoord {coord!r} is "
@@ -1150,7 +1150,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                             ownval=mesh,
                         )
                     )
-                location = self.location()
+                location = self.location
                 if coord.location != location:
                     raise ValueError(
                         msg.format(
@@ -1957,7 +1957,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return result
 
-    def _a_meshcoord(self):
+    def _any_meshcoord(self):
+        """Return a MeshCoord if there are any, else None."""
         mesh_coords = self.coords(mesh_coords=True)
         if mesh_coords:
             result = mesh_coords[0]
@@ -1965,6 +1966,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             result = None
         return result
 
+    @property
     def mesh(self):
         """
         Return the unstructured :class:`~iris.experimental.ugrid.Mesh`
@@ -1980,11 +1982,12 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             or ``None``.
 
         """
-        result = self._a_meshcoord()
+        result = self._any_meshcoord()
         if result is not None:
             result = result.mesh
         return result
 
+    @property
     def location(self):
         """
         Return the mesh "location" of the cube data, if the cube has any
@@ -2000,7 +2003,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             or ``None``.
 
         """
-        result = self._a_meshcoord()
+        result = self._any_meshcoord()
         if result is not None:
             result = result.location
         return result
@@ -2019,7 +2022,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             or ``None``.
 
         """
-        result = self._a_meshcoord()
+        result = self._any_meshcoord()
         if result is not None:
             (result,) = self.coord_dims(result)  # result is a 1-tuple
         return result

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1970,13 +1970,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Return the unstructured :class:`~iris.experimental.ugrid.Mesh`
         associated with the cube, if the cube has any
         :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
-        or None if it has none.
+        or ``None`` if it has none.
 
         Returns:
-        * mesh (:class:`iris.experimental.ugrid.Mesh` or None)
+
+        * mesh (:class:`iris.experimental.ugrid.Mesh` or None):
             The mesh of the cube
             :class:`~iris.experimental.ugrid.MeshCoord`\\s,
-            or None.
+            or ``None``.
 
         """
         result = self._a_meshcoord()
@@ -1986,16 +1987,17 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def location(self):
         """
-        Return the "location" of the cube mesh, if the cube has any
+        Return the mesh "location" of the cube data, if the cube has any
         :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
-        or None if it has none.
+        or ``None`` if it has none.
 
         Returns:
-        * location (str or None)
+
+        * location (str or None):
             The mesh location of the cube
-            :class:`~iris.experimental.ugrid.MeshCoord`\\s,
-            one of 'face' / 'edge' / 'node',
-            or None.
+            :class:`~iris.experimental.ugrid.MeshCoord`\\s
+            (i.e. one of 'face' / 'edge' / 'node'),
+            or ``None``.
 
         """
         result = self._a_meshcoord()
@@ -2007,13 +2009,14 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         """
         Return the cube dimension of the mesh, if the cube has any
         :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
-        or None if it has none.
+        or ``None`` if it has none.
 
         Returns:
-        * mesh_dim (int, or None)
+
+        * mesh_dim (int, or None):
             the cube dimension which the cube
             :class:`~iris.experimental.ugrid.MeshCoord`\\s map to,
-            or None.
+            or ``None``.
 
         """
         result = self._a_meshcoord()

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1134,24 +1134,43 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def _add_unique_aux_coord(self, coord, data_dims):
         data_dims = self._check_multi_dim_metadata(coord, data_dims)
         if hasattr(coord, "mesh"):
-            existing_meshcoords = self.coords(mesh_coords=True)
-            if len(existing_meshcoords) > 0:
-                co = existing_meshcoords[0]
-                mesh, location = co.mesh, co.location
-                if coord.location != location:
-                    msg = (
-                        f"Location of Meshcoord {coord!r} is "
-                        f"{coord.location!s}, which does not match existing"
-                        f"cube location of {location!s}."
-                    )
-                    raise ValueError(msg)
+            mesh = self.mesh()
+            if mesh:
+                msg = (
+                    "{item} of Meshcoord {coord!r} is "
+                    "{thisval!r}, which does not match existing "
+                    "cube {item} of {ownval!r}."
+                )
                 if coord.mesh != mesh:
-                    msg = (
-                        f"Mesh of Meshcoord {coord!r} is "
-                        f"{coord.mesh!r}, which does not match existing"
-                        f"cube mesh of {mesh!r}."
+                    raise ValueError(
+                        msg.format(
+                            item="mesh",
+                            coord=coord,
+                            thisval=coord.mesh,
+                            ownval=mesh,
+                        )
                     )
-                    raise ValueError(msg)
+                location = self.location()
+                if coord.location != location:
+                    raise ValueError(
+                        msg.format(
+                            item="location",
+                            coord=coord,
+                            thisval=coord.location,
+                            ownval=location,
+                        )
+                    )
+                mesh_dims = (self.mesh_dim(),)
+                if data_dims != mesh_dims:
+                    raise ValueError(
+                        msg.format(
+                            item="mesh dimension",
+                            coord=coord,
+                            thisval=data_dims,
+                            ownval=mesh_dims,
+                        )
+                    )
+
         self._aux_coords_and_dims.append((coord, data_dims))
 
     def add_aux_factory(self, aux_factory):
@@ -1938,30 +1957,68 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
         return result
 
+    def _a_meshcoord(self):
+        mesh_coords = self.coords(mesh_coords=True)
+        if mesh_coords:
+            result = mesh_coords[0]
+        else:
+            result = None
+        return result
+
     def mesh(self):
         """
         Return the unstructured :class:`~iris.experimental.ugrid.Mesh`
-        associated with the cube, or None if there is none.
+        associated with the cube, if the cube has any
+        :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
+        or None if it has none.
+
+        Returns:
+        * mesh (:class:`iris.experimental.ugrid.Mesh` or None)
+            The mesh of the cube
+            :class:`~iris.experimental.ugrid.MeshCoord`\\s,
+            or None.
 
         """
-        result = self.coords(mesh_coords=True)
-        if len(result) == 0:
-            result = None
-        else:
-            result = result[0].mesh
+        result = self._a_meshcoord()
+        if result is not None:
+            result = result.mesh
         return result
 
     def location(self):
         """
-        Return the mesh location of the cube, if the cube has an unstructured
-        :class:`~iris.experimental.ugrid.Mesh`, or None if there is none.
+        Return the "location" of the cube mesh, if the cube has any
+        :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
+        or None if it has none.
+
+        Returns:
+        * location (str or None)
+            The mesh location of the cube
+            :class:`~iris.experimental.ugrid.MeshCoord`\\s,
+            one of 'face' / 'edge' / 'node',
+            or None.
 
         """
-        result = self.coords(mesh_coords=True)
-        if len(result) == 0:
-            result = None
-        else:
-            result = result[0].location
+        result = self._a_meshcoord()
+        if result is not None:
+            result = result.location
+        return result
+
+    def mesh_dim(self):
+        """
+        Return the cube dimension of the mesh, if the cube has any
+        :class:`~iris.experimental.ugrid.MeshCoord`\\ s,
+        or None if it has none.
+
+        Returns:
+        * mesh_dim (int, or None)
+            the cube dimension which the cube
+            :class:`~iris.experimental.ugrid.MeshCoord`\\s map to,
+            or None.
+
+        """
+        result = self._a_meshcoord()
+        if result is not None:
+            (result,) = self.coord_dims(result)  # result is a 1-tuple
         return result
 
     def cell_measures(self, name_or_cell_measure=None):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1133,6 +1133,25 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
     def _add_unique_aux_coord(self, coord, data_dims):
         data_dims = self._check_multi_dim_metadata(coord, data_dims)
+        if hasattr(coord, "mesh"):
+            existing_meshcoords = self.coords(mesh_coords=True)
+            if len(existing_meshcoords) > 0:
+                co = existing_meshcoords[0]
+                mesh, location = co.mesh, co.location
+                if coord.location != location:
+                    msg = (
+                        f"Location of Meshcoord {coord!r} is "
+                        f"{coord.location!s}, which does not match existing"
+                        f"cube location of {location!s}."
+                    )
+                    raise ValueError(msg)
+                if coord.mesh != mesh:
+                    msg = (
+                        f"Mesh of Meshcoord {coord!r} is "
+                        f"{coord.mesh!r}, which does not match existing"
+                        f"cube mesh of {mesh!r}."
+                    )
+                    raise ValueError(msg)
         self._aux_coords_and_dims.append((coord, data_dims))
 
     def add_aux_factory(self, aux_factory):

--- a/lib/iris/tests/stock/mesh.py
+++ b/lib/iris/tests/stock/mesh.py
@@ -1,0 +1,159 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Helper functions making objects for unstructured mesh testing."""
+
+
+import numpy as np
+
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+from iris.experimental.ugrid import Connectivity, Mesh, MeshCoord
+
+# Default creation controls for creating a test Mesh.
+# Note: we're not creating any kind of sensible 'normal' mesh here, the numbers
+# of nodes/faces/edges are quite arbitrary and the connectivities we generate
+# are pretty random too.
+_TEST_N_NODES = 15
+_TEST_N_FACES = 3
+_TEST_N_EDGES = 5
+_TEST_N_BOUNDS = 4
+
+
+def sample_mesh(n_nodes=None, n_faces=None, n_edges=None):
+    """
+    Make a test mesh.
+
+    Mesh has faces edges, face-coords and edge-coords, numbers of which can be controlled.
+
+    """
+    if n_nodes is None:
+        n_nodes = _TEST_N_NODES
+    if n_faces is None:
+        n_faces = _TEST_N_FACES
+    if n_edges is None:
+        n_edges = _TEST_N_EDGES
+    node_x = AuxCoord(
+        1100 + np.arange(n_nodes),
+        standard_name="longitude",
+        units="degrees_east",
+        long_name="long-name",
+        var_name="var-name",
+        attributes={"a": 1, "b": "c"},
+    )
+    node_y = AuxCoord(1200 + np.arange(n_nodes), standard_name="latitude")
+
+    # Define a rather arbitrary edge-nodes connectivity.
+    # Some nodes are left out, because n_edges*2 < n_nodes.
+    conns = np.arange(n_edges * 2, dtype=int)
+    # Missing nodes include #0-5, because we add 5.
+    conns = ((conns + 5) % n_nodes).reshape((n_edges, 2))
+    edge_nodes = Connectivity(conns, cf_role="edge_node_connectivity")
+    conns = np.arange(n_edges * 2, dtype=int)
+
+    # Some numbers for the edge coordinates.
+    edge_x = AuxCoord(2100 + np.arange(n_edges), standard_name="longitude")
+    edge_y = AuxCoord(2200 + np.arange(n_edges), standard_name="latitude")
+
+    # Define a rather arbitrary face-nodes connectivity.
+    # Some nodes are left out, because n_faces*n_bounds < n_nodes.
+    conns = np.arange(n_faces * _TEST_N_BOUNDS, dtype=int)
+    conns = (conns % n_nodes).reshape((n_faces, _TEST_N_BOUNDS))
+    face_nodes = Connectivity(conns, cf_role="face_node_connectivity")
+
+    # Some numbers for the edge coordinates.
+    face_x = AuxCoord(3100 + np.arange(n_faces), standard_name="longitude")
+    face_y = AuxCoord(3200 + np.arange(n_faces), standard_name="latitude")
+
+    mesh = Mesh(
+        topology_dimension=2,
+        node_coords_and_axes=[(node_x, "x"), (node_y, "y")],
+        connectivities=[face_nodes, edge_nodes],
+        edge_coords_and_axes=[(edge_x, "x"), (edge_y, "y")],
+        face_coords_and_axes=[(face_x, "x"), (face_y, "y")],
+    )
+    return mesh
+
+
+def sample_meshcoord(mesh=None, location="face", axis="x", **extra_kwargs):
+    """
+    Create a test MeshCoord.
+
+    The creation args are defaulted, including the mesh.
+    If not provided as an arg, a new mesh is created with sample_mesh().
+
+    """
+    if mesh is None:
+        mesh = sample_mesh()
+    result = MeshCoord(mesh=mesh, location=location, axis=axis, **extra_kwargs)
+    return result
+
+
+def sample_mesh_cube(
+    nomesh=False, n_z=2, with_parts=False, **meshcoord_kwargs
+):
+    """
+    Create a 2d test cube with 1 'normal' and 1 unstructured dimension (with a Mesh).
+
+    Result contains : dimcoords for both dims; an auxcoord on the unstructured dim; 2 mesh-coords.
+    By default, the mesh is provided by :func:`sample_mesh`, so coordinates and connectivity  are not realistic.
+
+    Kwargs:
+    * nomesh(bool):
+        If set, don't add MeshCoords, so dim 1 is just a plain anonymous dim.
+    * n_z (int):
+        Length of the 'normal' dim.  If 0, it is *omitted*.
+    * with_parts (bool):
+        If set, return all the constituent component coords
+    * meshcoord_kwargs (dict):
+        Extra controls passed to :func:`sample_meshcoord` for MeshCoord creation, to allow user-specified
+        location/mesh.  The 'axis' key is not available, as we always add both an 'x' and 'y' MeshCOord.
+
+    Returns:
+    * cube  :  if with_parts not set
+    * (cube, parts)  : if with_parts is set
+        'parts' is (mesh, dim0-dimcoord, dim1-dimcoord, dim1-auxcoord, x-meshcoord [or None], y-meshcoord [or None]).
+
+    """
+    if nomesh:
+        mesh = None
+        n_faces = 5
+    else:
+        mesh = meshcoord_kwargs.pop("mesh", None)
+        if mesh is None:
+            mesh = sample_mesh()
+        meshx, meshy = (
+            sample_meshcoord(axis=axis, mesh=mesh, **meshcoord_kwargs)
+            for axis in ("x", "y")
+        )
+        n_faces = meshx.shape[0]
+
+    mesh_dimco = DimCoord(
+        np.arange(n_faces), long_name="i_mesh_face", units="1"
+    )
+
+    auxco_x = AuxCoord(np.zeros(n_faces), long_name="mesh_face_aux", units="1")
+
+    zco = DimCoord(np.arange(n_z), long_name="level", units=1)
+    cube = Cube(np.zeros((n_z, n_faces)), long_name="mesh_phenom")
+    cube.add_dim_coord(zco, 0)
+    if nomesh:
+        mesh_coords = []
+    else:
+        mesh_coords = [meshx, meshy]
+
+    cube.add_dim_coord(mesh_dimco, 1)
+    for co in mesh_coords + [auxco_x]:
+        cube.add_aux_coord(co, 1)
+
+    if not with_parts:
+        result = cube
+    else:
+        if nomesh:
+            meshx, meshy = None, None
+        parts = (mesh, zco, mesh_dimco, auxco_x, meshx, meshy)
+        result = (cube, parts)
+
+    return result

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2051,13 +2051,13 @@ class Test_mesh(tests.IrisTest):
         _add_test_meshcube(self)
 
     def test_mesh(self):
-        result = self.cube.mesh()
+        result = self.cube.mesh
         self.assertIs(result, self.mesh)
 
     def test_no_mesh(self):
         # Replace standard setUp cube with a no-mesh version.
         _add_test_meshcube(self, nomesh=True)
-        result = self.cube.mesh()
+        result = self.cube.mesh
         self.assertIsNone(result)
 
 
@@ -2069,19 +2069,19 @@ class Test_location(tests.IrisTest):
     def test_no_mesh(self):
         # Replace standard setUp cube with a no-mesh version.
         _add_test_meshcube(self, nomesh=True)
-        result = self.cube.location()
+        result = self.cube.location
         self.assertIsNone(result)
 
     def test_mesh(self):
         cube = self.cube
-        result = cube.location()
+        result = cube.location
         self.assertEqual(result, self.meshco_x.location)
 
     def test_alternate_location(self):
         # Replace standard setUp cube with an edge-based version.
         _add_test_meshcube(self, location="edge")
         cube = self.cube
-        result = cube.location()
+        result = cube.location
         self.assertEqual(result, "edge")
 
 
@@ -2138,7 +2138,7 @@ class Test__init__mesh(tests.IrisTest):
             dim_coords_and_dims=[(dimco_z, 0), (dimco_mesh, 1)],
             aux_coords_and_dims=[(meshco, 1)],
         )
-        self.assertEqual(cube.mesh(), meshco.mesh)
+        self.assertEqual(cube.mesh, meshco.mesh)
 
     def test_fail_dim_meshcoord(self):
         # As "test_mesh", but attempt to use the meshcoord as a dim-coord.
@@ -2160,7 +2160,7 @@ class Test__init__mesh(tests.IrisTest):
             np.zeros(n_faces),
             aux_coords_and_dims=[(meshco_x, 0), (meshco_y, 0)],
         )
-        self.assertEqual(cube.mesh(), meshco_x.mesh)
+        self.assertEqual(cube.mesh, meshco_x.mesh)
 
     def test_multi_meshcoords_same_axis(self):
         # *Not* an error, as long as the coords are distinguishable.
@@ -2175,7 +2175,7 @@ class Test__init__mesh(tests.IrisTest):
             np.zeros(n_faces),
             aux_coords_and_dims=[(meshco_1, 0), (meshco_2, 0)],
         )
-        self.assertEqual(cube.mesh(), meshco_1.mesh)
+        self.assertEqual(cube.mesh, meshco_1.mesh)
 
     def test_fail_meshcoords_different_locations(self):
         # Same as successful 'multi_mesh', but different locations.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1960,7 +1960,7 @@ class Test_copy(tests.IrisTest):
         self._check_copy(cube, cube.copy())
 
 
-def _add_test_meshcube(self, nomesh=False, location="face"):
+def _add_test_meshcube(self, nomesh=False, **meshcoord_kwargs):
     # A common setup action : Create a standard test cube with a variety of
     # types of coord, and add various objects to the testcase,
     # i.e. to "self".
@@ -1968,9 +1968,11 @@ def _add_test_meshcube(self, nomesh=False, location="face"):
         mesh = None
         n_faces = 5
     else:
-        mesh = create_test_mesh()
+        mesh = meshcoord_kwargs.pop("mesh", None)
+        if mesh is None:
+            mesh = create_test_mesh()
         meshx, meshy = (
-            create_test_meshcoord(axis=axis, mesh=mesh, location=location)
+            create_test_meshcoord(axis=axis, mesh=mesh, **meshcoord_kwargs)
             for axis in ("x", "y")
         )
         n_faces = meshx.shape[0]
@@ -2106,6 +2108,39 @@ class Test_location(tests.IrisTest):
         cube = self.cube
         result = cube.location()
         self.assertEqual(result, "edge")
+
+
+class Test__eq__mesh(tests.IrisTest):
+    """
+    Check that cubes with meshes support == as expected.
+
+    Note: there is no special code for this in iris.cube.Cube : it is
+    provided by the coord comparisons.
+
+    """
+
+    def setUp(self):
+        # Create a 'standard' test cube.
+        _add_test_meshcube(self)
+
+    def test_copied_cube_match(self):
+        cube = self.cube
+        cube2 = cube.copy()
+        self.assertEqual(cube, cube2)
+
+    def test_same_mesh_match(self):
+        cube1 = self.cube
+        # re-create an identical cube, using the same mesh.
+        _add_test_meshcube(self, mesh=self.mesh)
+        cube2 = self.cube
+        self.assertEqual(cube1, cube2)
+
+    def test_new_mesh_different(self):
+        cube1 = self.cube
+        # re-create an identical cube, using the same mesh.
+        _add_test_meshcube(self)
+        cube2 = self.cube
+        self.assertNotEqual(cube1, cube2)
 
 
 class Test_dtype(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -38,48 +38,44 @@ _TEST_BOUNDS = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS)
 _TEST_BOUNDS = _TEST_BOUNDS.reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
 
 
-def _create_test_mesh():
+def _create_test_mesh(n_nodes=None, n_faces=None, n_edges=None):
+    if n_nodes is None:
+        n_nodes = _TEST_N_NODES
+    if n_faces is None:
+        n_faces = _TEST_N_FACES
+    if n_edges is None:
+        n_edges = _TEST_N_EDGES
     node_x = AuxCoord(
-        1100 + np.arange(_TEST_N_NODES),
+        1100 + np.arange(n_nodes),
         standard_name="longitude",
         units="degrees_east",
         long_name="long-name",
         var_name="var-name",
         attributes={"a": 1, "b": "c"},
     )
-    node_y = AuxCoord(
-        1200 + np.arange(_TEST_N_NODES), standard_name="latitude"
-    )
+    node_y = AuxCoord(1200 + np.arange(n_nodes), standard_name="latitude")
 
     # Define a rather arbitrary edge-nodes connectivity.
     # Some nodes are left out, because n_edges*2 < n_nodes.
-    conns = np.arange(_TEST_N_EDGES * 2, dtype=int)
+    conns = np.arange(n_edges * 2, dtype=int)
     # Missing nodes include #0-5, because we add 5.
-    conns = ((conns + 5) % _TEST_N_NODES).reshape((_TEST_N_EDGES, 2))
+    conns = ((conns + 5) % n_nodes).reshape((n_edges, 2))
     edge_nodes = Connectivity(conns, cf_role="edge_node_connectivity")
-    conns = np.arange(_TEST_N_EDGES * 2, dtype=int)
+    conns = np.arange(n_edges * 2, dtype=int)
 
     # Some numbers for the edge coordinates.
-    edge_x = AuxCoord(
-        2100 + np.arange(_TEST_N_EDGES), standard_name="longitude"
-    )
-    edge_y = AuxCoord(
-        2200 + np.arange(_TEST_N_EDGES), standard_name="latitude"
-    )
+    edge_x = AuxCoord(2100 + np.arange(n_edges), standard_name="longitude")
+    edge_y = AuxCoord(2200 + np.arange(n_edges), standard_name="latitude")
 
     # Define a rather arbitrary face-nodes connectivity.
     # Some nodes are left out, because n_faces*n_bounds < n_nodes.
-    conns = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS, dtype=int)
-    conns = (conns % _TEST_N_NODES).reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
+    conns = np.arange(n_faces * _TEST_N_BOUNDS, dtype=int)
+    conns = (conns % n_nodes).reshape((n_faces, _TEST_N_BOUNDS))
     face_nodes = Connectivity(conns, cf_role="face_node_connectivity")
 
     # Some numbers for the edge coordinates.
-    face_x = AuxCoord(
-        3100 + np.arange(_TEST_N_FACES), standard_name="longitude"
-    )
-    face_y = AuxCoord(
-        3200 + np.arange(_TEST_N_FACES), standard_name="latitude"
-    )
+    face_x = AuxCoord(3100 + np.arange(n_faces), standard_name="longitude")
+    face_y = AuxCoord(3200 + np.arange(n_faces), standard_name="latitude")
 
     mesh = Mesh(
         topology_dimension=2,

--- a/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_MeshCoord.py
@@ -20,99 +20,23 @@ from iris.common.metadata import BaseMetadata
 from iris.cube import Cube
 from iris.experimental.ugrid import Connectivity, Mesh
 from iris._lazy_data import is_lazy_data
+import iris.tests.stock.mesh
+from iris.tests.stock.mesh import sample_mesh, sample_meshcoord
 
 from iris.experimental.ugrid import MeshCoord
-
-# Default creation controls for creating a test Mesh.
-# Note: we're not creating any kind of sensible 'normal' mesh here, the numbers
-# of nodes/faces/edges are quite arbitrary and the connectivities we generate
-# are pretty random too.
-_TEST_N_NODES = 15
-_TEST_N_FACES = 3
-_TEST_N_EDGES = 5
-_TEST_N_BOUNDS = 4
-
-# Default actual points + bounds.
-_TEST_POINTS = np.arange(_TEST_N_FACES)
-_TEST_BOUNDS = np.arange(_TEST_N_FACES * _TEST_N_BOUNDS)
-_TEST_BOUNDS = _TEST_BOUNDS.reshape((_TEST_N_FACES, _TEST_N_BOUNDS))
-
-
-def _create_test_mesh(n_nodes=None, n_faces=None, n_edges=None):
-    if n_nodes is None:
-        n_nodes = _TEST_N_NODES
-    if n_faces is None:
-        n_faces = _TEST_N_FACES
-    if n_edges is None:
-        n_edges = _TEST_N_EDGES
-    node_x = AuxCoord(
-        1100 + np.arange(n_nodes),
-        standard_name="longitude",
-        units="degrees_east",
-        long_name="long-name",
-        var_name="var-name",
-        attributes={"a": 1, "b": "c"},
-    )
-    node_y = AuxCoord(1200 + np.arange(n_nodes), standard_name="latitude")
-
-    # Define a rather arbitrary edge-nodes connectivity.
-    # Some nodes are left out, because n_edges*2 < n_nodes.
-    conns = np.arange(n_edges * 2, dtype=int)
-    # Missing nodes include #0-5, because we add 5.
-    conns = ((conns + 5) % n_nodes).reshape((n_edges, 2))
-    edge_nodes = Connectivity(conns, cf_role="edge_node_connectivity")
-    conns = np.arange(n_edges * 2, dtype=int)
-
-    # Some numbers for the edge coordinates.
-    edge_x = AuxCoord(2100 + np.arange(n_edges), standard_name="longitude")
-    edge_y = AuxCoord(2200 + np.arange(n_edges), standard_name="latitude")
-
-    # Define a rather arbitrary face-nodes connectivity.
-    # Some nodes are left out, because n_faces*n_bounds < n_nodes.
-    conns = np.arange(n_faces * _TEST_N_BOUNDS, dtype=int)
-    conns = (conns % n_nodes).reshape((n_faces, _TEST_N_BOUNDS))
-    face_nodes = Connectivity(conns, cf_role="face_node_connectivity")
-
-    # Some numbers for the edge coordinates.
-    face_x = AuxCoord(3100 + np.arange(n_faces), standard_name="longitude")
-    face_y = AuxCoord(3200 + np.arange(n_faces), standard_name="latitude")
-
-    mesh = Mesh(
-        topology_dimension=2,
-        node_coords_and_axes=[(node_x, "x"), (node_y, "y")],
-        connectivities=[face_nodes, edge_nodes],
-        edge_coords_and_axes=[(edge_x, "x"), (edge_y, "y")],
-        face_coords_and_axes=[(face_x, "x"), (face_y, "y")],
-    )
-    return mesh
-
-
-def _default_create_args():
-    # Produce a minimal set of default constructor args
-    kwargs = {"location": "face", "axis": "x", "mesh": _create_test_mesh()}
-    # NOTE: *don't* include coord_system or climatology.
-    # We expect to only set those (non-default) explicitly.
-    return kwargs
-
-
-def _create_test_meshcoord(**override_kwargs):
-    kwargs = _default_create_args()
-    # Apply requested overrides and additions.
-    kwargs.update(override_kwargs)
-    # Create and return the test coord.
-    result = MeshCoord(**kwargs)
-    return result
 
 
 class Test___init__(tests.IrisTest):
     def setUp(self):
-        self.meshcoord = _create_test_meshcoord()
+        mesh = sample_mesh()
+        self.mesh = mesh
+        self.meshcoord = sample_meshcoord(mesh=mesh)
 
     def test_basic(self):
-        kwargs = _default_create_args()
-        meshcoord = _create_test_meshcoord(**kwargs)
-        for key, val in kwargs.items():
-            self.assertEqual(getattr(meshcoord, key), val)
+        meshcoord = self.meshcoord
+        self.assertEqual(meshcoord.mesh, self.mesh)
+        self.assertEqual(meshcoord.location, "face")
+        self.assertEqual(meshcoord.axis, "x")
         self.assertIsInstance(meshcoord, MeshCoord)
         self.assertIsInstance(meshcoord, Coord)
 
@@ -120,7 +44,7 @@ class Test___init__(tests.IrisTest):
         # Check the derived properties of the meshcoord against the correct
         # underlying mesh coordinate.
         for axis in Mesh.AXES:
-            meshcoord = _create_test_meshcoord(axis=axis)
+            meshcoord = sample_meshcoord(axis=axis)
             # N.B.
             node_x_coord = meshcoord.mesh.coord(include_nodes=True, axis=axis)
             for key in node_x_coord.metadata._fields:
@@ -134,25 +58,25 @@ class Test___init__(tests.IrisTest):
 
     def test_fail_bad_mesh(self):
         with self.assertRaisesRegex(TypeError, "must be a.*Mesh"):
-            _create_test_meshcoord(mesh=mock.sentinel.odd)
+            sample_meshcoord(mesh=mock.sentinel.odd)
 
     def test_valid_locations(self):
         for loc in Mesh.LOCATIONS:
-            meshcoord = _create_test_meshcoord(location=loc)
+            meshcoord = sample_meshcoord(location=loc)
             self.assertEqual(meshcoord.location, loc)
 
     def test_fail_bad_location(self):
         with self.assertRaisesRegex(ValueError, "not a valid Mesh location"):
-            _create_test_meshcoord(location="bad")
+            sample_meshcoord(location="bad")
 
     def test_fail_bad_axis(self):
         with self.assertRaisesRegex(ValueError, "not a valid Mesh axis"):
-            _create_test_meshcoord(axis="q")
+            sample_meshcoord(axis="q")
 
 
 class Test__readonly_properties(tests.IrisTest):
     def setUp(self):
-        self.meshcoord = _create_test_meshcoord()
+        self.meshcoord = sample_meshcoord()
 
     def test_fixed_metadata(self):
         # Check that you cannot set any of these on an existing MeshCoord.
@@ -188,7 +112,7 @@ class Test__inherited_properties(tests.IrisTest):
     """
 
     def setUp(self):
-        self.meshcoord = _create_test_meshcoord()
+        self.meshcoord = sample_meshcoord()
 
     def test_inherited_properties(self):
         # Check that these are settable, and affect equality.
@@ -211,14 +135,15 @@ class Test__points_and_bounds(tests.IrisTest):
     # Basic method testing only, for 3 locations with simple array values.
     # See Test_MeshCoord__dataviews for more detailed checks.
     def test_node(self):
-        meshcoord = _create_test_meshcoord(location="node")
+        meshcoord = sample_meshcoord(location="node")
+        n_nodes = (
+            iris.tests.stock.mesh._TEST_N_NODES
+        )  # n-nodes default for sample mesh
         self.assertIsNone(meshcoord.core_bounds())
-        self.assertArrayAllClose(
-            meshcoord.points, 1100 + np.arange(_TEST_N_NODES)
-        )
+        self.assertArrayAllClose(meshcoord.points, 1100 + np.arange(n_nodes))
 
     def test_edge(self):
-        meshcoord = _create_test_meshcoord(location="edge")
+        meshcoord = sample_meshcoord(location="edge")
         points, bounds = meshcoord.core_points(), meshcoord.core_bounds()
         self.assertEqual(points.shape, meshcoord.shape)
         self.assertEqual(bounds.shape, meshcoord.shape + (2,))
@@ -237,7 +162,7 @@ class Test__points_and_bounds(tests.IrisTest):
         )
 
     def test_face(self):
-        meshcoord = _create_test_meshcoord(location="face")
+        meshcoord = sample_meshcoord(location="face")
         points, bounds = meshcoord.core_points(), meshcoord.core_bounds()
         self.assertEqual(points.shape, meshcoord.shape)
         self.assertEqual(bounds.shape, meshcoord.shape + (4,))
@@ -254,10 +179,10 @@ class Test__points_and_bounds(tests.IrisTest):
 
 class Test___eq__(tests.IrisTest):
     def setUp(self):
-        self.mesh = _create_test_mesh()
+        self.mesh = sample_mesh()
 
     def _create_common_mesh(self, **kwargs):
-        return _create_test_meshcoord(mesh=self.mesh, **kwargs)
+        return sample_meshcoord(mesh=self.mesh, **kwargs)
 
     def test_same_mesh(self):
         meshcoord1 = self._create_common_mesh()
@@ -266,10 +191,10 @@ class Test___eq__(tests.IrisTest):
 
     def test_different_identical_mesh(self):
         # For equality, must have the SAME mesh (at present).
-        mesh1 = _create_test_mesh()
-        mesh2 = _create_test_mesh()  # Presumably identical, but not the same
-        meshcoord1 = _create_test_meshcoord(mesh=mesh1)
-        meshcoord2 = _create_test_meshcoord(mesh=mesh2)
+        mesh1 = sample_mesh()
+        mesh2 = sample_mesh()  # Presumably identical, but not the same
+        meshcoord1 = sample_meshcoord(mesh=mesh1)
+        meshcoord2 = sample_meshcoord(mesh=mesh2)
         # These should NOT compare, because the Meshes are not identical : at
         # present, Mesh equality is not implemented (i.e. limited to identity)
         self.assertNotEqual(meshcoord2, meshcoord1)
@@ -287,7 +212,7 @@ class Test___eq__(tests.IrisTest):
 
 class Test__copy(tests.IrisTest):
     def test_basic(self):
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         meshcoord2 = meshcoord.copy()
         self.assertIsNot(meshcoord2, meshcoord)
         self.assertEqual(meshcoord2, meshcoord)
@@ -295,12 +220,12 @@ class Test__copy(tests.IrisTest):
         self.assertIs(meshcoord2.mesh, meshcoord.mesh)
 
     def test_fail_copy_newpoints(self):
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         with self.assertRaisesRegex(ValueError, "Cannot change the content"):
             meshcoord.copy(points=meshcoord.points)
 
     def test_fail_copy_newbounds(self):
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         with self.assertRaisesRegex(ValueError, "Cannot change the content"):
             meshcoord.copy(bounds=meshcoord.bounds)
 
@@ -308,7 +233,7 @@ class Test__copy(tests.IrisTest):
 class Test__getitem__(tests.IrisTest):
     def test_slice_wholeslice_1tuple(self):
         # The only slicing case that we support, to enable cube slicing.
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         meshcoord2 = meshcoord[
             :,
         ]
@@ -319,23 +244,23 @@ class Test__getitem__(tests.IrisTest):
 
     def test_slice_whole_slice_singlekey(self):
         # A slice(None) also fails, if not presented in a 1-tuple.
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         with self.assertRaisesRegex(ValueError, "Cannot index"):
             meshcoord[:]
 
     def test_fail_slice_part(self):
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         with self.assertRaisesRegex(ValueError, "Cannot index"):
             meshcoord[:1]
 
 
 class Test__str_repr(tests.IrisTest):
     def setUp(self):
-        mesh = _create_test_mesh()
+        mesh = sample_mesh()
         self.mesh = mesh
         # Give mesh itself a name: makes a difference between str and repr.
         self.mesh.rename("test_mesh")
-        self.meshcoord = _create_test_meshcoord(mesh=mesh)
+        self.meshcoord = sample_meshcoord(mesh=mesh)
 
     def _expected_elements_regexp(
         self,
@@ -371,9 +296,7 @@ class Test__str_repr(tests.IrisTest):
         self.assertRegex(result, re_expected)
 
     def test_alternative_location_and_axis(self):
-        meshcoord = _create_test_meshcoord(
-            mesh=self.mesh, location="edge", axis="y"
-        )
+        meshcoord = sample_meshcoord(mesh=self.mesh, location="edge", axis="y")
         result = str(meshcoord)
         re_expected = r", location='edge', axis='y'"
         self.assertRegex(result, re_expected)
@@ -384,7 +307,7 @@ class Test__str_repr(tests.IrisTest):
         node_coord = mesh.coord(include_nodes=True, axis="x")
         node_coord.long_name = None
         # Make a new meshcoord, based on the modified mesh.
-        meshcoord = _create_test_meshcoord(mesh=self.mesh)
+        meshcoord = sample_meshcoord(mesh=self.mesh)
         result = str(meshcoord)
         re_expected = self._expected_elements_regexp(long_name=False)
         self.assertRegex(result, re_expected)
@@ -396,7 +319,7 @@ class Test__str_repr(tests.IrisTest):
         node_coord.standard_name = None
         node_coord.axis = "x"  # This is required : but it's a kludge !!
         # Make a new meshcoord, based on the modified mesh.
-        meshcoord = _create_test_meshcoord(mesh=self.mesh)
+        meshcoord = sample_meshcoord(mesh=self.mesh)
         result = str(meshcoord)
         re_expected = self._expected_elements_regexp(standard_name=False)
         self.assertRegex(result, re_expected)
@@ -407,7 +330,7 @@ class Test__str_repr(tests.IrisTest):
         node_coord = mesh.coord(include_nodes=True, axis="x")
         node_coord.attributes = None
         # Make a new meshcoord, based on the modified mesh.
-        meshcoord = _create_test_meshcoord(mesh=self.mesh)
+        meshcoord = sample_meshcoord(mesh=self.mesh)
         result = str(meshcoord)
         re_expected = self._expected_elements_regexp(attributes=False)
         self.assertRegex(result, re_expected)
@@ -418,7 +341,7 @@ class Test__str_repr(tests.IrisTest):
         node_coord = mesh.coord(include_nodes=True, axis="x")
         node_coord.attributes.clear()
         # Make a new meshcoord, based on the modified mesh.
-        meshcoord = _create_test_meshcoord(mesh=self.mesh)
+        meshcoord = sample_meshcoord(mesh=self.mesh)
         result = str(meshcoord)
         re_expected = self._expected_elements_regexp(attributes=False)
         self.assertRegex(result, re_expected)
@@ -428,8 +351,8 @@ class Test_cube_containment(tests.IrisTest):
     # Check that we can put a MeshCoord into a cube, and have it behave just
     # like a regular AuxCoord.
     def setUp(self):
-        meshcoord = _create_test_meshcoord()
-        data_shape = (2,) + _TEST_POINTS.shape
+        meshcoord = sample_meshcoord()
+        data_shape = (2,) + meshcoord.shape
         cube = Cube(np.zeros(data_shape))
         cube.add_aux_coord(meshcoord, 1)
         self.meshcoord = meshcoord
@@ -509,7 +432,7 @@ class Test_cube_containment(tests.IrisTest):
 
 class Test_auxcoord_conversion(tests.IrisTest):
     def test_basic(self):
-        meshcoord = _create_test_meshcoord()
+        meshcoord = sample_meshcoord()
         auxcoord = AuxCoord.from_coord(meshcoord)
         for propname, auxval in auxcoord.metadata._asdict().items():
             meshval = getattr(meshcoord, propname)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Adding additonal mesh-specific Cube support:
 * add `cube.mesh()` and `cube.location()` access methods
 * make `cube.__eq__` compare mesh + location
 * adjust all cube creation + coord management to ensure any/all MeshCoords are always inter-compatible

Reference #4063.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
