### PR TITLE
Remove `time_return` benchmarks

### DIFF
--- a/benchmarks/benchmarks/aux_factory.py
+++ b/benchmarks/benchmarks/aux_factory.py
@@ -44,10 +44,6 @@ class FactoryCommon:
         specified in the subclass."""
         self.create()
 
-    def time_return(self):
-        """Return an instance of the benchmarked factory."""
-        self.factory
-
 
 class HybridHeightFactory(FactoryCommon):
     def setup(self):

--- a/benchmarks/benchmarks/coords.py
+++ b/benchmarks/benchmarks/coords.py
@@ -51,10 +51,6 @@ class CoordCommon:
         specified in the subclass."""
         self.create()
 
-    def time_return(self):
-        """Return an instance of the benchmarked coord."""
-        self.component
-
 
 class DimCoord(CoordCommon):
     def setup(self):

--- a/benchmarks/benchmarks/cube.py
+++ b/benchmarks/benchmarks/cube.py
@@ -68,10 +68,6 @@ class ComponentCommon:
         general_cube_copy = general_cube.copy(data=data_2d)
         self.add_method(general_cube_copy, *self.add_args)
 
-    def time_return(self):
-        """Return a cube that includes an instance of the benchmarked component."""
-        self.cube
-
 
 class Cube:
     def time_basic(self):
@@ -205,9 +201,6 @@ class MeshCoord:
     @disable_repeat_between_setup
     def time_remove(self, n_faces):
         self.cube.remove_coord(self.mesh_coord)
-
-    def time_return(self, n_faces):
-        _ = self.cube
 
 
 class Merge:

--- a/benchmarks/benchmarks/experimental/ugrid/__init__.py
+++ b/benchmarks/benchmarks/experimental/ugrid/__init__.py
@@ -47,10 +47,6 @@ class UGridCommon:
         specified in the subclass."""
         self.create()
 
-    def time_return(self, *params):
-        """Return an instance of the benchmarked object."""
-        _ = self.object
-
 
 class Connectivity(UGridCommon):
     def setup(self, n_faces):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The `time_return` benchmarks offer no performance information, since they effectively do nothing. Their minimal runtime is vulnerable to result noise - lots of false positives.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
