### PR TITLE
Bump black version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -190,7 +190,7 @@ def black(session: nox.sessions.Session):
 
     """
     # Pip install the session requirements.
-    session.install("black==21.5b2")
+    session.install("black")
     # Execute the black format checker on the package.
     session.run("black", "--check", PACKAGE)
     # Execute the black format checker on this file.

--- a/noxfile.py
+++ b/noxfile.py
@@ -190,7 +190,7 @@ def black(session: nox.sessions.Session):
 
     """
     # Pip install the session requirements.
-    session.install("black==21.5b1")
+    session.install("black==21.5b2")
     # Execute the black format checker on the package.
     session.run("black", "--check", PACKAGE)
     # Execute the black format checker on this file.

--- a/noxfile.py
+++ b/noxfile.py
@@ -190,7 +190,7 @@ def black(session: nox.sessions.Session):
 
     """
     # Pip install the session requirements.
-    session.install("black")
+    session.install("black==21.5b2")
     # Execute the black format checker on the package.
     session.run("black", "--check", PACKAGE)
     # Execute the black format checker on this file.

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b2
+  - black
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b1
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b2
+  - black
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b1
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b2
+  - black
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -34,7 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b1
+  - black=21.5b2
   - filelock
   - flake8
   - imagehash>=4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies.
 
 asv
-black==21.5b2
+black
 filelock
 imagehash>=4.0
 nose

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies.
 
 asv
-black==21.5b1
+black==21.5b2
 filelock
 imagehash>=4.0
 nose

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies.
 
 asv
-black
+black==21.5b2
 filelock
 imagehash>=4.0
 nose


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the `black` version to the latest offering by unpinning.

I did consider removing `black` from the list of dependencies, but we do require to include `black` for those that want to test `iris` with `nox` on their local host.

Rather than continually update the specific `black` version in several places, I suggest we simply let the `black` version float to the latest version at environment package dependency resolve time, and allow the `pre-commit-bot` to notify us when a later version of `black` is available to the community.

Seems like a reasonable compromise to take here.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
