### PR TITLE
Fb fix cube coord arithmetic

### DIFF
--- a/docs/iris/src/whatsnew/3.0.2.rst
+++ b/docs/iris/src/whatsnew/3.0.2.rst
@@ -25,6 +25,12 @@ This document explains the changes made to Iris for this release
       where one cell's bounds align with the requested maximum and minimum, as
       reported in :issue:`3391`. (:pull:`4059`)
 
+   #. `@bjlittle`_ resolved a regression in arithmetic behaviour between a coordinate
+      and a cube which resulted in a ``NotYetImplementedError`` being raised, as reported
+      in :issue:`4000`. This fix supports ``+``, ``-``, ``*``, and ``/`` operations
+      between a coordinate and a cube, and for convenience additionally includes
+      :meth:`iris.cube.Cube.__neg__` support. (:pull:`4159`)
+
    📚 **Documentation**
 
    #. `@bjlittle`_ updated the ``intersphinx_mapping`` and fixed documentation
@@ -46,7 +52,7 @@ This document explains the changes made to Iris for this release
       the dask 'test access'.  This makes loading of netcdf files with a large number of variables significantly faster.
       (:pull:`4135`)
 
-   Note that, the contributions labelled ``pre-v3.1.0`` are part of the forthcoming
+   Note that, the above contributions labelled with ``pre-v3.1.0`` are part of the forthcoming
    Iris v3.1.0 release, but require to be included in this patch release.
 
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3754,37 +3754,49 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
     def __hash__(self):
         return hash(id(self))
 
-    def __add__(self, other):
-        return iris.analysis.maths.add(self, other)
+    __add__ = iris.analysis.maths.add
 
     def __iadd__(self, other):
         return iris.analysis.maths.add(self, other, in_place=True)
 
     __radd__ = __add__
 
-    def __sub__(self, other):
-        return iris.analysis.maths.subtract(self, other)
+    __sub__ = iris.analysis.maths.subtract
 
     def __isub__(self, other):
         return iris.analysis.maths.subtract(self, other, in_place=True)
 
+    def __rsub__(self, other):
+        return (-self) + other
+
     __mul__ = iris.analysis.maths.multiply
-    __rmul__ = iris.analysis.maths.multiply
 
     def __imul__(self, other):
         return iris.analysis.maths.multiply(self, other, in_place=True)
+
+    __rmul__ = __mul__
 
     __div__ = iris.analysis.maths.divide
 
     def __idiv__(self, other):
         return iris.analysis.maths.divide(self, other, in_place=True)
 
-    __truediv__ = iris.analysis.maths.divide
+    def __rdiv__(self, other):
+        data = 1 / self.core_data()
+        reciprocal = self.copy(data=data)
+        return iris.analysis.maths.multiply(reciprocal, other)
 
-    def __itruediv__(self, other):
-        return iris.analysis.maths.divide(self, other, in_place=True)
+    __truediv__ = __div__
+
+    __itruediv__ = __idiv__
+
+    __rtruediv__ = __rdiv__
 
     __pow__ = iris.analysis.maths.exponentiate
