### PR TITLE
Add missing commit to v3.2.x and update version number

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -108,7 +108,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.2.0"
+__version__ = "3.2.0.post0"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 author = SciTools Developers
 author_email = scitools-iris-dev@googlegroups.com
 classifiers =
-    Development Status :: 5 Production/Stable
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
     Operating System :: MacOS


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A [commit that fixes the PyPI classifies](https://github.com/SciTools/iris/commit/ba77f5d08f33524bd38ea6a55df3efc50bbdd53f) which was added to v3.1.x unfortunately missed the mergeback to `main`.

I have cherry picked that commit and updated the version number


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
