### PR TITLE
Skip TestConstrainedLoad if data missing

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -104,6 +104,9 @@ This document explains the changes made to Iris for this release
    http://www.nationalarchives.gov.uk/doc/open-government-licence since this
    always works locally, but never within CI. (:pull:`4307`)
 
+#. `@wjbenfold`_ netCDF integration tests now skip TestConstrainedLoad if
+   test data is missing (:pull:`4319`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -104,7 +104,7 @@ This document explains the changes made to Iris for this release
    http://www.nationalarchives.gov.uk/doc/open-government-licence since this
    always works locally, but never within CI. (:pull:`4307`)
 
-#. `@wjbenfold`_ netCDF integration tests now skip TestConstrainedLoad if
+#. `@wjbenfold`_ netCDF integration tests now skip ``TestConstrainedLoad`` if
    test data is missing (:pull:`4319`)
 
 

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -707,6 +707,7 @@ data:
         self.assertEqual(cs.false_northing, 0.0)
 
 
+@tests.skip_data
 class TestConstrainedLoad(tests.IrisTest):
     filename = tests.get_data_path(
         ("NetCDF", "label_and_climate", "A1B-99999a-river-sep-2070-2099.nc")


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Added the skip data decorator to TestConstrainedLoad in the integration tests for NetCDF
<!-- Tell us all about your new feature, improvement, or bug fix -->
Running the tests without access to the test data was causing test failures when they should have been skipped (specifically from the integration tests for NetCDF, in the TestConstrainedLoad class). This is no longer the case.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
