### PR TITLE
Remove redundant testing assert methods

### DIFF
--- a/docs/src/developers_guide/testing_tools.rst
+++ b/docs/src/developers_guide/testing_tools.rst
@@ -24,8 +24,7 @@ Custom assertions
 =================
 
 :class:`iris.tests.IrisTest` supports a variety of custom unittest-style
-assertions, such as :meth:`~iris.tests.IrisTest_nometa.assertStringEqual`,
-:meth:`~iris.tests.IrisTest_nometa.assertArrayEqual`,
+assertions, such as :meth:`~iris.tests.IrisTest_nometa.assertArrayEqual`,
 :meth:`~iris.tests.IrisTest_nometa.assertArrayAlmostEqual`.
 
 .. _create-missing:

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -237,6 +237,8 @@ This document explains the changes made to Iris for this release
    unlimited time dimension.
    (:pull:`4827`)
 
+#. `@rcomer`_ removed some now redundant testing methods. (:pull:`4838`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -561,16 +561,6 @@ class IrisTest_nometa(unittest.TestCase):
         matches.extend(message for message in messages if expr.search(message))
 
     @contextlib.contextmanager
-    def assertWarnsRegexp(self, expected_regexp=""):
-        # Check that a warning is raised matching a given expression.
-        with self._recordWarningMatches(expected_regexp) as matches:
-            yield
-
-        msg = "Warning matching '{}' not raised."
-        msg = msg.format(expected_regexp)
-        self.assertTrue(matches, msg)
-
-    @contextlib.contextmanager
     def assertLogs(self, logger=None, level=None, msg_regex=None):
         """
         An extended version of the usual :meth:`unittest.TestCase.assertLogs`,

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -223,25 +223,6 @@ class IrisTest_nometa(unittest.TestCase):
             relative_path = os.path.join(*relative_path)
         return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
-    def assertStringEqual(
-        self, reference_str, test_str, type_comparison_name="strings"
-    ):
-        if reference_str != test_str:
-            diff = "\n".join(
-                difflib.unified_diff(
-                    reference_str.splitlines(),
-                    test_str.splitlines(),
-                    "Reference",
-                    "Test result",
-                    "",
-                    "",
-                    0,
-                )
-            )
-            self.fail(
-                "{} do not match:\n{}".format(type_comparison_name, diff)
-            )
-
     def result_path(self, basename=None, ext=""):
         """
         Return the full path to a test result, generated from the \

--- a/lib/iris/tests/integration/test_netcdf.py
+++ b/lib/iris/tests/integration/test_netcdf.py
@@ -599,15 +599,15 @@ data:
             cube = iris.load_cube(nc_path)
         test_crs = cube.coord("projection_y_coordinate").coord_system
         actual = str(test_crs.as_cartopy_crs().datum)
-        self.assertStringEqual(expected, actual)
+        self.assertMultiLineEqual(expected, actual)
 
     def test_no_load_datum_wkt(self):
         nc_path = tlc.cdl_to_nc(self.datum_wkt_cdl)
-        with self.assertWarnsRegexp("iris.FUTURE.datum_support"):
+        with self.assertWarnsRegex(FutureWarning, "iris.FUTURE.datum_support"):
             cube = iris.load_cube(nc_path)
         test_crs = cube.coord("projection_y_coordinate").coord_system
         actual = str(test_crs.as_cartopy_crs().datum)
-        self.assertStringEqual(actual, "unknown")
+        self.assertMultiLineEqual(actual, "unknown")
 
     def test_load_datum_cf_var(self):
         expected = "OSGB 1936"
@@ -616,15 +616,15 @@ data:
             cube = iris.load_cube(nc_path)
         test_crs = cube.coord("projection_y_coordinate").coord_system
         actual = str(test_crs.as_cartopy_crs().datum)
-        self.assertStringEqual(expected, actual)
+        self.assertMultiLineEqual(expected, actual)
 
     def test_no_load_datum_cf_var(self):
         nc_path = tlc.cdl_to_nc(self.datum_cf_var_cdl)
-        with self.assertWarnsRegexp("iris.FUTURE.datum_support"):
+        with self.assertWarnsRegex(FutureWarning, "iris.FUTURE.datum_support"):
             cube = iris.load_cube(nc_path)
         test_crs = cube.coord("projection_y_coordinate").coord_system
         actual = str(test_crs.as_cartopy_crs().datum)
-        self.assertStringEqual(actual, "unknown")
+        self.assertMultiLineEqual(actual, "unknown")
 
     def test_save_datum(self):
         expected = "OSGB 1936"
@@ -663,7 +663,7 @@ data:
 
         test_crs = cube.coord("projection_y_coordinate").coord_system
         actual = str(test_crs.as_cartopy_crs().datum)
