### PR TITLE
combine and skip cirrus-ci tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,9 +18,8 @@ container:
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
   SKIP_LINT_TASK: ""
-  SKIP_TEST_MINIMAL_TASK: ""
+  SKIP_TEST_MINIMAL_TASK: "1"
   SKIP_TEST_FULL_TASK: ""
-  SKIP_GALLERY_TASK: ""
   SKIP_DOCTEST_TASK: ""
   SKIP_LINKCHECK_TASK: ""
   # Skip task groups by type. Set to a non-empty string to skip.
@@ -174,25 +173,6 @@ test_full_task:
     - echo "test_data_dir = ${IRIS_TEST_DATA_DIR}/test_data" >> ${SITE_CFG}
     - echo "doc_dir = ${CIRRUS_WORKING_DIR}/docs" >> ${SITE_CFG}
     - nox --session tests -- --verbose
-
-
-#
-# Testing Documentation Gallery (Linux)
-#
-gallery_task:
-  only_if: ${SKIP_GALLERY_TASK} == "" && ${SKIP_ALL_DOC_TASKS} == ""
-  << : *CREDITS_TEMPLATE
-  env:
-    PY_VER: 3.8
-  name: "${CIRRUS_OS}: py${PY_VER} doc tests (gallery)"
-  << : *IRIS_TEST_DATA_TEMPLATE
-  << : *LINUX_TASK_TEMPLATE
-  tests_script:
-    - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-    - echo "[Resources]" > ${SITE_CFG}
-    - echo "test_data_dir = ${IRIS_TEST_DATA_DIR}/test_data" >> ${SITE_CFG}
-    - echo "doc_dir = ${CIRRUS_WORKING_DIR}/docs" >> ${SITE_CFG}
-    - nox --session gallery -- --verbose
 
 
 #

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -175,6 +175,10 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ refactored ``setup.py`` into ``setup.cfg``. (:pull:`4168`)
 
+#. `@bjlittle`_ rationalised the `cirrus-ci`_ tasks by combining the gallery
+   and doc-test tasks, and disabling the minimal tests in favour for the
+   full tests. (:pull:`4179`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/noxfile.py
+++ b/noxfile.py
@@ -220,9 +220,9 @@ def tests(session: nox.sessions.Session):
 
 
 @nox.session(python=PY_VER, venv_backend="conda")
-def gallery(session: nox.sessions.Session):
+def doctest(session: nox.sessions.Session):
     """
-    Perform iris gallery doc-tests.
+    Perform iris gallery and doc-tests.
 
     Parameters
     ----------
@@ -238,21 +238,6 @@ def gallery(session: nox.sessions.Session):
         "iris.tests.runner",
         "--gallery-tests",
     )
-
-
-@nox.session(python=PY_VER, venv_backend="conda")
-def doctest(session: nox.sessions.Session):
-    """
-    Perform iris doc-tests.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    """
-    prepare_venv(session)
-    session.install("--no-deps", "--editable", ".")
     session.cd("docs")
     session.run(
         "make",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR rationalises the `cirris-ci` tasks.

We require to be a little bit more savvy when it comes to the resources that we are using on `cirrus-ci`.

As such this PR skips the minimal tests, and combines the doc-tests and doc gallery tests into one task.

The effort and resource spent on performing the minimal tests are duplicated by the full tests, therefore let's skip them on `cirrus-ci`. Note that, minimal tests can still be run locally via `nox`, if the developer wishes.

Also, there is effort and resource spin-up duplication between the documentation tasks, therefore the doc-tests and gallery tests have been combined at the `nox` level - akin to why the linting task combines several similar jobs together.

Note that, the documentation link-check task will soon be combined with the new spell checking task once #3882 lands.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
