### PR TITLE
pre-commit isort and black --check only for cirrus-ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ iris_test_data_template: &IRIS_TEST_DATA_TEMPLATE
 #
 # Linting
 #
-lint_task:
+precommit_task:
   only_if: ${SKIP_LINT_TASK} == ""
   << : *CREDITS_TEMPLATE
   auto_cancellation: true
@@ -113,17 +113,17 @@ lint_task:
     image: python:3.8
     cpu: 2
     memory: 4G
-  name: "${CIRRUS_OS}: linting"
+  name: "${CIRRUS_OS}: pre-commit hooks"
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_TASK_NAME} py${PYTHON_VERSION}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
-  lint_script:
+  precommit_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
     - pip list
-    - nox --session lint
+    - nox --session precommit
 
 
 #

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ env:
   # Increment the build number to force new pip cache upload.
   PIP_CACHE_BUILD: "0"
   # Pip packages to be upgraded/installed.
-  PIP_CACHE_PACKAGES: "nox pip setuptools wheel"
+  PIP_CACHE_PACKAGES: "nox pip pyyaml setuptools wheel"
   # Conda packages to be installed.
   CONDA_CACHE_PACKAGES: "nox pip"
   # Git commit hash for iris test data.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: black
         pass_filenames: false
-        args: [--config=./pyproject.toml, --check, .]
+        args: [--config=./pyproject.toml, .]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
@@ -46,7 +46,7 @@ repos:
     hooks:
     -   id: isort
         types: [file, python]
-        args: [--filter-files, --check]
+        args: [--filter-files]
 
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.10.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -182,15 +182,19 @@ def lint(session: nox.sessions.Session):
     with open(".pre-commit-config.yaml", "r") as fi:
         config = yaml.load(fi, Loader=yaml.FullLoader)
 
-    # Enumerate singleton pre-commit hooks.
-    hooks = [
+    # Enumerate the ids of pre-commit hooks we want to run.
+    # We're only capturing the hook id of pre-commit repos with *one*
+    # registered hook. This is a simple approach to filtering out
+    # the "https://github.com/pre-commit/pre-commit-hooks" hooks,
+    # all of which we don't want to run within nox.
+    ids = [
         entry["hooks"][0]["id"]
         for entry in config["repos"]
         if len(entry["hooks"]) == 1
     ]
 
     # Execute the pre-commit linting hooks.
-    [session.run("pre-commit", "run", "--all-files", hook) for hook in hooks]
+    [session.run("pre-commit", "run", "--all-files", id) for id in ids]
 
 
 @nox.session(python=PY_VER, venv_backend="conda")

--- a/noxfile.py
+++ b/noxfile.py
@@ -182,18 +182,18 @@ def lint(session: nox.sessions.Session):
     with open(".pre-commit-config.yaml", "r") as fi:
         config = yaml.load(fi, Loader=yaml.FullLoader)
 
-    # Enumerate the ids of pre-commit hooks we want to run.
-    # We're only capturing the hook id of pre-commit repos with *one*
-    # registered hook. This is a simple approach to filtering out
-    # the "https://github.com/pre-commit/pre-commit-hooks" hooks,
-    # all of which we don't want to run within nox.
+    # List of pre-commit hook ids that we don't want to run.
+    excluded = ["no-commit-to-branch"]
+
+    # Enumerate the ids of pre-commit hooks we do want to run.
     ids = [
-        entry["hooks"][0]["id"]
+        hook["id"]
         for entry in config["repos"]
-        if len(entry["hooks"]) == 1
+        for hook in entry["hooks"]
+        if hook["id"] not in excluded
     ]
 
-    # Execute the pre-commit linting hooks.
+    # Execute the pre-commit hooks.
     [session.run("pre-commit", "run", "--all-files", id) for id in ids]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -163,9 +163,9 @@ def prepare_venv(session: nox.sessions.Session) -> None:
 
 
 @nox.session
-def lint(session: nox.sessions.Session):
+def precommit(session: nox.sessions.Session):
     """
-    Perform pre-commit linting of iris codebase.
+    Perform pre-commit hooks of iris codebase.
 
     Parameters
     ----------

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@ For further details, see https://nox.thea.codes/en/stable/#
 import hashlib
 import os
 from pathlib import Path
-from urllib.parse import unquote, urlsplit
 
 import nox
 from nox.logger import logger
@@ -183,16 +182,15 @@ def lint(session: nox.sessions.Session):
     with open(".pre-commit-config.yaml", "r") as fi:
         config = yaml.load(fi, Loader=yaml.FullLoader)
 
-    # Enumerate the pre-commit hooks.
+    # Enumerate singleton pre-commit hooks.
     hooks = [
-        Path(urlsplit(unquote(entry["repo"])).path).name
+        entry["hooks"][0]["id"]
         for entry in config["repos"]
+        if len(entry["hooks"]) == 1
     ]
 
     # Execute the pre-commit linting hooks.
-    for hook in hooks:
-        if hook != "pre-commit-hooks":
-            session.run("pre-commit", "run", "--all-files", hook)
+    [session.run("pre-commit", "run", "--all-files", hook) for hook in hooks]
 
 
 @nox.session(python=PY_VER, venv_backend="conda")

--- a/noxfile.py
+++ b/noxfile.py
@@ -186,9 +186,12 @@ def lint(session: nox.sessions.Session):
 
     # Ensure black and isort only perform a status check
     # with a custom pre-commit configuration.
+    hooks = []
     for entry in config["repos"]:
-        package = Path(urlsplit(unquote(entry["repo"])).path).name
-        if package in ["black", "isort"]:
+        hook = Path(urlsplit(unquote(entry["repo"])).path).name
+        hooks.append(hook)
+        if hook in ["black", "isort"]:
+            # Enforce a "--check" for the hook.
             entry["hooks"][0]["args"].insert(0, "--check")
 
     with NamedTemporaryFile(mode="w+t", delete=False) as temp:
@@ -197,9 +200,9 @@ def lint(session: nox.sessions.Session):
     # Execute the pre-commit linting tasks with the custom
     # pre-commit configuration.
     cmd = ["pre-commit", "run", "--all-files", f"--config={temp.name}"]
-    hooks = ["black", "blacken-docs", "flake8", "isort"]
     for hook in hooks:
-        session.run(*cmd, hook)
+        if hook != "pre-commit-hooks":
+            session.run(*cmd, hook)
 
 
 @nox.session(python=PY_VER, venv_backend="conda")


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR re-instates the `pre-commit` behaviour for the `black` and `isort` hooks, whereby they will automatically correct files in-place on `git commit` rather than performing a `--check`. This means that developers no longer require to explicitly install `black` or `isort`; this will all be managed by `pre-commit`.

Subsequently, the linting `cirrus-ci` task customises the `pre-commit-config.yaml` to ensure that `black` and `isort` only perform a `--check`, and will fail when a non-compliance is detected, as required.

Closes #4226 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
