### PR TITLE
Update percentile tests

### DIFF
--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -89,11 +89,12 @@ class AggregateMixin:
         self.check_percentile_calc(data, axis, percent, expected, approx=True)
 
 
-class MaskedAggregateMixin:
+class ScipyAggregateMixin:
     """
-    Tests for calculations on masked data.  Will only work if using the standard
-    (scipy) method.  Needs to be used with AggregateMixin, as these tests re-use its
-    method.
+    Tests for calculations specific to the default (scipy) function.  Includes
+    tests on masked data and tests to verify that the function is called with
+    the expected keywords.  Needs to be used with AggregateMixin, as some of
+    these tests re-use its method.
 
     """
 
@@ -181,7 +182,7 @@ class MaskedAggregateMixin:
             self.assertEqual(mocked_mquantiles.call_args.kwargs[key], val)
 
 
-class Test_aggregate(tests.IrisTest, AggregateMixin, MaskedAggregateMixin):
+class Test_aggregate(tests.IrisTest, AggregateMixin, ScipyAggregateMixin):
     """Tests for standard aggregation method on real data."""
 
     def setUp(self):
@@ -303,7 +304,7 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
 
 
 class Test_lazy_aggregate(
-    tests.IrisTest, AggregateMixin, MaskedAggregateMixin, MultiAxisMixin
+    tests.IrisTest, AggregateMixin, ScipyAggregateMixin, MultiAxisMixin
 ):
     """Tests for standard aggregation on lazy data."""
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Follow up to #3901, with some updates to the percentile tests:

* I realized the tests for checking that our `alphap`, `betap` kwargs get passed to `scipy` weren't quite right for the lazy case because
  * Passing a non-lazy array means that `map_blocks` never actually gets called!
  * We _expect_ the `mquantiles` call to happen when the data is realized, so we need a call to `as_concrete_data`.  Note that the tests would currently pass without the `as_concrete_data` call, because `mquantiles` is initially applied to a 0D array, as described at #4598, but that might change at some point.

* Added basic tests to verify that `numpy.percentile` gets called as expected for fast method.

Happily, the tests all still pass 🙂

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
