### PR TITLE
docs: fix docs/conf.py plot_gallery warning

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -329,8 +329,10 @@ sphinx_gallery_conf = {
     "gallery_dirs": ["generated/gallery"],
     # filename pattern for the files in the gallery
     "filename_pattern": "/plot_",
-    # filename patternt to ignore in the gallery
+    # filename pattern to ignore in the gallery
     "ignore_pattern": r"__init__\.py",
+    # force gallery building, unless overridden (see src/Makefile)
+    "plot_gallery": "'True'",
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR resolves the following warning which is raised when building the documentation with `html-noplot` or `html-quick`
![image](https://user-images.githubusercontent.com/2051656/151198345-595be102-c9d5-4631-aa35-d37c2ea3797b.png)

Also see:
- https://github.com/sphinx-gallery/sphinx-gallery/issues/302
- https://github.com/sphinx-gallery/sphinx-gallery/pull/304

Note that, the `plot_gallery=0` directive to `make` within the `docs/src/Makefile` ensures that the documentation gallery is not built.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
