### PR TITLE
Implement full Mercator parameter support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ env:
   # Conda packages to be installed.
   CONDA_CACHE_PACKAGES: "nox pip"
   # Git commit hash for iris test data.
-  IRIS_TEST_DATA_VERSION: "2.7"
+  IRIS_TEST_DATA_VERSION: "2.8"
   # Base directory for the iris-test-data.
   IRIS_TEST_DATA_DIR: ${HOME}/iris-test-data
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -40,6 +40,10 @@ This document explains the changes made to Iris for this release
 #. `@pp-mo`_ fixed cube arithmetic operation for cubes with meshes.
    (:issue:`4454`, :pull:`4651`)
 
+#. `@wjbenfold`_ added support for CF-compliant treatment of
+   ``standard_parallel`` and ``scale_factor_at_projection_origin`` to
+   :class:`~iris.coord_system.Mercator`. (:issue:`3844`, :pull:`4609`)
+
 
 🐛 Bugs Fixed
 =============

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -56,6 +56,10 @@ NOTE: section above is a template for bugfix patches
 
 #. N/A
 
+#. `@wjbenfold`_ added support for CF-compliant treatment of
+   ``standard_parallel`` and ``scale_factor_at_projection_origin`` to
+   :class:`~iris.coord_system.Mercator`. (:issue:`3844`, :pull:`4609`)
+
 
 🐛 Bugs Fixed
 =============

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -56,10 +56,6 @@ NOTE: section above is a template for bugfix patches
 
 #. N/A
 
-#. `@wjbenfold`_ added support for CF-compliant treatment of
-   ``standard_parallel`` and ``scale_factor_at_projection_origin`` to
-   :class:`~iris.coord_system.Mercator`. (:issue:`3844`, :pull:`4609`)
-
 
 🐛 Bugs Fixed
 =============

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1083,6 +1083,7 @@ class Mercator(CoordSystem):
         longitude_of_projection_origin=None,
         ellipsoid=None,
         standard_parallel=None,
+        scale_factor_at_projection_origin=None,
         false_easting=None,
         false_northing=None,
     ):
@@ -1100,11 +1101,17 @@ class Mercator(CoordSystem):
         * standard_parallel:
             The latitude where the scale is 1. Defaults to 0.0 .
 
+        * scale_factor_at_projection_origin:
+            Scale factor at natural origin. Defaults to unused.
+
         * false_easting:
             X offset from the planar origin in metres. Defaults to 0.0.
 
         * false_northing:
             Y offset from the planar origin in metres. Defaults to 0.0.
+
+        Note: Only one of ``latitude_true_scale`` and
+        ``scale_factor_at_projection_origin`` should be included.
 
         """
         #: True longitude of planar origin in degrees.
@@ -1115,8 +1122,20 @@ class Mercator(CoordSystem):
         #: Ellipsoid definition (:class:`GeogCS` or None).
         self.ellipsoid = ellipsoid
 
-        #: The latitude where the scale is 1.
-        self.standard_parallel = _arg_default(standard_parallel, 0)
+        if scale_factor_at_projection_origin is None:
+            #: The latitude where the scale is 1.
+            self.standard_parallel = _arg_default(standard_parallel, 0)
+        else:
+            if standard_parallel is None:
+                # The scale factor at the origin of the projection
+                self.scale_factor_at_projection_origin = _arg_default(
+                    scale_factor_at_projection_origin, 0
+                )
+            else:
+                raise ValueError(
+                    "It does not make sense to provide both "
+                    '"scale_factor" and "latitude_true_scale". '
+                )
 
         #: X offset from the planar origin in metres.
         self.false_easting = _arg_default(false_easting, 0)
@@ -1130,6 +1149,8 @@ class Mercator(CoordSystem):
             "{self.longitude_of_projection_origin!r}, "
             "ellipsoid={self.ellipsoid!r}, "
             "standard_parallel={self.standard_parallel!r}, "
+            "scale_factor_at_projection_origin="
+            "{self.scale_factor_at_projection_origin!r}, "
             "false_easting={self.false_easting!r}, "
             "false_northing={self.false_northing!r})"
         )
@@ -1142,6 +1163,7 @@ class Mercator(CoordSystem):
             central_longitude=self.longitude_of_projection_origin,
             globe=globe,
             latitude_true_scale=self.standard_parallel,
+            scale_factor=self.scale_factor_at_projection_origin,
             false_easting=self.false_easting,
             false_northing=self.false_northing,
         )

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1110,7 +1110,7 @@ class Mercator(CoordSystem):
         * false_northing:
             Y offset from the planar origin in metres. Defaults to 0.0.
 
-        Note: Only one of ``latitude_true_scale`` and
+        Note: Only one of ``standard_parallel`` and
         ``scale_factor_at_projection_origin`` should be included.
 
         """
