### PR TITLE
Stop CI from clobbering commits on lockfile updates

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -29,11 +29,11 @@ jobs:
   
   no_clobber:
     runs-on: ubuntu-latest
-    # allow users to force a workflow dispatch by setting the clobber=true on a workflow dispatch
-    # if: "${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.clobber) }}"
     steps:
       # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
-      # the lockfile bot has made the head commit, abort the workflow
+      # the lockfile bot has made the head commit, abort the workflow.
+      # This job can be manually overridden by running directly from the github actions panel
+      # (known as a "workflow_dispatch") and setting the `clobber` input to "yes".
       - uses: actions/script@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -28,7 +28,7 @@ jobs:
   no_clobber:
     runs-on: ubuntu-latest
     # allow users to force a workflow dispatch by setting the clobber=true on a workflow dispatch
-    if: ${{ !(github.event_name == "workflow_dispatch" && github.event.inputs.clobber) }}
+    if: "${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.clobber) }}"
     steps:
       # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
       # the lockfile bot has made the head commit, abort the workflow
@@ -36,6 +36,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            console.log(context)
+            if (context.eventName == "workflow_dispatch") {
+              1+1
+            }
             github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
             .then(res => {
               const committer = res.data.commit.commit.committer?.name
@@ -52,59 +56,59 @@ jobs:
               }
             })
 
-  gen_lockfiles:
-    # this is a matrix job: it splits to create new lockfiles for each
-    # of the CI test python versions.
-    # this list below should be changed when covering more python versions
-    # TODO: generate this matrix automatically from the list of available py**.yml files
-    #       ref: https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
-    runs-on: ubuntu-latest
+  # gen_lockfiles:
+  #   # this is a matrix job: it splits to create new lockfiles for each
+  #   # of the CI test python versions.
+  #   # this list below should be changed when covering more python versions
+  #   # TODO: generate this matrix automatically from the list of available py**.yml files
+  #   #       ref: https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
+  #   runs-on: ubuntu-latest
     
-    strategy:
-      matrix:
-        python: ['36', '37', '38']
+  #   strategy:
+  #     matrix:
+  #       python: ['36', '37', '38']
     
-    steps:
-      - uses: actions/checkout@v2
-      - name: install conda-lock
-        run: |
-          source $CONDA/bin/activate base
-          conda install -y -c conda-forge conda-lock
-      - name: generate lockfile
-        run: |
-          $CONDA/bin/conda-lock lock -p linux-64 -f requirements/ci/py${{matrix.python}}.yml
-          mv conda-linux-64.lock py${{matrix.python}}-linux-64.lock
-      - name: output lockfile
-        uses: actions/upload-artifact@v2
-        with:
-          path: py${{matrix.python}}-linux-64.lock
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: install conda-lock
+  #       run: |
+  #         source $CONDA/bin/activate base
+  #         conda install -y -c conda-forge conda-lock
+  #     - name: generate lockfile
+  #       run: |
+  #         $CONDA/bin/conda-lock lock -p linux-64 -f requirements/ci/py${{matrix.python}}.yml
+  #         mv conda-linux-64.lock py${{matrix.python}}-linux-64.lock
+  #     - name: output lockfile
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: py${{matrix.python}}-linux-64.lock
     
-  create_pr:
-    # once the matrix job has completed all the lock files will have been uploaded as artifacts.
-    # Download the artifacts, add them to the repo, and create a PR.
-    runs-on: ubuntu-latest
-    needs: gen_lockfiles
+  # create_pr:
+  #   # once the matrix job has completed all the lock files will have been uploaded as artifacts.
+  #   # Download the artifacts, add them to the repo, and create a PR.
+  #   runs-on: ubuntu-latest
+  #   needs: gen_lockfiles
     
-    steps:
-      - uses: actions/checkout@v2
-      - name: get artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: get artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: artifacts
           
