### PR TITLE
Only try to work out the differences between points for multiple

### DIFF
--- a/lib/iris/tests/unit/util/test__coord_regular.py
+++ b/lib/iris/tests/unit/util/test__coord_regular.py
@@ -94,6 +94,18 @@ class Test_points_step(tests.IrisTest):
         self.assertEqual(exp_avdiff, result_avdiff)
         self.assertFalse(result)
 
+    def test_single_point(self):
+        lone_point = np.array([4])
+        result_avdiff, result = points_step(lone_point)
+        self.assertTrue(np.isnan(result_avdiff))
+        self.assertTrue(result)
+
+    def test_no_points(self):
+        no_points = np.array([])
+        result_avdiff, result = points_step(no_points)
+        self.assertTrue(np.isnan(result_avdiff))
+        self.assertTrue(result)
+
 
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1399,7 +1399,8 @@ def regular_step(coord):
 def points_step(points):
     """Determine whether a NumPy array has a regular step."""
     # Calculations only make sense with multiple points
-    if len(points) >= 2:
+    points = np.asanyarray(points)
+    if points.size >= 2:
         diffs = np.diff(points)
         avdiff = np.mean(diffs)
         # TODO: This value for `rtol` is set for test_analysis to pass...

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1398,10 +1398,15 @@ def regular_step(coord):
 
 def points_step(points):
     """Determine whether a NumPy array has a regular step."""
-    diffs = np.diff(points)
-    avdiff = np.mean(diffs)
-    # TODO: This value for `rtol` is set for test_analysis to pass...
-    regular = np.allclose(diffs, avdiff, rtol=0.001)
+    # Calculations only make sense with multiple points
+    if len(points) >= 2:
+        diffs = np.diff(points)
+        avdiff = np.mean(diffs)
+        # TODO: This value for `rtol` is set for test_analysis to pass...
+        regular = np.allclose(diffs, avdiff, rtol=0.001)
+    else:
+        avdiff = np.nan
+        regular = True
     return avdiff, regular
 
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1397,7 +1397,18 @@ def regular_step(coord):
 
 
 def points_step(points):
-    """Determine whether a NumPy array has a regular step."""
+    """Determine whether `points` has a regular step.
+
+    Parameters
+    ----------
+    points : numeric, array-like
+        The sequence of values to check for a regular difference.
+
+    Returns
+    -------
+    numeric, bool
+        A tuple containing the average difference between values, and whether the difference is regular.
+    """
     # Calculations only make sense with multiple points
     points = np.asanyarray(points)
     if points.size >= 2:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Causes `iris.util.points_step` to check whether there are multiple points to check before trying (thus averting a warning is caused by only one point being provided).

<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #4250.

### Questions for reviewer

- Is it better to apply the fix here, or to apply it in `coords.from_regular` and thus leave this so that it warns when called with a single point (albeit cryptically) so that people calling it are aware that they may not be doing what they meant? I personally think that the np.nan return value of avdiff (which matches the current behaviour) is sufficient.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
