### PR TITLE
avoid setuptools deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ keywords =
     ugrid
     visualisation
 license = LGPL-3.0-or-later
-license_file = COPYING.LESSER
+license_files = COPYING.LESSER
 long_description = file: README.md
 long_description_content_type = text/markdown
 name = scitools-iris


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR resolves the `setuptools` deprecation warning being issued whenever an `sdist` or `wheel` of `iris` is built:
```
SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
```

See [setuptools v56.0.0 - deprecations](https://setuptools.pypa.io/en/latest/history.html#v56-0-0) for further details.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
