### PR TITLE
Stop using nc_time_axis.CalendarDateTime

### DIFF
--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -61,7 +61,9 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@rcomer`_ introduced the ``nc-time-axis >=1.4`` minimum pin, reflecting that
+   we no longer use the deprecated :class:`nc_time_axis.CalendarDateTime`
+   when plotting against time coordinates. (:pull:`4584`)
 
 
 📚 Documentation

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -591,7 +591,7 @@ def _fixup_dates(coord, values):
             r = [datetime.datetime(*date) for date in dates]
         else:
             try:
-                import nc_time_axis
+                import nc_time_axis  # noqa: F401
             except ImportError:
                 msg = (
                     "Cannot plot against time in a non-gregorian "
@@ -603,12 +603,10 @@ def _fixup_dates(coord, values):
                 raise IrisError(msg)
 
             r = [
-                nc_time_axis.CalendarDateTime(
-                    cftime.datetime(*date, calendar=coord.units.calendar),
-                    coord.units.calendar,
-                )
+                cftime.datetime(*date, calendar=coord.units.calendar)
                 for date in dates
             ]
+
         values = np.empty(len(r), dtype=object)
         values[:] = r
     return values

--- a/lib/iris/tests/integration/plot/test_netcdftime.py
+++ b/lib/iris/tests/integration/plot/test_netcdftime.py
@@ -18,10 +18,6 @@ import numpy as np
 
 from iris.coords import AuxCoord
 
-if tests.NC_TIME_AXIS_AVAILABLE:
-    from nc_time_axis import CalendarDateTime
-
-
 # Run tests in no graphics mode if matplotlib is not available.
 if tests.MPL_AVAILABLE:
     import iris.plot as iplt
@@ -48,9 +44,8 @@ class Test(tests.GraphicsTest):
             )
             for atime in times
         ]
-        expected_ydata = np.array(
-            [CalendarDateTime(time, calendar) for time in times]
-        )
+
+        expected_ydata = times
         (line1,) = iplt.plot(time_coord)
         result_ydata = line1.get_ydata()
         self.assertArrayEqual(expected_ydata, result_ydata)

--- a/lib/iris/tests/unit/plot/test__fixup_dates.py
+++ b/lib/iris/tests/unit/plot/test__fixup_dates.py
@@ -23,6 +23,7 @@ class Test(tests.IrisTest):
         unit = Unit("hours since 2000-04-13 00:00:00", calendar="gregorian")
         coord = AuxCoord([1, 3, 6], "time", units=unit)
         result = _fixup_dates(coord, coord.points)
+        self.assertIsInstance(result[0], datetime.datetime)
         expected = [
             datetime.datetime(2000, 4, 13, 1),
             datetime.datetime(2000, 4, 13, 3),
@@ -34,6 +35,7 @@ class Test(tests.IrisTest):
         unit = Unit("seconds since 2000-04-13 00:00:00", calendar="gregorian")
         coord = AuxCoord([1, 1.25, 1.5], "time", units=unit)
         result = _fixup_dates(coord, coord.points)
+        self.assertIsInstance(result[0], datetime.datetime)
         expected = [
             datetime.datetime(2000, 4, 13, 0, 0, 1),
             datetime.datetime(2000, 4, 13, 0, 0, 1),

--- a/lib/iris/tests/unit/plot/test__fixup_dates.py
+++ b/lib/iris/tests/unit/plot/test__fixup_dates.py
@@ -52,9 +52,7 @@ class Test(tests.IrisTest):
             cftime.datetime(2000, 2, 29, calendar=calendar),
             cftime.datetime(2000, 2, 30, calendar=calendar),
         ]
-        self.assertArrayEqual(
-            [cdt.datetime for cdt in result], expected_datetimes
-        )
+        self.assertArrayEqual(result, expected_datetimes)
 
     @tests.skip_nc_time_axis
     def test_365_day_calendar(self):
@@ -67,9 +65,7 @@ class Test(tests.IrisTest):
             cftime.datetime(2000, 2, 25, 1, 0, calendar=calendar),
             cftime.datetime(2000, 2, 25, 2, 30, calendar=calendar),
         ]
-        self.assertArrayEqual(
-            [cdt.datetime for cdt in result], expected_datetimes
-        )
+        self.assertArrayEqual(result, expected_datetimes)
 
     @tests.skip_nc_time_axis
     def test_360_day_calendar_attribute(self):

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -25,7 +25,7 @@ dependencies:
   - graphviz
   - iris-sample-data >=2.4.0
   - mo_pack
-  - nc-time-axis >=1.3
+  - nc-time-axis >=1.4
   - pandas
   - pip
   - python-stratify

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ test =
     requests
 all =
     mo_pack
-    nc-time-axis>=1.3
+    nc-time-axis>=1.4
     pandas
     stratify
     %(docs)s


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
`nc_time_axis.CalendarDateTime` was deprecated at v1.4 of `nc-time-axis` and we are encouraged to pass the `cftime` objects directly, which is nicer.  Fixes the easy part of #4574.

References
https://github.com/SciTools/nc-time-axis/pull/80 new plotting functionality introduced.
https://github.com/SciTools/nc-time-axis/pull/86 `CalendarDateTime`s deprecated.

I will add a whatsnew when I know that merge is imminent.  Or in a separate PR if the reviewer prefers.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
