### PR TITLE
Utility class in netcdf loader should not be public.

### DIFF
--- a/lib/iris/fileformats/_nc_load_rules/actions.py
+++ b/lib/iris/fileformats/_nc_load_rules/actions.py
@@ -18,7 +18,7 @@ not :
 
 3) Iris-specific info is (still) stored in additional properties created on
    the engine object :
-       engine.cf_var, .cube, .cube_parts, .requires, .rule_triggered, .filename
+       engine.cf_var, .cube, .cube_parts, .requires, .rules_triggered, .filename
 
 Our "rules" are just action routines.
 The top-level 'run_actions' routine decides which actions to call, based on the
@@ -78,7 +78,7 @@ def action_function(func):
             # but also may vary depending on whether it successfully
             # triggered, and if so what it matched.
             rule_name = _default_rulenamesfunc(func.__name__)
-        engine.rule_triggered.add(rule_name)
+        engine.rules_triggered.add(rule_name)
 
     func._rulenames_func = _default_rulenamesfunc
     return inner

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -498,7 +498,7 @@ def _actions_activation_stats(engine, cf_name):
 
     print("Rules Triggered:")
 
-    for rule in sorted(list(engine.rule_triggered)):
+    for rule in sorted(list(engine.rules_triggered)):
         print("\t%s" % rule)
 
     print("Case Specific Facts:")
@@ -610,7 +610,7 @@ def _load_cube(engine, cf, cf_var, filename):
     engine.cube = cube
     engine.cube_parts = {}
     engine.requires = {}
-    engine.rule_triggered = _OrderedAddableList()
+    engine.rules_triggered = _OrderedAddableList()
     engine.filename = filename
 
     # Assert all the case-specific facts.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -570,13 +570,20 @@ def _get_cf_var_data(cf_var, filename):
     return as_lazy_data(proxy, chunks=chunks)
 
 
-class OrderedAddableList(list):
-    # Used purely in actions debugging, to accumulate a record of which actions
-    # were activated.
-    # It replaces a set, so as to record the ordering of operations, with
-    # possible repeats, and it also numbers the entries.
-    # Actions routines invoke the 'add' method, which thus effectively converts
-    # a set.add into a list.append.
+class _OrderedAddableList(list):
+    """
+    A custom container object for actions recording.
+    
+    Used purely in actions debugging, to accumulate a record of which actions
+    were activated.
+
+    It replaces a set, so as to preserve the ordering of operations, with
+    possible repeats, and it also numbers the entries.
+
+    The actions routines invoke an 'add' method, so this effectively replaces
+    a set.add with a list.append.
+
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._n_add = 0
@@ -602,7 +609,7 @@ def _load_cube(engine, cf, cf_var, filename):
     engine.cube = cube
     engine.cube_parts = {}
     engine.requires = {}
-    engine.rule_triggered = OrderedAddableList()
+    engine.rule_triggered = _OrderedAddableList()
     engine.filename = filename
 
     # Assert all the case-specific facts.

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -573,7 +573,7 @@ def _get_cf_var_data(cf_var, filename):
 class _OrderedAddableList(list):
     """
     A custom container object for actions recording.
-    
+
     Used purely in actions debugging, to accumulate a record of which actions
     were activated.
 
@@ -584,6 +584,7 @@ class _OrderedAddableList(list):
     a set.add with a list.append.
 
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._n_add = 0


### PR DESCRIPTION
Just spotted that our  API docs include the class `iris.fileformats.netcdf.OrderedAddableList`, which is unintended.

This was introduced in Iris v3.1.0, when we replaced the Pyke rules, but it seems has mistakenly been published as part of the public API + appears in the API docs, e.g. :
https://scitools-iris.readthedocs.io/en/v3.1.0/generated/api/iris/fileformats/netcdf.html#iris.fileformats.netcdf.OrderedAddableList

I don't think it's a big deal to just say this was a mistake + withdraw it, i.e. no deprecation or warnings required.

"Ideally" this might be combined with a desirable reorganisation of the netcdf package #4291, 
but that is basically for developers' benefit, whereas this is about the public API, so let's keep it separate.
