### PR TITLE
remove asv package dependency

### DIFF
--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -31,7 +31,6 @@ dependencies:
   - python-stratify
 
 # Test dependencies.
-  - asv
   - filelock
   - imagehash >=4.0
   - nose

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -31,7 +31,6 @@ dependencies:
   - python-stratify
 
 # Test dependencies.
-  - asv
   - filelock
   - imagehash >=4.0
   - nose

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,6 @@ docs =
     sphinxcontrib-napoleon
     sphinx-panels
 test =
-    asv
     filelock
     imagehash>=4.0
     nose


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Remove the unrequired `asv` package dependency.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
