### PR TITLE
Mesh recombine

### DIFF
--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -18,6 +18,7 @@ from ...config import get_logger
 from .load import PARSE_UGRID_ON_LOAD, load_mesh, load_meshes
 from .mesh import Connectivity, Mesh, MeshCoord
 from .save import save_mesh
+from .utils import recombine_submeshes
 
 __all__ = [
     "Connectivity",
@@ -26,6 +27,7 @@ __all__ = [
     "PARSE_UGRID_ON_LOAD",
     "load_mesh",
     "load_meshes",
+    "recombine_submeshes",
     "save_mesh",
 ]
 

--- a/lib/iris/experimental/ugrid/utils.py
+++ b/lib/iris/experimental/ugrid/utils.py
@@ -8,7 +8,7 @@
 Utility operations specific to unstructured data.
 
 """
-from typing import AnyStr, Iterable
+from typing import AnyStr, Iterable, Union
 
 import dask.array as da
 import numpy as np
@@ -16,233 +16,232 @@ import numpy as np
 from iris.cube import Cube
 
 
-def recombine_regions(
-    full_mesh_cube: Cube,
-    region_cubes: Iterable[Cube],
+def recombine_submeshes(
+    mesh_cube: Cube,
+    submesh_cubes: Union[Iterable[Cube], Cube],
     index_coord_name: AnyStr = "i_mesh_index",
 ) -> Cube:
     """
-    Put data from regional sub-meshes back onto the original full mesh.
+    Put data from sub-meshes back onto the original full mesh.
 
-    The result is a region_cube identical to 'full_mesh_cube', but with its data
-    replaced by a combination of data from the provided 'region_cubes'.
-    The result metadata, including name and units, are also replaced by those
-    of the 'region_cubes' (which must all be the same).
+    The result is a cube like ``mesh_cube``, but with its data replaced by a
+    combination of the data in the ``submesh_cubes``.
 
-    Args:
-
-    * full_mesh_cube
-        Describes the full mesh and mesh-location to which the region data
-        refers, and acts as a template for the result.
+    Parameters
+    ----------
+    mesh_cube : Cube
+        Describes the mesh and mesh-location onto which the all the
+        ``submesh-cubes``' data are mapped, and acts as a template for the
+        result.
         Must have a :class:`~iris.experimental.ugrid.mesh.Mesh`.
 
-    * region_cubes
-        Contain data on a subset of the 'full_mesh_cube' mesh locations.
-        The region cubes do not need to have a mesh.  There must be at least
-        1 of them, to determine the result phenomenon.
+    submesh_cubes : iterable of Cube, or Cube
+        Cubes, each with data on a _subset_ of the ``mesh_cube`` mesh locations.
+        The submesh cubes do not need to have a mesh.
+        There must be at least 1 of them, to determine the result phenomenon.
+        Their metadata (names, units and attributes) must all be the same,
+        _except_ that 'var_name' is ignored.
+        Their dtypes must all be the same.
         Their shapes and dimension-coords must all match those of
-        'full_mesh_cube', except in the mesh dimension, which can have
-        different sizes between the regions, and from the 'full_mesh_cube'.
-        The mesh dimension of each region cube must have a 1-D coord named by
-        'index_coord_name'.  Although these region index coords can vary in
-        length, they must all have matching metadata (names, units and
-        attributes), and must also match the coord of that name in the
-        'full_mesh_cube', if there is one.
-        The ".points" values of the region index coords specify, for each
-        datapoint, its location in the original mesh -- i.e. they are indices
-        into the relevant mesh-location dimension.
+        ``mesh_cube``, except in the mesh dimension, which can have different
+        sizes between the submeshes, and from the ``mesh_cube``.
+        The mesh dimension of each must have a 1-D coord named by
+        ``index_coord_name``.  These "index coords" can vary in length, but
+        they must all have matching metadata (units, attributes and names
+        except 'var_name'), and must also match the coord of that name in
+        ``mesh_cube``, if there is one.
+        The ".points" values of the index coords specify, for each datapoint,
+        its location in the original mesh -- i.e. they are indices into the
+        relevant mesh-location dimension.
 
-    * index_coord_name
-        Coord name of the index coords in each region cubes, containing the
-        mesh location indices.
+    index_coord_name : Cube
+        Coord name of an index coord containing the mesh location indices, in
+        every submesh cube.
 
-    Result:
+    Returns
+    -------
+    result_cube
+        A cube with the same mesh, location, and shape as ``mesh_cube``, but
+        with its data replaced by that from the``submesh_cubes``.
+        The result phenomeon identity is also that of the``submesh_cubes``,
+        i.e. units, attributes and names (except 'var_name', which is None).
 
-    * result_cube
-        An unstructured region_cube identical to 'full_mesh_cube', and with the
-        same mesh and location, but with its data and ".metadata" replaced by
-        that from the 'region_cubes'.
-        Where regions overlap, the result data comes from the last-listed of the
-        original region cubes which contain that location.
-        Where no region contains a datapoint, it will be masked in the result.
-        HINT: alternatively, values covered by no region can be taken from the
-        original 'full_mesh_cube' data, if 'full_mesh_cube' is *also* passed
-        as the first of the 'region_cubes'.
+    Notes
+    -----
+    Where regions overlap, the result data comes from the submesh cube
+    containing that location which appears _last_ in ``submesh_cubes``.
+
+    Where no region contains a datapoint, it will be masked in the result.
+    HINT: alternatively, values covered by no region can be set to the
+    original 'full_mesh_cube' data value, if 'full_mesh_cube' is *also* passed
+    as the first of the 'region_cubes'.
+
+    The ``result_cube`` dtype is that of the ``submesh_cubes``.
 
     """
-    if not region_cubes:
-        raise ValueError("'region_cubes' must be non-empty.")
+    if not submesh_cubes:
+        raise ValueError("'submesh_cubes' must be non-empty.")
 
-    mesh_dim = full_mesh_cube.mesh_dim()
+    mesh_dim = mesh_cube.mesh_dim()
     if mesh_dim is None:
-        raise ValueError("'full_mesh_cube' has no \".mesh\".")
-
-    # Check the basic required properties of the input.
-    mesh_dim_coords = full_mesh_cube.coords(
-        dim_coords=True, dimensions=(mesh_dim,)
-    )
-    if not mesh_dim_coords:
-        err = (
-            "'full_mesh_cube' has no dim-coord on the mesh dimension, "
-            f"(dimension {mesh_dim})."
-        )
-        raise ValueError(err)
+        raise ValueError("'mesh_cube' has no \".mesh\".")
 
     #
     # Perform consistency checks on all the region-cubes.
     #
+    if not isinstance(submesh_cubes, Iterable):
+        # Treat a single submesh cube input as a list-of-1.
+        submesh_cubes = [submesh_cubes]
 
-    def metadata_no_varname(cube_or_coord):
-        # Get a metadata object but omit any var_name.
-        metadata = cube_or_coord.metadata
-        fields = metadata._asdict()
-        fields["var_name"] = None
-        result = metadata.__class__(**fields)
-        return result
-
-    n_regions = len(region_cubes)
-    n_dims = full_mesh_cube.ndim
-    regioncube_metadata = None
+    result_metadata = None
+    result_dtype = None
     indexcoord_metadata = None
-    for i_region, region_cube in enumerate(region_cubes):
-        reg_cube_str = (
-            f'Region cube #{i_region}/{n_regions}, "{region_cube.name()}"'
+    for i_sub, cube in enumerate(submesh_cubes):
+        sub_str = (
+            f"Submesh cube #{i_sub + 1}/{len(submesh_cubes)}, "
+            f'"{cube.name()}"'
         )
-        reg_ndims = region_cube.ndim
 
         # Check dimensionality.
-        if reg_ndims != n_dims:
+        if cube.ndim != mesh_cube.ndim:
             err = (
-                f"{reg_cube_str} has {reg_ndims} dimensions, but "
-                f"'full_mesh_cube' has {n_dims}."
+                f"{sub_str} has {cube.ndim} dimensions, but "
+                f"'mesh_cube' has {mesh_cube.ndim}."
             )
             raise ValueError(err)
 
-        # Get region_cube metadata, which will apply to the result..
-        region_cube_metadata = metadata_no_varname(region_cube)
-        if regioncube_metadata is None:
-            # Store the first region-cube metadata as a reference
-            regioncube_metadata = region_cube_metadata
-        elif region_cube_metadata != regioncube_metadata:
-            # Check subsequent region-cubes metadata against the first.
-            err = (
-                f"{reg_cube_str} has metadata {region_cube_metadata}, "
-                "which does not match that of the first region region_cube, "
-                f'"{region_cubes[0].name()}", '
-                f"which is {regioncube_metadata}."
-            )
-            raise ValueError(err)
+        # Get cube metadata + dtype : must match, and will apply to the result
+        dtype = cube.dtype
+        metadata = cube.metadata._replace(var_name=None)
+        if i_sub == 0:
+            # Store the first-cube metadata + dtype as reference
+            result_metadata = metadata
+            result_dtype = dtype
+        else:
+            # Check subsequent region-cubes metadata + dtype against the first
+            if metadata != result_metadata:
+                err = (
+                    f"{sub_str} has metadata {metadata}, "
+                    "which does not match that of the other region_cubes, "
+                    f"which is {result_metadata}."
+                )
+                raise ValueError(err)
+            elif dtype != result_dtype:
+                err = (
+                    f"{sub_str} has a dtype of {dtype}, "
+                    "which does not match that of the other region_cubes, "
+                    f"which is {result_dtype}."
+                )
+                raise ValueError(err)
 
-        # For each dim, check that coords match other regions, and full-cube.
-        for i_dim in range(full_mesh_cube.ndim):
+        # For each dim, check that coords match other regions, and full-cube
+        for i_dim in range(mesh_cube.ndim):
             if i_dim == mesh_dim:
-                # mesh dim : look for index coords (by name).
-                fulldim = full_mesh_cube.coords(
+                # mesh dim : look for index coords (by name)
+                full_coord = mesh_cube.coords(
                     name_or_coord=index_coord_name, dimensions=(i_dim,)
                 )
-                regdim = region_cube.coords(
+                sub_coord = cube.coords(
                     name_or_coord=index_coord_name, dimensions=(i_dim,)
                 )
             else:
                 # non-mesh dims : look for dim-coords (only)
-                fulldim = full_mesh_cube.coords(
+                full_coord = mesh_cube.coords(
                     dim_coords=True, dimensions=(i_dim,)
                 )
-                regdim = region_cube.coords(
-                    dim_coords=True, dimensions=(i_dim,)
-                )
+                sub_coord = cube.coords(dim_coords=True, dimensions=(i_dim,))
 
-            if fulldim:
-                (fulldim,) = fulldim
-                full_dimname = fulldim.name()
-                fulldim_metadata = metadata_no_varname(fulldim)
-            if regdim:
-                (regdim,) = regdim
-                reg_dimname = regdim.name()
-                regdim_metadata = metadata_no_varname(regdim)
+            if full_coord:
+                (full_coord,) = full_coord
+                full_dimname = full_coord.name()
+                full_metadata = full_coord.metadata._replace(var_name=None)
+            if sub_coord:
+                (sub_coord,) = sub_coord
+                sub_dimname = sub_coord.name()
+                sub_metadata = sub_coord.metadata._replace(var_name=None)
 
             err = None
-            # N.B. checks for mesh- and non-mesh-dims are different.
+            # N.B. checks for mesh- and non-mesh-dims are different
             if i_dim != mesh_dim:
-                # i_dim == mesh_dim :  checks for non-mesh dims.
-                if fulldim and not regdim:
+                # i_dim == mesh_dim :  checks for non-mesh dims
+                if full_coord and not sub_coord:
                     err = (
-                        f"{reg_cube_str} has no dim-coord for dimension "
-                        "{i_dim}, to match the 'full_mesh_cube' dimension "
+                        f"{sub_str} has no dim-coord for dimension "
+                        "{i_dim}, to match the 'mesh_cube' dimension "
                         f'"{full_dimname}".'
                     )
-                elif regdim and not fulldim:
+                elif sub_coord and not full_coord:
                     err = (
-                        f'{reg_cube_str} has a dim-coord "{reg_dimname}" for '
-                        f"dimension {i_dim}, but 'full_mesh_cube' has none."
+                        f'{sub_str} has a dim-coord "{sub_dimname}" for '
+                        f"dimension {i_dim}, but 'mesh_cube' has none."
                     )
-                elif regdim != fulldim:
+                elif sub_coord != full_coord:
                     err = (
-                        f'{reg_cube_str} has a dim-coord "{reg_dimname}" for '
+                        f'{sub_str} has a dim-coord "{sub_dimname}" for '
                         f"dimension {i_dim}, which does not match that "
-                        f"of 'full_mesh_cube', \"{full_dimname}\"."
+                        f"of 'mesh_cube', \"{full_dimname}\"."
                     )
             else:
                 # i_dim == mesh_dim :  different rules for this one
-                if not regdim:
+                if not sub_coord:
                     # Must have an index coord on the mesh dimension
                     err = (
-                        f'{reg_cube_str} has no "{index_coord_name}" coord on '
+                        f'{sub_str} has no "{index_coord_name}" coord on '
                         f"the mesh dimension (dimension {mesh_dim})."
                     )
-                elif fulldim and regdim_metadata != fulldim_metadata:
+                elif full_coord and sub_metadata != full_metadata:
                     # May *not* have full-cube index, but if so it must match
                     err = (
-                        f"{reg_cube_str} has an index coord "
+                        f"{sub_str} has an index coord "
                         f'"{index_coord_name}" whose ".metadata" does not '
-                        "match that on 'full_mesh_cube' :  "
-                        f"{regdim_metadata} != {fulldim_metadata}."
+                        "match that on 'mesh_cube' :  "
+                        f"{sub_metadata} != {full_metadata}."
                     )
 
-                # At this point, we know we *have* an index coord, and it does not
-                # conflict with the one on 'full_mesh_cube' (if any).
-                # Now check for matches between the region cubes.
-                if indexcoord_metadata is None:
-                    # Store first occurrence (from first region-cube)
-                    indexcoord_metadata = regdim_metadata
-                elif regdim_metadata != indexcoord_metadata:
-                    # Compare subsequent occurences (from other region-cubes)
-                    err = (
-                        f"{reg_cube_str} has an index coord "
-                        f'"{index_coord_name}" whose ".metadata" does not '
-                        f"match that of the first region-cube :  "
-                        f"{regdim_metadata} != {indexcoord_metadata}."
-                    )
+            if err:
+                raise ValueError(err)
 
-        if err:
-            raise ValueError(err)
+            # At this point, we know we *have* an index coord, and it does
+            # not conflict with the one on 'mesh_cube' (if any).
+            # Now check for matches between the region cubes.
+            if indexcoord_metadata is None:
+                # Store first occurrence (from first region-cube)
+                indexcoord_metadata = sub_metadata
+            elif sub_metadata != indexcoord_metadata:
+                # Compare subsequent occurrences (from other region-cubes)
+                err = (
+                    f"{sub_str} has an index coord "
+                    f'"{index_coord_name}" whose ".metadata" does not '
+                    f"match that of the first region-cube :  "
+                    f"{sub_metadata} != {indexcoord_metadata}."
+                )
 
     # Use the mesh_dim to transpose inputs + outputs, if required, as it is
     # simpler for all the array operations to always have the mesh dim *last*.
-    if mesh_dim == full_mesh_cube.ndim - 1:
-        # Mesh dim is already the last one : no tranposes required
+    if mesh_dim == mesh_cube.ndim - 1:
+        # Mesh dim is already the last one : no tranpose required
         untranspose_dims = None
     else:
-        dim_range = np.arange(full_mesh_cube.ndim, dtype=int)
-        # Transpose all inputs to mesh-last order.
+        dim_range = np.arange(mesh_cube.ndim, dtype=int)
+        # Transpose all inputs to mesh-last order
         tranpose_dims = [i_dim for i_dim in dim_range if i_dim != mesh_dim] + [
             mesh_dim
-        ]  # chop out mesh_dim + put it at the end.
+        ]  # chop out mesh_dim + put it at the end
 
         def transposed_copy(cube, dim_order):
             cube = cube.copy()
-            cube.transpose()
+            cube.transpose(dim_order)
             return cube
 
-        full_mesh_cube = transposed_copy(full_mesh_cube, tranpose_dims)
-        region_cubes = [
+        mesh_cube = transposed_copy(mesh_cube, tranpose_dims)
+        submesh_cubes = [
             transposed_copy(region_cube, tranpose_dims)
-            for region_cube in region_cubes
+            for region_cube in submesh_cubes
         ]
 
-        # Also prepare for transforming the output back to the original order.
+        # Also prepare for transforming the output back to the original order
         untranspose_dims = dim_range.copy()
-        # Neat trick to produce the reverse operation.
+        # Neat trick to produce the reverse operation
         untranspose_dims[tranpose_dims] = dim_range
 
     #
@@ -259,15 +258,15 @@ def recombine_regions(
         # alignment, to satisfy da.map_blocks
         assert all(size == 1 for size in regioninds.shape[:-1])
         inds = regioninds.flatten()
-        # Assign blocks with indexing on the last dim only.
+        # Assign blocks with indexing on the last dim only
         target[..., inds] = regiondata
         return target
 
     # Create an initially 'empty' (all-masked) dask array matching the input.
-    # N.B. this does not use the full_mesh_cube.lazy_data() array, but only its
+    # N.B. this does not use the mesh_cube.lazy_data() array, but only its
     # shape and dtype, since the data itself is not used in the calculation.
     # N.B. chunking matches the input cube, allowing performance control.
-    input_data = full_mesh_cube.lazy_data()
+    input_data = mesh_cube.lazy_data()
     result_array = da.ma.masked_array(
         da.zeros(
             input_data.shape,
@@ -284,39 +283,39 @@ def recombine_regions(
     # Notes on resultant calculation properties:
     # 1. map_blocks is chunk-mapped, so it is parallelisable and space-saving
     # 2. However, fetching less than a whole chunk is not efficient
-    for region_cube in region_cubes:
+    for cube in submesh_cubes:
         # Lazy data array from the region cube
-        datarr = region_cube.lazy_data()
+        sub_data = cube.lazy_data()
 
-        # Lazy indices from the mesh-dim coord.
-        mesh_dimcoord = region_cube.coord(
-            name_or_coord=index_coord_name, dimensions=region_cube.ndim - 1
+        # Lazy indices from the mesh-dim coord
+        mesh_dimcoord = cube.coord(
+            name_or_coord=index_coord_name, dimensions=cube.ndim - 1
         )
         indarr = mesh_dimcoord.lazy_points()
 
-        # Extend indarr dimensions to align it with the 'target' array dims.
+        # Extend indarr dimensions to align it with the 'target' array dims
         assert indarr.ndim == 1
-        shape = (1,) * (region_cube.ndim - 1) + indarr.shape
+        shape = (1,) * (cube.ndim - 1) + indarr.shape
         indarr = indarr.reshape(shape)
 
-        # Apply the operation to paste from one region into the target.
-        # N.B. replacing 'result_array' each time around the loop.
+        # Apply the operation to paste from one region into the target
+        # N.B. replacing 'result_array' each time around the loop
         result_array = da.map_blocks(
             fill_region,
             result_array,
-            datarr,
+            sub_data,
             indarr,
             dtype=result_array.dtype,
             meta=np.ndarray,
         )
 
-    # Construct the result cube.
-    result_cube = full_mesh_cube.copy()
+    # Construct the result cube
+    result_cube = mesh_cube.copy()
     result_cube.data = result_array
     # Copy names, units + attributes from region data (N.B. but not var_name)
-    result_cube.metadata = regioncube_metadata
+    result_cube.metadata = result_metadata
     if untranspose_dims:
-        # Re-order dims as in the original input.
+        # Re-order dims as in the original input
         result_cube.transpose(untranspose_dims)
 
     return result_cube

--- a/lib/iris/experimental/ugrid/utils.py
+++ b/lib/iris/experimental/ugrid/utils.py
@@ -1,0 +1,324 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
+"""
+Utility operations specific to unstructured data.
+
+"""
+from typing import AnyStr, Iterable
+
+import dask.array as da
+import numpy as np
+
+from iris.cube import Cube
+
+
+def recombine_regions(
+    full_mesh_cube: Cube,
+    region_cubes: Iterable[Cube],
+    index_coord_name: AnyStr = "i_mesh_index",
+) -> Cube:
+    """
+    Put data from regional sub-meshes back onto the original full mesh.
+
+    The result is a region_cube identical to 'full_mesh_cube', but with its data
+    replaced by a combination of data from the provided 'region_cubes'.
+    The result metadata, including name and units, are also replaced by those
+    of the 'region_cubes' (which must all be the same).
+
+    Args:
+
+    * full_mesh_cube
+        Describes the full mesh and mesh-location to which the region data
+        refers, and acts as a template for the result.
+        Must have a :class:`~iris.experimental.ugrid.mesh.Mesh`.
+        Its mesh dimension must have a dimension coordinate, containing a
+        simple sequence of index values == "np.arange(n_mesh)".
+
+    * region_cubes
+        Contain data on a subset of the 'full_mesh_cube' mesh locations.
+        The region cubes do not need to have a mesh.  There must be at least
+        1 of them, to determine the result phenomenon.
+        Their shapes and dimension-coords must all match those of
+        'full_mesh_cube', except in the mesh dimension, which can have
+        different sizes between the regions, and from the 'full_mesh_cube'.
+        The mesh dimension of each region cube must have a 1-D coord named by
+        'index_coord_name'.  Although these region index coords can vary in
+        length, they must all have matching metadata (names, units and
+        attributes), and must also match the coord of that name in the
+        'full_mesh_cube', if there is one.
+        The ".points" values of the region index coords specify, for each
+        datapoint, its location in the original mesh -- i.e. they are indices
+        into the relevant mesh-location dimension.
+
+    * index_coord_name
+        Coord name of the index coords in each region cubes, containing the
+        mesh location indices.
+
+    Result:
+
+    * result_cube
+        An unstructured region_cube identical to 'full_mesh_cube', and with the
+        same mesh and location, but with its data replaced by that from the
+        'region_cubes'.
+        Where regions overlap, the result data comes from the last-listed of the
+        original region cubes which contain that location.
+        Where no region contains a datapoint, it will be masked in the result.
+        HINT: alternatively, values covered by no region can be taken from the
+        original 'full_mesh_cube' data, if 'full_mesh_cube' is *also* passed
+        as the first of the 'region_cubes'.
+
+    """
+    if not region_cubes:
+        raise ValueError("'region_cubes' must be non-empty.")
+
+    mesh_dim = full_mesh_cube.mesh_dim()
+    if mesh_dim is None:
+        raise ValueError("'full_mesh_cube' has no \".mesh\".")
+
+    # Check the basic required properties of the input.
+    mesh_dim_coords = full_mesh_cube.coords(
+        dim_coords=True, dimensions=(mesh_dim,)
+    )
+    if not mesh_dim_coords:
+        err = (
+            "'full_mesh_cube' has no dim-coord on the mesh dimension, "
+            f"(dimension {mesh_dim})."
+        )
+        raise ValueError(err)
+
+    #
+    # Perform consistency checks on all the region-cubes.
+    #
+
+    def metadata_no_varname(cube_or_coord):
+        # Get a metadata object but omit any var_name.
+        metadata = cube_or_coord.metadata
+        fields = metadata._asdict()
+        fields["var_name"] = None
+        result = metadata.__class__(**fields)
+        return result
+
+    n_regions = len(region_cubes)
+    n_dims = full_mesh_cube.ndim
+    regioncube_metadata = None
+    indexcoord_metadata = None
+    for i_region, region_cube in enumerate(region_cubes):
+        reg_cube_str = (
+            f'Region cube #{i_region}/{n_regions}, "{region_cube.name()}"'
+        )
+        reg_ndims = region_cube.ndim
+
+        # Check dimensionality.
+        if reg_ndims != n_dims:
+            err = (
+                f"{reg_cube_str} has {reg_ndims} dimensions, but "
+                f"'full_mesh_cube' has {n_dims}."
+            )
+            raise ValueError(err)
+
+        # Get region_cube metadata, which will apply to the result..
+        region_cube_metadata = metadata_no_varname(region_cube)
+        if regioncube_metadata is None:
+            # Store the first region-cube metadata as a reference
+            regioncube_metadata = region_cube_metadata
+        elif region_cube_metadata != regioncube_metadata:
+            # Check subsequent region-cubes metadata against the first.
+            err = (
+                f"{reg_cube_str} has metadata {region_cube_metadata}, "
+                "which does not match that of the first region region_cube, "
+                f'"{region_cubes[0].name()}", '
+                f"which is {regioncube_metadata}."
+            )
+            raise ValueError(err)
+
+        # For each dim, check that coords match other regions, and full-cube.
+        for i_dim in range(full_mesh_cube.ndim):
+            if i_dim == mesh_dim:
+                # mesh dim : look for index coords (by name).
+                fulldim = full_mesh_cube.coords(
+                    name_or_coord=index_coord_name, dimensions=(i_dim,)
+                )
+                regdim = region_cube.coords(
+                    name_or_coord=index_coord_name, dimensions=(i_dim,)
+                )
+            else:
+                # non-mesh dims : look for dim-coords (only)
+                fulldim = full_mesh_cube.coords(
+                    dim_coords=True, dimensions=(i_dim,)
+                )
+                regdim = region_cube.coords(
+                    dim_coords=True, dimensions=(i_dim,)
+                )
+
+            if fulldim:
+                (fulldim,) = fulldim
+                full_dimname = fulldim.name()
+                fulldim_metadata = metadata_no_varname(fulldim)
+            if regdim:
+                (regdim,) = regdim
+                reg_dimname = regdim.name()
+                regdim_metadata = metadata_no_varname(regdim)
+
+            err = None
+            # N.B. checks for mesh- and non-mesh-dims are different.
+            if i_dim != mesh_dim:
+                # i_dim == mesh_dim :  checks for non-mesh dims.
+                if fulldim and not regdim:
+                    err = (
+                        f"{reg_cube_str} has no dim-coord for dimension "
+                        "{i_dim}, to match the 'full_mesh_cube' dimension "
+                        f'"{full_dimname}".'
+                    )
+                elif regdim and not fulldim:
+                    err = (
+                        f'{reg_cube_str} has a dim-coord "{reg_dimname}" for '
+                        f"dimension {i_dim}, but 'full_mesh_cube' has none."
+                    )
+                elif regdim != fulldim:
+                    err = (
+                        f'{reg_cube_str} has a dim-coord "{reg_dimname}" for '
+                        f"dimension {i_dim}, which does not match that "
+                        f"of 'full_mesh_cube', \"{full_dimname}\"."
+                    )
+            else:
+                # i_dim == mesh_dim :  different rules for this one
+                if not regdim:
+                    # Must have an index coord on the mesh dimension
+                    err = (
+                        f'{reg_cube_str} has no "{index_coord_name}" coord on '
+                        f"the mesh dimension (dimension {mesh_dim})."
+                    )
+                elif fulldim and regdim_metadata != fulldim_metadata:
+                    # May *not* have full-cube index, but if so it must match
+                    err = (
+                        f"{reg_cube_str} has an index coord "
+                        f'"{index_coord_name}" whose ".metadata" does not '
+                        "match that on 'full_mesh_cube' :  "
+                        f"{regdim_metadata} != {fulldim_metadata}."
+                    )
+
+                # At this point, we know we *have* an index coord, and it does not
+                # conflict with the one on 'full_mesh_cube' (if any).
+                # Now check for matches between the region cubes.
+                if indexcoord_metadata is None:
+                    # Store first occurrence (from first region-cube)
+                    indexcoord_metadata = regdim_metadata
+                elif regdim_metadata != indexcoord_metadata:
+                    # Compare subsequent occurences (from other region-cubes)
+                    err = (
+                        f"{reg_cube_str} has an index coord "
+                        f'"{index_coord_name}" whose ".metadata" does not '
+                        f"match that of the first region-cube :  "
+                        f"{regdim_metadata} != {indexcoord_metadata}."
+                    )
+
+        if err:
+            raise ValueError(err)
+
+    # Use the mesh_dim to transpose inputs + outputs, if required, as it is
+    # simpler for all the array operations to always have the mesh dim *last*.
+    if mesh_dim == full_mesh_cube.ndim - 1:
+        # Mesh dim is already the last one : no tranposes required
+        untranspose_dims = None
+    else:
+        dim_range = np.arange(full_mesh_cube.ndim, dtype=int)
+        # Transpose all inputs to mesh-last order.
+        tranpose_dims = [i_dim for i_dim in dim_range if i_dim != mesh_dim] + [
+            mesh_dim
+        ]  # chop out mesh_dim + put it at the end.
+
+        def transposed_copy(cube, dim_order):
+            cube = cube.copy()
+            cube.transpose()
+            return cube
+
+        full_mesh_cube = transposed_copy(full_mesh_cube, tranpose_dims)
+        region_cubes = [
+            transposed_copy(region_cube, tranpose_dims)
+            for region_cube in region_cubes
+        ]
+
+        # Also prepare for transforming the output back to the original order.
+        untranspose_dims = dim_range.copy()
+        # Neat trick to produce the reverse operation.
+        untranspose_dims[tranpose_dims] = dim_range
+
+    #
+    # Here's the core operation..
+    #
+    def fill_region(target, regiondata, regioninds):
+        if not target.flags.writeable:
+            # The initial input can be a section of a da.zeros(), which has no
+            # real array "behind" it.  This means that real arrays created in
+            # memory are only chunk-sized, but it also means that 'target' may
+            # not be writeable.  So take a copy to fix that, where needed.
+            target = target.copy()
+        # N.B. Indices are basically 1D, but may have leading *1 dims for
+        # alignment, to satisfy da.map_blocks
+        assert all(size == 1 for size in regioninds.shape[:-1])
+        inds = regioninds.flatten()
+        # Assign blocks with indexing on the last dim only.
+        target[..., inds] = regiondata
+        return target
+
+    # Create an initially 'empty' (all-masked) dask array matching the input.
+    # N.B. this does not use the full_mesh_cube.lazy_data() array, but only its
+    # shape and dtype, since the data itself is not used in the calculation.
+    # N.B. chunking matches the input cube, allowing performance control.
+    input_data = full_mesh_cube.lazy_data()
+    result_array = da.ma.masked_array(
+        da.zeros(
+            input_data.shape,
+            dtype=input_data.dtype,
+            chunks=input_data.chunksize,
+        ),
+        True,
+    )
+
+    # Wrap this repeatedly with a lazy operation to assign each region.
+    # It is done this way because we couldn't get map_blocks to correctly wrap
+    # a function which does all regions in a single operation.
+    # TODO: replace with a single-stage solution: Probably better, if possible.
+    # Notes on resultant calculation properties:
+    # 1. map_blocks is chunk-mapped, so it is parallelisable and space-saving
+    # 2. However, fetching less than a whole chunk is not efficient
+    for region_cube in region_cubes:
+        # Lazy data array from the region cube
+        datarr = region_cube.lazy_data()
+
+        # Lazy indices from the mesh-dim coord.
+        mesh_dimcoord = region_cube.coord(
+            name_or_coord=index_coord_name, dimensions=region_cube.ndim - 1
+        )
+        indarr = mesh_dimcoord.lazy_points()
+
+        # Extend indarr dimensions to align it with the 'target' array dims.
+        assert indarr.ndim == 1
+        shape = (1,) * (region_cube.ndim - 1) + indarr.shape
+        indarr = indarr.reshape(shape)
+
+        # Apply the operation to paste from one region into the target.
+        # N.B. replacing 'result_array' each time around the loop.
+        result_array = da.map_blocks(
+            fill_region,
+            result_array,
+            datarr,
+            indarr,
+            dtype=result_array.dtype,
+            meta=np.ndarray,
+        )
+
+    # Construct the result cube.
+    result_cube = full_mesh_cube.copy()
+    result_cube.data = result_array
+    # Copy names, units + attributes from region data (N.B. but not var_name)
+    result_cube.metadata = regioncube_metadata
+    if untranspose_dims:
+        # Re-order dims as in the original input.
+        result_cube.transpose(untranspose_dims)
+
+    return result_cube

--- a/lib/iris/experimental/ugrid/utils.py
+++ b/lib/iris/experimental/ugrid/utils.py
@@ -35,8 +35,6 @@ def recombine_regions(
         Describes the full mesh and mesh-location to which the region data
         refers, and acts as a template for the result.
         Must have a :class:`~iris.experimental.ugrid.mesh.Mesh`.
-        Its mesh dimension must have a dimension coordinate, containing a
-        simple sequence of index values == "np.arange(n_mesh)".
 
     * region_cubes
         Contain data on a subset of the 'full_mesh_cube' mesh locations.
@@ -62,8 +60,8 @@ def recombine_regions(
 
     * result_cube
         An unstructured region_cube identical to 'full_mesh_cube', and with the
-        same mesh and location, but with its data replaced by that from the
-        'region_cubes'.
+        same mesh and location, but with its data and ".metadata" replaced by
+        that from the 'region_cubes'.
         Where regions overlap, the result data comes from the last-listed of the
         original region cubes which contain that location.
         Where no region contains a datapoint, it will be masked in the result.

--- a/lib/iris/experimental/ugrid/utils.py
+++ b/lib/iris/experimental/ugrid/utils.py
@@ -270,7 +270,7 @@ def recombine_submeshes(
     result_array = da.ma.masked_array(
         da.zeros(
             input_data.shape,
-            dtype=input_data.dtype,
+            dtype=result_dtype,
             chunks=input_data.chunksize,
         ),
         True,
@@ -314,7 +314,7 @@ def recombine_submeshes(
     result_cube.data = result_array
     # Copy names, units + attributes from region data (N.B. but not var_name)
     result_cube.metadata = result_metadata
-    if untranspose_dims:
+    if untranspose_dims is not None:
         # Re-order dims as in the original input
         result_cube.transpose(untranspose_dims)
 

--- a/lib/iris/tests/unit/experimental/ugrid/utils/__init__.py
+++ b/lib/iris/tests/unit/experimental/ugrid/utils/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :mod:`iris.experimental.ugrid.utils` package."""

--- a/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
+++ b/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
@@ -1,0 +1,149 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Unit tests for :func:`iris.experimental.ugrid.utils.recombine_regions`.
+
+"""
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+import numpy as np
+
+from iris.experimental.ugrid.utils import recombine_regions
+from iris.tests.stock.mesh import sample_mesh, sample_mesh_cube
+
+
+def common_test_setup(self):
+    n_mesh = 20
+    mesh = sample_mesh(n_nodes=20, n_edges=0, n_faces=n_mesh)
+    mesh_cube = sample_mesh_cube(n_z=2, mesh=mesh)
+    n_regions = 4  # it doesn't divide neatly
+    region_len = n_mesh // n_regions
+    i_points = np.arange(n_mesh)
+    region_inds = [
+        np.where((i_points // region_len) == i_region)
+        for i_region in range(n_regions)
+    ]
+    # Disturb slightly to ensure some gaps + some overlaps
+    region_inds = [list(indarr[0]) for indarr in region_inds]
+    region_inds[2] = region_inds[2][:-2]  # missing points
+    region_inds[3] += region_inds[1][:2]  # duplicates
+    self.mesh_cube = mesh_cube
+    self.region_inds = region_inds
+    self.region_cubes = [mesh_cube[..., inds] for inds in region_inds]
+    for i_cube, cube in enumerate(self.region_cubes):
+        cube.data[0] = i_cube + 1
+        cube.data[1] = i_cube + 1001
+
+    # Also construct an array to match the expected result.
+    # basic layer showing region allocation (large -ve values for missing)
+    expected = np.array(
+        [
+            1.0,
+            1,
+            1,
+            1,
+            1,
+            4,
+            4,
+            2,
+            2,
+            2,
+            3,
+            3,
+            3,
+            -99999,
+            -99999,  # missing points
+            4,
+            4,
+            4,
+            4,
+            4,
+        ]
+    )
+    # second layer should be same but +1000.
+    expected = np.stack([expected, expected + 1000])
+    # convert to masked array with missing points.
+    expected = np.ma.masked_less(expected, 0)
+    self.expected_result = expected
+
+
+class TestRecombine__data(tests.IrisTest):
+    def setUp(self):
+        common_test_setup(self)
+
+    def test_basic(self):
+        result = recombine_regions(
+            self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
+        )
+        self.assertMaskedArrayEqual(result.data, self.expected_result)
+
+    def test_single_region(self):
+        region = self.region_cubes[1]
+        result = recombine_regions(
+            self.mesh_cube, [region], index_coord_name="i_mesh_face"
+        )
+        # Construct a snapshot of the expected result.
+        # basic layer showing region allocation (large -ve values for missing)
+        expected = np.ma.masked_array(np.zeros(self.mesh_cube.shape), True)
+        inds = region.coord("i_mesh_face").points
+        expected[..., inds] = region.data
+        self.assertMaskedArrayEqual(result.data, expected)
+
+    def test_region_overlaps(self):
+        # generate two identical regions with different values.
+        region1 = self.region_cubes[2]
+        region1.data[:] = 101.0
+        inds = region1.coord("i_mesh_face").points
+        region2 = region1.copy()
+        region2.data[:] = 202.0
+        # check that result values all come from the second.
+        result1 = recombine_regions(
+            self.mesh_cube, [region1, region2], index_coord_name="i_mesh_face"
+        )
+        result1 = result1[..., inds].data
+        self.assertArrayEqual(result1, 202.0)
+        # swap the region order, and it should resolve the other way.
+        result2 = recombine_regions(
+            self.mesh_cube, [region2, region1], index_coord_name="i_mesh_face"
+        )
+        result2 = result2[..., inds].data
+        self.assertArrayEqual(result2, 101.0)
+
+    def test_missing_points(self):
+        # check results with and without a specific region included.
+        region2 = self.region_cubes[2]
+        inds = region2.coord("i_mesh_face").points
+        # With all regions, no points in reg1 are masked
+        result_all = recombine_regions(
+            self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
+        )
+        self.assertTrue(np.all(~result_all[..., inds].data.mask))
+        # Without region1, all points in reg1 are masked
+        regions_not2 = [
+            cube for cube in self.region_cubes if cube is not region2
+        ]
+        result_not2 = recombine_regions(
+            self.mesh_cube, regions_not2, index_coord_name="i_mesh_face"
+        )
+        self.assertTrue(np.all(result_not2[..., inds].data.mask))
+
+
+class TestRecombine__checks(tests.IrisTest):
+    def setUp(self):
+        common_test_setup(self)
+
+    def test_no_regions(self):
+        with self.assertRaisesRegex(
+            ValueError, "'region_cubes' must be non-empty"
+        ):
+            recombine_regions(self.mesh_cube, [])
+
+
+if __name__ == "__main__":
+    # Make it runnable in its own right.
+    tests.main()

--- a/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
+++ b/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
@@ -42,28 +42,12 @@ def common_test_setup(self):
     # Also construct an array to match the expected result.
     # basic layer showing region allocation (large -ve values for missing)
     expected = np.array(
-        [
-            1.0,
-            1,
-            1,
-            1,
-            1,
-            4,
-            4,
-            2,
-            2,
-            2,
-            3,
-            3,
-            3,
-            -99999,
-            -99999,  # missing points
-            4,
-            4,
-            4,
-            4,
-            4,
-        ]
+        [1.0, 1, 1, 1, 1]
+        + [4, 4]
+        + [2, 2, 2]  # points in #1 overlapped by #3
+        + [3, 3, 3]
+        + [-99999, -99999]
+        + [4, 4, 4, 4, 4]  # missing points
     )
     # second layer should be same but +1000.
     expected = np.stack([expected, expected + 1000])

--- a/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
+++ b/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_regions.py
@@ -64,6 +64,7 @@ class TestRecombine__data(tests.IrisTest):
         result = recombine_regions(
             self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
         )
+        self.assertTrue(result.has_lazy_data())
         self.assertMaskedArrayEqual(result.data, self.expected_result)
 
     def test_single_region(self):

--- a/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_submeshes.py
+++ b/lib/iris/tests/unit/experimental/ugrid/utils/test_recombine_submeshes.py
@@ -4,7 +4,7 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """
-Unit tests for :func:`iris.experimental.ugrid.utils.recombine_regions`.
+Unit tests for :func:`iris.experimental.ugrid.utils.recombine_submeshes`.
 
 """
 # Import iris.tests first so that some things can be initialised before
@@ -16,7 +16,7 @@ import numpy as np
 
 from iris.coords import AuxCoord
 from iris.cube import CubeList
-from iris.experimental.ugrid.utils import recombine_regions
+from iris.experimental.ugrid.utils import recombine_submeshes
 from iris.tests.stock.mesh import sample_mesh, sample_mesh_cube
 
 
@@ -84,7 +84,7 @@ class TestRecombine__data(tests.IrisTest):
         common_test_setup(self)
 
     def test_basic(self):
-        result = recombine_regions(
+        result = recombine_submeshes(
             self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
         )
         self.assertTrue(result.has_lazy_data())
@@ -93,7 +93,7 @@ class TestRecombine__data(tests.IrisTest):
     def test_chunking(self):
         # Make non-standard testcube with higher dimensions + specific chunking
         common_test_setup(self, shape_3d=(10, 3), data_chunks=(3, 2, -1))
-        result = recombine_regions(
+        result = recombine_submeshes(
             self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
         )
         # Check that the result chunking matches the input.
@@ -101,7 +101,7 @@ class TestRecombine__data(tests.IrisTest):
 
     def test_single_region(self):
         region = self.region_cubes[1]
-        result = recombine_regions(
+        result = recombine_submeshes(
             self.mesh_cube, [region], index_coord_name="i_mesh_face"
         )
         # Construct a snapshot of the expected result.
@@ -119,13 +119,13 @@ class TestRecombine__data(tests.IrisTest):
         region2 = region1.copy()
         region2.data[:] = 202.0
         # check that result values all come from the second.
-        result1 = recombine_regions(
+        result1 = recombine_submeshes(
             self.mesh_cube, [region1, region2], index_coord_name="i_mesh_face"
         )
         result1 = result1[..., inds].data
         self.assertArrayEqual(result1, 202.0)
         # swap the region order, and it should resolve the other way.
-        result2 = recombine_regions(
+        result2 = recombine_submeshes(
             self.mesh_cube, [region2, region1], index_coord_name="i_mesh_face"
         )
         result2 = result2[..., inds].data
@@ -136,7 +136,7 @@ class TestRecombine__data(tests.IrisTest):
         region2 = self.region_cubes[2]
         inds = region2.coord("i_mesh_face").points
         # With all regions, no points in reg1 are masked
-        result_all = recombine_regions(
+        result_all = recombine_submeshes(
             self.mesh_cube, self.region_cubes, index_coord_name="i_mesh_face"
         )
         self.assertTrue(np.all(~result_all[..., inds].data.mask))
@@ -144,7 +144,7 @@ class TestRecombine__data(tests.IrisTest):
         regions_not2 = [
             cube for cube in self.region_cubes if cube is not region2
         ]
-        result_not2 = recombine_regions(
+        result_not2 = recombine_submeshes(
             self.mesh_cube, regions_not2, index_coord_name="i_mesh_face"
         )
         self.assertTrue(np.all(result_not2[..., inds].data.mask))
@@ -156,9 +156,9 @@ class TestRecombine__checks(tests.IrisTest):
 
     def test_no_regions(self):
         with self.assertRaisesRegex(
-            ValueError, "'region_cubes' must be non-empty"
+            ValueError, "'submesh_cubes' must be non-empty"
         ):
-            recombine_regions(self.mesh_cube, [])
+            recombine_submeshes(self.mesh_cube, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First-version for "recombining" sub-mesh information.

It's worth noting that supporting location-index-sets would make this easier, as then the sub-region cubes would simply be referred to a common mesh+location, and the awkward 'special index coords' would not be required.

Without that, though, various alternative APIs are feasible + I could still be persuaded to change.
In particular, we _could_ replace 'full_mesh_cube' with 'mesh' + 'location' args -- it's effectively more logical, as we can deduce everything else from the region cubes.
So, that might be slightly neater, but more work is required .  Where elements could map both mesh and non-mesh dims, it could get complicated.

TODOs:
   - [x] tests for all the consistency checks
   - [x] tests for other features + functions
      - [x] transposed forms
      - [x] zero + multiple non-mesh (structured) dimensions
      - [x] dtypes
      - [x] mask behaviours
      - [x] NaNs
   - [x] tests for lazy behaviour
   - [ ] benchmarks showing sensible use of memory in lazy evaluation (as this is a known practical requirement)
