### PR TITLE
Default connectivity start_index

### DIFF
--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -3643,7 +3643,7 @@ def _build_connectivity(connectivity_var, file_path, location_dims):
     indices_data = netcdf._get_cf_var_data(connectivity_var, file_path)
 
     cf_role = connectivity_var.cf_role
-    start_index = connectivity_var.start_index
+    start_index = getattr(connectivity_var, 'start_index', None)
 
     dim_names = connectivity_var.dimensions
     # Connectivity arrays must have two dimensions.

--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -3643,7 +3643,7 @@ def _build_connectivity(connectivity_var, file_path, location_dims):
     indices_data = netcdf._get_cf_var_data(connectivity_var, file_path)
 
     cf_role = connectivity_var.cf_role
-    start_index = getattr(connectivity_var, "start_index", None)
+    start_index = getattr(connectivity_var, "start_index", 0)
 
     dim_names = connectivity_var.dimensions
     # Connectivity arrays must have two dimensions.

--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -3643,7 +3643,7 @@ def _build_connectivity(connectivity_var, file_path, location_dims):
     indices_data = netcdf._get_cf_var_data(connectivity_var, file_path)
 
     cf_role = connectivity_var.cf_role
-    start_index = getattr(connectivity_var, 'start_index', None)
+    start_index = getattr(connectivity_var, "start_index", None)
 
     dim_names = connectivity_var.dimensions
     # Connectivity arrays must have two dimensions.

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -23,8 +23,7 @@
     "gallery_tests.test_plot_anomaly_log_colouring.TestAnomalyLogColouring.test_plot_anomaly_log_colouring.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ecc164e78e979b19b3789b0885a564a56cc2c65e3ec69469db1bdb9a853c1e24.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e796979a1b39781b2881a564a56ccac6da3e87947bcb1bdb9a843c1e24.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png"
     ],
     "gallery_tests.test_plot_atlantic_profiles.TestAtlanticProfiles.test_plot_atlantic_profiles.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Allow 'start_index' to default to 0 when creating Connectivity from a file-var, if var has no 'start_index' attribute.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
