### PR TITLE
Support cartopy 0.20 and proj 8.1.0

### DIFF
--- a/benchmarks/conda_lock_plugin.py
+++ b/benchmarks/conda_lock_plugin.py
@@ -31,7 +31,10 @@ class CondaLock(Conda):
         super().__init__(conf, python, requirements)
 
     def _uninstall_project(self):
-        if self._get_installed_commit_hash():
+        installed_hash = self._get_installed_commit_hash()
+        if installed_hash:
+            log.info(f"Clearing conda environment for {self.name}")
+            self._cache._remove_cache_dir(installed_hash)
             # we can only run the uninstall command if an environment has already
             # been made before, otherwise there is no python to use to uninstall
             super()._uninstall_project()

--- a/docs/gallery_code/general/plot_projections_and_annotations.py
+++ b/docs/gallery_code/general/plot_projections_and_annotations.py
@@ -61,7 +61,7 @@ def make_plot(projection_name, projection_crs):
         overlay_data, 20, linewidths=2.0, colors="darkgreen", linestyles="-"
     )
 
-    # Draw a margin line, some way in from the border of the 'main' data...
+    # Draw a high resolution margin line, inset from the pcolormesh border.
     # First calculate rectangle corners, 7% in from each corner of the data.
     x_coord, y_coord = main_data.coord(axis="x"), main_data.coord(axis="y")
     x_start, x_end = np.min(x_coord.points), np.max(x_coord.points)
@@ -70,8 +70,15 @@ def make_plot(projection_name, projection_crs):
     margin_fractions = np.array([margin, 1.0 - margin])
     x_lower, x_upper = x_start + (x_end - x_start) * margin_fractions
     y_lower, y_upper = y_start + (y_end - y_start) * margin_fractions
-    box_x_points = x_lower + (x_upper - x_lower) * np.array([0, 1, 1, 0, 0])
-    box_y_points = y_lower + (y_upper - y_lower) * np.array([0, 0, 1, 1, 0])
+    steps = np.linspace(0, 1)
+    zeros, ones = np.zeros(steps.size), np.ones(steps.size)
+    x_delta, y_delta = (x_upper - x_lower), (y_upper - y_lower)
+    x_points = x_lower + x_delta * np.concatenate(
+        (steps, ones, steps[::-1], zeros)
+    )
+    y_points = y_lower + y_delta * np.concatenate(
+        (zeros, steps, ones, steps[::-1])
+    )
     # Get the Iris coordinate sytem of the X coordinate (Y should be the same).
     cs_data1 = x_coord.coord_system
     # Construct an equivalent Cartopy coordinate reference system ("crs").
