### PR TITLE
Remove Cartopy 0.19 workaround

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -138,6 +138,9 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ modified the ``animation`` test to prevent it throwing a warning
    that sometimes interferes with unrelated tests. (:pull:`4330`)
 
+#. `@rcomer`_ removed a now redundant workaround in :func:`~iris.plot.contourf`.
+   (:pull:`4349`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -1089,17 +1089,6 @@ def contourf(cube, *args, **kwargs):
             zorder = result.collections[0].zorder - 0.1
             axes = kwargs.get("axes", None)
 
-            # Workaround for cartopy#1780.  We do not want contour to shrink
-            # extent.
-            if axes is None:
-                _axes = plt.gca()
-            else:
-                _axes = axes
-
-            # Subsequent calls to dataLim.update_from_data_xy should not ignore
-            # current extent.
-            _axes.dataLim.ignore(False)
-
             contour(
                 cube,
                 levels=levels,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Just tidying up after myself 😊

These lines are a workaround for https://github.com/SciTools/cartopy/issues/1780, which caused a lot of test failures in Iris (see #4125).  The issue was fixed in https://github.com/SciTools/cartopy/pull/1784, which is included in the Cartopy 0.20 release.  Since we have now pinned to Cartopy>=0.20 (#4331), this workaround is now redundant.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
