### PR TITLE
Fix bug in gallery_tests runner

### DIFF
--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -117,7 +117,7 @@ class TestRunner:
         if self.gallery_tests:
             import iris.config
 
-            default_doc_path = os.path.join(sys.path[0], "docs", "iris")
+            default_doc_path = os.path.join(sys.path[0], "docs")
             doc_path = iris.config.get_option(
                 "Resources", "doc_dir", default=default_doc_path
             )


### PR DESCRIPTION
`default_doc_path` is incorrect, docs have been moved out of subdir `docs/iris` -> `docs`.

## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
