### PR TITLE
Explicit metadata manager classes.

### DIFF
--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -15,11 +15,8 @@ import cf_units
 import dask.array as da
 import numpy as np
 
-from iris.common import (
-    CFVariableMixin,
-    CoordMetadata,
-    metadata_manager_factory,
-)
+from iris.common import CFVariableMixin
+from iris.common.metadata import CoordMetadataManager
 import iris.coords
 
 
@@ -40,7 +37,7 @@ class AuxCoordFactory(CFVariableMixin, metaclass=ABCMeta):
     def __init__(self):
         # Configure the metadata manager.
         if not hasattr(self, "_metadata_manager"):
-            self._metadata_manager = metadata_manager_factory(CoordMetadata)
+            self._metadata_manager = CoordMetadataManager()
 
         #: Descriptive name of the coordinate made by the factory
         self.long_name = None
@@ -390,7 +387,7 @@ class HybridHeightFactory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         if delta and delta.nbounds not in (0, 2):
@@ -579,7 +576,7 @@ class HybridPressureFactory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coords meet necessary conditions.
@@ -788,7 +785,7 @@ class OceanSigmaZFactory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coordinates meet necessary conditions.
@@ -1093,7 +1090,7 @@ class OceanSigmaFactory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coordinates meet necessary conditions.
@@ -1280,7 +1277,7 @@ class OceanSg1Factory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coordinates meet necessary conditions.
@@ -1507,7 +1504,7 @@ class OceanSFactory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coordinates meet necessary conditions.
@@ -1729,7 +1726,7 @@ class OceanSg2Factory(AuxCoordFactory):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        self._metadata_manager = CoordMetadataManager()
         super().__init__()
 
         # Check that provided coordinates meet necessary conditions.

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1343,7 +1343,7 @@ class DimCoordMetadata(CoordMetadata):
         return super().equal(other, lenient=lenient)
 
 
-def make_metadata_manager_class(cls, **kwargs):
+def make_metadata_manager_class(cls):
     """
     A factory function which creates a metadata "manager" class to handle
     a given type of metadata (a subclass of BaseMetadata).
@@ -1372,7 +1372,7 @@ def make_metadata_manager_class(cls, **kwargs):
         emsg = "Require a subclass of {!r}, got {!r}."
         raise TypeError(emsg.format(BaseMetadata.__name__, cls))
 
-    def __init__(self, **kwargs):
+    def __init__(self):
         # Get handled metadata type (a class property)
         cls = self.cls
 
@@ -1380,23 +1380,11 @@ def make_metadata_manager_class(cls, **kwargs):
         # access than via the property self.fields --> self.cls._fields.
         self._fields = cls._fields
 
-        # Check that kwargs has only valid fields for the specified metadata.
-        if kwargs:
-            extra = [
-                field for field in kwargs.keys() if field not in self._fields
-            ]
-            if extra:
-                bad = ", ".join(map(lambda field: "{!r}".format(field), extra))
-                emsg = "Invalid {!r} field parameters, got {}."
-                raise ValueError(emsg.format(cls.__name__, bad))
-
-        # Create all the metadata fields in the manager instance.
+        # Populate all the metadata fields with blanks.
+        # N.B. in the container constructors, the init values are then written
+        # into the container properties.
         for field in self._fields:
             setattr(self, field, None)
-
-        # Populate with the provided kwargs.
-        for field, value in kwargs.items():
-            setattr(self, field, value)
 
     def __eq__(self, other):
         if not hasattr(other, "cls"):
@@ -1436,7 +1424,7 @@ def make_metadata_manager_class(cls, **kwargs):
         return self.cls(**fields)
 
     # Define the name, (inheritance) bases and namespace of the dynamic class.
-    name = "MetadataManager"
+    name = cls.__name__ + "Manager"
     bases = ()
     namespace = {
         "DEFAULT_NAME": cls.DEFAULT_NAME,

--- a/lib/iris/common/mixin.py
+++ b/lib/iris/common/mixin.py
@@ -202,7 +202,7 @@ class CFVariableMixin:
 
     @metadata.setter
     def metadata(self, metadata):
-        cls = self._metadata_manager.cls
+        cls = self._metadata_manager.metadata_class
         fields = self._metadata_manager.fields
         arg = metadata
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -23,14 +23,13 @@ import numpy.ma as ma
 
 from iris._data_manager import DataManager
 import iris._lazy_data as _lazy
-from iris.common import (
-    AncillaryVariableMetadata,
-    BaseMetadata,
-    CellMeasureMetadata,
-    CFVariableMixin,
-    CoordMetadata,
-    DimCoordMetadata,
-    metadata_manager_factory,
+from iris.common import CFVariableMixin
+from iris.common.metadata import (
+    AncillaryVariableMetadataManager,
+    BaseMetadataManager,
+    CellMeasureMetadataManager,
+    CoordMetadataManager,
+    DimCoordMetadataManager,
 )
 import iris.exceptions
 import iris.time
@@ -98,7 +97,7 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
 
         # Configure the metadata manager.
         if not hasattr(self, "_metadata_manager"):
-            self._metadata_manager = metadata_manager_factory(BaseMetadata)
+            self._metadata_manager = BaseMetadataManager()
 
         #: CF standard name of the quantity that the metadata represents.
         self.standard_name = standard_name
@@ -727,9 +726,7 @@ class AncillaryVariable(_DimensionalMetadata):
         """
         # Configure the metadata manager.
         if not hasattr(self, "_metadata_manager"):
