### PR TITLE
lru metadata manager factory

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -71,6 +71,19 @@ This document explains the changes made to Iris for this release
    unexpected artifacts in some edge cases, as shown at :issue:`4086`. (:pull:`4150`)
 
 
+🚀 Performance Enhancements
+===========================
+
+#. `@bjlittle`_ added support for automated ``import`` linting with `isort`_, which
+   also includes significant speed-ups for Iris imports. (:pull:`4174`)
+
+#. `@bjlittle`_ Optimised the creation of dynamic metadata manager classes within the
+   :func:`~iris.common.metadata.metadata_manager_factory`, resulting in a significant
+   speed-up in the creation of Iris :class:`~iris.coords.AncillaryVariable`,
+   :class:`~iris.coords.AuxCoord`, :class:`~iris.coords.CellMeasure`, and
+   :class:`~iris.cube.Cube` instances. (:pull:`4227`)
+
+
 💣 Incompatible Changes
 =======================
 
@@ -182,9 +195,6 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ consolidated the ``.flake8`` configuration into ``setup.cfg``.
    (:pull:`4200`)
-
-#. `@bjlittle`_ added support for automated ``import`` linting with `isort`_.
-   (:pull:`4174`)
 
 #. `@bjlittle`_ renamed ``iris/master`` branch to ``iris/main`` and migrated
    references of ``master`` to ``main`` within codebase. (:pull:`4202`)

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -58,6 +58,12 @@ This document explains the changes made to Iris for this release
 #. N/A
 
 
+🚀 Performance Enhancements
+===========================
+
+#. N/A
+
+
 🔥 Deprecations
 ===============
 

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1344,10 +1344,12 @@ def _factory_cache(cls):
         #: The metadata class to be manufactured by this factory.
         self.cls = cls
 
-        # Proxy for self.cls._fields
+        # Proxy for self.cls._fields for later internal use, as this
+        # saves on indirect property lookup via self.cls
         self._fields = cls._fields
 
         # Initialise the metadata class fields in the instance.
+        # Use cls directly here since it's available.
         for field in cls._fields:
             setattr(self, field, None)
 
@@ -1411,12 +1413,7 @@ def _factory_cache(cls):
         fields = {field: getattr(self, field) for field in self._fields}
         return self.cls(**fields)
 