@@ -1134,7 +1134,8 @@ class Mercator(CoordSystem):
             else:
                 raise ValueError(
                     "It does not make sense to provide both "
-                    '"scale_factor" and "latitude_true_scale". '
+                    '"scale_factor_at_projection_origin" and '
+                    '"standard_parallel".'
                 )
 
         #: X offset from the planar origin in metres.

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -1122,12 +1122,15 @@ class Mercator(CoordSystem):
         #: Ellipsoid definition (:class:`GeogCS` or None).
         self.ellipsoid = ellipsoid
 
+        # Initialise to None, then set based on arguments
+        #: The latitude where the scale is 1.
+        self.standard_parallel = None
+        # The scale factor at the origin of the projection
+        self.scale_factor_at_projection_origin = None
         if scale_factor_at_projection_origin is None:
-            #: The latitude where the scale is 1.
             self.standard_parallel = _arg_default(standard_parallel, 0)
         else:
             if standard_parallel is None:
-                # The scale factor at the origin of the projection
                 self.scale_factor_at_projection_origin = _arg_default(
                     scale_factor_at_projection_origin, 0
                 )

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -445,8 +445,9 @@ def build_mercator_coordinate_system(engine, cf_grid_var):
     )
     false_easting = getattr(cf_grid_var, CF_ATTR_GRID_FALSE_EASTING, None)
     false_northing = getattr(cf_grid_var, CF_ATTR_GRID_FALSE_NORTHING, None)
-    # Iris currently only supports Mercator projections with specific
-    # scale_factor_at_projection_origin. This is checked elsewhere.
+    scale_factor_at_projection_origin = getattr(
+        cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None
+    )
 
     ellipsoid = None
     if (
@@ -460,6 +461,7 @@ def build_mercator_coordinate_system(engine, cf_grid_var):
         longitude_of_projection_origin,
         ellipsoid=ellipsoid,
         standard_parallel=standard_parallel,
+        scale_factor_at_projection_origin=scale_factor_at_projection_origin,
         false_easting=false_easting,
         false_northing=false_northing,
     )
@@ -1251,17 +1253,20 @@ def has_supported_mercator_parameters(engine, cf_name):
     is_valid = True
     cf_grid_var = engine.cf_var.cf_group[cf_name]
 
+    standard_parallel = getattr(
+        cf_grid_var, CF_ATTR_GRID_STANDARD_PARALLEL, None
+    )
     scale_factor_at_projection_origin = getattr(
         cf_grid_var, CF_ATTR_GRID_SCALE_FACTOR_AT_PROJ_ORIGIN, None
     )
 
     if (
         scale_factor_at_projection_origin is not None
-        and scale_factor_at_projection_origin != 1
+        and standard_parallel is not None
     ):
         warnings.warn(
-            "Scale factors other than 1.0 not yet supported for "
-            "Mercator projections"
+            "It does not make sense to provide both "
+            '"scale_factor_at_projection_origin" and "standard_parallel".'
         )
         is_valid = False
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2563,12 +2563,13 @@ class Saver:
                     )
                     cf_var_grid.false_easting = cs.false_easting
                     cf_var_grid.false_northing = cs.false_northing
-                    if cs.scale_factor_at_projection_origin is not None:
+                    # Only one of these should be set
+                    if cs.standard_parallel is not None:
+                        cf_var_grid.standard_parallel = cs.standard_parallel
+                    elif cs.scale_factor_at_projection_origin is not None:
                         cf_var_grid.scale_factor_at_projection_origin = (
                             cs.scale_factor_at_projection_origin
                         )
-                    if cs.standard_parallel is not None:
-                        cf_var_grid.standard_parallel = cs.standard_parallel
 
                 # lcc
                 elif isinstance(cs, iris.coord_systems.LambertConformal):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2563,7 +2563,12 @@ class Saver:
                     )
                     cf_var_grid.false_easting = cs.false_easting
                     cf_var_grid.false_northing = cs.false_northing
