### PR TITLE
added link check ignore and ensured https use

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -347,6 +347,8 @@ linkcheck_ignore = [
     "http://cfconventions.org",
     "http://code.google.com/p/msysgit/downloads/list",
     "http://effbot.org",
+    "https://help.github.com",
+    "https://docs.github.com",
     "https://github.com",
     "http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html",
     "http://schacon.github.com/git",

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -157,7 +157,7 @@ Ask for Your Changes to be Reviewed or Merged
 When you are ready to ask for someone to review your code and consider a merge:
 
 #. Go to the URL of your forked repo, say
-   ``http://github.com/your-user-name/iris``.
+   ``https://github.com/your-user-name/iris``.
 #. Use the 'Switch Branches' dropdown menu near the top left of the page to
    select the branch with your changes:
 
@@ -190,7 +190,7 @@ Delete a Branch on Github
    git push origin :my-unwanted-branch
 
 Note the colon ``:`` before ``test-branch``.  See also:
-http://github.com/guides/remove-a-remote-branch
+https://github.com/guides/remove-a-remote-branch
 
 
 Several People Sharing a Single Repository
@@ -203,7 +203,7 @@ share it via github.
 First fork iris into your account, as from :ref:`forking`.
 
 Then, go to your forked repository github page, say
-``http://github.com/your-user-name/iris``, select :guilabel:`Settings`,
+``https://github.com/your-user-name/iris``, select :guilabel:`Settings`,
 :guilabel:`Manage Access` and then :guilabel:`Invite collaborator`.
 
 .. note:: For more information on sharing your repository see the

--- a/docs/src/developers_guide/gitwash/forking.rst
+++ b/docs/src/developers_guide/gitwash/forking.rst
@@ -7,7 +7,7 @@ Making Your own Copy (fork) of Iris
 ===================================
 
 You need to do this only once.  The instructions here are very similar
-to the instructions at http://help.github.com/forking/, please see
+to the instructions at https://help.github.com/forking/, please see
 that page for more detail.  We're repeating some of it here just to give the
 specifics for the `Iris`_ project, and to suggest some default names.
 

--- a/docs/src/developers_guide/gitwash/git_links.inc
+++ b/docs/src/developers_guide/gitwash/git_links.inc
@@ -9,8 +9,8 @@
    nipy, NIPY, Nipy, etc...
 
 .. _git: http://git-scm.com/
-.. _github: http://github.com
-.. _github help: http://help.github.com
+.. _github: https://github.com
+.. _github help: https://help.github.com
 .. _git documentation: https://git-scm.com/docs
 
 .. _git clone: http://schacon.github.com/git/git-clone.html


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Linkcheck is failing on the github docs url.  This PR `ignores` that url and ensure some references are `https` and not `http`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
