### PR TITLE
missing whatnew entry

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -96,7 +96,8 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@bjlittle`_ introduced the ``cartopy >=0.20`` minimum pin.
+   (:pull:`4331`)
 
 
 📚 Documentation
@@ -126,8 +127,7 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ netCDF integration tests now skip ``TestConstrainedLoad`` if
    test data is missing (:pull:`4319`)
 
-
-#. `@wjbenfold`_ excluded "Good First Issue" labelled issues from being
+#. `@wjbenfold`_ excluded ``Good First Issue`` labelled issues from being
    marked stale. (:pull:`4317`)
 
 #. `@tkknight`_ added additional make targets for reducing the time of the
@@ -137,6 +137,7 @@ This document explains the changes made to Iris for this release
 
 #. `@rcomer`_ modified the ``animation`` test to prevent it throwing a warning
    that sometimes interferes with unrelated tests. (:pull:`4330`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Seems worthwhile adding a `whatnew` entry to highlight the `cartopy >=0.20` minimum pin introduced by #4331 for the community.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