@@ -80,8 +87,8 @@ def make_plot(projection_name, projection_crs):
     # NOTE: the 'transform' keyword specifies a non-display coordinate system
     # for the plot points (as used by the "iris.plot" functions).
     plt.plot(
-        box_x_points,
-        box_y_points,
+        x_points,
+        y_points,
         transform=crs_data1,
         linewidth=2.0,
         color="white",

--- a/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
+++ b/lib/iris/tests/integration/experimental/test_regrid_ProjectedUnstructured.py
@@ -68,16 +68,23 @@ class TestProjectedUnstructured(tests.IrisTest):
         res = self.src.regrid(uk_grid, ProjectedUnstructuredNearest(crs))
 
         self.assertArrayShapeStats(
-            res, (1, 6, 17, 11), 315.8873266, 11.0006664668, rtol=1e-8
+            res,
+            (1, 6, 17, 11),
+            315.8854720963427,
+            11.000539210625737,
+            rtol=1e-8,
         )
         self.assertArrayShapeStats(
-            res[:, 0], (1, 17, 11), 299.99993826, 4.1356150388e-5
+            res[:, 0],
+            (1, 17, 11),
+            299.9999985207442,
+            3.53574517015874e-05,
         )
         expected_subset = np.array(
             [
-                [318.936829, 318.936829, 318.936829],
-                [318.936829, 318.936829, 318.936829],
-                [318.935163, 318.935163, 318.935163],
+                [318.92881733, 318.92881733, 318.92881733],
+                [318.92881733, 318.92881733, 318.92881733],
+                [318.92881733, 318.92881733, 318.92881733],
             ]
         )
         self.assertArrayAlmostEqual(

--- a/lib/iris/tests/integration/plot/test_vector_plots.py
+++ b/lib/iris/tests/integration/plot/test_vector_plots.py
@@ -155,8 +155,8 @@ class MixinVectorPlotCases:
             for coord in cube.coords():
                 coord.coord_system = patch_coord_system
         re_msg = (
-            "Can only plot .* lat-lon projection, .* "
-            "This .* translates as Cartopy.*Mercator"
+            r"Can only plot .* lat-lon projection, .* "
+            r"This .* translates as Cartopy \+proj=merc .*"
         )
         with self.assertRaisesRegex(ValueError, re_msg):
             self.plot(

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -23,7 +23,8 @@
     "gallery_tests.test_plot_anomaly_log_colouring.TestAnomalyLogColouring.test_plot_anomaly_log_colouring.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ec4464e185a39f93931e9b1e91696d2949dde6e63e26a47a5ad391938d9a5a0c.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ecc164e78e979b19b3789b0885a564a56cc2c65e3ec69469db1bdb9a853c1e24.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ece164e68e979b19b3781b0885a564a56ccac65e3ec69469db1bdb9a853c1e24.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ec4464e384a39b13931a9b1c85696da968d5e6e63e26847bdbd399938d3c5a4c.png"
     ],
     "gallery_tests.test_plot_atlantic_profiles.TestAtlanticProfiles.test_plot_atlantic_profiles.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/9f8260536bd28e1320739437b5f437b0a51d66f4cc5d08fcd00fdb1c93fcb21c.png",
@@ -101,11 +102,13 @@
     ],
     "gallery_tests.test_plot_orca_projection.TestOrcaProjection.test_plot_orca_projection.2": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/f2c464ce9e399332e1b74ce1cc79338c6586e5b33b31b37a66c9664cc06e1a64.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/a58660ce9e739b31c93d1cc9c8df33863383e33b3f11c03f2664366cc8ee3cc1.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a58660ce9e739b31c93d1cc9c8df33863383e33b3f11c03f2664366cc8ee3cc1.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/a58660ce9e739b31c93d1c89c8df33863783e23b3f11c07f2664366cc8ee3cc1.png"
     ],
     "gallery_tests.test_plot_orca_projection.TestOrcaProjection.test_plot_orca_projection.3": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa817a83846ea46ce539c93391de32cc86cf87a33fa168721cdb3e896e374b04.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/be817a87845ea56cec79817a919e338436a5c1e73fa16c736c4a3e816a1e6b1c.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be817a87845ea56cec79817a919e338436a5c1e73fa16c736c4a3e816a1e6b1c.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/be817a8784dea56cec79817a919e338437a5c1e73fa16c726c4a3e816a1c6b1c.png"
     ],
     "gallery_tests.test_plot_polar_stereo.TestPolarStereo.test_plot_polar_stereo.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ba1e615ec7e097ad961f9cb190f038e091c2c1e73f07c11f6f386b3cc1793e01.png"
