### PR TITLE
Corrected plot_anomaly_log_colouring for new Matplotlib linscale rules.

### DIFF
--- a/docs/gallery_code/general/plot_anomaly_log_colouring.py
+++ b/docs/gallery_code/general/plot_anomaly_log_colouring.py
@@ -68,13 +68,13 @@ def main():
     # Create a 'logarithmic' data normalization.
     anom_norm = mcols.SymLogNorm(
         linthresh=minimum_log_level,
-        linscale=1,
+        linscale=0.01,
         vmin=-maximum_scale_level,
         vmax=maximum_scale_level,
     )
     # Setting "linthresh=minimum_log_level" makes its non-logarithmic
     # data range equal to our 'zero band'.
-    # Setting "linscale=1" maps the whole zero band to the middle colour value
+    # Setting "linscale=0.01" maps the whole zero band to the middle colour value
     # (i.e., 0.5), which is the neutral point of a "diverging" style colormap.
 
     # Create an Axes, specifying the map projection.

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -23,8 +23,7 @@
     "gallery_tests.test_plot_anomaly_log_colouring.TestAnomalyLogColouring.test_plot_anomaly_log_colouring.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ecc164e78e979b19b3789b0885a564a56cc2c65e3ec69469db1bdb9a853c1e24.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e796979a1b39781b2881a564a56ccac6da3e87947bcb1bdb9a843c1e24.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png"
     ],
     "gallery_tests.test_plot_atlantic_profiles.TestAtlanticProfiles.test_plot_atlantic_profiles.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Restores output of the anomaly log colouring gallery to pre #4087 by using a new `linscale` argument (can't go back to `linscale=0` as no longer allowed by Matplotlib).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
