### PR TITLE
Add a method to return a CubeList from CubeList.copy()

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -173,6 +173,7 @@ This document explains the changes made to Iris for this release
     core dev names are automatically included by the common_links.inc:
 
 .. _@akuhnregnier: https://github.com/akuhnregnier
+.. _@Badboy-16: https://github.com/Badboy-16
 .. _@gcaria: https://github.com/gcaria
 .. _@MHBalsmeier: https://github.com/MHBalsmeier
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -52,6 +52,9 @@ This document explains the changes made to Iris for this release
    printing these objects skips metadata elements that are set to None or an
    empty string or dictionary. (:pull:`4040`)
 
+#. `@Badboy-16`_ implemented a ``CubeList.copy()`` method to return a
+   ``CubeList`` object instead of a ``list``. (:pull:`4094`)
+
 
 🐛 Bugs Fixed
 =============

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -707,6 +707,13 @@ class CubeList(list):
         """
         _lazy.co_realise_cubes(*self)
 
+    def copy(self):
+        """
+        Return a CubeList when CubeList.copy() is called.
+        """
+        if type(self) == CubeList:
+            return deepcopy(self)
+
 
 def _is_single_item(testee):
     """

--- a/lib/iris/tests/test_cube.py
+++ b/lib/iris/tests/test_cube.py
@@ -88,5 +88,14 @@ class TestEquality(tests.IrisTest):
         self.assertIs(cube.__ne__(Terry()), NotImplemented)
 
 
+class Test_CubeList_copy(tests.IrisTest):
+    def setUp(self):
+        self.cube_list = iris.cube.CubeList()
+        self.copied_cube_list = self.cube_list.copy()
+
+    def test_copy(self):
+        self.assertIsInstance(self.copied_cube_list, iris.cube.CubeList)
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/test_cube.py
+++ b/lib/iris/tests/test_cube.py
@@ -88,14 +88,5 @@ class TestEquality(tests.IrisTest):
         self.assertIs(cube.__ne__(Terry()), NotImplemented)
 
 
-class Test_CubeList_copy(tests.IrisTest):
-    def setUp(self):
-        self.cube_list = iris.cube.CubeList()
-        self.copied_cube_list = self.cube_list.copy()
-
-    def test_copy(self):
-        self.assertIsInstance(self.copied_cube_list, iris.cube.CubeList)
-
-
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -602,5 +602,14 @@ class TestRealiseData(tests.IrisTest):
         )
 
 
+class Test_CubeList_copy(tests.IrisTest):
+    def setUp(self):
+        self.cube_list = iris.cube.CubeList()
+        self.copied_cube_list = self.cube_list.copy()
+
+    def test_copy(self):
+        self.assertIsInstance(self.copied_cube_list, iris.cube.CubeList)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
 🚀 Pull Request

### Description
I had a go to resolve issue #4066 .
A method copy() was created in the CubeList class to return a CubeList object instead of a list.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
