### PR TITLE
RTD support link update

### DIFF
--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -11,9 +11,9 @@
 .. _core developers: https://github.com/SciTools/scitools.org.uk/blob/master/contributors.json
 .. _generating sss keys for GitHub: https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account
 .. _GitHub Help Documentation: https://docs.github.com/en/github
+.. _Iris GitHub Discussions: https://github.com/SciTools/iris/discussions
 .. _Iris: https://github.com/SciTools/iris
 .. _Iris GitHub: https://github.com/SciTools/iris
-.. _iris mailing list: https://groups.google.com/forum/#!forum/scitools-iris
 .. _iris-sample-data: https://github.com/SciTools/iris-sample-data
 .. _iris-test-data: https://github.com/SciTools/iris-test-data
 .. _issue: https://github.com/SciTools/iris/issues

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -244,12 +244,8 @@ html_context = {
             "https://github.com/SciTools/iris",
         ),
         (
-            '<i class="fa fa-comments fa-fw"></i> Users Google Group',
-            "https://groups.google.com/forum/#!forum/scitools-iris",
-        ),
-        (
-            '<i class="fa fa-comments fa-fw"></i> Developers Google Group',
-            "https://groups.google.com/forum/#!forum/scitools-iris-dev",
+            '<i class="fa fa-comments fa-fw"></i> GitHub Discussions',
+            "https://github.com/SciTools/iris/discussions",
         ),
         (
             '<i class="fa fa-question fa-fw"></i> StackOverflow for "How Do I?"',

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -25,7 +25,7 @@ In what follows we'll refer to the upstream iris ``master`` branch, as
 * If you can possibly avoid it, avoid merging trunk or any other branches into
   your feature branch while you are working.
 * If you do find yourself merging from trunk, consider :ref:`rebase-on-trunk`
-* Ask on the `iris mailing list`_ if you get stuck.
+* Ask on the `Iris GitHub Discussions`_ if you get stuck.
 * Ask for code review!
 
 This way of working helps to keep work well organized, with readable history.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR swaps the RTD Support links for Google Groups in favour for the GitHub Discussions.

See [here](https://bjlittle-iris.readthedocs.io/en/latest/) for a version of the rendered documentation of this PR.

In particular, see:

![image](https://user-images.githubusercontent.com/2051656/120396339-4e082280-c32e-11eb-92d3-b758ab370c99.png)



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
