### PR TITLE
Include note to strip out Artifactory

### DIFF
--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -68,6 +68,13 @@ or simply::
 
 and add the changed lockfiles to your pull request.
 
+.. note::
+
+   If your installation of conda runs through Artifactory or another similar
+   proxy then you will need to amend that lockfile to use URLs that Github
+   Actions can access. A utility to strip out Artifactory exists in the
+   ``ssstack`` tool.
+
 New lockfiles are generated automatically each week to ensure that Iris continues to be
 tested against the latest available version of its dependencies.
 Each week the yaml files in ``requirements/ci`` are resolved by a GitHub Action.

--- a/docs/src/whatsnew/dev.rst
+++ b/docs/src/whatsnew/dev.rst
@@ -91,6 +91,8 @@ This document explains the changes made to Iris for this release
 
 #. `@tkknight`_ added a page to show the issues that have been voted for.  See
    :ref:`voted_issues`. (:issue:`3307`, :pull:`4617`)
+#. `@wjbenfold`_ added a note about fixing proxy URLs in lockfiles generated
+   because dependencies have changed. (:pull:`4666`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Making a lock-file might include URLs routed through your proxy. I've added a note to the docs to point this out

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
