### PR TITLE
Suppress warning in animation test

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,6 +124,9 @@ This document explains the changes made to Iris for this release
    Useful for development purposes only.  For more information see
    :ref:`contributing.documentation.building` the documentation. (:pull:`4333`)
 
+#. `@rcomer`_ modified the ``animation`` test to prevent it throwing a warning
+   that sometimes interferes with unrelated tests. (:pull:`4330`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/lib/iris/tests/experimental/test_animate.py
+++ b/lib/iris/tests/experimental/test_animate.py
@@ -59,8 +59,12 @@ class IntegrationTest(tests.GraphicsTest):
 
         ani = animate.animate(cube_iter, iplt.contourf)
 
-        # Disconnect the first draw callback to stop the animation
+        # Disconnect the first draw callback to stop the animation.
         ani._fig.canvas.mpl_disconnect(ani._first_draw_id)
+        # Update flag to indicate drawing happens.  Without this, a warning is
+        # thrown when the ani object is destroyed, and this warning sometimes
+        # interferes with unrelated tests (#4330).
+        ani._draw_was_started = True
 
         ani = [ani]
         # Extract frame data

--- a/lib/iris/tests/experimental/test_animate.py
+++ b/lib/iris/tests/experimental/test_animate.py
@@ -12,6 +12,8 @@ Test the animation of cubes within iris.
 # importing anything else
 import iris.tests as tests  # isort:skip
 
+import warnings
+
 import numpy as np
 
 import iris
@@ -21,6 +23,11 @@ from iris.coord_systems import GeogCS
 if tests.MPL_AVAILABLE:
     import iris.experimental.animate as animate
     import iris.plot as iplt
+
+# Suppress warning about animation deletion, as it tends to "leak" into other,
+# unrelated tests.
+msg = "Animation was deleted without rendering anything."
+warnings.filterwarnings("ignore", msg, UserWarning, "matplotlib.animation")
 
 
 @tests.skip_plot

--- a/lib/iris/tests/experimental/test_animate.py
+++ b/lib/iris/tests/experimental/test_animate.py
@@ -12,8 +12,6 @@ Test the animation of cubes within iris.
 # importing anything else
 import iris.tests as tests  # isort:skip
 
-import warnings
-
 import numpy as np
 
 import iris
@@ -23,11 +21,6 @@ from iris.coord_systems import GeogCS
 if tests.MPL_AVAILABLE:
     import iris.experimental.animate as animate
     import iris.plot as iplt
-
-# Suppress warning about animation deletion, as it tends to "leak" into other,
-# unrelated tests.
-msg = "Animation was deleted without rendering anything."
-warnings.filterwarnings("ignore", msg, UserWarning, "matplotlib.animation")
 
 
 @tests.skip_plot


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Occasionally we get test failures because `assertWarns` finds a warning about animation deletion when it is expecting something else, in tests that have nothing to do with animation.  Running this single test module prior to this change shows that the warning is thrown here.  I thought it might be worth suppressing it, but obviously I have no way to check whether it will cure the problem of interfering with other tests, as it only happens sporadically.

Worth a try?

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
