### PR TITLE
drop black and flake8 dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ env:
   # Increment the build number to force new pip cache upload.
   PIP_CACHE_BUILD: "0"
   # Pip packages to be upgraded/installed.
-  PIP_CACHE_PACKAGES: "pip setuptools wheel nox"
+  PIP_CACHE_PACKAGES: "nox pip setuptools wheel"
   # Conda packages to be installed.
   CONDA_CACHE_PACKAGES: "nox pip"
   # Git commit hash for iris test data.
@@ -116,7 +116,7 @@ lint_task:
     image: python:3.8
     cpu: 2
     memory: 4G
-  name: "${CIRRUS_OS}: black, flake8 and isort"
+  name: "${CIRRUS_OS}: linting"
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script:
@@ -126,9 +126,7 @@ lint_task:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
     - pip list
-    - nox --session black
-    - nox --session flake8
-    - nox --session isort
+    - nox --session lint
 
 
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.0.1'
+    rev: "v4.0.1"
     hooks:
         # Prevent giant files from being committed.
     -   id: check-added-large-files
@@ -17,24 +17,23 @@ repos:
         # Don't commit to main branch.
     -   id: no-commit-to-branch
 -   repo: https://github.com/psf/black
-    rev: '21.6b0'
+    rev: "21.6b0"
     hooks:
     -   id: black
         # Force black to run on whole repo, using settings from pyproject.toml
         pass_filenames: false
-        args: [--config=./pyproject.toml, .]
+        args: ["--config=./pyproject.toml", "--check", "docs", "lib", "noxfile.py", "setup.py"]
 -   repo: https://github.com/PyCQA/flake8
-    rev: '3.9.2'
+    rev: "3.9.2"
     hooks:
-        # Run flake8.
     -   id: flake8
-        args: [--config=./setup.cfg]
+        args: ["--config=./setup.cfg"]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.1
+    rev: "5.9.1"
     hooks:
     -   id: isort
         name: isort
-        args: ["--filter-files"]
+        args: ["--filter-files", "--check"]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,18 +20,18 @@ repos:
     rev: "21.6b0"
     hooks:
     -   id: black
-        # Force black to run on whole repo, using settings from pyproject.toml
         pass_filenames: false
         args: ["--config=./pyproject.toml", "--check", "docs", "lib", "noxfile.py", "setup.py"]
 -   repo: https://github.com/PyCQA/flake8
     rev: "3.9.2"
     hooks:
     -   id: flake8
-        args: ["--config=./setup.cfg"]
+        args: ["--config=./setup.cfg", "docs", "lib", "noxfile.py", "setup.py"]
 -   repo: https://github.com/pycqa/isort
     rev: "5.9.1"
     hooks:
     -   id: isort
+        # Use settings from pyproject.toml
         name: isort
         args: ["--filter-files", "--check"]
 -   repo: https://github.com/asottile/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,10 @@ repos:
     rev: "5.9.1"
     hooks:
     -   id: isort
-        # Use settings from pyproject.toml
+        # Align CLI usage with other hooks, rather than use isort "src_paths" option
+        # in the pyproject.toml configuration.
         name: isort
-        args: ["--filter-files", "--check"]
+        args: ["--filter-files", "--check", "docs", "lib", "noxfile.py", "setup.py"]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.8.0
     hooks:

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -129,7 +129,6 @@ This document explains the changes made to Iris for this release
    they render better in the published documentation.  See :issue:`4085`.
    (:pull:`4100`)
 
-
 💼 Internal
 ===========
 
@@ -187,6 +186,9 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ added the `blacken-docs`_ ``pre-commit`` hook to automate
    ``black`` linting of documentation code blocks. (:pull:`4205`)
