### PR TITLE
Permit fast percentile with mdtol=0

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -121,6 +121,7 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ added caching to the calculation of the points array in a
    :class:`~iris.coords.DimCoord` created using
    :meth:`~iris.coords.DimCoord.from_regular`. (:pull:`4698`)
+
 #. `@wjbenfold`_ introduced caching in :func:`_lazy_data._optimum_chunksize` and
    :func:`iris.fileformats.pp_load_rules._epoch_date_hours` to reduce time spent
    repeating calculations. (:pull:`4716`)
@@ -128,6 +129,9 @@ This document explains the changes made to Iris for this release
 #. `@pp-mo`_ made :meth:`~iris.cube.Cube.add_aux_factory` faster.
    (:pull:`4718`)
 
+#. `@wjbenfold`_ permitted the fast percentile aggregation method to be used on
+   masked data when the missing data tolerance is set to 0. (:issue:`4735`,
+   :pull:`4755`)
 
 
 🔥 Deprecations

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -108,6 +108,9 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ fixed plotting of circular coordinates to extend kwarg arrays
    as well as the data. (:issue:`466`, :pull:`4649`)
 
+#. `@wjbenfold`_ corrected the axis on which masking is applied when an
+   aggregator adds a trailing dimension. (:pull:`4755`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -593,6 +593,12 @@ class _Aggregator:
         ):
             fraction_not_missing = data.count(axis=axis) / data.shape[axis]
             mask_update = 1 - mdtol > fraction_not_missing
+            if result.ndim > mask_update.ndim:
+                # call_func created trailing dimension.
+                mask_update = np.broadcast_to(
+                    mask_update.reshape(mask_update.shape + (1,)),
+                    result.shape,
+                )
             if ma.isMaskedArray(result):
                 result.mask = result.mask | mask_update
             else:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -592,8 +592,8 @@ class _Aggregator:
             and result is not ma.masked
         ):
             fraction_not_missing = data.count(axis=axis) / data.shape[axis]
-            mask_update = 1 - mdtol > fraction_not_missing
-            if np.array(result).ndim > np.array(mask_update).ndim:
+            mask_update = np.array(1 - mdtol > fraction_not_missing)
+            if np.array(result).ndim > mask_update.ndim:
                 # call_func created trailing dimension.
                 mask_update = np.broadcast_to(
                     mask_update.reshape(mask_update.shape + (1,)),

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -593,11 +593,11 @@ class _Aggregator:
         ):
             fraction_not_missing = data.count(axis=axis) / data.shape[axis]
             mask_update = 1 - mdtol > fraction_not_missing
-            if result.ndim > mask_update.ndim:
+            if np.array(result).ndim > np.array(mask_update).ndim:
                 # call_func created trailing dimension.
                 mask_update = np.broadcast_to(
                     mask_update.reshape(mask_update.shape + (1,)),
-                    result.shape,
+                    np.array(result).shape,
                 )
             if ma.isMaskedArray(result):
                 result.mask = result.mask | mask_update

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -39,6 +39,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 import functools
 from functools import wraps
+import warnings
 
 import dask.array as da
 import numpy as np
@@ -1297,7 +1298,12 @@ def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
             )
             if ma.is_masked(data):
                 raise TypeError(msg)
-        result = np.percentile(data, percent, axis=-1)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "Warning: 'partition' will ignore the 'mask' of the MaskedArray.",
+            )
+            result = np.percentile(data, percent, axis=-1)
         result = result.T
     else:
         quantiles = percent / 100.0

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -52,9 +52,9 @@ class AggregateMixin:
             self.assertFalse(is_lazy)
 
         if approx:
-            self.assertArrayAlmostEqual(actual, expected)
+            self.assertMaskedArrayAlmostEqual(actual, expected)
         else:
-            self.assertArrayEqual(actual, expected)
+            self.assertMaskedArrayEqual(actual, expected)
 
     def test_1d_single(self):
         data = np.arange(11)
