### PR TITLE
Turn off documentation type hints

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -209,6 +209,7 @@ todo_include_todos = True
 # api generation configuration
 autodoc_member_order = "groupwise"
 autodoc_default_flags = ["show-inheritance"]
+autodoc_typehints = "none"
 autosummary_generate = True
 autosummary_imported_members = True
 autopackage_name = ["iris"]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
From https://github.com/SciTools/iris/discussions/4383#discussioncomment-1917571 and replies, there seems to be a consensus that we don't want to display type annotations in the docs.  There are not many examples in Iris so far, but for [recombine_submeshes](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/experimental/ugrid/utils.html#iris.experimental.ugrid.utils.recombine_submeshes) this PR turns

![with_type_hint](https://user-images.githubusercontent.com/10599679/149970082-bc6f0db8-aeb7-42f8-94dd-344c65922fc1.png)
 into
![without_type_hint](https://user-images.githubusercontent.com/10599679/149970342-293c4475-ee8f-4462-aa8f-c580649b1a51.png)



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
