### PR TITLE
add release version to sphinx-panel title

### DIFF
--- a/docs/src/whatsnew/3.1.rst
+++ b/docs/src/whatsnew/3.1.rst
@@ -7,7 +7,7 @@ This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)
 
 
-.. dropdown:: :opticon:`report` Release Highlights
+.. dropdown:: :opticon:`report` v3.1.0 Release Highlights
    :container: + shadow
    :title: text-primary text-center font-weight-bold
    :body: bg-light


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR makes a minor change to the `whatsnew` for the `v3.1.0` release in the `v3.1.x` release feature branch, by adding the version to the `sphinx-panel` for the release highlights.

This is to align with the pattern adopted in #4320, in readiness for any `v3.1.x` patches.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
