### PR TITLE
Last steps before v3.2.1 release

### DIFF
--- a/docs/src/whatsnew/3.2.rst
+++ b/docs/src/whatsnew/3.2.rst
@@ -25,8 +25,8 @@ This document explains the changes made to Iris for this release
    any issues or feature requests for improving Iris. Enjoy!
 
 
-v3.2.1 |build_date| [unreleased]
-********************************
+v3.2.1 (11 Mar 2022)
+====================
 
 .. dropdown:: :opticon:`alert` v3.2.1 Patches
    :container: + shadow
@@ -47,10 +47,6 @@ v3.2.1 |build_date| [unreleased]
    #. `@trexfeathers`_ avoided a dimensionality mismatch when streaming the
       :attr:`~iris.coords.Coord.bounds` array for a scalar
       :class:`~iris.coords.Coord`. (:pull:`4610`).
-
-   💼 **Internal**
-
-   #. N/A
 
 
 📢 Announcements

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -108,7 +108,7 @@ except ImportError:
 
 
 # Iris revision.
-__version__ = "3.2.0.post0"
+__version__ = "3.2.1"
 
 # Restrict the names imported when using "from iris import *"
 __all__ = [


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Now that the bug fixes #4610 and #4605 are in I would to cut the v3.2.1 release. 

In this PR I updated the version string and what's new. I also made a fix to a problem with the whats new that I had introduced in #4604. Turns out that underlining your headings with `*` (aka for chapters) adds an extra link in the side panel. Below shows what the current docs build for the v3.2.x branch looks like:
![image](https://user-images.githubusercontent.com/8101163/157885480-5d3c0124-fe00-43a4-a1f1-616620566c6e.png)

Fixing the underline to be `=` (aka for sections), the build of this branch looks like:
![image](https://user-images.githubusercontent.com/8101163/157885748-b108e482-4526-4199-80f5-17cb621403a2.png)



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