-    # Restrict factory to appropriate metadata classes only.
-    if not issubclass(cls, BaseMetadata):
-        emsg = "Require a subclass of {!r}, got {!r}."
-        raise TypeError(emsg.format(BaseMetadata.__name__, cls))
-
-    # Define the name, (inheritance) bases and namespace of the dynamic class.
+    # Define the name, (inheritance) bases, and namespace of the dynamic class.
     name = "MetadataManager"
     bases = ()
     namespace = {

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1440,7 +1440,10 @@ def _factory_cache(cls):
     if cls is CubeMetadata:
         namespace["_names"] = cls._names
 
-    return type(name, bases, namespace)
+    # Dynamically create the metadata manager class.
+    MetadataManager = type(name, bases, namespace)
+
+    return MetadataManager
 
 
 def metadata_manager_factory(cls, **kwargs):
@@ -1463,6 +1466,9 @@ def metadata_manager_factory(cls, **kwargs):
         Initial values for the manufactured metadata instance. Unspecified
         fields will default to a value of 'None'.
 
+    Returns:
+        A manager instance for the provided metadata ``cls``.
+
     """
     # Check whether kwargs have valid fields for the specified metadata.
     if kwargs:
@@ -1472,13 +1478,14 @@ def metadata_manager_factory(cls, **kwargs):
             emsg = "Invalid {!r} field parameters, got {}."
             raise ValueError(emsg.format(cls.__name__, bad))
 
-    # Dynamically create the class at runtime or get a cached version of it
-    Metadata = _factory_cache(cls)
+    # Dynamically create the metadata manager class at runtime or get a cached
+    # version of it.
+    MetadataManager = _factory_cache(cls)
 
-    # Now manufacture an instance of that class.
-    metadata = Metadata(cls, **kwargs)
+    # Now manufacture an instance of the metadata manager class.
+    manager = MetadataManager(cls, **kwargs)
 
-    return metadata
+    return manager
 
 
 #: Convenience collection of lenient metadata combine services.

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -13,7 +13,7 @@ from abc import ABCMeta
 from collections import namedtuple
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
-from functools import lru_cache, wraps
+from functools import wraps
 import re
 
 import numpy as np
@@ -1338,7 +1338,9 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
-@lru_cache
+_FACTORY_CACHE = {}
+
+
 def metadata_manager_factory(cls, **kwargs):
     """
     A class instance factory function responsible for manufacturing
@@ -1469,8 +1471,11 @@ def metadata_manager_factory(cls, **kwargs):
     if cls is CubeMetadata:
         namespace["_names"] = cls._names
 
-    # Dynamically create the class.
-    Metadata = type(name, bases, namespace)
+    # Dynamically create the class
+    Metadata = _FACTORY_CACHE.setdefault(
+        str(cls), type(name, bases, namespace)
+    )
+
     # Now manufacture an instance of that class.
     metadata = Metadata(cls, **kwargs)
 

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1344,6 +1344,9 @@ def _factory_cache(cls):
         #: The metadata class to be manufactured by this factory.
         self.cls = cls
 
+        # Proxy for self.cls._fields
+        self._fields = cls._fields
+
         # Initialise the metadata class fields in the instance.
         for field in cls._fields:
             setattr(self, field, None)
@@ -1364,7 +1367,7 @@ def _factory_cache(cls):
 
     def __getstate__(self):
         """Return the instance state to be pickled."""
-        return {field: getattr(self, field) for field in self.fields}
+        return {field: getattr(self, field) for field in self._fields}
 
     def __ne__(self, other):
         match = self.__eq__(other)
@@ -1387,7 +1390,7 @@ def _factory_cache(cls):
         args = ", ".join(
             [
                 "{}={!r}".format(field, getattr(self, field))
-                for field in self.fields
+                for field in self._fields
             ]
         )
         return "{}({})".format(self.__class__.__name__, args)
@@ -1401,11 +1404,11 @@ def _factory_cache(cls):
     def fields(self):
         """Return the name of the metadata members."""
         # Proxy for built-in namedtuple._fields property.
-        return self.cls._fields
+        return self._fields
 
     @property
     def values(self):
-        fields = {field: getattr(self, field) for field in self.fields}
+        fields = {field: getattr(self, field) for field in self._fields}
         return self.cls(**fields)
 
     # Restrict factory to appropriate metadata classes only.

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1341,16 +1341,11 @@ class DimCoordMetadata(CoordMetadata):
 @lru_cache(maxsize=None)
 def _factory_cache(cls):
     def __init__(self, cls, **kwargs):
-        # Restrict to only dealing with appropriate metadata classes.
-        if not issubclass(cls, BaseMetadata):
-            emsg = "Require a subclass of {!r}, got {!r}."
-            raise TypeError(emsg.format(BaseMetadata.__name__, cls))
-
         #: The metadata class to be manufactured by this factory.
         self.cls = cls
 
         # Initialise the metadata class fields in the instance.
-        for field in self.fields:
+        for field in cls._fields:
             setattr(self, field, None)
 
         # Populate with provided kwargs, which have already been verified

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1339,7 +1339,7 @@ class DimCoordMetadata(CoordMetadata):
 
 
 @lru_cache
-def _factory_cache(cls, **kwargs):
+def _factory_cache(cls):
     def __init__(self, cls, **kwargs):
         # Restrict to only dealing with appropriate metadata classes.
         if not issubclass(cls, BaseMetadata):
@@ -1418,14 +1418,6 @@ def _factory_cache(cls, **kwargs):
         emsg = "Require a subclass of {!r}, got {!r}."
         raise TypeError(emsg.format(BaseMetadata.__name__, cls))
 
-    # Check whether kwargs have valid fields for the specified metadata.
-    if kwargs:
-        extra = [field for field in kwargs.keys() if field not in cls._fields]
-        if extra:
-            bad = ", ".join(map(lambda field: "{!r}".format(field), extra))
-            emsg = "Invalid {!r} field parameters, got {}."
-            raise ValueError(emsg.format(cls.__name__, bad))
-
     # Define the name, (inheritance) bases and namespace of the dynamic class.
     name = "MetadataManager"
     bases = ()
@@ -1472,9 +1464,16 @@ def metadata_manager_factory(cls, **kwargs):
         fields will default to a value of 'None'.
 
     """
+    # Check whether kwargs have valid fields for the specified metadata.
+    if kwargs:
+        extra = [field for field in kwargs.keys() if field not in cls._fields]
+        if extra:
+            bad = ", ".join(map(lambda field: "{!r}".format(field), extra))
+            emsg = "Invalid {!r} field parameters, got {}."
+            raise ValueError(emsg.format(cls.__name__, bad))
 
     # Dynamically create the class at runtime or get a cached version of it
-    Metadata = _factory_cache(cls, **kwargs)
+    Metadata = _factory_cache(cls)
 
     # Now manufacture an instance of that class.
     metadata = Metadata(cls, **kwargs)

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1338,7 +1338,7 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def _factory_cache(cls):
     def __init__(self, cls, **kwargs):
         # Restrict to only dealing with appropriate metadata classes.

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -13,7 +13,7 @@ from abc import ABCMeta
 from collections import namedtuple
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
-from functools import wraps
+from functools import lru_cache, wraps
 import re
 
 import numpy as np
@@ -1338,6 +1338,7 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
+@lru_cache
 def metadata_manager_factory(cls, **kwargs):
     """
     A class instance factory function responsible for manufacturing

--- a/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
+++ b/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
@@ -167,8 +167,8 @@ class Test_instance__pickle(tests.IrisTest):
             self.units,
             self.attributes,
         )
