### PR TITLE
drop pyugrid in site.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,6 @@ all =
     mo_pack
     nc-time-axis>=1.3
     pandas
-    pyugrid
     stratify
     %(docs)s
     %(test)s


### PR DESCRIPTION
## 🚀 Pull Request

### Description
PR #4371 prompted me to go and check our dependencies (thanks @rcomer)

As a result, we can now drop `pyugrid` as an optional dependency; we now have our own UGRID support within `iris` :stuck_out_tongue_winking_eye: 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
