### PR TITLE
Fix coord_categorisation.add_weekday

### DIFF
--- a/docs/src/developers_guide/contributing_code_formatting.rst
+++ b/docs/src/developers_guide/contributing_code_formatting.rst
@@ -39,7 +39,7 @@ linted according to our ``.flake8`` configuration file. Note that,
 for each ``.pre-commit-config.yaml`` git hook.
 
 Additionally, you may wish to enable ``black`` for your preferred
-`editor/IDE <https://black.readthedocs.io/en/stable/editor_integration.html#editor-integration>`_.
+`editor/IDE <https://black.readthedocs.io/en/stable/integrations/editors.html>`_.
 
 With the ``pre-commit`` configured, the output of performing a ``git commit``
 will look similar to::

--- a/lib/iris/coord_categorisation.py
+++ b/lib/iris/coord_categorisation.py
@@ -93,7 +93,7 @@ def add_categorised_coord(
 # Private "helper" function
 def _pt_date(coord, time):
     """
-    Return the date of a time-coordinate point.
+    Return the datetime of a time-coordinate point.
 
     Args:
 
@@ -103,14 +103,11 @@ def _pt_date(coord, time):
         value of a coordinate point
 
     Returns:
-        datetime.date
+        cftime.datetime
     """
     # NOTE: All of the currently defined categorisation functions are
     # calendar operations on Time coordinates.
-    #  - All these currently depend on Unit::num2date, which is deprecated (!!)
-    #  - We will want to do better, when we sort out our own Calendars.
-    #  - For now, just make sure these all call through this one function.
-    return coord.units.num2date(time)
+    return coord.units.num2date(time, only_use_cftime_datetimes=True)
 
 
 # --------------------------------------------


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
See #4137 

Explicitly make the `coord_categorisation` functions always use a `cftime.datetime` instance, so that tests pass with `cf_units` v2.1.5.  I also removed the comment about `Unit.num2date` being deprecated.  That comment dated back to the days when `Unit` was part of Iris, and I can't see anything in `cf_units.__init__.py` to suggest `Unit.num2date` is deprecated.

I also fixed a link to the `black` docs.  This duplicates part of #4132, but it looks like the main tests in that PR can't pass without pulling in this change anyway.

I am on leave for the next week but happy if someone else applies any changes here if they are needed in the meantime.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