@@ -237,18 +240,21 @@
         "https://scitools.github.io/test-iris-imagehash/images/v4/bf80e2f1c17f1d0ac457c8d619a637213749699b6bb34e3666e4b04e944d9d89.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ea05392995bac6d691ce3f21666569d86a96c6360ee195cb91e8ce54953b313b.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ea05392995bac6d691ea3f21666569d86a97c6320ee195cb91e8ce559539391b.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1585e885ea7a1785fa7a157a177a017a1585e817a885ea85e86a1785fa7a17.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1585e885ea7a1785fa7a157a177a017a1585e817a885ea85e86a1785fa7a17.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7a81857e7a817a817a817a81817e7a81857e857e857e857e7a81.png"
     ],
     "iris.tests.test_mapping.TestLimitedAreaCube.test_outline.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e3e80857e7a817a817a817a81817f7a81857e857e857e857e7a81.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e7e21857e7a817a817a857a81857a7a81857a857e857a857e7a84.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa1585e885e87a1785fa7a177a177e807a1585e85fa0857a85e86817857f6a16.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1585e885e86a1785fa7a177a177e807a1585e817a885ea85e86817857f7a17.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa1585e885e86a1785fa7a177a177e807a1585e817a885ea85e86817857f7a17.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81857e857e3e81857e7a857a817e817a81857a7a81817e857e857a857e7a81.png"
     ],
     "iris.tests.test_mapping.TestLimitedAreaCube.test_pcolormesh.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/bf81e6b1c17e1d4884bfc8df39a43720374969db69b34e26c4e4b0ca904f9d89.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/ea57396995a8c6d691ea3f25664569d86b16c63686ed958991ea4a549531393b.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ea57396995a8c6d691ea3e25664569d96b16c63684e9958b91ea4a559431793b.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea57396995a8c6d691ea3e25664569d96b16c63684e9958b91ea4a559431793b.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ea813b49957ec4b7917e3f60266978d97a9562366e81954a914ec6cc957a0f98.png"
     ],
     "iris.tests.test_mapping.TestLimitedAreaCube.test_scatter.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ea053d2e916ac2d9c4d894346b24f3477acf68ad39329ed8c696e136c1ab9a71.png",
@@ -619,7 +625,8 @@
     ],
     "iris.tests.test_plot.TestPcolormesh.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/e95e696994b196b593b19a1ec3c591c5c6e596191e4e693269336c36391a6e3a.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/e9693878969696139296c38f9bcc3474692169cb6c7339393c6cc387c78796cc.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e9693878969696139296c38f9bcc3474692169cb6c7339393c6cc387c78796cc.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e97a387e968596319697c3c19284a62c93ad60c36933393a6c7e793a6c6b31cd.png"
     ],
     "iris.tests.test_plot.TestPcolormesh.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/e85e87a197a1695a97a16d5a97a17d5a97a17806785a7816685a7e86685ad687.png",
@@ -648,7 +655,8 @@
     ],
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_yx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/bc7a1c32d3c366cdc785c39986cdc78ec792e7a6960d584939793c3438703873.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/e129c7169ed638ec9ed6387196c761c665396724612dcf0d693896929ed698c9.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e129c7169ed638ec9ed6387196c761c665396724612dcf0d693896929ed698c9.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e96ac79796953c4c9685383996c538e69692637261696b49693ac796693ac71b.png"
     ],
     "iris.tests.test_plot.TestPcolormeshNoBounds.test_zx.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/ea1f781f95e085e895e0fd4295e095ea95a085e87a153e7e95e06a1778157a17.png",
@@ -843,7 +851,8 @@
     "iris.tests.test_plot.TestPlotOtherCoordSystems.test_plot_tmerc.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/e63399cd99cd64b29999335965369b262649c98c9b3966c6998d3319ccd69333.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/e665326d999ecc9b3319b3246666cce69b496cccccc9669923193336666699a6.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/e665326d999acc9b3319b3246666cce69b496cccccc966996719333666669986.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e665326d999acc9b3319b3246666cce69b496cccccc966996719333666669986.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/e665326d999ecc92b399b32466269326b369cccccccd64d96199631364f33333.png"
     ],
     "iris.tests.test_plot.TestQuickplotPlot.test_t.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/83ffb5d67fd4e5962211d9c6a443da77d5389c8ed346d923d011d968dc00da48.png",

--- a/lib/iris/tests/results/unit/analysis/cartography/project/TestAll/cube.cml
+++ b/lib/iris/tests/results/unit/analysis/cartography/project/TestAll/cube.cml
@@ -9,10 +9,10 @@
         <dimCoord id="1d45e087" points="[0.0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="float64"/>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="8f75dad5" points="[[inf, inf, -27.1960378264, ..., -26.4183314681,
-		 inf, inf],
-		[inf, -7.60877872467, -22.5253246282, ...,
-		 -20.3389131851, -6.6367758118, inf],
+        <auxCoord id="8f75dad5" points="[[nan, nan, -27.1960378264, ..., -26.4183314681,
+		 nan, nan],
+		[nan, -7.60877872467, -22.5253246282, ...,
+		 -20.3389131851, -6.6367758118, nan],
 		[11.9373960713, 1.68737720645, -19.7510869281,
 		 ..., -16.5990751865, 3.75281337984,
 		 12.1482298878],
