### PR TITLE
Fix load_http bug, extend testing, and note to docs

### DIFF
--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -177,6 +177,9 @@ This document explains the changes made to Iris for this release
    to indicate cloud fraction greater than 7.9 oktas, rather than 7.5 
    (:issue:`3305`, :pull:`4535`)
 
+#. `@lbdreyer`_ fixed a bug in `iris.io.load_http` which was missing an import
+   (:pull:`4580`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -177,7 +177,7 @@ This document explains the changes made to Iris for this release
    to indicate cloud fraction greater than 7.9 oktas, rather than 7.5 
    (:issue:`3305`, :pull:`4535`)
 
-#. `@lbdreyer`_ fixed a bug in `iris.io.load_http` which was missing an import
+#. `@lbdreyer`_ fixed a bug in :class:`iris.io.load_http` which was missing an import
    (:pull:`4580`)
 
 

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -44,6 +44,8 @@ All the load functions share very similar arguments:
         standard library function :func:`os.path.expanduser` and
         module :mod:`fnmatch` for more details.
 
+        If supplying a URL, only OPeNDAP Data Sources are supported.
+
     * constraints:
         Either a single constraint, or an iterable of constraints.
         Each constraint can be either a string, an instance of
@@ -287,6 +289,7 @@ def load(uris, constraints=None, callback=None):
 
     * uris:
         One or more filenames/URIs, as a string or :class:`pathlib.PurePath`.
+        If supplying a URL, only OPeNDAP Data Sources are supported.
 
     Kwargs:
 
@@ -315,6 +318,7 @@ def load_cube(uris, constraint=None, callback=None):
 
     * uris:
         One or more filenames/URIs, as a string or :class:`pathlib.PurePath`.
+        If supplying a URL, only OPeNDAP Data Sources are supported.
 
     Kwargs:
 
@@ -354,6 +358,7 @@ def load_cubes(uris, constraints=None, callback=None):
 
     * uris:
         One or more filenames/URIs, as a string or :class:`pathlib.PurePath`.
+        If supplying a URL, only OPeNDAP Data Sources are supported.
 
     Kwargs:
 
@@ -399,6 +404,7 @@ def load_raw(uris, constraints=None, callback=None):
 
     * uris:
         One or more filenames/URIs, as a string or :class:`pathlib.PurePath`.
+        If supplying a URL, only OPeNDAP Data Sources are supported.
 
     Kwargs:
 

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -44,7 +44,9 @@ All the load functions share very similar arguments:
         standard library function :func:`os.path.expanduser` and
         module :mod:`fnmatch` for more details.
 
-        If supplying a URL, only OPeNDAP Data Sources are supported.
+        .. warning::
+
+            If supplying a URL, only OPeNDAP Data Sources are supported.
 
     * constraints:
         Either a single constraint, or an iterable of constraints.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -825,12 +825,12 @@ def _translate_constraints_to_var_callback(constraints):
 
 def load_cubes(filenames, callback=None, constraints=None):
     """
-    Loads cubes from a list of NetCDF filenames/URLs.
+    Loads cubes from a list of NetCDF filenames/OPeNDAP URLs.
 
     Args:
 
     * filenames (string/list):
-        One or more NetCDF filenames/DAP URLs to load from.
+        One or more NetCDF filenames/OPeNDAP URLs to load from.
 
     Kwargs:
 

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -216,7 +216,7 @@ def load_files(filenames, callback, constraints=None):
 
 def load_http(urls, callback):
     """
-    Takes a list of urls and a callback function, and returns a generator
+    Takes a list of OPeNDAP URLs and a callback function, and returns a generator
     of Cubes from the given URLs.
 
     .. note::
@@ -226,11 +226,11 @@ def load_http(urls, callback):
 
     """
     # Create default dict mapping iris format handler to its associated filenames
+    from iris.fileformats import FORMAT_AGENT
+
     handler_map = collections.defaultdict(list)
     for url in urls:
-        handling_format_spec = iris.fileformats.FORMAT_AGENT.get_spec(
-            url, None
-        )
+        handling_format_spec = FORMAT_AGENT.get_spec(url, None)
         handler_map[handling_format_spec].append(url)
 
     # Call each iris format handler with the appropriate filenames

--- a/lib/iris/tests/test_load.py
+++ b/lib/iris/tests/test_load.py
@@ -12,6 +12,9 @@ Test the main loading API.
 import iris.tests as tests  # isort:skip
 
 import pathlib
+from unittest import mock
+
+import netCDF4
 
 import iris
 import iris.io
@@ -148,19 +151,20 @@ class TestLoadRaw(tests.IrisTest):
         self.assertEqual(len(cubes), 1)
 
 
-class TestOpenDAP(tests.IrisTest):
-    def test_load(self):
-        # Check that calling iris.load_* with a http URI triggers a call to
-        # ``iris.io.load_http``
+class TestOPeNDAP(tests.IrisTest):
+    def setUp(self):
+        self.url = "http://geoport.whoi.edu:80/thredds/dodsC/bathy/gom15"
 
-        url = "http://geoport.whoi.edu:80/thredds/dodsC/bathy/gom15"
+    def test_load_http_called(self):
+        # Check that calling iris.load_* with an http URI triggers a call to
+        # ``iris.io.load_http``
 
         class LoadHTTPCalled(Exception):
             pass
 
         def new_load_http(passed_urls, *args, **kwargs):
             self.assertEqual(len(passed_urls), 1)
-            self.assertEqual(url, passed_urls[0])
+            self.assertEqual(self.url, passed_urls[0])
             raise LoadHTTPCalled()
 
         try:
@@ -174,10 +178,27 @@ class TestOpenDAP(tests.IrisTest):
                 iris.load_cubes,
             ]:
                 with self.assertRaises(LoadHTTPCalled):
-                    fn(url)
+                    fn(self.url)
 
         finally:
             iris.io.load_http = orig
+
+    def test_netCDF_Dataset_call(self):
+        # Check that load_http calls netCDF4.Dataset and supplies the expected URL.
+
+        # To avoid making a request to an OPeNDAP server in a test, instead
+        # mock the call to netCDF.Dataset so that it returns a dataset for a
+        # local file.
+        filename = tests.get_data_path(
+            ("NetCDF", "global", "xyt", "SMALL_total_column_co2.nc")
+        )
+        fake_dataset = netCDF4.Dataset(filename)
+
+        with mock.patch(
+            "netCDF4.Dataset", return_value=fake_dataset
+        ) as dataset_loader:
+            next(iris.io.load_http([self.url], callback=None))
+        dataset_loader.assert_called_with(self.url, mode="r")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This addresses two issues relating to loading files via OPeNDAP

**Fix iris.io.load_http and add extra testing**
It looks like `iris.io.load_http` broke in Iris 3.1 when we moved imports around. I have added the import (`from iris.fileformats import FORMAT_AGENT`)
Unfortunately a lack of testing meant we didn't catch it! Currently, the only OPeNDAP related testing we have is:
* we test load/load_cube/load_cubes/load_raw call iris.io.load_http
* we check that the format_picker selects the correct FormatSpecification ('NetCDF OPeNDAP'). 

You can see these two tests in [this commit](https://github.com/SciTools/iris/pull/422/commits/f1a9f0603c4b283921e99f1bec381c40bc570af1).
Testing with http files is quite difficult as we don't want to be tied to trying to access an OPeNDAP server which may go down! I have proposed a testing strategy which is a bit hacky but at least will test all operation Iris performs before it call the netCDF library (which is all we really need to test)

**Add documentation**
A user raised the issue that someone could quite reasonably read the documentation, see Iris.load takes a URI and supply it with a non-OPeNDAP URL. I have added clarification to say we only support OPeNDAP URLS.
The trouble with this is that the restriction of OPeNDAP is due to NetCDF (since we just pass the URL onto NetCDF) so if NetCDF were to start support something else, our documentation may be out of date. Should we be concerned about this?


Would be nice to get this into Iris 3.2 before the release if possible?
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
