### PR TITLE
Simple support for selective netcdf loading.

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -62,6 +62,10 @@ This document explains the changes made to Iris for this release
    :attr:`~iris.cube.Cube.attributes`, and improving spacing throughout.
    (:pull:`4206`)
 
+#. `@pp-mo`_ and `@lbdreyer`_ optimised loading netcdf files, resulting in a
+   speed up when loading with a single :func:`~iris.NameConstraint`.
+   (:pull:`4176`)
+
 
 🐛 Bugs Fixed
 =============

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -63,7 +63,9 @@ This document explains the changes made to Iris for this release
    (:pull:`4206`)
 
 #. `@pp-mo`_ and `@lbdreyer`_ optimised loading netcdf files, resulting in a
-   speed up when loading with a single :func:`~iris.NameConstraint`.
+   speed up when loading with a single :func:`~iris.NameConstraint`. Note, this
+   optimisation only applies when matching on standard name, long name or
+   NetCDF variable name, not when matching on STASH.
    (:pull:`4176`)
 
 

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -90,7 +90,12 @@ FORMAT_AGENT.add_spec(
 #
 FORMAT_AGENT.add_spec(
     FormatSpecification(
-        "NetCDF", MagicNumber(4), 0x43444601, netcdf.load_cubes, priority=5
+        "NetCDF",
+        MagicNumber(4),
+        0x43444601,
+        netcdf.load_cubes,
+        priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -102,6 +107,7 @@ FORMAT_AGENT.add_spec(
         0x43444602,
         netcdf.load_cubes,
         priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -114,6 +120,7 @@ FORMAT_AGENT.add_spec(
         0x894844460D0A1A0A,
         netcdf.load_cubes,
         priority=5,
+        constraint_aware_handler=True,
     )
 )
 
@@ -124,6 +131,7 @@ _nc_dap = FormatSpecification(
     lambda protocol: protocol in ["http", "https"],
     netcdf.load_cubes,
     priority=6,
+    constraint_aware_handler=True,
 )
 FORMAT_AGENT.add_spec(_nc_dap)
 del _nc_dap

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -37,7 +37,6 @@ from iris.aux_factory import (
     OceanSigmaZFactory,
 )
 import iris.config
-import iris._constraints
 import iris.coord_systems
 import iris.coords
 import iris.exceptions
@@ -771,6 +770,7 @@ def translate_constraints_to_var_callback(constraints):
     For now, ONLY handles a single NameConstraint with no 'STASH' component.
 
     """
+    import iris._constraints
     constraints = iris._constraints.list_of_constraints(constraints)
     result = None
     if len(constraints) == 1:
@@ -787,9 +787,10 @@ def translate_constraints_to_var_callback(constraints):
                 for name in constraint._names:
                     expected = getattr(constraint, name)
                     if name != "STASH" and expected != "none":
+                        attr_name = 'cf_name' if name == 'var_name' else name
                         # Fetch property : N.B. CFVariable caches the property values
                         # The use of a default here is the only difference from the code in NameConstraint.
-                        actual = getattr(cf_datavar, name, "")
+                        actual = getattr(cf_datavar, attr_name, "")
                         if actual != expected:
                             match = False
                             break

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -791,6 +791,8 @@ def _translate_constraints_to_var_callback(constraints):
                         attr_name = "cf_name" if name == "var_name" else name
                         # Fetch property : N.B. CFVariable caches the property values
                         # The use of a default here is the only difference from the code in NameConstraint.
+                        if not hasattr(cf_datavar, attr_name):
+                            continue
                         actual = getattr(cf_datavar, attr_name, "")
                         if actual != expected:
                             match = False

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -759,7 +759,7 @@ def _load_aux_factory(engine, cube):
         cube.add_aux_factory(factory)
 
 
-def translate_constraints_to_var_callback(constraints):
+def _translate_constraints_to_var_callback(constraints):
     """
     Translate load constraints into a simple data-var filter function, if possible.
 
@@ -822,7 +822,7 @@ def load_cubes(filenames, callback=None, constraints=None):
     from iris.io import run_callback
 
     # Create a low-level data-var filter from the original load constraints, if they are suitable.
-    var_callback = translate_constraints_to_var_callback(constraints)
+    var_callback = _translate_constraints_to_var_callback(constraints)
 
     # Create an actions engine.
     engine = _actions_engine()

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -771,6 +771,7 @@ def translate_constraints_to_var_callback(constraints):
 
     """
     import iris._constraints
+
     constraints = iris._constraints.list_of_constraints(constraints)
     result = None
     if len(constraints) == 1:
@@ -787,7 +788,7 @@ def translate_constraints_to_var_callback(constraints):
                 for name in constraint._names:
                     expected = getattr(constraint, name)
                     if name != "STASH" and expected != "none":
-                        attr_name = 'cf_name' if name == 'var_name' else name
+                        attr_name = "cf_name" if name == "var_name" else name
                         # Fetch property : N.B. CFVariable caches the property values
                         # The use of a default here is the only difference from the code in NameConstraint.
                         actual = getattr(cf_datavar, attr_name, "")

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -672,5 +672,19 @@ data:
         self.assertEqual(cs.false_northing, 0.0)
 
 
+class TestConstrainedLoad(tests.IrisTest):
+    filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'A1B-99999a-river-sep-2070-2099.nc'))
+
+    def test_netcdf_with_NameConstraint(self):
+        constr = iris.NameConstraint(var_name='cdf_temp_dmax_tmean_abs')
+        cubes = iris.load(self.filename, constr)
+        self.assertEqual(len(cubes), 1)
+        self.assertEqual(cubes[0].var_name, 'cdf_temp_dmax_tmean_abs')
+
+    def test_netcdf_with_no_constraint(self):
+        cubes = iris.load(self.filename)
+        self.assertEqual(len(cubes), 3)
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -673,13 +673,15 @@ data:
 
 
 class TestConstrainedLoad(tests.IrisTest):
-    filename = tests.get_data_path(('NetCDF', 'label_and_climate', 'A1B-99999a-river-sep-2070-2099.nc'))
+    filename = tests.get_data_path(
+        ("NetCDF", "label_and_climate", "A1B-99999a-river-sep-2070-2099.nc")
+    )
 
     def test_netcdf_with_NameConstraint(self):
-        constr = iris.NameConstraint(var_name='cdf_temp_dmax_tmean_abs')
+        constr = iris.NameConstraint(var_name="cdf_temp_dmax_tmean_abs")
         cubes = iris.load(self.filename, constr)
         self.assertEqual(len(cubes), 1)
-        self.assertEqual(cubes[0].var_name, 'cdf_temp_dmax_tmean_abs')
+        self.assertEqual(cubes[0].var_name, "cdf_temp_dmax_tmean_abs")
 
     def test_netcdf_with_no_constraint(self):
         cubes = iris.load(self.filename)

--- a/lib/iris/tests/unit/fileformats/netcdf/test__translate_constraints_to_var_callback.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__translate_constraints_to_var_callback.py
@@ -5,14 +5,14 @@
 # licensing details.
 """
 Unit tests for
-:func:`iris.fileformats.netcdf.translate_constraints_to_var_callback`.
+:func:`iris.fileformats.netcdf._translate_constraints_to_var_callback`.
 
 """
 
 from unittest.mock import Mock
 
 import iris
-from iris.fileformats.netcdf import translate_constraints_to_var_callback
+from iris.fileformats.netcdf import _translate_constraints_to_var_callback
 
 # import iris tests first so that some things can be initialised before
 # importing anything else
@@ -36,44 +36,44 @@ class Test(tests.IrisTest):
             iris.NameConstraint(standard_name="x_wind"),
             iris.NameConstraint(var_name="var1"),
         ]
-        result = translate_constraints_to_var_callback(constrs)
+        result = _translate_constraints_to_var_callback(constrs)
         self.assertIsNone(result)
 
     def test_non_NameConstraint(self):
         constr = iris.AttributeConstraint(STASH="m01s00i002")
-        result = translate_constraints_to_var_callback(constr)
+        result = _translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 
     def test_str_constraint(self):
-        result = translate_constraints_to_var_callback("x_wind")
+        result = _translate_constraints_to_var_callback("x_wind")
         self.assertIsNone(result)
 
     def test_Constaint_with_name(self):
         constr = iris.Constraint(name="x_wind")
-        result = translate_constraints_to_var_callback(constr)
+        result = _translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 
     def test_NameConstraint_standard_name(self):
         constr = iris.NameConstraint(standard_name="x_wind")
-        callback = translate_constraints_to_var_callback(constr)
+        callback = _translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, False, True])
 
     def test_NameConstraint_long_name(self):
         constr = iris.NameConstraint(long_name="x component of wind")
-        callback = translate_constraints_to_var_callback(constr)
+        callback = _translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [False, False, True, True])
 
     def test_NameConstraint_var_name(self):
         constr = iris.NameConstraint(var_name="var1")
-        callback = translate_constraints_to_var_callback(constr)
+        callback = _translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, True, True])
 
     def test_NameConstraint_standard_name_var_name(self):
         constr = iris.NameConstraint(standard_name="x_wind", var_name="var1")
-        callback = translate_constraints_to_var_callback(constr)
+        callback = _translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, False, True])
 
@@ -83,7 +83,7 @@ class Test(tests.IrisTest):
             long_name="x component of wind",
             var_name="var1",
         )
-        callback = translate_constraints_to_var_callback(constr)
+        callback = _translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [False, False, False, True])
 
@@ -91,7 +91,7 @@ class Test(tests.IrisTest):
         constr = iris.NameConstraint(
             standard_name="x_wind", STASH="m01s00i024"
         )
-        result = translate_constraints_to_var_callback(constr)
+        result = _translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test__translate_constraints_to_var_callback.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test__translate_constraints_to_var_callback.py
@@ -22,11 +22,14 @@ import iris.tests as tests
 
 class Test(tests.IrisTest):
     data_variables = [
-        CFDataVariable('var1', MagicMock(standard_name='x_wind')),
-        CFDataVariable('var2', MagicMock(standard_name='y_wind')),
-        CFDataVariable('var1', MagicMock(long_name='x component of wind')),
-        CFDataVariable('var1', MagicMock(standard_name='x_wind', long_name='x component of wind')),
-        CFDataVariable('var1', MagicMock()),
+        CFDataVariable("var1", MagicMock(standard_name="x_wind")),
+        CFDataVariable("var2", MagicMock(standard_name="y_wind")),
+        CFDataVariable("var1", MagicMock(long_name="x component of wind")),
+        CFDataVariable(
+            "var1",
+            MagicMock(standard_name="x_wind", long_name="x component of wind"),
+        ),
+        CFDataVariable("var1", MagicMock()),
     ]
 
     def test_multiple_constraints(self):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_translate_constraints_to_var_callback.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_translate_constraints_to_var_callback.py
@@ -9,80 +9,88 @@ Unit tests for
 
 """
 
-# import iris tests first so that some things can be initialised before
-# importing anything else
-import iris.tests as tests
-
 from unittest.mock import Mock
 
 import iris
 from iris.fileformats.netcdf import translate_constraints_to_var_callback
 
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
 
 class Test(tests.IrisTest):
     data_variables = [
-        Mock(standard_name='x_wind', cf_name='var1'),
-        Mock(standard_name='y_wind', cf_name='var2'),
-        Mock(long_name='x component of wind', cf_name='var1'),
-        Mock(standard_name='x_wind', long_name='x component of wind',
-             cf_name='var1')
+        Mock(standard_name="x_wind", cf_name="var1"),
+        Mock(standard_name="y_wind", cf_name="var2"),
+        Mock(long_name="x component of wind", cf_name="var1"),
+        Mock(
+            standard_name="x_wind",
+            long_name="x component of wind",
+            cf_name="var1",
+        ),
     ]
 
     def test_multiple_constraints(self):
-        constrs = [iris.NameConstraint(standard_name='x_wind'),
-                   iris.NameConstraint(var_name='var1')]
+        constrs = [
+            iris.NameConstraint(standard_name="x_wind"),
+            iris.NameConstraint(var_name="var1"),
+        ]
         result = translate_constraints_to_var_callback(constrs)
         self.assertIsNone(result)
 
     def test_non_NameConstraint(self):
-        constr = iris.AttributeConstraint(STASH='m01s00i002')
+        constr = iris.AttributeConstraint(STASH="m01s00i002")
         result = translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 
     def test_str_constraint(self):
-        result = translate_constraints_to_var_callback('x_wind')
+        result = translate_constraints_to_var_callback("x_wind")
         self.assertIsNone(result)
 
     def test_Constaint_with_name(self):
-        constr = iris.Constraint(name='x_wind')
+        constr = iris.Constraint(name="x_wind")
         result = translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 
     def test_NameConstraint_standard_name(self):
-        constr = iris.NameConstraint(standard_name='x_wind')
+        constr = iris.NameConstraint(standard_name="x_wind")
         callback = translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, False, True])
 
     def test_NameConstraint_long_name(self):
-        constr = iris.NameConstraint(long_name='x component of wind')
+        constr = iris.NameConstraint(long_name="x component of wind")
         callback = translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [False, False, True, True])
 
     def test_NameConstraint_var_name(self):