+
+    def __neg__(self):
+        return self.copy(data=-self.core_data())
+
     # END OPERATOR OVERLOADS
 
     def collapsed(self, coords, aggregator, **kwargs):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2655,7 +2655,7 @@ def save(
         local_keys.update(different_value_keys)
 
     def is_valid_packspec(p):
-        """ Only checks that the datatype is valid. """
+        """Only checks that the datatype is valid."""
         if isinstance(p, dict):
             if "dtype" in p:
                 return is_valid_packspec(p["dtype"])

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -516,7 +516,7 @@ class TestPackedData(tests.IrisTest):
         self._single_test("i2", "single_packed_signed.cdl")
 
     def test_single_packed_unsigned(self):
-        """Test saving a single CF-netCDF file with packing into unsigned. """
+        """Test saving a single CF-netCDF file with packing into unsigned."""
         self._single_test("u1", "single_packed_unsigned.cdl")
 
     def test_single_packed_manual_scale(self):

--- a/lib/iris/tests/test_cube_to_pp.py
+++ b/lib/iris/tests/test_cube_to_pp.py
@@ -275,7 +275,7 @@ class TestPPSave(tests.IrisTest, pp.PPTest):
 
 
 class FakePPEnvironment:
-    """ fake a minimal PP environment for use in cross-section coords, as in PP save rules """
+    """fake a minimal PP environment for use in cross-section coords, as in PP save rules"""
 
     y = [1, 2, 3, 4]
     z = [111, 222, 333, 444]

--- a/lib/iris/tests/test_file_save.py
+++ b/lib/iris/tests/test_file_save.py
@@ -33,7 +33,7 @@ CHKSUM_ERR = "Mismatch between checksum of iris.save and {}.save."
 
 
 def save_by_filename(filename1, filename2, cube, saver_fn, iosaver=None):
-    """ Saves a cube to two different filenames using iris.save and the save method of the object representing the file type directly"""
+    """Saves a cube to two different filenames using iris.save and the save method of the object representing the file type directly"""
     # Save from object direct
     saver_fn(cube, filename1)
 
@@ -46,7 +46,7 @@ def save_by_filename(filename1, filename2, cube, saver_fn, iosaver=None):
 def save_by_filehandle(
     filehandle1, filehandle2, cube, fn_saver, binary_mode=True
 ):
-    """ Saves a cube to two different filehandles using iris.save and the save method of the object representing the file type directly"""
+    """Saves a cube to two different filehandles using iris.save and the save method of the object representing the file type directly"""
     mode = "wb" if binary_mode else "w"
 
     # Save from object direct
@@ -60,7 +60,7 @@ def save_by_filehandle(
 
 @tests.skip_data
 class TestSaveMethods(tests.IrisTest):
-    """ Base class for file saving tests. Loads data and creates/deletes tempfiles"""
+    """Base class for file saving tests. Loads data and creates/deletes tempfiles"""
 
     def setUp(self):
         self.cube1 = iris.load_cube(

--- a/lib/iris/tests/unit/fileformats/test_rules.py
+++ b/lib/iris/tests/unit/fileformats/test_rules.py
@@ -238,7 +238,7 @@ class TestLoadCubes(tests.IrisTest):
 
 
 class Test_scalar_cell_method(tests.IrisTest):
-    """ Tests for iris.fileformats.rules.scalar_cell_method() function """
+    """Tests for iris.fileformats.rules.scalar_cell_method() function"""
 
     def setUp(self):
         self.cube = stock.simple_2d()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR addresses issue #4000.

The `Coord` and `Cube` arithmetic behaviour regressed in #3422, and as a result caused a `NotYetImplementedError` exception to be raise whenever a `Coord op Cube` operation was attempted.

This PR addresses this, and also extends the capability to include missing reflected `Cube` arithmetic operations i.e., `iris.cube.Cube.__rsub__`, `iris.cube.Cube.__rdiv__`, and `iris.cube.Cube.__rtruediv__`. In addition to this, the `iris.cube.Cube.__neg__` dunder method has also been implemented for convenience i.e., you can now do `result = -cube`.

So in summary you can now do the following `+`, `-`, `/` and `*` operations between:
- a `Coord` and a `Cube`
- a `Cube` and a `Coord`
- a `Cube` and a `Cube`
- a `Coord` and a (`int`, `float`, `numpy.number`)
- a (`int`, `float`, `numpy.number`) and a `Coord`
- a (`int`, `float`, `numpy.number`, `numpy.ndarray`, `numpy.MaskedArray`) and a `Cube`
- a `Cube` and a (`int`, `float`, `numpy.number`, `numpy.ndarray`, `numpy.MaskedArray`

Note that, arithmetic between a `Coord` and a `Coord` is not supported, at this time.

Also note that, in this context `Coord` means a subclass of `iris.coords._DimensionalMetadata` i.e., `iris.coords.AuxCoord`, `iris.coords.DimCoord`, `iris.coords.AncillaryVariable`, and `iris.coords.CellMeasure`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