@@ -223,7 +223,7 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
         percent = 50
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked
-        expected = np.arange(shape[-1]) + 5.5
+        expected = ma.arange(shape[-1]) + 5.5
         expected[0] = ma.masked
         self.check_percentile_calc(data, axis, percent, expected, mdtol=0)
 
@@ -313,7 +313,7 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked
         data = as_lazy_data(data)
-        expected = np.arange(shape[-1]) + 5.5
+        expected = ma.arange(shape[-1]) + 5.5
         expected[0] = ma.masked
         self.check_percentile_calc(data, axis, percent, expected, mdtol=0)
 

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -206,7 +206,9 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
         self.agg_method = PERCENTILE.aggregate
 
     def test_masked(self):
-        shape = (2, 11)
+        # Using (3,11) because np.percentile returns a masked array anyway with
+        # (2, 11)
+        shape = (3, 11)
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked
         emsg = (
@@ -219,6 +221,8 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
             )
 
     def test_masked_mdtol_0(self):
+        # Using (3,11) because np.percentile returns a masked array anyway with
+        # (2, 11)
         shape = (3, 11)
         axis = 0
         percent = 50
@@ -293,6 +297,8 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         self.agg_method = PERCENTILE.lazy_aggregate
 
     def test_masked(self):
+        # Using (3,11) because np.percentile returns a masked array anyway with
+        # (2, 11)
         shape = (2, 11)
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -208,11 +208,24 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
         shape = (2, 11)
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked
-        emsg = "Cannot use fast np.percentile method with masked array."
+        emsg = (
+            "Cannot use fast np.percentile method with masked array unless "
+            "mdtol is 0."
+        )
         with self.assertRaisesRegex(TypeError, emsg):
             PERCENTILE.aggregate(
                 data, axis=0, percent=50, fast_percentile_method=True
             )
+
+    def test_masked_mdtol_0(self):
+        shape = (2, 11)
+        axis = 0
+        percent = 50
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        expected = np.arange(shape[-1]) + 5.5
+        expected[0] = ma.masked
+        self.check_percentile_calc(data, axis, percent, expected, mdtol=0)
 
     @mock.patch("numpy.percentile")
     def test_numpy_percentile_called(self, mocked_percentile):
@@ -286,9 +299,23 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         actual = PERCENTILE.lazy_aggregate(
             data, axis=0, percent=50, fast_percentile_method=True
         )
-        emsg = "Cannot use fast np.percentile method with masked array."
+        emsg = (
+            "Cannot use fast np.percentile method with masked array unless "
+            "mdtol is 0."
+        )
         with self.assertRaisesRegex(TypeError, emsg):
             as_concrete_data(actual)
+
+    def test_masked_mdtol_0(self):
+        shape = (2, 11)
+        axis = 0
+        percent = 50
+        data = ma.arange(np.prod(shape)).reshape(shape)
+        data[0, ::2] = ma.masked
+        data = as_lazy_data(data)
+        expected = np.arange(shape[-1]) + 5.5
+        expected[0] = ma.masked
+        self.check_percentile_calc(data, axis, percent, expected, mdtol=0)
 
     @mock.patch("numpy.percentile", return_value=np.array([2, 4]))
     def test_numpy_percentile_called(self, mocked_percentile):

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -297,8 +297,6 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         self.agg_method = PERCENTILE.lazy_aggregate
 
     def test_masked(self):
-        # Using (3,11) because np.percentile returns a masked array anyway with
-        # (2, 11)
         shape = (2, 11)
         data = ma.arange(np.prod(shape)).reshape(shape)
         data[0, ::2] = ma.masked
@@ -314,6 +312,8 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
             as_concrete_data(actual)
 
     def test_masked_mdtol_0(self):
+        # Using (3,11) because np.percentile returns a masked array anyway with
+        # (2, 11)
         shape = (3, 11)
         axis = 0
         percent = 50


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #4735

We can't do the full check in the `PercentileAggregator.lazy_aggregate` method because we can't inspect the array to check if it's masked when it's lazy so I've left it where it was but done a check on `mdtol` out there where we know about it.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
