### PR TITLE
Minor fixes for regridding tests

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -220,6 +220,8 @@ This document explains the changes made to Iris for this release
    using assertArrayAllClose following :issue:`3993`.
    (:pull:`4421`)
 
+#. `@rcomer`_ applied minor fixes to some regridding tests. (:pull:`4432`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/lib/iris/tests/integration/analysis/__init__.py
+++ b/lib/iris/tests/integration/analysis/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Integration tests for the :mod:`iris.analysis` package."""

--- a/lib/iris/tests/integration/analysis/test_area_weighted.py
+++ b/lib/iris/tests/integration/analysis/test_area_weighted.py
@@ -9,8 +9,6 @@
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-import tempfile
-
 import iris
 from iris.analysis import AreaWeighted
 
@@ -37,8 +35,8 @@ class AreaWeightedTests(tests.IrisTest):
         self.assertTrue(self.cube.has_lazy_data())
         self.assertTrue(out.has_lazy_data())
         # Save the data
-        with tempfile.TemporaryFile(suffix=".nc") as fp:
-            iris.save(out, fp)
+        with self.temp_filename(suffix=".nc") as fname:
+            iris.save(out, fname)
 
     def test_regrid_area_w_lazy_chunked(self):
         # Chunked data makes the regridder run repeatedly
@@ -49,8 +47,8 @@ class AreaWeightedTests(tests.IrisTest):
         self.assertTrue(self.cube.has_lazy_data())
         self.assertTrue(out.has_lazy_data())
         # Save the data
-        with tempfile.TemporaryFile(suffix=".nc") as fp:
-            iris.save(out, fp)
+        with self.temp_filename(suffix=".nc") as fname:
+            iris.save(out, fname)
 
     def test_regrid_area_w_real_save(self):
         real_cube = self.cube.copy()
@@ -60,8 +58,8 @@ class AreaWeightedTests(tests.IrisTest):
         # Realise the data
         out.data
         # Save the data
-        with tempfile.TemporaryFile(suffix=".nc") as fp:
-            iris.save(out, fp)
+        with self.temp_filename(suffix=".nc") as fname:
+            iris.save(out, fname)
 
     def test_regrid_area_w_real_start(self):
         real_cube = self.cube.copy()
@@ -69,8 +67,8 @@ class AreaWeightedTests(tests.IrisTest):
         # Regrid the cube onto the template.
         out = real_cube.regrid(self.template_cube, AreaWeighted())
         # Save the data
-        with tempfile.TemporaryFile(suffix=".nc") as fp:
-            iris.save(out, fp)
+        with self.temp_filename(suffix=".nc") as fname:
+            iris.save(out, fname)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Running the tests under `pytest`, I got `TypeError`s from these four tests, apparently because `save` expected a string but got an int.  These tests will have been missed by `nose` within the CI because the `__init__.py` was missing.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
