### PR TITLE
Added mesh_from_coords (AVD-1877)

### DIFF
--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -2818,11 +2818,7 @@ def mesh_from_coords(coord_1, coord_2):
 
         >>> print(cube_w_mesh.mesh.name())
         Topology data of 2D unstructured mesh
-        >>> mesh_coord_names = [
-        ...     coord.name()
-        ...     for coord in cube_w_mesh.coords()
-        ...     if isinstance(coord, MeshCoord)
-        ... ]
+        >>> mesh_coord_names = cube_w_mesh.coords(mesh_coords=True)
         >>> print(f"MeshCoords: {mesh_coord_names}")
         MeshCoords: ['latitude', 'longitude']
 

--- a/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
@@ -89,6 +89,7 @@ class Test1Dim(tests.IrisTest):
             _ = self.create()
 
     def test_coord_invalid_axis(self):
+        # TODO: augment guess_axis to accept "X" or "Y".
         # Identical to original lon, but with a non-axis name.
         self.lon = self.lon.__class__(
             points=self.lon.points,
@@ -99,12 +100,22 @@ class Test1Dim(tests.IrisTest):
             units=self.lon.units,
             attributes=self.lon.attributes
         )
-        with self.assertRaisesRegex(ValueError, ""):
+        with self.assertRaisesRegex(ValueError, "Unable to guess coord axis.*"):
             _ = self.create()
 
     def test_coord_axis_mismatch(self):
-        # coord_2 not orthogonal
-        pass
+        # Identical to original lat, but with the same names as lon.
+        self.lat = self.lat.__class__(
+            points=self.lat.points,
+            bounds=self.lat.bounds,
+            standard_name=self.lon.standard_name,
+            long_name=self.lon.long_name,
+            var_name=self.lon.var_name,
+            units=self.lat.units,
+            attributes=self.lat.units
+        )
+        with self.assertRaisesRegex(ValueError, ""):
+            _ = self.create()
 
 
 class Test2Dim(Test1Dim):

