### PR TITLE
docs: remove duplicate first contributor entry

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -27,9 +27,9 @@ This document explains the changes made to Iris for this release
 📢 Announcements
 ================
 
-#. Welcome to `@wjbenfold`_, `@tinyendian`_, `@larsbarring`_, `@akuhnregnier`_,
-   `@bsherratt`_ and `@aaronspring`_ who made their first contributions to Iris.
-   The first of many we hope!
+#. Welcome to `@wjbenfold`_, `@tinyendian`_, `@larsbarring`_, `@bsherratt`_ and
+   `@aaronspring`_ who made their first contributions to Iris. The first of
+   many we hope!
 #. Congratulations to `@wjbenfold`_ who has become a core developer for Iris! 🎉
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR removes a duplicate entry for a first time contributor, who'd actually contributed for the first time in `iris` 3.1


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