-        constr = iris.NameConstraint(var_name='var1')
+        constr = iris.NameConstraint(var_name="var1")
         callback = translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, True, True])
 
     def test_NameConstraint_standard_name_var_name(self):
-        constr = iris.NameConstraint(standard_name='x_wind',
-                                     var_name='var1')
+        constr = iris.NameConstraint(standard_name="x_wind", var_name="var1")
         callback = translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [True, False, False, True])
 
     def test_NameConstraint_standard_name_long_name_var_name(self):
-        constr = iris.NameConstraint(standard_name='x_wind',
-                                     long_name='x component of wind',
-                                     var_name='var1')
+        constr = iris.NameConstraint(
+            standard_name="x_wind",
+            long_name="x component of wind",
+            var_name="var1",
+        )
         callback = translate_constraints_to_var_callback(constr)
         result = [callback(var) for var in self.data_variables]
         self.assertArrayEqual(result, [False, False, False, True])
 
     def test_NameConstraint_with_STASH(self):
-        constr = iris.NameConstraint(standard_name='x_wind', STASH='m01s00i024')
+        constr = iris.NameConstraint(
+            standard_name="x_wind", STASH="m01s00i024"
+        )
         result = translate_constraints_to_var_callback(constr)
         self.assertIsNone(result)
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test_translate_constraints_to_var_callback.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_translate_constraints_to_var_callback.py
@@ -1,0 +1,91 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for
+:func:`iris.fileformats.netcdf.translate_constraints_to_var_callback`.
+
+"""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+import iris.tests as tests
+
+from unittest.mock import Mock
+
+import iris
+from iris.fileformats.netcdf import translate_constraints_to_var_callback
+
+
+class Test(tests.IrisTest):
+    data_variables = [
+        Mock(standard_name='x_wind', cf_name='var1'),
+        Mock(standard_name='y_wind', cf_name='var2'),
+        Mock(long_name='x component of wind', cf_name='var1'),
+        Mock(standard_name='x_wind', long_name='x component of wind',
+             cf_name='var1')
+    ]
+
+    def test_multiple_constraints(self):
+        constrs = [iris.NameConstraint(standard_name='x_wind'),
+                   iris.NameConstraint(var_name='var1')]
+        result = translate_constraints_to_var_callback(constrs)
+        self.assertIsNone(result)
+
+    def test_non_NameConstraint(self):
+        constr = iris.AttributeConstraint(STASH='m01s00i002')
+        result = translate_constraints_to_var_callback(constr)
+        self.assertIsNone(result)
+
+    def test_str_constraint(self):
+        result = translate_constraints_to_var_callback('x_wind')
+        self.assertIsNone(result)
+
+    def test_Constaint_with_name(self):
+        constr = iris.Constraint(name='x_wind')
+        result = translate_constraints_to_var_callback(constr)
+        self.assertIsNone(result)
+
+    def test_NameConstraint_standard_name(self):
+        constr = iris.NameConstraint(standard_name='x_wind')
+        callback = translate_constraints_to_var_callback(constr)
+        result = [callback(var) for var in self.data_variables]
+        self.assertArrayEqual(result, [True, False, False, True])
+
+    def test_NameConstraint_long_name(self):
+        constr = iris.NameConstraint(long_name='x component of wind')
+        callback = translate_constraints_to_var_callback(constr)
+        result = [callback(var) for var in self.data_variables]
+        self.assertArrayEqual(result, [False, False, True, True])
+
+    def test_NameConstraint_var_name(self):
+        constr = iris.NameConstraint(var_name='var1')
+        callback = translate_constraints_to_var_callback(constr)
+        result = [callback(var) for var in self.data_variables]
+        self.assertArrayEqual(result, [True, False, True, True])
+
+    def test_NameConstraint_standard_name_var_name(self):
+        constr = iris.NameConstraint(standard_name='x_wind',
+                                     var_name='var1')
+        callback = translate_constraints_to_var_callback(constr)
+        result = [callback(var) for var in self.data_variables]
+        self.assertArrayEqual(result, [True, False, False, True])
+
+    def test_NameConstraint_standard_name_long_name_var_name(self):
+        constr = iris.NameConstraint(standard_name='x_wind',
+                                     long_name='x component of wind',
+                                     var_name='var1')
+        callback = translate_constraints_to_var_callback(constr)
+        result = [callback(var) for var in self.data_variables]
+        self.assertArrayEqual(result, [False, False, False, True])
+
+    def test_NameConstraint_with_STASH(self):
+        constr = iris.NameConstraint(standard_name='x_wind', STASH='m01s00i024')
+        result = translate_constraints_to_var_callback(constr)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
An initial heads-up on a really simple way of speeding up netcdf loads ...
... with files of many variables, as in #4134 

This is actually much simpler than I imagined, but ..
**Blockers to completion**
  * probably needs discussion
  * intended usage might require to select multiple data-vars
  * not sure how to test this

### Background...

Following #4135, ESMValTool devs are reporting that iris loading is [still too slow, where you want only one from a whole lot of diagnostics](https://github.com/ESMValGroup/ESMValCore/pull/1153#issuecomment-853223610).

This example follows [what we did for UM files in similar circumstances](https://github.com/SciTools/iris/pull/1240).
It's notable that, in creating a `iris.fileformats.cf.CFReader`, we are still doing a whole-file analysis, that includes the unwanted data-variables.  
I actually don't think you can avoid that, as only context will distinguish a CF data-variable from an aux-coord.
However, the cost of this is not huge.  I am finding <1sec for the testfile mentioned in #4134 
( which is : ~250mB, ~300 variables of content float[1 * 79 * 143 * 144] )

#### Some sample timings:
Using testfiles with many identical (small) variables:
**n-vars**  :  **timings without // with fix**
    1 :   0.04  //  0.01   [loading 1 of N named variables]
  10 :   0.14  //  0.02
  30 :   0.45  //  0.03
100 :   1.70  //  0.07
300 :   8.19  //  0.40
(**314**) :  45.36  //  0.59

case (**314**) is based on the testfile mentioned in #4134 
( I suspect it may be slower than the '300' because the variables _data_ is larger??  WIP )
with the code like
```
cube = iris.load_cube(
    'Iris_multivar_data_file.nc',
    NameConstraint(long_name='Air Surface Temperature'))
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