+
+#. `@bjlittle`_ consolidated `nox`_ ``black``, ``flake8`` and ``isort`` sessions
+   into one ``lint`` session using ``pre-commit``. (:pull:`4181`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,7 +86,8 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@bjlittle`_ dropped both `black`_ and `flake8`_ package dependencies
+   from our `conda`_ YAML and ``setup.cfg`` PyPI requirements. (:pull:`4181`)
 
 
 📚 Documentation

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,12 +15,6 @@ from nox.logger import logger
 #: Default to reusing any pre-existing nox environments.
 nox.options.reuse_existing_virtualenvs = True
 
-#: Root directory.
-ROOT_DIR = Path(__file__).resolve().parent
-
-#: Name of the package to test.
-PACKAGE = str(ROOT_DIR / "lib" / "iris")
-
 #: Cirrus-CI environment variable hook.
 PY_VER = os.environ.get("PY_VER", ["3.7", "3.8"])
 
@@ -162,9 +156,9 @@ def prepare_venv(session: nox.sessions.Session) -> None:
 
 
 @nox.session
-def flake8(session: nox.sessions.Session):
+def lint(session: nox.sessions.Session):
     """
-    Perform flake8 linting of iris.
+    Perform pre-commit linting of iris codebase.
 
     Parameters
     ----------
@@ -173,54 +167,9 @@ def flake8(session: nox.sessions.Session):
 
     """
     # Pip install the session requirements.
-    session.install("flake8")
-    # Execute the flake8 linter on the package.
-    session.run("flake8", PACKAGE)
-    # Execute the flake8 linter on root Python files.
-    for fname in ROOT_DIR.glob("*.py"):
-        session.run("flake8", str(fname))
-
-
-@nox.session
-def black(session: nox.sessions.Session):
-    """
-    Perform black format checking of iris.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    """
-    # Pip install the session requirements.
-    session.install("black==21.5b2")
-    # Execute the black format checker on the package.
-    session.run("black", "--check", PACKAGE)
-    # Execute the black format checker on root Python files.
-    for fname in ROOT_DIR.glob("*.py"):
-        session.run("black", "--check", str(fname))
-
-
-@nox.session
-def isort(session: nox.sessions.Session):
-    """
-    Perform isort import checking of iris codebase.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    """
-    # Pip install the session requirements.
-    session.install("isort")
-    # Execute the isort import checker on the package.
-    session.run("isort", "--check", str(PACKAGE))
-    # Execute the isort import checker on the documentation.
-    session.run("isort", "--check", str(ROOT_DIR / "docs"))
-    # Execute the isort import checker on the root Python files.
-    for fname in ROOT_DIR.glob("*.py"):
-        session.run("isort", "--check", str(fname))
+    session.install("pre-commit")
+    # Execute the pre-commit linting tasks.
+    session.run("pre-commit", "run", "--all-files")
 
 
 @nox.session(python=PY_VER, venv_backend="conda")

--- a/noxfile.py
+++ b/noxfile.py
@@ -169,7 +169,10 @@ def lint(session: nox.sessions.Session):
     # Pip install the session requirements.
     session.install("pre-commit")
     # Execute the pre-commit linting tasks.
-    session.run("pre-commit", "run", "--all-files")
+    cmd = ["pre-commit", "run", "--all-files"]
+    hooks = ["black", "blacken-docs", "flake8", "isort"]
+    for hook in hooks:
+        session.run(*cmd, hook)
 
 
 @nox.session(python=PY_VER, venv_backend="conda")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[build-system]
+# Defined by PEP 518
+requires = [
+  "scitools-pyke",
+  "setuptools>=40.8.0",
+  "wheel",
+]
+# Defined by PEP 517
+build-backend = "setuptools.build_meta"
+
+
 [tool.black]
 line-length = 79
 target-version = ['py37', 'py38']
@@ -29,15 +40,6 @@ exclude = '''
 )
 '''
 
-[build-system]
-# Defined by PEP 518
-requires = [
-  "scitools-pyke",
-  "setuptools>=40.8.0",
-  "wheel",
-]
-# Defined by PEP 517
-build-backend = "setuptools.build_meta"
 
 [tool.isort]
 force_sort_within_sections = "True"
@@ -53,4 +55,10 @@ extend_skip = [
   "tools",
 ]
 skip_gitignore = "True"
+src_paths = [
+  "docs",
+  "lib",
+  "noxfile.py",
+  "setup.py",
+]
 verbose = "False"

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -34,9 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b2
   - filelock
-  - flake8
   - imagehash>=4.0
   - nose
   - pillow<7

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -34,9 +34,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=21.5b2
   - filelock
-  - flake8
   - imagehash>=4.0
   - nose
   - pillow<7

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,9 +77,7 @@ docs =
     sphinx-panels
 test =
     asv
-    black==21.5b2
     filelock
-    flake8
     imagehash>=4.0
     nose
     pillow<7


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Akin to PR #4174 and `isort`, this PR drops the `black` and `flake` package dependencies from both our `conda` YAML and PyPI `setup.cfg` requirements.

We're now advocating the use of `pre-commit` for developers, which will take care of your linting needs. Additionally, developers (and users alike) can easily install these packages explicitly, if they wish.

The reason for dropping these packages is to reduce the `iris` dependency bloat, but also due to the regular cadence in version bumping that is required - hardly a major maintenance overhead, but this has cause recent difficulties, particularly with `black`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
