### PR TITLE
CellMethods now printed in CF-compliant manner

### DIFF
--- a/docs/src/userguide/interpolation_and_regridding.rst
+++ b/docs/src/userguide/interpolation_and_regridding.rst
@@ -75,8 +75,8 @@ Let's take the air temperature cube we've seen previously:
             pressure                    1000.0 hPa
             time                        1998-12-01 00:00:00, bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Cell methods:
-            mean within years           time
-            mean over years             time
+            time                        mean within years
+            time                        mean over years
         Attributes:
             STASH                       m01s16i203
             source                      Data from Met Office Unified Model
@@ -94,9 +94,9 @@ We can interpolate specific values from the coordinates of the cube:
             pressure                    1000.0 hPa
             time                        1998-12-01 00:00:00, bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         Cell methods:
-            mean within years           time
-            mean over years             time
-        Attributes:
+            time                        mean within years
+            time                        mean over years
+         Attributes:
             STASH                       m01s16i203
             source                      Data from Met Office Unified Model
 

--- a/lib/iris/_representation/cube_printout.py
+++ b/lib/iris/_representation/cube_printout.py
@@ -257,11 +257,11 @@ class CubePrinter:
                         add_scalar_row(item.name, item.content)
                         if item.extra:
                             add_scalar_row(item_to_extra_indent + item.extra)
-                elif "attribute" in title or "cell method" in title:
+                elif "attribute" in title:
                     for title, value in zip(sect.names, sect.values):
                         add_scalar_row(title, value)
-                elif "scalar cell measure" in title:
-                    # These are just strings: nothing in the 'value' column.
+                elif "scalar cell measure" in title or "cell method" in title:
+                    # These are just strings: nothing extra in the 'value' column.
                     for name in sect.contents:
                         add_scalar_row(name)
                 else:

--- a/lib/iris/_representation/cube_printout.py
+++ b/lib/iris/_representation/cube_printout.py
@@ -261,9 +261,8 @@ class CubePrinter:
                     for title, value in zip(sect.names, sect.values):
                         add_scalar_row(title, value)
                 elif "cell method" in title:
-                    title = ", ".join(sect.names)
-                    for value in sect.values:
-                        add_scalar_row(title, value)
+                    for title, value in zip(sect.names, sect.values):
+                        add_scalar_row(", ".join(title), value)
                 elif "scalar cell measure" in title:
                     # These are just strings: nothing in the 'value' column.
                     for name in sect.contents:

--- a/lib/iris/_representation/cube_printout.py
+++ b/lib/iris/_representation/cube_printout.py
@@ -260,8 +260,12 @@ class CubePrinter:
                 elif "attribute" in title:
                     for title, value in zip(sect.names, sect.values):
                         add_scalar_row(title, value)
-                elif "scalar cell measure" in title or "cell method" in title:
-                    # These are just strings: nothing extra in the 'value' column.
+                elif "cell method" in title:
+                    title = ", ".join(sect.names)
+                    for value in sect.values:
+                        add_scalar_row(title, value)
+                elif "scalar cell measure" in title:
+                    # These are just strings: nothing in the 'value' column.
                     for name in sect.contents:
                         add_scalar_row(name)
                 else:

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -223,11 +223,11 @@ class CellMethodSection(Section):
         self.contents = []
         for method in cell_methods:
             name = method.method
+            content = str(method)
             # Remove "method: " from the front of the string, leaving the value.
-            value = str(method)[len(name + ": ") :]
+            value = content[len(name + ": ") :]
             self.names.append(name)
             self.values.append(value)
-            content = "{}: {}".format(name, value)
             self.contents.append(content)
 
 

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -222,13 +222,13 @@ class CellMethodSection(Section):
         self.values = []
         self.contents = []
         for method in cell_methods:
