### PR TITLE
Cubelist contain only cubes -- resurrected

### DIFF
--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
@@ -1,3 +1,0 @@
-* The `append`, `extend` and `insert` methods of :class:`iris.cube.CubeList`
-now perform a check to ensure that only :class:`iris.cube.Cube` instances are
-added.

--- a/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
+++ b/docs/iris/src/whatsnew/contributions_2.3.0/bugfix_2018-Dec-07_only_cubes_in_cubelists.txt
@@ -1,0 +1,3 @@
+* The `append`, `extend` and `insert` methods of :class:`iris.cube.CubeList`
+now perform a check to ensure that only :class:`iris.cube.Cube` instances are
+added.

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -112,9 +112,9 @@ This document explains the changes made to Iris for this release
    is applied when an aggregator adds a trailing dimension. (:pull:`4755`)
 
 *  `@rcomer`_ and  `@pp-mo`_  ensured that all methods to create or modify a
-:class:`iris.cube.CubeList` check that it only contains cubes.  According to
-code comments, this was supposedly already the case, but there were several bugs
-and loopholes.
+   :class:`iris.cube.CubeList` check that it only contains cubes.  According to
+   code comments, this was supposedly already the case, but there were several bugs
+   and loopholes.
 
 
 💣 Incompatible Changes

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -111,6 +111,11 @@ This document explains the changes made to Iris for this release
 #. `@wjbenfold`_ and `@rcomer`_ (reviewer) corrected the axis on which masking
    is applied when an aggregator adds a trailing dimension. (:pull:`4755`)
 
+*  `@rcomer`_ and  `@pp-mo`_  ensured that all methods to create or modify a
+:class:`iris.cube.CubeList` check that it only contains cubes.  According to
+code comments, this was supposedly already the case, but there were several bugs
+and loopholes.
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -241,6 +241,18 @@ class CubeList(list):
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
+    #  __setslice__ is only required for python2.7 compatibility.
+    def __setslice__(self, *args):
+        cubes = args[-1]
+        if isinstance(cubes, Cube) or not isinstance(
+                cubes, collections.Iterable):
+            raise TypeError('Assigning to a slice of a cubelist requires '
+                            'a sequence of cubes.')
+        elif not all([isinstance(cube, Cube) for cube in cubes]):
+            raise ValueError('Elements of cubelists must be Cube instances.')
+
+        super(CubeList, self).__setslice__(*args)
+
     def append(self, cube):
         """
         Append a cube.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -225,12 +225,6 @@ class CubeList(list):
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
-    #  __setslice__ is only required for python2.7 compatibility.
-    def __setslice__(self, *args):
-        args_list = list(args)
-        args_list[-1] = CubeList(args[-1])
-        super(CubeList, self).__setslice__(*args_list)
-
     def append(self, cube):
         """
         Append a cube.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -152,16 +152,13 @@ class CubeList(list):
 
     """
 
-    def __new__(cls, list_of_cubes=None):
-        """Given a :class:`list` of cubes, return a CubeList instance."""
-        cube_list = list.__new__(cls, list_of_cubes)
-
-        # Check that all items in the incoming list are cubes.
-        if not all([isinstance(cube, Cube) for cube in cube_list]):
-            raise ValueError(
-                "All items in list_of_cubes must be Cube " "instances."
-            )
-        return cube_list
+    def __init__(self, *args, **kwargs):
+        """Given an iterable of cubes, return a CubeList instance."""
+        # Do whatever a list does, to initialise ourself "as a list"
+        super().__init__(*args, **kwargs)
+        # Check that all items in the list are cubes.
+        for cube in self:
+            self._assert_is_cube(cube)
 
     def __str__(self):
         """Runs short :meth:`Cube.summary` on every cube."""
@@ -177,13 +174,16 @@ class CubeList(list):
 
     def __repr__(self):
         """Runs repr on every cube."""
-        return '[%s]' % ',\n'.join([repr(cube) for cube in self])
+        return "[%s]" % ",\n".join([repr(cube) for cube in self])
 
     @staticmethod
     def _assert_is_cube(obj):
-        if not isinstance(obj, Cube):
-            msg = ("Object of type '{}' does not belong in a cubelist.")
-            raise ValueError(msg.format(type(obj).__name__))
+        if not hasattr(obj, "add_aux_coord"):
+            msg = (
+                r"Object {obj} cannot be put in a cubelist, "
+                "as it is not a Cube."
+            )
+            raise ValueError(msg)
 
     # TODO #370 Which operators need overloads?
 
@@ -212,7 +212,7 @@ class CubeList(list):
         """
         Add a sequence of cubes to the cubelist in place.
         """
-        super(CubeList, self).__iadd__(CubeList(other_cubes))
+        return super(CubeList, self).__iadd__(CubeList(other_cubes))
 
     def __setitem__(self, key, cube_or_sequence):
         """Set self[key] to cube or sequence of cubes"""

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -147,25 +147,28 @@ class _CubeFilterCollection:
 
 def _check_iscube(obj):
     """