-                    cf_var_grid.scale_factor_at_projection_origin = 1.0
+                    if cs.scale_factor_at_projection_origin is not None:
+                        cf_var_grid.scale_factor_at_projection_origin = (
+                            cs.scale_factor_at_projection_origin
+                        )
+                    if cs.standard_parallel is not None:
+                        cf_var_grid.standard_parallel = cs.standard_parallel
 
                 # lcc
                 elif isinstance(cs, iris.coord_systems.LambertConformal):

--- a/lib/iris/tests/results/coord_systems/Mercator.xml
+++ b/lib/iris/tests/results/coord_systems/Mercator.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<mercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="90.0" standard_parallel="0.0"/>
+<mercator ellipsoid="GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.909)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="90.0" scale_factor_at_projection_origin="None" standard_parallel="0.0"/>

--- a/lib/iris/tests/results/netcdf/netcdf_merc.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_merc.cml
@@ -53,15 +53,15 @@
 		 45.5158, 45.9993]]" shape="(192, 192)" standard_name="longitude" units="Unit('degrees')" value_type="float32" var_name="lon"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="970d5aa6" points="[-5.16102e+06, -5.10719e+06, -5.05336e+06, ...,
+        <dimCoord id="732bd7eb" points="[-5.16102e+06, -5.10719e+06, -5.05336e+06, ...,
 		5.01299e+06, 5.06682e+06, 5.12065e+06]" shape="(192,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float32" var_name="x">
-          <mercator ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" standard_parallel="0.0"/>
+          <mercator ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" scale_factor_at_projection_origin="1.0" standard_parallel="None"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="072b8f17" points="[5.16101e+06, 5.10718e+06, 5.05335e+06, ...,
+        <dimCoord id="2a475a6a" points="[5.16101e+06, 5.10718e+06, 5.05335e+06, ...,
 		-5.01294e+06, -5.06678e+06, -5.12061e+06]" shape="(192,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float32" var_name="y">
-          <mercator ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" standard_parallel="0.0"/>
+          <mercator ellipsoid="GeogCS(6378169.0)" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" scale_factor_at_projection_origin="1.0" standard_parallel="None"/>
         </dimCoord>
       </coord>
       <coord>

--- a/lib/iris/tests/results/netcdf/netcdf_merc_false.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_merc_false.cml
@@ -6,17 +6,17 @@
     </attributes>
     <coords>
       <coord datadims="[2]">
-        <dimCoord id="7979c65f" long_name="x-coordinate in Cartesian system" points="[-5950000.0, -5925000.0, -5900000.0, -5875000.0,
+        <dimCoord id="94e59ce8" long_name="x-coordinate in Cartesian system" points="[-5950000.0, -5925000.0, -5900000.0, -5875000.0,
 		-5850000.0, -5825000.0, -5800000.0, -5775000.0,
 		-5750000.0, -5725000.0]" shape="(10,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64" var_name="x">
-          <mercator ellipsoid="GeogCS(6371229.0)" false_easting="-12500.0" false_northing="-12500.0" longitude_of_projection_origin="12.0" standard_parallel="-2.0"/>
+          <mercator ellipsoid="GeogCS(6371229.0)" false_easting="-12500.0" false_northing="-12500.0" longitude_of_projection_origin="12.0" scale_factor_at_projection_origin="None" standard_parallel="-2.0"/>
         </dimCoord>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="f5c6807e" long_name="y-coordinate in Cartesian system" points="[-6200000.0, -6175000.0, -6150000.0, -6125000.0,
+        <dimCoord id="a72902b5" long_name="y-coordinate in Cartesian system" points="[-6200000.0, -6175000.0, -6150000.0, -6125000.0,
 		-6100000.0, -6075000.0, -6050000.0, -6025000.0,
 		-6000000.0, -5975000.0]" shape="(10,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64" var_name="y">
-          <mercator ellipsoid="GeogCS(6371229.0)" false_easting="-12500.0" false_northing="-12500.0" longitude_of_projection_origin="12.0" standard_parallel="-2.0"/>
+          <mercator ellipsoid="GeogCS(6371229.0)" false_easting="-12500.0" false_northing="-12500.0" longitude_of_projection_origin="12.0" scale_factor_at_projection_origin="None" standard_parallel="-2.0"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">

--- a/lib/iris/tests/results/netcdf/netcdf_merc_scale_factor.cml
+++ b/lib/iris/tests/results/netcdf/netcdf_merc_scale_factor.cml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" units="unknown" var_name="wibble">
+    <attributes>
+      <attribute name="Conventions" value="CF-1.7"/>
+    </attributes>
+    <coords>
+      <coord datadims="[1]">
+        <dimCoord id="5ae9804c" points="[0.0, 12.5, 25.0, 37.5, 50.0]" shape="(5,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64" var_name="projection_x_coordinate">
+          <mercator ellipsoid="None" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" scale_factor_at_projection_origin="1.2" standard_parallel="None"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="502d5aa1" points="[0.0, 12.5, 25.0, 37.5, 50.0]" shape="(5,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64" var_name="projection_y_coordinate">
+          <mercator ellipsoid="None" false_easting="0.0" false_northing="0.0" longitude_of_projection_origin="0.0" scale_factor_at_projection_origin="1.2" standard_parallel="None"/>
+        </dimCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x1936d0c2" dtype="float64" mask_checksum="no-masked-elements" shape="(5, 5)"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator.cdl
@@ -13,7 +13,7 @@ variables:
 		mercator:longitude_of_projection_origin = 49. ;
 		mercator:false_easting = 0. ;
 		mercator:false_northing = 0. ;
-		mercator:scale_factor_at_projection_origin = 1. ;
+		mercator:standard_parallel = 0. ;
 	int64 projection_y_coordinate(projection_y_coordinate) ;
 		projection_y_coordinate:axis = "Y" ;
 		projection_y_coordinate:units = "m" ;

--- a/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator_no_ellipsoid.cdl
+++ b/lib/iris/tests/results/unit/fileformats/netcdf/Saver/write/mercator_no_ellipsoid.cdl
@@ -10,7 +10,7 @@ variables:
 		mercator:longitude_of_projection_origin = 49. ;
 		mercator:false_easting = 0. ;
 		mercator:false_northing = 0. ;
-		mercator:scale_factor_at_projection_origin = 1. ;
+		mercator:standard_parallel = 0. ;
 	int64 projection_y_coordinate(projection_y_coordinate) ;
 		projection_y_coordinate:axis = "Y" ;
 		projection_y_coordinate:units = "m" ;

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -228,6 +228,12 @@ class TestNetCDFLoad(tests.IrisTest):
         )
         self.assertCML(cube, ("netcdf", "netcdf_merc_false.cml"))
 
+    def test_load_merc_non_unit_scale_factor(self):
+        raise NotImplementedError
+
+    def test_load_merc_standard_parallel(self):
+        raise NotImplementedError
+
     def test_load_stereographic_grid(self):
         # Test loading a single CF-netCDF file with a stereographic
         # grid_mapping.

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -218,9 +218,9 @@ class TestNetCDFLoad(tests.IrisTest):
         )
         self.assertCML(cube, ("netcdf", "netcdf_merc.cml"))
 
-    def test_load_merc_false_en_grid(self):
+    def test_load_complex_merc_grid(self):
         # Test loading a single CF-netCDF file with a Mercator grid_mapping that
-        # includes false easting and northing
+        # includes false easting and northing and a standard parallel
         cube = iris.load_cube(
             tests.get_data_path(
                 ("NetCDF", "mercator", "false_east_north_merc.nc")
@@ -228,11 +228,15 @@ class TestNetCDFLoad(tests.IrisTest):
         )
         self.assertCML(cube, ("netcdf", "netcdf_merc_false.cml"))
 
-    def test_load_merc_non_unit_scale_factor(self):
-        raise NotImplementedError
-
-    def test_load_merc_standard_parallel(self):
-        raise NotImplementedError
+    def test_load_merc_grid_non_unit_scale_factor(self):
+        # Test loading a single CF-netCDF file with a Mercator grid_mapping that
+        # includes a non-unit scale factor at projection origin
+        cube = iris.load_cube(
+            tests.get_data_path(
+                ("NetCDF", "mercator", "non_unit_scale_factor_merc.nc")
+            )
+        )
+        self.assertCML(cube, ("netcdf", "netcdf_merc_scale_factor.cml"))
 
     def test_load_stereographic_grid(self):
         # Test loading a single CF-netCDF file with a stereographic

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
@@ -445,7 +445,7 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
     #
     # All non-latlon coordinate systems ...
     # These all have projection-x/y coordinates with units of metres.
-    # They all work the same way, except that Mercator/Stereographic have
+    # They all work the same way, except that Stereographic has
     # parameter checking routines that can fail.
     # NOTE: various mapping types *require* certain addtional properties
     #   - without which an error will occur during translation.
@@ -490,37 +490,12 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         )
         self.check_result(result, cube_cstype=ics.Mercator)
 
-    def test_mapping_mercator__fail_unsupported(self):
-        # Provide a mercator grid-mapping with a non-unity scale factor, which
-        # we cannot handle.
-        # Result : fails to convert into a coord-system, and emits a warning.
-        #
-        # Rules Triggered:
-        #     001 : fc_default
-        #     002 : fc_provides_grid_mapping_(mercator) --(FAILED check has_supported_mercator_parameters)
-        #     003 : fc_provides_coordinate_(projection_y)
-        #     004 : fc_provides_coordinate_(projection_x)
-        #     005 : fc_build_coordinate_(projection_y)(FAILED projected coord with non-projected cs)
-        #     006 : fc_build_coordinate_(projection_x)(FAILED projected coord with non-projected cs)
-        # Notes:
-        #     * grid-mapping identified : NONE
-        #     * dim-coords identified : proj-x and -y
-        #     * coords built : NONE  (no dim or aux coords: cube has no coords)
-        warning = "not yet supported for Mercator"
-        result = self.run_testcase(
-            warning=warning,
-            mapping_type_name=hh.CF_GRID_MAPPING_MERCATOR,
-            mapping_scalefactor=2.0,
-        )
-        self.check_result(result, cube_no_cs=True, cube_no_xycoords=True)
-
     def test_mapping_stereographic(self):
         result = self.run_testcase(mapping_type_name=hh.CF_GRID_MAPPING_STEREO)
         self.check_result(result, cube_cstype=ics.Stereographic)
 
     def test_mapping_stereographic__fail_unsupported(self):
-        # As for 'test_mapping_mercator__fail_unsupported', provide a non-unity
-        # scale factor, which we cannot handle.
+        # Provide a non-unity scale factor, which we cannot handle.
         # Result : fails to convert into a coord-system, and emits a warning.
         #
         # Rules Triggered:
@@ -531,7 +506,9 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         #     005 : fc_build_coordinate_(projection_y)(FAILED projected coord with non-projected cs)
         #     006 : fc_build_coordinate_(projection_x)(FAILED projected coord with non-projected cs)
         # Notes:
-        #     as for 'mercator__fail_unsupported', above
+        #     * grid-mapping identified : NONE
+        #     * dim-coords identified : proj-x and -y
+        #     * coords built : NONE  (no dim or aux coords: cube has no coords)
         warning = "not yet supported for stereographic"
         result = self.run_testcase(
             warning=warning,

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_mercator_coordinate_system.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_mercator_coordinate_system.py
@@ -29,6 +29,70 @@ class TestBuildMercatorCoordinateSystem(tests.IrisTest):
             longitude_of_projection_origin=-90,
             semi_major_axis=6377563.396,
             semi_minor_axis=6356256.909,
+            standard_parallel=10,
+        )
+
+        cs = build_mercator_coordinate_system(None, cf_grid_var)
+
+        expected = Mercator(
+            longitude_of_projection_origin=(
+                cf_grid_var.longitude_of_projection_origin
+            ),
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis, cf_grid_var.semi_minor_axis
+            ),
+            standard_parallel=(cf_grid_var.standard_parallel),
+        )
+        self.assertEqual(cs, expected)
+
+    def test_inverse_flattening(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=-90,
+            semi_major_axis=6377563.396,
+            inverse_flattening=299.3249646,
+            standard_parallel=10,
+        )
+
+        cs = build_mercator_coordinate_system(None, cf_grid_var)
+
+        expected = Mercator(
+            longitude_of_projection_origin=(
+                cf_grid_var.longitude_of_projection_origin
+            ),
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                inverse_flattening=cf_grid_var.inverse_flattening,
+            ),
+            standard_parallel=(cf_grid_var.standard_parallel),
+        )
+        self.assertEqual(cs, expected)
+
+    def test_longitude_missing(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            semi_major_axis=6377563.396,
+            inverse_flattening=299.3249646,
+            standard_parallel=10,
+        )
+
+        cs = build_mercator_coordinate_system(None, cf_grid_var)
+
+        expected = Mercator(
+            ellipsoid=iris.coord_systems.GeogCS(
+                cf_grid_var.semi_major_axis,
+                inverse_flattening=cf_grid_var.inverse_flattening,
+            ),
+            standard_parallel=(cf_grid_var.standard_parallel),
+        )
+        self.assertEqual(cs, expected)
+
+    def test_standard_parallel_missing(self):
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=-90,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909,
         )
 
         cs = build_mercator_coordinate_system(None, cf_grid_var)
