### PR TITLE
NetCDF Generation Adjustments

### DIFF
--- a/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
+++ b/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
@@ -11,8 +11,7 @@ Where possible benchmarks should be parameterised for two sizes of input data:
   * minimal: enables detection of regressions in parts of the run-time that do
              NOT scale with data size.
   * large: large enough to exclusively detect regressions in parts of the
-           run-time that scale with data size. Aim for benchmark time ~20x
-           that of the minimal benchmark.
+           run-time that scale with data size.
 
 """
 import os

--- a/benchmarks/benchmarks/load/ugrid.py
+++ b/benchmarks/benchmarks/load/ugrid.py
@@ -10,8 +10,7 @@ Where possible benchmarks should be parameterised for two sizes of input data:
   * minimal: enables detection of regressions in parts of the run-time that do
              NOT scale with data size.
   * large: large enough to exclusively detect regressions in parts of the
-           run-time that scale with data size. Aim for benchmark time ~20x
-           that of the minimal benchmark.
+           run-time that scale with data size.
 
 """
 
@@ -39,7 +38,7 @@ def load_mesh(*args, **kwargs):
 
 
 class BasicLoading:
-    params = [1, int(4.1e6)]
+    params = [1, int(2e5)]
     param_names = ["number of faces"]
 
     def setup_common(self, **kwargs):
@@ -75,7 +74,7 @@ class DataRealisation:
     warmup_time = 0.0
     timeout = 300.0
 
-    params = [1, int(4e6)]
+    params = [1, int(2e5)]
     param_names = ["number of faces"]
 
     def setup_common(self, **kwargs):
@@ -102,7 +101,7 @@ class DataRealisationTime(DataRealisation):
 
 
 class Callback:
-    params = [1, int(4.5e6)]
+    params = [1, int(2e5)]
     param_names = ["number of faces"]
 
     def setup_common(self, **kwargs):

--- a/benchmarks/benchmarks/load/ugrid.py
+++ b/benchmarks/benchmarks/load/ugrid.py
@@ -57,6 +57,9 @@ class BasicLoading:
 class BasicLoadingTime(BasicLoading):
     """Same as BasicLoading, but scaling over a time series - an unlimited dimension."""
 
+    # NOTE iris#4834 - careful how big the time dimension is (time dimension
+    #  is UNLIMITED).
+
     param_names = ["number of time steps"]
 
     def setup(self, *args):

--- a/benchmarks/benchmarks/save.py
+++ b/benchmarks/benchmarks/save.py
@@ -10,8 +10,7 @@ Where possible benchmarks should be parameterised for two sizes of input data:
   * minimal: enables detection of regressions in parts of the run-time that do
              NOT scale with data size.
   * large: large enough to exclusively detect regressions in parts of the
-           run-time that scale with data size. Aim for benchmark time ~20x
-           that of the minimal benchmark.
+           run-time that scale with data size.
 
 """
 from iris import save

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -232,11 +232,8 @@ This document explains the changes made to Iris for this release
    bin in the system PATH.
    (:pull:`4794`)
 
-#. `@trexfeathers`_ and `@pp-mo`_ fixed the CDL headers for
-   :mod:`iris.tests.stock.netcdf` to allow generation of NetCDF-4 files with an
-   unlimited time dimension.
-   (:pull:`4827`)
-
+#. `@trexfeathers`_ and `@pp-mo`_ improved generation of stock NetCDF files.
+   (:pull:`4827`, :pull:`4836`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/tests/stock/file_headers/xios_2D_face_half_levels.cdl
+++ b/lib/iris/tests/stock/file_headers/xios_2D_face_half_levels.cdl
@@ -55,8 +55,4 @@ variables:
 		:name = "${DATASET_NAME}" ;
 //		original name = "lfric_ngvat_2D_1t_face_half_levels_main_conv_rain"
 		:Conventions = "UGRID" ;
-
-// data
-data:
-  time_instant = 0 ;
 }

--- a/lib/iris/tests/stock/file_headers/xios_3D_face_full_levels.cdl
+++ b/lib/iris/tests/stock/file_headers/xios_3D_face_full_levels.cdl
@@ -58,8 +58,4 @@ variables:
 		:name = "${DATASET_NAME}" ;
 //		original name = "lfric_ngvat_3D_1t_full_level_face_grid_main_u3"
 		:Conventions = "UGRID" ;
-
-// data
-data:
-  time_instant = 0 ;
 }

--- a/lib/iris/tests/stock/file_headers/xios_3D_face_half_levels.cdl
+++ b/lib/iris/tests/stock/file_headers/xios_3D_face_half_levels.cdl
@@ -58,8 +58,4 @@ variables:
 		:name = "${DATASET_NAME}" ;
 //		original name = "lfric_ngvat_3D_1t_half_level_face_grid_derived_theta_in_w3"
 		:Conventions = "UGRID" ;
-
-// data
-data:
-  time_instant = 0 ;
 }

--- a/lib/iris/tests/stock/netcdf.py
+++ b/lib/iris/tests/stock/netcdf.py
@@ -51,13 +51,13 @@ def ncgen_from_cdl(
             f_out.write(cdl_str)
     if cdl_path:
         # Create netcdf from stored CDL file.
-        call_args = [NCGEN_PATHSTR, cdl_path, "-k4", "-o", nc_path]
+        call_args = [NCGEN_PATHSTR, cdl_path, "-k3", "-o", nc_path]
         call_kwargs = {}
     else:
         # No CDL file : pipe 'cdl_str' directly into the ncgen program.
         if not cdl_str:
             raise ValueError("Must provide either 'cdl_str' or 'cdl_path'.")
-        call_args = [NCGEN_PATHSTR, "-k4", "-o", nc_path]
+        call_args = [NCGEN_PATHSTR, "-k3", "-o", nc_path]
         call_kwargs = dict(input=cdl_str, encoding="ascii")
 
     subprocess.run(call_args, check=True, **call_kwargs)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

1. Removed data from CDL headers (introduced in #4827) - served no purpose
2. Used `-k3` for `ncgen` - creates a standard NetCDF-4 file ([documentation](https://linux.die.net/man/1/ncgen))
3. Reduced size of UGRID benchmarks to cope with #4834.
   Have made the size consistent across all relevant benchmarks, even those that don't suffer the problem.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
