### PR TITLE
Fix aggregated_by mdtol/masked constant problem

### DIFF
--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -42,6 +42,10 @@ This document explains the changes made to Iris for this release
    :func:`iris.plot.plot` no longer defaults to placing a "Y" coordinate (e.g.
    latitude) on the y-axis of the plot. (:issue:`4493`, :pull:`4601`)
 
+#. `@rcomer`_ fixed :meth:`~iris.cube.Cube.aggregated_by` with `mdtol` for 1D
+   cubes where an aggregated section is entirely masked, reported at
+   :issue:`3190`.  (:pull:`4246`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -582,7 +582,11 @@ class _Aggregator:
         mdtol = kwargs.pop("mdtol", None)
 
         result = self.call_func(data, axis=axis, **kwargs)
-        if mdtol is not None and ma.isMaskedArray(data):
+        if (
+            mdtol is not None
+            and ma.is_masked(data)
+            and result is not ma.masked
+        ):
             fraction_not_missing = data.count(axis=axis) / data.shape[axis]
             mask_update = 1 - mdtol > fraction_not_missing
             if ma.isMaskedArray(result):

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -156,6 +156,19 @@ class Test_aggregate(tests.IrisTest):
             self.assertArrayAlmostEqual(result, mock_return.copy())
         mock_method.assert_called_once_with(data, axis=axis)
 
+    def test_allmasked_1D_with_mdtol(self):
+        data = ma.masked_all((3,))
+        axis = 0
+        mdtol = 0.5
+        mock_return = ma.masked
+        with mock.patch.object(
+            self.TEST, "call_func", return_value=mock_return
+        ) as mock_method:
+            result = self.TEST.aggregate(data, axis, mdtol=mdtol)
+
+        self.assertIs(result, mock_return.copy())
+        mock_method.assert_called_once_with(data, axis=axis)
+
     def test_returning_scalar_mdtol(self):
         # Test the case when the data aggregation function returns a scalar and
         # turns it into a masked array.

--- a/lib/iris/tests/unit/analysis/test_Aggregator.py
+++ b/lib/iris/tests/unit/analysis/test_Aggregator.py
@@ -166,7 +166,7 @@ class Test_aggregate(tests.IrisTest):
         ) as mock_method:
             result = self.TEST.aggregate(data, axis, mdtol=mdtol)
 
-        self.assertIs(result, mock_return.copy())
+        self.assertIs(result, mock_return)
         mock_method.assert_called_once_with(data, axis=axis)
 
     def test_returning_scalar_mdtol(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #3190.  Note that the examples provided there all involve 1D cubes and by the time `Aggregator.aggregate` is called, `Cube.aggregated_by`  has sliced out and passed the array for one particular section.  So the problem boils down to the issue illustrated in the new test:  if you average an entirely masked array, you get the `ma.masked` constant, whose `mask` attribute is read-only.  In this situation, there is no point doing anything extra for `mdtol` anyway, so just skip the loop.

I have verified that the three examples from #3190 all work with this change.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
