### PR TITLE
Use partial to make cube pickleable

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -140,6 +140,10 @@ This document explains the changes made to Iris for this release
    coordinate bounds using minimum and maximum for unordered coordinates,
    fixing :issue:`1528`. (:pull:`4315`)
 
+#. `@wjbenfold`_ changed how a delayed unit conversion is performed on a cube
+   so that a cube with lazy data awaiting a unit conversion can be pickled.
+   (:issue:`4354 `, :pull:`4377`)
+
 
 💣 Incompatible Changes
 =======================
@@ -150,7 +154,9 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. N/A
+#. `@wjbenfold`_ resolved an issue that previously caused regridding with lazy
+   data to take significantly longer than with real data. Relevant benchmark
+   shows a time decrease from >10s to 625ms. (:issue:`4280`, :pull:`4400`)
 
 
 🔥 Deprecations

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -152,7 +152,7 @@ This document explains the changes made to Iris for this release
 
 #. `@wjbenfold`_ resolved an issue that previously caused regridding with lazy
    data to take significantly longer than with real data. Benchmark
-   :class:`HorizontalChunkedRegridding.time_regrid_area_w` shows a time decrease
+   :class:`benchmarks.HorizontalChunkedRegridding` shows a time decrease
    from >10s to 625ms. (:issue:`4280`, :pull:`4400`)
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,10 +124,6 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ fixed :meth:`~iris.cube.Cube.subset` to alway return ``None`` if
    no value match is found.  (:pull:`4417`)
 
-#. `@wjbenfold`_ resolved an issue that previously caused regridding with lazy
-   data to take significantly longer than with real data. Relevant benchmark
-   shows a time decrease from >10s to 625ms. (:issue:`4280`, :pull:`4400`)
-
 #. `@wjbenfold`_ changed :meth:`iris.util.points_step` to stop it from warning
    when applied to a single point (:issue:`4250`, :pull:`4367`)
 
@@ -155,8 +151,9 @@ This document explains the changes made to Iris for this release
 ===========================
 
 #. `@wjbenfold`_ resolved an issue that previously caused regridding with lazy
-   data to take significantly longer than with real data. Relevant benchmark
-   shows a time decrease from >10s to 625ms. (:issue:`4280`, :pull:`4400`)
+   data to take significantly longer than with real data. Benchmark
+   :class:`HorizontalChunkedRegridding.time_regrid_area_w` shows a time decrease
+   from >10s to 625ms. (:issue:`4280`, :pull:`4400`)
 
 
 🔥 Deprecations

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1052,8 +1052,10 @@ class Cube(CFVariableMixin):
             new_unit = unit
 
             # Define a delayed conversion operation (i.e. a callback).
