### PR TITLE
Fix broken links in plotting_a_cube.rst

### DIFF
--- a/docs/src/userguide/plotting_a_cube.rst
+++ b/docs/src/userguide/plotting_a_cube.rst
@@ -218,7 +218,7 @@ Plotting 2-Dimensional Cubes
 Creating Maps
 -------------
 Whenever a 2D plot is created using an :class:`iris.coord_systems.CoordSystem`,
-a cartopy :class:`~cartopy.mpl.GeoAxes` instance is created, which can be
+a cartopy :class:`~cartopy.mpl.geoaxes.GeoAxes` instance is created, which can be
 accessed with the :func:`matplotlib.pyplot.gca` function.
 
 Given the current map, you can draw gridlines and coastlines amongst other 
@@ -226,8 +226,8 @@ things.
 
 .. seealso::
 
-    :meth:`cartopy's gridlines() <cartopy.mpl.GeoAxes.gridlines>`,
-    :meth:`cartopy's coastlines() <cartopy.mpl.GeoAxes.coastlines>`.
+    :meth:`cartopy's gridlines() <cartopy.mpl.geoaxes.GeoAxes.gridlines>`,
+    :meth:`cartopy's coastlines() <cartopy.mpl.geoaxes.GeoAxes.coastlines>`.
 
 
 Cube Contour

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -160,6 +160,9 @@ This document explains the changes made to Iris for this release
 
 #. `@trexfeathers`_ added more detail on making `iris-test-data`_ available
    during :ref:`developer_running_tests`. (:pull:`4359`)
+   
+#. `@TornadoAli`_ fixed broken links to Cartopy's docs from within the :ref:`userguide creating maps
+   section <creating-maps>`. (:pull:`4409`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fix broken cartopy links in plotting_a_cube.rst. Using as a test of if/how non-members of the Scitools core contributors can edit the Iris docs via the 'Edit in Github' button on the ReadTheDocs page.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