-            self._metadata_manager = metadata_manager_factory(
-                AncillaryVariableMetadata
-            )
+            self._metadata_manager = AncillaryVariableMetadataManager()
 
         super().__init__(
             values=data,
@@ -839,7 +836,7 @@ class CellMeasure(AncillaryVariable):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CellMeasureMetadata)
+        self._metadata_manager = CellMeasureMetadataManager()
 
         super().__init__(
             data=data,
@@ -1363,7 +1360,7 @@ class Coord(_DimensionalMetadata):
         """
         # Configure the metadata manager.
         if not hasattr(self, "_metadata_manager"):
-            self._metadata_manager = metadata_manager_factory(CoordMetadata)
+            self._metadata_manager = CoordMetadataManager()
 
         super().__init__(
             values=points,
@@ -2429,7 +2426,7 @@ class DimCoord(Coord):
 
         """
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(DimCoordMetadata)
+        self._metadata_manager = DimCoordMetadataManager()
 
         super().__init__(
             points,
@@ -2784,7 +2781,7 @@ class CellMethod(iris.util._OrderedHashable):
                 "'method' must be a string - got a '%s'" % type(method)
             )
 
-        default_name = BaseMetadata.DEFAULT_NAME
+        default_name = BaseMetadataManager.DEFAULT_NAME
         _coords = []
 
         if coords is None:
@@ -2792,12 +2789,12 @@ class CellMethod(iris.util._OrderedHashable):
         elif isinstance(coords, Coord):
             _coords.append(coords.name(token=True))
         elif isinstance(coords, str):
-            _coords.append(BaseMetadata.token(coords) or default_name)
+            _coords.append(BaseMetadataManager.token(coords) or default_name)
         else:
             normalise = (
                 lambda coord: coord.name(token=True)
                 if isinstance(coord, Coord)
-                else BaseMetadata.token(coord) or default_name
+                else BaseMetadataManager.token(coord) or default_name
             )
             _coords.extend([normalise(coord) for coord in coords])
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -37,13 +37,8 @@ import iris.analysis
 from iris.analysis.cartography import wrap_lons
 import iris.analysis.maths
 import iris.aux_factory
-from iris.common import (
-    CFVariableMixin,
-    CoordMetadata,
-    CubeMetadata,
-    DimCoordMetadata,
-    metadata_manager_factory,
-)
+from iris.common import CFVariableMixin, CoordMetadata, DimCoordMetadata
+from iris.common.metadata import CubeMetadataManager
 import iris.coord_systems
 import iris.coords
 import iris.exceptions
@@ -902,7 +897,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             raise TypeError("Invalid data type: {!r}.".format(data))
 
         # Configure the metadata manager.
-        self._metadata_manager = metadata_manager_factory(CubeMetadata)
+        self._metadata_manager = CubeMetadataManager()
 
         # Initialise the cube data manager.
         self._data_manager = DataManager(data)
@@ -1908,7 +1903,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             (which itself defaults to `unknown`) as defined in
             :class:`iris.common.CFVariableMixin`.
 
-            (b) a cell_measure instance with metadata equal to that of
+            (b) a cell_measure instance with metada equal to that of
             the desired cell_measures.
 
         See also :meth:`Cube.cell_measure()<iris.cube.Cube.cell_measure>`.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1903,7 +1903,7 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             (which itself defaults to `unknown`) as defined in
             :class:`iris.common.CFVariableMixin`.
 
-            (b) a cell_measure instance with metada equal to that of
+            (b) a cell_measure instance with metadata equal to that of
             the desired cell_measures.
 
         See also :meth:`Cube.cell_measure()<iris.cube.Cube.cell_measure>`.

--- a/lib/iris/tests/unit/common/metadata/test_make_metadata_manager_class.py
+++ b/lib/iris/tests/unit/common/metadata/test_make_metadata_manager_class.py
@@ -20,10 +20,11 @@ from cf_units import Unit
 from iris.common.metadata import (
     AncillaryVariableMetadata,
     BaseMetadata,
+    BaseMetadataManager,
     CellMeasureMetadata,
     CoordMetadata,
     CubeMetadata,
-    metadata_manager_factory,
+    make_metadata_manager_class,
 )
 
 BASES = [
@@ -42,12 +43,7 @@ class Test_factory(tests.IrisTest):
 
         emsg = "Require a subclass of 'BaseMetadata'"
         with self.assertRaisesRegex(TypeError, emsg):
-            _ = metadata_manager_factory(Other)
-
-    def test__kwargs_invalid(self):
-        emsg = "Invalid 'BaseMetadata' field parameters, got 'wibble'."
-        with self.assertRaisesRegex(ValueError, emsg):
-            metadata_manager_factory(BaseMetadata, wibble="nope")
+            _ = make_metadata_manager_class(Other)
 
 
 class Test_instance(tests.IrisTest):
@@ -59,80 +55,68 @@ class Test_instance(tests.IrisTest):
             "DEFAULT_NAME",
             "__init__",
             "__eq__",
-            "__getstate__",
             "__ne__",
-            "__reduce__",
             "__repr__",
-            "__setstate__",
+            "cls",
             "fields",
             "name",
             "token",
             "values",
         ]
         for base in self.bases:
-            metadata = metadata_manager_factory(base)
+            manager_cls = make_metadata_manager_class(base)
             for name in namespace:
-                self.assertTrue(hasattr(metadata, name))
+                self.assertTrue(hasattr(manager_cls, name))
             if base is CubeMetadata:
-                self.assertTrue(hasattr(metadata, "_names"))
-            self.assertIs(metadata.cls, base)
-
-    def test__kwargs_default(self):
-        for base in self.bases:
-            kwargs = dict(zip(base._fields, [None] * len(base._fields)))
-            metadata = metadata_manager_factory(base)
-            self.assertEqual(metadata.values._asdict(), kwargs)
-
-    def test__kwargs(self):
-        for base in self.bases:
-            kwargs = dict(zip(base._fields, range(len(base._fields))))
-            metadata = metadata_manager_factory(base, **kwargs)
-            self.assertEqual(metadata.values._asdict(), kwargs)
+                self.assertTrue(hasattr(manager_cls, "_names"))
+            self.assertIs(manager_cls.cls, base)
 
 
 class Test_instance___eq__(tests.IrisTest):
     def setUp(self):
-        self.metadata = metadata_manager_factory(BaseMetadata)
+        self.manager = make_metadata_manager_class(BaseMetadata)()
 
     def test__not_implemented(self):
-        self.assertNotEqual(self.metadata, 1)
+        self.assertNotEqual(self.manager, 1)
 
     def test__not_is_cls(self):
         base = BaseMetadata
-        other = metadata_manager_factory(base)
+        other = make_metadata_manager_class(base)()
         self.assertIs(other.cls, base)
         other.cls = CoordMetadata
-        self.assertNotEqual(self.metadata, other)
+        self.assertNotEqual(self.manager, other)
 
     def test__not_values(self):
         standard_name = mock.sentinel.standard_name
-        other = metadata_manager_factory(
-            BaseMetadata, standard_name=standard_name
-        )
+        other = make_metadata_manager_class(BaseMetadata)()
+        other.standard_name = standard_name
         self.assertEqual(other.standard_name, standard_name)
         self.assertIsNone(other.long_name)
         self.assertIsNone(other.var_name)
         self.assertIsNone(other.units)
         self.assertIsNone(other.attributes)
-        self.assertNotEqual(self.metadata, other)
+        self.assertNotEqual(self.manager, other)
 
     def test__same_default(self):
-        other = metadata_manager_factory(BaseMetadata)
-        self.assertEqual(self.metadata, other)
+        other = make_metadata_manager_class(BaseMetadata)()
+        self.assertEqual(self.manager, other)
 
     def test__same(self):
         kwargs = dict(
             standard_name=1, long_name=2, var_name=3, units=4, attributes=5
         )
-        metadata = metadata_manager_factory(BaseMetadata, **kwargs)
-        other = metadata_manager_factory(BaseMetadata, **kwargs)
-        self.assertEqual(metadata.values._asdict(), kwargs)
-        self.assertEqual(metadata, other)
+        this = make_metadata_manager_class(BaseMetadata)()
+        other = make_metadata_manager_class(BaseMetadata)()
+        for key, val in kwargs.items():
+            for manager in (this, other):
+                setattr(manager, key, val)
+        self.assertEqual(manager.values._asdict(), kwargs)
+        self.assertEqual(manager, other)
 
 
 class Test_instance____repr__(tests.IrisTest):
     def setUp(self):
-        self.metadata = metadata_manager_factory(BaseMetadata)
+        self.manager = make_metadata_manager_class(BaseMetadata)()
 
     def test(self):
         standard_name = mock.sentinel.standard_name
@@ -142,13 +126,13 @@ class Test_instance____repr__(tests.IrisTest):
         attributes = mock.sentinel.attributes
         values = (standard_name, long_name, var_name, units, attributes)
 
-        for field, value in zip(self.metadata.fields, values):
-            setattr(self.metadata, field, value)
+        for field, value in zip(self.manager.fields, values):
+            setattr(self.manager, field, value)
 
-        result = repr(self.metadata)
+        result = repr(self.manager)
         expected = (
-            "MetadataManager(standard_name={!r}, long_name={!r}, var_name={!r}, "
-            "units={!r}, attributes={!r})"
+            "BaseMetadataManager(standard_name={!r}, long_name={!r}, "
+            "var_name={!r}, units={!r}, attributes={!r})"
         )
         self.assertEqual(result, expected.format(*values))
 
@@ -168,16 +152,22 @@ class Test_instance__pickle(tests.IrisTest):
             self.attributes,
         )
         self.kwargs = dict(zip(BaseMetadata._fields, values))
