### PR TITLE
Update #4504 doctests for #4528

### DIFF
--- a/docs/src/further_topics/ugrid/operations.rst
+++ b/docs/src/further_topics/ugrid/operations.rst
@@ -393,7 +393,7 @@ etcetera:
                 latitude                        x          -
                 longitude                       x          -
             Attributes:
-                Conventions                 CF-1.7
+                Conventions                 'CF-1.7'
 
 .. note::
 
@@ -495,7 +495,7 @@ earlier:
                 latitude                        x          -
                 longitude                       x          -
             Attributes:
-                Conventions                 CF-1.7
+                Conventions                 'CF-1.7'
 
         # Convert our mesh+data to a PolyData object.
         # Just plotting a single height level.
@@ -827,7 +827,7 @@ with the
                 latitude                             x               -
                 longitude                            -               x
             Attributes:
-                Conventions                 CF-1.7
+                Conventions                 'CF-1.7'
 
         # Initialise the regridder.
         >>> rg = MeshToGridESMFRegridder(mesh_cube1, sample_grid)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Fix to make some doctests introduced by the UGRID docs (#4504) compliant with the latest `attributes` printout in `Cube` summaries (#4528) (the attributes change was made between the last update to the UGRID docs branch and the time when it was merged, so this only got caught by the post-merge CI).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
