### PR TITLE
Allow comparison between Cell and numpy array or list of len = 1.

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -60,6 +60,9 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
+#. `@gcaria`_ fixed :class:`~iris.coords.Cell` comparison with
+   0-dimensional arrays and 1-dimensional arrays with len=1. (:pull:`4083`)
+
 #. `@gcaria`_ fixed :meth:`~iris.cube.Cube.cell_measure_dims` to also accept the
    string name of a :class:`~iris.coords.CellMeasure`. (:pull:`3931`)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -809,7 +809,6 @@ class CellMeasure(AncillaryVariable):
         attributes=None,
         measure=None,
     ):
-
         """
         Constructs a single cell measure.
 
@@ -1151,6 +1150,13 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         Non-Cell vs Cell comparison is used to define Constraint matching.
 
         """
+
+        if (isinstance(other, list) and len(other) == 1) or (
+            isinstance(other, np.ndarray) and other.shape == (1,)
+        ):
+            other = other[0]
+        if isinstance(other, np.ndarray) and other.shape == ():
+            other = float(other)
         if not (
             isinstance(other, (int, float, np.number, Cell))
             or hasattr(other, "timetuple")
@@ -1315,7 +1321,6 @@ class Coord(_DimensionalMetadata):
         coord_system=None,
         climatological=False,
     ):
-
         """
         Coordinate abstract base class. As of ``v3.0.0`` you **cannot** create an instance of :class:`Coord`.
 

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -92,6 +92,16 @@ class Test___common_cmp__(tests.IrisTest):
         self.assertLess(cell, dt)
         self.assertLessEqual(cell, dt)
 
+    def test_0D_numpy_array(self):
+        # Check that cell comparison works with 0D numpy arrays
+
+        cell = Cell(1.3)
+
+        self.assertGreater(np.array(1.5), cell)
+        self.assertLess(np.array(1.1), cell)
+        self.assertGreaterEqual(np.array(1.3), cell)
+        self.assertLessEqual(np.array(1.3), cell)
+
 
 class Test___eq__(tests.IrisTest):
     def test_datetimelike(self):

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -112,6 +112,7 @@ class Test___common_cmp__(tests.IrisTest):
         self.assertGreaterEqual(np.array([1.3]), cell)
         self.assertLessEqual(np.array([1.3]), cell)
 
+
 class Test___eq__(tests.IrisTest):
     def test_datetimelike(self):
         # Check that cell equality works with objects with a "timetuple".

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -102,6 +102,15 @@ class Test___common_cmp__(tests.IrisTest):
         self.assertGreaterEqual(np.array(1.3), cell)
         self.assertLessEqual(np.array(1.3), cell)
 
+    def test_len_1_numpy_array(self):
+        # Check that cell comparison works with numpy arrays of len=1
+
+        cell = Cell(1.3)
+
+        self.assertGreater(np.array([1.5]), cell)
+        self.assertLess(np.array([1.1]), cell)
+        self.assertGreaterEqual(np.array([1.3]), cell)
+        self.assertLessEqual(np.array([1.3]), cell)
 
 class Test___eq__(tests.IrisTest):
     def test_datetimelike(self):


### PR DESCRIPTION
Fixes #2914.

A simple fix to allow numpy arrays (or lists) with only one element to be compared to a Cell.