### PR TITLE
Cell comparison: remove ancient netcdftime/cftime workarounds

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -60,6 +60,9 @@ This document explains the changes made to Iris for this release
    variables and cell measures that map to a cube dimension of length 1 are now
    included in the respective vector sections. (:pull:`4945`)
 
+#. `@rcomer`_ removed some old redundant code that prevented determining the
+   order of time cells. (:issue:`4697`, :pull:`4729`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -18,7 +18,6 @@ import operator
 import warnings
 import zlib
 
-import cftime
 import dask.array as da
 import numpy as np
 import numpy.ma as ma
@@ -1411,16 +1410,6 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         ):
             raise ValueError("Unexpected operator_method")
 
-        # Prevent silent errors resulting from missing cftime
-        # behaviour.
-        if isinstance(other, cftime.datetime) or (
-            isinstance(self.point, cftime.datetime)
-            and not isinstance(other, iris.time.PartialDateTime)
-        ):
-            raise TypeError(
-                "Cannot determine the order of " "cftime.datetime objects"
-            )
-
         if isinstance(other, Cell):
             # Cell vs Cell comparison for providing a strict sort order
             if self.bound is None:
@@ -1485,19 +1474,7 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
                 else:
                     me = max(self.bound)
 
-            # Work around to handle cftime.datetime comparison, which
-            # doesn't return NotImplemented on failure in some versions of the
-            # library
-            try:
-                result = operator_method(me, other)
-            except TypeError:
-                rop = {
-                    operator.lt: operator.gt,
-                    operator.gt: operator.lt,
-                    operator.le: operator.ge,
-                    operator.ge: operator.le,
-                }[operator_method]
-                result = rop(other, me)
+            result = operator_method(me, other)
 
         return result
 

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -30,33 +30,6 @@ class Test___common_cmp__(tests.IrisTest):
         with self.assertRaisesRegex(exception_type, regexp):
             cell >= other
 
-    def test_cftime_cell(self):
-        # Check that cell comparison when the cell contains
-        # cftime.datetime objects raises an exception otherwise
-        # this will fall back to id comparison producing unreliable
-        # results.
-        cell = Cell(cftime.datetime(2010, 3, 21))
-        dt = mock.Mock(timetuple=mock.Mock())
-        self.assert_raises_on_comparison(
-            cell, dt, TypeError, "determine the order of cftime"
-        )
-        self.assert_raises_on_comparison(
-            cell, 23, TypeError, "determine the order of cftime"
-        )
-        self.assert_raises_on_comparison(
-            cell, "hello", TypeError, "Unexpected type.*str"
-        )
-
-    def test_cftime_other(self):
-        # Check that cell comparison to a cftime.datetime object
-        # raises an exception otherwise this will fall back to id comparison
-        # producing unreliable results.
-        dt = cftime.datetime(2010, 3, 21)
-        cell = Cell(mock.Mock(timetuple=mock.Mock()))
-        self.assert_raises_on_comparison(
-            cell, dt, TypeError, "determine the order of cftime"
-        )
-
     def test_PartialDateTime_bounded_cell(self):
         # Check that bounded comparisions to a PartialDateTime
         # raise an exception. These are not supported as they
@@ -85,10 +58,9 @@ class Test___common_cmp__(tests.IrisTest):
     def test_datetime_unbounded_cell(self):
         # Check that cell comparison works with datetimes.
         dt = datetime.datetime(2000, 6, 15)
-        cell = Cell(datetime.datetime(2000, 1, 1))
-        # Note the absence of the inverse of these
-        # e.g. self.assertGreater(dt, cell).
-        # See http://bugs.python.org/issue8005
+        cell = Cell(cftime.datetime(2000, 1, 1))
+        self.assertGreater(dt, cell)
+        self.assertGreaterEqual(dt, cell)
         self.assertLess(cell, dt)
         self.assertLessEqual(cell, dt)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #4697.  The example given there now produces

```
[Cell(point=cftime.datetime(2022, 3, 8, 12, 0, 0, 0, calendar='standard', has_year_zero=False), bound=None), Cell(point=cftime.datetime(2022, 3, 9, 12, 0, 0, 0, calendar='standard', has_year_zero=False), bound=None)]
```

The first workaround was added at #1016.  From the comments on the tests I removed, the comparisons were then falling back to comparing object ids, so presumably rich comparison was not implemented in that version of netcdftime _at all_.  It is implemented now:
https://github.com/Unidata/cftime/blob/dc75368cd02bbcd1352dbecfef10404a58683f94/src/cftime/_cftime.pyx#L1314

The second workaround was added at #2440.  The comment there says that `NotImplemented` was not always being returned by the comparison method.  If I've understood correctly, @bjlittle put in a fix for this at https://github.com/Unidata/cftime/pull/81 where, as far as I can tell, python2 was the main complication.  @bjlittle's fix was merged in 2018 and we are now [pinned to cftime >= 1.5](https://github.com/SciTools/iris/blob/7db0bdb6acad80537ac33d3b051155dabfeb5e39/requirements/ci/py38.yml#L15) which is [only a year old](https://github.com/Unidata/cftime/releases/tag/v1.5.0rel).  So I think we should be safe.

I'm currently targetting `main`, but I wonder if this should actually go in a patch release?  #4697 suggests that this has now become a problem because time cell points have changed from being `datetime.datetime` to `cftime.datetime`.  This was a [breaking change in cf-units v3.0](https://github.com/SciTools/cf-units/releases/tag/v3.0.0).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
