### PR TITLE
Tweak to speed up dask wrapping of netcdf variables

### DIFF
--- a/docs/iris/src/whatsnew/3.0.2.rst
+++ b/docs/iris/src/whatsnew/3.0.2.rst
@@ -44,7 +44,7 @@ This document explains the changes made to Iris for this release
 
    #. `@pp-mo`_ adjusted the use of :func:`dask.array.from_array` in :func:`iris._lazy_data.as_lazy_data`, to avoid
       the dask 'test access'.  This makes loading of netcdf files with a large number of variables significantly faster.
-      (:pull:`4135`) [``pre-v3.1.0``]
+      (:pull:`4135`)
 
    Note that, the contributions labelled ``pre-v3.1.0`` are part of the forthcoming
    Iris v3.1.0 release, but require to be included in this patch release.

--- a/docs/iris/src/whatsnew/3.0.2.rst
+++ b/docs/iris/src/whatsnew/3.0.2.rst
@@ -44,7 +44,7 @@ This document explains the changes made to Iris for this release
 
    #. `@pp-mo`_ adjusted the use of :func:`dask.array.from_array` in :func:`iris._lazy_data.as_lazy_data`, to avoid
       the dask 'test access'.  This makes loading of netcdf files with large numbers variables significantly faster.
-      (:pull:`4134`) [``pre-v3.1.0``]
+      (:pull:`4135`) [``pre-v3.1.0``]
 
    Note that, the contributions labelled ``pre-v3.1.0`` are part of the forthcoming
    Iris v3.1.0 release, but require to be included in this patch release.

--- a/docs/iris/src/whatsnew/3.0.2.rst
+++ b/docs/iris/src/whatsnew/3.0.2.rst
@@ -43,7 +43,7 @@ This document explains the changes made to Iris for this release
       :ref:`skipping Cirrus-CI tasks`. (:pull:`4019`) [``pre-v3.1.0``]
 
    #. `@pp-mo`_ adjusted the use of :func:`dask.array.from_array` in :func:`iris._lazy_data.as_lazy_data`, to avoid
-      the dask 'test access'.  This makes loading of netcdf files with large numbers variables significantly faster.
+      the dask 'test access'.  This makes loading of netcdf files with a large number of variables significantly faster.
       (:pull:`4135`) [``pre-v3.1.0``]
 
    Note that, the contributions labelled ``pre-v3.1.0`` are part of the forthcoming

--- a/docs/iris/src/whatsnew/3.0.2.rst
+++ b/docs/iris/src/whatsnew/3.0.2.rst
@@ -42,6 +42,10 @@ This document explains the changes made to Iris for this release
       developers to easily disable `cirrus-ci`_ tasks. See
       :ref:`skipping Cirrus-CI tasks`. (:pull:`4019`) [``pre-v3.1.0``]
 
+   #. `@pp-mo`_ adjusted the use of :func:`dask.array.from_array` in :func:`iris._lazy_data.as_lazy_data`, to avoid
+      the dask 'test access'.  This makes loading of netcdf files with large numbers variables significantly faster.
+      (:pull:`4134`) [``pre-v3.1.0``]
+
    Note that, the contributions labelled ``pre-v3.1.0`` are part of the forthcoming
    Iris v3.1.0 release, but require to be included in this patch release.
 

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -192,7 +192,9 @@ def as_lazy_data(data, chunks=None, asarray=False):
     if isinstance(data, ma.core.MaskedConstant):
         data = ma.masked_array(data.data, mask=data.mask)
     if not is_lazy_data(data):
-        data = da.from_array(data, chunks=chunks, asarray=asarray)
+        data = da.from_array(
+            data, chunks=chunks, asarray=asarray, meta=np.ndarray
+        )
     return data
 
 

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -71,12 +71,12 @@ class Test_co_realise_cubes(tests.IrisTest):
         cube_e = Cube(derived_e)
         co_realise_cubes(cube_a, cube_b, cube_c, cube_d, cube_e)
         # Though used more than once, the source data should only get fetched
-        # twice by dask. Once when dask performs an initial data access with
-        # no data payload to ascertain the metadata associated with the
-        # dask.array (this access is specific to dask 2+, see
-        # dask.array.utils.meta_from_array), and again when the whole data is
-        # accessed.
-        self.assertEqual(wrapped_array.access_count, 2)
+        # once by dask, when the whole data is accessed.
+        # This also ensures that dask does *not* performs an initial data
+        # access with no data payload to ascertain the metadata associated with
+        # the dask.array (this access is specific to dask 2+,
+        # see dask.array.utils.meta_from_array).
+        self.assertEqual(wrapped_array.access_count, 1)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
+++ b/lib/iris/tests/unit/lazy_data/test_co_realise_cubes.py
@@ -72,7 +72,7 @@ class Test_co_realise_cubes(tests.IrisTest):
         co_realise_cubes(cube_a, cube_b, cube_c, cube_d, cube_e)
         # Though used more than once, the source data should only get fetched
         # once by dask, when the whole data is accessed.
-        # This also ensures that dask does *not* performs an initial data
+        # This also ensures that dask does *not* perform an initial data
         # access with no data payload to ascertain the metadata associated with
         # the dask.array (this access is specific to dask 2+,
         # see dask.array.utils.meta_from_array).


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Hopefully, addresses #4134
This significantly improves a problem with slow loading, which applies to netcdf files with lots of  variables
The change is tiny, but significant !

I think this problem has existed ever since we moved to Dask 2.0.
At that point we identified much slower loading of large PP/FF files, and fixed it [like this](https://github.com/SciTools/iris/pull/3659).
[That code is still in place](https://github.com/SciTools/iris/blob/v3.0.x/lib/iris/fileformats/pp.py#L597-L600) : in view of this new approach, that can probably now be removed -- and should be !
But as this is intended as a "quick win" for v3.0.2, I'll defer that until later.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
