### PR TITLE
Fix refresh lockfile worrkflow pull request title

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -116,7 +116,7 @@ jobs:
           author: "Lockfile bot <noreply@github.com>"
           delete-branch: true
           branch: auto-update-lockfiles
-          title: [iris.ci] environment lockfiles auto-update
+          title: "[iris.ci] environment lockfiles auto-update"
           body: |
             Lockfiles updated to the latest resolvable environment.
           labels: |


### PR DESCRIPTION
## 🚀 Pull Request

### Description
I merged #4578 but when I check the action it was complaining that there was an error in the file: https://github.com/SciTools/iris/actions/runs/1824096068/workflow

It looks like gha didn't like the pull request title containing square brackets (unfortunately I didn't test this when I was testing it previously!) 

A solution is to put the title in quotes


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