--- a/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
@@ -1,0 +1,126 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for the :func:`iris.experimental.ugrid.mesh_from_coords`.
+
+"""
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+from iris.coords import AuxCoord, DimCoord
+from iris.experimental.ugrid import Connectivity, mesh_from_coords
+
+
+class Test1Dim(tests.IrisTest):
+    def setUp(self):
+        self.lon = DimCoord(
+            points=[0.5, 1.5, 2.5],
+            bounds=[[0, 1], [1, 2], [2, 3]],
+            standard_name="longitude",
+            long_name="test lon",
+            var_name="lon",
+            units="degrees",
+            attributes={"test": 1}
+            )
+        # Should be fine with either a DimCoord or an AuxCoord.
+        self.lat = AuxCoord(
+            points=[0.5, 2.5, 1.5],
+            bounds=[[0, 1], [2, 3], [1, 2]],
+            long_name="test lat",
+            var_name="lat",
+            units="degrees",
+            attributes={"test": 1}
+        )
+
+    def create(self):
+        return mesh_from_coords(self.lon, self.lat)
+
+    def test_dimensionality(self):
+        mesh = self.create()
+        self.assertEqual(1, mesh.topology_dimension)
+
+        self.assertEqual([0, 1, 1, 2, 2, 3], mesh.node_x)
+        self.assertEqual([0, 1, 2, 3, 1, 2], mesh.node_y)
+        self.assertEqual([0.5, 1.5, 2.5], mesh.edge_x)
+        self.assertEqual([0.5, 2.5, 1.5], mesh.edge_y)
+        self.assertIsNotNone(mesh.face_x)
+        self.assertIsNotNone(mesh.face_y)
+
+        for conn_name in Connectivity.UGRID_CF_ROLES:
+            conn = getattr(mesh, conn_name)
+            if conn_name == "edge_node_connectivity":
+                self.assertEqual([[0, 1], [2, 3], [4, 5]], conn.indices)
+            else:
+                self.assertIsNone(conn)
+
+    def test_node_metadata(self):
+        mesh = self.create()
+        pairs = [(self.lon, mesh.node_x), (self.lat, mesh.node_y)]
+        for expected_coord, actual_coord in pairs:
+            for attr in ("standard_name", "long_name", "units", "attributes"):
+                expected = getattr(expected_coord, attr)
+                actual = getattr(actual_coord, attr)
+                self.assertEqual(expected, actual)
+            self.assertIsNone(actual_coord.var_name)
+
+    def test_mesh_metadata(self):
+        # Inappropriate to guess these values from the input coords.
+        mesh = self.create()
+        for attr in ("standard_name", "long_name", "var_name", "units", "attributes"):
+            self.assertIsNone(getattr(mesh, attr))
+
+    def test_not_coord(self):
+        self.lon = "not a Coord"
+        with self.assertRaisesRegex(ValueError, "Expected a Coord.*"):
+            _ = self.create()
+
+    def test_coord_shape_mismatch(self):
+        lat_orig = self.lat.copy(self.lat.points, self.lat.bounds)
+        self.lat = lat_orig.copy(points=lat_orig.points)
+        with self.assertRaisesRegex(ValueError, ".*bounds shape must be"):
+            _ = self.create()
+
+        self.lat = lat_orig.copy(points=lat_orig.points[-1])
+        with self.assertRaisesRegex(ValueError, ".*points shape must be"):
+            _ = self.create()
+
+    def test_coord_invalid_axis(self):
+        # Identical to original lon, but with a non-axis name.
+        self.lon = self.lon.__class__(
+            points=self.lon.points,
+            bounds=self.lon.bounds,
+            standard_name="air_temperature",
+            long_name="foo",
+            var_name="bar",
+            units=self.lon.units,
+            attributes=self.lon.attributes
+        )
+        with self.assertRaisesRegex(ValueError, ""):
+            _ = self.create()
+
+    def test_coord_axis_mismatch(self):
+        # coord_2 not orthogonal
+        pass
+
+
+class Test2Dim(Test1Dim):
+    def setUp(self):
+        pass
+
+    def test_dimensionality(self):
+        # topology_dimension, coords, connectivities
+        pass
+
+
+class TestInvalidBounds(tests.IrisTest):
+    """Invalid bounds not supported."""
+    def test_no_bounds(self):
+        pass
+
+    def test_1_bound(self):
+        # shape = (n, 1)
+        pass

--- a/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_mesh_from_coords.py
@@ -11,8 +11,11 @@ Unit tests for the :func:`iris.experimental.ugrid.mesh_from_coords`.
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
+import numpy as np
+
 from iris.coords import AuxCoord, DimCoord
 from iris.experimental.ugrid import Connectivity, mesh_from_coords
+from iris.tests.stock import simple_2d_w_multidim_coords
 
 
 class Test1Dim(tests.IrisTest):
@@ -44,23 +47,42 @@ class Test1Dim(tests.IrisTest):
         mesh = self.create()
         self.assertEqual(1, mesh.topology_dimension)
 
-        self.assertEqual([0, 1, 1, 2, 2, 3], mesh.node_x)
-        self.assertEqual([0, 1, 2, 3, 1, 2], mesh.node_y)
-        self.assertEqual([0.5, 1.5, 2.5], mesh.edge_x)
-        self.assertEqual([0.5, 2.5, 1.5], mesh.edge_y)
-        self.assertIsNone(mesh.face_x)
-        self.assertIsNone(mesh.face_y)
+        self.assertArrayEqual(
+            [0, 1, 1, 2, 2, 3], mesh.node_coords.node_x.points
+        )
+        self.assertArrayEqual(
+            [0, 1, 2, 3, 1, 2], mesh.node_coords.node_y.points
+        )
+        self.assertArrayEqual([0.5, 1.5, 2.5], mesh.edge_coords.edge_x.points)
+        self.assertArrayEqual([0.5, 2.5, 1.5], mesh.edge_coords.edge_y.points)
+        self.assertIsNone(getattr(mesh, "face_coords", None))
 
         for conn_name in Connectivity.UGRID_CF_ROLES:
-            conn = getattr(mesh, conn_name)
+            conn = getattr(mesh, conn_name, None)
             if conn_name == "edge_node_connectivity":
-                self.assertEqual([[0, 1], [2, 3], [4, 5]], conn.indices)
+                self.assertArrayEqual([[0, 1], [2, 3], [4, 5]], conn.indices)
             else:
                 self.assertIsNone(conn)
 
     def test_node_metadata(self):
         mesh = self.create()
-        pairs = [(self.lon, mesh.node_x), (self.lat, mesh.node_y)]
+        pairs = [
+            (self.lon, mesh.node_coords.node_x),
+            (self.lat, mesh.node_coords.node_y),
+        ]
+        for expected_coord, actual_coord in pairs:
+            for attr in ("standard_name", "long_name", "units", "attributes"):
+                expected = getattr(expected_coord, attr)
+                actual = getattr(actual_coord, attr)
+                self.assertEqual(expected, actual)
+            self.assertIsNone(actual_coord.var_name)
+
+    def test_centre_metadata(self):
+        mesh = self.create()
+        pairs = [
+            (self.lon, mesh.edge_coords.edge_x),
+            (self.lat, mesh.edge_coords.edge_y),
+        ]
         for expected_coord, actual_coord in pairs:
             for attr in ("standard_name", "long_name", "units", "attributes"):
                 expected = getattr(expected_coord, attr)
@@ -75,10 +97,30 @@ class Test1Dim(tests.IrisTest):
             "standard_name",
             "long_name",
             "var_name",
-            "units",
-            "attributes",
         ):
             self.assertIsNone(getattr(mesh, attr))
+        self.assertTrue(mesh.units.is_unknown())
+        self.assertDictEqual({}, mesh.attributes)
+
+    def test_lazy(self):
+        self.lon = AuxCoord(
+            points=self.lon.lazy_points(),
+            bounds=self.lon.lazy_bounds(),
+            standard_name="longitude",
+        )
+        self.lat = AuxCoord(
+            points=self.lat.lazy_points(),
+            bounds=self.lat.lazy_bounds(),
+            standard_name="latitude",
+        )
+
+        mesh = self.create()
+        for coord in list(mesh.all_coords):
+            if coord is not None:
+                self.assertTrue(coord.has_lazy_points())
+        for conn in list(mesh.all_connectivities):
+            if conn is not None:
+                self.assertTrue(conn.has_lazy_indices())
 
     def test_not_coord(self):
         self.lon = "not a Coord"
@@ -87,44 +129,47 @@ class Test1Dim(tests.IrisTest):
 
     def test_coord_shape_mismatch(self):
         lat_orig = self.lat.copy(self.lat.points, self.lat.bounds)
-        self.lat = lat_orig.copy(points=lat_orig.points)
+        self.lat = lat_orig.copy(
+            points=lat_orig.points, bounds=np.tile(lat_orig.bounds, 2)
+        )
         with self.assertRaisesRegex(ValueError, ".*bounds shape must be"):
             _ = self.create()
 
-        self.lat = lat_orig.copy(points=lat_orig.points[-1])
+        self.lat = lat_orig.copy(
+            points=lat_orig.points[-1], bounds=lat_orig.bounds[-1]
+        )
         with self.assertRaisesRegex(ValueError, ".*points shape must be"):
             _ = self.create()
 
-    def test_coord_invalid_axis(self):
-        # TODO: augment guess_axis to accept "X" or "Y".
-        # Identical to original lon, but with a non-axis name.
-        self.lon = self.lon.__class__(
-            points=self.lon.points,
-            bounds=self.lon.bounds,
-            standard_name="air_temperature",
-            long_name="foo",
-            var_name="bar",
-            units=self.lon.units,
-            attributes=self.lon.attributes,
-        )
+    def test_coords_not_orthogonal(self):
+        def replace_standard_name(coord, standard_name):
+            return coord.__class__(
+                points=coord.points,
+                bounds=coord.bounds,
+                standard_name=standard_name,
+                long_name=coord.long_name,
+                var_name=coord.var_name,
+                units=coord.units,
+                attributes=coord.attributes,
+            )
+
+        # Identical to original lat, but with the same names as lon.
+        self.lat = replace_standard_name(self.lat, self.lon.standard_name)
+        with self.assertRaisesRegex(ValueError, ".*Both axes == X ."):
+            _ = self.create()
+
+        new_standard_name = "air_temperature"
+        self.lon = replace_standard_name(self.lon, new_standard_name)
+        self.lat = replace_standard_name(self.lat, new_standard_name)
         with self.assertRaisesRegex(
-            ValueError, "Unable to guess coord axis.*"
+            ValueError, f".*Both standard_names == {new_standard_name}"
         ):
             _ = self.create()
 
-    def test_coord_axis_mismatch(self):
-        # Identical to original lat, but with the same names as lon.
-        self.lat = self.lat.__class__(
-            points=self.lat.points,
-            bounds=self.lat.bounds,
-            standard_name=self.lon.standard_name,
-            long_name=self.lon.long_name,
-            var_name=self.lon.var_name,
-            units=self.lat.units,
-            attributes=self.lat.units,
-        )
+        self.lon = replace_standard_name(self.lon, None)
+        self.lat = replace_standard_name(self.lon, None)
         with self.assertRaisesRegex(
-            ValueError, "coord_2 must be orthogonal.*"
+            ValueError, ".*Both coords' metadata identical."
         ):
             _ = self.create()
 
@@ -155,21 +200,38 @@ class Test2Dim(Test1Dim):
         mesh = self.create()
         self.assertEqual(2, mesh.topology_dimension)
 
-        self.assertEqual([0, 0.5, 1, 1, 1.5, 2, 2, 2.5, 3], mesh.node_x)
-        self.assertEqual([0, 1, 0, 2, 3, 2, 1, 2, 1], mesh.node_y)
-        self.assertIsNone(mesh.edge_x)
-        self.assertIsNone(mesh.edge_y)
-        self.assertEqual([0.5, 1.5, 2.5], mesh.face_x)
-        self.assertEqual([0.5, 2.5, 1.5], mesh.face_y)
+        self.assertArrayEqual(
+            [0, 0.5, 1, 1, 1.5, 2, 2, 2.5, 3], mesh.node_coords.node_x.points
+        )
+        self.assertArrayEqual(
+            [0, 1, 0, 2, 3, 2, 1, 2, 1], mesh.node_coords.node_y.points
+        )
+        self.assertIsNone(mesh.edge_coords.edge_x)
+        self.assertIsNone(mesh.edge_coords.edge_y)
+        self.assertArrayEqual([0.5, 1.5, 2.5], mesh.face_coords.face_x.points)
+        self.assertArrayEqual([0.5, 2.5, 1.5], mesh.face_coords.face_y.points)
 
         for conn_name in Connectivity.UGRID_CF_ROLES:
-            conn = getattr(mesh, conn_name)
+            conn = getattr(mesh, conn_name, None)
             if conn_name == "face_node_connectivity":
-                self.assertEqual(
+                self.assertArrayEqual(
                     [[0, 1, 2], [3, 4, 5], [6, 7, 8]], conn.indices
                 )
             else:
                 self.assertIsNone(conn)
+
+    def test_centre_metadata(self):
+        mesh = self.create()
+        pairs = [
+            (self.lon, mesh.face_coords.face_x),
+            (self.lat, mesh.face_coords.face_y),
+        ]
+        for expected_coord, actual_coord in pairs:
+            for attr in ("standard_name", "long_name", "units", "attributes"):
+                expected = getattr(expected_coord, attr)
+                actual = getattr(actual_coord, attr)
+                self.assertEqual(expected, actual)
+            self.assertIsNone(actual_coord.var_name)
 
 
 class TestInvalidBounds(tests.IrisTest):
@@ -187,6 +249,18 @@ class TestInvalidBounds(tests.IrisTest):
         lon = AuxCoord(points=[0.5, 1.5, 2.5], bounds=[[0, 1], [1, 2], [2, 3]])
         lat = AuxCoord(points=[0, 1, 2], bounds=[[0.5], [1.5], [2.5]])
         with self.assertRaisesRegex(
-            ValueError, "coord_2 has invalid bounds: shape (n, 1)"
+            ValueError, r"coord_2 has invalid bounds: shape.*"
         ):
             _ = mesh_from_coords(lon, lat)
+
+
+class TestInvalidPoints(tests.IrisTest):
+    """Only 1D coords supported."""
+
+    def test_2d_coord(self):
+        cube = simple_2d_w_multidim_coords()[:3, :3]
+        coord_1, coord_2 = cube.coords()
+        with self.assertRaisesRegex(
+            ValueError, "Coordinates must have ndim == 1.*"
+        ):
+            _ = mesh_from_coords(coord_1, coord_2)

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -251,17 +251,25 @@ def guess_coord_axis(coord):
         "projection_x_coordinate",
     ):
         axis = "X"
+    elif coord.standard_name is None and coord.long_name == "X":
+        axis = "X"
     elif coord.standard_name in (
         "latitude",
         "grid_latitude",
         "projection_y_coordinate",
     ):
         axis = "Y"
+    elif coord.standard_name is None and coord.long_name == "Y":
+        axis = "Y"
     elif coord.units.is_convertible("hPa") or coord.attributes.get(
         "positive"
     ) in ("up", "down"):
         axis = "Z"
+    elif coord.standard_name is None and coord.long_name == "Z":
+        axis = "Z"
     elif coord.units.is_time_reference():
+        axis = "T"
+    elif coord.standard_name is None and coord.long_name == "T":
         axis = "T"
 
     return axis

--- a/requirements/ci/nox.lock/py37-linux-64.lock
+++ b/requirements/ci/nox.lock/py37-linux-64.lock
@@ -120,7 +120,7 @@ https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.6-mpi_mpich_h996c276_1
 https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2#77242bfb1e74a627fb06319b5a2d3b95
 https://conda.anaconda.org/conda-forge/noarch/idna-3.1-pyhd3deb0d_0.tar.bz2#9c9aea4b8391264477df484f798562d0
 https://conda.anaconda.org/conda-forge/noarch/imagesize-1.2.0-py_0.tar.bz2#5879bd2c4b399a5072468e5fe587bf1b
-https://conda.anaconda.org/conda-forge/noarch/iris-sample-data-2.3.0-pyh9f0ad1d_0.tar.bz2#e4a33192da1a6dc4967ba18c6c765945
+https://conda.anaconda.org/conda-forge/noarch/iris-sample-data-2.4.0-pyhd8ed1ab_0.tar.bz2#18ee9c07cf945a33f92caf1ee3d23ad9
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.2-h78a0170_0.tar.bz2#ac0c23e6f3bbb61569781f00b5666f97
 https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2#709e8671651c7ec3d1ad07800339ff1d
 https://conda.anaconda.org/conda-forge/noarch/mccabe-0.6.1-py_1.tar.bz2#a326cb400c1ccd91789f3e7d02124d61

--- a/requirements/ci/nox.lock/py38-linux-64.lock
+++ b/requirements/ci/nox.lock/py38-linux-64.lock
@@ -119,7 +119,7 @@ https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.6-mpi_mpich_h996c276_1
 https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2#77242bfb1e74a627fb06319b5a2d3b95
 https://conda.anaconda.org/conda-forge/noarch/idna-3.1-pyhd3deb0d_0.tar.bz2#9c9aea4b8391264477df484f798562d0
 https://conda.anaconda.org/conda-forge/noarch/imagesize-1.2.0-py_0.tar.bz2#5879bd2c4b399a5072468e5fe587bf1b
-https://conda.anaconda.org/conda-forge/noarch/iris-sample-data-2.3.0-pyh9f0ad1d_0.tar.bz2#e4a33192da1a6dc4967ba18c6c765945
+https://conda.anaconda.org/conda-forge/noarch/iris-sample-data-2.4.0-pyhd8ed1ab_0.tar.bz2#18ee9c07cf945a33f92caf1ee3d23ad9
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.2-h78a0170_0.tar.bz2#ac0c23e6f3bbb61569781f00b5666f97
 https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2#709e8671651c7ec3d1ad07800339ff1d
 https://conda.anaconda.org/conda-forge/noarch/mccabe-0.6.1-py_1.tar.bz2#a326cb400c1ccd91789f3e7d02124d61

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -23,7 +23,7 @@ dependencies:
 # Optional dependencies.
   - esmpy >=7.0
   - graphviz
-  - iris-sample-data
+  - iris-sample-data >=2.4.0
   - mo_pack
   - nc-time-axis
   - pandas

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -23,7 +23,7 @@ dependencies:
 # Optional dependencies.
   - esmpy >=7.0
   - graphviz
-  - iris-sample-data
+  - iris-sample-data >=2.4.0
   - mo_pack
   - nc-time-axis
   - pandas


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adds the ability to construct a `Mesh` from two `Coords` in `iris.experimental.ugrid`.

**I expect this to fail on doctests until `iris-sample-data` `v2.4.0` is available for use by Miniconda.** I was able to manually demonstrate this would work on my local machine by replacing the lockfile URL with the [front-end URL](https://anaconda.org/conda-forge/iris-sample-data/2.4.0/download/noarch/iris-sample-data-2.4.0-pyhd8ed1ab_0.tar.bz2) instead. Once `v2.4.0` is available the doctests should be re-spun (check using `conda search iris-esmf-regrid -c conda-forge`).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
