### PR TITLE
ng-vat v0.2 is iris v3.1a0

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -106,7 +106,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.1.dev0"
+__version__ = "3.1a0"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR sets the `iris` version to 3.1a0 in preparation for an internal engineering tag on the `mesh-data-model` feature branch.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
