### PR TITLE
Assorted improvements to `Cube.intersection`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -26,8 +26,8 @@ This document explains the changes made to Iris for this release
 📢 Announcements
 ================
 
-#. Welcome to `@wjbenfold`_, `@tinyendian`_ and `@larsbarring`_ who made their
-   first contributions to Iris.  The first of many we hope!
+#. Welcome to `@wjbenfold`_, `@tinyendian`_, `@larsbarring`_, and `@bsherratt`_
+   who made their first contributions to Iris.  The first of many we hope!
 
 
 ✨ Features

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -81,6 +81,9 @@ This document explains the changes made to Iris for this release
    :attr:`~iris.experimental.ugrid.mesh.Connectivity.indices` under the
    `UGRID`_ model. (:pull:`4375`)
 
+#. `@bsherratt`_ added a `threshold` parameter to
+   :meth:`~iris.cube.Cube.intersection` (:pull:`4363`)
+
 
 🐛 Bugs Fixed
 =============
@@ -89,6 +92,9 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ fixed :meth:`~iris.cube.Cube.intersection` for special cases where
    one cell's bounds align with the requested maximum and negative minimum, fixing
    :issue:`4221`. (:pull:`4278`)
+
+#. `@bsherratt`_ fixed further edge cases in
+   :meth:`~iris.cube.Cube.intersection`, including :issue:`3698` (:pull:`4363`)
 
 #. `@tinyendian`_ fixed the error message produced by :meth:`~iris.cube.CubeList.concatenate_cube`
    when a cube list contains cubes with different names, which will no longer report
@@ -187,6 +193,7 @@ This document explains the changes made to Iris for this release
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
+.. _@bsherratt: https://github.com/bsherratt
 .. _@larsbarring: https://github.com/larsbarring
 .. _@tinyendian: https://github.com/tinyendian
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1935,6 +1935,34 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
         self.assertEqual(result.data[0, 0, 0], 1)
         self.assertEqual(result.data[0, 0, -1], 1)
 
+    def test_threshold_half(self):
+        cube = create_cube(0, 10, bounds=True)
+        result = cube.intersection(longitude=(1, 6.999), threshold=0.5)
+        self.assertArrayEqual(result.coord("longitude").bounds[0], [0.5, 1.5])
+        self.assertArrayEqual(result.coord("longitude").bounds[-1], [5.5, 6.5])
+        self.assertEqual(result.data[0, 0, 0], 1)
+        self.assertEqual(result.data[0, 0, -1], 6)
+
+    def test_threshold_full(self):
+        cube = create_cube(0, 10, bounds=True)
+        result = cube.intersection(longitude=(0.5, 7.499), threshold=1)
+        self.assertArrayEqual(result.coord("longitude").bounds[0], [0.5, 1.5])
+        self.assertArrayEqual(result.coord("longitude").bounds[-1], [5.5, 6.5])
+        self.assertEqual(result.data[0, 0, 0], 1)
+        self.assertEqual(result.data[0, 0, -1], 6)
+
+    def test_threshold_wrapped(self):
+        # Test that a cell is wrapped to `maximum` if required to exceed
+        # the threshold
+        cube = create_cube(-180, 180, bounds=True)
+        result = cube.intersection(longitude=(0.4, 360.4), threshold=0.2)
+        self.assertArrayEqual(result.coord("longitude").bounds[0], [0.5, 1.5])
+        self.assertArrayEqual(
+            result.coord("longitude").bounds[-1], [359.5, 360.5]
+        )
+        self.assertEqual(result.data[0, 0, 0], 181)
+        self.assertEqual(result.data[0, 0, -1], 180)
+
 
 def unrolled_cube():
     data = np.arange(5, dtype="f4")

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1910,6 +1910,31 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
             result_lons.bounds[-1], np.array([60.0, 60.1], dtype=dtype)
         )
 
+    def test_ignore_bounds_wrapped(self):
+        # Test `ignore_bounds` fully ignores bounds when wrapping
+        cube = create_cube(0, 360, bounds=True)
+        result = cube.intersection(
+            longitude=(10.25, 370.25), ignore_bounds=True
+        )
+        # Expect points 11..370 not bounds [9.5, 10.5] .. [368.5, 369.5]
+        self.assertArrayEqual(
+            result.coord("longitude").bounds[0], [10.5, 11.5]
+        )
+        self.assertArrayEqual(
+            result.coord("longitude").bounds[-1], [369.5, 370.5]
+        )
+        self.assertEqual(result.data[0, 0, 0], 11)
+        self.assertEqual(result.data[0, 0, -1], 10)
+
+    def test_within_cell(self):
+        # Test cell is included when it entirely contains the requested range
+        cube = create_cube(0, 10, bounds=True)
+        result = cube.intersection(longitude=(0.7, 0.8))
+        self.assertArrayEqual(result.coord("longitude").bounds[0], [0.5, 1.5])
+        self.assertArrayEqual(result.coord("longitude").bounds[-1], [0.5, 1.5])
+        self.assertEqual(result.data[0, 0, 0], 1)
+        self.assertEqual(result.data[0, 0, -1], 1)
+
 
 def unrolled_cube():
     data = np.arange(5, dtype="f4")

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1963,6 +1963,18 @@ class Test_intersection__ModulusBounds(tests.IrisTest):
         self.assertEqual(result.data[0, 0, 0], 181)
         self.assertEqual(result.data[0, 0, -1], 180)
 
+    def test_threshold_wrapped_gap(self):
+        # Test that a cell is wrapped to `maximum` if required to exceed
+        # the threshold (even with a gap in the range)
+        cube = create_cube(-180, 180, bounds=True)
+        result = cube.intersection(longitude=(0.4, 360.35), threshold=0.2)
+        self.assertArrayEqual(result.coord("longitude").bounds[0], [0.5, 1.5])
+        self.assertArrayEqual(
+            result.coord("longitude").bounds[-1], [359.5, 360.5]
+        )
+        self.assertEqual(result.data[0, 0, 0], 181)
+        self.assertEqual(result.data[0, 0, -1], 180)
+
 
 def unrolled_cube():
     data = np.arange(5, dtype="f4")


### PR DESCRIPTION
## 🚀 Pull Request

### Description

The first concern was that the documentation is not sufficiently specific. I think two key questions users will want answered when they read it are:
- For coordinates with bounds, how much of a cell must overlap with the range in order to be included?
- If requesting a full 0-360 degrees splits a cell, which side of the range does the cell go to?

From the code, it looks like the answers are, respectively:
- Essentially any overlap, unless a very small range is requested, in which case it might miss a cell - only bounds/points are checked, not the intersection as intervals.
- Lower, unless the requested range hits a cell bound exactly (only recently addressed, in #4059). This is always based on bounds, regardless of `ignore_bounds`, potentially taking a point out of the requested range (as in #3698).

Instead of simply documenting those quirks, I've tried to fix them. I also introduced a `threshold` argument, so that the answer to "how much overlap" is "configurable" instead of "0".

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
- No whatsnew yet - mainly as I wasn't sure what category to put it under.