### PR TITLE
Overnight benchmarks remove ambiguity between file and commit names.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,12 +79,13 @@ jobs:
             cd benchmarks/.asv/performance-shifts
             for commit_file in *
             do
-              pr_number=$(git log "$commit_file"^! --oneline | grep -o "#[0-9]*" | tail -1 | cut -c 2-)
+              commit="${file_path%.*}"
+              pr_number=$(git log "$commit"^! --oneline | grep -o "#[0-9]*" | tail -1 | cut -c 2-)
               assignee=$(gh pr view $pr_number --json author -q '.["author"]["login"]' --repo $GITHUB_REPOSITORY)
-              title="Performance Shift(s): \`$commit_file\`"
+              title="Performance Shift(s): \`$commit\`"
               body="
           Benchmark comparison has identified performance shifts at commit \
-          $commit_file (#$pr_number). Please review the report below and \
+          $commit (#$pr_number). Please review the report below and \
           take corrective/congratulatory action as appropriate \
           :slightly_smiling_face:
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,7 +79,7 @@ jobs:
             cd benchmarks/.asv/performance-shifts
             for commit_file in *
             do
-              commit="${file_path%.*}"
+              commit="${commit_file%.*}"
               pr_number=$(git log "$commit"^! --oneline | grep -o "#[0-9]*" | tail -1 | cut -c 2-)
               assignee=$(gh pr view $pr_number --json author -q '.["author"]["login"]' --repo $GITHUB_REPOSITORY)
               title="Performance Shift(s): \`$commit\`"

--- a/noxfile.py
+++ b/noxfile.py
@@ -432,7 +432,7 @@ def benchmarks(
                     # Dir is used by .github/workflows/benchmarks.yml,
                     #  but not cached - intended to be discarded after run.
                     shifts_dir.mkdir(exist_ok=True, parents=True)
-                    shifts_path = shifts_dir / after
+                    shifts_path = (shifts_dir / after).with_suffix(".txt")
                     with shifts_path.open("w") as shifts_file:
                         shifts_file.write(shifts)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Fixes something I didn't catch during testing (presumably because I used a known commit rather than the ones that were a problem).

```
pr_number=$(git log "$commit_file"^! --oneline | grep -o "#[0-9]*" | tail -1 | cut -c 2-)
...
fatal: ambiguous argument 'b42c65da': both revision and filename
...
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
