### PR TITLE
CPerf and SPerf Benchmark Fixes

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,7 +30,9 @@ used to generate benchmark test objects/files; see
 but will defer to any value already set in the shell.
 * `BENCHMARK_DATA` - optional - path to a directory for benchmark synthetic
 test data, which the benchmark scripts will create if it doesn't already
-exist. Defaults to `<root>/benchmarks/.data/` if not set.
+exist. Defaults to `<root>/benchmarks/.data/` if not set. Note that some of
+the generated files, especially in the 'SPerf' suite, are many GB in size so
+plan accordingly.
 * `ON_DEMAND_BENCHMARKS` - optional - when set (to any value): benchmarks
 decorated with `@on_demand_benchmark` are included in the ASV run. Usually
 coupled with the ASV `--bench` argument to only run the benchmark(s) of

--- a/benchmarks/benchmarks/generate_data/__init__.py
+++ b/benchmarks/benchmarks/generate_data/__init__.py
@@ -22,6 +22,7 @@ from os import environ
 from pathlib import Path
 from subprocess import CalledProcessError, check_output, run
 from textwrap import dedent
+from warnings import warn
 
 from iris._lazy_data import as_concrete_data
 from iris.fileformats import netcdf
@@ -47,6 +48,11 @@ default_data_dir = (Path(__file__).parents[2] / ".data").resolve()
 BENCHMARK_DATA = Path(environ.get("BENCHMARK_DATA", default_data_dir))
 if BENCHMARK_DATA == default_data_dir:
     BENCHMARK_DATA.mkdir(exist_ok=True)
+    message = (
+        f"No BENCHMARK_DATA env var, defaulting to {BENCHMARK_DATA}. "
+        "Note that some benchmark files are GB in size."
+    )
+    warn(message)
 elif not BENCHMARK_DATA.is_dir():
     message = f"Not a directory: {BENCHMARK_DATA} ."
     raise ValueError(message)