-        self.assertStringEqual(expected, actual)
+        self.assertMultiLineEqual(expected, actual)
 
 
 def _get_scale_factor_add_offset(cube, datatype):

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -295,7 +295,7 @@ class TestCFReader(tests.IrisTest):
                         except OSError:
                             pass
                     buf.seek(0)
-                    self.assertStringEqual("", buf.read())
+                    self.assertMultiLineEqual("", buf.read())
 
 
 @tests.skip_data

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -548,18 +548,18 @@ class Test_Datums(tests.IrisTest):
     def test_default_none(self):
         cs = GeogCS(6543210, 6500000)  # Arbitrary radii
         cartopy_crs = cs.as_cartopy_crs()
-        self.assertStringEqual(cartopy_crs.datum.name, "unknown")
+        self.assertMultiLineEqual(cartopy_crs.datum.name, "unknown")
 
     def test_set_persist(self):
         cs = GeogCS.from_datum(datum="WGS84")
         cartopy_crs = cs.as_cartopy_crs()
-        self.assertStringEqual(
+        self.assertMultiLineEqual(
             cartopy_crs.datum.name, "World Geodetic System 1984"
         )
 
         cs = GeogCS.from_datum(datum="OSGB36")
         cartopy_crs = cs.as_cartopy_crs()
-        self.assertStringEqual(cartopy_crs.datum.name, "OSGB 1936")
+        self.assertMultiLineEqual(cartopy_crs.datum.name, "OSGB 1936")
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
+++ b/lib/iris/tests/unit/experimental/representation/test_CubeRepresentation.py
@@ -28,7 +28,7 @@ class Test__instantiation(tests.IrisTest):
 
     def test_cube_attributes(self):
         self.assertEqual(id(self.cube), self.representer.cube_id)
-        self.assertStringEqual(str(self.cube), self.representer.cube_str)
+        self.assertMultiLineEqual(str(self.cube), self.representer.cube_str)
 
     def test__heading_contents(self):
         content = set(self.representer.sections_data.values())

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/__init__.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/__init__.py
@@ -117,7 +117,7 @@ class Mixin__nc_load_actions:
         # Always returns a single cube.
         return cube
 
-    def run_testcase(self, warning=None, **testcase_kwargs):
+    def run_testcase(self, warning_regex=None, **testcase_kwargs):
         """
         Run a testcase with chosen options, returning a test cube.
 
@@ -133,10 +133,10 @@ class Mixin__nc_load_actions:
             print(cdl_string)
             print("------\n")
 
-        if warning is None:
+        if warning_regex is None:
             context = self.assertNoWarningsRegexp()
         else:
-            context = self.assertWarnsRegexp(warning)
+            context = self.assertWarnsRegex(UserWarning, warning_regex)
         with context:
             cube = self.load_cube_from_cdl(cdl_string, cdl_path, nc_path)
 

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
@@ -407,7 +407,9 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         # Notes:
         #     * behaviours all the same as 'test_bad_gridmapping_nameproperty'
         warning = "Missing.*grid mapping variable 'grid'"
-        result = self.run_testcase(warning=warning, gridmapvar_name="grid_2")
+        result = self.run_testcase(
+            warning_regex=warning, gridmapvar_name="grid_2"
+        )
         self.check_result(result, cube_no_cs=True)
 
     def test_latlon_bad_latlon_unit(self):
@@ -503,6 +505,30 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
             mapping_type_name=hh.CF_GRID_MAPPING_MERCATOR
         )
         self.check_result(result, cube_cstype=ics.Mercator)
+
+    def test_mapping_mercator__fail_unsupported(self):
+        # Provide a mercator grid-mapping with a non-unity scale factor, which
+        # we cannot handle.
+        # Result : fails to convert into a coord-system, and emits a warning.
+        #
+        # Rules Triggered:
+        #     001 : fc_default
+        #     002 : fc_provides_grid_mapping_(mercator) --(FAILED check has_supported_mercator_parameters)
+        #     003 : fc_provides_coordinate_(projection_y)
+        #     004 : fc_provides_coordinate_(projection_x)
+        #     005 : fc_build_coordinate_(projection_y)(FAILED projected coord with non-projected cs)
+        #     006 : fc_build_coordinate_(projection_x)(FAILED projected coord with non-projected cs)
+        # Notes:
+        #     * grid-mapping identified : NONE
+        #     * dim-coords identified : proj-x and -y
+        #     * coords built : NONE  (no dim or aux coords: cube has no coords)
+        warning = "not yet supported for Mercator"
+        result = self.run_testcase(
+            warning_regex=warning,
+            mapping_type_name=hh.CF_GRID_MAPPING_MERCATOR,
+            mapping_scalefactor=2.0,
+        )
+        self.check_result(result, cube_no_cs=True, cube_no_xycoords=True)
 
     def test_mapping_stereographic(self):
         result = self.run_testcase(mapping_type_name=hh.CF_GRID_MAPPING_STEREO)
@@ -633,7 +659,7 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         #     * coords built : lat + lon, with no coord-system (see above)
         warning = "Missing.*grid mapping variable 'grid'"
         result = self.run_testcase(
-            warning=warning,
+            warning_regex=warning,
             gridmapvar_name="moved",
             xco_name="longitude",
             xco_units="degrees_east",
@@ -690,7 +716,7 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         #     * coords built : rotated lat + lon, with no coord-system (see above)
         warning = "Missing.*grid mapping variable 'grid'"
         result = self.run_testcase(
-            warning=warning,
+            warning_regex=warning,
             gridmapvar_name="moved",
             xco_name="grid_longitude",
             xco_units="degrees",
@@ -752,7 +778,7 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         #     * effectively, just like previous 2 cases
         warning = "Missing.*grid mapping variable 'grid'"
         result = self.run_testcase(
-            warning=warning,
+            warning_regex=warning,
             gridmapvar_name="moved",
             xco_name="projection_x",
             xco_units="m",
@@ -872,7 +898,9 @@ class Test__nondimcoords(Mixin__grid_mapping, tests.IrisTest):
         #     * in terms of rule triggering, this is not distinct from the
         #       "normal" case : but latitude is now created as an aux-coord.
         warning = "must be.* monotonic"
-        result = self.run_testcase(warning=warning, yco_values=[0.0, 0.0])
+        result = self.run_testcase(
+            warning_regex=warning, yco_values=[0.0, 0.0]
+        )
         self.check_result(result, yco_is_aux=True)
 
 

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__grid_mappings.py
@@ -506,30 +506,6 @@ class Test__grid_mapping(Mixin__grid_mapping, tests.IrisTest):
         )
         self.check_result(result, cube_cstype=ics.Mercator)
 
-    def test_mapping_mercator__fail_unsupported(self):
-        # Provide a mercator grid-mapping with a non-unity scale factor, which
-        # we cannot handle.
-        # Result : fails to convert into a coord-system, and emits a warning.
-        #
-        # Rules Triggered:
-        #     001 : fc_default
-        #     002 : fc_provides_grid_mapping_(mercator) --(FAILED check has_supported_mercator_parameters)
-        #     003 : fc_provides_coordinate_(projection_y)
-        #     004 : fc_provides_coordinate_(projection_x)
-        #     005 : fc_build_coordinate_(projection_y)(FAILED projected coord with non-projected cs)
-        #     006 : fc_build_coordinate_(projection_x)(FAILED projected coord with non-projected cs)
-        # Notes:
-        #     * grid-mapping identified : NONE
-        #     * dim-coords identified : proj-x and -y
-        #     * coords built : NONE  (no dim or aux coords: cube has no coords)
-        warning = "not yet supported for Mercator"
-        result = self.run_testcase(
-            warning_regex=warning,
-            mapping_type_name=hh.CF_GRID_MAPPING_MERCATOR,
-            mapping_scalefactor=2.0,
-        )
-        self.check_result(result, cube_no_cs=True, cube_no_xycoords=True)
-
     def test_mapping_stereographic(self):
         result = self.run_testcase(mapping_type_name=hh.CF_GRID_MAPPING_STEREO)
         self.check_result(result, cube_cstype=ics.Stereographic)

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__hybrid_formulae.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__hybrid_formulae.py
@@ -207,7 +207,7 @@ variables:
         result = self.run_testcase(
             formula_root_name="unknown",
             term_names=["a", "b"],
-            warning="Ignored formula of unrecognised type: 'unknown'.",
+            warning_regex="Ignored formula of unrecognised type: 'unknown'.",
         )
         # Check that it picks up the terms, but *not* the factory root coord,
         # which is simply discarded.
@@ -226,7 +226,7 @@ variables:
 
         extra_type = "ocean_sigma_coordinate"
         result = self.run_testcase(
-            extra_formula_type=extra_type, warning=warning
+            extra_formula_type=extra_type, warning_regex=warning
         )
         # NOTE: FOR NOW, check expected behaviour : only one factory will be
         # built, but there are coordinates (terms) for both types.

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__time_coords.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__time_coords.py
@@ -313,7 +313,7 @@ class Mixin__singlecoord__tests(Mixin__timecoords__common):
         #     002 : fc_provides_coordinate_(time[[_period]])
         #     003 : fc_build_coordinate_(time[[_period]])
         msg = "Failed to create.* dimension coordinate"
-        result = self.run_testcase(values_all_zero=True, warning=msg)
+        result = self.run_testcase(values_all_zero=True, warning_regex=msg)
         self.check_result(result, "aux")
 
     def test_dim_fails_typeident(self):

--- a/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_Saver.py
@@ -549,8 +549,9 @@ class Test_write_fill_value(tests.IrisTest):
         # Test that a warning is raised if the data contains the fill value.
         cube = self._make_cube(">f4")
         fill_value = 1
-        with self.assertWarnsRegexp(
-            "contains unmasked data points equal to the fill-value"
+        with self.assertWarnsRegex(
+            UserWarning,
+            "contains unmasked data points equal to the fill-value",
         ):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
@@ -560,8 +561,9 @@ class Test_write_fill_value(tests.IrisTest):
         # when it is of a byte type.
         cube = self._make_cube(">i1")
         fill_value = 1
-        with self.assertWarnsRegexp(
-            "contains unmasked data points equal to the fill-value"
+        with self.assertWarnsRegex(
+            UserWarning,
+            "contains unmasked data points equal to the fill-value",
         ):
             with self._netCDF_var(cube, fill_value=fill_value):
                 pass
@@ -571,8 +573,9 @@ class Test_write_fill_value(tests.IrisTest):
         # value if no fill_value argument is supplied.
         cube = self._make_cube(">f4")
         cube.data[0, 0] = nc.default_fillvals["f4"]
-        with self.assertWarnsRegexp(
-            "contains unmasked data points equal to the fill-value"
+        with self.assertWarnsRegex(
+            UserWarning,
+            "contains unmasked data points equal to the fill-value",
         ):
             with self._netCDF_var(cube):
                 pass

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -92,7 +92,7 @@ class Test_save(tests.IrisTest):
         data_64 = np.linspace(0, 1, num=10, endpoint=False).reshape(2, 5)
         checksum_32 = field_checksum(data_64.astype(">f4"))
         msg = "Downcasting array precision from float64 to float32 for save."
-        with self.assertWarnsRegexp(msg):
+        with self.assertWarnsRegex(UserWarning, msg):
             checksum_64 = field_checksum(data_64.astype(">f8"))
         self.assertEqual(checksum_32, checksum_64)
 
@@ -105,7 +105,7 @@ class Test_save(tests.IrisTest):
             [1.0, field.bmdi, 3.0], dtype=np.float32
         )
         msg = "PPField data contains unmasked points"
-        with self.assertWarnsRegexp(msg):
+        with self.assertWarnsRegex(UserWarning, msg):
             with self.temp_filename(".pp") as temp_filename:
                 with open(temp_filename, "wb") as pp_file:
                     field.save(pp_file)
@@ -117,7 +117,7 @@ class Test_save(tests.IrisTest):
         # Make float32 data, as float64 default produces an extra warning.
         field.data = np.array([1.0, field.bmdi, 3.0], dtype=np.float32)
         msg = "PPField data contains unmasked points"
-        with self.assertWarnsRegexp(msg):
+        with self.assertWarnsRegex(UserWarning, msg):
             with self.temp_filename(".pp") as temp_filename:
                 with open(temp_filename, "wb") as pp_file:
                     field.save(pp_file)

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -94,7 +94,7 @@ class TestExpandFilespecs(tests.IrisTest):
             .format(self.tmpdir)
         )
 
-        self.assertStringEqual(str(err.exception), expected)
+        self.assertMultiLineEqual(str(err.exception), expected)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/test_Future.py
+++ b/lib/iris/tests/unit/test_Future.py
@@ -12,6 +12,7 @@ import iris.tests as tests  # isort:skip
 import warnings
 
 from iris import Future
+import iris._deprecation
 
 
 def patched_future(value=False, deprecated=False, error=False):
@@ -45,7 +46,7 @@ class Test___setattr__(tests.IrisTest):
     def test_deprecated_warning(self):
         future = patched_future(deprecated=True, error=False)
         msg = "'Future' property 'example_future_flag' is deprecated"
-        with self.assertWarnsRegexp(msg):
+        with self.assertWarnsRegex(iris._deprecation.IrisDeprecation, msg):
             future.example_future_flag = False
 
     def test_deprecated_error(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
A long time ago Iris implemented some bespoke `assert` methods to help with testing.  For two of these we now have equivalent methods in `unittest`:

* [assertMultiLineEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertMultiLineEqual) (new in python3.1) appears to do the same as our [assertStringEqual](https://github.com/SciTools/iris/blob/a908a27937e4ca8eb810001ebd64f11ff75dce72/lib/iris/tests/__init__.py#L226).
* [assertWarnsRegex](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarnsRegex) (new in python3.2) does the same job as our [assertWarnsRegexp](https://github.com/SciTools/iris/blob/a908a27937e4ca8eb810001ebd64f11ff75dce72/lib/iris/tests/__init__.py#L564), except it additionally checks the warning type, which seems like a better test to me.  I find these two particularly confusing because my editor suggests both as I'm typing and I can never remember which is which!

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
