### PR TITLE
Remove no_clobber task from Refresh lockfiles Action

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -2,7 +2,7 @@
 # available packages and dependencies.
 #
 # Environment specifications are given as conda environment.yml files found in
-# `requirements/ci/py**.yml`.  These state the pacakges required, the conda channels
+# `requirements/ci/py**.yml`.  These state the packages required, the conda channels
 # that the packages will be pulled from, and any versions of packages that need to be
 # pinned at specific versions.
 #
@@ -14,12 +14,6 @@ name: Refresh Lockfiles
 
 on:
   workflow_dispatch:
-    inputs:
-      clobber:
-        description: |
-          Force the workflow to run, potentially clobbering any commits already made to the branch. 
-          Enter "yes" or "true" to run.
-        default: "no"
   schedule:
     # Run once a week on a Saturday night 
     # N.B. "should" be quoted, according to
@@ -28,38 +22,6 @@ on:
 
 
 jobs:
-  
-  no_clobber:
-    if: "github.repository == 'SciTools/iris'"
-    runs-on: ubuntu-latest
-    steps:
-      # check if the auto-update-lockfiles branch exists.  If it does, and someone other than
-      # the lockfile bot has made the head commit, abort the workflow.
-      # This job can be manually overridden by running directly from the github actions panel
-      # (known as a "workflow_dispatch") and setting the `clobber` input to "yes".
-      - uses: actions/script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            if (context.eventName == "workflow_dispatch") {
-              const clobber = context.payload.inputs.clobber || "no";
-              if (["yes", "true", "y"].includes(clobber.trim().toLowerCase())) {
-                core.info("Manual override, continuing workflow, potentially overwriting previous commits to auto-update-lockfiles");
-                return
-              }
-            }
-            github.repos.getBranch({...context.repo, branch: "auto-update-lockfiles"}).then(res => {
-              const committer = res.data.commit.commit.committer;
-              if (committer && committer.name === "Lockfile bot") {
-                core.info("Lockfile bot was the last to push to auto-update-lockfiles. Continue.");
-              } else {
-                core.setFailed("New commits to auto-update-lockfiles since bot last ran. Abort!");
-              }
-            }).catch(err => {
-              if (err.status === 404) {
-                  core.info("auto-update-lockfiles branch not found, continue");
-              }
-            })
 
   gen_lockfiles:
     # this is a matrix job: it splits to create new lockfiles for each
@@ -69,7 +31,6 @@ jobs:
     #       ref: https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
     if: "github.repository == 'SciTools/iris'"
     runs-on: ubuntu-latest
-    needs: no_clobber
     
     strategy:
       matrix:

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -82,6 +82,8 @@ jobs:
           title: "[iris.ci] environment lockfiles auto-update"
           body: |
             Lockfiles updated to the latest resolvable environment.
+
+            If the CI test suite fails, create a new branch based of this pull request and add the required fixes to that branch.
           labels: |
             New: Pull Request
             Bot

--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -72,14 +72,11 @@ New lockfiles are generated automatically each week to ensure that Iris continue
 tested against the latest available version of its dependencies.
 Each week the yaml files in ``requirements/ci`` are resolved by a GitHub Action.
 If the resolved environment has changed, a pull request is created with the new lock files.
-The CI test suite will run on this pull request and fixes for failed tests can be pushed to
-the ``auto-update-lockfiles`` branch to be included in the PR. 
-Once a developer has pushed to this branch, the auto-update process will not run again until
-the PR is merged, to prevent overwriting developer commits.
-The auto-updater can still be invoked manually in this situation by going to the `GitHub Actions`_
-page for the workflow, and manually running using the "Run Workflow" button.  
-By default, this will also not override developer commits.  To force an update, you must 
-confirm "yes" in the "Run Worflow" prompt.
+The CI test suite will run on this pull request. If the tests fail, a developer
+will need to create a new branch based off the ``auto-update-lockfiles`` branch 
+and add the required fixes to this new branch. If the fixes are made to the
+``auto-update-lockfiles`` branch these will be overwritten the next time the 
+Github Action is run.
 
 
 .. _skipping Cirrus-CI tasks:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Closes #4606

Currently the no_clobber task is broken. It looks like `github.repos` is no longer returning what we expect. My best guess would be that this may need to be changed to `github.rest.repos` but I'm not sure! I struggled to find much information on this!

However, at yesterday's peloton we discussed changing our development workflow such that when a ``auto-update-lockfiles`` branch fails the tests, a developer creates a new branch with those changes, and adds the fixes onto their own branch and then we merge the new branch. 

Effectively reverts the change added in #4157


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
