### PR TITLE
drop cirrus-ci minimal tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,13 +18,11 @@ container:
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
   SKIP_LINT_TASK: ""
-  SKIP_TEST_MINIMAL_TASK: ""
-  SKIP_TEST_FULL_TASK: ""
+  SKIP_TEST_TASK: ""
   SKIP_GALLERY_TASK: ""
   SKIP_DOCTEST_TASK: ""
   SKIP_LINKCHECK_TASK: ""
   # Skip task groups by type. Set to a non-empty string to skip.
-  SKIP_ALL_TEST_TASKS: ""
   SKIP_ALL_DOC_TASKS: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
@@ -130,37 +128,17 @@ lint_task:
 
 
 #
-# Testing Minimal (Linux)
+# Testing (Linux)
 #
-test_minimal_task:
-  only_if: ${SKIP_TEST_MINIMAL_TASK} == "" && ${SKIP_ALL_TEST_TASKS} == ""
+test_task:
+  only_if: ${SKIP_TEST_TASK} == ""
   << : *CREDITS_TEMPLATE
   matrix:
     env:
       PY_VER: 3.7
     env:
       PY_VER: 3.8
-  name: "${CIRRUS_OS}: py${PY_VER} tests (minimal)"
-  << : *LINUX_TASK_TEMPLATE
-  tests_script:
-    - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-    - echo "[Resources]" > ${SITE_CFG}
-    - echo "doc_dir = ${CIRRUS_WORKING_DIR}/docs" >> ${SITE_CFG}
-    - nox --session tests -- --verbose
-
-
-#
-# Testing Full (Linux)
-#
-test_full_task:
-  only_if: ${SKIP_TEST_FULL_TASK} == "" && ${SKIP_ALL_TEST_TASKS} == ""
-  << : *CREDITS_TEMPLATE
-  matrix:
-    env:
-      PY_VER: 3.7
-    env:
-      PY_VER: 3.8
-  name: "${CIRRUS_OS}: py${PY_VER} tests (full)"
+  name: "${CIRRUS_OS}: py${PY_VER} tests"
   container:
     image: gcc:latest
     cpu: 6


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR consolidates the `minimal` and `full` testing for `cirrus-ci` into one task that runs the `full` tests. The `full` tests are fully inclusive of the `minimal` tests.

Running both `minimal` and `full` test tasks (for all Python distributions) is a waste of time, resource and compute credits. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
