### PR TITLE
fix trove classifier

### DIFF
--- a/docs/src/whatsnew/3.1.rst
+++ b/docs/src/whatsnew/3.1.rst
@@ -1,6 +1,6 @@
 .. include:: ../common_links.inc
 
-v3.1 (16 Sep 2021)
+v3.1 (17 Sep 2021)
 ******************
 
 This document explains the changes made to Iris for this release

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 author = SciTools Developers
 author_email = scitools-iris-dev@googlegroups.com
 classifiers =
-    Development Status :: 5 Production/Stable
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: MacOS


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR fixes the malformed [PyPI trove classifer](https://pypi.org/classifiers/), which is preventing the `iris` sdist and binary wheel being uploaded to PyPI due to stricter metadata checks.

The `iris` v3.1.0 release date has also been updated. We can re-tag and re-release afresh after this PR is merged.

I'll purge the existing tag on `16 Sept 2021`, which is safe to do, as we've not packaged the release yet (so no need to bump versions or perform a `post` release).


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
