### PR TITLE
Clarify interpolate and regrid scheme use

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4450,7 +4450,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             dates or times may optionally be supplied as datetime.datetime or
             cftime.datetime instances.
         * scheme:
-            The type of interpolation to use to interpolate from this
+            An instance of the type of interpolation to use to interpolate from this
             :class:`~iris.cube.Cube` to the given sample points. The
             interpolation schemes currently available in Iris are:
 
@@ -4523,7 +4523,7 @@ calendar='gregorian')
         * grid:
             A :class:`~iris.cube.Cube` that defines the target grid.
         * scheme:
-            The type of regridding to use to regrid this cube onto the
+            An instance of the type of regridding to use to regrid this cube onto the
             target grid. The regridding schemes in Iris currently include:
 
                 * :class:`iris.analysis.Linear`\*,


### PR DESCRIPTION
Recently we had a user having trouble with regridding as they had not realised that they need to provide an _instance_ of the scheme, rather than just the class.

I.e. they did
`cube.regrid(target_grid, iris.analysis.Linear)`
rather than 
`cube.regrid(target_grid, iris.analysis.Linear())`

From the docs, we don't make it clear that we want an instance rather the class itself. And it's perfectly reasonable for a function to accept a class (and then under the hood, that function instantiates the class when/how it needs to)

I wondered if we should clarify this in the docs, specifically in the API docs (we already have examples of regrid/interpolate in the user guide).

In this PR I have proposed a simple addition for both the regrid and interpolate methods. However I note that the interpolate method includes an example and maybe it would be preferable to, instead, just include an example for the regrid?
