### PR TITLE
Test deprecation warnings: don't use np.float or np.int

### DIFF
--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridReader.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridReader.py
@@ -16,8 +16,6 @@ import iris.tests as tests  # isort:skip
 
 from unittest import mock
 
-import numpy as np
-
 from iris.experimental.ugrid.cf import (
     CFUGridAuxiliaryCoordinateVariable,
     CFUGridConnectivityVariable,
@@ -56,17 +54,17 @@ class Test_build_cf_groups(tests.IrisTest):
     @classmethod
     def setUpClass(cls):
         # Replicating syntax from test_CFReader.Test_build_cf_groups__formula_terms.
-        cls.mesh = netcdf_ugrid_variable("mesh", "", np.int)
-        cls.node_x = netcdf_ugrid_variable("node_x", "node", np.float)
-        cls.node_y = netcdf_ugrid_variable("node_y", "node", np.float)
-        cls.face_x = netcdf_ugrid_variable("face_x", "face", np.float)
-        cls.face_y = netcdf_ugrid_variable("face_y", "face", np.float)
+        cls.mesh = netcdf_ugrid_variable("mesh", "", int)
+        cls.node_x = netcdf_ugrid_variable("node_x", "node", float)
+        cls.node_y = netcdf_ugrid_variable("node_y", "node", float)
+        cls.face_x = netcdf_ugrid_variable("face_x", "face", float)
+        cls.face_y = netcdf_ugrid_variable("face_y", "face", float)
         cls.face_nodes = netcdf_ugrid_variable(
-            "face_nodes", "face vertex", np.int
+            "face_nodes", "face vertex", int
         )
-        cls.levels = netcdf_ugrid_variable("levels", "levels", np.int)
+        cls.levels = netcdf_ugrid_variable("levels", "levels", int)
         cls.data = netcdf_ugrid_variable(
-            "data", "levels face", np.float, coordinates="face_x face_y"
+            "data", "levels face", float, coordinates="face_x face_y"
         )
 
         # Add necessary attributes for mesh recognition.

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -83,13 +83,13 @@ class Test_translate__formula_terms(tests.IrisTest):
             "delta", "height", np.float64, bounds="delta_bnds"
         )
         self.delta_bnds = netcdf_variable(
-            "delta_bnds", "height bnds", np.float
+            "delta_bnds", "height bnds", np.float64
         )
         self.sigma = netcdf_variable(
             "sigma", "height", np.float64, bounds="sigma_bnds"
         )
         self.sigma_bnds = netcdf_variable(
-            "sigma_bnds", "height bnds", np.float
+            "sigma_bnds", "height bnds", np.float64
         )
         self.orography = netcdf_variable("orography", "lat lon", np.float64)
         formula_terms = "a: delta b: sigma orog: orography"
@@ -185,13 +185,13 @@ class Test_build_cf_groups__formula_terms(tests.IrisTest):
             "delta", "height", np.float64, bounds="delta_bnds"
         )
         self.delta_bnds = netcdf_variable(
-            "delta_bnds", "height bnds", np.float
+            "delta_bnds", "height bnds", np.float64
         )
         self.sigma = netcdf_variable(
             "sigma", "height", np.float64, bounds="sigma_bnds"
         )
         self.sigma_bnds = netcdf_variable(
-            "sigma_bnds", "height bnds", np.float
+            "sigma_bnds", "height bnds", np.float64
         )
         self.orography = netcdf_variable("orography", "lat lon", np.float64)
         formula_terms = "a: delta b: sigma orog: orography"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Some warnings in our test output are easy to get rid of.  E.g.

```
 /tmp/cirrus-ci-build/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridReader.py:60: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
```
  /tmp/cirrus-ci-build/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridReader.py:59: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
