### PR TITLE
Allow passing of method keyword to numpy.percentile

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1996,7 +1996,7 @@ fast_percentile_method : bool
     exception is raised if the data are masked and the missing data tolerance
     is not 0.  Defaults to False.
 
-**kwargs : dict, optional
+kwargs : dict, optional
     Passed to :func:`scipy.stats.mstats.mquantiles` or :func:`numpy.percentile`.
 
 **For example**:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1299,7 +1299,7 @@ def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
     # Get hold of method keyword to pass it to numpy.percentile, or just remove it
     # from kwargs so it's ignored for scipy mquantiles.  Note that kwargs always
     # contains alphap and betap so we can't pass it to numpy.percentile.
-    method = kwargs.pop("method", "linear")
+    method = kwargs.pop("method", None)
     if fast_percentile_method:
         if kwargs.pop("error_on_masked", False):
             msg = (
@@ -1313,7 +1313,12 @@ def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
                 "ignore",
                 "Warning: 'partition' will ignore the 'mask' of the MaskedArray.",
             )
-            result = np.percentile(data, percent, axis=-1, method=method)
+            pc_kwargs = dict(axis=-1)
+            if method is not None:
+                pc_kwargs["method"] = method
+
+            result = np.percentile(data, percent, **pc_kwargs)
+
         result = result.T
     else:
         quantiles = percent / 100.0
@@ -1997,9 +2002,9 @@ Additional kwargs associated with the use of this aggregator:
     betap are ignored. An exception is raised if the data are masked and the
     missing data tolerance is not 0.
     Defaults to False.
-* method (str):
+* method (str, optional):
     Passed to :func:`numpy.percentile`, if fast_percentile_method is True.
-    Otherwise ignored.  Defaults to "linear".
+    Otherwise ignored.
 
 **For example**:
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1296,6 +1296,10 @@ def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
     Calculate percentiles along the trailing axis of a 1D or 2D array.
 
     """
+    # Get hold of method keyword to pass it to numpy.percentile, or just remove it
+    # from kwargs so it's ignored for scipy mquantiles.  Note that kwargs always
+    # contains alphap and betap so we can't pass it to numpy.percentile.
+    method = kwargs.pop("method", "linear")
     if fast_percentile_method:
         if kwargs.pop("error_on_masked", False):
             msg = (
@@ -1309,7 +1313,7 @@ def _calc_percentile(data, percent, fast_percentile_method=False, **kwargs):
                 "ignore",
                 "Warning: 'partition' will ignore the 'mask' of the MaskedArray.",
             )
-            result = np.percentile(data, percent, axis=-1)
+            result = np.percentile(data, percent, axis=-1, method=method)
         result = result.T
     else:
         quantiles = percent / 100.0
@@ -1346,7 +1350,7 @@ def _percentile(data, percent, fast_percentile_method=False, **kwargs):
 
     **kwargs
         passed to scipy.stats.mstats.mquantiles if fast_percentile_method is
-        False
+        False.  Otherwise "method" is extracted and passed to numpy.percentile.
 
     """
     if not isinstance(percent, Iterable):
@@ -1993,6 +1997,9 @@ Additional kwargs associated with the use of this aggregator:
     betap are ignored. An exception is raised if the data are masked and the
     missing data tolerance is not 0.
     Defaults to False.
+* method (str):
+    Passed to :func:`numpy.percentile`, if fast_percentile_method is True.
+    Otherwise ignored.  Defaults to "linear".
 
 **For example**:
 

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -196,6 +196,13 @@ class Test_aggregate(tests.IrisTest, AggregateMixin, ScipyAggregateMixin):
         with self.assertRaisesRegex(ValueError, emsg):
             PERCENTILE.aggregate("dummy", axis=0)
 
+    def test_wrong_kwarg(self):
+        # Test we get an error out of scipy if we pass the numpy keyword.
+        data = range(5)
+        emsg = "unexpected keyword argument"
+        with self.assertRaisesRegex(TypeError, emsg):
+            PERCENTILE.aggregate(data, percent=50, axis=0, method="nearest")
+
 
 class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
     """Tests for fast percentile method on real data."""

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -239,6 +239,9 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
         self.agg_method(data, axis=0, percent=42, fast_percentile_method=True)
         mocked_percentile.assert_called_once()
 
+        # Check that we left "method" keyword to numpy's default.
+        self.assertNotIn("method", mocked_percentile.call_args.kwargs)
+
     @mock.patch("numpy.percentile")
     def test_chosen_kwarg_passed(self, mocked_percentile):
         data = np.arange(5)
@@ -353,8 +356,11 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         as_concrete_data(result)
         mocked_percentile.assert_called()
 
+        # Check we have left "method" keyword to numpy's default.
+        self.assertNotIn("method", mocked_percentile.call_args.kwargs)
+
     @mock.patch("numpy.percentile")
-    def test_chosen_kwarg_passed(self, mocked_percentile):
+    def test_chosen_method_kwarg_passed(self, mocked_percentile):
         data = da.arange(5)
         percent = [42, 75]
         axis = 0

--- a/lib/iris/tests/unit/analysis/test_PERCENTILE.py
+++ b/lib/iris/tests/unit/analysis/test_PERCENTILE.py
@@ -239,6 +239,23 @@ class Test_fast_aggregate(tests.IrisTest, AggregateMixin):
         self.agg_method(data, axis=0, percent=42, fast_percentile_method=True)
         mocked_percentile.assert_called_once()
 
+    @mock.patch("numpy.percentile")
+    def test_chosen_kwarg_passed(self, mocked_percentile):
+        data = np.arange(5)
+        percent = [42, 75]
+        axis = 0
+
+        self.agg_method(
+            data,
+            axis=axis,
+            percent=percent,
+            fast_percentile_method=True,
+            method="nearest",
+        )
+        self.assertEqual(
+            mocked_percentile.call_args.kwargs["method"], "nearest"
+        )
+
 
 class MultiAxisMixin:
     """
@@ -335,6 +352,26 @@ class Test_lazy_fast_aggregate(tests.IrisTest, AggregateMixin, MultiAxisMixin):
         self.assertTrue(is_lazy_data(result))
         as_concrete_data(result)
         mocked_percentile.assert_called()
+
+    @mock.patch("numpy.percentile")
+    def test_chosen_kwarg_passed(self, mocked_percentile):
+        data = da.arange(5)
+        percent = [42, 75]
+        axis = 0
+
+        result = self.agg_method(
+            data,
+            axis=axis,
+            percent=percent,
+            fast_percentile_method=True,
+            method="nearest",
+        )
+
+        self.assertTrue(is_lazy_data(result))
+        as_concrete_data(result)
+        self.assertEqual(
+            mocked_percentile.call_args.kwargs["method"], "nearest"
+        )
 
 
 class Test_lazy_aggregate(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
The `PERCENTILE` fast method will be more versatile if we can choose our interpolation method.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
