### PR TITLE
Update Matplotlib links

### DIFF
--- a/docs/src/userguide/plotting_a_cube.rst
+++ b/docs/src/userguide/plotting_a_cube.rst
@@ -5,10 +5,9 @@ Plotting a Cube
 ===============
 
 Iris utilises the power of Python's 
-`Matplotlib <http://matplotlib.sourceforge.net/>`_ package in order to generate 
+`Matplotlib <https://matplotlib.org/>`_ package in order to generate 
 high quality, production ready 1D and 2D plots. 
-The functionality of the Matplotlib 
-`pyplot <http://matplotlib.sourceforge.net/api/pyplot_api.html>`_ module has 
+The functionality of the Matplotlib :py:mod:`~matplotlib.pyplot` module has 
 been extended within Iris to facilitate easy visualisation of a cube's data.
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Updated a couple of Matplotlib links in the User Guide.  They were both automatically redirecting, but the `pyplot` link landed at v2.0.2 of the Matplotlib docs 😬

I'm not convinced this is big enough to warrant a whatsnew, but will add one if the reviewer disagrees.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
