### PR TITLE
Updated GHA frequency and table name for Voted Issues

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -314,6 +314,7 @@ html_js_files = [
 # url link checker.  Some links work but report as broken, lets ignore them.
 # See https://www.sphinx-doc.org/en/1.2/config.html#options-for-the-linkcheck-builder
 linkcheck_ignore = [
+    "http://catalogue.ceda.ac.uk/uuid/82adec1f896af6169112d09cc1174499",
     "http://cfconventions.org",
     "http://code.google.com/p/msysgit/downloads/list",
     "http://effbot.org",

--- a/docs/src/voted_issues.rst
+++ b/docs/src/voted_issues.rst
@@ -20,7 +20,7 @@ the below table.
 
 .. raw:: html
 
-   <table id="example" class="display" style="width:100%">
+   <table id="voted_issues_table" class="display" style="width:100%">
       <thead>
          <tr>
             <th>👍</th>
@@ -37,7 +37,7 @@ the below table.
 
    <script type="text/javascript">
         $(document).ready(function() {
-           $('#example').DataTable( {
+           $('#voted_issues_table').DataTable( {
               <!-- "ajax": 'voted-issues.json', -->
               "ajax": 'https://raw.githubusercontent.com/scitools/voted_issues/main/voted-issues.json',
               "lengthMenu": [10, 25, 50, 100],
@@ -48,8 +48,9 @@ the below table.
    </script>
    <p></p>
 
-.. note:: The data in this table is updated daily and is sourced from
-          `voted-issues.json`_.
+
+.. note:: The data in this table is updated every 30 minutes and is sourced
+          from `voted-issues.json`_.
           For the latest data please see the `issues on GitHub`_.
           Note that the list on Github does not show the number of votes 👍
           only the total number of comments for the whole issue.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Updated the voted issues pages:
- Frequency is now every 30 mins for the GitHub action update (see the [other repo pr](https://github.com/SciTools/voted_issues/pull/3/files#diff-5b66dbc188123409edf84583bdd8306da438eab6c8a6d70b51c78129431401a9R8) for info)
- Changed table name in the JavaScript


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
