### PR TITLE
update trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Operating System :: Unix
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR includes a minor update to the PyPI Trove classifiers to drop our reference to `py37`. This should be corrected for the `v3.2.0` release.

Note that this PR is targeting the `v3.2.x` release feature branch, so once merged this change will appear in `main` on merge-back.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