-            name = method.coord
-            content = str(method)
-            # Remove "method: " from the front of the string, leaving the value.
-            value = content[len(name + ": ") :]
-            self.names.append(name)
-            self.values.append(value)
-            self.contents.append(content)
+            for content in str(method).split("\n"):
+                name = content.split(":")[0]
+                # Remove "method: " from the front of the string, leaving the value.
+                value = content[len(f"{name}: ") :]
+                self.names.append(name)
+                self.values.append(value)
+                self.contents.append(content)
 
 
 class CubeSummary:

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -222,13 +222,13 @@ class CellMethodSection(Section):
         self.values = []
         self.contents = []
         for method in cell_methods:
-            for content in str(method).split("\n"):
-                name = content.split(":")[0]
-                # Remove "method: " from the front of the string, leaving the value.
-                value = content[len(f"{name}: ") :]
-                self.names.append(name)
-                self.values.append(value)
-                self.contents.append(content)
+            content = str(method)
+            names = content.split(":")[:-1]
+            # Remove "coord: " or "coord1: coord2: " from the front of the string, leaving the value.
+            value = content.split(":")[-1][1:]
+            self.names += names
+            self.values.append(value)
+            self.contents.append(content)
 
 
 class CubeSummary:

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -226,7 +226,7 @@ class CellMethodSection(Section):
             names = content.split(": ")[:-1]
             # Remove "coord: " or "coord1: coord2: " from the front of the string, leaving the value.
             value = content.split(": ")[-1]
-            self.names += names
+            self.names.append(names)
             self.values.append(value)
             self.contents.append(content)
 

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -222,7 +222,7 @@ class CellMethodSection(Section):
         self.values = []
         self.contents = []
         for method in cell_methods:
-            name = method.method
+            name = method.coord
             content = str(method)
             # Remove "method: " from the front of the string, leaving the value.
             value = content[len(name + ": ") :]

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -223,9 +223,9 @@ class CellMethodSection(Section):
         self.contents = []
         for method in cell_methods:
             content = str(method)
-            names = content.split(":")[:-1]
+            names = content.split(": ")[:-1]
             # Remove "coord: " or "coord1: coord2: " from the front of the string, leaving the value.
-            value = content.split(":")[-1][1:]
+            value = content.split(": ")[-1]
             self.names += names
             self.values.append(value)
             self.contents.append(content)

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -53,7 +53,7 @@ from iris.analysis._interpolation import (
 )
 from iris.analysis._regrid import CurvilinearRegridder, RectilinearRegridder
 import iris.coords
