### PR TITLE
pre-commit sort-all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,9 @@ repos:
     -   id: blacken-docs
         types: [file, rst]
         additional_dependencies: [black==21.6b0]
+
+-   repo: https://github.com/aio-libs/sort-all
+    rev: v1.1.0
+    hooks:
+    -   id: sort-all
+        types: [file, python]

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -148,6 +148,9 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ refactored :mod:`iris.experimental.ugrid` into sub-modules.
    (:pull:`4347`).
 
+#. `@bjlittle`_ enabled the `sort-all`_ `pre-commit`_ hook to automatically
+   sort ``__all__`` entries into alphabetical order. (:pull:`4353`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
@@ -155,9 +158,9 @@ This document explains the changes made to Iris for this release
 .. _@tinyendian: https://github.com/tinyendian
 
 
-
 .. comment
     Whatsnew resources in alphabetical order:
 
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
 .. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions/
+.. _sort-all: https://github.com/aio-libs/sort-all

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -107,19 +107,19 @@ __version__ = "3.2.dev0"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [
+    "AttributeConstraint",
+    "Constraint",
+    "FUTURE",
+    "Future",
+    "IrisDeprecation",
+    "NameConstraint",
     "load",
     "load_cube",
     "load_cubes",
     "load_raw",
-    "save",
-    "Constraint",
-    "AttributeConstraint",
-    "NameConstraint",
     "sample_data_path",
+    "save",
     "site_configuration",
-    "Future",
-    "FUTURE",
-    "IrisDeprecation",
 ]
 
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -56,29 +56,29 @@ import iris.coords
 from iris.exceptions import LazyAggregatorError
 
 __all__ = (
+    "Aggregator",
+    "AreaWeighted",
     "COUNT",
     "GMEAN",
     "HMEAN",
+    "Linear",
     "MAX",
     "MEAN",
     "MEDIAN",
     "MIN",
+    "Nearest",
     "PEAK",
     "PERCENTILE",
     "PROPORTION",
+    "PointInCell",
     "RMS",
     "STD_DEV",
     "SUM",
+    "UnstructuredNearest",
     "VARIANCE",
     "WPERCENTILE",
-    "Aggregator",
     "WeightedAggregator",
     "clear_phenomenon_identity",
-    "Linear",
-    "AreaWeighted",
-    "Nearest",
-    "UnstructuredNearest",
-    "PointInCell",
 )
 
 

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -26,7 +26,7 @@ import iris.coord_systems
 import iris.coords
 from iris.util import delta
 
-__all__ = ["cube_delta", "differentiate", "curl"]
+__all__ = ["cube_delta", "curl", "differentiate"]
 
 
 def _construct_delta_coord(coord):

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -28,6 +28,8 @@ from ._grid_angles import gridcell_angles, rotate_grid_vectors
 # List of contents to control Sphinx autodocs.
 # Unfortunately essential to get docs for the grid_angles functions.
 __all__ = [
+    "DistanceDifferential",
+    "PartialDifferential",
     "area_weights",
     "cosine_latitude_weights",
     "get_xy_contiguous_bounded_grids",
@@ -39,8 +41,6 @@ __all__ = [
     "rotate_winds",
     "unrotate_pole",
     "wrap_lons",
-    "DistanceDifferential",
-    "PartialDifferential",
 ]
 
 # This value is used as a fall-back if the cube does not define the earth

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -32,13 +32,13 @@ __all__ = [
     "CoordMetadata",
     "CubeMetadata",
     "DimCoordMetadata",
-    "hexdigest",
-    "metadata_filter",
-    "metadata_manager_factory",
     "SERVICES",
     "SERVICES_COMBINE",
     "SERVICES_DIFFERENCE",
     "SERVICES_EQUAL",
+    "hexdigest",
+    "metadata_filter",
+    "metadata_manager_factory",
 ]
 
 

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -45,16 +45,16 @@ except ImportError:
 
 
 __all__ = [
-    "load",
-    "save",
-    "load_cubes",
-    "PPField",
-    "as_fields",
-    "load_pairs_from_fields",
-    "save_pairs_from_cube",
-    "save_fields",
-    "STASH",
     "EARTH_RADIUS",
+    "PPField",
+    "STASH",
+    "as_fields",
+    "load",
+    "load_cubes",
+    "load_pairs_from_fields",
+    "save",
+    "save_fields",
+    "save_pairs_from_cube",
 ]
 
 

--- a/lib/iris/fileformats/um/__init__.py
+++ b/lib/iris/fileformats/um/__init__.py
@@ -17,9 +17,9 @@ from ._fast_load import FieldCollation, structured_um_loading
 from ._ff_replacement import load_cubes, load_cubes_32bit_ieee, um_to_pp
 
 __all__ = [
-    "um_to_pp",
+    "FieldCollation",
     "load_cubes",
     "load_cubes_32bit_ieee",
     "structured_um_loading",
-    "FieldCollation",
+    "um_to_pp",
 ]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR enables the [sort-all](https://github.com/aio-libs/sort-all) `pre-commit` hook, which automatically sorts `__all__` lists alphabetically.

Recently I've seen a few PRs where authors had to move entries manually on request by a reviewer, which is a wee bit haphazard and tiresome. There have also been debates regarding sort order etc.

This will no longer be an issue, thanks to `pre-commit` automation and the opinionated `sort-all` hook. It also means that there's one less thing for the PR author/reviewer to think about :partying_face: 

Note that, `sort-all` can be manually installed and executed from the command line, if devs so wish. However, it's only available on [PyPI](https://pypi.org/project/sort-all/) atm


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
