### PR TITLE
Correct long_name for STASH 9215

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -172,6 +172,10 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ stopped :meth:`iris.coord_systems.GeogCS.as_cartopy_projection`
    from assuming the globe to be the Earth (:issue:`4408`, :pull:`4497`)
 
+#. `@rcomer`_ corrected the ``long_name`` mapping from UM stash code ``m01s09i215``
+   to indicate cloud fraction greater than 7.9 oktas, rather than 7.5 
+   (:issue:`3305`, :pull:`4535`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -681,7 +681,7 @@ STASH_TO_CF = {
     'm01s09i212': CFName(None, 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_4p5_oktas', 'kft'),
     'm01s09i213': CFName(None, 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_5p5_oktas', 'kft'),
     'm01s09i214': CFName(None, 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_6p5_oktas', 'kft'),
-    'm01s09i215': CFName(None, 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_7p5_oktas', 'kft'),
+    'm01s09i215': CFName(None, 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_7p9_oktas', 'kft'),
     'm01s09i216': CFName(None, 'cloud_area_fraction_assuming_random_overlap', '1'),
     'm01s09i217': CFName(None, 'cloud_area_fraction_assuming_maximum_random_overlap', '1'),
     'm01s09i218': CFName(None, 'cloud_area_fraction_assuming_only_consider_surface_to_1000_feet_asl', '1'),


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #3305.  The relevant lines of the [UM STASHmaster metadata file](https://code.metoffice.gov.uk/trac/um/browser/main/trunk/rose-meta/um-atmos/HEAD/etc/stash/STASHmaster/STASHmaster-meta.conf) read:

```
[stashmaster:code(9215)]
description=CLOUD BASE ASL COVER.GT.7.9 OCTA KFT
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
