### PR TITLE
propagate ugrid logger and address `np.int` deprecations

### DIFF
--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -37,7 +37,9 @@ import os.path
 import warnings
 
 
-def get_logger(name, datefmt=None, fmt=None, level=None, propagate=None):
+def get_logger(
+    name, datefmt=None, fmt=None, level=None, propagate=None, handler=True
+):
     """
     Create a :class:`logging.Logger` with a :class:`logging.StreamHandler`
     and custom :class:`logging.Formatter`.
@@ -68,16 +70,14 @@ def get_logger(name, datefmt=None, fmt=None, level=None, propagate=None):
         passed to the handlers of higher level loggers. Defaults to
         ``False``.
 
+    * handler:
+        Create and attach a :class:`logging.StreamHandler` to the
+        logger. Defaults to ``True``.
+
+    Returns:
+        A :class:`logging.Logger`.
+
     """
-    if datefmt is None:
-        # Default date format string.
-        datefmt = "%d-%m-%Y %H:%M:%S"
-
-    # Default format string.
-    _fmt = "%(asctime)s %(name)s %(levelname)s - %(message)s"
-    # Append additional format string, if appropriate.
-    fmt = _fmt if fmt is None else f"{_fmt} {fmt}"
-
     if level is None:
         # Default logging level.
         level = "INFO"
@@ -91,16 +91,25 @@ def get_logger(name, datefmt=None, fmt=None, level=None, propagate=None):
     logger.setLevel(level)
     logger.propagate = propagate
 
-    # Create a formatter.
-    formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
+    # Create and add the handler to the logger, if required.
+    if handler:
+        if datefmt is None:
+            # Default date format string.
+            datefmt = "%d-%m-%Y %H:%M:%S"
 
-    # Create a logging handler.
-    handler = logging.StreamHandler()
-    # handler.setLevel(level)
-    handler.setFormatter(formatter)
+        # Default format string.
+        _fmt = "%(asctime)s %(name)s %(levelname)s - %(message)s"
+        # Append additional format string, if appropriate.
+        fmt = _fmt if fmt is None else f"{_fmt} {fmt}"
 
-    # Add the handler to the logger.
-    logger.addHandler(handler)
+        # Create a formatter.
+        formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
+
+        # Create a logging handler.
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+
+        logger.addHandler(handler)
 
     return logger
 

--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -14,16 +14,10 @@ CF UGRID Conventions (v1.0), https://ugrid-conventions.github.io/ugrid-conventio
     definition at :const:`iris.experimental.ugrid.load.PARSE_UGRID_ON_LOAD`.
 
 """
-# Configure the logger.
 from ...config import get_logger
-
-logger = get_logger(__name__, fmt="[%(cls)s.%(funcName)s]")
-
-# Lazy imports to avoid circularity.
-from .load import load_mesh, load_meshes, PARSE_UGRID_ON_LOAD  # isort:skip
-from .mesh import Connectivity, Mesh, MeshCoord  # isort:skip
-from .save import save_mesh  # isort:skip
-
+from .load import PARSE_UGRID_ON_LOAD, load_mesh, load_meshes
+from .mesh import Connectivity, Mesh, MeshCoord
+from .save import save_mesh
 
 __all__ = [
     "Connectivity",
@@ -34,3 +28,6 @@ __all__ = [
     "load_meshes",
     "save_mesh",
 ]
+
+# Configure the logger as a root logger.
+logger = get_logger(__name__, fmt="[%(cls)s.%(funcName)s]", level="NOTSET")

--- a/lib/iris/experimental/ugrid/cf.py
+++ b/lib/iris/experimental/ugrid/cf.py
@@ -12,9 +12,12 @@ Eventual destination: :mod:`iris.fileformats.cf`.
 """
 import logging
 
-from . import logger
+from ...config import get_logger
 from ...fileformats import cf
 from .mesh import Connectivity
+
+# Configure the logger.
+logger = get_logger(__name__, propagate=True, handler=False)
 
 
 class CFUGridConnectivityVariable(cf.CFVariable):

--- a/lib/iris/experimental/ugrid/load.py
+++ b/lib/iris/experimental/ugrid/load.py
@@ -17,7 +17,7 @@ from itertools import groupby
 from pathlib import Path
 import threading
 
-from . import logger
+from ...config import get_logger
 from ...coords import AuxCoord
 from ...fileformats import netcdf
 from ...fileformats._nc_load_rules.helpers import get_attr_units, get_names
@@ -30,6 +30,9 @@ from .cf import (
     CFUGridReader,
 )
 from .mesh import Connectivity, Mesh
+
+# Configure the logger.
+logger = get_logger(__name__, propagate=True, handler=False)
 
 
 class ParseUGridOnLoad(threading.local):

