### PR TITLE
Widen cube printout for long ancil or cell-measure names.

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2424,7 +2424,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     delta = max_line_offset - min_alignment + 5
                     cube_header = "%-*s (%s)" % (
                         int(name_padding + delta),
-                        self.name() or "unknown",
+                        nameunit,
                         dimension_header,
                     )
                     alignment += delta
@@ -2481,7 +2481,11 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
 
             # Calculate the maximum line offset.
             max_line_offset = 0
-            for coord in all_coords:
+            for coord in (
+                list(all_coords)
+                + self.ancillary_variables()
+                + self.cell_measures()
+            ):
                 max_line_offset = max(
                     max_line_offset,
                     len(

--- a/lib/iris/tests/results/cdm/str_repr/simple.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/simple.__str__.txt
@@ -1,4 +1,4 @@
-thingness                                                                                 (foo: 11)
+thingness / (1)                                                                           (foo: 11)
      Dimension coordinates:
           foo                                                                                 x
      Auxiliary coordinates:

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -596,6 +596,58 @@ class Test_summary(tests.IrisTest):
             self.cube.add_aux_coord(coord)
         self.assertIn("baz", self.cube.summary())
 
+    def test_long_components(self):
+        # Check that components with long names 'stretch' the printout correctly.
+        cube = Cube(np.zeros((20, 20, 20)), units=1)
+        dimco = DimCoord(np.arange(20), long_name="dimco")
+        auxco = AuxCoord(np.zeros(20), long_name="auxco")
+        ancil = AncillaryVariable(np.zeros(20), long_name="ancil")
+        cellm = CellMeasure(np.zeros(20), long_name="cellm")
+        cube.add_dim_coord(dimco, 0)
+        cube.add_aux_coord(auxco, 0)
+        cube.add_cell_measure(cellm, 1)
+        cube.add_ancillary_variable(ancil, 2)
+
+        original_summary = cube.summary()
+        long_name = "long_name______________________________________"
+        for component in (dimco, auxco, ancil, cellm):
+            # For each (type of) component, set a long name so the header columns get shifted.
+            old_name = component.name()
+            component.rename(long_name)
+            new_summary = cube.summary()
+            component.rename(
+                old_name
+            )  # Put each back the way it was afterwards
+
+            # Check that the resulting 'stretched' output has dimension columns aligned correctly.
+            lines = new_summary.split("\n")
+            header = lines[0]
+            colon_inds = [
+                i_char for i_char, char in enumerate(header) if char == ":"
+            ]
+            for line in lines[1:]:
+                # Replace all '-' with 'x' to make checking easier, and add a final buffer space.
+                line = line.replace("-", "x") + " "
+                if " x " in line:
+                    # For lines with any columns : check that columns are where expected
+                    for col_ind in colon_inds:
+                        # Chop out chars before+after each expected column.
+                        self.assertEqual(
+                            line[col_ind - 1 : col_ind + 2], " x "
+                        )
+
+            # Finally also: compare old with new, but replacing new name and ignoring spacing differences
+            def collapse_space(string):
+                # Replace all multiple spaces with a single space.
+                while "  " in string:
+                    string = string.replace("  ", " ")
+                return string
+
+            self.assertEqual(
+                collapse_space(new_summary).replace(long_name, old_name),
+                collapse_space(original_summary),
+            )
+
 
 class Test_is_compatible(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fixes #4123 

NOTE: adding  the test exposed ***another*** bug in cube printout : When widening, it stopped showing the cube units !
I have fixed that as well, but it did cause a knock-on in one other test (see separate commit with results-file change).

I would really rather have tidied up first, with #3998 
 -- after all, this bug has probably happened ***because of*** the unreasonable complexity of the Cube.summary code !
But this one is quite a simple fix, and if we do #3998 later it can check that it still passes this test.
And there is still a good deal of work needed to inject good levels of testing into #3998 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
