### PR TITLE
Benchmarking issues: put PR link in bullet point

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,8 +93,11 @@ jobs:
               fi
               title="Performance Shift(s): \`$commit\`"
               body="
-          Benchmark comparison has identified performance shifts at commit \
-          $commit (#$pr_number). Please review the report below and \
+          Benchmark comparison has identified performance shifts at
+          
+          * commit $commit (#$pr_number).
+          
+          Please review the report below and \
           take corrective/congratulatory action as appropriate \
           :slightly_smiling_face:
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
I'm lazy and don't like to do any more clicking than necessary!  If a PR link appears in a bulleted list then the PR's title gets spelt out so you can see what it was without clicking through.

I don't know how to test this change to verify it will have the effect I expect...

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