-    Raise a warning if obj does not look like a cube.
+    Raise an exception if obj does not look like a cube.
     """
     if not hasattr(obj, 'add_aux_coord'):
-        msg = ("Cubelist now contains object of type '{}'.  This may "
-               "adversely affect subsequent operations.")
-        warnings.warn(msg.format(type(obj).__name__))
+        msg = ("Object of type '{}' does not look like a cube so can't be "
+               "included in cubelist.")
+        raise TypeError(msg.format(type(obj).__name__))
 
 
 def _check_cube_sequence(sequence):
     """
-    Raise one or more warnings if sequence contains elements that are not
-    Cubes (or cube-like).  Skip this if the sequence is a CubeList, as we can
-    assume it was already checked.
+    Raise an exception if sequence contains an element that is not a Cube (or
+    cube-like).  Skip this if the sequence is a CubeList, as we can assume it
+    was already checked.
     """
     if (isinstance(sequence, collections.Iterable) and
             not isinstance(sequence, Cube) and
             not isinstance(sequence, CubeList)):
         for obj in sequence:
-            _check_iscube(obj)
+            if not hasattr(obj, 'add_aux_coord'):
+                msg = ("Sequence contains object of type '{}', which does not "
+                       "look like a cube so can't be included in cubelist.")
+                raise ValueError(msg.format(type(obj).__name__))
 
 
 class CubeList(list):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -156,10 +156,7 @@ class CubeList(list):
         """Given a :class:`list` of cubes, return a CubeList instance."""
         cube_list = list.__new__(cls, list_of_cubes)
 
-        # Check that all items in the incoming list are cubes. Note that this
-        # checking does not guarantee that a CubeList instance *always* has
-        # just cubes in its list as the append & __getitem__ methods have not
-        # been overridden.
+        # Check that all items in the incoming list are cubes.
         if not all([isinstance(cube, Cube) for cube in cube_list]):
             raise ValueError(
                 "All items in list_of_cubes must be Cube " "instances."
@@ -209,6 +206,48 @@ class CubeList(list):
         result = super().__getslice__(start, stop)
         result = CubeList(result)
         return result
+
+    def append(self, cube):
+        """
+        Append a cube.
+        """
+        if isinstance(cube, Cube):
+            super(CubeList, self).append(cube)
+        else:
+            raise TypeError('Only Cube instances can be appended to cubelists.'
+                            '  Got {}.'.format(type(cube)))
+
+    def extend(self, other_cubes):
+        """
+        Extend cubelist by appending the cubes contained in other_cubes.
+
+        Args:
+
+        * other_cubes:
+           A cubelist or other sequence of cubes.
+        """
+        if isinstance(other_cubes, Cube):
+            raise TypeError(
+                'Use append to add a single cube to the cubelist.')
+        elif not isinstance(other_cubes, collections.Iterable):
+            raise TypeError(
+                'Can only extend with a sequece of Cube instances.')
+        elif isinstance(other_cubes, CubeList) or all(
+                [isinstance(cube, Cube) for cube in other_cubes]):
+            super(CubeList, self).extend(other_cubes)
+        else:
+            raise TypeError('All items in other_cubes must be Cube '
+                            'instances.')
+
+    def insert(self, index, cube):
+        """
+        Insert a cube before index.
+        """
+        if isinstance(cube, Cube):
+            super(CubeList, self).insert(index, cube)
+        else:
+            raise TypeError('Only Cube instances can be inserted into '
+                            'cubelists.  Got {}.'.format(type(cube)))
 
     def xml(self, checksum=False, order=True, byteorder=True):
         """Return a string of the XML that this list of cubes represents."""

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -227,7 +227,8 @@ class CubeList(list):
         if isinstance(cube, Cube):
             super(CubeList, self).__setitem__(key, cube)
         else:
-            raise TypeError('Elements of cubelists must be Cube instances')
+            raise TypeError('Elements of cubelists must be Cube instances.  '
+                            'Got {}.'.format(type(cube)))
 
     def append(self, cube):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -222,13 +222,24 @@ class CubeList(list):
             raise ValueError('All items in added sequence must be Cube '
                              'instances.')
 
-    def __setitem__(self, key, cube):
-        """Set self[key] to cube"""
-        if isinstance(cube, Cube):
-            super(CubeList, self).__setitem__(key, cube)
+    def __setitem__(self, key, cube_or_sequence):
+        """Set self[key] to cube or sequence of cubes"""
+        if isinstance(key, int):
+            if not isinstance(cube_or_sequence, Cube):
+                raise TypeError('Elements of cubelists must be Cube instances.'
+                                '  Got {}.'.format(type(cube_or_sequence)))
         else:
-            raise TypeError('Elements of cubelists must be Cube instances.  '
-                            'Got {}.'.format(type(cube)))
+            # key is a slice (or exception will come from list method).
+            if isinstance(cube_or_sequence, Cube) or not isinstance(
+                    cube_or_sequence, collections.Iterable):
+                raise TypeError('Assigning to a slice of a cubelist requires '
+                                'a sequence of cubes.')
+            elif not all([isinstance(cube, Cube) for
+                          cube in cube_or_sequence]):
+                raise ValueError(
+                    'Elements of cubelists must be Cube instances.')
+
+        super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     def append(self, cube):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -201,11 +201,10 @@ class CubeList(list):
         was already checked.
         """
         if (isinstance(sequence, collections.Iterable) and
-            not isinstance(sequence, Cube) and
-            not isinstance(sequence, CubeList)):
+                not isinstance(sequence, Cube) and
+                not isinstance(sequence, CubeList)):
             for obj in sequence:
                 self._check_iscube(obj)
