### PR TITLE
adopt flake8 maccabe complexity metric

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ all =
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 
 max-line-length = 80
+max-complexity = 50
 select = C,E,F,W,B,B950
 ignore =
     # E203: whitespace before ':'


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR introduces the `flake8` [mccabe](https://github.com/PyCQA/mccabe) algorithm to provide a metric on `iris` code complexity.

This empirical metric can then form part of the discussion between a PR author and reviewer/s with regards to the complexity of code being proposed.

According to [McCabe](https://github.com/PyCQA/mccabe#plugin-for-flake8), code with a score greater than `10` is deemed too complex. Currently `iris` has a `mccabe` score of `50`.

Adopting the `maccabe` metric will allow us to target and reduce complexity within `iris`, but also be aware of any potential rise in complexity.

As per `flake8`, the complexity warnings/errors issued by `mccabe` can be explicitly ignored, if so deemed suitable and appropriate. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