-        self.kwargs = dict(zip(BaseMetadata._fields, values))
-        self.metadata = metadata_manager_factory(BaseMetadata, **self.kwargs)
+        kwargs = dict(zip(BaseMetadata._fields, values))
+        self.metadata = metadata_manager_factory(BaseMetadata, **kwargs)
 
     def test_pickle(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
+++ b/lib/iris/tests/unit/common/metadata/test_metadata_manager_factory.py
@@ -36,14 +36,6 @@ BASES = [
 
 
 class Test_factory(tests.IrisTest):
-    def test__subclass_invalid(self):
-        class Other:
-            pass
-
-        emsg = "Require a subclass of 'BaseMetadata'"
-        with self.assertRaisesRegex(TypeError, emsg):
-            _ = metadata_manager_factory(Other)
-
     def test__kwargs_invalid(self):
         emsg = "Invalid 'BaseMetadata' field parameters, got 'wibble'."
         with self.assertRaisesRegex(ValueError, emsg):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR cycles back to the Common Metadata API and includes some small but significant optimisations to the `iris.common.metadata.metadata_manager_factory` function.

The `metadata_manager_factory` function leverages the benefit of creating metadata manager classes dynamically at runtime, but this is a relatively expensive operation compared to creating equivalent but static classes.

Employing a simple LRU caching strategy for the metadata manager classes created at runtime provides significant savings, along with careful avoidance of property lookups and type checking when creating instances of the dynamic classes.

The following `asv` metrics provide support for this proposed change:

<img width="475" alt="Capture" src="https://user-images.githubusercontent.com/2051656/124678149-d9d71680-deb9-11eb-8a0a-434fd2eca0dc.PNG">

In particular, note the performance gains when creating common `iris` first-class objects, such as:
* `iris.coords.AncillaryVariable` (significant)
* `iris.coords.AuxCoord` (significant)
* `iris.coords.DimCoord` (meh)
* `iris.coords.CellMeasure` (significant)
* `iris.cube.Cube` (significant)

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
