### PR TITLE
Add release docs sections describing the role of a Release Manager

### DIFF
--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -258,7 +258,7 @@ Post Release Steps
 
 .. _SciTools/iris: https://github.com/SciTools/iris
 .. _tag on the SciTools/Iris: https://github.com/SciTools/iris/releases
-.. _GitHub Discussions forum: https://github.com/SciTools/iris/discussions/categories/releases
+.. _GitHub Releases Discussion Forum: https://github.com/SciTools/iris/discussions/categories/releases
 .. _conda-forge Anaconda channel: https://anaconda.org/conda-forge/iris
 .. _conda-forge iris-feedstock: https://github.com/conda-forge/iris-feedstock
 .. _CFEP-05: https://github.com/conda-forge/cfep/blob/master/cfep-05.md

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -11,6 +11,20 @@ The summary below is of the main areas that constitute the release.  The final
 section details the :ref:`iris_development_releases_steps` to take.
 
 
+.. _release-manager:
+
+Release Manager
+---------------
+A Release Manager will be nominated for each release of Iris. This role involves:
+
+* deciding which features and bug fixes should be included in the release
+* managing the project board for the release
+* updating the iris dev community via the discussion board
+
+The Release Manager will make the release, ensuring that all the steps outlined
+on this page are completed.
+
+
 Before Release
 --------------
 

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -19,7 +19,7 @@ A Release Manager will be nominated for each release of Iris. This role involves
 
 * deciding which features and bug fixes should be included in the release
 * managing the project board for the release
-* using a `GitHub Discussions forum`_ for documenting intent and capturing any 
+* using a `GitHub Releases Discussion Forum`_ for documenting intent and capturing any 
   discussion about the release
 
 The Release Manager will make the release, ensuring that all the steps outlined
@@ -258,7 +258,7 @@ Post Release Steps
 
 .. _SciTools/iris: https://github.com/SciTools/iris
 .. _tag on the SciTools/Iris: https://github.com/SciTools/iris/releases
-.. _GitHub Discussions forum: https://github.com/SciTools/iris/discussions
+.. _GitHub Discussions forum: https://github.com/SciTools/iris/discussions/categories/releases
 .. _conda-forge Anaconda channel: https://anaconda.org/conda-forge/iris
 .. _conda-forge iris-feedstock: https://github.com/conda-forge/iris-feedstock
 .. _CFEP-05: https://github.com/conda-forge/cfep/blob/master/cfep-05.md

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -11,7 +11,7 @@ The summary below is of the main areas that constitute the release.  The final
 section details the :ref:`iris_development_releases_steps` to take.
 
 
-.. _release-manager:
+.. _release_manager:
 
 Release Manager
 ---------------
@@ -19,7 +19,8 @@ A Release Manager will be nominated for each release of Iris. This role involves
 
 * deciding which features and bug fixes should be included in the release
 * managing the project board for the release
-* updating the iris dev community via the discussion board
+* using a `GitHub Discussions forum`_ for documenting intent and capturing any 
+  discussion about the release
 
 The Release Manager will make the release, ensuring that all the steps outlined
 on this page are completed.
@@ -257,6 +258,7 @@ Post Release Steps
 
 .. _SciTools/iris: https://github.com/SciTools/iris
 .. _tag on the SciTools/Iris: https://github.com/SciTools/iris/releases
+.. _GitHub Discussions forum: https://github.com/SciTools/iris/discussions
 .. _conda-forge Anaconda channel: https://anaconda.org/conda-forge/iris
 .. _conda-forge iris-feedstock: https://github.com/conda-forge/iris-feedstock
 .. _CFEP-05: https://github.com/conda-forge/cfep/blob/master/cfep-05.md

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -168,6 +168,9 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ added more detail on making `iris-test-data`_ available
    during :ref:`developer_running_tests`. (:pull:`4359`)
 
+#. `@lbdreyer`_ added a section to the release documentation outlining the role
+   of the :ref:`release-manager`. (:pull:`4412`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -169,7 +169,7 @@ This document explains the changes made to Iris for this release
    during :ref:`developer_running_tests`. (:pull:`4359`)
 
 #. `@lbdreyer`_ added a section to the release documentation outlining the role
-   of the :ref:`release-manager`. (:pull:`4412`)
+   of the :ref:`release_manager`. (:pull:`4413`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
@tkknight, earlier we discussed adding a short section to the releases docs to outline what the release manager does. What do you think of this?


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
