### PR TITLE
change master to main references

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,7 +87,7 @@ linux_task_template: &LINUX_TASK_TEMPLATE
 # YAML alias for compute credits.
 #
 compute_credits_template: &CREDITS_TEMPLATE
-  # Only use credits for non-DRAFT pull-requests to SciTools/iris master branch by collaborators
+  # Only use credits for non-DRAFT pull-requests to SciTools/iris main branch by collaborators
   use_compute_credits: ${CIRRUS_REPO_FULL_NAME} == "SciTools/iris" && ${CIRRUS_USER_COLLABORATOR} == "true" && ${CIRRUS_PR_DRAFT} == "false" && ${CIRRUS_PR} != ""
 
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,7 +87,7 @@ linux_task_template: &LINUX_TASK_TEMPLATE
 # YAML alias for compute credits.
 #
 compute_credits_template: &CREDITS_TEMPLATE
-  # Only use credits for non-DRAFT pull-requests to SciTools/iris main branch by collaborators
+  # Restrict where compute credits are used.
   use_compute_credits: ${CIRRUS_REPO_FULL_NAME} == "SciTools/iris" && ${CIRRUS_USER_COLLABORATOR} == "true" && ${CIRRUS_PR_DRAFT} == "false" && ${CIRRUS_PR} != ""
 
 

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -7,7 +7,7 @@
 # pinned at specific versions.
 #
 # For environments that have changed, a pull request will be made and submitted
-# to the master branch
+# to the main branch
 
 name: Refresh Lockfiles
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
         # Check for debugger imports and py37+ `breakpoint()` calls in Python source.
     -   id: debug-statements
-        # Don't commit to master branch.
+        # Don't commit to main branch.
     -   id: no-commit-to-branch
 -   repo: https://github.com/psf/black
     rev: '21.6b0'

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 <p align="center">
 <a href="https://cirrus-ci.com/github/SciTools/iris">
-<img src="https://api.cirrus-ci.com/github/SciTools/iris.svg?branch=master"
+<img src="https://api.cirrus-ci.com/github/SciTools/iris.svg?branch=main"
      alt="Cirrus-CI"></a>
 <a href="https://scitools-iris.readthedocs.io/en/latest/?badge=latest">
 <img src="https://readthedocs.org/projects/scitools-iris/badge/?version=latest"
      alt="Documentation Status"></a>
-<a href="https://results.pre-commit.ci/latest/github/SciTools/iris/master">
-<img src="https://results.pre-commit.ci/badge/github/SciTools/iris/master.svg"
+<a href="https://results.pre-commit.ci/latest/github/SciTools/iris/main">
+<img src="https://results.pre-commit.ci/badge/github/SciTools/iris/main.svg"
      alt="pre-commit.ci status"></a>
 <a href="https://anaconda.org/conda-forge/iris">
 <img src="https://img.shields.io/conda/v/conda-forge/iris?color=orange&label=conda-forge%7Ciris&logo=conda-forge&logoColor=white"
@@ -28,7 +28,7 @@
 <a href="https://github.com/SciTools/iris/releases">
 <img src="https://img.shields.io/github/v/release/scitools/iris"
      alt="latest release"></a>
-<a href="https://github.com/SciTools/iris/commits/master">
+<a href="https://github.com/SciTools/iris/commits/main">
 <img src="https://img.shields.io/github/commits-since/SciTools/iris/latest.svg"
      alt="Commits since last release"></a>
 <a href="https://zenodo.org/badge/latestdoi/5312648">

--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -2,9 +2,9 @@
     Common resources in alphabetical order:
 
 .. _black: https://black.readthedocs.io/en/stable/
-.. _.cirrus.yml: https://github.com/SciTools/iris/blob/master/.cirrus.yml
+.. _.cirrus.yml: https://github.com/SciTools/iris/blob/main/.cirrus.yml
 .. _flake8: https://flake8.pycqa.org/en/stable/
-.. _.flake8.yml: https://github.com/SciTools/iris/blob/master/.flake8
+.. _.flake8.yml: https://github.com/SciTools/iris/blob/main/.flake8
 .. _cirrus-ci: https://cirrus-ci.com/github/SciTools/iris
 .. _conda: https://docs.conda.io/en/latest/
 .. _contributor: https://github.com/SciTools/scitools.org.uk/blob/master/contributors.json
@@ -28,7 +28,7 @@
 .. _pull request: https://github.com/SciTools/iris/pulls
 .. _pull requests: https://github.com/SciTools/iris/pulls
 .. _Read the Docs: https://scitools-iris.readthedocs.io/en/latest/
