### PR TITLE
Make cube summary list attributes last.

### DIFF
--- a/lib/iris/_representation.py
+++ b/lib/iris/_representation.py
@@ -311,7 +311,7 @@ class CubeSummary:
             "Scalar cell measures:",
             scalar_cell_measures,
         )
-        add_scalar_section(AttributeSection, "Attributes:", cube.attributes)
         add_scalar_section(
             CellMethodSection, "Cell methods:", cube.cell_methods
         )
+        add_scalar_section(AttributeSection, "Attributes:", cube.attributes)

--- a/lib/iris/tests/unit/representation/test_representation.py
+++ b/lib/iris/tests/unit/representation/test_representation.py
@@ -72,8 +72,8 @@ class Test_CubeSummary(tests.IrisTest):
         expected_scalar_sections = [
             "Scalar coordinates:",
             "Scalar cell measures:",
-            "Attributes:",
             "Cell methods:",
+            "Attributes:",
         ]
 
         self.assertEqual(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Proposing to move the position of cell-methods in a Cube summary.

At present, if present, cell-methods appear last.
But attributes are a much more common content, and they include global attributes, which **_always_** appear last in an ncdump.
So I think it's less confusing if attributes always appear last in a cube summary too.

**If we want to do this, we should definitely include it alongside the new-cube summary in #4206**

Closes : #4211

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