-            def pointwise_convert(values):
-                return old_unit.convert(values, new_unit)
+            # def pointwise_convert(values):
+            #     return old_unit.convert(values, new_unit)
+
+            pointwise_convert = partial(old_unit.convert, other=new_unit)
 
             new_data = _lazy.lazy_elementwise(
                 self.lazy_data(), pointwise_convert

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1051,10 +1051,6 @@ class Cube(CFVariableMixin):
             old_unit = self.units
             new_unit = unit
 
-            # Define a delayed conversion operation (i.e. a callback).
-            # def pointwise_convert(values):
-            #     return old_unit.convert(values, new_unit)
-
             pointwise_convert = partial(old_unit.convert, other=new_unit)
 
             new_data = _lazy.lazy_elementwise(

--- a/lib/iris/tests/test_pickling.py
+++ b/lib/iris/tests/test_pickling.py
@@ -16,9 +16,10 @@ import io
 import pickle
 
 import cf_units
+import numpy as np
 
 import iris
-from iris._lazy_data import as_concrete_data
+from iris._lazy_data import as_concrete_data, as_lazy_data
 
 
 class TestPickle(tests.IrisTest):
@@ -73,6 +74,14 @@ class TestPickle(tests.IrisTest):
         cube = iris.load_cube(filename)
         # Pickle and unpickle. Do not perform any CML tests
         # to avoid side effects.
+        _, recon_cube = next(self.pickle_then_unpickle(cube))
+        self.assertEqual(recon_cube, cube)
+
+    def test_cube_with_deferred_unit_conversion(self):
+        real_data = np.arange(12.0).reshape((3, 4))
+        lazy_data = as_lazy_data(real_data)
+        cube = iris.cube.Cube(lazy_data, units="m")
+        cube.convert_units("ft")
         _, recon_cube = next(self.pickle_then_unpickle(cube))
         self.assertEqual(recon_cube, cube)
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -10,6 +10,7 @@
 import iris.tests as tests  # isort:skip
 
 from itertools import permutations
+import pickle
 from unittest import mock
 
 from cf_units import Unit
@@ -3161,6 +3162,34 @@ class Test__eq__meta(tests.IrisTest):
         cube2.add_cell_method(cmth1)
         cube2.add_cell_method(cmth2)
         self.assertTrue(cube1 == cube2)
+
+
+class Test_pickle(tests.IrisTest):
+    """Unit tests for pickling of Cube objects"""
+
+    def test_pickle_real(self):
+        data = np.arange(12.0).reshape((3, 4))
+        cube = iris.cube.Cube(data)
+        pickle_data = pickle.dumps(cube)
+        restored_cube = pickle.loads(pickle_data)
+        self.assertEqual(cube, restored_cube)
+
+    def test_pickle_lazy(self):
+        real_data = np.arange(12.0).reshape((3, 4))
+        lazy_data = as_lazy_data(real_data)
+        cube = iris.cube.Cube(lazy_data)
+        pickle_data = pickle.dumps(cube)
+        restored_cube = pickle.loads(pickle_data)
+        self.assertEqual(cube, restored_cube)
+
+    def test_pickle_deferred_unit_conversion(self):
+        real_data = np.arange(12.0).reshape((3, 4))
+        lazy_data = as_lazy_data(real_data)
+        cube = iris.cube.Cube(lazy_data, units="m")
+        cube.convert_units("ft")
+        pickle_data = pickle.dumps(cube)
+        restored_cube = pickle.loads(pickle_data)
+        self.assertEqual(cube, restored_cube)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -10,7 +10,6 @@
 import iris.tests as tests  # isort:skip
 
 from itertools import permutations
-import pickle
 from unittest import mock
 
 from cf_units import Unit
@@ -3162,34 +3161,6 @@ class Test__eq__meta(tests.IrisTest):
         cube2.add_cell_method(cmth1)
         cube2.add_cell_method(cmth2)
         self.assertTrue(cube1 == cube2)
-
-
-class Test_pickle(tests.IrisTest):
-    """Unit tests for pickling of Cube objects"""
-
-    def test_pickle_real(self):
-        data = np.arange(12.0).reshape((3, 4))
-        cube = iris.cube.Cube(data)
-        pickle_data = pickle.dumps(cube)
-        restored_cube = pickle.loads(pickle_data)
-        self.assertEqual(cube, restored_cube)
-
-    def test_pickle_lazy(self):
-        real_data = np.arange(12.0).reshape((3, 4))
-        lazy_data = as_lazy_data(real_data)
-        cube = iris.cube.Cube(lazy_data)
-        pickle_data = pickle.dumps(cube)
-        restored_cube = pickle.loads(pickle_data)
-        self.assertEqual(cube, restored_cube)
-
-    def test_pickle_deferred_unit_conversion(self):
-        real_data = np.arange(12.0).reshape((3, 4))
-        lazy_data = as_lazy_data(real_data)
-        cube = iris.cube.Cube(lazy_data, units="m")
-        cube.convert_units("ft")
-        pickle_data = pickle.dumps(cube)
-        restored_cube = pickle.loads(pickle_data)
-        self.assertEqual(cube, restored_cube)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Where previously a function was defined within cube.convert_units if the cube had lazy data, now a partial object is created instead.

<!-- Tell us all about your new feature, improvement, or bug fix -->
The definition of a function at runtime was preventing pickling of a cube that had lazy data and was awaiting a convert_units operation. This is no longer the case. (fixes #4354)

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