--- a/benchmarks/benchmarks/generate_data/stock.py
+++ b/benchmarks/benchmarks/generate_data/stock.py
@@ -9,11 +9,21 @@ Wrappers for using :mod:`iris.tests.stock` methods for benchmarking.
 See :mod:`benchmarks.generate_data` for an explanation of this structure.
 """
 
+from hashlib import sha256
+import json
 from pathlib import Path
 
 from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD, load_mesh
 
 from . import BENCHMARK_DATA, REUSE_DATA, load_realised, run_function_elsewhere
+
+
+def hash_args(*args, **kwargs):
+    """Convert arguments into a short hash - for preserving args in filenames."""
+    arg_string = str(args)
+    kwarg_string = json.dumps(kwargs)
+    full_string = arg_string + kwarg_string
+    return sha256(full_string.encode()).hexdigest()[:10]
 
 
 def _create_file__xios_common(func_name, **kwargs):
@@ -23,7 +33,7 @@ def _create_file__xios_common(func_name, **kwargs):
         func = getattr(netcdf, func_name_)
         print(func(temp_file_dir, **kwargs_), end="")
 
-    args_hash = hash(str(kwargs))
+    args_hash = hash_args(**kwargs)
     save_path = (BENCHMARK_DATA / f"{func_name}_{args_hash}").with_suffix(
         ".nc"
     )
@@ -95,7 +105,7 @@ def sample_mesh(n_nodes=None, n_faces=None, n_edges=None, lazy_values=False):
         save_mesh(new_mesh, save_path_)
 
     arg_list = [n_nodes, n_faces, n_edges]
-    args_hash = hash(str(arg_list))
+    args_hash = hash_args(*arg_list)
     save_path = (BENCHMARK_DATA / f"sample_mesh_{args_hash}").with_suffix(
         ".nc"
     )
@@ -139,7 +149,7 @@ def sample_meshcoord(sample_mesh_kwargs=None, location="face", axis="x"):
         new_meshcoord = sample_meshcoord(mesh=input_mesh)
         save_mesh(new_meshcoord.mesh, save_path_)
 
-    args_hash = hash(str(sample_mesh_kwargs))
+    args_hash = hash_args(**sample_mesh_kwargs)
     save_path = (
         BENCHMARK_DATA / f"sample_mesh_coord_{args_hash}"
     ).with_suffix(".nc")

--- a/benchmarks/benchmarks/sperf/__init__.py
+++ b/benchmarks/benchmarks/sperf/__init__.py
@@ -23,6 +23,7 @@ class FileMixin:
     # Allows time for large file generation.
     timeout = 3600.0
     # Largest file with these params: ~90GB.
+    #  Total disk space: ~410GB.
     params = [
         [12, 384, 640, 960, 1280, 1668],
         [1, 36, 72],

--- a/benchmarks/benchmarks/sperf/__init__.py
+++ b/benchmarks/benchmarks/sperf/__init__.py
@@ -20,10 +20,13 @@ from ..generate_data.ugrid import make_cubesphere_testfile
 class FileMixin:
     """For use in any benchmark classes that work on a file."""
 
+    # Allows time for large file generation.
+    timeout = 3600.0
+    # Largest file with these params: ~90GB.
     params = [
         [12, 384, 640, 960, 1280, 1668],
         [1, 36, 72],
-        [1, 3, 36, 72],
+        [1, 3, 10],
     ]
     param_names = ["cubesphere_C<N>", "N levels", "N time steps"]
     # cubesphere_C<N>: notation refers to faces per panel.
@@ -33,11 +36,6 @@ class FileMixin:
         self.file_path = make_cubesphere_testfile(
             c_size=c_size, n_levels=n_levels, n_times=n_times
         )
-
-    def teardown(self, _):
-        # All the params together could fill >4TB.
-        #  Better to take longer to setup and use less file space.
-        self.file_path.unlink(missing_ok=True)
 
     def load_cube(self):
         with PARSE_UGRID_ON_LOAD.context():

--- a/benchmarks/benchmarks/sperf/__init__.py
+++ b/benchmarks/benchmarks/sperf/__init__.py
@@ -34,6 +34,11 @@ class FileMixin:
             c_size=c_size, n_levels=n_levels, n_times=n_times
         )
 
+    def teardown(self, _):
+        # All the params together could fill >4TB.
+        #  Better to take longer to setup and use less file space.
+        self.file_path.unlink(missing_ok=True)
+
     def load_cube(self):
         with PARSE_UGRID_ON_LOAD.context():
             return load_cube(str(self.file_path))

--- a/benchmarks/benchmarks/sperf/combine_regions.py
+++ b/benchmarks/benchmarks/sperf/combine_regions.py
@@ -16,20 +16,21 @@ from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 from iris.experimental.ugrid.utils import recombine_submeshes
 
 from .. import TrackAddedMemoryAllocation, on_demand_benchmark
-from ..generate_data.ugrid import make_cube_like_2d_cubesphere
+from ..generate_data.ugrid import BENCHMARK_DATA, make_cube_like_2d_cubesphere
 
 
 class Mixin:
     # Characterise time taken + memory-allocated, for various stages of combine
     # operations on cubesphere-like test data.
-    timeout = 180.0
+    timeout = 300.0
     params = [100, 200, 300, 500, 1000, 1668]
     param_names = ["cubesphere_C<N>"]
     # Fix result units for the tracking benchmarks.
     unit = "Mb"
+    temp_save_path = BENCHMARK_DATA / "tmp.nc"
 
     def _parametrised_cache_filename(self, n_cubesphere, content_name):
-        return f"cube_C{n_cubesphere}_{content_name}.nc"
+        return BENCHMARK_DATA / f"cube_C{n_cubesphere}_{content_name}.nc"
 
     def _make_region_cubes(self, full_mesh_cube):
         """Make a fixed number of region cubes from a full meshcube."""
@@ -139,6 +140,9 @@ class Mixin:
         # Fix dask usage mode for all the subsequent performance tests.
         self.fix_dask_settings()
 
+    def teardown(self, _):
+        self.temp_save_path.unlink(missing_ok=True)
+
     def fix_dask_settings(self):
         """
         Fix "standard" dask behaviour for time+space testing.
@@ -164,6 +168,9 @@ class Mixin:
             index_coord_name="i_mesh_face",
         )
         return result
+
+    def save(self):
+        save(self.recombined_cube, self.temp_save_path)
 
 
 @on_demand_benchmark
@@ -215,15 +222,15 @@ class SaveData(Mixin):
 
     def time_save(self, n_cubesphere):
         # Save to disk, which must compute data + stream it to file.
-        save(self.recombined_cube, "tmp.nc")
+        self.save()
 
     @TrackAddedMemoryAllocation.decorator()
     def track_addedmem_save(self, n_cubesphere):
