### PR TITLE
min pin for numpy (nep29)

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -126,6 +126,9 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ introduced the ``cf-units >=3`` and ``nc-time-axis >=1.3``
    minimum pins. (:pull:`4356`)
 
+#. `@bjlittle`_ introduced the ``numpy >=1.19`` minimum pin, in
+   accordance with `NEP-29`_ deprecation policy. (:pull:`4386`)
+
 
 📚 Documentation
 ================
@@ -191,5 +194,6 @@ This document explains the changes made to Iris for this release
     Whatsnew resources in alphabetical order:
 
 .. _GitHub: https://github.com/SciTools/iris/issues/new/choose
+.. _NEP-29: https://numpy.org/neps/nep-0029-deprecation_policy.html
 .. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions/
 .. _sort-all: https://github.com/aio-libs/sort-all

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -16,7 +16,7 @@ dependencies:
   - dask >=2
   - matplotlib
   - netcdf4
-  - numpy >=1.14
+  - numpy >=1.18
   - python-xxhash
   - scipy
 

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -16,7 +16,7 @@ dependencies:
   - dask >=2
   - matplotlib
   - netcdf4
-  - numpy >=1.18
+  - numpy >=1.19
   - python-xxhash
   - scipy
 

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -16,7 +16,7 @@ dependencies:
   - dask >=2
   - matplotlib
   - netcdf4
-  - numpy >=1.14
+  - numpy >=1.18
   - python-xxhash
   - scipy
 

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -16,7 +16,7 @@ dependencies:
   - dask >=2
   - matplotlib
   - netcdf4
-  - numpy >=1.18
+  - numpy >=1.19
   - python-xxhash
   - scipy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     dask[array]>=2
     matplotlib
     netcdf4
-    numpy>=1.14
+    numpy>=1.18
     scipy
     xxhash
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     dask[array]>=2
     matplotlib
     netcdf4
-    numpy>=1.18
+    numpy>=1.19
     scipy
     xxhash
 packages = find:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR introduces a minimum pin for `numpy>=1.18` in order to honour [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html).

`numpy` is approximately 24 months old, and the latest version is 1.21, so we're supporting greater than the latest 3 minor versions.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
