### PR TITLE
Add lbcode 9 support to pp_load_rules

### DIFF
--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -956,7 +956,7 @@ def convert(f):
     )
 
 
-def _all_other_rules(f):
+def _all_other_rules(f):  # noqa C901
     """
     This deals with all the other rules that have not been factored into any of
     the other convert_scalar_coordinate functions above.
@@ -1156,6 +1156,27 @@ def _all_other_rules(f):
         )
 
     if (
+        f.bdx != 0.0
+        and f.bdx != f.bmdi
+        and len(f.lbcode) != 5
+        and f.lbcode[0] == 9
+    ):
+        dim_coords_and_dims.append(
+            (
+                DimCoord.from_regular(
+                    f.bzx,
+                    f.bdx,
+                    f.lbnpt,
+                    standard_name="projection_x_coordinate",
+                    units="metres",
+                    circular=(f.lbhem in [0, 4]),
+                    coord_system=None,
+                ),
+                1,
+            )
+        )
+
+    if (
         f.bdy != 0.0
         and f.bdy != f.bmdi
         and len(f.lbcode) != 5
@@ -1191,6 +1212,26 @@ def _all_other_rules(f):
                     units="degrees",
                     coord_system=f.coord_system(),
                     with_bounds=True,
+                ),
+                0,
+            )
+        )
+
+    if (
+        f.bdy != 0.0
+        and f.bdy != f.bmdi
+        and len(f.lbcode) != 5
+        and f.lbcode[0] == 9
+    ):
+        dim_coords_and_dims.append(
+            (
+                DimCoord.from_regular(
+                    f.bzy,
+                    f.bdy,
+                    f.lbrow,
+                    standard_name="projection_y_coordinate",
+                    units="metres",
+                    coord_system=None,
                 ),
                 0,
             )


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
In response to support query, adding support for lbcode 9 (cartesian grid). Doing so by not assigning a coordinate system to the coordinates. Units in metres as per convention.

Had to stop flake checking `_all_other_rules` because it was too complicated for it and this didn't seem the time to fix that.

To do:
- [ ] Check with @pp-mo (or anyone else more familiar with this code than me) if this method is legit or if I need to do more for this to be done
- [ ] Qu: should I be setting a different name to `standard_name`, and should it be set to something different?
- [ ] Add tests (can ask original proposer for example file)
- [ ] Add whatsnew

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
