### PR TITLE
Use assertArrayAllClose for sqrt test

### DIFF
--- a/lib/iris/tests/results/analysis/sqrt.cml
+++ b/lib/iris/tests/results/analysis/sqrt.cml
@@ -39,6 +39,6 @@
       </coord>
     </coords>
     <cellMethods/>
-    <data checksum="0x09ef96ca" dtype="float64" shape="(73, 96)"/>
+    <data dtype="float64" shape="(73, 96)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -554,7 +554,7 @@ class TestExponentiate(tests.IrisTest):
 
         e = a ** 0.5
 
-        self.assertArrayEqual(e.data, a.data ** 0.5)
+        self.assertArrayAllClose(e.data, a.data ** 0.5)
         self.assertCML(e, ("analysis", "sqrt.cml"), checksum=False)
         self.assertRaises(ValueError, iris.analysis.maths.exponentiate, a, 0.3)
 

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -554,8 +554,8 @@ class TestExponentiate(tests.IrisTest):
 
         e = a ** 0.5
 
-        self.assertArrayAllClose(e.data, a.data ** 0.5)
-        self.assertCML(e, ("analysis", "sqrt.cml"))
+        self.assertArrayEqual(e.data, a.data ** 0.5)
+        self.assertCML(e, ("analysis", "sqrt.cml"), checksum=False)
         self.assertRaises(ValueError, iris.analysis.maths.exponentiate, a, 0.3)
 
     def test_type_error(self):

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -554,7 +554,7 @@ class TestExponentiate(tests.IrisTest):
 
         e = a ** 0.5
 
-        self.assertArrayEqual(e.data, a.data ** 0.5)
+        self.assertArrayAllClose(e.data, a.data ** 0.5)
         self.assertCML(e, ("analysis", "sqrt.cml"))
         self.assertRaises(ValueError, iris.analysis.maths.exponentiate, a, 0.3)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This is a small change to the square root test to resolve #3993.  Instead of checking absolute equality in the floating point numbers, use an allclose test instead.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
