### PR TITLE
remove pillow pin from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ docs =
 test =
     filelock
     imagehash>=4.0
-    pillow<7
     pre-commit
     requests
     pytest


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR is a follow-up to #4826, where we forgot to remove the `pillow` pin from `setup.cfg`.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
