### PR TITLE
remove __future__ and six references

### DIFF
--- a/docs/gallery_code/oceanography/plot_load_nemo.py
+++ b/docs/gallery_code/oceanography/plot_load_nemo.py
@@ -8,8 +8,6 @@ different time dimensions in these files can prevent Iris from concatenating
 them without the intervention shown here.
 """
 
-from __future__ import unicode_literals
-
 import matplotlib.pyplot as plt
 
 import iris

--- a/lib/iris/tests/unit/constraints/__init__.py
+++ b/lib/iris/tests/unit/constraints/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Unit tests for the :mod:`iris._constraints` module."""
-
-from __future__ import absolute_import, division, print_function
-from six.moves import filter, input, map, range, zip  # noqa

--- a/lib/iris/tests/unit/constraints/test_NameConstraint.py
+++ b/lib/iris/tests/unit/constraints/test_NameConstraint.py
@@ -5,9 +5,6 @@
 # licensing details.
 """Unit tests for the `iris._constraints.NameConstraint` class."""
 
-from __future__ import absolute_import, division, print_function
-from six.moves import filter, input, map, range, zip  # noqa
-
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris.tests as tests


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR mops up some missed `__future__` and `six` references from our recent porting to Python 3 exploits.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
