### PR TITLE
Clearer error message when using concatenate_cube on multi-variable cubes list

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -146,6 +146,7 @@ This document explains the changes made to Iris for this release
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
+.. _@tinyendian: https://github.com/tinyendian
 
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -74,6 +74,10 @@ This document explains the changes made to Iris for this release
    one cell's bounds align with the requested maximum and negative minimum, fixing
    :issue:`4221`. (:pull:`4278`)
 
+#. `@tinyendian`_ fixed the error message produced by :meth:`~iris.cube.CubeList.concatenate_cube`
+   when a cube list contains cubes with different names, which will no longer report
+   "Cube names differ: var1 != var1" if var1 appears multiple times in the list
+   (:issue:`4342`, :pull:`4345`)
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -555,7 +555,9 @@ class CubeList(list):
         else:
             msgs = []
             msgs.append(
-                "Cube names differ: {} != {}".format(unique_names[0], unique_names[1])
+                "Cube names differ: {} != {}".format(
+                    unique_names[0], unique_names[1]
+                )
             )
             raise iris.exceptions.ConcatenateError(msgs)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -555,7 +555,7 @@ class CubeList(list):
         else:
             msgs = []
             msgs.append(
-                "Cube names differ: {} != {}".format(names[0], names[1])
+                "Cube names differ: {} != {}".format(unique_names[0], unique_names[1])
             )
             raise iris.exceptions.ConcatenateError(msgs)
 

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -49,6 +49,21 @@ class Test_concatenate_cube(tests.IrisTest):
         with self.assertRaises(iris.exceptions.ConcatenateError):
             CubeList([self.cube1, cube2]).concatenate_cube()
 
+    def test_names_differ_fail(self):
+        self.cube2 = Cube([1, 2, 3], "air_temperature", units="K")
+        self.cube2.add_dim_coord(
+            DimCoord([3, 4, 5], "time", units=self.units), 0
+        )
+        self.cube3 = Cube([1, 2, 3], "air_pressure", units="Pa")
+        self.cube3.add_dim_coord(
+            DimCoord([3, 4, 5], "time", units=self.units), 0
+        )
+        exc_regexp = "Cube names differ: air_temperature != air_pressure"
+        with self.assertRaisesRegex(
+            iris.exceptions.ConcatenateError, exc_regexp
+        ):
+            CubeList([self.cube1, self.cube2, self.cube3]).concatenate_cube()
+
     def test_empty(self):
         exc_regexp = "can't concatenate an empty CubeList"
         with self.assertRaisesRegex(ValueError, exc_regexp):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This pull request addresses issue #4342: cube method `concatenate_cube()` can produce confusing error messages, reporting that `var1 != var1` when a user (erroneously) attempts to concatenate a multi-variable cube list consisting of, e.g., multiple time steps of var1 and var2  with `cubes = [var1, var1, var2, ...]`.

The reason for this behaviour is that the error message in the method quotes the first two elements of list `names`, which can be identical in the above scenario. This pull request replaces `names` with list `unique_names` when generating the error message - the latter list is used as a criterion for `concatenate_cube()` to reject concatenation, and it is guaranteed to produce non-identical variable names.  This should give the user better feedback on why concatenation failed.

It should not be necessary to handle the cases of length-zero or length-1 list, since `len(unique_names)` should always be `>=2`, given that the method will fail earlier on an empty cube list, and it will accept length 1 for concatenation.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