-.. _readthedocs.yml: https://github.com/SciTools/iris/blob/master/requirements/ci/readthedocs.yml
+.. _readthedocs.yml: https://github.com/SciTools/iris/blob/main/requirements/ci/readthedocs.yml
 .. _SciTools: https://github.com/SciTools
 .. _scitools-iris: https://pypi.org/project/scitools-iris/
 .. _sphinx: https://www.sphinx-doc.org/en/master/

--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -145,6 +145,6 @@ See the `pre-commit.ci dashboard`_ for details of recent past and active Iris jo
 
 .. _Cirrus-CI Dashboard: https://cirrus-ci.com/github/SciTools/iris
 .. _Cirrus-CI Documentation: https://cirrus-ci.org/guide/writing-tasks/
-.. _.pre-commit-config.yaml: https://github.com/SciTools/iris/blob/master/.pre-commit-config.yaml
+.. _.pre-commit-config.yaml: https://github.com/SciTools/iris/blob/main/.pre-commit-config.yaml
 .. _pre-commit.ci dashboard: https://results.pre-commit.ci/repo/github/5312648
 .. _GitHub Actions: https://github.com/SciTools/iris/actions/workflows/refresh-lockfiles.yml

--- a/docs/src/developers_guide/contributing_documentation.rst
+++ b/docs/src/developers_guide/contributing_documentation.rst
@@ -110,7 +110,7 @@ or ignore the url.
           ``.readthedocs.yml``.
 
 
-.. _conf.py: https://github.com/SciTools/iris/blob/master/docs/src/conf.py
+.. _conf.py: https://github.com/SciTools/iris/blob/main/docs/src/conf.py
 
 
 .. _contributing.documentation.api:

--- a/docs/src/developers_guide/contributing_getting_involved.rst
+++ b/docs/src/developers_guide/contributing_getting_involved.rst
@@ -19,7 +19,7 @@ information is provided.
 
 A `pull request`_ may also be created by anyone who has become a
 **contributor** to Iris_.  Permissions to merge pull requests to the
-main code base (master) are only given to **core developers** of Iris_, this is
+``main`` branch are only given to **core developers** of Iris_, this is
 to ensure a measure of control.
 
 To get started we suggest reading recent `issues`_ and `pull requests`_

--- a/docs/src/developers_guide/contributing_graphics_tests.rst
+++ b/docs/src/developers_guide/contributing_graphics_tests.rst
@@ -51,7 +51,7 @@ This consists of:
  * The hashes of known **acceptable** results for each test are stored in a
    lookup dictionary, saved to the repo file
    ``lib/iris/tests/results/imagerepo.json``
-   (`link <https://github.com/SciTools/iris/blob/master/lib/iris/tests/results/imagerepo.json>`_) .
+   (`link <https://github.com/SciTools/iris/blob/main/lib/iris/tests/results/imagerepo.json>`_) .
 
  * An actual reference image for each hash value is stored in a *separate*
    public repository https://github.com/SciTools/test-iris-imagehash.
@@ -163,4 +163,4 @@ To add your changes to Iris, you need to make two pull requests (PR).
   image-listing file in ``test-iris-imagehash``.
 
 
-.. _Iris Cirrus-CI matrix: https://github.com/scitools/iris/blob/master/.cirrus.yml
+.. _Iris Cirrus-CI matrix: https://github.com/scitools/iris/blob/main/.cirrus.yml

--- a/docs/src/developers_guide/gitwash/configure_git.rst
+++ b/docs/src/developers_guide/gitwash/configure_git.rst
@@ -139,18 +139,18 @@ You use the alias with::
 and it gives graph / text output something like this (but with color!)::
 
     * 6d8e1ee - (HEAD, origin/my-fancy-feature, my-fancy-feature) NF - a fancy file (45 minutes ago) [Matthew Brett]
