### PR TITLE
rtd with latest mambaforge image for faster building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,3 @@ python:
       path: .
       extra_requirements:
         - docs
-
-formats:
-  - htmlzip
-  - pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,20 +1,24 @@
 version: 2
 
 build:
-    image: latest
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
 
 conda:
-    environment: requirements/ci/readthedocs.yml
+  environment: requirements/ci/readthedocs.yml
 
 sphinx:
-    configuration: docs/src/conf.py
-    fail_on_warning: false
+  configuration: docs/src/conf.py
+  fail_on_warning: false
 
 python:
-    install: 
-        - method: setuptools
-          path: .
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 formats:
-    - htmlzip
-    - pdf
+  - htmlzip
+  - pdf

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -200,6 +200,9 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ clarified behaviour of :func:`iris.load` in :ref:`userguide loading section
    <loading_iris_cubes>`. (:pull:`4462`)
 
+#. `@bjlittle`_ migrated readthedocs to use mambaforge for `faster documentation building`_.
+   (:pull:`4476`)
+
 
 💼 Internal
 ===========
@@ -273,3 +276,4 @@ This document explains the changes made to Iris for this release
 .. _NEP-29: https://numpy.org/neps/nep-0029-deprecation_policy.html
 .. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions/
 .. _sort-all: https://github.com/aio-libs/sort-all
+.. _faster documentation building: https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adopts the latest `mambaforge` image workflow from RTD to build our documentation, replacing our previous use of the RTD [Legacy build specification](https://docs.readthedocs.io/en/stable/config-file/v2.html#legacy-build-specification).

When using the legacy RTD specification, typically I've seen documentation builds taking between `670-730 seconds`.

Using the latest `mambaforge` image, this PR built its documentation in `454 seconds`... which is quite an improvement :rocket: 

(although, this is only a sample of one :wink:)

The built documentation associated with this PR can be viewed [here](https://bjlittle-iris.readthedocs.io/en/latest/), and the raw RTD build log can be viewed [here](https://readthedocs.org/api/v2/build/15679017.txt).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
