### PR TITLE
Additional fix to ignore varnames in recombine input checks.

### DIFF
--- a/lib/iris/experimental/ugrid/utils.py
+++ b/lib/iris/experimental/ugrid/utils.py
@@ -176,12 +176,18 @@ def recombine_submeshes(
                         f'{sub_str} has a dim-coord "{sub_dimname}" for '
                         f"dimension {i_dim}, but 'mesh_cube' has none."
                     )
-                elif sub_coord != full_coord:
-                    err = (
-                        f'{sub_str} has a dim-coord "{sub_dimname}" for '
-                        f"dimension {i_dim}, which does not match that "
-                        f"of 'mesh_cube', \"{full_dimname}\"."
-                    )
+                else:
+                    # Use a varname-tolerant whole-coord comparison here.
+                    sub_coord = sub_coord.copy()
+                    full_coord = full_coord.copy()
+                    sub_coord.var_name = None
+                    full_coord.var_name = None
+                    if sub_coord != full_coord:
+                        err = (
+                            f'{sub_str} has a dim-coord "{sub_dimname}" for '
+                            f"dimension {i_dim}, which does not match that "
+                            f"of 'mesh_cube', \"{full_dimname}\"."
+                        )
             else:
                 # i_dim == mesh_dim :  different rules for this one
                 if not sub_coord:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Additional to #4437

Found that, when saved+ re-loaded, the 'region' cubes can fail to compare with the original 'fullmesh' cube,
due to var-names being assigned.

This hopefully fixes that.

**TODO:** add a test

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
