### PR TITLE
address np printoptions pre/post v1.22

### DIFF
--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1059,13 +1059,14 @@ def format_array(arr):
     ffunc = str
     max_line_len = 50
 
-    formatArray = np.core.arrayprint._formatArray
-    format_options = np.core.arrayprint._format_options
+    # Format the array with version 1.13 legacy behaviour
+    with np.printoptions(legacy="1.13"):
+        # Use this (private) routine for more control.
+        formatArray = np.core.arrayprint._formatArray
+        # N.B. the 'legacy' arg had different forms in different numpy versions
+        # -- fetch the required form from the internal options dict
+        legacy_key = np.core.arrayprint._format_options["legacy"]
 
-    options = np.get_printoptions()
-    options["legacy"] = "1.13"
-
-    with np.printoptions(**options):
         result = formatArray(
             arr,
             ffunc,
@@ -1074,7 +1075,7 @@ def format_array(arr):
             separator=", ",
             edge_items=edge_items,
             summary_insert=summary_insert,
-            legacy=format_options["legacy"],
+            legacy=legacy_key,
         )
 
     return result

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1065,7 +1065,7 @@ def format_array(arr):
         formatArray = np.core.arrayprint._formatArray
         # N.B. the 'legacy' arg had different forms in different numpy versions
         # -- fetch the required form from the internal options dict
-        legacy_key = np.core.arrayprint._format_options["legacy"]
+        format_options_legacy = np.core.arrayprint._format_options["legacy"]
 
         result = formatArray(
             arr,
@@ -1075,7 +1075,7 @@ def format_array(arr):
             separator=", ",
             edge_items=edge_items,
             summary_insert=summary_insert,
-            legacy=legacy_key,
+            legacy=format_options_legacy,
         )
 
     return result

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -10,7 +10,6 @@ Miscellaneous utility functions.
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Hashable, Iterable
-from contextlib import contextmanager
 import copy
 import functools
 import inspect
@@ -1054,18 +1053,19 @@ def format_array(arr):
 
     """
 
-    summary_insert = ""
     summary_threshold = 85
+    summary_insert = "..." if arr.size > summary_threshold else ""
     edge_items = 3
     ffunc = str
-    formatArray = np.core.arrayprint._formatArray
     max_line_len = 50
-    legacy = "1.13"
-    if arr.size > summary_threshold:
-        summary_insert = "..."
+
+    formatArray = np.core.arrayprint._formatArray
+    format_options = np.core.arrayprint._format_options
+
     options = np.get_printoptions()
-    options["legacy"] = legacy
-    with _printopts_context(**options):
+    options["legacy"] = "1.13"
+
+    with np.printoptions(**options):
         result = formatArray(
             arr,
             ffunc,
@@ -1074,27 +1074,10 @@ def format_array(arr):
             separator=", ",
             edge_items=edge_items,
             summary_insert=summary_insert,
-            legacy=legacy,
+            legacy=format_options["legacy"],
         )
 
     return result
-
-
-@contextmanager
-def _printopts_context(**kwargs):
-    """
-    Update the numpy printoptions for the life of this context manager.
-
-    Note: this function can be removed with numpy>=1.15 thanks to
-          https://github.com/numpy/numpy/pull/10406
-
-    """
-    original_opts = np.get_printoptions()
-    np.set_printoptions(**kwargs)
-    try:
-        yield
-    finally:
-        np.set_printoptions(**original_opts)
 
 
 def new_axis(src_cube, scalar_coord=None):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR addresses the test failures within #4480 when updating to the latest `numpy` v1.22.0.

We've now dropped support within `iris` for `py37` (#4481) but we still require to support `numpy` >= v1.19 ([NEP29 Support Table](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table)). However https://github.com/numpy/numpy/pull/19686 introduced a change that impacts `iris.util.format_array` due to our use of the internal `numpy.core.arrayprint._formatArray` function.

This PR maintains our continuing `numpy` v1.13 legacy array printing format for `py38` and `numpy` >= 1.19.

As a separate concern, it would be wise to commit to addressing #3048, by _at least_ bumping to the more recent `numpy` v1.21 legacy array printing.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
