### PR TITLE
`iris.analysis.AreaWeighted` regrid speedup

### DIFF
--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -71,6 +71,7 @@ class AreaWeightedRegridder:
             self.meshgrid_x,
             self.meshgrid_y,
             self.weights_info,
+            self.index_info,
         ) = _regrid_info
 
     def __call__(self, cube):
@@ -124,6 +125,7 @@ class AreaWeightedRegridder:
             self.meshgrid_x,
             self.meshgrid_y,
             self.weights_info,
+            self.index_info,
         )
         return _regrid_area_weighted_rectilinear_src_and_grid__perform(
             cube, _regrid_info, mdtol=self._mdtol

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -896,8 +896,8 @@ def _regrid_area_weighted_rectilinear_src_and_grid__prepare(
     # perform step and the indices we'll need to extract from the cube we're
     # regridding (src_data)
 
-    result_y_extent = len(cached_y_indices)
-    result_x_extent = len(cached_x_indices)
+    result_y_extent = len(grid_y_bounds)
+    result_x_extent = len(grid_x_bounds)
 
     # Total number of points
     num_target_pts = result_y_extent * result_x_extent
@@ -913,8 +913,11 @@ def _regrid_area_weighted_rectilinear_src_and_grid__prepare(
         (len(cached_y_indices), len(cached_x_indices)), False, dtype=np.bool_
     )
 
-    # To permit fancy indexing, we're going to store our data in an array of
-    # the size of the biggest. This means we need to track whether the data in
+    # To permit fancy indexing, we need to store our data in an array whose
+    # first two dimensions represent the indices needed for the target cell.
+    # Since target cells can require a different number of indices, the size of
+    # these dimensions should be the maximum of this number.
+    # This means we need to track whether the data in
     # that array is actually required and build those squared-off arrays
     # TODO: Consider if a proper mask would be better
     src_area_datas_required = np.full(
@@ -936,7 +939,7 @@ def _regrid_area_weighted_rectilinear_src_and_grid__prepare(
             # Determine whether to mask element i, j based on whether
             # there are valid weights.
             weights = cached_weights[j][i]
-            if isinstance(weights, bool) and not weights:
+            if weights is False:
                 # Prepare for the src_data not being masked by storing the
                 # information that will let us fill the data with zeros and
                 # weights as one. The weighted average result will be the same,
@@ -967,7 +970,7 @@ def _regrid_area_weighted_rectilinear_src_and_grid__prepare(
                 else:
                     x_indices = list(x_indices)
 
-                # For the weights, we just need the lengths of these as we'd
+                # For the weights, we just need the lengths of these as we're
                 # dropping them into a pre-made array
 
                 len_y = len(y_indices)

--- a/lib/iris/tests/integration/analysis/test_area_weighted.py
+++ b/lib/iris/tests/integration/analysis/test_area_weighted.py
@@ -1,0 +1,73 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Integration tests for area weighted regridding."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+import tempfile
+
+import iris
+from iris.analysis import AreaWeighted
+
+
+@tests.skip_data
+class AreaWeightedTests(tests.IrisTest):
+    def setup(self):
+        # Prepare a cube and a template
+
+        cube_file_path = tests.get_data_path(
+            ["NetCDF", "regrid", "regrid_xyt.nc"]
+        )
+        self.cube = iris.load_cube(cube_file_path)
+
+        template_file_path = tests.get_data_path(
+            ["NetCDF", "regrid", "regrid_template_global_latlon.nc"]
+        )
+        self.template_cube = iris.load_cube(template_file_path)
+
+    def test_regrid_area_w_lazy(self):
+        # Regrid the cube onto the template.
+        out = self.cube.regrid(self.template_cube, AreaWeighted())
+        # Check data is still lazy
+        self.assertTrue(self.cube.has_lazy_data())
+        self.assertTrue(out.has_lazy_data())
+        # Save the data
+        with tempfile.TemporaryFile(suffix=".nc") as fp:
+            iris.save(out, fp)
+
+    def test_regrid_area_w_lazy_chunked(self):
+        # Chunked data makes the regridder run repeatedly
+        self.cube.data = self.cube.lazy_data().rechunk((1, -1, -1))
+        # Regrid the cube onto the template.
+        out = self.cube.regrid(self.template_cube, AreaWeighted())
+        # Check data is still lazy
+        self.assertTrue(self.cube.has_lazy_data())
+        self.assertTrue(out.has_lazy_data())
+        # Save the data
+        with tempfile.TemporaryFile(suffix=".nc") as fp:
+            iris.save(out, fp)
+
+    def test_regrid_area_w_real_save(self):
+        real_cube = self.cube.copy()
+        real_cube.data
+        # Regrid the cube onto the template.
+        out = real_cube.regrid(self.template_cube, AreaWeighted())
+        # Realise the data
+        out.data
+        # Save the data
+        with tempfile.TemporaryFile(suffix=".nc") as fp:
+            iris.save(out, fp)
+
+    def test_regrid_area_w_real_start(self):
+        real_cube = self.cube.copy()
+        real_cube.data
+        # Regrid the cube onto the template.
+        out = real_cube.regrid(self.template_cube, AreaWeighted())
+        # Save the data
+        with tempfile.TemporaryFile(suffix=".nc") as fp:
+            iris.save(out, fp)

--- a/lib/iris/tests/integration/analysis/test_area_weighted.py
+++ b/lib/iris/tests/integration/analysis/test_area_weighted.py
@@ -17,7 +17,7 @@ from iris.analysis import AreaWeighted
 
 @tests.skip_data
 class AreaWeightedTests(tests.IrisTest):
-    def setup(self):
+    def setUp(self):
         # Prepare a cube and a template
 
         cube_file_path = tests.get_data_path(
@@ -71,3 +71,7 @@ class AreaWeightedTests(tests.IrisTest):
         # Save the data
         with tempfile.TemporaryFile(suffix=".nc") as fp:
             iris.save(out, fp)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 import numpy as np
 
+from iris import load_cube
 from iris.analysis._area_weighted import AreaWeightedRegridder
 from iris.coord_systems import GeogCS
 from iris.coords import DimCoord
@@ -245,6 +246,42 @@ class Test(tests.IrisTest):
         self.assertArrayShapeStats(
             result, (9, 8, 5), expected_mean, expected_std
         )
+
+
+@tests.skip_data
+class TestLazy(tests.IrisTest):
+    # Setup
+    def setup(self) -> None:
+        # Prepare a cube and a template
+
+        cube_file_path = tests.get_data_path(
+            ["NetCDF", "regrid", "regrid_xyt.nc"]
+        )
+        self.cube = load_cube(cube_file_path)
+
+        template_file_path = tests.get_data_path(
+            ["NetCDF", "regrid", "regrid_template_global_latlon.nc"]
+        )
+        self.template_cube = load_cube(template_file_path)
+
+        # Chunked data makes the regridder run repeatedly
+        self.cube.data = self.cube.lazy_data().rechunk((1, -1, -1))
+
+    def test_src_stays_lazy(self) -> None:
+        cube = self.cube.copy()
+        # Regrid the cube onto the template.
+        regridder = AreaWeightedRegridder(cube, self.template_cube)
+        regridder.regrid(cube)
+        # Base cube stays lazy
+        self.assertTrue(cube.has_lazy_data())
+
+    def test_output_lazy(self) -> None:
+        cube = self.cube.copy()
+        # Regrid the cube onto the template.
+        regridder = AreaWeightedRegridder(cube, self.template_cube)
+        out = regridder.regrid(cube)
+        # Lazy base cube means lazy output
+        self.assertTrue(out.has_lazy_data())
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -271,7 +271,7 @@ class TestLazy(tests.IrisTest):
         cube = self.cube.copy()
         # Regrid the cube onto the template.
         regridder = AreaWeightedRegridder(cube, self.template_cube)
-        regridder.regrid(cube)
+        regridder(cube)
         # Base cube stays lazy
         self.assertTrue(cube.has_lazy_data())
 
@@ -279,7 +279,7 @@ class TestLazy(tests.IrisTest):
         cube = self.cube.copy()
         # Regrid the cube onto the template.
         regridder = AreaWeightedRegridder(cube, self.template_cube)
-        out = regridder.regrid(cube)
+        out = regridder(cube)
         # Lazy base cube means lazy output
         self.assertTrue(out.has_lazy_data())
 

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -50,7 +50,7 @@ class Test(tests.IrisTest):
                 src_grid, target_grid
             )
         )
-        self.assertEqual(len(_regrid_info), 9)
+        self.assertEqual(len(_regrid_info), 10)
         with mock.patch(
             "iris.experimental.regrid."
             "_regrid_area_weighted_rectilinear_src_and_grid__prepare",

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -251,7 +251,7 @@ class Test(tests.IrisTest):
 @tests.skip_data
 class TestLazy(tests.IrisTest):
     # Setup
-    def setup(self) -> None:
+    def setUp(self) -> None:
         # Prepare a cube and a template
 
         cube_file_path = tests.get_data_path(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
Aiming to speed up the regridding of chunked data with `iris.analysis.AreaWeighted` regridder

<!-- Tell us all about your new feature, improvement, or bug fix -->
Moving more weight construction and construction of indices to be applied to the regridded cube all into the prepare step of the regridder, rather than the perform step (which gets repeated on chunked data)

See #4280 for context

To do:

- [x] Check benchmark performance
- [x] Consider additional testing and benchmarking
- [x] Explain here which lines have just had indentation changes rather than being rewritten
- [ ] Add to whatsnew

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
