### PR TITLE
Fix license PyPI classifier

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -222,6 +222,8 @@ This document explains the changes made to Iris for this release
 
 #. `@rcomer`_ applied minor fixes to some regridding tests. (:pull:`4432`)
 
+#. `@lbdreyer`_ corrected the license PyPI classifier. (:pull:`4435`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ author_email = scitools-iris-dev@googlegroups.com
 classifiers =
     Development Status :: 5 Production/Stable
     Intended Audience :: Science/Research
-    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
     Operating System :: MacOS
     Operating System :: POSIX
     Operating System :: POSIX :: Linux


### PR DESCRIPTION
Small issue - spotted that the PyPI classifier incorrectly states that Iris is GPL instead of LGPL.