-from iris.exceptions import CoordinateNotFoundError, LazyAggregatorError
+from iris.exceptions import LazyAggregatorError
 
 __all__ = (
     "COUNT",

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -53,7 +53,7 @@ from iris.analysis._interpolation import (
 )
 from iris.analysis._regrid import CurvilinearRegridder, RectilinearRegridder
 import iris.coords
-from iris.exceptions import LazyAggregatorError, CoordinateNotFoundError
+from iris.exceptions import CoordinateNotFoundError, LazyAggregatorError
 
 __all__ = (
     "COUNT",

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1003,16 +1003,8 @@ class Aggregator(_Aggregator):
                 )
             coord_names.append(coord.name())
 
-        # Add a cell method. If both y and x coords are specified, replace with "area"
+        # Add a cell method.
         method_name = self.cell_method.format(**kwargs)
-        try:
-            spatial_coords = [cube.coord(axis=axis) for axis in "yx"]
-        except CoordinateNotFoundError:
-            pass
-        else:
-            if all([x in coord_names for x in spatial_coords]):
-                [coord_names.pop(c) for c in spatial_coords]
-                coord_names.append("area")
         cell_method = iris.coords.CellMethod(method_name, coord_names)
         cube.add_cell_method(cell_method)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2817,7 +2817,7 @@ class CellMethod(iris.util._OrderedHashable):
 
     def __str__(self):
         """Return a custom string representation of CellMethod in CF-format"""
-        # Group related coord names intervals and comments
+        # Group related coord names intervals and comments together
         cell_components = zip_longest(
             self.coord_names, self.intervals, self.comments, fillvalue=""
         )

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2830,7 +2830,7 @@ class CellMethod(iris.util._OrderedHashable):
             other_info = ", ".join(filter(None, chain((interval, comment))))
             other_infos.append(other_info)
 
-        result = f"{''.join([f'{c}: ' for c in coords])} {self.method}"
+        result = f"{''.join([f'{c}: ' for c in coords])}{self.method}"
         if any(other_infos):
             result += f" ({', '.join(other_infos)})"
         return result

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2817,27 +2817,23 @@ class CellMethod(iris.util._OrderedHashable):
 
     def __str__(self):
         """Return a custom string representation of CellMethod in CF-format"""
-        # Ungroup related coord names intervals and comments
+        # Group related coord names intervals and comments
         cell_components = zip_longest(
             self.coord_names, self.intervals, self.comments, fillvalue=""
         )
 
-        collection_summaries = []
+        coords = []
+        other_infos = []
 
         for coord_name, interval, comment in cell_components:
+            coords.append(coord_name)
             other_info = ", ".join(filter(None, chain((interval, comment))))
-            if other_info:
-                coord_summary = "%s: %s (%s)" % (
-                    coord_name,
-                    self.method,
-                    other_info,
-                )
-            else:
-                coord_summary = "%s: %s" % (coord_name, self.method)
+            other_infos.append(other_info)
 
-            collection_summaries.append(coord_summary)
-
-        return "\n ".join(collection_summaries)
+        result = f"{''.join([f'{c}: ' for c in coords])} {self.method}"
+        if any(other_infos):
+            result += f" ({', '.join(other_infos)})"
+        return result
 
     def __add__(self, other):
         # Disable the default tuple behaviour of tuple concatenation

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2816,25 +2816,24 @@ class CellMethod(iris.util._OrderedHashable):
         self._init(method, tuple(_coords), tuple(_intervals), tuple(_comments))
 
     def __str__(self):
-        """Return a custom string representation of CellMethod"""
-        # Group related coord names intervals and comments together
+        """Return a custom string representation of CellMethod in CF-format"""
+        # Ungroup related coord names intervals and comments
         cell_components = zip_longest(
             self.coord_names, self.intervals, self.comments, fillvalue=""
         )
 
         collection_summaries = []
-        cm_summary = "%s: " % self.method
 
         for coord_name, interval, comment in cell_components:
             other_info = ", ".join(filter(None, chain((interval, comment))))
             if other_info:
-                coord_summary = "%s (%s)" % (coord_name, other_info)
+                coord_summary = "%s: %s (%s)" % (self.method, coord_name, other_info)
             else:
-                coord_summary = "%s" % coord_name
+                coord_summary = "%s: %s" % (self.method, coord_name)
 
             collection_summaries.append(coord_summary)
 
-        return cm_summary + ", ".join(collection_summaries)
+        return "\n ".join(collection_summaries)
 
     def __add__(self, other):
         # Disable the default tuple behaviour of tuple concatenation

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2827,7 +2827,11 @@ class CellMethod(iris.util._OrderedHashable):
         for coord_name, interval, comment in cell_components:
             other_info = ", ".join(filter(None, chain((interval, comment))))
             if other_info:
-                coord_summary = "%s: %s (%s)" % (self.method, coord_name, other_info)
+                coord_summary = "%s: %s (%s)" % (
+                    self.method,
+                    coord_name,
+                    other_info,
+                )
             else:
                 coord_summary = "%s: %s" % (self.method, coord_name)
 

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2828,12 +2828,12 @@ class CellMethod(iris.util._OrderedHashable):
             other_info = ", ".join(filter(None, chain((interval, comment))))
             if other_info:
                 coord_summary = "%s: %s (%s)" % (
-                    self.method,
                     coord_name,
+                    self.method,
                     other_info,
                 )
             else:
-                coord_summary = "%s: %s" % (self.method, coord_name)
+                coord_summary = "%s: %s" % (coord_name, self.method)
 
             collection_summaries.append(coord_summary)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -750,9 +750,9 @@ class Cube(CFVariableMixin):
                 time                        \
 1998-12-01 00:00:00, bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             Cell methods:
-                mean within years           time
-                mean over years             time
-            Attributes:
+                time                        mean within years
+                time                        mean over years
+             Attributes:
                 STASH                       m01s16i203
                 source                      Data from Met Office Unified Model
 

--- a/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
@@ -8,12 +8,9 @@ air_temperature / (K)               (latitude: 73; longitude: 96)
         pressure                    1000.0 hPa
         time                        1998-12-01 00:00:00
     Cell methods:
-        longitude                   mean (6 minutes, This is a test comment)
-        latitude                    mean (12 minutes)
-        longitude                   average (6 minutes, This is another test comment)
-        latitude                    average (15 minutes, This is another comment)
-        longitude                   average
-        latitude                    average
+        longitude, latitude         mean (6 minutes, This is a test comment, 12 minutes)
+        longitude, latitude         average (6 minutes, This is another test comment,15 minutes, This is another comment)
+        longitude, latitude         average
         longitude                   percentile (6 minutes, This is another test comment)
     Attributes:
         STASH                       m01s16i203

--- a/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
@@ -8,10 +8,10 @@ air_temperature / (K)               (latitude: 73; longitude: 96)
         pressure                    1000.0 hPa
         time                        1998-12-01 00:00:00
     Cell methods:
-        longitude, latitude          mean (6 minutes, This is a test comment, 12 minutes)
-        longitude, latitude          average (6 minutes, This is another test comment, 15 minutes, This is another comment)
-        longitude, latitude          average
-        longitude                    percentile (6 minutes, This is another test comment)
+        longitude, latitude         mean (6 minutes, This is a test comment, 12 minutes)
+        longitude, latitude         average (6 minutes, This is another test comment, 15 minutes, This is another comment)
+        longitude, latitude         average
+        longitude                   percentile (6 minutes, This is another test comment)
     Attributes:
         STASH                       m01s16i203
         source                      Data from Met Office Unified Model

--- a/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
@@ -8,10 +8,10 @@ air_temperature / (K)               (latitude: 73; longitude: 96)
         pressure                    1000.0 hPa
         time                        1998-12-01 00:00:00
     Cell methods:
-        area                        mean (6 minutes, This is a test comment, 12 minutes)
-        area                        average (6 minutes, This is another test comment,15 minutes, This is another comment)
-        area                        average
-        longitude                   percentile (6 minutes, This is another test comment)
+        longitude, latitude          mean (6 minutes, This is a test comment, 12 minutes)
+        longitude, latitude          average (6 minutes, This is another test comment, 15 minutes, This is another comment)
+        longitude, latitude          average
+        longitude                    percentile (6 minutes, This is another test comment)
     Attributes:
         STASH                       m01s16i203
         source                      Data from Met Office Unified Model

--- a/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
@@ -8,10 +8,13 @@ air_temperature / (K)               (latitude: 73; longitude: 96)
         pressure                    1000.0 hPa
         time                        1998-12-01 00:00:00
     Cell methods:
-        mean                        longitude (6 minutes, This is a test comment), latitude (12 minutes)
-        average                     longitude (6 minutes, This is another test comment), latitude (15 minutes, This is another comment)
-        average                     longitude, latitude
-        percentile                  longitude (6 minutes, This is another test comment)
+        longitude                   mean (6 minutes, This is a test comment)
+        latitude                    mean (12 minutes)
+        longitude                   average (6 minutes, This is another test comment)
+        latitude                    average (15 minutes, This is another comment)
+        longitude                   average
+        latitude                    average
+        longitude                   percentile (6 minutes, This is another test comment)
     Attributes:
         STASH                       m01s16i203
         source                      Data from Met Office Unified Model

--- a/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
+++ b/lib/iris/tests/results/cdm/str_repr/cell_methods.__str__.txt
@@ -8,9 +8,9 @@ air_temperature / (K)               (latitude: 73; longitude: 96)
         pressure                    1000.0 hPa
         time                        1998-12-01 00:00:00
     Cell methods:
-        longitude, latitude         mean (6 minutes, This is a test comment, 12 minutes)
-        longitude, latitude         average (6 minutes, This is another test comment,15 minutes, This is another comment)
-        longitude, latitude         average
+        area                        mean (6 minutes, This is a test comment, 12 minutes)
+        area                        average (6 minutes, This is another test comment,15 minutes, This is another comment)
+        area                        average
         longitude                   percentile (6 minutes, This is another test comment)
     Attributes:
         STASH                       m01s16i203

--- a/lib/iris/tests/unit/coords/test_CellMethod.py
+++ b/lib/iris/tests/unit/coords/test_CellMethod.py
@@ -77,14 +77,14 @@ class Test(tests.IrisTest):
         token = "air_temperature"
         coord = AuxCoord(1, standard_name=token)
         result = CellMethod(self.method, coords=[coord, token])
-        expected = "{0}: {1}\n {2}: {1}".format(token, self.method, token)
+        expected = "{0}: {0}: {1}".format(token, self.method)
         self.assertEqual(str(result), expected)
 
     def test_mixture_default(self):
         token = "air temperature"  # includes space
         coord = AuxCoord(1, long_name=token)
         result = CellMethod(self.method, coords=[coord, token])
-        expected = "unknown: {0}\n unknown: {0}".format(self.method)
+        expected = "unknown: unknown: {}".format(self.method)
         self.assertEqual(str(result), expected)
 
 

--- a/lib/iris/tests/unit/coords/test_CellMethod.py
+++ b/lib/iris/tests/unit/coords/test_CellMethod.py
@@ -22,7 +22,7 @@ class Test(tests.IrisTest):
     def _check(self, token, coord, default=False):
         result = CellMethod(self.method, coords=coord)
         token = token if not default else BaseMetadata.DEFAULT_NAME
-        expected = "{}: {}".format(self.method, token)
+        expected = "{}: {}".format(token, self.method)
         self.assertEqual(str(result), expected)
 
     def test_coord_standard_name(self):
@@ -64,27 +64,27 @@ class Test(tests.IrisTest):
     def test_string(self):
         token = "air_temperature"
         result = CellMethod(self.method, coords=token)
-        expected = "{}: {}".format(self.method, token)
+        expected = "{}: {}".format(token, self.method)
         self.assertEqual(str(result), expected)
 
     def test_string_default(self):
         token = "air temperature"  # includes space
         result = CellMethod(self.method, coords=token)
-        expected = "{}: unknown".format(self.method)
+        expected = "unknown: {}".format(self.method)
         self.assertEqual(str(result), expected)
 
     def test_mixture(self):
         token = "air_temperature"
         coord = AuxCoord(1, standard_name=token)
         result = CellMethod(self.method, coords=[coord, token])
-        expected = "{}: {}, {}".format(self.method, token, token)
+        expected = "{0}: {1}\n {2}: {1}".format(token, self.method, token)
         self.assertEqual(str(result), expected)
 
     def test_mixture_default(self):
         token = "air temperature"  # includes space
         coord = AuxCoord(1, long_name=token)
         result = CellMethod(self.method, coords=[coord, token])
-        expected = "{}: unknown, unknown".format(self.method)
+        expected = "unknown: {0}\n unknown: {0}".format(self.method)
         self.assertEqual(str(result), expected)
 
 

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -198,12 +198,13 @@ class Test__get_bits(tests.IrisTest):
         contents = self.representer.str_headings["Cell methods:"]
         content_str = ",".join(content for content in contents)
         for method in self.cube.cell_methods:
-            for content in str(method).split("\n"):
-                name = content.split(":")[0]
-                # Remove "method: " from the front of the string, leaving the value.
-                value = content[len(f"{name}: ") :]
+            content = str(method)
+            names = content.split(":")[:-1]
+            # Remove "coord: " or "coord1: coord2: " from the front of the string, leaving the value.
+            value = content.split(":")[-1][1:]
+            for name in names:
                 self.assertIn(name, content_str)
-                self.assertIn(value, content_str)
+            self.assertIn(value, content_str)
 
 
 @tests.skip_data

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -198,10 +198,12 @@ class Test__get_bits(tests.IrisTest):
         contents = self.representer.str_headings["Cell methods:"]
         content_str = ",".join(content for content in contents)
         for method in self.cube.cell_methods:
-            name = method.method
-            value = str(method)[len(name + ": ") :]
-            self.assertIn(name, content_str)
-            self.assertIn(value, content_str)
+            for content in str(method).split("\n"):
+                name = content.split(":")[0]
+                # Remove "method: " from the front of the string, leaving the value.
+                value = content[len(f"{name}: ") :]
+                self.assertIn(name, content_str)
+                self.assertIn(value, content_str)
 
 
 @tests.skip_data

--- a/lib/iris/tests/unit/representation/cube_printout/test_CubePrintout.py
+++ b/lib/iris/tests/unit/representation/cube_printout/test_CubePrintout.py
@@ -508,8 +508,8 @@ class TestCubePrintout__to_string(tests.IrisTest):
         expected = [
             "name / (1)                          (-- : 1)",
             "    Cell methods:",
-            "        stdev                       area",
-            "        mean                        y (10m, vertical), time (3min, =duration)",
+            "        area                        stdev",
+            "        y, time                     mean (10m, vertical, 3min, =duration)",
         ]
         self.assertEqual(rep, expected)
 

--- a/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
+++ b/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
@@ -198,7 +198,7 @@ class Test_CubeSummary(tests.IrisTest):
 
         rep = CubeSummary(cube)
         cell_method_section = rep.scalar_sections["Cell methods:"]
-        expected_contents = ["mean: x, y", "mean: x"]
+        expected_contents = ["x: mean\ny: mean", "x: mean"]
         self.assertEqual(cell_method_section.contents, expected_contents)
 
     def test_scalar_cube(self):

--- a/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
+++ b/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
@@ -198,7 +198,7 @@ class Test_CubeSummary(tests.IrisTest):
 
         rep = CubeSummary(cube)
         cell_method_section = rep.scalar_sections["Cell methods:"]
-        expected_contents = ["area: mean", "x: mean"]
+        expected_contents = ["x: y: mean", "x: mean"]
         self.assertEqual(cell_method_section.contents, expected_contents)
 
     def test_scalar_cube(self):

--- a/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
+++ b/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
@@ -198,7 +198,7 @@ class Test_CubeSummary(tests.IrisTest):
 
         rep = CubeSummary(cube)
         cell_method_section = rep.scalar_sections["Cell methods:"]
-        expected_contents = ["x: y: mean", "x: mean"]
+        expected_contents = ["area: mean", "x: mean"]
         self.assertEqual(cell_method_section.contents, expected_contents)
 
     def test_scalar_cube(self):

--- a/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
+++ b/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
@@ -198,7 +198,7 @@ class Test_CubeSummary(tests.IrisTest):
 
         rep = CubeSummary(cube)
         cell_method_section = rep.scalar_sections["Cell methods:"]
-        expected_contents = ["x: mean\ny: mean", "x: mean"]
+        expected_contents = ["x: y: mean", "x: mean"]
         self.assertEqual(cell_method_section.contents, expected_contents)
 
     def test_scalar_cube(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Fixes #3592 

This simple PR rearranges the order in which CellMethod information is formatted by the __str__ method. The grouping of this information (where multiple coords refer to the same method) has therefore been removed.
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
