### PR TITLE
Add 'Good First Issue' label to reasons an issue doesn't go stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -59,11 +59,11 @@ jobs:
 
           # Labels on issues exempted from stale.
           exempt-issue-labels: |
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
 
           # Labels on prs exempted from stale.
           exempt-pr-labels: |
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
 
           # Max number of operations per run.
           operations-per-run: 300

--- a/docs/src/userguide/loading_iris_cubes.rst
+++ b/docs/src/userguide/loading_iris_cubes.rst
@@ -215,14 +215,6 @@ constraint to ``load``::
     level_10 = iris.Constraint(model_level_number=10)
     cubes = iris.load(filename, forecast_6 & level_10)
 
-.. note::
-
-    Whilst ``&`` is supported, the ``|`` that might reasonably be expected
-    is not. This is because "or" constraints could lead to a cube which did
-    not cover a hyper-rectangular region if these constraints were on
-    different coordinates. If an "or" type constraint on a single coordinate
-    is useful then it may be obtained by passing a function to :class:`iris.Constraint`.
-
 As well as being able to combine constraints using ``&``,
 the :class:`iris.Constraint` class can accept multiple arguments,
 and a list of values can be given to constrain a coordinate to one of

--- a/docs/src/userguide/loading_iris_cubes.rst
+++ b/docs/src/userguide/loading_iris_cubes.rst
@@ -215,6 +215,14 @@ constraint to ``load``::
     level_10 = iris.Constraint(model_level_number=10)
     cubes = iris.load(filename, forecast_6 & level_10)
 
+.. note::
+
+    Whilst ``&`` is supported, the ``|`` that might reasonably be expected
+    is not. This is because "or" constraints could lead to a cube which did
+    not cover a hyper-rectangular region if these constraints were on
+    different coordinates. If an "or" type constraint on a single coordinate
+    is useful then it may be obtained by passing a function to :class:`iris.Constraint`.
+
 As well as being able to combine constraints using ``&``,
 the :class:`iris.Constraint` class can accept multiple arguments,
 and a list of values can be given to constrain a coordinate to one of

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,6 +86,10 @@ This document explains the changes made to Iris for this release
    always works locally, but never within CI. (:pull:`4307`)
 
 
+#. `@wjbenfold`_ excluded "Good First Issue" labelled issues from being
+   marked stale. (:pull:`4317`)
+
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Added "Good First Issue" to the exempt list for both exempt-issue-labels and exempt-pr-labels so that these won't be made stale.
<!-- Tell us all about your new feature, improvement, or bug fix -->
Based on a suggestion by @trexfeathers in Peloton today, stopping good first issues from going stale means that there's a supply of them for new developers to get involved through (particularly as there aren't a huge number of them).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
