### PR TITLE
optimise pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,18 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+files: |
+    (?x)(
+        noxfile\.py|
+        setup\.py|
+        docs\/.+\.py|
+        lib\/.+\.py
+    )
+minimum_pre_commit_version: 1.21.0
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.0.1"
+    rev: v4.0.1
     hooks:
         # Prevent giant files from being committed.
     -   id: check-added-large-files
@@ -16,27 +26,31 @@ repos:
     -   id: debug-statements
         # Don't commit to main branch.
     -   id: no-commit-to-branch
+
 -   repo: https://github.com/psf/black
-    rev: "21.6b0"
+    rev: 21.6b0
     hooks:
     -   id: black
         pass_filenames: false
-        args: ["--config=./pyproject.toml", "--check", "docs", "lib", "noxfile.py", "setup.py"]
+        args: [--config=./pyproject.toml, --check, .]
+
 -   repo: https://github.com/PyCQA/flake8
-    rev: "3.9.2"
+    rev: 3.9.2
     hooks:
     -   id: flake8
-        args: ["--config=./setup.cfg", "docs", "lib", "noxfile.py", "setup.py"]
+        types: [file, python]
+        args: [--config=./setup.cfg]
+
 -   repo: https://github.com/pycqa/isort
-    rev: "5.9.1"
+    rev: 5.9.1
     hooks:
     -   id: isort
-        # Align CLI usage with other hooks, rather than use isort "src_paths" option
-        # in the pyproject.toml configuration.
-        name: isort
-        args: ["--filter-files", "--check", "docs", "lib", "noxfile.py", "setup.py"]
+        types: [file, python]
+        args: [--filter-files, --check]
+
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.8.0
     hooks:
     -   id: blacken-docs
+        types: [file, rst]
         additional_dependencies: [black==21.6b0]

--- a/lib/iris/tests/test_std_names.py
+++ b/lib/iris/tests/test_std_names.py
@@ -26,14 +26,25 @@ class TestStandardNames(tests.IrisTest):
 
         # Check for some known standard names
         valid_nameset = set(["air_density", "northward_wind", "wind_speed"])
-        self.assertTrue(valid_nameset.issubset(keyset), "Known standard name missing from STD_NAMES")
+        self.assertTrue(
+            valid_nameset.issubset(keyset),
+            "Known standard name missing from STD_NAMES",
+        )
 
         # Check for some invalid standard names
-        invalid_nameset = set(["invalid_air_density", "invalid_northward_wind",
-                               "invalid_wind_speed",
-                               "stratiform_snowfall_rate"])
-        self.assertSetEqual(invalid_nameset - keyset, invalid_nameset,
-                            "\nInvalid standard name(s) present in STD_NAMES")
+        invalid_nameset = set(
+            [
+                "invalid_air_density",
+                "invalid_northward_wind",
+                "invalid_wind_speed",
+                "stratiform_snowfall_rate",
+            ]
+        )
+        self.assertSetEqual(
+            invalid_nameset - keyset,
+            invalid_nameset,
+            "\nInvalid standard name(s) present in STD_NAMES",
+        )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,33 +13,17 @@ build-backend = "setuptools.build_meta"
 line-length = 79
 target-version = ['py37', 'py38']
 include = '\.pyi?$'
-exclude = '''
-
+extend-exclude = '''
 (
   /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | compiled_krb
-    | dist
-    | etc
-    | iris_image_test_output
+    | pyke_rules
     | sphinxext
     | tools
   )/
-  | gitwash_dumper.py
-  | _ff_cross_references.py  # auto-generated files
-  | std_names.py
+  | _ff_cross_references.py
   | um_cf_map.py
 )
 '''
-
 
 [tool.isort]
 force_sort_within_sections = "True"
@@ -55,10 +39,4 @@ extend_skip = [
   "tools",
 ]
 skip_gitignore = "True"
-src_paths = [
-  "docs",
-  "lib",
-  "noxfile.py",
-  "setup.py",
-]
 verbose = "False"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR plays to the strengths of `pre-commit` and filters files at the right level before running the hooks.

This configuration works for local developer commits on only the files that have changed (optimisation), and for `cirrus-ci` when `pre-commit` hooks are run against all files. In addition, the behaviour of the tools which the hooks call still honour their specific configuration.

This undoes a major regression introduced in #4181. Oops :blush: 



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
