### PR TITLE
Test wrangling vs v3.0.x

### DIFF
--- a/docs/iris/src/whatsnew/3.0.4.rst
+++ b/docs/iris/src/whatsnew/3.0.4.rst
@@ -31,6 +31,10 @@ This document explains the changes made to Iris for this release
       to allow use of the latest versions of `cftime`_, `cf-units`_ and `nc-time-axis`_.
       (:pull:`4222`)
 
+   #. `@rcomer`_ modified test modules so they run consistently under ``pytest`` and
+      ``nose``, and also fixed some minor issues with :class:`~iris.time.PartialDateTime`.
+      (:pull:`4249`)
+
    Note that, we are forced to drop support for ``Python 3.6`` in this patch due to
    the third-party package dependencies required by (:pull:`4222`).
 

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -22,7 +22,7 @@ import iris.tests as tests
 
 
 class SystemInitialTest(tests.IrisTest):
-    def system_test_supported_filetypes(self):
+    def test_supported_filetypes(self):
         nx, ny = 60, 60
         data = np.arange(nx * ny, dtype=">f4").reshape(nx, ny)
 
@@ -74,7 +74,7 @@ class SystemInitialTest(tests.IrisTest):
                 new_cube, ("system", "supported_filetype_%s.cml" % filetype)
             )
 
-    def system_test_imports_general(self):
+    def test_imports_general(self):
         if tests.MPL_AVAILABLE:
             import matplotlib  # noqa
         import netCDF4  # noqa

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -25,7 +25,7 @@ import iris.exceptions
 import iris.tests.stock
 
 
-class TestMixin:
+class MergeMixin:
     """
     Mix-in class for attributes & utilities common to these test cases.
 
@@ -55,7 +55,7 @@ class TestMixin:
 
 
 @tests.skip_data
-class TestSingleCube(tests.IrisTest, TestMixin):
+class TestSingleCube(tests.IrisTest, MergeMixin):
     def setUp(self):
         self._data_path = tests.get_data_path(("PP", "globClim1", "theta.pp"))
         self._num_cubes = 1
@@ -63,7 +63,7 @@ class TestSingleCube(tests.IrisTest, TestMixin):
 
 
 @tests.skip_data
-class TestMultiCube(tests.IrisTest, TestMixin):
+class TestMultiCube(tests.IrisTest, MergeMixin):
     def setUp(self):
         self._data_path = tests.get_data_path(
             ("PP", "globClim1", "dec_subset.pp")

--- a/lib/iris/tests/unit/analysis/scipy_interpolate/__init__.py
+++ b/lib/iris/tests/unit/analysis/scipy_interpolate/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris.analysis.scipy_interpolate` module."""

--- a/lib/iris/tests/unit/time/__init__.py
+++ b/lib/iris/tests/unit/time/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris.time` module."""

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -224,12 +224,12 @@ class Test___eq__(tests.IrisTest, _Test_operator):
         self.expected_value = EQ_EXPECTATIONS
 
     def test_cftime_equal(self):
-        pdt = PartialDateTime(month=3, microsecond=2)
+        pdt = PartialDateTime(month=3, second=2)
         other = cftime.datetime(year=2013, month=3, day=20, second=2)
         self.assertTrue(pdt == other)
 
     def test_cftime_not_equal(self):
-        pdt = PartialDateTime(month=3, microsecond=2)
+        pdt = PartialDateTime(month=3, second=2)
         other = cftime.datetime(year=2013, month=4, day=20, second=2)
         self.assertFalse(pdt == other)
 

--- a/lib/iris/time.py
+++ b/lib/iris/time.py
@@ -155,8 +155,17 @@ class PartialDateTime:
                     other_attr = other.microsecond
                     if attr is not None and attr != other_attr:
                         result = False
+
             except AttributeError:
-                result = NotImplemented
+                result = other.__eq__(self)
+                if result is NotImplemented:
+                    # Equaliy is undefined between these objects.  We don't
+                    # want Python to fall back to the default `object`
+                    # behaviour (which compares using object IDs), so we raise
+                    # an exception here instead.
+                    fmt = "unable to compare PartialDateTime with {}"
+                    raise TypeError(fmt.format(type(other)))
+
         return result
 
     def __ne__(self, other):
@@ -164,14 +173,3 @@ class PartialDateTime:
         if result is not NotImplemented:
             result = not result
         return result
-
-    def __cmp__(self, other):
-        # Since we've defined all the rich comparison operators (via
-        # functools.total_ordering), we can only reach this point if
-        # neither this class nor the other class had a rich comparison
-        # that could handle the type combination.
-        # We don't want Python to fall back to the default `object`
-        # behaviour (which compares using object IDs), so we raise an
-        # exception here instead.
-        fmt = "unable to compare PartialDateTime with {}"
-        raise TypeError(fmt.format(type(other)))

--- a/lib/iris/time.py
+++ b/lib/iris/time.py
@@ -159,7 +159,7 @@ class PartialDateTime:
             except AttributeError:
                 result = other.__eq__(self)
                 if result is NotImplemented:
-                    # Equaliy is undefined between these objects.  We don't
+                    # Equality is undefined between these objects.  We don't
                     # want Python to fall back to the default `object`
                     # behaviour (which compares using object IDs), so we raise
                     # an exception here instead.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Replacement for #4192, targeting the v3.0.x branch.

This PR gets our tests running consistently under `pytest` and `nose`.  We had some `__init__.py` files missing so some tests have not been running under `nose`/`setuptools`/`nox`.  Once reinstated, three of the tests for `PartialDateTime` failed, so this PR also includes changes to address that.  See inline comments for explanations of individual changes.

I have verified that pointing `pytest` at this new branch produces 5216 passess and 22 skips.  `python setup.py test` also finds 5148 tests, but some are falling over with memory allocation errors 😕.  So let's see how the CI fairs...

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
