### PR TITLE
Fix nearest_neighbour_index for edge case where requested point is float and bounds are int

### DIFF
--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -54,6 +54,10 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ ensured that a :class:`matplotlib.axes.Axes`'s position is preserved
    when Iris replaces it with a :class:`cartopy.mpl.geoaxes.GeoAxes`, fixing
    :issue:`1157`.  (:pull:`4273`)
+   
+#. `@rcomer`_ fixed :meth:`~iris.coords.Coord.nearest_neighbour_index` for edge
+   cases where the requested point is float and the coordinate has integer
+   bounds, reported at :issue:`2969`. (:pull:`4245`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2440,7 +2440,9 @@ class Coord(_DimensionalMetadata):
         if self.has_bounds():
             # make bounds ranges complete+separate, so point is in at least one
             increasing = self.bounds[0, 1] > self.bounds[0, 0]
-            bounds = bounds.copy()
+            # identify data type that bounds and point can safely cast to
+            dtype = np.result_type(bounds, np.min_scalar_type(point))
+            bounds = bounds.astype(dtype)
             # sort the bounds cells by their centre values
             sort_inds = np.argsort(np.mean(bounds, axis=1))
             bounds = bounds[sort_inds]

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2441,7 +2441,7 @@ class Coord(_DimensionalMetadata):
             # make bounds ranges complete+separate, so point is in at least one
             increasing = self.bounds[0, 1] > self.bounds[0, 0]
             # identify data type that bounds and point can safely cast to
-            dtype = np.result_type(bounds, np.min_scalar_type(point))
+            dtype = np.result_type(bounds, point)
             bounds = bounds.astype(dtype)
             # sort the bounds cells by their centre values
             sort_inds = np.argsort(np.mean(bounds, axis=1))

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -74,6 +74,11 @@ class Test_nearest_neighbour_index__ascending(tests.IrisTest):
         target = [0, 0, 0, 0, 0]
         self._test_nearest_neighbour_index(target)
 
+    def test_bounded_float_point(self):
+        coord = DimCoord(1, bounds=[0, 2])
+        result = coord.nearest_neighbour_index(2.5)
+        self.assertEqual(result, 0)
+
 
 class Test_nearest_neighbour_index__descending(tests.IrisTest):
     def setUp(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #2969.  The example given there now returns `None` as expected.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
