### PR TITLE
`MAX_RUN` into docs

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -49,6 +49,9 @@ This document explains the changes made to Iris for this release
    ``standard_parallel`` and ``scale_factor_at_projection_origin`` to
    :class:`~iris.coord_system.Mercator`. (:issue:`3844`, :pull:`4609`)
 
+#. `@wjbenfold`_ and `@stephenworsley`_ (reviewer) added a maximum run length
+   aggregator (:class:`~iris.analysis.MAX_RUN`). (:pull:`4676`)
+
 
 🐛 Bugs Fixed
 =============

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -64,6 +64,7 @@ __all__ = (
     "HMEAN",
     "Linear",
     "MAX",
+    "MAX_RUN",
     "MEAN",
     "MEDIAN",
     "MIN",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
`iris.analysis.MAX_RUN` hadn't made it into the API docs or what's new. This is fixed here.

Closes #4725 

Docs build here: https://www-avd/~wbenfold/iris/whatsnew/latest.html

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
