### PR TITLE
Allow 10Gb for test runs in Cirrus.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,6 +167,8 @@ task:
     MPL_RC_DIR: ${HOME}/.config/matplotlib
     MPL_RC_FILE: ${HOME}/.config/matplotlib/matplotlibrc
   name: "${CIRRUS_OS}: py${PY_VER} doctests and gallery"
+  container:
+    memory: 6G
   << : *IRIS_TEST_DATA_TEMPLATE
   << : *LINUX_TASK_TEMPLATE
   tests_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,7 +146,7 @@ task:
   container:
     image: gcc:latest
     cpu: 6
-    memory: 8G
+    memory: 10G
   << : *IRIS_TEST_DATA_TEMPLATE
   << : *LINUX_TASK_TEMPLATE
   tests_script:


### PR DESCRIPTION
This promises to be an ultra-simple fix for our latest CI problems,
as noted [here](https://github.com/SciTools/iris/pull/4794#issuecomment-1154032367)

Wellll, a sufficient stop-gap anyway.
It could well still be the right time to adopt #4503 