### PR TITLE
Update to loading docs to cover absence of 'or' for constraints

### DIFF
--- a/docs/src/userguide/loading_iris_cubes.rst
+++ b/docs/src/userguide/loading_iris_cubes.rst
@@ -217,11 +217,15 @@ constraint to ``load``::
 
 .. note::
 
-    Whilst ``&`` is supported, the ``|`` that might reasonably be expected
-    is not. This is because "or" constraints could lead to a cube which did
-    not cover a hyper-rectangular region if these constraints were on
-    different coordinates. If an "or" type constraint on a single coordinate
-    is useful then it may be obtained by passing a function to :class:`iris.Constraint`.
+    Whilst ``&`` is supported, the ``|`` that might reasonably be expected is
+    not. Explanation as to why is in the :class:`iris.Constraint` reference
+    documentation.
+
+    For an example of constraining to multiple ranges of the same coordinate to
+    generate one cube, see the :class:`iris.Constraint` reference documentation.
+
+    To generate multiple cubes, each constrained to a different range of the
+    same coordinate, use :py:func:`iris.load_cubes`.
 
 As well as being able to combine constraints using ``&``,
 the :class:`iris.Constraint` class can accept multiple arguments,

--- a/docs/src/userguide/loading_iris_cubes.rst
+++ b/docs/src/userguide/loading_iris_cubes.rst
@@ -215,6 +215,14 @@ constraint to ``load``::
     level_10 = iris.Constraint(model_level_number=10)
     cubes = iris.load(filename, forecast_6 & level_10)
 
+.. note::
+
+    Whilst ``&`` is supported, the ``|`` that might reasonably be expected
+    is not. This is because "or" constraints could lead to a cube which did
+    not cover a hyper-rectangular region if these constraints were on
+    different coordinates. If an "or" type constraint on a single coordinate
+    is useful then it may be obtained by passing a function to :class:`iris.Constraint`.
+
 As well as being able to combine constraints using ``&``,
 the :class:`iris.Constraint` class can accept multiple arguments,
 and a list of values can be given to constrain a coordinate to one of

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -96,6 +96,9 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ improved readability in :ref:`userguide interpolation
    section <interpolation>`. (:pull:`4314`)
 
+#. `@wjbenfold`_ added explanation about the absence of | operator for
+   :class:`iris.Constraint` to :ref:`userguide loading section <constrained-loading>`. (:pull:`4321`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,7 +97,8 @@ This document explains the changes made to Iris for this release
    section <interpolation>`. (:pull:`4314`)
 
 #. `@wjbenfold`_ added explanation about the absence of | operator for
-   :class:`iris.Constraint` to :ref:`userguide loading section <constrained-loading>`. (:pull:`4321`)
+   :class:`iris.Constraint` to :ref:`userguide loading section
+   <constrained-loading>` and to api reference documentation. (:pull:`4321`)
 
 
 💼 Internal

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -83,7 +83,8 @@ class Constraint:
             ambiguous what should be extracted.
 
             To generate multiple cubes, each constrained to a different range of
-            the same coordinate, use :py:func:`iris.load_cubes`.
+            the same coordinate, use :py:func:`iris.load_cubes` or
+            :py:func:`iris.cube.CubeList.extract_cubes`.
 
             A constraint covering multiple ranges of the same coordinate may be
             used to generate a single cube like so::

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -87,7 +87,7 @@ class Constraint:
             :py:func:`iris.cube.CubeList.extract_cubes`.
 
             A constraint covering multiple ranges of the same coordinate may be
-            used to generate a single cube like so::
+            created like so::
 
                 def latitude_bands(cell):
                     return (0 < cell < 30) or (60 < cell < 90)

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -73,6 +73,26 @@ class Constraint:
                        model_level_number=[10, 12])
                        & Constraint(ensemble_member=2)
 
+        .. note::
+            Whilst ``&`` is supported, the ``|`` that might reasonably be expected
+            is not. This is because each constraint describes a boxlike region, and
+            thus the intersection of these constraints (obtained with ``&``) will
+            also describe a boxlike region. Allowing the union of two constraints
+            (with the ``|`` symbol) would allow the description of a non-boxlike
+            region. These are difficult to describe with cubes and so it would be
+            ambiguous what should be extracted.
+
+            To generate multiple cubes, each constrained to a different range of
+            the same coordinate, use :py:func:`iris.load_cubes`.
+
+            A constraint covering multiple ranges of the same coordinate may be
+            used to generate a single cube like so::
+
+                def latitude_bands(cell):
+                    return (0 < cell < 30) or (60 < cell < 90)
+
+                Constraint(cube_func=latitude_bands)
+
         Constraint filtering is performed at the cell level.
         For further details on how cell comparisons are performed see
         :class:`iris.coords.Cell`.

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -86,8 +86,8 @@ class Constraint:
             the same coordinate, use :py:func:`iris.load_cubes` or
             :py:func:`iris.cube.CubeList.extract_cubes`.
 
-            A constraint covering multiple ranges of the same coordinate may be
-            created like so::
+            A cube can be constrained to multiple ranges within the same coordinate
+            using something like the following constraint::
 
                 def latitude_bands(cell):
                     return (0 < cell < 30) or (60 < cell < 90)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Added documentation to Iris Constrained Loading docs to highlight that Constraints don't support ¦ (and explain why)
<!-- Tell us all about your new feature, improvement, or bug fix -->
Whilst addressing a recent support request it seemed that there should be an ability to logically "or" Constraints as well as to "and" them. The reasons for this weren't immediately obvious, so documenting it seems useful for the future. I've done so.

I'd note, I'm not 100% convinced that this is an improvement to the quality of the docs, as I can see the argument that in catering for an edge case of misunderstanding the docs may become less easily understood by those without this misunderstanding (particularly as loading is likely to be one of the first bits of documentation a new user reads). Happy to discuss the merits of this and/or axe this PR on that basis.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
