### PR TITLE
'Deep' benchmarks to catch scaling with field count

### DIFF
--- a/benchmarks/benchmarks/load/__init__.py
+++ b/benchmarks/benchmarks/load/__init__.py
@@ -24,8 +24,10 @@ from ..generate_data.um_files import create_um_files
 
 
 class LoadAndRealise:
+    # For data generation
+    timeout = 600.0
     params = [
-        [(2, 2, 2), (1280, 960, 5), (2, 2, 10000)],
+        [(2, 2, 2), (1280, 960, 5), (2, 2, 1000)],
         [False, True],
         ["FF", "PP", "NetCDF"],
     ]
@@ -155,7 +157,7 @@ class StructuredFF:
     avoiding the cost of merging.
     """
 
-    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 10000)], [False, True]]
+    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 1000)], [False, True]]
     param_names = ["xyz", "structured_loading"]
 
     def setup_cache(self) -> dict:

--- a/benchmarks/benchmarks/load/__init__.py
+++ b/benchmarks/benchmarks/load/__init__.py
@@ -25,7 +25,7 @@ from ..generate_data.um_files import create_um_files
 
 class LoadAndRealise:
     params = [
-        [(2, 2, 2), (1280, 960, 5)],
+        [(2, 2, 2), (1280, 960, 5), (2, 2, 10000)],
         [False, True],
         ["FF", "PP", "NetCDF"],
     ]
@@ -68,7 +68,7 @@ class LoadAndRealise:
 
 class STASHConstraint:
     # xyz sizes mimic LoadAndRealise to maximise file re-use.
-    params = [[(2, 2, 2), (1280, 960, 5)], ["FF", "PP"]]
+    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 10000)], ["FF", "PP"]]
     param_names = ["xyz", "file_format"]
 
     def setup_cache(self) -> dict:
@@ -155,7 +155,7 @@ class StructuredFF:
     avoiding the cost of merging.
     """
 
-    params = [[(2, 2, 2), (1280, 960, 5)], [False, True]]
+    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 10000)], [False, True]]
     param_names = ["xyz", "structured_loading"]
 
     def setup_cache(self) -> dict:

--- a/benchmarks/benchmarks/load/__init__.py
+++ b/benchmarks/benchmarks/load/__init__.py
@@ -70,7 +70,7 @@ class LoadAndRealise:
 
 class STASHConstraint:
     # xyz sizes mimic LoadAndRealise to maximise file re-use.
-    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 10000)], ["FF", "PP"]]
+    params = [[(2, 2, 2), (1280, 960, 5), (2, 2, 1000)], ["FF", "PP"]]
     param_names = ["xyz", "file_format"]
 
     def setup_cache(self) -> dict:

--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -102,6 +102,9 @@ This document explains the changes made to Iris for this release
    infrastructure (see :ref:`contributing.benchmarks`), building on 2 hard
    years of lessons learned 🎉. (:pull:`4477`, :pull:`4562`, :pull:`4571`,
    :pull:`4583`, :pull:`4621`)
+#. `@wjbenfold`_ used the aforementioned benchmarking infrastructure to
+   introduce deep (large 3rd dimension) loading and realisation benchmarks.
+   (:pull:`4654`)
 #. `@wjbenfold`_ made :func:`iris.tests.stock.simple_1d` respect the
    ``with_bounds`` argument. (:pull:`4658`)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Some speed issues in `.pp` and `.ff` files scale with field number, rather than field size (due to chunking strategy). This PR adds some relatively small but deep file tests to the load benchmarks.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
