### PR TITLE
GeogCS.as_cartopy_projection handling non-Earth planets

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -150,7 +150,7 @@ This document explains the changes made to Iris for this release
    (:issue:`4460 `, :pull:`4470`)
 
 #. `@wjbenfold`_ stopped :meth:`iris.coord_systems.GeogCS.as_cartopy_projection`
-   from assuming the globe to be the earth (:issue:`4408`, :pull:`4497`)
+   from assuming the globe to be the Earth (:issue:`4408`, :pull:`4497`)
 
 
 💣 Incompatible Changes

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -149,6 +149,9 @@ This document explains the changes made to Iris for this release
    instead of one latitude and one longitude.
    (:issue:`4460 `, :pull:`4470`)
 
+#. `@wjbenfold`_ stopped :meth:`iris.coord_systems.GeogCS.as_cartopy_projection`
+   from assuming the globe to be the earth (:issue:`4408`, :pull:`4497`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -297,7 +297,10 @@ class GeogCS(CoordSystem):
         return ccrs.Geodetic(self.as_cartopy_globe())
 
     def as_cartopy_projection(self):
-        return ccrs.PlateCarree()
+        return ccrs.PlateCarree(
+            central_longitude=self.longitude_of_prime_meridian,
+            globe=self.as_cartopy_globe(),
+        )
 
     def as_cartopy_globe(self):
         # Explicitly set `ellipse` to None as a workaround for

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -188,6 +188,23 @@ class Test_GeogCS_as_cartopy_globe(tests.IrisTest):
         self.assertEqual(res, expected)
 
 
+class Test_GeogCS_as_cartopy_projection(tests.IrisTest):
+    def test_as_cartopy_projection(self):
+        geogcs_args = {
+            "semi_major_axis": 6543210,
+            "semi_minor_axis": 6500000,
+            "longitude_of_prime_meridian": 30,
+        }
+        cs = GeogCS(**geogcs_args)
+        cs_projection = cs.as_cartopy_projection()
+        res = {
+            "semi_major_axis": cs_projection.globe.semimajor_axis,
+            "semi_minor_axis": cs_projection.globe.semiminor_axis,
+            "longitude_of_prime_meridian": cs_projection.prime_meridian.longitude,
+        }
+        self.assertEqual(res, geogcs_args)
+
+
 class Test_GeogCS_as_cartopy_crs(tests.IrisTest):
     def test_as_cartopy_crs(self):
         cs = GeogCS(6543210, 6500000)

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -196,14 +196,19 @@ class Test_GeogCS_as_cartopy_projection(tests.IrisTest):
             "longitude_of_prime_meridian": 30,
         }
         cs = GeogCS(**geogcs_args)
-        cs_projection = cs.as_cartopy_projection()
-        exps = [
-            f"a={geogcs_args['semi_major_axis']}",
-            f"b={geogcs_args['semi_minor_axis']}",
-            f"lon_0={geogcs_args['longitude_of_prime_meridian']}",
-        ]
-        for exp in exps:
-            self.assertTrue(exp in cs_projection.srs)
+        res = cs.as_cartopy_projection()
+
+        globe = ccrs.Globe(
+            semimajor_axis=geogcs_args["semi_major_axis"],
+            semiminor_axis=geogcs_args["semi_minor_axis"],
+            ellipse=None,
+        )
+        expected = ccrs.PlateCarree(
+            globe=globe,
+            central_longitude=geogcs_args["longitude_of_prime_meridian"],
+        )
+
+        self.assertEqual(res, expected)
 
 
 class Test_GeogCS_as_cartopy_crs(tests.IrisTest):

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -197,12 +197,13 @@ class Test_GeogCS_as_cartopy_projection(tests.IrisTest):
         }
         cs = GeogCS(**geogcs_args)
         cs_projection = cs.as_cartopy_projection()
-        res = {
-            "semi_major_axis": cs_projection.globe.semimajor_axis,
-            "semi_minor_axis": cs_projection.globe.semiminor_axis,
-            "longitude_of_prime_meridian": cs_projection.prime_meridian.longitude,
-        }
-        self.assertEqual(res, geogcs_args)
+        exps = [
+            f"a={geogcs_args['semi_major_axis']}",
+            f"b={geogcs_args['semi_minor_axis']}",
+            f"lon_0={geogcs_args['longitude_of_prime_meridian']}",
+        ]
+        for exp in exps:
+            self.assertTrue(exp in cs_projection.srs)
 
 
 class Test_GeogCS_as_cartopy_crs(tests.IrisTest):

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -213,7 +213,7 @@ class TestBoundedCube(tests.GraphicsTest):
         self.assertEqual(
             iplt.default_projection(self.cube),
             ccrs.PlateCarree(
-                self.cube.coord_system("CoordSystem").as_cartopy_globe()
+                globe=self.cube.coord_system("CoordSystem").as_cartopy_globe()
             ),
         )
         np_testing.assert_array_almost_equal(

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -211,7 +211,10 @@ class TestBoundedCube(tests.GraphicsTest):
 
     def test_default_projection_and_extent(self):
         self.assertEqual(
-            iplt.default_projection(self.cube), ccrs.PlateCarree()
+            iplt.default_projection(self.cube),
+            ccrs.PlateCarree(
+                self.cube.coord_system("CoordSystem").as_cartopy_globe()
+            ),
         )
         np_testing.assert_array_almost_equal(
             iplt.default_projection_extent(self.cube),

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -52,7 +52,7 @@ class TestAll(tests.IrisTest):
             1,
         )
 
-        self.tcs = iris.coord_systems.GeogCS(6000000)
+        self.tcs = iris.coord_systems.GeogCS(6371229)
 
     def test_is_iris_coord_system(self):
         res, _ = project(self.cube, self.tcs)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #4408 by passing the `GeogCS` as a globe to the `cartopy.crs.PlateCarree` constructor

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