-    *   d304a73 - (origin/placeholder, placeholder) Merge pull request #48 from hhuuggoo/master (2 weeks ago) [Jonathan Terhorst]
+    *   d304a73 - (origin/placeholder, placeholder) Merge pull request #48 from hhuuggoo/main (2 weeks ago) [Jonathan Terhorst]
     |\
     | * 4aff2a8 - fixed bug 35, and added a test in test_bugfixes (2 weeks ago) [Hugo]
     |/
     * a7ff2e5 - Added notes on discussion/proposal made during Data Array Summit. (2 weeks ago) [Corran Webster]
     * 68f6752 - Initial implimentation of AxisIndexer - uses 'index_by' which needs to be changed to a call on an Axes object - this is all very sketchy right now. (2 weeks ago) [Corr
-    *   376adbd - Merge pull request #46 from terhorst/master (2 weeks ago) [Jonathan Terhorst]
+    *   376adbd - Merge pull request #46 from terhorst/main (2 weeks ago) [Jonathan Terhorst]
     |\
     | * b605216 - updated joshu example to current api (3 weeks ago) [Jonathan Terhorst]
     | * 2e991e8 - add testing for outer ufunc (3 weeks ago) [Jonathan Terhorst]
     | * 7beda5a - prevent axis from throwing an exception if testing equality with non-axis object (3 weeks ago) [Jonathan Terhorst]
     | * 65af65e - convert unit testing code to assertions (3 weeks ago) [Jonathan Terhorst]
-    | *   956fbab - Merge remote-tracking branch 'upstream/master' (3 weeks ago) [Jonathan Terhorst]
+    | *   956fbab - Merge remote-tracking branch 'upstream/main' (3 weeks ago) [Jonathan Terhorst]
     | |\
     | |/

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -34,8 +34,8 @@ what you've done, and why you did it.
 
 See `linux git workflow`_ for some explanation.
 
-Consider Deleting Your Master Branch
-====================================
+Consider Deleting Your Main Branch
+==================================
 
 It may sound strange, but deleting your own ``main`` branch can help reduce
 confusion about which branch you are on.  See `deleting master on github`_ for

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -11,10 +11,10 @@ git by following :ref:`configure-git`.  Now you are ready for some real work.
 Workflow Summary
 ================
 
-In what follows we'll refer to the upstream iris ``master`` branch, as
+In what follows we'll refer to the upstream iris ``main`` branch, as
 "trunk".
 
-* Don't use your ``master`` (that is on your fork) branch for anything.
+* Don't use your ``main`` (that is on your fork) branch for anything.
   Consider deleting it.
 * When you are starting a new set of changes, fetch any changes from trunk,
   and start a new *feature branch* from that.
@@ -37,7 +37,7 @@ See `linux git workflow`_ for some explanation.
 Consider Deleting Your Master Branch
 ====================================
 
-It may sound strange, but deleting your own ``master`` branch can help reduce
+It may sound strange, but deleting your own ``main`` branch can help reduce
 confusion about which branch you are on.  See `deleting master on github`_ for
 details.
 
@@ -54,8 +54,8 @@ From time to time you should fetch the upstream (trunk) changes from github::
 
 This will pull down any commits you don't have, and set the remote branches to
 point to the right commit.  For example, 'trunk' is the branch referred to by
-(remote/branchname) ``upstream/master`` - and if there have been commits since
-you last checked, ``upstream/master`` will change after you do the fetch.
+(remote/branchname) ``upstream/main`` - and if there have been commits since
+you last checked, ``upstream/main`` will change after you do the fetch.
 
 .. _make-feature-branch:
 
@@ -78,7 +78,7 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     # Update the mirror of trunk
     git fetch upstream
     # Make new feature branch starting at current trunk
-    git branch my-new-feature upstream/master
+    git branch my-new-feature upstream/main
     git checkout my-new-feature
 
 Generally, you will want to keep your feature branches on your public github_
@@ -183,7 +183,7 @@ Delete a Branch on Github
 
 ::
 
-   git checkout master
+   git checkout main
    # delete branch locally
    git branch -D my-unwanted-branch
    # delete branch on github
@@ -223,7 +223,7 @@ Your collaborators can then commit directly into that repo with the
 usual::
 
      git commit -am 'ENH - much better code'
-     git push origin master # pushes directly into your repo
+     git push origin main  # pushes directly into your repo
 
 Explore Your Repository
 -----------------------

--- a/docs/src/developers_guide/gitwash/set_up_fork.rst
+++ b/docs/src/developers_guide/gitwash/set_up_fork.rst
@@ -29,11 +29,11 @@ Clone Your Fork
    ``git branch -a`` to show you all branches.  You'll get something
    like::
 
-      * master
-      remotes/origin/master
+      * main
+      remotes/origin/main
 
-   This tells you that you are currently on the ``master`` branch, and
-   that you also have a ``remote`` connection to ``origin/master``.
+   This tells you that you are currently on the ``main`` branch, and
+   that you also have a ``remote`` connection to ``origin/main``.
    What remote repository is ``remote/origin``? Try ``git remote -v`` to
    see the URLs for the remote.  They will point to your github fork.
 

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -25,7 +25,7 @@ number of releases, is in :ref:`iris_development_deprecations`.
 Release Branch
 --------------
 
-Once the features intended for the release are on ``master``, a release branch
+Once the features intended for the release are on ``main``, a release branch
 should be created, in the ``SciTools/iris`` repository.  This will have the name:
 
     :literal:`v{major release number}.{minor release number}.x`
@@ -156,13 +156,13 @@ Merge Back
 ----------
 
 After the release is cut, the changes from the release branch should be merged
-back onto the ``SciTools/iris`` ``master`` branch.
+back onto the ``SciTools/iris`` ``main`` branch.
 
-To achieve this, first cut a local branch from the latest ``master`` branch,
+To achieve this, first cut a local branch from the latest ``main`` branch,
 and `git merge` the :literal:`.x` release branch into it. Ensure that the
 ``iris.__version__``, ``docs/src/whatsnew/index.rst`` and ``docs/src/whatsnew/latest.rst``
 are correct, before committing these changes and then proposing a pull-request
-on the ``master`` branch of ``SciTools/iris``.
+on the ``main`` branch of ``SciTools/iris``.
 
 
 Point Releases
@@ -177,7 +177,7 @@ New features shall not be included in a point release, these are for bug fixes.
 
 A point release does not require a release candidate, but the rest of the
 release process is to be followed, including the merge back of changes into
-``master``.
+``main``.
 
 
 .. _iris_development_releases_steps:
@@ -223,7 +223,7 @@ Post Release Steps
 ~~~~~~~~~~~~~~~~~~
 
 #. Check the documentation has built on `Read The Docs`_.  The build is
-   triggered by any commit to ``master``.  Additionally check that the versions
+   triggered by any commit to ``main``.  Additionally check that the versions
    available in the pop out menu in the bottom left corner include the new
    release version.  If it is not present you will need to configure the
    versions available in the **admin** dashboard in `Read The Docs`_.
@@ -238,7 +238,7 @@ Post Release Steps
 #. Add back in the reference to ``latest.rst`` to the ``whatsnew`` index
    ``docs/src/whatsnew/index.rst``
 #. Update ``iris.__init__.py`` version string to show as ``1.10.dev0``
-#. Merge back to ``master``
+#. Merge back to ``main``
 
 
 .. _SciTools/iris: https://github.com/SciTools/iris

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -108,7 +108,7 @@ all the packages from the `testing` and `documentation` sections.
           are supported and tested against by Iris, view the contents of
           the `requirements/ci`_ directory.
 
-.. _requirements/ci: https://github.com/scitools/iris/tree/master/requirements/ci
+.. _requirements/ci: https://github.com/scitools/iris/tree/main/requirements/ci
 
 Finally you need to run the command to configure your shell environment
 to find your local Iris code::

--- a/docs/src/whatsnew/2.3.rst
+++ b/docs/src/whatsnew/2.3.rst
@@ -238,7 +238,7 @@ Documentation
 =============
 
 * Adopted a
-  `new colour logo for Iris <https://github.com/SciTools/iris/blob/master/docs/src/_static/Iris7_1_trim_100.png>`_
+  `new colour logo for Iris <https://github.com/SciTools/iris/blob/main/docs/src/_static/Iris7_1_trim_100.png>`_
 
 * Added a gallery example showing how to concatenate NEMO ocean model data,
   see :ref:`sphx_glr_generated_gallery_oceanography_plot_load_nemo.py`.

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -147,7 +147,7 @@ This document explains the changes made to Iris for this release
    environment info. (:pull:`3990`)
 
 #. `@bjlittle`_ enabled `cirrus-ci`_ compute credits for non-draft pull-requests
-   from collaborators targeting the Iris ``master`` branch. (:pull:`4007`)
+   from collaborators targeting the Iris ``main`` branch. (:pull:`4007`)
 
 #. `@akuhnregnier`_ replaced `deprecated numpy 1.20 aliases for builtin types`_.
    (:pull:`3997`)
@@ -199,8 +199,8 @@ This document explains the changes made to Iris for this release
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _Met Office: https://www.metoffice.gov.uk/
 .. _numpy: https://numpy.org/doc/stable/release/1.20.0-notes.html
-.. |pre-commit.ci| image:: https://results.pre-commit.ci/badge/github/SciTools/iris/master.svg
-.. _pre-commit.ci: https://results.pre-commit.ci/latest/github/SciTools/iris/master
+.. |pre-commit.ci| image:: https://results.pre-commit.ci/badge/github/SciTools/iris/main.svg
+.. _pre-commit.ci: https://results.pre-commit.ci/latest/github/SciTools/iris/main
 .. |PyPI| image:: https://img.shields.io/pypi/v/scitools-iris?color=orange&label=pypi%7Cscitools-iris
 .. _PyPI: https://pypi.org/project/scitools-iris/
 .. _Python 3.8: https://www.python.org/downloads/release/python-380/

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -181,6 +181,9 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ added support for automated ``import`` linting with `isort`_.
    (:pull:`4174`)
 
+#. `@bjlittle`_ renamed ``iris/master`` branch to ``iris/main`` and migrated
+   references of ``master`` to ``main`` within codebase. (:pull:`4202`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,8 +15,11 @@ from nox.logger import logger
 #: Default to reusing any pre-existing nox environments.
 nox.options.reuse_existing_virtualenvs = True
 
+#: Root directory.
+ROOT_DIR = Path(__file__).resolve().parent
+
 #: Name of the package to test.
-PACKAGE = str("lib" / Path("iris"))
+PACKAGE = str(ROOT_DIR / "lib" / "iris")
 
 #: Cirrus-CI environment variable hook.
 PY_VER = os.environ.get("PY_VER", ["3.7", "3.8"])
@@ -172,9 +175,10 @@ def flake8(session: nox.sessions.Session):
     # Pip install the session requirements.
     session.install("flake8")
     # Execute the flake8 linter on the package.
-    session.run("flake8", PACKAGE)
-    # Execute the flake8 linter on this file.
-    session.run("flake8", __file__)
+    session.run("flake8", str(PACKAGE))
+    # Execute the flake8 linter on root Python files.
+    for fname in ROOT_DIR.glob("*.py"):
+        session.run("flake8", str(fname))
 
 
 @nox.session
@@ -191,9 +195,10 @@ def black(session: nox.sessions.Session):
     # Pip install the session requirements.
     session.install("black==21.5b2")
     # Execute the black format checker on the package.
-    session.run("black", "--check", PACKAGE)
-    # Execute the black format checker on this file.
-    session.run("black", "--check", __file__)
+    session.run("black", "--check", str(PACKAGE))
+    # Execute the black format checker on root Python files.
+    for fname in ROOT_DIR.glob("*.py"):
+        session.run("black", "--check", str(fname))
 
 
 @nox.session
@@ -209,8 +214,13 @@ def isort(session: nox.sessions.Session):
     """
     # Pip install the session requirements.
     session.install("isort")
-    # Execute the isort import checker.
-    session.run("isort", "--check", ".")
+    # Execute the isort import checker on the package.
+    session.run("isort", "--check", str(PACKAGE))
+    # Execute the isort import checker on the documentation.
+    session.run("isort", "--check", str(ROOT_DIR / "docs"))
+    # Execute the isort import checker on the root Python files.
+    for fname in ROOT_DIR.glob("*.py"):
+        session.run("isort", "--check", str(fname))
 
 
 @nox.session(python=PY_VER, venv_backend="conda")

--- a/noxfile.py
+++ b/noxfile.py
@@ -175,7 +175,7 @@ def flake8(session: nox.sessions.Session):
     # Pip install the session requirements.
     session.install("flake8")
     # Execute the flake8 linter on the package.
-    session.run("flake8", str(PACKAGE))
+    session.run("flake8", PACKAGE)
     # Execute the flake8 linter on root Python files.
     for fname in ROOT_DIR.glob("*.py"):
         session.run("flake8", str(fname))
@@ -195,7 +195,7 @@ def black(session: nox.sessions.Session):
     # Pip install the session requirements.
     session.install("black==21.5b2")
     # Execute the black format checker on the package.
-    session.run("black", "--check", str(PACKAGE))
+    session.run("black", "--check", PACKAGE)
     # Execute the black format checker on root Python files.
     for fname in ROOT_DIR.glob("*.py"):
         session.run("black", "--check", str(fname))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ force_sort_within_sections = "True"
 known_first_party = "iris"
 line_length = 79
 profile = "black"
-skip = [
+extend_skip = [
   "_build",
   "compiled_krb",
   "fc_rules_cf.krb",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
After the renaming of the `iris/master` branch to `iris/main`, this pull-request changes all relevant `master` references to be `main` within `iris`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
