### PR TITLE
Installation instructions adapted to the requirement cftime>=1.5.

### DIFF
--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -70,10 +70,10 @@ The rest can be done with pip. Begin with numpy::
 Finally, Iris and its Python dependencies can be installed with the following
 command::
 
-  pip3 install setuptools cftime==1.2.1 cf-units scitools-iris
+  pip3 install setuptools cftime cf-units scitools-iris
 
 This procedure was tested on a Ubuntu 20.04 system on the
-27th of January, 2021.
+25th of July, 2021.
 Be aware that through updates of the involved Debian and/or Python packages,
 dependency conflicts might arise or the procedure might have to be modified.
 

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -52,16 +52,9 @@ this section are valid for Debian-based Linux distributions (Debian, Ubuntu,
 Kubuntu, etc.).
 
 Iris and its dependencies need some shared libraries in order to work properly.
-These can be installed
-with apt::
+These can be installed with apt::
 
   sudo apt-get install python3-pip python3-tk libudunits2-dev libproj-dev proj-bin libgeos-dev libcunit1-dev
-
-Consider executing::
-
-  sudo apt-get update
-
-before and after installation of Debian packages.
 
 The rest can be done with pip::
 
@@ -69,7 +62,7 @@ The rest can be done with pip::
 
 This procedure was tested on a Ubuntu 20.04 system on the
 26th of July, 2021.
-Be aware that through updates of the involved Debian and/or Python packages,
+Be aware that through updates of the involved Debian packages,
 dependency conflicts might arise or the procedure might have to be modified.
 
 .. _installing_from_source:

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -63,7 +63,7 @@ Consider executing::
 
 before and after installation of Debian packages.
 
-The rest can be done with pip. Begin with numpy::
+The rest can be done with pip::
 
   pip3 install scitools-iris
 

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -65,15 +65,10 @@ before and after installation of Debian packages.
 
 The rest can be done with pip. Begin with numpy::
 
-  pip3 install numpy
-
-Finally, Iris and its Python dependencies can be installed with the following
-command::
-
-  pip3 install setuptools cftime cf-units scitools-iris
+  pip3 install scitools-iris
 
 This procedure was tested on a Ubuntu 20.04 system on the
-25th of July, 2021.
+26th of July, 2021.
 Be aware that through updates of the involved Debian and/or Python packages,
 dependency conflicts might arise or the procedure might have to be modified.
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -135,6 +135,9 @@ This document explains the changes made to Iris for this release
 #. `@tkknight`_ documented the ``--force`` command line option when creating
    a conda development environment. See :ref:`installing_from_source`.
    (:pull:`4240`)
+   
+#. `@MHBalsmeier`_ updated and simplified non-conda installation on Debian-based distros.
+   (:pull:`4260`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -135,7 +135,7 @@ This document explains the changes made to Iris for this release
 #. `@tkknight`_ documented the ``--force`` command line option when creating
    a conda development environment. See :ref:`installing_from_source`.
    (:pull:`4240`)
-   
+
 #. `@MHBalsmeier`_ updated and simplified non-conda installation on Debian-based distros.
    (:pull:`4260`)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description

I adapted the from source installation instructions to the requirement `cftime>=1.5` which will be needed soon, as discussed in #4258.
