### PR TITLE
(corrects the mess with branches in #4596) Use crs.globe in _crs_distance_differentials()

### DIFF
--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -40,7 +40,7 @@ v3.2.1 |build_date| [unreleased]
 
    #. `@dennissergeev`_ changed _crs_distance_differentials() so that it uses the `Globe`
       attribute from a given CRS instead of creating a new `ccrs.Globe()` object.
-      This allows iris to deal with non-Earth semi-major axes.
+      Iris can now handle non-Earth semi-major axes, as discussed in :issue:`4582` (:pull:`4605`).
 
    💼 **Internal**
 

--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -38,7 +38,9 @@ v3.2.1 |build_date| [unreleased]
 
    🐛 **Bugs Fixed**
 
-   #. N/A
+   #. `@dennissergeev`_ changed _crs_distance_differentials() so that it uses the `Globe`
+      attribute from a given CRS instead of creating a new `ccrs.Globe()` object.
+      This allows iris to deal with non-Earth semi-major axes.
 
    💼 **Internal**
 
@@ -388,6 +390,7 @@ v3.2.1 |build_date| [unreleased]
 .. _@aaronspring: https://github.com/aaronspring
 .. _@akuhnregnier: https://github.com/akuhnregnier
 .. _@bsherratt: https://github.com/bsherratt
+.. _@dennissergeev: https://github.com/dennissergeev
 .. _@larsbarring: https://github.com/larsbarring
 .. _@pdearnshaw: https://github.com/pdearnshaw
 .. _@SimonPeatman: https://github.com/SimonPeatman

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -927,7 +927,7 @@ def _crs_distance_differentials(crs, x, y):
 
     """
     # Make a true-latlon coordinate system for distance calculations.
-    crs_latlon = ccrs.Geodetic(globe=ccrs.Globe(ellipse="sphere"))
+    crs_latlon = ccrs.Geodetic(globe=crs.globe)
     # Transform points to true-latlon (just to get the true latitudes).
     _, true_lat = _transform_xy(crs, x, y, crs_latlon)
     # Get coordinate differentials w.r.t. true-latlon.

--- a/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_rotate_winds.py
@@ -493,5 +493,18 @@ class TestRoundTrip(tests.IrisTest):
         self.assertArrayAlmostEqual(res_y, y2d)
 
 
+class TestNonEarthPlanet(tests.IrisTest):
+    def test_non_earth_semimajor_axis(self):
+        u, v = uv_cubes()
+        u.coord("grid_latitude").coord_system = iris.coord_systems.GeogCS(123)
+        u.coord("grid_longitude").coord_system = iris.coord_systems.GeogCS(123)
+        v.coord("grid_latitude").coord_system = iris.coord_systems.GeogCS(123)
+        v.coord("grid_longitude").coord_system = iris.coord_systems.GeogCS(123)
+        other_cs = iris.coord_systems.RotatedGeogCS(
+            0, 0, ellipsoid=iris.coord_systems.GeogCS(123)
+        )
+        rotate_winds(u, v, other_cs)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Addresses the first point in https://github.com/SciTools/iris/issues/4582 by making iris.analysis.cartography._crs_distance_differentials() use the .globe attribute of the input crs parameter instead of creating a new ccrs.Globe() object.

Apologies for messing the [previous PR](#4596). This PR repeats the necessary changes, including updates of `whatsnew`, but now on a correct branch.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