--- a/lib/iris/experimental/ugrid/mesh.py
+++ b/lib/iris/experimental/ugrid/mesh.py
@@ -18,17 +18,20 @@ from typing import Iterable
 from dask import array as da
 import numpy as np
 
-from . import logger
 from ... import _lazy_data as _lazy
 from ...common import (
     CFVariableMixin,
     metadata_filter,
     metadata_manager_factory,
 )
+from ...config import get_logger
 from ...coords import AuxCoord, _DimensionalMetadata
 from ...exceptions import ConnectivityNotFoundError, CoordinateNotFoundError
 from ...util import guess_coord_axis
 from .metadata import ConnectivityMetadata, MeshCoordMetadata, MeshMetadata
+
+# Configure the logger.
+logger = get_logger(__name__, propagate=True, handler=False)
 
 #: Numpy "threshold" printoptions default argument.
 NP_PRINTOPTIONS_THRESHOLD = 10

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
@@ -16,8 +16,10 @@ import iris.tests as tests  # isort:skip
 
 import numpy as np
 
-from iris.experimental.ugrid import logger
-from iris.experimental.ugrid.cf import CFUGridAuxiliaryCoordinateVariable
+from iris.experimental.ugrid.cf import (
+    CFUGridAuxiliaryCoordinateVariable,
+    logger,
+)
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
 )
@@ -25,7 +27,7 @@ from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
 
 def named_variable(name):
     # Don't need to worry about dimensions or dtype for these tests.
-    return netcdf_ugrid_variable(name, "", np.int)
+    return netcdf_ugrid_variable(name, "", int)
 
 
 class TestIdentify(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
@@ -16,8 +16,7 @@ import iris.tests as tests  # isort:skip
 
 import numpy as np
 
-from iris.experimental.ugrid import logger
-from iris.experimental.ugrid.cf import CFUGridConnectivityVariable
+from iris.experimental.ugrid.cf import CFUGridConnectivityVariable, logger
 from iris.experimental.ugrid.mesh import Connectivity
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
@@ -26,7 +25,7 @@ from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
 
 def named_variable(name):
     # Don't need to worry about dimensions or dtype for these tests.
-    return netcdf_ugrid_variable(name, "", np.int)
+    return netcdf_ugrid_variable(name, "", int)
 
 
 class TestIdentify(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
@@ -16,8 +16,7 @@ import iris.tests as tests  # isort:skip
 
 import numpy as np
 
-from iris.experimental.ugrid import logger
-from iris.experimental.ugrid.cf import CFUGridMeshVariable
+from iris.experimental.ugrid.cf import CFUGridMeshVariable, logger
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
 )
@@ -25,7 +24,7 @@ from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
 
 def named_variable(name):
     # Don't need to worry about dimensions or dtype for these tests.
-    return netcdf_ugrid_variable(name, "", np.int)
+    return netcdf_ugrid_variable(name, "", int)
 
 
 class TestIdentify(tests.IrisTest):

--- a/lib/iris/tests/unit/experimental/ugrid/load/test_load_meshes.py
+++ b/lib/iris/tests/unit/experimental/ugrid/load/test_load_meshes.py
@@ -17,8 +17,11 @@ from subprocess import check_call
 import tempfile
 from uuid import uuid4
 
-from iris.experimental.ugrid import logger
-from iris.experimental.ugrid.load import PARSE_UGRID_ON_LOAD, load_meshes
+from iris.experimental.ugrid.load import (
+    PARSE_UGRID_ON_LOAD,
+    load_meshes,
+    logger,
+)
 
 
 def setUpModule():

--- a/lib/iris/tests/unit/experimental/ugrid/mesh/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/mesh/test_Mesh.py
@@ -13,7 +13,8 @@ import numpy as np
 
 from iris.coords import AuxCoord
 from iris.exceptions import ConnectivityNotFoundError, CoordinateNotFoundError
-from iris.experimental.ugrid import logger, mesh, metadata
+from iris.experimental.ugrid import mesh, metadata
+from iris.experimental.ugrid.mesh import logger
 
 
 class TestMeshCommon(tests.IrisTest):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR is a follow-up from #4347 and configures the `iris.experimental.ugrid.logger` to be a root logger.

The descendant modules `iris.experimental.ugrid.cf`, `iris.experimental.ugrid.load` and `iris.experimental.ugrid.mesh` now all configure their loggers to propagating their messages upwards to the root logger for appropriate handling.

Raising the `level` of the `iris.experimental.ugrid.logger` root logger above `NOTSET` will filter descendant logger messages appropriately; typically, this should not be necessary. Currently, the root logger is configured to report all descendant logger messages.

Alter the descendant logger `level`, as normal, to control logging e.g.,
```python
from iris.experimental.ugrid.load import logger

logger.setLevel("DEBUG")
```
will enable `iris.experimental.ugrid.load.logger` debug messages to be reported by the root logger (after propagation) using its stream handler.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