-
 
     # TODO #370 Which operators need overloads?
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -144,6 +144,26 @@ class _CubeFilterCollection:
             [pair.merged(unique) for pair in self.pairs]
         )
 
+def _check_iscube(obj):
+    """
+    Raise a warning if obj does not look like a cube.
+    """
+    if not hasattr(obj, 'add_aux_coord'):
+        msg = ("Cubelist now contains object of type '{}'.  This may "
+               "adversely affect subsequent operations.")
+        warnings.warn(msg.format(type(obj).__name__))
+
+def _check_cube_sequence(sequence):
+    """
+    Raise one or more warnings if sequence contains elements that are not
+    Cubes (or cube-like).  Skip this if the sequence is a CubeList, as we can
+    assume it was already checked.
+    """
+    if (isinstance(sequence, collections.Iterable) and
+            not isinstance(sequence, Cube) and
+            not isinstance(sequence, CubeList)):
+        for obj in sequence:
+            _check_iscube(obj)
 
 class CubeList(list):
     """
@@ -177,34 +197,7 @@ class CubeList(list):
 
     def __repr__(self):
         """Runs repr on every cube."""
-        return "[%s]" % ",\n".join([repr(cube) for cube in self])
-
-    def _repr_html_(self):
-        from iris.experimental.representation import CubeListRepresentation
-
-        representer = CubeListRepresentation(self)
-        return representer.repr_html()
-
-    def _check_iscube(self, obj):
-        """
-        Raise a warning if obj is not a cube.
-        """
-        if not isinstance(obj, Cube):
-            msg = ('Cubelist now contains object of type {}.  This may '
-                   'adversely affect subsequent operations.')
-            warnings.warn(msg.format(type(obj)))
-
-    def _check_cube_sequence(self, sequence):
-        """
-        Raise one or more warnings if sequence contains elements that are not
-        Cubes.  Skip this if the sequence is a CubeList, as we can assume it
-        was already checked.
-        """
-        if (isinstance(sequence, collections.Iterable) and
-                not isinstance(sequence, Cube) and
-                not isinstance(sequence, CubeList)):
-            for obj in sequence:
-                self._check_iscube(obj)
+        return '[%s]' % ',\n'.join([repr(cube) for cube in self])
 
     # TODO #370 Which operators need overloads?
 
@@ -233,31 +226,31 @@ class CubeList(list):
         """
         Add a sequence of cubes to the cubelist in place.
         """
-        self._check_cube_sequence(other_cubes)
+        _check_cube_sequence(other_cubes)
         super(CubeList, self).__iadd__(other_cubes)
 
     def __setitem__(self, key, cube_or_sequence):
         """Set self[key] to cube or sequence of cubes"""
         if isinstance(key, int):
             # should have single cube.
-            self._check_iscube(cube_or_sequence)
+            _check_iscube(cube_or_sequence)
         else:
             # key is a slice (or exception will come from list method).
-            self._check_cube_sequence(cube_or_sequence)
+            _check_cube_sequence(cube_or_sequence)
 
         super(CubeList, self).__setitem__(key, cube_or_sequence)
 
     #  __setslice__ is only required for python2.7 compatibility.
     def __setslice__(self, *args):
         cubes = args[-1]
-        self._check_cube_sequence(cubes)
+        _check_cube_sequence(cubes)
         super(CubeList, self).__setslice__(*args)
 
     def append(self, cube):
         """
         Append a cube.
         """
-        self._check_iscube(cube)
+        _check_iscube(cube)
         super(CubeList, self).append(cube)
 
     def extend(self, other_cubes):
@@ -269,14 +262,14 @@ class CubeList(list):
         * other_cubes:
            A cubelist or other sequence of cubes.
         """
