### PR TITLE
Addaux speedup

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -93,7 +93,7 @@ This document explains the changes made to Iris for this release
    :class:`~iris.coords.DimCoord` created using
    :meth:`~iris.coords.DimCoord.from_regular`. (:pull:`4698`)
 
-#. `@pp-mo`_ streamlined :meth:`~iris.cube.Cube.add_aux_factory`.
+#. `@pp-mo`_ made :meth:`~iris.cube.Cube.add_aux_factory` faster.
    (:pull:`4718`)
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -93,6 +93,10 @@ This document explains the changes made to Iris for this release
    :class:`~iris.coords.DimCoord` created using
    :meth:`~iris.coords.DimCoord.from_regular`. (:pull:`4698`)
 
+#. `@pp-mo`_ streamlined :meth:`~iris.cube.Cube.add_aux_factory`.
+   (:pull:`xxxx`)
+
+
 
 🔥 Deprecations
 ===============

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -94,7 +94,7 @@ This document explains the changes made to Iris for this release
    :meth:`~iris.coords.DimCoord.from_regular`. (:pull:`4698`)
 
 #. `@pp-mo`_ streamlined :meth:`~iris.cube.Cube.add_aux_factory`.
-   (:pull:`xxxx`)
+   (:pull:`4718`)
 
 
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1189,13 +1189,15 @@ class Cube(CFVariableMixin):
                 "iris.aux_factory.AuxCoordFactory."
             )
 
+        # Get all 'real' coords (i.e. not derived ones) : use private data
+        # rather than cube.coords(), as that is quite slow.
         def coordsonly(coords_and_dims):
             return [coord for coord, dims in coords_and_dims]
 
         cube_coords = coordsonly(self._dim_coords_and_dims) + coordsonly(
             self._aux_coords_and_dims
         )
-        # self.coords()
+
         for dependency in aux_factory.dependencies:
             ref_coord = aux_factory.dependencies[dependency]
             if ref_coord is not None and ref_coord not in cube_coords:

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1188,7 +1188,14 @@ class Cube(CFVariableMixin):
                 "Factory must be a subclass of "
                 "iris.aux_factory.AuxCoordFactory."
             )
-        cube_coords = self.coords()
+
+        def coordsonly(coords_and_dims):
+            return [coord for coord, dims in coords_and_dims]
+
+        cube_coords = coordsonly(self._dim_coords_and_dims) + coordsonly(
+            self._aux_coords_and_dims
+        )
+        # self.coords()
         for dependency in aux_factory.dependencies:
             ref_coord = aux_factory.dependencies[dependency]
             if ref_coord is not None and ref_coord not in cube_coords:


### PR DESCRIPTION
In response to https://github.com/SciTools/iris/issues/4713 and several similar benchmark performance triggers, 
which seem to indicate that the time to call `iris.cube.Cube.add_aux_factory` is highly variable.
Actually, it seems on reflection that this time is unexpectedly **_long_**.

This attempts to address the speed issue, by 
Initial local testing results ...
```
$ nox --session="benchmarks(custom)" -- continuous -e --bench AuxFactory "2f9c8d0da~1..c60ff9a80"
nox > Running session benchmarks(custom)
  . . .
Running ASV...
nox > cd benchmarks
nox > asv machine --yes
  . . .
· Ignoring ASV setting(s): `python`. Benchmark environment management is delegated to third party script(s).
· Creating environments
· Discovering benchmarks
· Running 6 total benchmarks (2 commits * 1 environments * 3 benchmarks)
[  0.00%] · For scitools-iris commit 2f9c8d0d <latest> (round 1/2):
[  0.00%] ·· Building for conda-delegated............
[  0.00%] ·· Benchmarking conda-delegated
[  8.33%] ··· Running (cube.AuxFactory.time_add--)....
[ 25.00%] · For scitools-iris commit c60ff9a8 <addaux_speedup> (round 1/2):
[ 25.00%] ·· Building for conda-delegated......
[ 25.00%] ·· Benchmarking conda-delegated
[ 33.33%] ··· Running (cube.AuxFactory.time_add--)...
[ 50.00%] · For scitools-iris commit c60ff9a8 <addaux_speedup> (round 2/2):
[ 50.00%] ·· Benchmarking conda-delegated
[ 58.33%] ··· cube.AuxFactory.time_add                                                                                                                                               77.6±0.3μs
[ 66.67%] ··· cube.AuxFactory.time_create                                                                                                                                            14.0±0.2μs
[ 75.00%] ··· cube.AuxFactory.time_return                                                                                                                                            85.7±0.5ns
[ 75.00%] · For scitools-iris commit 2f9c8d0d <latest> (round 2/2):
[ 75.00%] ·· Building for conda-delegated...
[ 75.00%] ·· Benchmarking conda-delegated
[ 83.33%] ··· cube.AuxFactory.time_add                                                                                                                                              7.23±0.06ms
[ 91.67%] ··· cube.AuxFactory.time_create                                                                                                                                            22.3±0.1μs
[100.00%] ··· cube.AuxFactory.time_return                                                                                                                                              88.2±1ns
.       before           after         ratio
     [2f9c8d0d]       [c60ff9a8]
     <latest>         <addaux_speedup>
-      22.3±0.1μs       14.0±0.2μs     0.63  cube.AuxFactory.time_create
-     7.23±0.06ms       77.6±0.3μs     0.01  cube.AuxFactory.time_add

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
nox > Session benchmarks(custom) was successful.

$ git status
```

If that's replicated, and tests all pass, it sounds like a win !