### PR TITLE
Avoid dimensionality mismatch between data array and CF variables.

### DIFF
--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -38,7 +38,9 @@ v3.2.1 |build_date| [unreleased]
 
    🐛 **Bugs Fixed**
 
-   #. N/A
+   #. `@trexfeathers`_ avoided a dimensionality mismatch when streaming the
+      :attr:`~iris.coords.Coord.bounds` array for a scalar
+      :class:`~iris.coords.Coord`. (:pull:`4610`)
 
    💼 **Internal**
 
@@ -194,7 +196,7 @@ v3.2.1 |build_date| [unreleased]
    from assuming the globe to be the Earth (:issue:`4408`, :pull:`4497`)
 
 #. `@rcomer`_ corrected the ``long_name`` mapping from UM stash code ``m01s09i215``
-   to indicate cloud fraction greater than 7.9 oktas, rather than 7.5 
+   to indicate cloud fraction greater than 7.9 oktas, rather than 7.5
    (:issue:`3305`, :pull:`4535`)
 
 #. `@lbdreyer`_ fixed a bug in :class:`iris.io.load_http` which was missing an import

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2865,10 +2865,11 @@ class Saver:
 
     @staticmethod
     def _lazy_stream_data(data, fill_value, fill_warn, cf_var):
-        if data.shape == (1,) + cf_var.shape:
+        if hasattr(data, "shape") and data.shape == (1,) + cf_var.shape:
             # Reduce dimensionality where bounds data is for a scalar point -
             #  bounds data is 2D but contains just 1 row, which causes
             #  broadcast ambiguity between the data and its 1D cf_var.
+            # (Don't do this check for string data).
             data = np.atleast_1d(data[0])
 
         if is_lazy_data(data):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2866,11 +2866,12 @@ class Saver:
     @staticmethod
     def _lazy_stream_data(data, fill_value, fill_warn, cf_var):
         if hasattr(data, "shape") and data.shape == (1,) + cf_var.shape:
-            # Reduce dimensionality where bounds data is for a scalar point -
-            #  bounds data is 2D but contains just 1 row, which causes
-            #  broadcast ambiguity between the data and its 1D cf_var.
             # (Don't do this check for string data).
-            data = np.atleast_1d(data[0])
+            # Reduce dimensionality where the data array has an extra dimension
+            #  versus the cf_var - to avoid a broadcasting ambiguity.
+            # Happens when bounds data is for a scalar point - array is 2D but
+            #  contains just 1 row, so the cf_var is 1D.
+            data = data.squeeze()
 
         if is_lazy_data(data):
 

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2865,6 +2865,12 @@ class Saver:
 
     @staticmethod
     def _lazy_stream_data(data, fill_value, fill_warn, cf_var):
+        if data.shape == (1,) + cf_var.shape:
+            # Reduce dimensionality where bounds data is for a scalar point -
+            #  bounds data is 2D but contains just 1 row, which causes
+            #  broadcast ambiguity between the data and its 1D cf_var.
+            data = np.atleast_1d(data[0])
+
         if is_lazy_data(data):
 
             def store(data, cf_var, fill_value):

--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -2871,7 +2871,7 @@ class Saver:
             #  versus the cf_var - to avoid a broadcasting ambiguity.
             # Happens when bounds data is for a scalar point - array is 2D but
             #  contains just 1 row, so the cf_var is 1D.
-            data = data.squeeze()
+            data = data.squeeze(axis=0)
 
         if is_lazy_data(data):
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -30,7 +30,7 @@ from iris.coord_systems import (
     TransverseMercator,
     VerticalPerspective,
 )
-from iris.coords import DimCoord
+from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 from iris.fileformats.netcdf import Saver
 import iris.tests.stock as stock
@@ -298,6 +298,21 @@ class Test_write(tests.IrisTest):
             with Saver(nc_path, "NETCDF4") as saver:
                 saver.write(cube)
             self.assertCDL(nc_path)
+
+    def test_dimensional_to_scalar(self):
+        # Bounds for 1 point are still in a 2D array.
+        scalar_bounds = self.array_lib.arange(2).reshape(1, 2)
+        scalar_point = scalar_bounds.mean()
+        scalar_data = self.array_lib.zeros(1)
+        scalar_coord = AuxCoord(points=scalar_point, bounds=scalar_bounds)
+        cube = Cube(scalar_data, aux_coords_and_dims=[(scalar_coord, 0)])[0]
+        with self.temp_filename(".nc") as nc_path:
+            with Saver(nc_path, "NETCDF4") as saver:
+                saver.write(cube)
+            ds = nc.Dataset(nc_path)
+            # Confirm successful save of 2D bounds array into single dimension.
+            self.assertEqual(2, ds.dimensions["bnds"].size)
+            ds.close()
 
 
 class Test__create_cf_bounds(tests.IrisTest):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -310,8 +310,9 @@ class Test_write(tests.IrisTest):
             with Saver(nc_path, "NETCDF4") as saver:
                 saver.write(cube)
             ds = nc.Dataset(nc_path)
-            # Confirm successful save of 2D bounds array into single dimension.
-            self.assertEqual(2, ds.dimensions["bnds"].size)
+            # Confirm that the only dimension is the one denoting the number
+            #  of bounds - have successfully saved the 2D bounds array into 1D.
+            self.assertEqual(["bnds"], list(ds.dimensions.keys()))
             ds.close()
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Closes #4599.

Corrects a problem where bounds for a scalar coordinate - still in a 2D array - where hitting a 'broadcast ambiguity' trying to save to a 1D CF variable.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