@@ -43,12 +107,13 @@ class TestBuildMercatorCoordinateSystem(tests.IrisTest):
         )
         self.assertEqual(cs, expected)
 
-    def test_inverse_flattening(self):
+    def test_scale_factor_at_projection_origin(self):
         cf_grid_var = mock.Mock(
             spec=[],
             longitude_of_projection_origin=-90,
             semi_major_axis=6377563.396,
-            inverse_flattening=299.3249646,
+            semi_minor_axis=6356256.909,
+            scale_factor_at_projection_origin=1.3,
         )
 
         cs = build_mercator_coordinate_system(None, cf_grid_var)
@@ -58,26 +123,11 @@ class TestBuildMercatorCoordinateSystem(tests.IrisTest):
                 cf_grid_var.longitude_of_projection_origin
             ),
             ellipsoid=iris.coord_systems.GeogCS(
-                cf_grid_var.semi_major_axis,
-                inverse_flattening=cf_grid_var.inverse_flattening,
+                cf_grid_var.semi_major_axis, cf_grid_var.semi_minor_axis
             ),
-        )
-        self.assertEqual(cs, expected)
-
-    def test_longitude_missing(self):
-        cf_grid_var = mock.Mock(
-            spec=[],
-            semi_major_axis=6377563.396,
-            inverse_flattening=299.3249646,
-        )
-
-        cs = build_mercator_coordinate_system(None, cf_grid_var)
-
-        expected = Mercator(
-            ellipsoid=iris.coord_systems.GeogCS(
-                cf_grid_var.semi_major_axis,
-                inverse_flattening=cf_grid_var.inverse_flattening,
-            )
+            scale_factor_at_projection_origin=(
+                cf_grid_var.scale_factor_at_projection_origin
+            ),
         )
         self.assertEqual(cs, expected)
 

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_has_supported_mercator_parameters.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_has_supported_mercator_parameters.py
@@ -79,7 +79,25 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertTrue(is_valid)
 