-      - name: Update lock files in repo
-        run: | 
-          cp artifacts/artifact/*.lock requirements/ci/nox.lock
-          rm -r artifacts
+  #     - name: Update lock files in repo
+  #       run: | 
+  #         cp artifacts/artifact/*.lock requirements/ci/nox.lock
+  #         rm -r artifacts
         
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
-        with:
-          commit-message: Updated environment lockfiles
-          committer: "Lockfile bot <noreply@github.com>"
-          author: "Lockfile bot <noreply@github.com>"
-          delete-branch: true
-          branch: auto-update-lockfiles
-          title: Update CI environment lockfiles
-          body: |
-            Lockfiles updated to the latest resolvable environment.
+  #     - name: Create Pull Request
+  #       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+  #       with:
+  #         commit-message: Updated environment lockfiles
+  #         committer: "Lockfile bot <noreply@github.com>"
+  #         author: "Lockfile bot <noreply@github.com>"
+  #         delete-branch: true
+  #         branch: auto-update-lockfiles
+  #         title: Update CI environment lockfiles
+  #         body: |
+  #           Lockfiles updated to the latest resolvable environment.

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -32,25 +32,25 @@ jobs:
     steps:
       # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
       # the lockfile bot has made the head commit, abort the workflow
-      uses: actions/script@v4
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
-          .then(res => {
-            const committer = res.data.commit.commit.committer?.name
-            if (committer === "Lockfile bot") {
-              core.info("Bot was last to update. Continue")
-            } else {
-              core.error("New commits since bot last ran. Abort!")
-              core.setFailed("Don't clobber commits, aborting workflow.")
-            }
-          })
-          .catch(err => {
-            if (err.status === 404) {
-                core.info("Branch not found, continue")
-            }
-          })
+      - uses: actions/script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
+            .then(res => {
+              const committer = res.data.commit.commit.committer?.name
+              if (committer === "Lockfile bot") {
+                core.info("Bot was last to update. Continue")
+              } else {
+                core.error("New commits since bot last ran. Abort!")
+                core.setFailed("Don't clobber commits, aborting workflow.")
+              }
+            })
+            .catch(err => {
+              if (err.status === 404) {
+                  core.info("Branch not found, continue")
+              }
+            })
 
   gen_lockfiles:
     # this is a matrix job: it splits to create new lockfiles for each

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -14,6 +14,11 @@ name: Refresh Lockfiles
 
 on:
   workflow_dispatch:
+    inputs:
+      clobber:
+        description: Force the workflow to run, potentially clobbering any commits already made to the branch
+        required: true
+        default: false
   schedule:
     # Run once a week on a Saturday night 
     - cron: 1 0 * * 6
@@ -21,6 +26,31 @@ on:
 
 jobs:
   
+  no_clobber:
+    # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
+    # the lockfile bot has made the head commit, abort the workflow
+    uses: actions/script@v4
+    # allow users to force a workflow dispatch by setting the clobber=true on a workflow dispatch
+    if: ${{ !(github.event_name == "workflow_dispatch" && github.event.inputs.clobber) }}
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      script: |
+        github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
+        .then(res => {
+          const committer = res.data.commit.commit.committer?.name
+          if (committer === "Lockfile bot") {
+            core.info("Bot was last to update. Continue")
+          } else {
+            core.error("New commits since bot last ran. Abort!")
+            core.setFailed("Don't clobber commits, aborting workflow.")
+          }
+        })
+        .catch(err => {
+          if (err.status === 404) {
+              core.info("Branch not found, continue")
+          }
+        })
+
   gen_lockfiles:
     # this is a matrix job: it splits to create new lockfiles for each
     # of the CI test python versions.
@@ -70,6 +100,8 @@ jobs:
         uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
         with:
           commit-message: Updated environment lockfiles
+          committer: "Lockfile bot <noreply@github.com>"
+          author: "Lockfile bot <noreply@github.com>"
           delete-branch: true
           branch: auto-update-lockfiles
           title: Update CI environment lockfiles

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -40,17 +40,15 @@ jobs:
             if (context.eventName == "workflow_dispatch") {
               1+1
             }
-            github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
-            .then(res => {
-              const committer = res.data.commit.commit.committer?.name
-              if (committer === "Lockfile bot") {
+            github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"}).then(res => {
+              const committer = res.data.commit.commit.committer
+              if (committer && committer.name === "Lockfile bot") {
                 core.info("Bot was last to update. Continue")
               } else {
                 core.error("New commits since bot last ran. Abort!")
                 core.setFailed("Don't clobber commits, aborting workflow.")
               }
-            })
-            .catch(err => {
+            }).catch(err => {
               if (err.status === 404) {
                   core.info("Branch not found, continue")
               }

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -17,7 +17,6 @@ on:
     inputs:
       clobber:
         description: Force the workflow to run, potentially clobbering any commits already made to the branch
-        required: true
         default: false
   schedule:
     # Run once a week on a Saturday night 
@@ -27,29 +26,31 @@ on:
 jobs:
   
   no_clobber:
-    # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
-    # the lockfile bot has made the head commit, abort the workflow
-    uses: actions/script@v4
+    runs-on: ubuntu-latest
     # allow users to force a workflow dispatch by setting the clobber=true on a workflow dispatch
     if: ${{ !(github.event_name == "workflow_dispatch" && github.event.inputs.clobber) }}
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      script: |
-        github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
-        .then(res => {
-          const committer = res.data.commit.commit.committer?.name
-          if (committer === "Lockfile bot") {
-            core.info("Bot was last to update. Continue")
-          } else {
-            core.error("New commits since bot last ran. Abort!")
-            core.setFailed("Don't clobber commits, aborting workflow.")
-          }
-        })
-        .catch(err => {
-          if (err.status === 404) {
-              core.info("Branch not found, continue")
-          }
-        })
+    steps:
+      # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
+      # the lockfile bot has made the head commit, abort the workflow
+      uses: actions/script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"})
+          .then(res => {
+            const committer = res.data.commit.commit.committer?.name
+            if (committer === "Lockfile bot") {
+              core.info("Bot was last to update. Continue")
+            } else {
+              core.error("New commits since bot last ran. Abort!")
+              core.setFailed("Don't clobber commits, aborting workflow.")
+            }
+          })
+          .catch(err => {
+            if (err.status === 404) {
+                core.info("Branch not found, continue")
+            }
+          })
 
   gen_lockfiles:
     # this is a matrix job: it splits to create new lockfiles for each

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -16,8 +16,10 @@ on:
   workflow_dispatch:
     inputs:
       clobber:
-        description: Force the workflow to run, potentially clobbering any commits already made to the branch
-        default: false
+        description: |
+          Force the workflow to run, potentially clobbering any commits already made to the branch. 
+          Enter "yes" or "true" to run.
+        default: "no"
   schedule:
     # Run once a week on a Saturday night 
     - cron: 1 0 * * 6
@@ -36,20 +38,23 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            if (context.eventName == "workflow_dispatch" && context.payload.inputs.clobber) {
-              core.info("manual override, continuing workflow ")
-              return
+            if (context.eventName == "workflow_dispatch") {
+              const clobber = context.payload.inputs.clobber || "no";
+              if (["yes", "true", "y"].includes(clobber.trim().toLowerCase())) {
+                core.info("Manual override, continuing workflow, potentially overwriting previous commits to auto-update-lockfiles");
+                return
+              }
             }
             github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"}).then(res => {
-              const committer = res.data.commit.commit.committer
+              const committer = res.data.commit.commit.committer;
               if (committer && committer.name === "Lockfile bot") {
-                core.info("Bot was last to update. Continue")
+                core.info("Lockfile bot was the last to push to auto-update-lockfiles. Continue.");
               } else {
-                core.setFailed("New commits since bot last ran. Abort!")
+                core.setFailed("New commits to auto-update-lockfiles since bot last ran. Abort!");
               }
             }).catch(err => {
               if (err.status === 404) {
-                  core.info("Branch not found, continue")
+                  core.info("auto-update-lockfiles branch not found, continue");
               }
             })
 
@@ -95,7 +100,7 @@ jobs:
           path: artifacts
           
       - name: Update lock files in repo
-        run: | 
+        run: |
           cp artifacts/artifact/*.lock requirements/ci/nox.lock
           rm -r artifacts
         

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -28,7 +28,7 @@ jobs:
   no_clobber:
     runs-on: ubuntu-latest
     # allow users to force a workflow dispatch by setting the clobber=true on a workflow dispatch
-    if: "${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.clobber) }}"
+    # if: "${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.clobber) }}"
     steps:
       # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
       # the lockfile bot has made the head commit, abort the workflow

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -36,17 +36,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            console.log(context)
-            if (context.eventName == "workflow_dispatch") {
-              1+1
+            if (context.eventName == "workflow_dispatch" && context.payload.inputs.clobber) {
+              core.info("manual override, continuing workflow ")
+              return
             }
             github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"}).then(res => {
               const committer = res.data.commit.commit.committer
               if (committer && committer.name === "Lockfile bot") {
                 core.info("Bot was last to update. Continue")
               } else {
-                core.error("New commits since bot last ran. Abort!")
-                core.setFailed("Don't clobber commits, aborting workflow.")
+                core.setFailed("New commits since bot last ran. Abort!")
               }
             }).catch(err => {
               if (err.status === 404) {
@@ -54,59 +53,60 @@ jobs:
               }
             })
 
-  # gen_lockfiles:
-  #   # this is a matrix job: it splits to create new lockfiles for each
-  #   # of the CI test python versions.
-  #   # this list below should be changed when covering more python versions
-  #   # TODO: generate this matrix automatically from the list of available py**.yml files
-  #   #       ref: https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
-  #   runs-on: ubuntu-latest
+  gen_lockfiles:
+    # this is a matrix job: it splits to create new lockfiles for each
+    # of the CI test python versions.
+    # this list below should be changed when covering more python versions
+    # TODO: generate this matrix automatically from the list of available py**.yml files
+    #       ref: https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
+    runs-on: ubuntu-latest
+    needs: no_clobber
     
-  #   strategy:
-  #     matrix:
-  #       python: ['36', '37', '38']
+    strategy:
+      matrix:
+        python: ['36', '37', '38']
     
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: install conda-lock
-  #       run: |
-  #         source $CONDA/bin/activate base
-  #         conda install -y -c conda-forge conda-lock
-  #     - name: generate lockfile
-  #       run: |
-  #         $CONDA/bin/conda-lock lock -p linux-64 -f requirements/ci/py${{matrix.python}}.yml
-  #         mv conda-linux-64.lock py${{matrix.python}}-linux-64.lock
-  #     - name: output lockfile
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: py${{matrix.python}}-linux-64.lock
+    steps:
+      - uses: actions/checkout@v2
+      - name: install conda-lock
+        run: |
+          source $CONDA/bin/activate base
+          conda install -y -c conda-forge conda-lock
+      - name: generate lockfile
+        run: |
+          $CONDA/bin/conda-lock lock -p linux-64 -f requirements/ci/py${{matrix.python}}.yml
+          mv conda-linux-64.lock py${{matrix.python}}-linux-64.lock
+      - name: output lockfile
+        uses: actions/upload-artifact@v2
+        with:
+          path: py${{matrix.python}}-linux-64.lock
     
-  # create_pr:
-  #   # once the matrix job has completed all the lock files will have been uploaded as artifacts.
-  #   # Download the artifacts, add them to the repo, and create a PR.
-  #   runs-on: ubuntu-latest
-  #   needs: gen_lockfiles
+  create_pr:
+    # once the matrix job has completed all the lock files will have been uploaded as artifacts.
+    # Download the artifacts, add them to the repo, and create a PR.
+    runs-on: ubuntu-latest
+    needs: gen_lockfiles
     
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: get artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: artifacts
+    steps:
+      - uses: actions/checkout@v2
+      - name: get artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
           
-  #     - name: Update lock files in repo
-  #       run: | 
-  #         cp artifacts/artifact/*.lock requirements/ci/nox.lock
-  #         rm -r artifacts
+      - name: Update lock files in repo
+        run: | 
+          cp artifacts/artifact/*.lock requirements/ci/nox.lock
+          rm -r artifacts
         
-  #     - name: Create Pull Request
-  #       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
-  #       with:
-  #         commit-message: Updated environment lockfiles
-  #         committer: "Lockfile bot <noreply@github.com>"
-  #         author: "Lockfile bot <noreply@github.com>"
-  #         delete-branch: true
-  #         branch: auto-update-lockfiles
-  #         title: Update CI environment lockfiles
-  #         body: |
-  #           Lockfiles updated to the latest resolvable environment.
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+        with:
+          commit-message: Updated environment lockfiles
+          committer: "Lockfile bot <noreply@github.com>"
+          author: "Lockfile bot <noreply@github.com>"
+          delete-branch: true
+          branch: auto-update-lockfiles
+          title: Update CI environment lockfiles
+          body: |
+            Lockfiles updated to the latest resolvable environment.

--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -66,6 +66,16 @@ and add the changed lockfiles to your pull request.
 
 New lockfiles are generated automatically each week to ensure that Iris continues to be
 tested against the latest available version of its dependencies.
+Each week the yaml files in ``requirements/ci`` are resolved by a GitHub Action.
+If the resolved environment has changed, a pull request is created with the new lock files.
+The CI test suite will run on this pull request and fixes for failed tests can be pushed to
+the ``auto-update-lockfiles`` branch to be included in the PR. 
+Once a developer has pushed to this branch, the auto-update process will not run again until
+the PR is merged, to prevent overwriting developer commits.
+The auto-updater can still be invoked manually in this situation by going to the `GitHub Actions`_
+page for the workflow, and manually running using the "Run Workflow" button.  
+By default, this will also not override developer commits.  To force an update, you must 
+confirm "yes" in the "Run Worflow" prompt.
 
 
 .. _skipping Cirrus-CI tasks:
@@ -137,3 +147,4 @@ See the `pre-commit.ci dashboard`_ for details of recent past and active Iris jo
 .. _Cirrus-CI Documentation: https://cirrus-ci.org/guide/writing-tasks/
 .. _.pre-commit-config.yaml: https://github.com/SciTools/iris/blob/master/.pre-commit-config.yaml
 .. _pre-commit.ci dashboard: https://results.pre-commit.ci/repo/github/5312648
+.. _GitHub Actions: https://github.com/SciTools/iris/actions/workflows/refresh-lockfiles.yml


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Added a step to the update lockfile workflow to first check if someone has committed to the `auto-update-lockfiles` branch since last run. If so, it will abort regenerating lockfiles.

This resolves #4156 (observed in #4137).

If you really want to run the workflow and potentially clobber anything on the branch, you can override this new check step by running from the actions panel and performing a manual workflow dispatch, setting the "clobber" value to YES.



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
