### PR TITLE
Extra datum translation

### DIFF
--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -124,6 +124,7 @@ class CoordSystem(metaclass=ABCMeta):
 
 _short_datum_names = {
     "OSGB 1936": "OSGB36",
+    "OSGB_1936": "OSGB36",
     "WGS 84": "WGS84",
 }
 

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -628,7 +628,6 @@ data:
 
     def test_save_datum(self):
         expected = "OSGB 1936"
-        # saved_crs = iris.coord_systems.GeogCS.from_datum(datum="OSGB36")
         saved_crs = iris.coord_systems.Mercator(
             ellipsoid=iris.coord_systems.GeogCS.from_datum("OSGB36")
         )


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

@jamesp pointed out that an example in the CF conventions shows a datum translation we don't yet cover - have added that.
Also took out an unnecessary comment I found whilst doing so.

There's a valid question of "what's the right value for this field to have when it's set in CF?", which I don't have a good answer for. Using `pyproj.CRS.to_cf` gives the following, which matches the existing translation (ellipsis mine):
```
>>> import pyproj
>>> crs = CRS.from_proj4("+proj=merc +datum=OSGB36")
>>> crs.to_cf()
{
    'crs_wkt': ...,
    'semi_major_axis': 6377563.396,
    'semi_minor_axis': 6356256.909237285,
    'inverse_flattening': 299.3249646,
    'reference_ellipsoid_name': 'Airy 1830',
    'longitude_of_prime_meridian': 0.0,
    'prime_meridian_name': 'Greenwich',
    'geographic_crs_name': 'unknown',
    'horizontal_datum_name': 'OSGB 1936',
    'projected_crs_name': 'unknown',
    'grid_mapping_name': 'mercator',
    'standard_parallel': 0.0,
    'longitude_of_projection_origin': 0.0,
    'false_easting': 0.0,
    'false_northing': 0.0,
    'scale_factor_at_projection_origin': 1.0
}
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
