### PR TITLE
Simple support for selective netcdf loading.

### DIFF
--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -95,7 +95,12 @@ FORMAT_AGENT.add_spec(
 #
 FORMAT_AGENT.add_spec(
     FormatSpecification(
-        "NetCDF", MagicNumber(4), 0x43444601, netcdf.load_cubes, priority=5
+        "NetCDF",
+        MagicNumber(4),
+        0x43444601,
+        netcdf.load_cubes,
+        priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -107,6 +112,7 @@ FORMAT_AGENT.add_spec(
         0x43444602,
         netcdf.load_cubes,
         priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -119,6 +125,7 @@ FORMAT_AGENT.add_spec(
         0x894844460D0A1A0A,
         netcdf.load_cubes,
         priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -129,6 +136,7 @@ _nc_dap = FormatSpecification(
     lambda protocol: protocol in ["http", "https"],
     netcdf.load_cubes,
     priority=6,
+    constraint_aware_handler=True,
 )
 FORMAT_AGENT.add_spec(_nc_dap)
 del _nc_dap


### PR DESCRIPTION
## 🚀 Pull Request

### Description
An initial heads-up on a really simple way of speeding up netcdf loads ...
... with files of many variables, as in #4134 

This is actually much simpler than I imagined, but ..
**Blockers to completion**
  * probably needs discussion
  * not sure how to test this

### Background...

Following #4135, ESMValTool devs are reporting that iris loading is [still too slow, where you want only one a whole lot of diagnostics](https://github.com/ESMValGroup/ESMValCore/pull/1153#issuecomment-853223610).

This example follows what we did for PP files in similar circumstances.
It's notable that, in creating a `iris.fileformats.cf.CFReader`, we are still doing a whole-file analysis, that includes the unwanted data-variables.  
I actually don't think you can avoid that, as only context will distinguish a CF data-variable from an aux-coord.
However, the cost of this is not huge.  I am finding <1sec for the testfile mentioned in #4134 (~250mB, 300 variables of content float[1,100]).

#### Some sample timings:
Using testfiles with many identical (small) variables:
**n-vars** : timings without // with fix
    1 :   0.04  //  0.01   [loading 1 of N named variables]
  10 :   0.14  //  0.02
  30 :   0.45  //  0.03
100 :   1.70  //  0.07
300 :   8.19  //  0.40
(**314**) :  44.17  //  0.61

case (**314**) is based on the testfile mentioned in #4314 
( I suspect it may be slower than the '300' because the variables _data_ is larger??  WIP )
with the code like
```
cube = iris.load_cube(
    'Iris_multivar_data_file.nc',
    NameConstraint(long_name='Air Surface Temperature'))
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
