### PR TITLE
Make concat mismatch warning for scalar coords more accurate

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -456,8 +456,8 @@ class _CubeSignature:
             always, testing metadata)
 
         Returns:
-            Tuple of the names of attributes that differ between `self` and
-            `other`.
+            Tuple of a descriptive error message and the names of attributes
+            that differ between `self` and `other`.
 
         """
         # Set up {name: attribute} dictionaries.

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -437,7 +437,7 @@ class _CubeSignature:
             av_and_dims = _CoordAndDims(av, tuple(dims))
             self.ancillary_variables_and_dims.append(av_and_dims)
 
-    def _coordinate_differences(self, other, attr):
+    def _coordinate_differences(self, other, attr, reason="metadata"):
         """
         Determine the names of the coordinates that differ between `self` and
         `other` for a coordinate attribute on a _CubeSignature.
@@ -450,6 +450,10 @@ class _CubeSignature:
         * attr (string):
             The _CubeSignature attribute within which differences exist
             between `self` and `other`.
+
+        * reason (string):
+            The reason to give for mismatch (function is normally, but not
+            always, testing metadata)
 
         Returns:
             Tuple of the names of attributes that differ between `self` and
@@ -476,6 +480,7 @@ class _CubeSignature:
                 if self_value != other_value:
                     diff_names.append(self_key)
             result = (
+                " " + reason,
                 ", ".join(diff_names),
                 ", ".join(diff_names),
             )
@@ -521,39 +526,31 @@ class _CubeSignature:
         if self.dim_metadata != other.dim_metadata:
             differences = self._coordinate_differences(other, "dim_metadata")
             msgs.append(
-                msg_template.format(
-                    "Dimension coordinates", " metadata", *differences
-                )
+                msg_template.format("Dimension coordinates", *differences)
             )
         # Check aux coordinates.
         if self.aux_metadata != other.aux_metadata:
             differences = self._coordinate_differences(other, "aux_metadata")
             msgs.append(
-                msg_template.format(
-                    "Auxiliary coordinates", " metadata", *differences
-                )
+                msg_template.format("Auxiliary coordinates", *differences)
             )
         # Check cell measures.
         if self.cm_metadata != other.cm_metadata:
             differences = self._coordinate_differences(other, "cm_metadata")
-            msgs.append(
-                msg_template.format("Cell measures", " metadata", *differences)
-            )
+            msgs.append(msg_template.format("Cell measures", *differences))
         # Check ancillary variables.
         if self.av_metadata != other.av_metadata:
             differences = self._coordinate_differences(other, "av_metadata")
             msgs.append(
-                msg_template.format(
-                    "Ancillary variables", " metadata", *differences
-                )
+                msg_template.format("Ancillary variables", *differences)
             )
         # Check scalar coordinates.
         if self.scalar_coords != other.scalar_coords:
-            differences = self._coordinate_differences(other, "scalar_coords")
+            differences = self._coordinate_differences(
+                other, "scalar_coords", reason="values or metadata"
+            )
             msgs.append(
-                msg_template.format(
-                    "Scalar coordinates", " values or metadata", *differences
-                )
+                msg_template.format("Scalar coordinates", *differences)
             )
         # Check ndim.
         if self.ndim != other.ndim:

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -452,11 +452,11 @@ class _CubeSignature:
             between `self` and `other`.
 
         Returns:
-            Tuple of a descriptive error message and the names of coordinates
-            that differ between `self` and `other`.
+            Tuple of the names of attributes that differ between `self` and
+            `other`.
 
         """
-        # Set up {name: coord_metadata} dictionaries.
+        # Set up {name: attribute} dictionaries.
         self_dict = {x.name(): x for x in getattr(self, attr)}
         other_dict = {x.name(): x for x in getattr(other, attr)}
         if len(self_dict) == 0:
@@ -466,7 +466,7 @@ class _CubeSignature:
         self_names = sorted(self_dict.keys())
         other_names = sorted(other_dict.keys())
 
-        # Compare coord metadata.
+        # Compare coord attributes.
         if len(self_names) != len(other_names) or self_names != other_names:
             result = ("", ", ".join(self_names), ", ".join(other_names))
         else:
@@ -476,7 +476,6 @@ class _CubeSignature:
                 if self_value != other_value:
                     diff_names.append(self_key)
             result = (
-                " metadata",
                 ", ".join(diff_names),
                 ", ".join(diff_names),
             )
@@ -522,29 +521,39 @@ class _CubeSignature:
         if self.dim_metadata != other.dim_metadata:
             differences = self._coordinate_differences(other, "dim_metadata")
             msgs.append(
-                msg_template.format("Dimension coordinates", *differences)
+                msg_template.format(
+                    "Dimension coordinates", " metadata", *differences
+                )
             )
         # Check aux coordinates.
         if self.aux_metadata != other.aux_metadata:
             differences = self._coordinate_differences(other, "aux_metadata")
             msgs.append(
-                msg_template.format("Auxiliary coordinates", *differences)
+                msg_template.format(
+                    "Auxiliary coordinates", " metadata", *differences
+                )
             )
         # Check cell measures.
         if self.cm_metadata != other.cm_metadata:
             differences = self._coordinate_differences(other, "cm_metadata")
-            msgs.append(msg_template.format("Cell measures", *differences))
+            msgs.append(
+                msg_template.format("Cell measures", " metadata", *differences)
+            )
         # Check ancillary variables.
         if self.av_metadata != other.av_metadata:
             differences = self._coordinate_differences(other, "av_metadata")
             msgs.append(
-                msg_template.format("Ancillary variables", *differences)
+                msg_template.format(
+                    "Ancillary variables", " metadata", *differences
+                )
             )
         # Check scalar coordinates.
         if self.scalar_coords != other.scalar_coords:
             differences = self._coordinate_differences(other, "scalar_coords")
             msgs.append(
-                msg_template.format("Scalar coordinates", *differences)
+                msg_template.format(
+                    "Scalar coordinates", " values or metadata", *differences
+                )
             )
         # Check ndim.
         if self.ndim != other.ndim:

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -154,7 +154,7 @@ class TestMessages(tests.IrisTest):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.coord("height").long_name = "alice"
-        exc_regexp = "Scalar coordinates metadata differ: .* != .*"
+        exc_regexp = "Scalar coordinates values or metadata differ: .* != .*"
         with self.assertRaisesRegex(ConcatenateError, exc_regexp):
             _ = concatenate([cube_1, cube_2], True)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Added a "reason" keyword argument to `_coordinate_differences` as currently it attaches the reason, and whilst it can diagnose some of the problem, it doesn't know if it's just been given metadata or also values to check, whereas the calling method does.

<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #4096

Question for reviewer:
- Is this the best place to implement this fix? Should it be shallower or deeper instead?

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
