### PR TITLE
Deprecate abf and dot

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -195,6 +195,11 @@ This document explains the changes made to Iris for this release
    believed to still be in use. The deprecation warnings invite users to contact
    the Iris Developers if this isn't the case. (:pull:`4525`)
 
+#. `@wjbenfold`_ deprecated :mod:`iris.fileformats.abf` and
+   :mod:`iris.fileformats.dot` as they are not believed to still be in use. The
+   deprecation warnings invite users to contact the Iris Developers if this
+   isn't the case. (:pull:`4515`)
+
 
 🔗 Dependencies
 ===============

--- a/lib/iris/fileformats/__init__.py
+++ b/lib/iris/fileformats/__init__.py
@@ -17,7 +17,7 @@ from iris.io.format_picker import (
     UriProtocol,
 )
 
-from . import abf, name, netcdf, nimrod, pp, um
+from . import name, netcdf, nimrod, pp, um
 
 __all__ = ["FORMAT_AGENT"]
 
@@ -224,16 +224,23 @@ FORMAT_AGENT.add_spec(
 
 #
 # ABF/ABL
+# TODO: now deprecated, remove later
 #
+def load_cubes_abf_abl(*args, **kwargs):
+    from . import abf
+
+    return abf.load_cubes(*args, **kwargs)
+
+
 FORMAT_AGENT.add_spec(
     FormatSpecification(
-        "ABF", FileExtension(), ".abf", abf.load_cubes, priority=3
+        "ABF", FileExtension(), ".abf", load_cubes_abf_abl, priority=3
     )
 )
 
 
 FORMAT_AGENT.add_spec(
     FormatSpecification(
-        "ABL", FileExtension(), ".abl", abf.load_cubes, priority=3
+        "ABL", FileExtension(), ".abl", load_cubes_abf_abl, priority=3
     )
 )

--- a/lib/iris/fileformats/abf.py
+++ b/lib/iris/fileformats/abf.py
@@ -23,10 +23,19 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
+from iris._deprecation import warn_deprecated
 from iris.coord_systems import GeogCS
 from iris.coords import AuxCoord, DimCoord
 import iris.fileformats
 import iris.io.format_picker
+
+wmsg = (
+    "iris.fileformats.abf has been deprecated and will be removed in a "
+    "future release. If you make use of this functionality, please contact "
+    "the Iris Developers to discuss how to retain it (which may involve "
+    "reversing the deprecation)."
+)
+warn_deprecated(wmsg)
 
 X_SIZE = 4320
 Y_SIZE = 2160

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -12,7 +12,16 @@ import os
 import subprocess
 
 import iris
+from iris._deprecation import warn_deprecated
 import iris.util
+
+wmsg = (
+    "iris.fileformats.dot has been deprecated and will be removed in a "
+    "future release. If you make use of this functionality, please contact "
+    "the Iris Developers to discuss how to retain it (which may involve "
+    "reversing the deprecation)."
+)
+warn_deprecated(wmsg)
 
 _GRAPH_INDENT = " " * 4
 _SUBGRAPH_INDENT = " " * 8


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
See #4394 

To do:
- [x] Work out whether this is the right way to deprecate a module - the warning for abf at least currently shows up on import of fileformats, which we may want to avoid. Not sure where to put it instead though - in every function?
- [x] Check wording of message and consider mentioning future mitigations (undo deprecation, use plugin architecture?)
- [x] Fix doctest that's failing due to the deprecation warnings

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
