### PR TITLE
update github app docs

### DIFF
--- a/docs/src/developers_guide/github_app.rst
+++ b/docs/src/developers_guide/github_app.rst
@@ -8,6 +8,15 @@ Token GitHub App
    This section of the documentation is applicable only to GitHub `SciTools`_
    Organisation **owners** and **administrators**.
 
+.. note::
+
+   The ``iris-actions`` GitHub App has been rebranded with the more generic
+   name ``scitools-ci``, as the app can be used for any `SciTools`_ repository,
+   not just ``iris`` specifically.
+
+   All of the following instructions are still applicable.
+
+
 This section describes how to create, configure, install and use our `SciTools`_
 GitHub App for generating tokens for use with *GitHub Actions* (GHA).
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds a clarification note to the GitHub App docs after renaming the `iris-actions` app to `scitools-ci`, as the app is now also used by `SciTools/cf-units` and is generally applicable throughout the SciTools organisation.

Decided a note was sufficient rather than re-spinning all the png assets.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
