### PR TITLE
bump ci to latest iris-test-data version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       IRIS_TEST_DATA_LOC_PATH: benchmarks
       IRIS_TEST_DATA_PATH: benchmarks/iris-test-data
-      IRIS_TEST_DATA_VERSION: "2.5"
+      IRIS_TEST_DATA_VERSION: "2.12"
       # Lets us manually bump the cache to rebuild
       ENV_CACHE_BUILD: "0"
       TEST_DATA_CACHE_BUILD: "2"

--- a/.github/workflows/ci-docs-tests.yml
+++ b/.github/workflows/ci-docs-tests.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: ["3.8"]
 
     env:
-      IRIS_TEST_DATA_VERSION: "2.10"
+      IRIS_TEST_DATA_VERSION: "2.12"
       ENV_NAME: "ci-docs-tests"
 
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ["3.8"]
 
     env:
-      IRIS_TEST_DATA_VERSION: "2.10"
+      IRIS_TEST_DATA_VERSION: "2.12"
       ENV_NAME: "ci-tests"
 
     steps:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the CI to use the latest version of `iris-test-data` i.e., [v2.12](https://github.com/SciTools/iris-test-data/releases/tag/v2.12).


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
