### PR TITLE
Straw Man: make collapsed points configurable

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1929,7 +1929,7 @@ class Coord(_DimensionalMetadata):
 
         return Cell(point, bound)
 
-    def collapsed(self, dims_to_collapse=None):
+    def collapsed(self, dims_to_collapse=None, points_func=None):
         """
         Returns a copy of this coordinate, which has been collapsed along
         the specified dimensions.
@@ -2003,7 +2003,10 @@ class Coord(_DimensionalMetadata):
                 ],
                 axis=-1,
             )
-            points = al.array(bounds.sum(axis=-1) * 0.5, dtype=self.dtype)
+            if points_func is None:
+                points = al.array(bounds.sum(axis=-1) * 0.5, dtype=self.dtype)
+            else:
+                points = points_func(self.core_points(), axis=dims_to_collapse)
 
             # Create the new collapsed coordinate.
             coord = self.copy(points=points, bounds=bounds)
@@ -2497,8 +2500,10 @@ class DimCoord(Coord):
         coord.circular = self.circular and coord.shape == self.shape
         return coord
 
-    def collapsed(self, dims_to_collapse=None):
-        coord = Coord.collapsed(self, dims_to_collapse=dims_to_collapse)
+    def collapsed(self, dims_to_collapse=None, points_func=None):
+        coord = Coord.collapsed(
+            self, dims_to_collapse=dims_to_collapse, points_func=points_func
+        )
         if self.circular and self.units.modulus is not None:
             bnds = coord.bounds.copy()
             bnds[0, 1] = coord.bounds[0, 0] + self.units.modulus

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3414,7 +3414,7 @@ class Cube(CFVariableMixin):
 
     # END OPERATOR OVERLOADS
 
-    def collapsed(self, coords, aggregator, **kwargs):
+    def collapsed(self, coords, aggregator, points_funcs=dict(), **kwargs):
         """
         Collapse one or more dimensions over the cube given the coordinate/s
         and an aggregation.
@@ -3568,7 +3568,11 @@ class Cube(CFVariableMixin):
                     for dim in dims_to_collapse
                     if dim in coord_dims
                 ]
-                collapsed_cube.replace_coord(coord.collapsed(local_dims))
+                collapsed_cube.replace_coord(
+                    coord.collapsed(
+                        local_dims, points_func=points_funcs.get(coord.name())
+                    )
+                )
 
         untouched_dims = sorted(untouched_dims)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Previously, @duncanwp proposed changing the behaviour of `coord.collapsed` to use a mean rather than the current behaviour of taking the mid-point between the newly calculated bounds (#3029).  This would have been a breaking change and, I think, there may be cases where the mean isn't the best choice.

What if we made the treatment of points a user choice?

Make a cube
```python
import iris
import iris.cube

cube = iris.cube.Cube(range(5))
coord1 = iris.coords.DimCoord(range(5), long_name='foo')
coord2 = iris.coords.AuxCoord([5,2,4,42,0], long_name='bar')
cube.add_dim_coord(coord1, 0)
cube.add_aux_coord(coord2, 0)
```

Default behaviour is unchanged
```python
print(cube.collapsed('foo', iris.analysis.MEAN))
```
```
unknown / (unknown)                 (scalar cube)
    Scalar coordinates:
        bar                         21, bound=(0, 42)
        foo                         2, bound=(0, 4)
    Cell methods:
        mean                        foo
```

But maybe we decide that the mean would be a better choice for 'bar'
```python
import numpy as np
print(cube.collapsed('foo', iris.analysis.MEAN, points_funcs=dict(bar=np.mean)))
```
```
    Scalar coordinates:
        bar                         10.6, bound=(0, 42)
        foo                         2, bound=(0, 4)
    Cell methods:
        mean                        foo
```

In applications that calculate climatologies (#4098), neither the mid-point nor the mean really work, because averaging Januarys can give us July:

```python
import datetime

import cf_units

times = [datetime.datetime(year, 1, 1) for year in range(2000, 2004)]
tunit = cf_units.Unit('days since 1970-01-01')
tcoord = iris.coords.DimCoord(tunit.date2num(times), units=tunit, standard_name='time')

print(tcoord.collapsed())
print(tcoord.collapsed(points_func=np.mean))
```
```
DimCoord([2001-07-02 00:00:00], bounds=[[2000-01-01 00:00:00, 2003-01-01 00:00:00]], standard_name='time', calendar='gregorian')
DimCoord([2001-07-02 06:00:00], bounds=[[2000-01-01 00:00:00, 2003-01-01 00:00:00]], standard_name='time', calendar='gregorian')

```

But we could reasonably use a max or min to get a sensible time of year

```python
print(tcoord.collapsed(points_func=np.max))
print(tcoord.collapsed(points_func=np.min))
```

```
DimCoord([2003-01-01 00:00:00], bounds=[[2000-01-01 00:00:00, 2003-01-01 00:00:00]], standard_name='time', calendar='gregorian')
DimCoord([2000-01-01 00:00:00], bounds=[[2000-01-01 00:00:00, 2003-01-01 00:00:00]], standard_name='time', calendar='gregorian')
```

Obviously it would need a lot more work to do this properly, including addressing `aggregated_by`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
