### PR TITLE
Use dask-core instead of dask in ci

### DIFF
--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy >=0.20
   - cf-units >=3
   - cftime >=1.5
-  - dask >=2
+  - dask-core >=2
   - matplotlib
   - netcdf4
   - numpy >=1.19

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy >=0.20
   - cf-units >=3
   - cftime >=1.5
-  - dask >=2
+  - dask-core >=2
   - matplotlib
   - netcdf4
   - numpy >=1.19


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Tried to reduce dependencies from installing dask via conda which installs like pip install dask[complete]. dask-core is like pip install dask. https://github.com/xgcm/xhistogram/pull/71#discussion_r752738286

Why? dask[complete] includes bokeh etc which are not needed here and likely speed up CI setup/install times


consider also for feedstock https://github.com/conda-forge/iris-feedstock/pull/77

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
