### PR TITLE
Add deprecation on routine usage.

### DIFF
--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -24,10 +24,10 @@ from iris._deprecation import warn_deprecated
 import iris.coord_systems
 
 wmsg = (
-    "iris.experimental.raster has been deprecated and will be removed in a "
-    "future release. If you make use of this functionality, please contact "
-    "the Iris Developers to discuss how to retain it (which may involve "
-    "reversing the deprecation)."
+    "iris.experimental.raster is deprecated since version 3.2, and will be "
+    "removed in a future release. If you make use of this functionality, "
+    "please contact the Iris Developers to discuss how to retain it (which may "
+    "involve reversing the deprecation)."
 )
 warn_deprecated(wmsg)
 
@@ -105,6 +105,14 @@ def export_geotiff(cube, fname):
     """
     Writes cube data to raster file format as a PixelIsArea GeoTiff image.
 
+    .. deprecated:: 3.2.0
+
+        This method is scheduled to be removed in a future release, and no
+        replacement is currently planned.
+        If you make use of this functionality, please contact the Iris
+        Developers to discuss how to retain it (which could include reversing
+        the deprecation).
+
     Args:
         * cube (Cube): The 2D regularly gridded cube slice to be exported.
                        The cube must have regular, contiguous bounds.
@@ -116,6 +124,13 @@ def export_geotiff(cube, fname):
         http://www.remotesensing.org/geotiff/spec/geotiff2.5.html#2.5.2.2
 
     """
+    wmsg = (
+        "iris.experimental.raster.export_geotiff has been deprecated, and will "
+        "be removed in a future release.  Please consult the docstring for "
+        "details."
+    )
+    warn_deprecated(wmsg)
+
     if cube.ndim != 2:
         raise ValueError("The cube must be two dimensional.")
 


### PR DESCRIPTION
While working on deprecations for 'iris.experimental.regrid', I happened to revisit this + concluded that it really should provide a runtime message when you call the routine, so I added one.
A slight escalation of the plan, but I think is worth it.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