-        self._check_cube_sequence(other_cubes)
+        _check_cube_sequence(other_cubes)
         super(CubeList, self).extend(other_cubes)
 
     def insert(self, index, cube):
         """
         Insert a cube before index.
         """
-        self._check_iscube(cube)
+        _check_iscube(cube)
         super(CubeList, self).insert(index, cube)
 
     def xml(self, checksum=False, order=True, byteorder=True):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -144,6 +144,7 @@ class _CubeFilterCollection:
             [pair.merged(unique) for pair in self.pairs]
         )
 
+
 def _check_iscube(obj):
     """
     Raise a warning if obj does not look like a cube.
@@ -152,6 +153,7 @@ def _check_iscube(obj):
         msg = ("Cubelist now contains object of type '{}'.  This may "
                "adversely affect subsequent operations.")
         warnings.warn(msg.format(type(obj).__name__))
+
 
 def _check_cube_sequence(sequence):
     """
@@ -164,6 +166,7 @@ def _check_cube_sequence(sequence):
             not isinstance(sequence, CubeList)):
         for obj in sequence:
             _check_iscube(obj)
+
 
 class CubeList(list):
     """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -207,6 +207,28 @@ class CubeList(list):
         result = CubeList(result)
         return result
 
+    def __iadd__(self, other_cubes):
+        """
+        Add a sequence of cubes to the cubelist in place.
+        """
+        if isinstance(other_cubes, Cube) or not isinstance(
+                other_cubes, collections.Iterable):
+            raise TypeError(
+                'Can only add a sequence of Cube instances.')
+        elif isinstance(other_cubes, CubeList) or all(
+                [isinstance(cube, Cube) for cube in other_cubes]):
+            super(CubeList, self).__iadd__(other_cubes)
+        else:
+            raise ValueError('All items in added sequence must be Cube '
+                             'instances.')
+
+    def __setitem__(self, key, cube):
+        """Set self[key] to cube"""
+        if isinstance(cube, Cube):
+            super(CubeList, self).__setitem__(key, cube)
+        else:
+            raise TypeError('Elements of cubelists must be Cube instances')
+
     def append(self, cube):
         """
         Append a cube.
@@ -231,13 +253,13 @@ class CubeList(list):
                 'Use append to add a single cube to the cubelist.')
         elif not isinstance(other_cubes, collections.Iterable):
             raise TypeError(
-                'Can only extend with a sequece of Cube instances.')
+                'Can only extend with a sequence of Cube instances.')
         elif isinstance(other_cubes, CubeList) or all(
                 [isinstance(cube, Cube) for cube in other_cubes]):
             super(CubeList, self).extend(other_cubes)
         else:
