### PR TITLE
Make iris.tests.stock.simple_1d respect bounds arg

### DIFF
--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -86,8 +86,8 @@ This document explains the changes made to Iris for this release
    infrastructure (see :ref:`contributing.benchmarks`), building on 2 hard
    years of lessons learned 🎉. (:pull:`4477`, :pull:`4562`, :pull:`4571`,
    :pull:`4583`, :pull:`4621`)
-#. `@wjbenfold`_ made :func:`iris.tests.stock.simple_1d` respect the ``bounds``
-   argument. (:pull:`4658`)
+#. `@wjbenfold`_ made :func:`iris.tests.stock.simple_1d` respect the
+   ``with_bounds`` argument. (:pull:`4658`)
 
 
 .. comment

--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -86,6 +86,8 @@ This document explains the changes made to Iris for this release
    infrastructure (see :ref:`contributing.benchmarks`), building on 2 hard
    years of lessons learned 🎉. (:pull:`4477`, :pull:`4562`, :pull:`4571`,
    :pull:`4583`, :pull:`4621`)
+#. `@wjbenfold`_ made :func:`iris.tests.stock.simple_1d` respect the ``bounds``
+   argument. (:pull:`4658`)
 
 
 .. comment

--- a/lib/iris/tests/stock/__init__.py
+++ b/lib/iris/tests/stock/__init__.py
@@ -99,7 +99,12 @@ def simple_1d(with_bounds=True):
     bounds = np.column_stack(
         [np.arange(11, dtype=np.int32), np.arange(11, dtype=np.int32) + 1]
     )
-    coord = DimCoord(points, long_name="foo", units="1", bounds=bounds)
+    coord = DimCoord(
+        points,
+        long_name="foo",
+        units="1",
+        bounds=bounds if with_bounds else None,
+    )
     cube.add_dim_coord(coord, 0)
     return cube
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
I can't see a reason why this function shouldn't respect the argument it accepts, so I've made it do so

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
