### PR TITLE
increase gha stale operations-per-run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -66,7 +66,7 @@ jobs:
             "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️"
 
           # Max number of operations per run.
-          operations-per-run: 30
+          operations-per-run: 300
 
           # Remove stale label from issues/prs on updates/comments.
           remove-stale-when-updated: true


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR increases the `operations-per-run` in order to cover the outstanding stale issues backlog.

Over time this value can be hopefully reduced.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
