### PR TITLE
stable cartopy feature download

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ linux_task_template: &LINUX_TASK_TEMPLATE
       - source ${HOME}/miniconda/etc/profile.d/conda.sh >/dev/null 2>&1
       - conda activate cartopy-cache >/dev/null 2>&1
       - cd $(mktemp -d)
-      - wget --quiet https://raw.githubusercontent.com/SciTools/cartopy/master/tools/cartopy_feature_download.py
+      - wget --quiet https://raw.githubusercontent.com/SciTools/cartopy/v0.20.0/tools/cartopy_feature_download.py
       - python cartopy_feature_download.py physical --output ${HOME}/.local/share/cartopy --no-warn
       - conda deactivate >/dev/null 2>&1
   nox_cache:

--- a/docs/src/whatsnew/3.0.rst
+++ b/docs/src/whatsnew/3.0.rst
@@ -583,7 +583,7 @@ v3.0.4 (22 July 2021)
 .. _Quality Flags: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags
 .. _iris-grib: https://github.com/SciTools/iris-grib
 .. _Cartopy: https://github.com/SciTools/cartopy
-.. _Cartopy's coastlines: https://scitools.org.uk/cartopy/docs/latest/matplotlib/geoaxes.html?highlight=coastlines#cartopy.mpl.geoaxes.GeoAxes.coastlines
+.. _Cartopy's coastlines: https://scitools.org.uk/cartopy/docs/latest/reference/generated/cartopy.mpl.geoaxes.GeoAxes.html?highlight=coastlines#cartopy.mpl.geoaxes.GeoAxes.coastlines
 .. _Cartopy#1105: https://github.com/SciTools/cartopy/pull/1105
 .. _Cartopy#1117: https://github.com/SciTools/cartopy/pull/1117
 .. _Dask: https://github.com/dask/dask


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR pulls the `cartopy_feature_download.py` script from the latest stable `cartopy` tag i.e., 0.20.0, during CI.

Closes #4306


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
