### PR TITLE
Plotting circular data extends args as well as the data

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -104,6 +104,9 @@ This document explains the changes made to Iris for this release
    causes NaN valued scalar coordinates to be able to merge be preserved during
    cube merging. (:pull:`4701`)
 
+#. `@wjbenfold`_ fixed plotting of circular coordinates to extend kwarg arrays
+   as well as the data. (:issue:`466`, :pull:`4649`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -985,23 +985,25 @@ def _map_common(
         y = np.append(y, y[:, 0:1], axis=1)
         x = np.append(x, x[:, 0:1] + 360 * direction, axis=1)
         data = ma.concatenate([data, data[:, 0:1]], axis=1)
-        # if "_v_data" in kwargs:
-        #     v_data = kwargs["_v_data"]
-        #     v_data = ma.concatenate([v_data, v_data[:, 0:1]], axis=1)
-        #     kwargs["_v_data"] = v_data
 
+        # Having extended the data, we also need to extend extra kwargs for
+        # matplotlib (e.g. point colours)
         for key, val in kwargs.items():
             if (
                 isinstance(val, np.ndarray)
                 and val.ndim >= 2
                 and val.shape[1] == original_length
             ):
+                # Construct indices that take only the first column of the data,
+                # regardless of its current shape.
                 endslice = tuple(
                     [
                         slice(0, 1) if ii == 1 else slice(None)
                         for ii in range(val.ndim)
                     ]
                 )
+                # Concatenate the first column to the end of the data then
+                # update kwargs
                 val = ma.concatenate([val, val[endslice]], axis=1)
                 kwargs[key] = val
 

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -978,16 +978,32 @@ def _map_common(
     # is useful in anywhere other than this plotting routine, it may be better
     # placed in the CS.
     if getattr(x_coord, "circular", False):
+        original_length = y.shape[1]
         _, direction = iris.util.monotonic(
             x_coord.points, return_direction=True
         )
         y = np.append(y, y[:, 0:1], axis=1)
         x = np.append(x, x[:, 0:1] + 360 * direction, axis=1)
         data = ma.concatenate([data, data[:, 0:1]], axis=1)
-        if "_v_data" in kwargs:
-            v_data = kwargs["_v_data"]
-            v_data = ma.concatenate([v_data, v_data[:, 0:1]], axis=1)
-            kwargs["_v_data"] = v_data
+        # if "_v_data" in kwargs:
+        #     v_data = kwargs["_v_data"]
+        #     v_data = ma.concatenate([v_data, v_data[:, 0:1]], axis=1)
+        #     kwargs["_v_data"] = v_data
+
+        for key, val in kwargs.items():
+            if (
+                isinstance(val, np.ndarray)
+                and val.ndim >= 2
+                and val.shape[1] == original_length
+            ):
+                endslice = tuple(
+                    [
+                        slice(0, 1) if ii == 1 else slice(None)
+                        for ii in range(val.ndim)
+                    ]
+                )
+                val = ma.concatenate([val, val[endslice]], axis=1)
+                kwargs[key] = val
 
     # Replace non-cartopy subplot/axes with a cartopy alternative and set the
     # transform keyword.

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -989,23 +989,17 @@ def _map_common(
         # Having extended the data, we also need to extend extra kwargs for
         # matplotlib (e.g. point colours)
         for key, val in kwargs.items():
-            if (
-                isinstance(val, np.ndarray)
-                and val.ndim >= 2
-                and val.shape[1] == original_length
-            ):
-                # Construct indices that take only the first column of the data,
-                # regardless of its current shape.
-                endslice = tuple(
-                    [
-                        slice(0, 1) if ii == 1 else slice(None)
-                        for ii in range(val.ndim)
-                    ]
-                )
+            try:
+                val_arr = np.array(val)
+            except TypeError:
+                continue
+            if val_arr.ndim >= 2 and val_arr.shape[1] == original_length:
                 # Concatenate the first column to the end of the data then
                 # update kwargs
-                val = ma.concatenate([val, val[endslice]], axis=1)
-                kwargs[key] = val
+                val_arr = ma.concatenate(
+                    [val_arr, val_arr[:, 0:1, ...]], axis=1
+                )
+                kwargs[key] = val_arr
 
     # Replace non-cartopy subplot/axes with a cartopy alternative and set the
     # transform keyword.

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -411,6 +411,9 @@
         "https://scitools.github.io/test-iris-imagehash/images/v4/acf939339a16c64de306318638673c738c19d71cf3866186d8636e69bd191b9e.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/edb23c529649c78de38773e538650c729e92279be12de1edc4f246b2139c3b01.png"
     ],
+    "iris.tests.test_plot.Test2dPoints.test_circular_changes.0": [
+        "https://scitools.github.io/test-iris-imagehash/images/v4/fa81c57a857e93bd9b193e436ec4ccb03b01c14a857e3e34911f3b816e81c57b.png"
+    ],
     "iris.tests.test_plot.TestAttributePositive.test_1d_positive_down.0": [
         "https://scitools.github.io/test-iris-imagehash/images/v4/87fef8117980c7c160078f1ffc049e7e90159a7a95419a7e910dcf1ece19ce3a.png",
         "https://scitools.github.io/test-iris-imagehash/images/v4/a7fe781b708487c360079e3bb4789869816bdb64c76b4a3cce7b4e749a6130c5.png"

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -326,6 +326,23 @@ class Test1dQuickplotScatter(Test1dScatter):
 
 @tests.skip_data
 @tests.skip_plot
+class Test2dPoints(tests.GraphicsTest):
+    def setUp(self):
+        super().setUp()
+        pp_file = tests.get_data_path(("PP", "globClim1", "u_wind.pp"))
+        self.cube = iris.load(pp_file)[0][0]
+
+    def test_circular_changes(self):
+        # Circular
+        iplt.pcolormesh(self.cube, vmax=50)
+        iplt.points(self.cube, s=self.cube.data)
+        plt.gca().coastlines()
+
+        self.check_graphic()
+
+
+@tests.skip_data
+@tests.skip_plot
 class TestAttributePositive(tests.GraphicsTest):
     def test_1d_positive_up(self):
         path = tests.get_data_path(("NetCDF", "ORCA2", "votemper.nc"))


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #466, which is caused by Iris extending cubes to handle the wrapping of circular coordinates when plotting but not doing the same for additional arguments to the plot.

Still to do:
* New test image
* What's new

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
