### PR TITLE
Fix array_equal behaviour for masked arrays

### DIFF
--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -363,7 +363,8 @@ def array_equal(array1, array2, withnans=False):
 
     def normalise_array(array):
         if not is_lazy_data(array):
-            array = np.asarray(array)
+            if not ma.isMaskedArray(array):
+                array = np.asarray(array)
         return array
 
     array1, array2 = normalise_array(array1), normalise_array(array2)


### PR DESCRIPTION
Current behaviour will compare the underlying data of a masked array and will sometimes compare masked arrays as unequal when they are otherwise equal for all unmasked points. This would cause an error in an iris-esmf-regrid PR as described here:
https://github.com/SciTools-incubator/iris-esmf-regrid/pull/138#issuecomment-991099896
