### PR TITLE
Change Cell equality to equate nans (fixes #4681)

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -84,6 +84,12 @@ This document explains the changes made to Iris for this release
    to ``stderr`` when a :class:`~iris.fileformats.cf.CFReader` that fails to
    initialise is garbage collected. (:issue:`3312`, :pull:`4646`)
 
+#. `@stephenworsley`_ aligned the behaviour of :obj:`~iris.coords.Cell` equality
+   to match :obj:`~iris.coords.Coord` equality with respect to NaN values.
+   Two NaN valued Cells are now considered equal. This fixes :issue:`4681` and
+   causes NaN valued scalar coordinates to be able to merge be preserved during
+   cube merging. (:pull:`4701`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1358,9 +1358,19 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         ):
             if self.bound is not None:
                 return self.contains_point(other)
+            elif isinstance(other, (float, np.number)) and np.isnan(other):
+                return isinstance(self.point, (float, np.number)) and np.isnan(
+                    self.point
+                )
             else:
                 return self.point == other
         elif isinstance(other, Cell):
+            if isinstance(other.point, (float, np.number)) and np.isnan(
+                other.point
+            ):
+                return isinstance(self.point, (float, np.number)) and np.isnan(
+                    self.point
+                )
             return (self.point == other.point) and (
                 self.bound == other.bound or self.bound == other.bound[::-1]
             )

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1353,24 +1353,27 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         compared.
 
         """
+
+        def nan_equality(x, y):
+            return (
+                isinstance(x, (float, np.number))
+                and np.isnan(x)
+                and isinstance(y, (float, np.number))
+                and np.isnan(y)
+            )
+
         if isinstance(other, (int, float, np.number)) or hasattr(
             other, "timetuple"
         ):
             if self.bound is not None:
                 return self.contains_point(other)
-            elif isinstance(other, (float, np.number)) and np.isnan(other):
-                return isinstance(self.point, (float, np.number)) and np.isnan(
-                    self.point
-                )
+            elif nan_equality(self.point, other):
+                return True
             else:
                 return self.point == other
         elif isinstance(other, Cell):
-            if isinstance(other.point, (float, np.number)) and np.isnan(
-                other.point
-            ):
-                return isinstance(self.point, (float, np.number)) and np.isnan(
-                    self.point
-                )
+            if nan_equality(self.point, other.point):
+                return True
             return (self.point == other.point) and (
                 self.bound == other.bound or self.bound == other.bound[::-1]
             )

--- a/lib/iris/tests/integration/merge/test_merge.py
+++ b/lib/iris/tests/integration/merge/test_merge.py
@@ -12,8 +12,9 @@ Integration tests for merging cubes.
 # before importing anything else.
 import iris.tests as tests  # isort:skip
 
-from iris.coords import DimCoord
+from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
+import numpy as np
 
 
 class TestContiguous(tests.IrisTest):
@@ -31,6 +32,31 @@ class TestContiguous(tests.IrisTest):
         self.assertTrue(coord2.is_contiguous())
         self.assertArrayEqual(coord2.points, [1, 2, 3])
         self.assertArrayEqual(coord2.bounds, coord1.bounds[::-1, ::-1])
+
+
+class TestNaNs(tests.IrisTest):
+    def test_merge_nan_coords(self):
+        # Test that nan valued coordinates merge together.
+        cube1 = Cube(np.ones([3, 4]), "air_temperature", units="K")
+        coord1 = DimCoord([1, 2, 3], long_name="x")
+        coord2 = DimCoord([0, 1, 2, 3], long_name="y")
+        nan_coord1 = AuxCoord(np.nan, long_name="nan1")
+        nan_coord2 = AuxCoord([np.nan] * 4, long_name="nan2")
+        cube1.add_dim_coord(coord1, 0)
+        cube1.add_dim_coord(coord2, 1)
+        cube1.add_aux_coord(nan_coord1)
+        cube1.add_aux_coord(nan_coord2, 1)
+        cubes = CubeList(cube1.slices_over("x"))
+        cube2 = cubes.merge_cube()
+
+        self.assertArrayEqual(
+            np.isnan(nan_coord1.points),
+            np.isnan(cube2.coord("nan1").points),
+        )
+        self.assertArrayEqual(
+            np.isnan(nan_coord2.points),
+            np.isnan(cube2.coord("nan2").points),
+        )
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/integration/merge/test_merge.py
+++ b/lib/iris/tests/integration/merge/test_merge.py
@@ -12,9 +12,10 @@ Integration tests for merging cubes.
 # before importing anything else.
 import iris.tests as tests  # isort:skip
 
+import numpy as np
+
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
-import numpy as np
 
 
 class TestContiguous(tests.IrisTest):

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -146,6 +146,14 @@ class Test___eq__(tests.IrisTest):
         self.assertNotEqual(cell, PartialDateTime(month=3, hour=12))
         self.assertNotEqual(cell, PartialDateTime(month=4))
 
+    def test_nan_other(self):
+        # Check that nans satisfy equality.
+        cell1 = Cell(np.nan)
+        cell2 = Cell(np.nan)
+        self.assertEqual(cell1, np.nan)
+        self.assertEqual(np.nan, cell1)
+        self.assertEqual(cell1, cell2)
+
 
 class Test_contains_point(tests.IrisTest):
     def test_datetimelike_bounded_cell(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Fixes #4681 by making Cell equality handle nans in the same way as Coord equality, i.e. returning true when comparing a nan value with another value. This causes scalar coords containing nans to merge into one scalar coord rather than creating a long AuxCoord.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
