### PR TITLE
bump version

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -103,7 +103,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.1.dev0"
+__version__ = "3.2.dev0"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR increments the `iris.__version__` given that the `v3.1.x` release feature is now cut, and the `v3.1.0` release is imminently pending.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
