### PR TITLE
Contourf Antialias Fix

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -62,6 +62,10 @@ This document explains the changes made to Iris for this release
 #. `@gcaria`_ fixed :meth:`~iris.cube.Cube.ancillary_variable_dims` to also accept
    the string name of a :class:`~iris.coords.AncillaryVariable`. (:pull:`3931`)
 
+#. `@rcomer`_ modified :func:`~iris.plot.contourf` to skip the special handling for
+   antialiasing when data values are too low for it to have an effect.  This caused
+   unexpected artifacts in some edge cases, as shown at :issue:`4086`. (:pull:`4148`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -64,7 +64,7 @@ This document explains the changes made to Iris for this release
 
 #. `@rcomer`_ modified :func:`~iris.plot.contourf` to skip the special handling for
    antialiasing when data values are too low for it to have an effect.  This caused
-   unexpected artifacts in some edge cases, as shown at :issue:`4086`. (:pull:`4148`)
+   unexpected artifacts in some edge cases, as shown at :issue:`4086`. (:pull:`4150`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -1082,7 +1082,7 @@ def contourf(cube, *args, **kwargs):
             colors = colors[:-1]
         else:
             colors = colors[:-1]
-        if len(levels) > 0:
+        if len(levels) > 0 and cube.data.max() > levels[0]:
             # Draw the lines just *below* the polygons to ensure we minimise
             # any boundary shift.
             zorder = result.collections[0].zorder - 0.1

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -12,6 +12,8 @@ import iris.tests as tests
 from unittest import mock
 
 import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
 
 from iris.tests.stock import simple_2d
 from iris.tests.unit.plot import TestGraphicStringCoord, MixinCoords
@@ -73,6 +75,27 @@ class TestCoords(tests.IrisTest, MixinCoords):
             "matplotlib.pyplot.contourf", return_value=mocker
         )
         self.draw_func = iplt.contourf
+
+
+@tests.skip_plot
+class TestAntialias(tests.IrisTest):
+    def test_skip_contour(self):
+        # Contours should not be added if data is all below second level.  See #4086.
+        cube = simple_2d()
+
+        levels = [5, 15, 20, 200]
+        colors = ["b", "r", "y"]
+
+        iplt.contourf(cube, levels=levels, colors=colors, antialiased=True)
+
+        ax = plt.gca()
+        # Expect 3 PathCollection objects (one for each colour) and no LineCollection
+        # objects.
+        for collection in ax.collections:
+            self.assertIsInstance(
+                collection, matplotlib.collections.PathCollection
+            )
+        self.assertEqual(len(ax.collections), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #4086 

As noted at #4086, our antialiasing handling exposed a matplotlib bug for a pretty specific edge case.  Regardless of this bug, it's a bit redundant to call `pyplot.contour` when the data do not span the requested levels, so we should plausibly get a tiny efficiency gain by skipping it when not needed.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
