### PR TITLE
Retire use of the `New:` labels.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug Report"
 about: Submit a bug report to help us improve Iris
 title: ''
-labels: 'New: Issue, Type: Bug'
+labels: 'Type: Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DA Documentation"
 about: Report an issue with the Iris documentation
 title: ''
-labels: 'New: Documentation, Type: Documentation'
+labels: 'Type: Documentation'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,6 @@
 name: "✨ Feature Request"
 about: Submit a request for a new feature in Iris
 title: ''
-labels: 'New: Feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -2,7 +2,6 @@
 name: "\U0001F4F0 Custom Issue"
 about: Submit a generic issue to help us improve Iris
 title: ''
-labels: 'New: Issue'
 assignees: ''
 
 ---


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The `New: ...` labels aren't being used for anything (to my knowledge) so I would like to remove them to simplify/tidy the repo.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
