### PR TITLE
Catch `AttributeError` from removing `CFReader._dataset` when it doesn't exist

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -71,6 +71,10 @@ This document explains the changes made to Iris for this release
    coordinate's direction is reversed. (:issue:`3249`, :issue:`423`,
    :issue:`4078`, :issue:`3756`, :pull:`4466`)
 
+#. `@wjbenfold`_ prevented an ``AttributeError`` being logged to ``stderr`` when
+   a :class:`~iris.fileformats.cf.CFReader` that fails to initialise is garbage
+   collected. (:issue:`3312`, :pull:`4646`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -62,10 +62,6 @@ NOTE: section above is a template for bugfix patches
 
 #. N/A
 
-#. `@wjbenfold`_ prevented an ``AttributeError`` being logged to ``stderr`` when
-   a :class:`~iris.fileformats.cf.CFReader` that fails to initialise is garbage
-   collected. (:issue:`3312`, :pull:`4646`)
-
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -62,6 +62,10 @@ NOTE: section above is a template for bugfix patches
 
 #. N/A
 
+#. `@wjbenfold`_ prevented an ``AttributeError`` being logged to ``stderr`` when
+   a `~iris.fileformats.cf.CFReader` that fails to initialise is garbage
+   collected. (:issue:`3312`, :pull:`4646`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst.template
+++ b/docs/src/whatsnew/latest.rst.template
@@ -63,7 +63,7 @@ NOTE: section above is a template for bugfix patches
 #. N/A
 
 #. `@wjbenfold`_ prevented an ``AttributeError`` being logged to ``stderr`` when
-   a `~iris.fileformats.cf.CFReader` that fails to initialise is garbage
+   a :class:`~iris.fileformats.cf.CFReader` that fails to initialise is garbage
    collected. (:issue:`3312`, :pull:`4646`)
 
 

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1044,6 +1044,7 @@ class CFReader:
     CFGroup = CFGroup
 
     def __init__(self, filename, warn=False, monotonic=False):
+        self._dataset = None
         self._filename = os.path.expanduser(filename)
 
         #: Collection of CF-netCDF variables associated with this netCDF file
@@ -1295,7 +1296,8 @@ class CFReader:
 
     def __del__(self):
         # Explicitly close dataset to prevent file remaining open.
-        self._dataset.close()
+        if self._dataset is not None:
+            self._dataset.close()
 
 
 def _getncattr(dataset, attr, default=None):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Based on #3312 and taking @evertrol up on the offer of replicating the changes in #3336.

Rather than setting `_dataset` to `None` I've taken the approach of catching and ignoring the attribute error on file close (OSErrors etc. will still be raised).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
