### PR TITLE
pytest less verbose

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   tests:
-    name: "${{ matrix.session }} py${{ matrix.python-version }} ${{ matrix.os }}"
+    name: "${{ matrix.session }} (py${{ matrix.python-version }} ${{ matrix.os }})"
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,7 @@ extend_skip = [
 ]
 skip_gitignore = "True"
 verbose = "False"
+
+[tool.pytest.ini_options]
+addopts = "-ra -q"
+testpaths = "lib/iris"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR lowers the verbosity of `pytest`.

`iris` currently has `>6,000` tests, which makes for a pretty meaty test report (and that's regardless of the amount of warnings spewing to the terminal).

As a developer, I only really care about tests when they fail. When that happens I want to see the detail of the failure quickly so that I can then investigate, diagnose and fix (hopefully).

Personally, I really don't need to see the details of tests that pass, only those that fail, and I think turning down the verbosity really helps (for me, anyways).

For example,

<details>
<summary>Here is a pytest run with 1 failure...</summary>

```shell
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
.............................................................ss......... [ 19%]
.....................s.................................................. [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
........................................................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 43%]
........................................................................ [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
........................................................................ [ 48%]
........................................................................ [ 49%]
........................................................................ [ 50%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
.............F.......................................................... [ 55%]
........................................................................ [ 56%]
........................................................................ [ 57%]
........................................................................ [ 58%]
........................................................................ [ 60%]
........................................................................ [ 61%]
........................................................................ [ 62%]
........................................................................ [ 63%]
........................................................................ [ 64%]
........................................................................ [ 65%]
........................................................................ [ 66%]
........................................................................ [ 67%]
........................................................................ [ 69%]
........................................................................ [ 70%]
........................................................................ [ 71%]
........................................................................ [ 72%]
........................................................................ [ 73%]
........................................................................ [ 74%]
........................................................................ [ 75%]
........................................................................ [ 76%]
........................................................................ [ 78%]
........................................................................ [ 79%]
........................................................................ [ 80%]
........................................................................ [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
........................................................................ [ 84%]
........................................................................ [ 86%]
........................................................................ [ 87%]
........................................................................ [ 88%]
........................................................................ [ 89%]
........................................................................ [ 90%]
........................................................................ [ 91%]
........................................................................ [ 92%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 96%]
........................................................................ [ 97%]
........................................................................ [ 98%]
....................ssssssssssssssssss.................................. [ 99%]
.......................
=================================== FAILURES ===================================
______________ Test.test__no_bases_with_abstract_members_property ______________
[gw1] linux -- Python 3.8.13 /home/runner/work/iris/iris/.nox/tests/bin/python
TypeError: Can't instantiate abstract class Metadata with abstract methods _members
During handling of the above exception, another exception occurred:
self = <iris.tests.unit.common.metadata.test__NamedTupleMeta.Test testMethod=test__no_bases_with_abstract_members_property>
    def test__no_bases_with_abstract_members_property(self):
        class Metadata(metaclass=_NamedTupleMeta):
            @property
            @abstractmethod
            def _members(self):
                pass
        expected = ["object"]
        self.assertEqual(self.names(Metadata.__bases__), expected)
        expected = ["Metadata", "object"]
        self.assertEqual(self.names(Metadata.__mro__), expected)
        emsg = (
            "Can't instantiate abstract class .* with abstract "
            "method _members"
        )
        with self.assertRaisesRegex(TypeError, emsg):
>           _ = Metadata()
E           AssertionError: "Can't instantiate abstract class .* with abstract method _members" does not match "Can't instantiate abstract class Metadata with abstract methods _members"
lib/iris/tests/unit/common/metadata/test__NamedTupleMeta.py:57: AssertionError
```
</details>

<details>
<summary> Here is the associated pytest short summary...</summary>

```shell
=========================== short test summary info ============================
SKIPPED [1] lib/iris/tests/experimental/test_raster.py:155: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/experimental/test_raster.py:149: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/experimental/test_raster.py:152: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:77: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:80: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:83: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:86: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:50: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:53: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:56: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:59: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:89: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:65: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:68: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:71: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:74: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:62: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:142: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:113: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:120: Test requires 'gdal'.
SKIPPED [1] lib/iris/tests/unit/experimental/raster/test_export_geotiff.py:168: Test requires 'gdal'.
FAILED lib/iris/tests/unit/common/metadata/test__NamedTupleMeta.py::Test::test__no_bases_with_abstract_members_property
1 failed, 6337 passed, 21 skipped, 1664 warnings in 238.27s (0:03:58)
```
</details>

I suspect whether this PR is merged or not comes down to individual developer preferences.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
