### PR TITLE
Weighted `aggregated_by`

### DIFF
--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -63,6 +63,7 @@
 .. _@QuLogic: https://github.com/QuLogic
 .. _@rcomer: https://github.com/rcomer
 .. _@rhattersley: https://github.com/rhattersley
+.. _@schlunma: https://github.com/schlunma
 .. _@stephenworsley: https://github.com/stephenworsley
 .. _@tkknight: https://github.com/tkknight
 .. _@trexfeathers: https://github.com/trexfeathers

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -31,6 +31,11 @@ This document explains the changes made to Iris for this release
 ✨ Features
 ===========
 
+#. `@schlunma`_ added weighted aggregation over "group coordinates":
+   :meth:`~iris.cube.Cube.aggregated_by` now accepts the keyword `weights` if a
+   :class:`~iris.analysis.WeightedAggregator` is used. (:issue:`4581`,
+   :pull:`4589`)
+
 #. `@wjbenfold`_ added support for ``false_easting`` and ``false_northing`` to
    :class:`~iris.coord_system.Mercator`. (:issue:`3107`, :pull:`4524`)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3831,21 +3831,6 @@ class Cube(CFVariableMixin):
         )
         return result
 
-    @staticmethod
-    def _get_aggregator_fn(aggregator_fn, axis, **kwargs):
-        """Return aggregator function that can handle weights."""
-        kwargs_copy = dict(kwargs)
-        kwargs_copy.pop("weights", None)
-        aggregator_fn = partial(aggregator_fn, axis=axis, **kwargs_copy)
-
-        def new_aggregator_fn(data_arr, weights):
-            """Weighted aggregation."""
-            if weights is None:
-                return aggregator_fn(data_arr)
-            return aggregator_fn(data_arr, weights=weights)
-
-        return new_aggregator_fn
-
     def aggregated_by(self, coords, aggregator, **kwargs):
         """
         Perform aggregation over the cube given one or more "group
@@ -4030,7 +4015,7 @@ x            -              -
             else:
                 groupby_subweights = (None for _ in range(len(groupby)))
 
-            agg = self._get_aggregator_fn(
+            agg = iris.analysis.create_weighted_aggregator_fn(
                 aggregator.lazy_aggregate, axis=dimension_to_groupby, **kwargs
             )
             result = list(map(agg, groupby_subcubes, groupby_subweights))

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3932,6 +3932,7 @@ x            -              -
         # or be 1D (in this case, their length must be equal to the length of the
         # dimension we are aggregating over).
         weights = kwargs.get("weights")
+        return_weights = kwargs.get("returned", False)
         if weights is not None:
             if weights.ndim == 1:
                 if len(weights) != self.shape[dimension_to_groupby]:
@@ -4025,7 +4026,7 @@ x            -              -
             # second is the aggregated weights). Convert these to two lists
             # (one for the aggregated data and one for the aggregated weights)
             # before combining the different slices.
-            if kwargs.get("returned", False):
+            if return_weights:
                 result, weights_result = list(zip(*result))
                 aggregateby_weights = da.stack(
                     weights_result, axis=dimension_to_groupby
@@ -4052,7 +4053,7 @@ x            -              -
                 result = aggregator.aggregate(
                     groupby_sub_cube.data, axis=dimension_to_groupby, **kwargs
                 )
-                if kwargs.get("returned", False):
+                if return_weights:
                     weights_result = result[1]
                     result = result[0]
                 else:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4096,7 +4096,8 @@ x            -              -
                     aggregateby_weights[tuple(cube_slice)] = weights_result
 
             # Restore original weights.
-            kwargs["weights"] = weights
+            if weights is not None:
+                kwargs["weights"] = weights
 
         # Add the aggregation meta data to the aggregate-by cube.
         aggregator.update_metadata(

--- a/lib/iris/tests/results/analysis/aggregated_by/easy.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/easy.cml
@@ -18,6 +18,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data dtype="float32" shape="(3, 2)" state="loaded"/>
+    <data checksum="0x255c5dc9" dtype="float32" shape="(3, 2)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/multi_missing.cml
@@ -36,6 +36,6 @@
         <coord name="level"/>
       </cellMethod>
     </cellMethods>
-    <data dtype="float64" shape="(9, 3, 3)" state="loaded"/>
+    <data checksum="0x272f6741" dtype="float64" mask_checksum="0x14a720c5" shape="(9, 3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_easy.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_easy.cml
@@ -18,6 +18,6 @@
         <coord name="longitude"/>
       </cellMethod>
     </cellMethods>
-    <data dtype="float32" shape="(2, 2)" state="loaded"/>
+    <data checksum="0x18ac8879" dtype="float32" shape="(2, 2)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_easy.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_easy.cml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float32" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="77a50eb5" points="[0.0, 10.0]" shape="(2,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </auxCoord>
+      </coord>
+      <coord datadims="[1]">
+        <auxCoord id="f913a8b3" points="[0.0, 10.0]" shape="(2,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </auxCoord>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="longitude"/>
+      </cellMethod>
+    </cellMethods>
+    <data dtype="float32" shape="(2, 2)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_multi.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_multi.cml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="be5cf21d" long_name="level" points="[1, 3, 3, 5, 7, 7, 9, 11, 11]" shape="(9,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="2e7cc9c8" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+        <coord name="level"/>
+      </cellMethod>
+    </cellMethods>
+    <data checksum="0x7381efcf" dtype="float64" shape="(9, 3, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_multi_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_multi_missing.cml
@@ -3,12 +3,15 @@
   <cube dtype="float64" long_name="temperature" units="kelvin">
     <coords>
       <coord datadims="[0]">
-        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>
       </coord>
       <coord datadims="[2]">
         <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
           <geogCS earth_radius="6371229.0"/>
         </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="be5cf21d" long_name="level" points="[1, 3, 3, 5, 7, 7, 9, 11, 11]" shape="(9,)" units="Unit('1')" value_type="int32"/>
       </coord>
       <coord datadims="[1]">
         <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
@@ -16,21 +19,23 @@
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord bounds="[[0, 0],
-		[1, 2],
-		[3, 5],
-		[6, 9],
-		[10, 14],
-		[15, 20],
-		[21, 27],
-		[28, 35]]" id="2e7cc9c8" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="2e7cc9c8" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
       </coord>
     </coords>
     <cellMethods>
       <cellMethod method="mean">
         <coord name="height"/>
+        <coord name="level"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x0a036160" dtype="float64" mask_checksum="0x5d2e43b6" shape="(8, 3, 3)"/>
+    <data checksum="0xc82973a9" dtype="float64" mask_checksum="0x14a720c5" shape="(9, 3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_multi_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_multi_shared.cml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[19, 17],
+		[16, 15],
+		[14, 0],
+		[13, 11],
+		[10, 10],
+		[9, 8],
+		[7, 5],
+		[4, 4],
+		[3, 2]]" id="35dc92ed" long_name="gamma" points="[18.0, 15.5, 7.0, 12.0, 10.0, 8.5, 6.0, 4.0, 2.5]" shape="(9,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 1, 2, 2, 3, 4, 4, 1, 5]" shape="(9,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="be5cf21d" long_name="level" points="[1, 3, 3, 5, 7, 7, 9, 11, 11]" shape="(9,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="2e7cc9c8" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 2],
+		[3, 4],
+		[5, 19],
+		[6, 8],
+		[9, 9],
+		[10, 11],
+		[12, 14],
+		[15, 15],
+		[16, 17]]" id="a5c170db" long_name="sigma" points="[1.0, 3.5, 12.0, 7.0, 9.0, 10.5, 13.0, 15.0, 16.5]" shape="(9,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+        <coord name="level"/>
+      </cellMethod>
+    </cellMethods>
+    <data checksum="0x7381efcf" dtype="float64" shape="(9, 3, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_single.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_single.cml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="2e7cc9c8" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+      </cellMethod>
+    </cellMethods>
+    <data checksum="0x25fc1e00" dtype="float64" shape="(8, 3, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_single_missing.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_single_missing.cml
@@ -31,6 +31,6 @@
         <coord name="height"/>
       </cellMethod>
     </cellMethods>
-    <data checksum="0x0a036160" dtype="float64" mask_checksum="0x5d2e43b6" shape="(8, 3, 3)"/>
+    <data checksum="0xf9d5b713" dtype="float64" mask_checksum="0x5d2e43b6" shape="(8, 3, 3)"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_single_shared.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_single_shared.cml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="2e7cc9c8" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="10b8e1fc" long_name="wibble" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+      </cellMethod>
+    </cellMethods>
+    <data checksum="0x25fc1e00" dtype="float64" shape="(8, 3, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/aggregated_by/weighted_single_shared_circular.cml
+++ b/lib/iris/tests/results/analysis/aggregated_by/weighted_single_shared_circular.cml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="temperature" units="kelvin">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0.0, 0.0],
+		[10.0, 20.0],
+		[30.0, 50.0],
+		[60.0, 90.0],
+		[100.0, 140.0],
+		[150.0, 200.0],
+		[210.0, 270.0],
+		[280.0, 360.0]]" circular="True" id="6c94ce47" long_name="circ_height" points="[0.0, 15.0, 40.0, 75.0, 120.0, 175.0, 240.0,
+		320.0]" shape="(8,)" units="Unit('degrees')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <auxCoord id="ecc4ad5a" long_name="height" points="[1, 2, 3, 4, 5, 6, 7, 8]" shape="(8,)" units="Unit('m')" value_type="int32"/>
+      </coord>
+      <coord datadims="[2]">
+        <dimCoord id="77a50eb5" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="latitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="f913a8b3" points="[0.0, 3.0, 6.0]" shape="(3,)" standard_name="longitude" units="Unit('degrees')" value_type="float32">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 0],
+		[1, 2],
+		[3, 5],
+		[6, 9],
+		[10, 14],
+		[15, 20],
+		[21, 27],
+		[28, 35]]" id="2e7cc9c8" points="[0.0, 1.5, 4.0, 7.5, 12.0, 17.5, 24.0, 31.5]" shape="(8,)" standard_name="model_level_number" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="mean">
+        <coord name="height"/>
+      </cellMethod>
+    </cellMethods>
+    <data checksum="0x25fc1e00" dtype="float64" shape="(8, 3, 3)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -14,7 +14,6 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
-from iris._lazy_data import as_concrete_data
 import iris.analysis
 import iris.coord_systems
 import iris.coords
@@ -786,10 +785,10 @@ class TestAggregateBy(tests.IrisTest):
                 [[8.0, 15.0], [10.0, 17.0], [15.0, 8.0]], dtype=np.float32
             ),
         )
+
         self.assertCML(
             aggregateby_cube,
             ("analysis", "aggregated_by", "easy.cml"),
-            checksum=False,
         )
 
         aggregateby_cube = self.cube_easy.aggregated_by(
@@ -915,6 +914,7 @@ class TestAggregateBy(tests.IrisTest):
         aggregateby_cube = self.cube_easy_weighted.aggregated_by(
             "longitude", iris.analysis.MEAN, weights=lon_weights
         )
+
         np.testing.assert_almost_equal(
             aggregateby_cube.data,
             np.array([[3.0, 8.0], [0.2, 4.0]], dtype=np.float32),
@@ -922,7 +922,6 @@ class TestAggregateBy(tests.IrisTest):
         self.assertCML(
             aggregateby_cube,
             ("analysis", "aggregated_by", "weighted_easy.cml"),
-            checksum=False,
         )
 
         aggregateby_cube = self.cube_easy_weighted.aggregated_by(
@@ -1052,13 +1051,9 @@ class TestAggregateBy(tests.IrisTest):
             "height", iris.analysis.MEAN
         )
 
-        # Realize data so that tests with lazy data pass (see
-        # test_lazy_aggregate_by.py).
-        aggregateby_cube.data = as_concrete_data(aggregateby_cube.data)
         self.assertCML(
             aggregateby_cube,
             ("analysis", "aggregated_by", "single_missing.cml"),
-            checksum=False,
         )
         self.assertMaskedArrayAlmostEqual(
             aggregateby_cube.data, single_expected
@@ -1116,13 +1111,9 @@ class TestAggregateBy(tests.IrisTest):
             weights=self.weights_single,
         )
 
-        # Realize data so that tests with lazy data pass (see
-        # test_lazy_aggregate_by.py).
-        aggregateby_cube.data = as_concrete_data(aggregateby_cube.data)
         self.assertCML(
             aggregateby_cube,
-            ("analysis", "aggregated_by", "single_missing.cml"),
-            checksum=False,
+            ("analysis", "aggregated_by", "weighted_single_missing.cml"),
         )
         self.assertMaskedArrayAlmostEqual(
             aggregateby_cube.data,
@@ -1184,13 +1175,9 @@ class TestAggregateBy(tests.IrisTest):
             ["height", "level"], iris.analysis.MEAN
         )
 
-        # Realize data so that tests with lazy data pass (see
-        # test_lazy_aggregate_by.py).
-        aggregateby_cube.data = as_concrete_data(aggregateby_cube.data)
         self.assertCML(
             aggregateby_cube,
             ("analysis", "aggregated_by", "multi_missing.cml"),
-            checksum=False,
         )
         self.assertMaskedArrayAlmostEqual(
             aggregateby_cube.data, multi_expected
@@ -1252,14 +1239,9 @@ class TestAggregateBy(tests.IrisTest):
             iris.analysis.MEAN,
             weights=self.weights_multi,
         )
-
-        # Realize data so that tests with lazy data pass (see
-        # test_lazy_aggregate_by.py).
-        aggregateby_cube.data = as_concrete_data(aggregateby_cube.data)
         self.assertCML(
             aggregateby_cube,
-            ("analysis", "aggregated_by", "multi_missing.cml"),
-            checksum=False,
+            ("analysis", "aggregated_by", "weighted_multi_missing.cml"),
         )
         self.assertMaskedArrayAlmostEqual(
             aggregateby_cube.data,

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -14,10 +14,10 @@ import numpy as np
 import numpy.ma as ma
 
 import iris
+from iris._lazy_data import as_concrete_data
 import iris.analysis
 import iris.coord_systems
 import iris.coords
-from iris._lazy_data import as_concrete_data
 
 
 class TestAggregateBy(tests.IrisTest):
@@ -1273,7 +1273,7 @@ class TestAggregateBy(tests.IrisTest):
             returned=True,
             weights=self.weights_single,
         )
-        assert isinstance(aggregateby_output, tuple)
+        self.assertTrue(isinstance(aggregateby_output, tuple))
 
         aggregateby_cube = aggregateby_output[0]
         self.assertCML(
@@ -1303,7 +1303,7 @@ class TestAggregateBy(tests.IrisTest):
             returned=True,
             weights=self.weights_multi,
         )
-        assert isinstance(aggregateby_output, tuple)
+        self.assertTrue(isinstance(aggregateby_output, tuple))
 
         aggregateby_cube = aggregateby_output[0]
         self.assertCML(

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -1662,5 +1662,43 @@ class TestRollingWindow(tests.IrisTest):
         self.assertArrayAlmostEqual(expected_result, res_cube.data)
 
 
+class TestCreateWeightedAggregatorFn(tests.IrisTest):
+    @staticmethod
+    def aggregator_fn(data, axis, **kwargs):
+        return (data, axis, kwargs)
+
+    def test_no_weights_supplied(self):
+        aggregator_fn = iris.analysis.create_weighted_aggregator_fn(
+            self.aggregator_fn, 42, test_kwarg="test"
+        )
+        output = aggregator_fn("dummy_array", None)
+        self.assertEqual(len(output), 3)
+        self.assertEqual(output[0], "dummy_array")
+        self.assertEqual(output[1], 42)
+        self.assertEqual(output[2], {"test_kwarg": "test"})
+
+    def test_weights_supplied(self):
+        aggregator_fn = iris.analysis.create_weighted_aggregator_fn(
+            self.aggregator_fn, 42, test_kwarg="test"
+        )
+        output = aggregator_fn("dummy_array", "w")
+        self.assertEqual(len(output), 3)
+        self.assertEqual(output[0], "dummy_array")
+        self.assertEqual(output[1], 42)
+        self.assertEqual(output[2], {"test_kwarg": "test", "weights": "w"})
+
+    def test_weights_in_kwargs(self):
+        kwargs = {"test_kwarg": "test", "weights": "ignored"}
+        aggregator_fn = iris.analysis.create_weighted_aggregator_fn(
+            self.aggregator_fn, 42, **kwargs
+        )
+        output = aggregator_fn("dummy_array", "w")
+        self.assertEqual(len(output), 3)
+        self.assertEqual(output[0], "dummy_array")
+        self.assertEqual(output[1], 42)
+        self.assertEqual(output[2], {"test_kwarg": "test", "weights": "w"})
+        self.assertEqual(kwargs, {"test_kwarg": "test", "weights": "ignored"})
+
+
 if __name__ == "__main__":
     tests.main()

--- a/lib/iris/tests/test_lazy_aggregate_by.py
+++ b/lib/iris/tests/test_lazy_aggregate_by.py
@@ -35,12 +35,13 @@ class TestLazyAggregateBy(test_aggregate_by.TestAggregateBy):
     def tearDown(self):
         super().tearDown()
 
-        # Note: easy cubes are not expected to have lazy data since PERCENTILE
-        # and WPERCENTILE are not lazy.
+        # Note: weighted easy cube is not expected to have lazy data since
+        # WPERCENTILE is not lazy.
         assert self.cube_single.has_lazy_data()
         assert self.cube_multi.has_lazy_data()
         assert self.cube_single_masked.has_lazy_data()
         assert self.cube_multi_masked.has_lazy_data()
+        assert self.cube_easy.has_lazy_data()
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_lazy_aggregate_by.py
+++ b/lib/iris/tests/test_lazy_aggregate_by.py
@@ -1,0 +1,48 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+import unittest
+
+from iris.tests import test_aggregate_by
+
+from iris._lazy_data import as_lazy_data
+
+
+# Simply redo the tests of test_aggregate_by.py with lazy data
+class TestLazyAggregateBy(test_aggregate_by.TestAggregateBy):
+    def setUp(self):
+        super().setUp()
+
+        self.cube_single.data = as_lazy_data(self.cube_single.data)
+        self.cube_multi.data = as_lazy_data(self.cube_multi.data)
+        self.cube_single_masked.data = as_lazy_data(
+            self.cube_single_masked.data
+        )
+        self.cube_multi_masked.data = as_lazy_data(self.cube_multi_masked.data)
+        self.cube_easy.data = as_lazy_data(self.cube_easy.data)
+        self.cube_easy_weighted.data = as_lazy_data(
+            self.cube_easy_weighted.data
+        )
+
+        assert self.cube_single.has_lazy_data()
+        assert self.cube_multi.has_lazy_data()
+        assert self.cube_single_masked.has_lazy_data()
+        assert self.cube_multi_masked.has_lazy_data()
+        assert self.cube_easy.has_lazy_data()
+        assert self.cube_easy_weighted.has_lazy_data()
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Note: easy cubes are not expected to have lazy data since PERCENTILE
+        # and WPERCENTILE are not lazy.
+        assert self.cube_single.has_lazy_data()
+        assert self.cube_multi.has_lazy_data()
+        assert self.cube_single_masked.has_lazy_data()
+        assert self.cube_multi_masked.has_lazy_data()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/iris/tests/test_lazy_aggregate_by.py
+++ b/lib/iris/tests/test_lazy_aggregate_by.py
@@ -5,9 +5,8 @@
 # licensing details.
 import unittest
 
-from iris.tests import test_aggregate_by
-
 from iris._lazy_data import as_lazy_data
+from iris.tests import test_aggregate_by
 
 
 # Simply redo the tests of test_aggregate_by.py with lazy data

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1175,11 +1175,34 @@ class Test_aggregated_by__lazy(tests.IrisTest):
             "simple_agg", SUM, weights=self.simple_weights, returned=True
         )
 
+        self.assertTrue(self.cube.has_lazy_data())
+
         self.assertTrue(isinstance(output, tuple))
         self.assertEqual(len(output), 2)
 
-        weights = output[1]
+        cube = output[0]
+        self.assertTrue(isinstance(cube, Cube))
+        self.assertTrue(cube.has_lazy_data())
+        self.assertEqual(cube.shape, (2, 11))
+        row_0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        row_1 = [
+            110.0,
+            114.0,
+            118.0,
+            122.0,
+            126.0,
+            130.0,
+            134.0,
+            138.0,
+            142.0,
+            146.0,
+            150.0,
+        ]
+        np.testing.assert_array_almost_equal(
+            cube.data, np.array([row_0, row_1])
+        )
 
+        weights = output[1]
         self.assertEqual(weights.shape, (2, 11))
         np.testing.assert_array_almost_equal(
             weights,

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -18,7 +18,7 @@ import numpy.ma as ma
 
 from iris._lazy_data import as_lazy_data
 import iris.analysis
-from iris.analysis import MEAN, Aggregator, WeightedAggregator
+from iris.analysis import MEAN, SUM, Aggregator, WeightedAggregator
 import iris.aux_factory
 from iris.aux_factory import HybridHeightFactory
 from iris.common.metadata import BaseMetadata
@@ -725,12 +725,32 @@ class Test_aggregated_by(tests.IrisTest):
         self.mock_agg.lazy_func = None
         self.mock_agg.post_process = mock.Mock(side_effect=lambda x, y, z: x)
 
+        self.mock_weighted_agg = mock.Mock(spec=WeightedAggregator)
+        self.mock_weighted_agg.cell_method = []
+
+        def mock_weighted_aggregate(*_, **kwargs):
+            if kwargs.get("returned", False):
+                return (mock.Mock(dtype="object"), mock.Mock(dtype="object"))
+            return mock.Mock(dtype="object")
+
+        self.mock_weighted_agg.aggregate = mock.Mock(
+            side_effect=mock_weighted_aggregate
+        )
+        self.mock_weighted_agg.aggregate_shape = mock.Mock(return_value=())
+        self.mock_weighted_agg.lazy_func = None
+        self.mock_weighted_agg.post_process = mock.Mock(
+            side_effect=lambda x, y, z, **kwargs: y
+        )
+
         self.ancillary_variable = AncillaryVariable(
             [0, 1, 2, 3], long_name="foo"
         )
         self.cube.add_ancillary_variable(self.ancillary_variable, 0)
         self.cell_measure = CellMeasure([0, 1, 2, 3], long_name="bar")
         self.cube.add_cell_measure(self.cell_measure, 0)
+
+        self.simple_weights = np.array([1.0, 0.0, 2.0, 2.0])
+        self.val_weights = np.ones_like(self.cube.data, dtype=np.float32)
 
     def test_2d_coord_simple_agg(self):
         # For 2d coords, slices of aggregated coord should be the same as
@@ -855,6 +875,136 @@ class Test_aggregated_by(tests.IrisTest):
         self.assertEqual(cube_agg.ancillary_variables(), [])
         self.assertEqual(cube_agg.cell_measures(), [])
 
+    def test_1d_weights(self):
+        self.cube.aggregated_by(
+            "simple_agg", self.mock_weighted_agg, weights=self.simple_weights
+        )
+
+        self.assertEqual(self.mock_weighted_agg.aggregate.call_count, 2)
+
+        # A simple mock.assert_called_with does not work due to ValueError: The
+        # truth value of an array with more than one element is ambiguous. Use
+        # a.any() or a.all()
+        call_1 = self.mock_weighted_agg.aggregate.mock_calls[0]
+        np.testing.assert_array_equal(
+            call_1.args[0],
+            np.array(
+                [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+                ]
+            ),
+        )
+        self.assertEqual(call_1.kwargs["axis"], 0)
+        np.testing.assert_array_almost_equal(
+            call_1.kwargs["weights"],
+            np.array(
+                [
+                    [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                ]
+            ),
+        )
+
+        call_2 = self.mock_weighted_agg.aggregate.mock_calls[1]
+        np.testing.assert_array_equal(
+            call_2.args[0],
+            np.array(
+                [
+                    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+                    [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43],
+                ]
+            ),
+        )
+        self.assertEqual(call_2.kwargs["axis"], 0)
+        np.testing.assert_array_almost_equal(
+            call_2.kwargs["weights"],
+            np.array(
+                [
+                    [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                    [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                ]
+            ),
+        )
+
+    def test_2d_weights(self):
+        self.cube.aggregated_by(
+            "val", self.mock_weighted_agg, weights=self.val_weights
+        )
+
+        self.assertEqual(self.mock_weighted_agg.aggregate.call_count, 3)
+
+        # A simple mock.assert_called_with does not work due to ValueError: The
+        # truth value of an array with more than one element is ambiguous. Use
+        # a.any() or a.all()
+        call_1 = self.mock_weighted_agg.aggregate.mock_calls[0]
+        np.testing.assert_array_equal(
+            call_1.args[0],
+            np.array(
+                [
+                    [0, 1, 2, 6, 7, 9],
+                    [11, 12, 13, 17, 18, 20],
+                    [22, 23, 24, 28, 29, 31],
+                    [33, 34, 35, 39, 40, 42],
+                ]
+            ),
+        )
+        self.assertEqual(call_1.kwargs["axis"], 1)
+        np.testing.assert_array_almost_equal(
+            call_1.kwargs["weights"], np.ones((4, 6))
+        )
+
+        call_2 = self.mock_weighted_agg.aggregate.mock_calls[1]
+        np.testing.assert_array_equal(
+            call_2.args[0],
+            np.array([[3, 4, 10], [14, 15, 21], [25, 26, 32], [36, 37, 43]]),
+        )
+        self.assertEqual(call_2.kwargs["axis"], 1)
+        np.testing.assert_array_almost_equal(
+            call_2.kwargs["weights"], np.ones((4, 3))
+        )
+
+        call_3 = self.mock_weighted_agg.aggregate.mock_calls[2]
+        np.testing.assert_array_equal(
+            call_3.args[0], np.array([[5, 8], [16, 19], [27, 30], [38, 41]])
+        )
+        self.assertEqual(call_3.kwargs["axis"], 1)
+        np.testing.assert_array_almost_equal(
+            call_3.kwargs["weights"], np.ones((4, 2))
+        )
+
+    def test_returned(self):
+        output = self.cube.aggregated_by(
+            "simple_agg", self.mock_weighted_agg, returned=True
+        )
+
+        self.assertTrue(isinstance(output, tuple))
+        self.assertEqual(len(output), 2)
+        self.assertEqual(output[0].shape, (2, 11))
+        self.assertEqual(output[1].shape, (2, 11))
+
+    def test_fail_1d_weights_wrong_len(self):
+        wrong_weights = np.array([1.0, 2.0])
+        msg = (
+            r"1D weights must have the same length as the dimension that is "
+            r"aggregated, got 2, expected 11"
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            self.cube.aggregated_by(
+                "val", self.mock_weighted_agg, weights=wrong_weights
+            )
+
+    def test_fail_weights_wrong_shape(self):
+        wrong_weights = np.ones((42, 1))
+        msg = (
+            r"Weights must either be 1D or have the same shape as the cube, "
+            r"got shape \(42, 1\) for weights, \(4, 11\) for cube"
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            self.cube.aggregated_by(
+                "val", self.mock_weighted_agg, weights=wrong_weights
+            )
+
 
 class Test_aggregated_by__lazy(tests.IrisTest):
     def setUp(self):
@@ -904,6 +1054,9 @@ class Test_aggregated_by__lazy(tests.IrisTest):
         self.cube.add_aux_coord(simple_agg_coord, 0)
         self.cube.add_aux_coord(val_coord, 1)
         self.cube.add_aux_coord(label_coord, 1)
+
+        self.simple_weights = np.array([1.0, 0.0, 2.0, 2.0])
+        self.val_weights = 2.0 * np.ones(self.cube.shape, dtype=np.float32)
 
     def test_agg_by_label__lazy(self):
         # Aggregate a cube on a string coordinate label where label
@@ -962,6 +1115,81 @@ class Test_aggregated_by__lazy(tests.IrisTest):
         )
         self.assertArrayEqual(result.data, means)
         self.assertFalse(result.has_lazy_data())
+
+    def test_1d_weights__lazy(self):
+        self.assertTrue(self.cube.has_lazy_data())
+
+        cube_agg = self.cube.aggregated_by(
+            "simple_agg", SUM, weights=self.simple_weights
+        )
+
+        self.assertTrue(self.cube.has_lazy_data())
+        self.assertTrue(cube_agg.has_lazy_data())
+        self.assertEqual(cube_agg.shape, (2, 11))
+
+        row_0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        row_1 = [
+            110.0,
+            114.0,
+            118.0,
+            122.0,
+            126.0,
+            130.0,
+            134.0,
+            138.0,
+            142.0,
+            146.0,
+            150.0,
+        ]
+        np.testing.assert_array_almost_equal(
+            cube_agg.data, np.array([row_0, row_1])
+        )
+
+    def test_2d_weights__lazy(self):
+        self.assertTrue(self.cube.has_lazy_data())
+
+        cube_agg = self.cube.aggregated_by(
+            "val", SUM, weights=self.val_weights
+        )
+
+        self.assertTrue(self.cube.has_lazy_data())
+        self.assertTrue(cube_agg.has_lazy_data())
+
+        self.assertEqual(cube_agg.shape, (4, 3))
+        np.testing.assert_array_almost_equal(
+            cube_agg.data,
+            np.array(
+                [
+                    [50.0, 34.0, 26.0],
+                    [182.0, 100.0, 70.0],
+                    [314.0, 166.0, 114.0],
+                    [446.0, 232.0, 158.0],
+                ]
+            ),
+        )
+
+    def test_returned__lazy(self):
+        self.assertTrue(self.cube.has_lazy_data())
+
+        output = self.cube.aggregated_by(
+            "simple_agg", SUM, weights=self.simple_weights, returned=True
+        )
+
+        self.assertTrue(isinstance(output, tuple))
+        self.assertEqual(len(output), 2)
+
+        weights = output[1]
+
+        self.assertEqual(weights.shape, (2, 11))
+        np.testing.assert_array_almost_equal(
+            weights,
+            np.array(
+                [
+                    [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0],
+                ]
+            ),
+        )
 
 
 class Test_rolling_window(tests.IrisTest):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull request implements weighted `aggregated_by`, e.g.,

```py
annual_mean_cube = monthly_mean_cube.aggregated_by('year', iris.analysis.MEAN, weights=n_days_per_month)
```

The implementation allows lazy and non-lazy aggregation, and fully supports the keyword `returned=True`. I also added a large number of tests to extensively test this feature; all seems to work fine.

Closes #4581.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
