### PR TITLE
Cache regular points generation

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -81,7 +81,9 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. N/A
+#. `@wjbenfold`_ added caching to the calculation of the points array in a
+   :class:`~iris.coords.DimCoord` created using
+   :meth:`~iris.coords.DimCoord.from_regular`. (:pull:`4698`)
 
 
 🔥 Deprecations

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2524,6 +2524,10 @@ class Coord(_DimensionalMetadata):
         return unique_value
 
 
+_regular_points = lru_cache(iris.util.regular_points)
+"""Caching version of iris.util.regular_points"""
+
+
 class DimCoord(Coord):
     """
     A coordinate that is 1D, and numeric, with values that have a strict monotonic ordering. Missing values are not
@@ -2573,9 +2577,7 @@ class DimCoord(Coord):
         """
         # Use lru_cache because this is done repeatedly with the same arguments
         # (particularly in field-based file loading).
-        points = lru_cache(iris.util.regular_points)(
-            zeroth, step, count
-        ).copy()
+        points = _regular_points(zeroth, step, count).copy()
         points.flags.writeable = False
 
         if with_bounds:

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1281,6 +1281,32 @@ def regular_step(coord):
     return avdiff.astype(coord.points.dtype)
 
 
+def regular_points(zeroth, step, count):
+    """Make an array of regular points.
+
+    Create an array of `count` points from `zeroth` + `step`, adding `step` each
+    time. In float32 if this gives a sufficiently regular array (tested with
+    points_step) and float64 if not.
+
+    Parameters
+    ----------
+    zeroth : number
+        The value *prior* to the first point value.
+
+    step : number
+        The numeric difference between successive point values.
+
+    count : number
+        The number of point values.
+
+    """
+    points = (zeroth + step) + step * np.arange(count, dtype=np.float32)
+    _, regular = iris.util.points_step(points)
+    if not regular:
+        points = (zeroth + step) + step * np.arange(count, dtype=np.float64)
+    return points
+
+
 def points_step(points):
     """Determine whether `points` has a regular step.
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Speed up for `pp` and `ff` file loading by caching expensive check at the start of `DimCoord` creation. I've introduced an extra array copy per `DimCoord` on a flat pp file, but I think the improvements on deep files outweighs this concern.

Benchmark results from dedicated machine:

```
All benchmarks:

       before           after         ratio
     [478fa635]       [c4c75aa1]
-      10.9±0.1ms      9.73±0.05ms     0.90  load.LoadAndRealise.time_load((1280, 960, 5), False, 'FF')
       33.4±0.9ms       31.9±0.3ms     0.95  load.LoadAndRealise.time_load((1280, 960, 5), False, 'NetCDF')
-      12.0±0.2ms      10.6±0.05ms     0.88  load.LoadAndRealise.time_load((1280, 960, 5), False, 'PP')
-      11.1±0.3ms      9.68±0.03ms     0.88  load.LoadAndRealise.time_load((1280, 960, 5), True, 'FF')
       32.0±0.6ms       32.6±0.6ms     1.02  load.LoadAndRealise.time_load((1280, 960, 5), True, 'NetCDF')
-      12.2±0.2ms       10.9±0.2ms     0.89  load.LoadAndRealise.time_load((1280, 960, 5), True, 'PP')
       1.76±0.01s       1.62±0.01s     0.92  load.LoadAndRealise.time_load((2, 2, 1000), False, 'FF')
       32.2±0.6ms       30.3±0.5ms     0.94  load.LoadAndRealise.time_load((2, 2, 1000), False, 'NetCDF')
-      1.94±0.02s          1.76±0s     0.91  load.LoadAndRealise.time_load((2, 2, 1000), False, 'PP')
-      1.83±0.04s          1.58±0s     0.87  load.LoadAndRealise.time_load((2, 2, 1000), True, 'FF')
       31.4±0.8ms         32.0±1ms     1.02  load.LoadAndRealise.time_load((2, 2, 1000), True, 'NetCDF')
-      1.96±0.01s       1.75±0.01s     0.89  load.LoadAndRealise.time_load((2, 2, 1000), True, 'PP')
      4.76±0.02ms      4.48±0.01ms     0.94  load.LoadAndRealise.time_load((2, 2, 2), False, 'FF')
       30.8±0.7ms       30.2±0.4ms     0.98  load.LoadAndRealise.time_load((2, 2, 2), False, 'NetCDF')
      5.05±0.04ms       4.73±0.5ms     0.94  load.LoadAndRealise.time_load((2, 2, 2), False, 'PP')
-     4.79±0.03ms      4.35±0.04ms     0.91  load.LoadAndRealise.time_load((2, 2, 2), True, 'FF')
       30.4±0.4ms       30.3±0.1ms     1.00  load.LoadAndRealise.time_load((2, 2, 2), True, 'NetCDF')
      5.11±0.06ms      4.65±0.01ms     0.91  load.LoadAndRealise.time_load((2, 2, 2), True, 'PP')
         62.4±3ms         63.0±2ms     1.01  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'FF')
       37.0±0.1ms         37.4±1ms     1.01  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'NetCDF')
       20.0±0.7ms       20.5±0.3ms     1.03  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'PP')
       30.6±0.4ms       31.4±0.7ms     1.03  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'FF')
       88.6±0.3ms       88.1±0.3ms     0.99  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'NetCDF')
       30.5±0.7ms         31.2±1ms     1.02  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'PP')
          399±4ms          397±7ms     0.99  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'FF')
      3.07±0.03ms      3.03±0.02ms     0.99  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'NetCDF')
          400±4ms          408±9ms     1.02  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'PP')
          406±7ms          413±5ms     1.02  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'FF')
      3.16±0.04ms      3.09±0.02ms     0.98  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'NetCDF')
          413±8ms          412±4ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'PP')
      1.07±0.01ms      1.08±0.01ms     1.01  load.LoadAndRealise.time_realise((2, 2, 2), False, 'FF')
      3.05±0.06ms      2.97±0.02ms     0.97  load.LoadAndRealise.time_realise((2, 2, 2), False, 'NetCDF')
      1.10±0.01ms      1.10±0.03ms     0.99  load.LoadAndRealise.time_realise((2, 2, 2), False, 'PP')
      1.08±0.01ms      1.13±0.01ms     1.04  load.LoadAndRealise.time_realise((2, 2, 2), True, 'FF')
      3.17±0.05ms      3.03±0.01ms     0.95  load.LoadAndRealise.time_realise((2, 2, 2), True, 'NetCDF')
      1.12±0.02ms      1.11±0.02ms     0.99  load.LoadAndRealise.time_realise((2, 2, 2), True, 'PP')
```

P.S. I had totally thought of this before I saw @rcomer's comment on #4690 but grateful for the prompt to try it out here

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
