### PR TITLE
Yaml fixes + clarifications.

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -22,7 +22,9 @@ on:
         default: "no"
   schedule:
     # Run once a week on a Saturday night 
-    - cron: 1 0 * * 6
+    # N.B. "should" be quoted, according to
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: "1 0 * * 6"
 
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,7 @@ name: Stale issues and pull-requests
 
 on:
   schedule:
-    # Run once an hour
+    # Run once a day
     # N.B. "should" be quoted, according to
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
     - cron: "0 0 * * *"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,13 @@
 # See https://github.com/actions/stale
 
 name: Stale issues and pull-requests
+
 on:
   schedule:
-    - cron: 0 0 * * *
+    # Run once an hour
+    # N.B. "should" be quoted, according to
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
@@ -59,11 +63,11 @@ jobs:
           stale-pr-label: Stale
 
           # Labels on issues exempted from stale.
-          exempt-issue-labels: |
+          exempt-issue-labels:
             "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
 
           # Labels on prs exempted from stale.
-          exempt-pr-labels: |
+          exempt-pr-labels:
             "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
 
           # Max number of operations per run.


### PR DESCRIPTION
I think this makes sense, and fixes https://github.com/SciTools/iris/issues/299#issuecomment-1040858264
Before, when loaded I was getting this :
```
import yaml
>>> with open('/home/h05/itpp/git/iris/iris_main/.github/workflows/stale.yml') as fo:
...   data = yaml.full_load(fo)
... 
>>> data['jobs']['stale']['steps'][0]['with']['exempt-issue-labels'] 
'"Status: Blocked,Status: Decision Required,Peloton 🚴\u200d♂️,Good First Issue"\n'
>>>
```
So ... that string has embedded quotes, and a newline at the end.
So I _think_ this must mean that it excludes labels called :
  * /"Status: Blocked/
  * /Status: Decision Required/
  * /Peloton 🚴\u200d♂️/
  * /Good First Issue"\n/

I.E. the first + last ones don't work!


With changes here,  I now get
```
>>> data['jobs']['stale']['steps'][0]['with']['exempt-issue-labels'] 
'Status: Blocked,Status: Decision Required,Peloton 🚴\u200d♂️,Good First Issue'
>>> 
```
Which I think is now correct, based on [this in the GitHub docs](https://github.com/actions/stale/blob/main/action.yml#L48-L51)

---

In the meantime while investigating with @trexfeathers  I found that there are some **_really_** odd corners to this.
For instance:
```
>>> data['on']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'on'
>>> data.keys()
dict_keys(['name', True, 'jobs'])
>>> data[True]
{'schedule': [{'cron': '0 0 * * *'}]}
>>> 
```
Apparently this is because : https://github.com/yaml/pyyaml/issues/613
So, a bad  choice for a keyname by GitHub ??