### PR TITLE
docs: fix whatnew entries

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -146,12 +146,12 @@ This document explains the changes made to Iris for this release
 
 #. `@wjbenfold`_ changed how a delayed unit conversion is performed on a cube
    so that a cube with lazy data awaiting a unit conversion can be pickled.
-   (:issue:`4354 `, :pull:`4377`)
+   (:issue:`4354`, :pull:`4377`)
 
 #. `@pp-mo`_ fixed a bug in netcdf loading, whereby *any* rotated latlon coordinate
    was mistakenly interpreted as a latitude, usually resulting in two 'latitude's
    instead of one latitude and one longitude.
-   (:issue:`4460 `, :pull:`4470`)
+   (:issue:`4460`, :pull:`4470`)
 
 
 💣 Incompatible Changes


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR introduces a minor fix to remove additional spacing that's causing `whatsnew` `:issue:` directives to not render correctly.

i.e., fixes the following
![image](https://user-images.githubusercontent.com/2051656/150129870-ee7cf71c-6223-4bc3-9fca-27055d54f992.png)


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