-        self.metadata = metadata_manager_factory(BaseMetadata, **self.kwargs)
+        # NOTE: for pickle we now need an actual reference class
+        # So we can't pickle something "instantly made up", it needs to be
+        # available as a property of a module.
+        # self.manager = make_metadata_manager_class(BaseMetadata)()
+        self.manager = BaseMetadataManager()
+        for key, val in self.kwargs.items():
+            setattr(self.manager, key, val)
 
     def test_pickle(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.temp_filename(suffix=".pkl") as fname:
                 with open(fname, "wb") as fo:
-                    pickle.dump(self.metadata, fo, protocol=protocol)
+                    pickle.dump(self.manager, fo, protocol=protocol)
                 with open(fname, "rb") as fi:
                     metadata = pickle.load(fi)
-                    self.assertEqual(metadata, self.metadata)
+                    self.assertEqual(metadata, self.manager)
 
 
 class Test_instance__fields(tests.IrisTest):
@@ -187,7 +177,7 @@ class Test_instance__fields(tests.IrisTest):
     def test(self):
         for base in self.bases:
             fields = base._fields
-            metadata = metadata_manager_factory(base)
+            metadata = make_metadata_manager_class(base)()
             self.assertEqual(metadata.fields, fields)
             for field in fields:
                 hasattr(metadata, field)
@@ -199,7 +189,7 @@ class Test_instance__values(tests.IrisTest):
 
     def test(self):
         for base in self.bases:
-            metadata = metadata_manager_factory(base)
+            metadata = make_metadata_manager_class(base)()
             result = metadata.values
             self.assertIsInstance(result, base)
             self.assertEqual(result._fields, base._fields)

--- a/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
@@ -141,7 +141,7 @@ class Test__metadata_setter(tests.IrisTest):
     def setUp(self):
         class Metadata:
             def __init__(self):
-                self.cls = BaseMetadata
+                self.metadata_class = BaseMetadata
                 self.fields = BaseMetadata._fields
                 self.standard_name = mock.sentinel.standard_name
                 self.long_name = mock.sentinel.long_name


### PR DESCRIPTION
This is intended as an alternative to #4227

At present, each metadata 'manager' object is created in its own unique class by the `iris.common.metadata.metadata_manager_factory` factory function.
But _in practice,_ there is only one such class definition for each type of metadata class (aka BaseMetadata subclass),
( actually, only 5 of these ).  All the manager types are identical re--creations of those.

#4227 notes this as performance problem, and adds caching to avoid re-creating a manager class each time.
So, effectively, this just creates 5 reference classes + re-uses them.

Quite apart from performance issues, I think that the way managers all have unique types is already pretty odd, and also the code is rather unusual and hard to follow.
As I think @bsherratt also suggests [there](https://github.com/SciTools/iris/pull/4227#pullrequestreview-700776584)

The _**reason**_ for the code complexity is the effort to avoid boilerplate repetition in the BaseMetadata class definitions and the related manager classes.

So, I feel that maybe a problem with #4277 is that the caching adds yet another "layer" to the code.
However, the basic performance problem it solves just goes back to defining each of the 5 manager classes once, instead of creating them dynamically.

Seeing that, and carefully considering the code + @bsherratt comments, I came to the conclusion that we can replace the factory approach with a more conventional class definition for each of the "manager classes".  
So that's what this attempts to do.

I'm keen to see if we can do that in a more explicit and easy-to-follow way, without re-introducing too much repetition or boilerplate.

N.B. the appropriate manager class is then referenced directly by containing objects, instead of calling the factory function.
( see the small changes in cube.py / coords.py / aux_factory.py )
