### PR TITLE
Update cf_units pin

### DIFF
--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -12,7 +12,7 @@ dependencies:
 
 # Core dependencies.
   - cartopy>=0.18
-  - cf-units>=2
+  - cf-units>=2.1.5
   - cftime<1.3.0
   - dask>=2
   - matplotlib

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -12,7 +12,7 @@ dependencies:
 
 # Core dependencies.
   - cartopy>=0.18
-  - cf-units>=2
+  - cf-units>=2.1.5
   - cftime<1.3.0
   - dask>=2
   - matplotlib

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -12,7 +12,7 @@ dependencies:
 
 # Core dependencies.
   - cartopy>=0.18
-  - cf-units>=2
+  - cf-units>=2.1.5
   - cftime<1.3.0
   - dask>=2
   - matplotlib

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,7 +1,7 @@
 # Core dependencies.
 
 cartopy>=0.18
-cf-units>=2
+cf-units>=2.1.5
 cftime<1.3.0
 dask[array]>=2
 matplotlib


### PR DESCRIPTION
Related to [this change](https://github.com/conda-forge/iris-feedstock/pull/67) to the iris conda-forge recipe.

I have updated the pin for cf_units. Note there is no change to setup.cfg as that only exists on the main branch.

I had considered waiting for the mergeback then doing it on main, but as we are now planning a 3.0.3 release it makes sense to just put it here