### PR TITLE
Changes for Matplotlib v3.5

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -222,6 +222,8 @@ This document explains the changes made to Iris for this release
    :func:`~iris.analysis.cartography.wrap_lons` and updated affected tests
    using assertArrayAllClose following :issue:`3993`.
    (:pull:`4421`)
+   
+#. `@rcomer`_ updated some tests to work with Matplotlib v3.5. (:pull:`4428`)
 
 #. `@rcomer`_ applied minor fixes to some regridding tests. (:pull:`4432`)
 

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -61,7 +61,8 @@
     "gallery_tests.test_plot_deriving_phenomena.TestDerivingPhenomena.test_plot_deriving_phenomena.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/b9993986866952e6c9464639c4766bd9c669916e7b99c1663f99768990763e81.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/b99139de866952e6c946c639c47e6bd18769d16e7a9981662e813699d0763e89.png",
-        "https://scitools.github.io/test-iris-imagehash/images/v4/ec97681793689768943c97e8926669d186e8c33f6c99c32e6b936c83d33e2c98.png"
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ec97681793689768943c97e8926669d186e8c33f6c99c32e6b936c83d33e2c98.png",
+        "https://scitools.github.io/test-iris-imagehash/images/v4/ec97681793689768943c96e890666bc586e1c33f2c99c33e6f956c93d23e2c98.png"
     ],
     "gallery_tests.test_plot_global_map.TestGlobalMap.test_plot_global_map.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/fa9979468566857ef07e3e8978566b91cb0179883c89946686a96b9d83766f81.png",

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -11,7 +11,6 @@ import iris.tests as tests  # isort:skip
 
 from unittest import mock
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -89,16 +88,10 @@ class TestAntialias(tests.IrisTest):
         levels = [5, 15, 20, 200]
         colors = ["b", "r", "y"]
 
-        iplt.contourf(cube, levels=levels, colors=colors, antialiased=True)
+        with mock.patch("matplotlib.pyplot.contour") as mocked_contour:
+            iplt.contourf(cube, levels=levels, colors=colors, antialiased=True)
 
-        ax = plt.gca()
-        # Expect 3 PathCollection objects (one for each colour) and no LineCollection
-        # objects.
-        for collection in ax.collections:
-            self.assertIsInstance(
-                collection, matplotlib.collections.PathCollection
-            )
-        self.assertEqual(len(ax.collections), 3)
+        mocked_contour.assert_not_called()
 
     def test_apply_contour_nans(self):
         # Presence of nans should not prevent contours being added.
@@ -109,13 +102,10 @@ class TestAntialias(tests.IrisTest):
         levels = [2, 4, 6, 8]
         colors = ["b", "r", "y"]
 
-        iplt.contourf(cube, levels=levels, colors=colors, antialiased=True)
+        with mock.patch("matplotlib.pyplot.contour") as mocked_contour:
+            iplt.contourf(cube, levels=levels, colors=colors, antialiased=True)
 
-        ax = plt.gca()
-        # If contour has been called, last collection will be a LineCollection.
-        self.assertIsInstance(
-            ax.collections[-1], matplotlib.collections.LineCollection
-        )
+        mocked_contour.assert_called_once()
 
     def tearDown(self):
         plt.close(self.fig)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Changes to get tests passing with Matplotlib v3.5.

* New image hash for one gallery example (see https://github.com/SciTools/test-iris-imagehash/pull/56)
* The antialias tests basically check whether `plt.contour` has been called, in addition to `plt.contourf`.  The tests previously relied on the fact that the two functions added different artist types to the axes, but this is no longer the case (https://github.com/matplotlib/matplotlib/issues/20906).  So have updated these tests to use `mock` instead.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
