### PR TITLE
Use numpy.linspace to generate grids built with reference point and spacings 

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2334,7 +2334,10 @@ class DimCoord(Coord):
             bounds values will be defined. Defaults to False.
 
         """
-        points = (zeroth + step) + step * np.arange(count, dtype=np.float32)
+        start = zeroth + step
+        end = zeroth + (count * step)
+        points = np.linspace(start, end, num=count, dtype=np.float32)
+
         _, regular = iris.util.points_step(points)
         if not regular:
             points = (zeroth + step) + step * np.arange(


### PR DESCRIPTION
Close #3559

A very simple fix taken straight from the issue's only comment.