-            raise TypeError('All items in other_cubes must be Cube '
-                            'instances.')
+            raise ValueError('All items in other_cubes must be Cube '
+                             'instances.')
 
     def insert(self, index, cube):
         """

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -25,6 +25,8 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 import iris.tests.stock
 
+NOT_CUBE_MSG = 'Cubelist now contains object of type '
+
 
 class Test_append(tests.IrisTest):
     def setUp(self):
@@ -38,9 +40,8 @@ class Test_append(tests.IrisTest):
         self.cubelist.append(self.cube2)
         self.assertEqual(self.cubelist[-1], self.cube2)
 
-    def test_fail(self):
-        msg = "Only Cube instances can be appended to cubelists.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist.append(None)
 
 
@@ -105,14 +106,14 @@ class Test_extend(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = 'Use append to add a single cube to the cubelist.'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegexp(TypeError, 'Cube is not iterable'):
             self.cubelist1.extend(self.cube1)
-        msg = 'Can only extend with a sequence of Cube instances.'
+        msg = "'NoneType' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
-        msg = 'All items in other_cubes must be Cube instances.'
-        with self.assertRaisesRegexp(ValueError, msg):
+
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist1.extend(range(3))
 
 
@@ -191,13 +192,15 @@ class Test_iadd(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = 'Can only add a sequence of Cube instances.'
+        msg = 'Cube is not iterable'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += self.cube1
+        msg = "'float' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += 1.
-        msg = 'All items in added sequence must be Cube instances.'
-        with self.assertRaisesRegexp(ValueError, msg):
+
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist1 += range(3)
 
 
@@ -211,9 +214,8 @@ class Test_insert(tests.IrisTest):
         self.cubelist.insert(1, self.cube2)
         self.assertEqual(self.cubelist[1], self.cube2)
 
-    def test_fail(self):
-        msg = "Only Cube instances can be inserted into cubelists.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist.insert(0, None)
 
 
@@ -376,15 +378,14 @@ class Test_setitem(tests.IrisTest):
             self.cubelist,
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
-    def test_fail(self):
-        msg = "Elements of cubelists must be Cube instances.  Got "
-        with self.assertRaisesRegexp(TypeError, msg):
+    def test_warn(self):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist[0] = None
-        msg = "Elements of cubelists must be Cube instances."
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG):
             self.cubelist[0:2] = [self.cube3, None]
-        msg = ('Assigning to a slice of a cubelist requires a sequence of '
-               'cubes.')
+
+    def test_fail(self):
+        msg = "can only assign an iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[:1] = 2.5
         with self.assertRaisesRegexp(TypeError, msg):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -24,6 +24,25 @@ from iris.fileformats.pp import STASH
 import iris.tests.stock
 
 
+class Test_append(tests.IrisTest):
+    def setUp(self):
+        self.cubelist = iris.cube.CubeList()
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+
+    def test_pass(self):
+        self.cubelist.append(self.cube1)
+        self.assertEqual(self.cubelist[-1], self.cube1)
+        self.cubelist.append(self.cube2)
+        self.assertEqual(self.cubelist[-1], self.cube2)
+
+    def test_fail(self):
+        msg = ("Only Cube instances can be appended to cubelists.  Got "
+               "<class 'NoneType'>")
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist.append(None)
+
+
 class Test_concatenate_cube(tests.IrisTest):
     def setUp(self):
         self.units = Unit(
@@ -68,6 +87,32 @@ class Test_concatenate_cube(tests.IrisTest):
         exc_regexp = "can't concatenate an empty CubeList"
         with self.assertRaisesRegex(ValueError, exc_regexp):
             CubeList([]).concatenate_cube()
+
+
+class Test_extend(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist1 = iris.cube.CubeList([self.cube1])
+        self.cubelist2 = iris.cube.CubeList([self.cube2])
+
+    def test_pass(self):
+        cubelist = self.cubelist1.copy()
+        cubelist.extend(self.cubelist2)
+        self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
+        cubelist.extend([self.cube2])
+        self.assertEqual(cubelist[-1], self.cube2)
+
+    def test_fail(self):
+        msg = 'Use append to add a single cube to the cubelist.'
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1.extend(self.cube1)
+        msg = 'Can only extend with a sequece of Cube instances.'
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1.extend(None)
+        msg = 'All items in other_cubes must be Cube instances.'
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1.extend(range(3))
 
 
 class Test_extract_overlapping(tests.IrisTest):
@@ -128,6 +173,23 @@ class Test_extract_overlapping(tests.IrisTest):
         a, b = cubes.extract_overlapping("time")
         self.assertEqual(a.coord("time"), self.cube[::-1].coord("time")[2:4])
         self.assertEqual(b.coord("time"), self.cube.coord("time")[2:4])
+
+
+class Test_insert(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist = iris.cube.CubeList([self.cube1] * 3)
+
+    def test_pass(self):
+        self.cubelist.insert(1, self.cube2)
+        self.assertEqual(self.cubelist[1], self.cube2)
+
+    def test_fail(self):
+        msg = ("Only Cube instances can be inserted into cubelists.  Got "
+               "<class 'NoneType'>")
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist.insert(0, None)
 
 
 class Test_merge_cube(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -25,7 +25,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 import iris.tests.stock
 
-NOT_CUBE_MSG = 'Cubelist now contains object of type '
+NOT_CUBE_MSG = "Cubelist now contains object of type '{}'"
 
 
 class Test_append(tests.IrisTest):
@@ -41,7 +41,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
 
@@ -113,7 +113,7 @@ class Test_extend(tests.IrisTest):
             self.cubelist1.extend(None)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
             self.cubelist1.extend(range(3))
 
 
@@ -200,7 +200,7 @@ class Test_iadd(tests.IrisTest):
             self.cubelist1 += 1.
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
             self.cubelist1 += range(3)
 
 
@@ -215,7 +215,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
 
@@ -379,9 +379,9 @@ class Test_setitem(tests.IrisTest):
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
-        with self.assertWarnsRegexp(NOT_CUBE_MSG):
+        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
     def test_fail(self):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -12,6 +12,8 @@ import iris.tests as tests  # isort:skip
 import collections
 from unittest import mock
 
+import copy
+
 from cf_units import Unit
 import numpy as np
 
@@ -37,8 +39,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = ("Only Cube instances can be appended to cubelists.  Got "
-               "<class 'NoneType'>")
+        msg = "Only Cube instances can be appended to cubelists.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist.append(None)
 
@@ -97,7 +98,7 @@ class Test_extend(tests.IrisTest):
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
     def test_pass(self):
-        cubelist = self.cubelist1.copy()
+        cubelist = copy.copy(self.cubelist1)
         cubelist.extend(self.cubelist2)
         self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
         cubelist.extend([self.cube2])
@@ -183,7 +184,7 @@ class Test_iadd(tests.IrisTest):
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
     def test_pass(self):
-        cubelist = self.cubelist1.copy()
+        cubelist = copy.copy(self.cubelist1)
         cubelist += self.cubelist2
         self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
         cubelist += [self.cube2]
@@ -211,8 +212,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_fail(self):
-        msg = ("Only Cube instances can be inserted into cubelists.  Got "
-               "<class 'NoneType'>")
+        msg = "Only Cube instances can be inserted into cubelists.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist.insert(0, None)
 
@@ -374,15 +374,21 @@ class Test_setitem(tests.IrisTest):
         self.cubelist[:2] = (self.cube2, self.cube3)
         self.assertEqual(
             self.cubelist,
-            iris.cube.Cubelist([self.cube2, self.cube3, self.cube1]))
+            iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
-        msg = ("Elements of cubelists must be Cube instances.  Got "
-               "<class 'NoneType'>.")
+        msg = "Elements of cubelists must be Cube instances.  Got "
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[0] = None
-        with self.assertRaisesRegexp(TypeError, msg):
+        msg = "Elements of cubelists must be Cube instances."
+        with self.assertRaisesRegexp(ValueError, msg):
             self.cubelist[0:2] = [self.cube3, None]
+        msg = ('Assigning to a slice of a cubelist requires a sequence of '
+               'cubes.')
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[:1] = 2.5
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[:1] = self.cube1
 
 
 class Test_xml(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -107,11 +107,11 @@ class Test_extend(tests.IrisTest):
         msg = 'Use append to add a single cube to the cubelist.'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(self.cube1)
-        msg = 'Can only extend with a sequece of Cube instances.'
+        msg = 'Can only extend with a sequence of Cube instances.'
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
         msg = 'All items in other_cubes must be Cube instances.'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegexp(ValueError, msg):
             self.cubelist1.extend(range(3))
 
 
@@ -173,6 +173,31 @@ class Test_extract_overlapping(tests.IrisTest):
         a, b = cubes.extract_overlapping("time")
         self.assertEqual(a.coord("time"), self.cube[::-1].coord("time")[2:4])
         self.assertEqual(b.coord("time"), self.cube.coord("time")[2:4])
+
+
+class Test_iadd(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist1 = iris.cube.CubeList([self.cube1])
+        self.cubelist2 = iris.cube.CubeList([self.cube2])
+
+    def test_pass(self):
+        cubelist = self.cubelist1.copy()
+        cubelist += self.cubelist2
+        self.assertEqual(cubelist, self.cubelist1 + self.cubelist2)
+        cubelist += [self.cube2]
+        self.assertEqual(cubelist[-1], self.cube2)
+
+    def test_fail(self):
+        msg = 'Can only add a sequence of Cube instances.'
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1 += self.cube1
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist1 += 1.
+        msg = 'All items in added sequence must be Cube instances.'
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.cubelist1 += range(3)
 
 
 class Test_insert(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -10,9 +10,8 @@
 import iris.tests as tests  # isort:skip
 
 import collections
-from unittest import mock
-
 import copy
+from unittest import mock
 
 from cf_units import Unit
 import numpy as np
@@ -25,14 +24,15 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 import iris.tests.stock
 
-NOT_CUBE_MSG = "Object of type '{}' does not belong in a cubelist."
+NOT_CUBE_MSG = "cannot be put in a cubelist, as it is not a Cube."
+NON_ITERABLE_MSG = "object is not iterable"
 
 
 class Test_append(tests.IrisTest):
     def setUp(self):
         self.cubelist = iris.cube.CubeList()
-        self.cube1 = iris.cube.Cube(1, long_name='foo')
-        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube1 = iris.cube.Cube(1, long_name="foo")
+        self.cube2 = iris.cube.Cube(1, long_name="bar")
 
     def test_pass(self):
         self.cubelist.append(self.cube1)
@@ -41,8 +41,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(ValueError,
-                                     NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist.append(None)
 
 
@@ -94,8 +93,8 @@ class Test_concatenate_cube(tests.IrisTest):
 
 class Test_extend(tests.IrisTest):
     def setUp(self):
-        self.cube1 = iris.cube.Cube(1, long_name='foo')
-        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube1 = iris.cube.Cube(1, long_name="foo")
+        self.cube2 = iris.cube.Cube(1, long_name="bar")
         self.cubelist1 = iris.cube.CubeList([self.cube1])
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
@@ -107,12 +106,11 @@ class Test_extend(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError, 'Cube is not iterable'):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
             self.cubelist1.extend(self.cube1)
-        msg = "'NoneType' object is not iterable"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
             self.cubelist1.extend(None)
-        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist1.extend(range(3))
 
 
@@ -178,8 +176,8 @@ class Test_extract_overlapping(tests.IrisTest):
 
 class Test_iadd(tests.IrisTest):
     def setUp(self):
-        self.cube1 = iris.cube.Cube(1, long_name='foo')
-        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube1 = iris.cube.Cube(1, long_name="foo")
+        self.cube2 = iris.cube.Cube(1, long_name="bar")
         self.cubelist1 = iris.cube.CubeList([self.cube1])
         self.cubelist2 = iris.cube.CubeList([self.cube2])
 
@@ -191,20 +189,18 @@ class Test_iadd(tests.IrisTest):
         self.assertEqual(cubelist[-1], self.cube2)
 
     def test_fail(self):
-        msg = 'Cube is not iterable'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
             self.cubelist1 += self.cube1
-        msg = "'float' object is not iterable"
-        with self.assertRaisesRegexp(TypeError, msg):
-            self.cubelist1 += 1.
-        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
+            self.cubelist1 += 1.0
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist1 += range(3)
 
 
 class Test_insert(tests.IrisTest):
     def setUp(self):
-        self.cube1 = iris.cube.Cube(1, long_name='foo')
-        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube1 = iris.cube.Cube(1, long_name="foo")
+        self.cube2 = iris.cube.Cube(1, long_name="bar")
         self.cubelist = iris.cube.CubeList([self.cube1] * 3)
 
     def test_pass(self):
@@ -212,8 +208,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(ValueError,
-                                     NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist.insert(0, None)
 
 
@@ -363,9 +358,9 @@ class Test_merge__time_triple(tests.IrisTest):
 
 class Test_setitem(tests.IrisTest):
     def setUp(self):
-        self.cube1 = iris.cube.Cube(1, long_name='foo')
-        self.cube2 = iris.cube.Cube(1, long_name='bar')
-        self.cube3 = iris.cube.Cube(1, long_name='boo')
+        self.cube1 = iris.cube.Cube(1, long_name="foo")
+        self.cube2 = iris.cube.Cube(1, long_name="bar")
+        self.cube3 = iris.cube.Cube(1, long_name="boo")
         self.cubelist = iris.cube.CubeList([self.cube1] * 3)
 
     def test_pass(self):
@@ -374,20 +369,18 @@ class Test_setitem(tests.IrisTest):
         self.cubelist[:2] = (self.cube2, self.cube3)
         self.assertEqual(
             self.cubelist,
-            iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
+            iris.cube.CubeList([self.cube2, self.cube3, self.cube1]),
+        )
 
     def test_fail(self):
-        with self.assertRaisesRegexp(ValueError,
-                                     NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist[0] = None
-        with self.assertRaisesRegexp(ValueError,
-                                     NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegex(ValueError, NOT_CUBE_MSG):
             self.cubelist[0:2] = [self.cube3, None]
 
-        msg = "can only assign an iterable"
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
             self.cubelist[:1] = 2.5
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, NON_ITERABLE_MSG):
             self.cubelist[:1] = self.cube1
 
 

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -25,7 +25,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 import iris.tests.stock
 
-NOT_CUBE_MSG = "bject of type '{}'"
+NOT_CUBE_MSG = "Object of type '{}' does not belong in a cubelist."
 
 
 class Test_append(tests.IrisTest):
@@ -41,7 +41,7 @@ class Test_append(tests.IrisTest):
         self.assertEqual(self.cubelist[-1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
@@ -212,7 +212,7 @@ class Test_insert(tests.IrisTest):
         self.assertEqual(self.cubelist[1], self.cube2)
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
@@ -377,7 +377,7 @@ class Test_setitem(tests.IrisTest):
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegexp(ValueError,
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
         with self.assertRaisesRegexp(ValueError,

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -365,17 +365,24 @@ class Test_setitem(tests.IrisTest):
     def setUp(self):
         self.cube1 = iris.cube.Cube(1, long_name='foo')
         self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cube3 = iris.cube.Cube(1, long_name='boo')
         self.cubelist = iris.cube.CubeList([self.cube1] * 3)
 
     def test_pass(self):
         self.cubelist[1] = self.cube2
         self.assertEqual(self.cubelist[1], self.cube2)
+        self.cubelist[:2] = (self.cube2, self.cube3)
+        self.assertEqual(
+            self.cubelist,
+            iris.cube.Cubelist([self.cube2, self.cube3, self.cube1]))
 
     def test_fail(self):
         msg = ("Elements of cubelists must be Cube instances.  Got "
                "<class 'NoneType'>.")
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[0] = None
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[0:2] = [self.cube3, None]
 
 
 class Test_xml(tests.IrisTest):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -25,7 +25,7 @@ import iris.exceptions
 from iris.fileformats.pp import STASH
 import iris.tests.stock
 
-NOT_CUBE_MSG = "Cubelist now contains object of type '{}'"
+NOT_CUBE_MSG = "bject of type '{}'"
 
 
 class Test_append(tests.IrisTest):
@@ -40,8 +40,9 @@ class Test_append(tests.IrisTest):
         self.cubelist.append(self.cube2)
         self.assertEqual(self.cubelist[-1], self.cube2)
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.append(None)
 
 
@@ -111,9 +112,7 @@ class Test_extend(tests.IrisTest):
         msg = "'NoneType' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1.extend(None)
-
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
             self.cubelist1.extend(range(3))
 
 
@@ -198,9 +197,7 @@ class Test_iadd(tests.IrisTest):
         msg = "'float' object is not iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist1 += 1.
-
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('int')):
+        with self.assertRaisesRegexp(ValueError, NOT_CUBE_MSG.format('int')):
             self.cubelist1 += range(3)
 
 
@@ -214,8 +211,9 @@ class Test_insert(tests.IrisTest):
         self.cubelist.insert(1, self.cube2)
         self.assertEqual(self.cubelist[1], self.cube2)
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist.insert(0, None)
 
 
@@ -378,10 +376,12 @@ class Test_setitem(tests.IrisTest):
             self.cubelist,
             iris.cube.CubeList([self.cube2, self.cube3, self.cube1]))
 
-    def test_warn(self):
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+    def test_fail(self):
+        with self.assertRaisesRegexp(TypeError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0] = None
-        with self.assertWarnsRegexp(NOT_CUBE_MSG.format('NoneType')):
+        with self.assertRaisesRegexp(ValueError,
+                                     NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
     def test_fail(self):

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -361,6 +361,23 @@ class Test_merge__time_triple(tests.IrisTest):
         self.assertCML(cube, checksum=False)
 
 
+class Test_setitem(tests.IrisTest):
+    def setUp(self):
+        self.cube1 = iris.cube.Cube(1, long_name='foo')
+        self.cube2 = iris.cube.Cube(1, long_name='bar')
+        self.cubelist = iris.cube.CubeList([self.cube1] * 3)
+
+    def test_pass(self):
+        self.cubelist[1] = self.cube2
+        self.assertEqual(self.cubelist[1], self.cube2)
+
+    def test_fail(self):
+        msg = ("Elements of cubelists must be Cube instances.  Got "
+               "<class 'NoneType'>.")
+        with self.assertRaisesRegexp(TypeError, msg):
+            self.cubelist[0] = None
+
+
 class Test_xml(tests.IrisTest):
     def setUp(self):
         self.cubes = CubeList([Cube(np.arange(3)), Cube(np.arange(3))])

--- a/lib/iris/tests/unit/cube/test_CubeList.py
+++ b/lib/iris/tests/unit/cube/test_CubeList.py
@@ -384,7 +384,6 @@ class Test_setitem(tests.IrisTest):
                                      NOT_CUBE_MSG.format('NoneType')):
             self.cubelist[0:2] = [self.cube3, None]
 
-    def test_fail(self):
         msg = "can only assign an iterable"
         with self.assertRaisesRegexp(TypeError, msg):
             self.cubelist[:1] = 2.5


### PR DESCRIPTION
## 🚀 Pull Request
Proposed revival of https://github.com/SciTools/iris/pull/3238

I was re-inspired to do this by a(nother) user issue with confused usage of a CubeList leading to mystifying error messages.
( like `mylist = CubeList([mylist, new_cube])` )

It foundered before because we kept thinking of new possible ways (methods) to add elements.
But I discovered a section in the Python docs, which I think is more complete + definitive
["Lists implement all of the common and mutable sequence operations.  Lists also provide the following additional methods"](https://docs.python.org/3/library/stdtypes.html#list)
So that makes me feel more secure about this now.

~Draft for now to check tests ...~

Ok now for real PR, I think

