### PR TITLE
Only run docs-building sessions with Python 3.8.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,8 +15,15 @@ from nox.logger import logger
 #: Default to reusing any pre-existing nox environments.
 nox.options.reuse_existing_virtualenvs = True
 
+#: Python versions we can run sessions under
+_PY_VERSIONS_ALL = ["3.7", "3.8"]
+_PY_VERSION_LATEST = _PY_VERSIONS_ALL[-1]
+
+#: One specific python version for docs builds
+_PY_VERSION_DOCSBUILD = _PY_VERSION_LATEST
+
 #: Cirrus-CI environment variable hook.
-PY_VER = os.environ.get("PY_VER", ["3.7", "3.8"])
+PY_VER = os.environ.get("PY_VER", _PY_VERSIONS_ALL)
 
 #: Default cartopy cache directory.
 CARTOPY_CACHE_DIR = os.environ.get("HOME") / Path(".local/share/cartopy")
@@ -197,7 +204,7 @@ def tests(session: nox.sessions.Session):
     )
 
 
-@nox.session(python=PY_VER, venv_backend="conda")
+@nox.session(python=_PY_VERSION_DOCSBUILD, venv_backend="conda")
 def doctest(session: nox.sessions.Session):
     """
     Perform iris doctests and gallery.
@@ -231,7 +238,7 @@ def doctest(session: nox.sessions.Session):
     )
 
 
-@nox.session(python=PY_VER, venv_backend="conda")
+@nox.session(python=_PY_VERSION_DOCSBUILD, venv_backend="conda")
 def linkcheck(session: nox.sessions.Session):
     """
     Perform iris doc link check.


### PR DESCRIPTION
## 🚀 Pull Request

### Make sessions that build docs (doctest, gallery, linkcheck) **_only_** support Python 3.8.

Hitherto we offered 'docstest-3.7' and 'docstest-3.8'.  We could still do that, but I'm choosing not to.
(since Py3.7 gives [different results in some cases](https://github.com/SciTools/iris/pull/4206#issuecomment-867465560))
Likewise, if nox is called specifying a specific _unsuitable_ python, via the PY_VER environment variable, we could still run the session, with Python3.8, but instead I chose not to allow it all.

So..
  1. `nox -s doctest` now runs with Python 3.8
     * whereas previously it ran "doctest-3.7", giving different results
  1. `PY_VER=3.8 nox -s doctest` still works
    * this is how cirrus invokes it
  2. `PY_VER=3.7 nox -s doctest` now gives an error
     * previously available

New behaviours demonstrated :
```
$ nox -l
Sessions defined in /net/home/h05/itpp/git/iris/iris_main/noxfile.py:

* lint -> Perform pre-commit linting of iris codebase.
* tests-3.7 -> Perform iris system, integration and unit tests.
* tests-3.8 -> Perform iris system, integration and unit tests.
* gallery -> Perform iris gallery doc-tests.
* doctest -> Perform iris doc-tests.
* linkcheck -> Perform iris doc link check.

sessions marked with * are selected, sessions marked with - are skipped.
```
```
$ PY_VER=3.8 nox -l
Sessions defined in /net/home/h05/itpp/git/iris/iris_main/noxfile.py:

* lint -> Perform pre-commit linting of iris codebase.
* tests -> Perform iris system, integration and unit tests.
* gallery -> Perform iris gallery doc-tests.
* doctest -> Perform iris doc-tests.
* linkcheck -> Perform iris doc link check.

sessions marked with * are selected, sessions marked with - are skipped.
```
```
$ PY_VER=3.7 nox -l
Sessions defined in /net/home/h05/itpp/git/iris/iris_main/noxfile.py:

* lint -> Perform pre-commit linting of iris codebase.
* tests -> Perform iris system, integration and unit tests.

sessions marked with * are selected, sessions marked with - are skipped.
```
```
$ nox -s doctest
nox > Running session doctest
nox > Creating conda env in .nox/doctest with python=3.8
 . . .
```
```
$ PY_VER=3.7 nox -s doctest
nox > Error while collecting sessions.
nox > Sessions not found: doctest
$ 
```