-        save(self.recombined_cube, "tmp.nc")
+        self.save()
 
     def track_filesize_saved(self, n_cubesphere):
-        save(self.recombined_cube, "tmp.nc")
-        return os.path.getsize("tmp.nc") * 1.0e-6
+        self.save()
+        return self.temp_save_path.stat().st_size * 1.0e-6
 
 
 @on_demand_benchmark
@@ -243,8 +250,8 @@ class FileStreamedCalc(Mixin):
 
     def time_stream_file2file(self, n_cubesphere):
         # Save to disk, which must compute data + stream it to file.
-        save(self.recombined_cube, "tmp.nc")
+        self.save()
 
     @TrackAddedMemoryAllocation.decorator()
     def track_addedmem_stream_file2file(self, n_cubesphere):
-        save(self.recombined_cube, "tmp.nc")
+        self.save()

--- a/benchmarks/benchmarks/sperf/combine_regions.py
+++ b/benchmarks/benchmarks/sperf/combine_regions.py
@@ -169,7 +169,7 @@ class Mixin:
         )
         return result
 
-    def save(self):
+    def save_recombined_cube(self):
         save(self.recombined_cube, self.temp_save_path)
 
 
@@ -222,14 +222,14 @@ class SaveData(Mixin):
 
     def time_save(self, n_cubesphere):
         # Save to disk, which must compute data + stream it to file.
-        self.save()
+        self.save_recombined_cube()
 
     @TrackAddedMemoryAllocation.decorator()
     def track_addedmem_save(self, n_cubesphere):
-        self.save()
+        self.save_recombined_cube()
 
     def track_filesize_saved(self, n_cubesphere):
-        self.save()
+        self.save_recombined_cube()
         return self.temp_save_path.stat().st_size * 1.0e-6
 
 
@@ -250,8 +250,8 @@ class FileStreamedCalc(Mixin):
 
     def time_stream_file2file(self, n_cubesphere):
         # Save to disk, which must compute data + stream it to file.
-        self.save()
+        self.save_recombined_cube()
 
     @TrackAddedMemoryAllocation.decorator()
     def track_addedmem_stream_file2file(self, n_cubesphere):
-        self.save()
+        self.save_recombined_cube()

--- a/benchmarks/benchmarks/sperf/load.py
+++ b/benchmarks/benchmarks/sperf/load.py
@@ -18,9 +18,6 @@ class Load(FileMixin):
 
 @on_demand_benchmark
 class Realise(FileMixin):
-    # The larger files take a long time to realise.
-    timeout = 600.0
-
     def setup(self, c_size, n_levels, n_times):
         super().setup(c_size, n_levels, n_times)
         self.loaded_cube = self.load_cube()

--- a/noxfile.py
+++ b/noxfile.py
@@ -517,7 +517,6 @@ def benchmarks(
         print(
             f'New ASV results for "{run_type}".\n'
             f'See "{publish_subdir}",'
-            f'\n  html in "{location / "html"}".'
             f'\n  or JSON files under "{location / "results"}".'
         )
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Various small corrections after trying out C/SPerf benchmarks in reality (not just on paper).

* Warnings about especially large test files and their location.
* Use a consistent hashing algorithm `hashlib.sha256()` when preserving file generation arguments in filenames.
  Previous use of `hash()` meant a different file name each time - not what was intended when aiming for file re-use!
* Fewer time steps in SPerf test files.
  * Previous parameters generated files up to `700GB` in size, and over `4TB` total for all files.
  * New parameters use `400GB` total, with the largest file at `90GB`.
* Longer benchmark timeouts to allow more time for test file generation.
* Place SPerf `combine_regions` files in the standard `BENCHMARK_DATA` location - they are sizeable so using the standard temp file space risked blowing allocated space.
* `test.stock.netcdf` file generation uses dask for filling the data variable - allows creating files larger than memory.
* Minor amendments to the information provided by the Nox benchmarks session.
* Improvements to the Nox C/SPerf sessions:
  * Allow individual benchmark failures without the whole run failing - we expect some benchmarks to blow memory on certain machines.
  * No 'round' repetition - required for accuracy when doing commit comparison, but wasteful here with the longer running benchmarks as there is less noise and we don't want the run to take 4x as long when it's already long-running!

No what's new entry as that's already covered by the original entry about benchmarks.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
