### PR TITLE
add gha workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@
 </h4>
 
 <p align="center">
-<a href="https://cirrus-ci.com/github/SciTools/iris">
-<img src="https://api.cirrus-ci.com/github/SciTools/iris.svg?branch=main"
-     alt="Cirrus-CI"></a>
+<a href="https://github.com/SciTools/iris/actions/workflows/ci-tests.yml">
+<img src="https://github.com/SciTools/iris/actions/workflows/ci-tests.yml/badge.svg?branch=main"
+     alt="ci-tests"></a>
+<a href="https://github.com/SciTools/iris/actions/workflows/ci-docs-tests.yml">
+<img src="https://github.com/SciTools/iris/actions/workflows/ci-docs-tests.yml/badge.svg?branch=main"
+     alt="ci-docs-tests"></a>
+<a href="https://github.com/SciTools/iris/actions/workflows/ci-docs-linkcheck.yml">
+<img src="https://github.com/SciTools/iris/actions/workflows/ci-docs-linkcheck.yml/badge.svg?branch=main"
+     alt="ci-docs-linkcheck"></a>
 <a href="https://scitools-iris.readthedocs.io/en/latest/?badge=latest">
 <img src="https://readthedocs.org/projects/scitools-iris/badge/?version=latest"
      alt="Documentation Status"></a>
 <a href="https://results.pre-commit.ci/latest/github/SciTools/iris/main">
 <img src="https://results.pre-commit.ci/badge/github/SciTools/iris/main.svg"
      alt="pre-commit.ci status"></a>
+</p>
+
+<p align="center">
 <a href="https://anaconda.org/conda-forge/iris">
 <img src="https://img.shields.io/conda/v/conda-forge/iris?color=orange&label=conda-forge%7Ciris&logo=conda-forge&logoColor=white"
      alt="conda-forge"></a>


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR removes the retired `cirrus-ci` status badge, and replaces it with the new GHA workflow status badges.

![image](https://user-images.githubusercontent.com/2051656/174308041-0aeb48d6-5cf1-4acf-b182-5a67fdf7f24c.png)

Also see [here](https://github.com/bjlittle/iris/tree/fix-badges#-----).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
