### PR TITLE
Contourf workaround for Cartopy 0.19

### DIFF
--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -1073,6 +1073,15 @@ def contourf(cube, *args, **kwargs):
             # any boundary shift.
             zorder = result.collections[0].zorder - 0.1
             axes = kwargs.get("axes", None)
+
+            # Workaround for cartopy#1780.  We do not want contour to modify
+            # extent, so get hold of it and re-apply it after contour call.
+            if axes is None:
+                _axes = plt.gca()
+            else:
+                _axes = axes
+            extent = _axes.get_extent()
+
             contour(
                 cube,
                 levels=levels,
@@ -1082,6 +1091,9 @@ def contourf(cube, *args, **kwargs):
                 coords=coords,
                 axes=axes,
             )
+
+            _axes.set_extent(extent, crs=_axes.projection)
+
             # Restore the current "image" to 'result' rather than the mappable
             # resulting from the additional call to contour().
             if axes:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A change at Cartopy 0.19 causes axes extent to be updated when contours are added (see https://github.com/SciTools/cartopy/issues/1780).  This is a problem for our special handling for antialiasing in `iris.plot.contourf` because maps are cropped around the extra contours (see discussion at #4125).  @greglucas has written a fix at https://github.com/SciTools/cartopy/pull/1784 but advised that it is unlikely to make it into a release soon.  So if we want Iris v3.0.2 to play nicely with Cartopy 0.19, we will probably need a workaround.  I propose this one, which just reinstates whatever the axes extent was before the call to `contour`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