@@ -20,10 +20,10 @@
 		[84.2615071705, 54.8444503701, 26.7572382165,
 		 ..., 30.1637424823, 58.6051855118,
 		 86.9541974993],
-		[inf, 62.6851802716, 39.629088106, ...,
-		 42.3249307728, 64.8680485778, inf],
-		[inf, inf, 46.2669891845, ..., 47.2804926757,
-		 inf, inf]]" shape="(10, 10)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+		[nan, 62.6851802716, 39.629088106, ...,
+		 42.3249307728, 64.8680485778, nan],
+		[nan, nan, 46.2669891845, ..., 47.2804926757,
+		 nan, nan]]" shape="(10, 10)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
           <rotatedGeogCS ellipsoid="GeogCS(6371229.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="177.5"/>
         </auxCoord>
       </coord>
@@ -37,20 +37,20 @@
         </dimCoord>
       </coord>
       <coord datadims="[2, 3]">
-        <auxCoord id="81715b9b" points="[[inf, inf, -168.158920348, ..., 169.237777806,
-		 inf, inf],
-		[inf, -164.537714569, -145.687716669, ...,
-		 147.432977295, 167.102016129, inf],
+        <auxCoord id="81715b9b" points="[[nan, nan, -168.158920348, ..., 169.237777806,
+		 nan, nan],
+		[nan, -164.537714569, -145.687716669, ...,
+		 147.432977295, 167.102016129, nan],
 		[-175.009062798, -147.024891707, -126.259029624,
 		 ..., 128.513092975, 150.23087042, 178.899397359],
 		..., 
 		[-58.34983089, -70.8813785605, -58.2031036304,
 		 ..., 60.1459645527, 72.0019781785,
 		 20.6956240803],
-		[inf, -35.1608514733, -42.5369291003, ...,
-		 43.052784475, 31.4703511243, inf],
-		[inf, inf, -15.3083916055, ..., 14.2709222711,
-		 inf, inf]]" shape="(10, 10)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+		[nan, -35.1608514733, -42.5369291003, ...,
+		 43.052784475, 31.4703511243, nan],
+		[nan, nan, -15.3083916055, ..., 14.2709222711,
+		 nan, nan]]" shape="(10, 10)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
           <rotatedGeogCS ellipsoid="GeogCS(6371229.0)" grid_north_pole_latitude="37.5" grid_north_pole_longitude="177.5"/>
         </auxCoord>
       </coord>

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -31,7 +31,7 @@ def low_res_4d():
 
 class TestAll(tests.IrisTest):
     def setUp(self):
-        cs = iris.coord_systems.GeogCS(654321)
+        cs = iris.coord_systems.GeogCS(6371229)
         self.cube = iris.cube.Cube(np.zeros(25).reshape(5, 5))
         self.cube.add_dim_coord(
             iris.coords.DimCoord(
@@ -52,7 +52,7 @@ class TestAll(tests.IrisTest):
             1,
         )
 
-        self.tcs = iris.coord_systems.GeogCS(600000)
+        self.tcs = iris.coord_systems.GeogCS(6000000)
 
     def test_is_iris_coord_system(self):
         res, _ = project(self.cube, self.tcs)

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools >=40.8.0
 
 # Core dependencies.
-  - cartopy >=0.18
+  - cartopy >=0.20
   - cf-units
   - cftime >=1.5
   - dask >=2

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools >=40.8.0
 
 # Core dependencies.
-  - cartopy >=0.18
+  - cartopy >=0.20
   - cf-units
   - cftime >=1.5
   - dask >=2

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ version = attr: iris.__version__
 [options]
 include_package_data = True
 install_requires =
-    cartopy>=0.18
+    cartopy>=0.20
     cf-units
     cftime>=1.5.0
     dask[array]>=2


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR includes the changes to support `cartopy` 0.20 and `proj` 8.0.1.

Also see the companion PR https://github.com/SciTools/test-iris-imagehash/pull/53 for the imagehash changes, which will require to be merged for this PR to pass.

Ref: https://github.com/SciTools/cartopy/pull/1252

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
