### PR TITLE
Add `iris.analysis.MAX_RUN` aggregator

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1479,9 +1479,13 @@ def _lazy_max_run(array, axis=None, **kwargs):
     if not callable(func):
         emsg = "function must be a callable. Got {}."
         raise TypeError(emsg.format(type(func)))
+    bool_array = func(array)
+    bool_array = np.logical_and(
+        bool_array, np.logical_not(da.ma.getmaskarray(array))
+    )
     padding = [(0, 0)] * array.ndim
     padding[axis] = (0, 1)
-    ones_zeros = da.pad(func(array), padding).astype(int)
+    ones_zeros = da.pad(bool_array, padding).astype(int)
     cum_sum = da.cumsum(ones_zeros, axis=axis)
     run_totals = da.where(ones_zeros == 0, cum_sum, 0)
     stepped_run_lengths = da.reductions.cumreduction(

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3713,6 +3713,10 @@ class Cube(CFVariableMixin):
             for coord in coords:
                 dims_to_collapse.update(self.coord_dims(coord))
 
+        if aggregator.cell_method == "max_run" and len(dims_to_collapse) > 1:
+            msg = "Not possible to calculate runs over more than one dimension"
+            raise ValueError(msg)
+
         if not dims_to_collapse:
             msg = (
                 "Cannot collapse a dimension which does not describe any "

--- a/lib/iris/tests/results/analysis/max_run_bar_2d.cml
+++ b/lib/iris/tests/results/analysis/max_run_bar_2d.cml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int64" long_name="thingness" units="1">
+    <coords>
+      <coord>
+        <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-15, 0],
+		[0, 15],
+		[15, 30],
+		[30, 45]]" id="b0d35dcf" long_name="foo" points="[-7.5, 7.5, 22.5, 37.5]" shape="(4,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="max_run">
+        <coord name="bar"/>
+      </cellMethod>
+    </cellMethods>
+    <data dtype="int64" shape="(4,)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/max_run_bar_2d_masked.cml
+++ b/lib/iris/tests/results/analysis/max_run_bar_2d_masked.cml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int64" long_name="thingness" units="1">
+    <coords>
+      <coord>
+        <dimCoord bounds="[[0, 15]]" id="434cbbd8" long_name="bar" points="[7.5]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[-15, 0],
+		[0, 15],
+		[15, 30],
+		[30, 45]]" id="b0d35dcf" long_name="foo" points="[-7.5, 7.5, 22.5, 37.5]" shape="(4,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="max_run">
+        <coord name="bar"/>
+      </cellMethod>
+    </cellMethods>
+    <data dtype="int64" shape="(4,)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/max_run_foo_1d.cml
+++ b/lib/iris/tests/results/analysis/max_run_foo_1d.cml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int64" long_name="thingness" units="1">
+    <coords>
+      <coord>
+        <dimCoord bounds="[[0, 11]]" id="b0d35dcf" long_name="foo" points="[5]" shape="(1,)" units="Unit('1')" value_type="int32"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="max_run">
+        <coord name="foo"/>
+      </cellMethod>
+    </cellMethods>
+    <data dtype="int64" shape="()" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/results/analysis/max_run_foo_2d.cml
+++ b/lib/iris/tests/results/analysis/max_run_foo_2d.cml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="int64" long_name="thingness" units="1">
+    <coords>
+      <coord datadims="[0]">
+        <dimCoord bounds="[[0, 5],
+		[5, 10],
+		[10, 15]]" id="434cbbd8" long_name="bar" points="[2.5, 7.5, 12.5]" shape="(3,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+      <coord>
+        <dimCoord bounds="[[-15, 45]]" id="b0d35dcf" long_name="foo" points="[15.0]" shape="(1,)" units="Unit('1')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods>
+      <cellMethod method="max_run">
+        <coord name="foo"/>
+      </cellMethod>
+    </cellMethods>
+    <data dtype="int64" shape="(3,)" state="loaded"/>
+  </cube>
+</cubes>

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -936,7 +936,7 @@ class TestAggregators(tests.IrisTest):
         gt5 = cube.collapsed(
             "foo",
             iris.analysis.MAX_RUN,
-            function=lambda val: val in [0, 1, 4, 5, 6, 8, 9],
+            function=lambda val: np.isin(val, [0, 1, 4, 5, 6, 8, 9]),
         )
         np.testing.assert_array_almost_equal(gt5.data, np.array([3]))
         gt5.data = gt5.data.astype("i8")
@@ -948,7 +948,7 @@ class TestAggregators(tests.IrisTest):
         gt6 = cube.collapsed(
             "foo",
             iris.analysis.MAX_RUN,
-            function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+            function=lambda val: np.isin(val, [0, 3, 4, 5, 7, 9, 11]),
         )
         np.testing.assert_array_almost_equal(
             gt6.data, np.array([1, 2, 1], dtype=np.float32)
@@ -959,7 +959,7 @@ class TestAggregators(tests.IrisTest):
         gt6 = cube.collapsed(
             "bar",
             iris.analysis.MAX_RUN,
-            function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+            function=lambda val: np.isin(val, [0, 3, 4, 5, 7, 9, 11]),
         )
         np.testing.assert_array_almost_equal(
             gt6.data, np.array([2, 2, 0, 3], dtype=np.float32)
@@ -971,7 +971,7 @@ class TestAggregators(tests.IrisTest):
             gt6 = cube.collapsed(
                 ("foo", "bar"),
                 iris.analysis.MAX_RUN,
-                function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+                function=lambda val: np.isin(val, [0, 3, 4, 5, 7, 9, 11]),
             )
 
     def test_weighted_sum_consistency(self):

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -931,6 +931,49 @@ class TestAggregators(tests.IrisTest):
             gt6, ("analysis", "count_foo_bar_2d.cml"), checksum=False
         )
 
+    def test_max_run(self):
+        cube = tests.stock.simple_1d()
+        gt5 = cube.collapsed(
+            "foo",
+            iris.analysis.MAX_RUN,
+            function=lambda val: val in [0, 1, 4, 5, 6, 8, 9],
+        )
+        np.testing.assert_array_almost_equal(gt5.data, np.array([3]))
+        gt5.data = gt5.data.astype("i8")
+        self.assertCML(gt5, ("analysis", "max_run_foo_1d.cml"), checksum=False)
+
+    def test_max_run_2d(self):
+        cube = tests.stock.simple_2d()
+
+        gt6 = cube.collapsed(
+            "foo",
+            iris.analysis.MAX_RUN,
+            function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+        )
+        np.testing.assert_array_almost_equal(
+            gt6.data, np.array([1, 2, 1], dtype=np.float32)
+        )
+        gt6.data = gt6.data.astype("i8")
+        self.assertCML(gt6, ("analysis", "max_run_foo_2d.cml"), checksum=False)
+
+        gt6 = cube.collapsed(
+            "bar",
+            iris.analysis.MAX_RUN,
+            function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+        )
+        np.testing.assert_array_almost_equal(
+            gt6.data, np.array([2, 2, 0, 3], dtype=np.float32)
+        )
+        gt6.data = gt6.data.astype("i8")
+        self.assertCML(gt6, ("analysis", "max_run_bar_2d.cml"), checksum=False)
+
+        with self.assertRaises(ValueError):
+            gt6 = cube.collapsed(
+                ("foo", "bar"),
+                iris.analysis.MAX_RUN,
+                function=lambda val: val in [0, 3, 4, 5, 7, 9, 11],
+            )
+
     def test_weighted_sum_consistency(self):
         # weighted sum with unit weights should be the same as a sum
         cube = tests.stock.simple_1d()

--- a/lib/iris/tests/unit/analysis/test_MAX_RUN.py
+++ b/lib/iris/tests/unit/analysis/test_MAX_RUN.py
@@ -1,0 +1,300 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the :data:`iris.analysis.MAX_RUN` aggregator."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+import numpy as np
+import numpy.ma as ma
+
+from iris._lazy_data import as_concrete_data, as_lazy_data, is_lazy_data
+from iris.analysis import MAX_RUN
+
+
+def bool_func(x):
+    return x == 1
+
+
+class UnmaskedTest(tests.IrisTest):
+    def setUp(self):
+        """
+        Set up 1d and 2d unmasked data arrays for max run testing.
+
+        Uses 1 and 3 rather than 1 and 0 to check that lambda is being applied.
+        """
+
+        self.data_1ds = [
+            (np.array([3, 1, 1, 3, 3, 3]), 2),  # One run
+            (np.array([3, 1, 1, 3, 1, 3]), 2),  # Two runs
+            (np.array([3, 3, 3, 3, 3, 3]), 0),  # No run
+            (np.array([3, 3, 1, 3, 3, 3]), 1),  # Max run of 1
+            (np.array([1, 1, 1, 3, 1, 3]), 3),  # Run to start
+            (np.array([3, 1, 3, 1, 1, 1]), 3),  # Run to end
+            (np.array([1, 1, 1, 1, 1, 1]), 6),  # All run
+        ]
+
+        self.data_2d_axis0 = np.array(
+            [
+                [3, 1, 1, 3, 3, 3],  # One run
+                [3, 1, 1, 3, 1, 3],  # Two runs
+                [3, 3, 3, 3, 3, 3],  # No run
+                [3, 3, 1, 3, 3, 3],  # Max run of 1
+                [1, 1, 1, 3, 1, 3],  # Run to start
+                [3, 1, 3, 1, 1, 1],  # Run to end
+                [1, 1, 1, 1, 1, 1],  # All run
+            ]
+        ).T
+        self.expected_2d_axis0 = np.array([2, 2, 0, 1, 3, 3, 6])
+
+        self.data_2d_axis1 = self.data_2d_axis0.T
+        self.expected_2d_axis1 = np.array([2, 2, 0, 1, 3, 3, 6])
+
+
+class MaskedTest(tests.IrisTest):
+    def setUp(self):
+        """
+        Set up 1d and 2d unmasked data arrays for max run testing.
+
+        Uses 1 and 3 rather than 1 and 0 to check that lambda is being applied.
+        """
+
+        self.data_1ds = [
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([0, 0, 0, 0, 0, 0])
+                ),
+                3,
+            ),  # No mask
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([0, 0, 0, 0, 1, 1])
+                ),
+                3,
+            ),  # Mask misses run
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([1, 1, 1, 0, 0, 0])
+                ),
+                1,
+            ),  # Mask max run
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([0, 0, 1, 0, 0, 0])
+                ),
+                2,
+            ),  # Partially mask run
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([1, 1, 1, 1, 1, 1])
+                ),
+                0,
+            ),  # All mask
+            (
+                ma.masked_array(
+                    np.array([1, 1, 1, 3, 1, 3]), np.array([1, 1, 1, 1, 0, 1])
+                ),
+                1,
+            ),  # All mask or run
+        ]
+
+        self.data_2d_axis0 = ma.masked_array(
+            np.array(
+                [
+                    [1, 1, 1, 3, 1, 3],
+                    [1, 1, 1, 3, 1, 3],
+                    [1, 1, 1, 3, 1, 3],
+                    [1, 1, 1, 3, 1, 3],
+                    [1, 1, 1, 3, 1, 3],
+                    [1, 1, 1, 3, 1, 3],
+                ]
+            ),
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0],  # No mask
+                    [0, 0, 0, 0, 1, 1],  # Mask misses run
+                    [1, 1, 1, 0, 0, 0],  # Mask max run
+                    [0, 0, 1, 0, 0, 0],  # Partially mask run
+                    [1, 1, 1, 1, 1, 1],  # All mask
+                    [1, 1, 1, 1, 0, 1],  # All mask or run
+                ]
+            ),
+        ).T
+
+        self.expected_2d_axis0 = np.array([3, 3, 1, 2, 0, 1])
+
+        self.data_2d_axis1 = self.data_2d_axis0.T
+        self.expected_2d_axis1 = np.array([3, 3, 1, 2, 0, 1])
+
+
+class RealMixin:
+    def run_func(self, *args, **kwargs):
+        return MAX_RUN.call_func(*args, **kwargs)
+
+    def check_array(self, result, expected):
+        self.assertArrayEqual(result, expected)
+
+
+class LazyMixin:
+    def run_func(self, *args, **kwargs):
+        return MAX_RUN.lazy_func(*args, **kwargs)
+
+    def check_array(self, result, expected):
+        self.assertTrue(is_lazy_data(result))
+        result = as_concrete_data(result)
+        self.assertArrayEqual(result, expected)
+
+
+class TestBasic(UnmaskedTest, RealMixin):
+    def test_1d(self):
+        for data, expected in self.data_1ds:
+            result = self.run_func(
+                data,
+                axis=0,
+                function=bool_func,
+            )
+            self.check_array(result, expected)
+
+    def test_2d_axis0(self):
+        result = self.run_func(
+            self.data_2d_axis0,
+            axis=0,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis0)
+
+    def test_2d_axis1(self):
+        result = self.run_func(
+            self.data_2d_axis1,
+            axis=1,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis1)
+
+
+class TestLazy(UnmaskedTest, LazyMixin):
+    def test_1d(self):
+        for data, expected in self.data_1ds:
+            data = as_lazy_data(data)
+            result = self.run_func(
+                data,
+                axis=0,
+                function=bool_func,
+            )
+            self.check_array(result, expected)
+
+    def test_2d_axis0(self):
+        data = as_lazy_data(self.data_2d_axis0)
+        result = self.run_func(
+            data,
+            axis=0,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis0)
+
+    def test_2d_axis1(self):
+        data = as_lazy_data(self.data_2d_axis1)
+        result = self.run_func(
+            data,
+            axis=1,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis1)
+
+
+class TestLazyChunked(UnmaskedTest, LazyMixin):
+    def test_1d(self):
+        for data, expected in self.data_1ds:
+            data = as_lazy_data(data)
+            data.rechunk(1)
+            result = self.run_func(
+                data,
+                axis=0,
+                function=bool_func,
+            )
+            self.check_array(result, expected)
+
+    def test_2d_axis0_chunk0(self):
+        data = as_lazy_data(self.data_2d_axis0)
+        data.rechunk(1, -1)
+        result = self.run_func(
+            data,
+            axis=0,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis0)
+
+    def test_2d_axis0_chunk1(self):
+        data = as_lazy_data(self.data_2d_axis0)
+        data.rechunk(-1, 1)
+        result = self.run_func(
+            data,
+            axis=0,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis0)
+
+    def test_2d_axis1_chunk0(self):
+        data = as_lazy_data(self.data_2d_axis1)
+        data.rechunk(1, -1)
+        result = self.run_func(
+            data,
+            axis=1,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis1)
+
+    def test_2d_axis1_chunk1(self):
+        data = as_lazy_data(self.data_2d_axis1)
+        data.rechunk(-1, 1)
+        result = self.run_func(
+            data,
+            axis=1,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis1)
+
+
+class TestMasked(MaskedTest, RealMixin):
+    def test_1d(self):
+        for data, expected in self.data_1ds:
+            result = self.run_func(
+                data,
+                axis=0,
+                function=bool_func,
+            )
+            self.check_array(result, expected)
+
+    def test_2d_axis0(self):
+        result = self.run_func(
+            self.data_2d_axis0,
+            axis=0,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis0)
+
+    def test_2d_axis1(self):
+        result = self.run_func(
+            self.data_2d_axis1,
+            axis=1,
+            function=bool_func,
+        )
+        self.check_array(result, self.expected_2d_axis1)
+
+
+class Test_name(tests.IrisTest):
+    def test(self):
+        self.assertEqual(MAX_RUN.name(), "max_run")
+
+
+class Test_cell_method(tests.IrisTest):
+    def test(self):
+        self.assertIsNone(MAX_RUN.cell_method)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/analysis/test_MAX_RUN.py
+++ b/lib/iris/tests/unit/analysis/test_MAX_RUN.py
@@ -52,7 +52,7 @@ class UnmaskedTest(tests.IrisTest):
         self.expected_2d_axis0 = np.array([2, 2, 0, 1, 3, 3, 6])
 
         self.data_2d_axis1 = self.data_2d_axis0.T
-        self.expected_2d_axis1 = np.array([2, 2, 0, 1, 3, 3, 6])
+        self.expected_2d_axis1 = self.expected_2d_axis0
 
 
 class MaskedTest(tests.IrisTest):
@@ -128,7 +128,7 @@ class MaskedTest(tests.IrisTest):
         self.expected_2d_axis0 = np.array([3, 3, 1, 2, 0, 1])
 
         self.data_2d_axis1 = self.data_2d_axis0.T
-        self.expected_2d_axis1 = np.array([3, 3, 1, 2, 0, 1])
+        self.expected_2d_axis1 = self.expected_2d_axis0
 
 
 class RealMixin:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Multiple users have raised that they would like to be able to calculate run statistics on cubes. I have implemented a maximum run length aggregator to address this need. This could be extended in future to other run statistics (e.g. average run length).

In order to make the use of this aggregator flexible, the condition for counting a cell in the run is provided as a callable argument that returns a boolean. Doing this does mean that it isn't possible for the aggregator to write the cell method and standard name in a CF-compliant fashion.

Another approach could be to constrain the possible conditions and thus output a CF-compliant result - would that be better?

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