-    def test_invalid_scale_factor(self):
+    def test_valid_scale_factor(self):
+        cf_name = "mercator"
+        cf_grid_var = mock.Mock(
+            spec=[],
+            longitude_of_projection_origin=0,
+            false_easting=0,
+            false_northing=0,
+            scale_factor_at_projection_origin=0.9,
+            semi_major_axis=6377563.396,
+            semi_minor_axis=6356256.909,
+        )
+        engine = _engine(cf_grid_var, cf_name)
+
+        is_valid = has_supported_mercator_parameters(engine, cf_name)
+
+        self.assertTrue(is_valid)
+
+    def test_invalid_scale_factor_and_standard_parallel(self):
+        raise NotImplementedError
         # Iris does not yet support scale factors other than one for
         # Mercator projections
         cf_name = "mercator"

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_has_supported_mercator_parameters.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_has_supported_mercator_parameters.py
@@ -97,8 +97,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
         self.assertTrue(is_valid)
 
     def test_invalid_scale_factor_and_standard_parallel(self):
-        raise NotImplementedError
-        # Iris does not yet support scale factors other than one for
+        # Scale factor and standard parallel cannot both be specified for
         # Mercator projections
         cf_name = "mercator"
         cf_grid_var = mock.Mock(
@@ -107,6 +106,7 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
             false_easting=0,
             false_northing=0,
             scale_factor_at_projection_origin=0.9,
+            standard_parallel=20,
             semi_major_axis=6377563.396,
             semi_minor_axis=6356256.909,
         )
@@ -118,7 +118,11 @@ class TestHasSupportedMercatorParameters(tests.IrisTest):
 
         self.assertFalse(is_valid)
         self.assertEqual(len(warns), 1)
-        self.assertRegex(str(warns[0]), "Scale factor")
+        self.assertRegex(
+            str(warns[0]),
+            "both "
+            '"scale_factor_at_projection_origin" and "standard_parallel"',
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Building on #4524, this PR goes further than adds support for the full set of CF parameters for a Mercator projection (see https://cfconventions.org/cf-conventions/cf-conventions.html#_mercator)

This fixes #3844 too.

I've made some choices about the defaults when making a Mercator Coord System that will change existing behaviour - currently (before #4524) on load we assume a standard parallel, but on write we ignore the standard parallel and save with a scale factor of 1 (despite these being mutually exclusive and depending on each other).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
