### PR TITLE
Cache during pp file load

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -99,6 +99,7 @@ import threading
 import iris._constraints
 from iris._deprecation import IrisDeprecation, warn_deprecated
 import iris.config
+from iris.coords import cache_coords
 import iris.io
 
 try:
@@ -280,6 +281,7 @@ def _load_collection(uris, constraints=None, callback=None):
     return result
 
 
+@cache_coords
 def load(uris, constraints=None, callback=None):
     """
     Loads any number of Cubes for each constraint.
@@ -309,6 +311,7 @@ def load(uris, constraints=None, callback=None):
     return _load_collection(uris, constraints, callback).merged().cubes()
 
 
+@cache_coords
 def load_cube(uris, constraint=None, callback=None):
     """
     Loads a single cube.
@@ -349,6 +352,7 @@ def load_cube(uris, constraint=None, callback=None):
     return cube
 
 
+@cache_coords
 def load_cubes(uris, constraints=None, callback=None):
     """
     Loads exactly one Cube for each constraint.
@@ -389,6 +393,7 @@ def load_cubes(uris, constraints=None, callback=None):
     return collection.cubes()
 
 
+@cache_coords
 def load_raw(uris, constraints=None, callback=None):
     """
     Loads non-merged cubes.

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -109,7 +109,9 @@ class _CoordMetaData(
         # Add circular flag metadata for dimensional coordinates.
         if hasattr(coord, "circular"):
             kwargs["circular"] = coord.circular
-        if isinstance(coord, iris.coords.DimCoord):
+        if isinstance(coord, iris.coords.DimCoord) or isinstance(
+            coord, iris.coords.DimCoordWrapper
+        ):
             # Mix the monotonic ordering into the metadata.
             if coord.points[0] == coord.points[-1]:
                 order = _CONSTANT

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -267,7 +267,7 @@ class _CoordConstraint:
         match the constraint.
 
         """
-        from iris.coords import Cell, DimCoord
+        from iris.coords import Cell, DimCoord, DimCoordWrapper
 
         # Cater for scalar cubes by setting the dimensionality to 1
         # when cube.ndim is 0.
@@ -305,9 +305,10 @@ class _CoordConstraint:
             def call_func(c):
                 return c == self._coord_thing
 
-            try_quick = isinstance(coord, DimCoord) and not isinstance(
-                self._coord_thing, Cell
-            )
+            try_quick = (
+                isinstance(coord, DimCoord)
+                or isinstance(coord, DimCoordWrapper)
+            ) and not isinstance(self._coord_thing, Cell)
 
         # Simple, yet dramatic, optimisation for the monotonic case.
         if try_quick:

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1805,7 +1805,10 @@ class ProtoCube:
             points_dtype = coord.dtype
             return (
                 not np.issubdtype(points_dtype, np.number),
-                not isinstance(coord, iris.coords.DimCoord),
+                not (
+                    isinstance(coord, iris.coords.DimCoord)
+                    or isinstance(coord, iris.coords.DimCoordWrapper)
+                ),
                 hint_dict.get(coord.name(), len(hint_dict) + 1),
                 axis_dict.get(
                     iris.util.guess_coord_axis(coord), len(axis_dict) + 1
@@ -1832,7 +1835,9 @@ class ProtoCube:
                     bounds_dtype = None
                 scalar_values.append(iris.coords.Cell(points[0], bounds))
                 kwargs = {}
-                if isinstance(coord, iris.coords.DimCoord):
+                if isinstance(coord, iris.coords.DimCoord) or isinstance(
+                    coord, iris.coords.DimCoordWrapper
+                ):
                     kwargs["circular"] = coord.circular
                 scalar_metadata.append(
                     _CoordMetaData(points_dtype, bounds_dtype, kwargs)

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -199,6 +199,12 @@ class _CoordPayload(
 
     @staticmethod
     def _coords_msgs(msgs, coord_group, defns_a, defns_b):
+        defns_a = [
+            iris.coords.DimCoordWrapper.unwrap(defn_a) for defn_a in defns_a
+        ]
+        defns_b = [
+            iris.coords.DimCoordWrapper.unwrap(defn_b) for defn_b in defns_b
+        ]
         if defns_a != defns_b:
             # Get a new list so we can modify it
             defns_b = list(defns_b)

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.lib.stride_tricks import as_strided
 import numpy.ma as ma
 
-from iris.coords import AuxCoord, DimCoord
+from iris.coords import AuxCoord, DimCoord, DimCoordWrapper
 import iris.util
 
 _DEFAULT_DTYPE = np.float16
@@ -471,7 +471,10 @@ class RectilinearInterpolator:
                     "rectilinear interpolation."
                 )
 
-            if not isinstance(coord, DimCoord):
+            if not (
+                isinstance(coord, DimCoord)
+                or isinstance(coord, DimCoordWrapper)
+            ):
                 # Check monotonic.
                 if not iris.util.monotonic(coord.points, strict=True):
                     msg = (
@@ -680,7 +683,10 @@ class RectilinearInterpolator:
 
         def gen_new_cube():
             if (
-                isinstance(new_coord, DimCoord)
+                (
+                    isinstance(new_coord, DimCoord)
+                    or isinstance(new_coord, DimCoordWrapper)
+                )
                 and len(dims) > 0
                 and dims[0] not in dims_with_dim_coords
             ):

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1478,6 +1478,16 @@ def metadata_filter(
             instance for instance in result if get_axis(instance) == axis
         ]
 
+    try:
+        obj = obj.unwrap(obj)
+    except AttributeError:
+        pass
+    for ii in range(len(result)):
+        try:
+            result[ii] = result[ii].unwrap(obj)
+        except AttributeError:
+            pass
+
     if obj is not None:
         if hasattr(obj, "__class__") and issubclass(
             obj.__class__, BaseMetadata

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -1484,7 +1484,7 @@ def metadata_filter(
         pass
     for ii in range(len(result)):
         try:
-            result[ii] = result[ii].unwrap(obj)
+            result[ii] = result[ii].unwrap(result[ii])
         except AttributeError:
             pass
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1779,7 +1779,9 @@ class Cube(CFVariableMixin):
         def extract_coord(coord_or_factory):
             if isinstance(coord_or_factory, iris.aux_factory.AuxCoordFactory):
                 coord = coord_or_factory.make_coord(self.coord_dims)
-            elif isinstance(coord_or_factory, iris.coords.Coord):
+            elif isinstance(coord_or_factory, iris.coords.Coord) or isinstance(
+                coord_or_factory, iris.coords.DimCoordWrapper
+            ):
                 coord = coord_or_factory
             else:
                 msg = "Expected Coord or AuxCoordFactory, got " "{!r}.".format(

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -295,7 +295,9 @@ def _coord_text(label, coord):
     """
     # Which bits to write?
     # Note: This is is not very OO but we are achieving a separation of DOT from cdm by doing this.
-    if isinstance(coord, iris.coords.DimCoord):
+    if isinstance(coord, iris.coords.DimCoord) or isinstance(
+        coord, iris.coords.DimCoordWrapper
+    ):
         _dot_attrs = ("standard_name", "long_name", "units", "circular")
     elif isinstance(coord, iris.coords.AuxCoord):
         _dot_attrs = ("standard_name", "long_name", "units")

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -14,7 +14,7 @@ import cf_units
 import numpy as np
 
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
-from iris.coords import AuxCoord, CellMethod, DimCoord
+from iris.coords import AuxCoord, CellMethod, DimCoord, DimCoordWrapper
 from iris.fileformats._pp_lbproc_pairs import LBPROC_MAP
 from iris.fileformats.rules import (
     ConversionMetadata,
@@ -1120,7 +1120,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzx,
                     f.bdx,
                     f.lbnpt,
@@ -1141,7 +1141,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzx,
                     f.bdx,
                     f.lbnpt,
@@ -1163,7 +1163,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzy,
                     f.bdy,
                     f.lbrow,
@@ -1183,7 +1183,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzy,
                     f.bdy,
                     f.lbrow,
@@ -1270,7 +1270,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzx,
                     f.bdx,
                     f.lbnpt,
@@ -1290,7 +1290,10 @@ def _all_other_rules(f):
         dim_coords_and_dims.append(
             (
                 DimCoord(
-                    f.y, long_name="pressure", units="hPa", bounds=f.y_bounds
+                    f.y,
+                    long_name="pressure",
+                    units="hPa",
+                    bounds=f.y_bounds,
                 ),
                 0,
             )
@@ -1304,7 +1307,10 @@ def _all_other_rules(f):
         dim_coords_and_dims.append(
             (
                 DimCoord(
-                    f.x, long_name="pressure", units="hPa", bounds=f.x_bounds
+                    f.x,
+                    long_name="pressure",
+                    units="hPa",
+                    bounds=f.x_bounds,
                 ),
                 1,
             )
@@ -1380,7 +1386,7 @@ def _all_other_rules(f):
     ):
         dim_coords_and_dims.append(
             (
-                DimCoord.from_regular(
+                DimCoordWrapper.from_regular(
                     f.bzx, f.bdx, f.lbnpt, long_name="site_number", units="1"
                 ),
                 1,

--- a/lib/iris/fileformats/um/_fast_load.py
+++ b/lib/iris/fileformats/um/_fast_load.py
@@ -29,7 +29,7 @@ import numpy as np
 
 # Be minimal about what we import from iris, to avoid circular imports.
 # Below, other parts of iris.fileformats are accessed via deferred imports.
-from iris.coords import DimCoord
+from iris.coords import DimCoord, DimCoordWrapper
 from iris.cube import CubeList
 from iris.exceptions import TranslationError
 from iris.fileformats.um._fast_load_structured_fields import (
@@ -235,7 +235,10 @@ def _convert_collation(collation):
         # and target everything else at aux_coords.
         for coord, dims in sorted(coords_and_dims, key=key_func):
             if (
-                isinstance(coord, DimCoord)
+                (
+                    isinstance(coord, DimCoord)
+                    or isinstance(coord, DimCoordWrapper)
+                )
                 and dims is not None
                 and len(dims) == 1
                 and dims[0] not in dim_coord_dims

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -165,7 +165,10 @@ def _get_plot_defn(cube, mode, ndims=2):
             aux_coords = [
                 coord
                 for coord in aux_coords
-                if isinstance(coord, iris.coords.DimCoord)
+                if (
+                    isinstance(coord, iris.coords.DimCoord)
+                    or isinstance(coord, iris.coords.DimCoordWrapper)
+                )
             ]
             if aux_coords:
                 aux_coords.sort(key=lambda coord: coord.metadata)

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1225,7 +1225,7 @@ class GraphicsTestMixin:
     def setUp(self):
         # Acquire threading non re-entrant blocking lock to ensure
         # thread-safe plotting.
-        _lock.acquire()
+        # _lock.acquire()
         # Make sure we have no unclosed plots from previous tests before
         # generating this one.
         if MPL_AVAILABLE:
@@ -1237,7 +1237,7 @@ class GraphicsTestMixin:
         if MPL_AVAILABLE:
             plt.close("all")
         # Release the non re-entrant blocking lock.
-        _lock.release()
+        # _lock.release()
 
 
 class GraphicsTest(GraphicsTestMixin, IrisTest):

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1225,7 +1225,7 @@ class GraphicsTestMixin:
     def setUp(self):
         # Acquire threading non re-entrant blocking lock to ensure
         # thread-safe plotting.
-        # _lock.acquire()
+        _lock.acquire()
         # Make sure we have no unclosed plots from previous tests before
         # generating this one.
         if MPL_AVAILABLE:
@@ -1237,7 +1237,7 @@ class GraphicsTestMixin:
         if MPL_AVAILABLE:
             plt.close("all")
         # Release the non re-entrant blocking lock.
-        # _lock.release()
+        _lock.release()
 
 
 class GraphicsTest(GraphicsTestMixin, IrisTest):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
A contributing factor to the speed of pp and ff loading in Iris is the repeated creation of identical `DimCoord`s that are then thrown away during the merge step. This PR introduces a `DimCoordWrapper` that maintains a cache of `DimCoord`s based on the methods and arguments used to create and mutate them.

Thoughts / concerns / RFC:
* Some tests are currently failing due to mocking matches (possibly they're too strict?)
* I'm fairly keen to stop the `DimCoordWrapper`s escaping from the load process into user code as calls to `isinstance(coord, DimCoord)` currently fail against them. Is it worth putting a catcher into the public load functions?
* Is this a good way to cache? Does anyone know a pre-written way of doing similar caching?
* Should I extend the caching (only currently done to `DimCoord`s made by `from_regular`) to cover ones made the normal way too?

---


```
nox > asv compare 591c9f4817e04422cd076a878704afc85482f1dc 03c22896b4456ba00f77bd1284423a71b34ac7e4

All benchmarks:

       before           after         ratio
     [591c9f48]       [03c22896]
-      11.1±0.3ms       9.24±0.2ms     0.83  load.LoadAndRealise.time_load((1280, 960, 5), False, 'FF')
       33.2±0.5ms       32.1±0.5ms     0.97  load.LoadAndRealise.time_load((1280, 960, 5), False, 'NetCDF')
       12.1±0.4ms       10.2±0.1ms    ~0.84  load.LoadAndRealise.time_load((1280, 960, 5), False, 'PP')
-     10.9±0.06ms       9.34±0.4ms     0.86  load.LoadAndRealise.time_load((1280, 960, 5), True, 'FF')
       32.6±0.3ms       31.8±0.3ms     0.98  load.LoadAndRealise.time_load((1280, 960, 5), True, 'NetCDF')
-     11.7±0.05ms      9.85±0.07ms     0.84  load.LoadAndRealise.time_load((1280, 960, 5), True, 'PP')
-      1.74±0.02s       1.48±0.01s     0.85  load.LoadAndRealise.time_load((2, 2, 1000), False, 'FF')
       30.9±0.9ms       30.6±0.4ms     0.99  load.LoadAndRealise.time_load((2, 2, 1000), False, 'NetCDF')
-         1.93±0s          1.64±0s     0.85  load.LoadAndRealise.time_load((2, 2, 1000), False, 'PP')
-      1.75±0.01s          1.46±0s     0.84  load.LoadAndRealise.time_load((2, 2, 1000), True, 'FF')
         32.3±1ms       30.9±0.5ms     0.95  load.LoadAndRealise.time_load((2, 2, 1000), True, 'NetCDF')
-      1.92±0.01s       1.64±0.01s     0.86  load.LoadAndRealise.time_load((2, 2, 1000), True, 'PP')
      4.75±0.09ms      4.55±0.03ms     0.96  load.LoadAndRealise.time_load((2, 2, 2), False, 'FF')
         31.2±1ms       31.3±0.8ms     1.00  load.LoadAndRealise.time_load((2, 2, 2), False, 'NetCDF')
       5.13±0.1ms       4.96±0.1ms     0.97  load.LoadAndRealise.time_load((2, 2, 2), False, 'PP')
      4.64±0.02ms      4.55±0.03ms     0.98  load.LoadAndRealise.time_load((2, 2, 2), True, 'FF')
       31.1±0.2ms       30.2±0.2ms     0.97  load.LoadAndRealise.time_load((2, 2, 2), True, 'NetCDF')
      5.03±0.02ms      4.92±0.02ms     0.98  load.LoadAndRealise.time_load((2, 2, 2), True, 'PP')
         61.0±1ms         62.0±1ms     1.02  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'FF')
       37.1±0.2ms       36.8±0.3ms     0.99  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'NetCDF')
       19.9±0.6ms       20.1±0.7ms     1.01  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'PP')
       30.0±0.2ms       30.8±0.2ms     1.02  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'FF')
       88.3±0.5ms       88.1±0.6ms     1.00  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'NetCDF')
       30.6±0.5ms       30.4±0.9ms     1.00  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'PP')
         400±10ms          400±4ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'FF')
      3.08±0.03ms      3.09±0.04ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'NetCDF')
          405±8ms          406±6ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'PP')
          402±4ms          409±3ms     1.02  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'FF')
      3.09±0.02ms      3.09±0.02ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'NetCDF')
          412±3ms          407±5ms     0.99  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'PP')
      1.10±0.03ms      1.09±0.04ms     0.99  load.LoadAndRealise.time_realise((2, 2, 2), False, 'FF')
      3.11±0.07ms      3.04±0.04ms     0.98  load.LoadAndRealise.time_realise((2, 2, 2), False, 'NetCDF')
      1.11±0.01ms      1.10±0.02ms     1.00  load.LoadAndRealise.time_realise((2, 2, 2), False, 'PP')
      1.08±0.02ms      1.09±0.02ms     1.01  load.LoadAndRealise.time_realise((2, 2, 2), True, 'FF')
      3.16±0.07ms      3.06±0.02ms     0.97  load.LoadAndRealise.time_realise((2, 2, 2), True, 'NetCDF')
      1.15±0.02ms      1.11±0.01ms     0.96  load.LoadAndRealise.time_realise((2, 2, 2), True, 'PP')
```
