### PR TITLE
Alternative Cell.__hash__ implementation for NaN support

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1266,7 +1266,13 @@ def _get_2d_coord_bound_grid(bounds):
     return result
 
 
-class Cell(namedtuple("Cell", ["point", "bound"])):
+class _Hash:
+    """Mutable hash property"""
+
+    slots = ("_hash",)
+
+
+class Cell(namedtuple("Cell", ["point", "bound"]), _Hash):
     """
     An immutable representation of a single cell of a coordinate, including the
     sample point and/or boundary position.
@@ -1326,6 +1332,18 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
 
         return super().__new__(cls, point, bound)
 
+    def __init__(self, *args, **kwargs):
+        # Pre-compute the hash value of this instance at creation time based
+        # on the Cell.point alone. This results in a significant performance
+        # gain, as Cell.__hash__ is reduced to a minimalist attribute lookup
+        # for each invocation.
+        try:
+            value = 0 if np.isnan(self.point) else hash((self.point,))
+        except TypeError:
+            # Passing a string to np.isnan causes this exception.
+            value = hash((self.point,))
+        self._hash = value
+
     def __mod__(self, mod):
         point = self.point
         bound = self.bound
@@ -1346,23 +1364,19 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
 
     def __hash__(self):
         # Required for >py39 and >np1.22.x due to changes in Cell behaviour for
-        # point=np.nan, as calling super().__hash__() returns a different
-        # hash and thus does not trigger the following call to Cell.__eq__
-        # to determine equality.
-        # Note that, no explicit Cell bound nan check is performed here.
+        # Cell.point=np.nan, as calling super().__hash__() returns a different
+        # hash each time and thus does not trigger the following call to
+        # Cell.__eq__ to determine equality.
+        # Note that, no explicit Cell.bound nan check is performed here.
         # That is delegated to Cell.__eq__ instead. It's imperative we keep
         # Cell.__hash__ light-weight to minimise performance degradation.
+        # Also see Cell.__init__ for Cell._hash assignment.
         # Reference:
         #   - https://bugs.python.org/issue43475
         #   - https://github.com/numpy/numpy/issues/18833
         #   - https://github.com/numpy/numpy/pull/18908
         #   - https://github.com/numpy/numpy/issues/21210
-
-        try:
-            point = "nan" if np.isnan(self.point) else self.point
-        except TypeError:
-            point = self.point
-        return hash((point,))
+        return self._hash
 
     def __eq__(self, other):
         """

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -155,6 +155,24 @@ class Test___eq__(tests.IrisTest):
         self.assertEqual(cell1, cell2)
 
 
+class Test___hash__(tests.IrisTest):
+    def test_nan__hash(self):
+        cell = Cell(np.nan, None)
+        self.assertEqual(cell._hash, 0)
+
+    def test_nan___hash__(self):
+        cell = Cell(np.nan, None)
+        self.assertEqual(cell.__hash__(), 0)
+
+    def test_non_nan__hash(self):
+        cell = Cell(1, None)
+        self.assertNotEqual(cell._hash, 0)
+
+    def test_non_nan___hash__(self):
+        cell = Cell("two", ("one", "three"))
+        self.assertNotEqual(cell.__hash__(), 0)
+
+
 class Test_contains_point(tests.IrisTest):
     def test_datetimelike_bounded_cell(self):
         point = object()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR is a follow-on from #4840, which extended our CI testing support to cover `py310` but unfortunately introduced a serious performance regression for `iris.coords.Cell` due to a required fix to circumvent changed behaviour in `numpy.nan` hashing.

This PR provides a performant alternative implementation.

Refer to the following benchmarking results of a commit based on this PR against `upstream/main` for `iris`.

<details>
<summary> Benchmarks that have stayed the same...</summary>

       before           after         ratio
     [c0c86c21]       [7e710259]
     <main~1>         <fix-cell-hash>
              n/a              n/a      n/a  aux_factory.FactoryCommon.time_create
       8.03±0.1μs      7.83±0.07μs     0.97  aux_factory.HybridHeightFactory.time_create
       9.87±0.2μs       9.64±0.2μs     0.98  coords.AncillaryVariable.time_create
          763±6ns         771±20ns     1.01  coords.AuxCoord.time_bounds
       18.0±0.2μs       17.6±0.3μs     0.98  coords.AuxCoord.time_create
          695±9ns         707±10ns     1.02  coords.AuxCoord.time_points
          349±9μs         352±10μs     1.01  coords.AuxCoordLazy.time_bounds
       26.0±0.6μs       26.0±0.8μs     1.00  coords.AuxCoordLazy.time_create
         347±10μs         352±10μs     1.01  coords.AuxCoordLazy.time_points
       10.6±0.1μs       10.7±0.4μs     1.01  coords.CellMeasure.time_create
      1.85±0.02μs      1.83±0.01μs     0.99  coords.CellMethod.time_create
              n/a              n/a      n/a  coords.CoordCommon.time_create
          216±7μs          220±7μs     1.02  coords.DimCoord.time_create
         65.0±1μs         66.7±1μs     1.03  coords.DimCoord.time_regular
       1.63±0.02s       1.64±0.04s     1.01  cube.Aggregation.time_aggregated_by
       55.2±0.4μs       55.2±0.4μs     1.00  cube.AncillaryVariable.time_add
       13.2±0.2μs       12.9±0.2μs     0.97  cube.AncillaryVariable.time_create
       65.0±0.5μs       65.1±0.4μs     1.00  cube.AuxCoord.time_add
       10.6±0.2μs       10.7±0.1μs     1.00  cube.AuxCoord.time_create
      8.12±0.09μs      8.01±0.05μs     0.99  cube.AuxCoord.time_return_coord_dims
      5.38±0.06μs      5.31±0.03μs     0.99  cube.AuxCoord.time_return_coords
       77.9±0.9μs         78.8±1μs     1.01  cube.AuxFactory.time_add
       14.0±0.3μs       14.0±0.3μs     1.00  cube.AuxFactory.time_create
       55.9±0.3μs       55.7±0.4μs     1.00  cube.CellMeasure.time_add
       13.5±0.2μs      13.4±0.09μs     0.99  cube.CellMeasure.time_create
       46.1±0.3μs       46.9±0.3μs     1.02  cube.CellMethod.time_add
      6.99±0.09μs      7.00±0.09μs     1.00  cube.CellMethod.time_create
              n/a              n/a      n/a  cube.ComponentCommon.time_add
              n/a              n/a      n/a  cube.ComponentCommon.time_create
          202±3ms          202±3ms     1.00  cube.Concatenate.time_concatenate
      6.40±0.04μs      6.50±0.06μs     1.02  cube.Cube.time_basic
          104±8ns          107±4ns     1.02  cube.Cube.time_rename
          253±5μs          257±2μs     1.02  cube.Equality.time_equality
        1.35±0.9s        1.33±0.4s     0.99  cube.Merge.time_merge
         37.0±1μs         38.0±1μs     1.03  cube.MeshCoord.time_add(10000)
         47.2±5μs         46.2±5μs     0.98  cube.MeshCoord.time_add(1000000)
         36.2±1μs         37.2±2μs     1.03  cube.MeshCoord.time_add(6)
       18.3±0.3μs       18.3±0.3μs     1.00  cube.MeshCoord.time_create(10000)
       18.3±0.3μs       18.1±0.2μs     0.98  cube.MeshCoord.time_create(1000000)
       18.5±0.4μs       18.1±0.2μs     0.98  cube.MeshCoord.time_create(6)
         91.9±4μs         94.1±7μs     1.02  cube.MeshCoord.time_remove(10000)
          115±2μs          116±3μs     1.01  cube.MeshCoord.time_remove(1000000)
         89.7±7μs         89.3±5μs     1.00  cube.MeshCoord.time_remove(6)
       3.53±0.4ms       3.53±0.5ms     1.00  experimental.ugrid.Connectivity.time_create(1000000)
       2.61±0.3ms       2.59±0.2ms     0.99  experimental.ugrid.Connectivity.time_create(6)
      1.13±0.02μs      1.15±0.02μs     1.02  experimental.ugrid.Connectivity.time_indices(1000000)
      1.13±0.02μs      1.15±0.02μs     1.02  experimental.ugrid.Connectivity.time_indices(6)
         32.0±4ms         38.0±4ms     1.19  experimental.ugrid.Connectivity.time_location_lengths(1000000)
      3.61±0.05ms      3.65±0.07ms     1.01  experimental.ugrid.Connectivity.time_location_lengths(6)
         35.9±4ms         39.0±5ms     1.09  experimental.ugrid.Connectivity.time_validate_indices(1000000)
       5.48±0.1ms       5.51±0.6ms     1.00  experimental.ugrid.Connectivity.time_validate_indices(6)
       5.82±0.2ms       6.21±0.4ms     1.07  experimental.ugrid.ConnectivityLazy.time_create(1000000)
      4.26±0.06ms       4.38±0.2ms     1.03  experimental.ugrid.ConnectivityLazy.time_create(6)
          323±9μs         327±10μs     1.01  experimental.ugrid.ConnectivityLazy.time_indices(1000000)
          323±9μs         323±10μs     1.00  experimental.ugrid.ConnectivityLazy.time_indices(6)
       32.3±0.5ms       32.6±0.7ms     1.01  experimental.ugrid.ConnectivityLazy.time_location_lengths(1000000)
       3.95±0.1ms       3.96±0.1ms     1.00  experimental.ugrid.ConnectivityLazy.time_location_lengths(6)
       36.1±0.7ms       36.3±0.5ms     1.01  experimental.ugrid.ConnectivityLazy.time_validate_indices(1000000)
       5.82±0.1ms       5.83±0.1ms     1.00  experimental.ugrid.ConnectivityLazy.time_validate_indices(6)
       8.63±0.1ms       8.98±0.1ms     1.04  experimental.ugrid.Mesh.time_add_connectivities(1000000)
          451±4μs          458±4μs     1.01  experimental.ugrid.Mesh.time_add_connectivities(6)
      7.91±0.06μs       7.87±0.1μs     0.99  experimental.ugrid.Mesh.time_add_coords(1000000)
      7.83±0.09μs      7.87±0.03μs     1.00  experimental.ugrid.Mesh.time_add_coords(6)
      5.40±0.03μs      5.43±0.06μs     1.01  experimental.ugrid.Mesh.time_connectivities(1000000)
      5.40±0.04μs      5.42±0.07μs     1.00  experimental.ugrid.Mesh.time_connectivities(6)
      6.74±0.05μs      6.85±0.06μs     1.02  experimental.ugrid.Mesh.time_coords(1000000)
       6.92±0.1μs      6.87±0.06μs     0.99  experimental.ugrid.Mesh.time_coords(6)
       8.78±0.1ms       9.01±0.2ms     1.03  experimental.ugrid.Mesh.time_create(1000000)
          544±8μs          545±6μs     1.00  experimental.ugrid.Mesh.time_create(6)
       25.3±0.8ms         26.0±1ms     1.03  experimental.ugrid.Mesh.time_eq(1000000)
         476±10μs          483±9μs     1.02  experimental.ugrid.Mesh.time_eq(6)
      5.28±0.04μs      5.31±0.05μs     1.01  experimental.ugrid.Mesh.time_remove_connectivities(1000000)
      5.32±0.06μs      5.33±0.06μs     1.00  experimental.ugrid.Mesh.time_remove_connectivities(6)
      8.43±0.05μs      8.49±0.08μs     1.01  experimental.ugrid.Mesh.time_remove_coords(1000000)
       8.49±0.2μs      8.46±0.06μs     1.00  experimental.ugrid.Mesh.time_remove_coords(6)
       9.09±0.2μs       8.95±0.2μs     0.98  experimental.ugrid.MeshCoord.time_bounds(10000)
       8.98±0.1μs       8.98±0.2μs     1.00  experimental.ugrid.MeshCoord.time_bounds(1000000)
       9.03±0.2μs       9.08±0.2μs     1.01  experimental.ugrid.MeshCoord.time_bounds(6)
          488±3μs          492±5μs     1.01  experimental.ugrid.MeshCoord.time_create(10000)
       33.1±0.7ms       34.0±0.6ms     1.02  experimental.ugrid.MeshCoord.time_create(1000000)
          301±4μs          299±3μs     0.99  experimental.ugrid.MeshCoord.time_create(6)
      4.95±0.05μs      4.92±0.04μs     0.99  experimental.ugrid.MeshCoord.time_points(10000)
      4.96±0.04μs      4.92±0.03μs     0.99  experimental.ugrid.MeshCoord.time_points(1000000)
      4.98±0.04μs      4.91±0.07μs     0.99  experimental.ugrid.MeshCoord.time_points(6)
       11.1±0.2ms       11.1±0.2ms     1.00  experimental.ugrid.MeshCoordLazy.time_bounds(10000)
          346±4ms          346±6ms     1.00  experimental.ugrid.MeshCoordLazy.time_bounds(1000000)
       10.1±0.2ms       10.1±0.2ms     1.00  experimental.ugrid.MeshCoordLazy.time_bounds(6)
      5.57±0.04ms      5.57±0.05ms     1.00  experimental.ugrid.MeshCoordLazy.time_create(10000)
      5.60±0.07ms      5.59±0.07ms     1.00  experimental.ugrid.MeshCoordLazy.time_create(1000000)
      5.53±0.06ms      5.55±0.05ms     1.00  experimental.ugrid.MeshCoordLazy.time_create(6)
       3.83±0.1ms      3.82±0.09ms     1.00  experimental.ugrid.MeshCoordLazy.time_points(10000)
       6.80±0.1ms       6.78±0.1ms     1.00  experimental.ugrid.MeshCoordLazy.time_points(1000000)
       3.88±0.1ms       3.85±0.1ms     0.99  experimental.ugrid.MeshCoordLazy.time_points(6)
         54.8±2μs         55.0±1μs     1.00  experimental.ugrid.MeshLazy.time_add_connectivities(1000000)
         53.0±1μs         53.7±1μs     1.01  experimental.ugrid.MeshLazy.time_add_connectivities(6)
       29.2±0.6μs       30.0±0.6μs     1.03  experimental.ugrid.MeshLazy.time_add_coords(1000000)
       27.4±0.9μs         28.8±1μs     1.05  experimental.ugrid.MeshLazy.time_add_coords(6)
       19.4±0.5μs       19.9±0.5μs     1.02  experimental.ugrid.MeshLazy.time_connectivities(1000000)
       18.7±0.5μs       19.2±0.6μs     1.03  experimental.ugrid.MeshLazy.time_connectivities(6)
       24.9±0.5μs       24.8±0.5μs     1.00  experimental.ugrid.MeshLazy.time_coords(1000000)
       24.1±0.6μs       24.3±0.6μs     1.01  experimental.ugrid.MeshLazy.time_coords(6)
          128±4μs          130±6μs     1.01  experimental.ugrid.MeshLazy.time_create(1000000)
          125±4μs          126±2μs     1.01  experimental.ugrid.MeshLazy.time_create(6)
          184±2ms          186±3ms     1.01  experimental.ugrid.MeshLazy.time_eq(1000000)
       49.7±0.8ms       49.4±0.7ms     1.00  experimental.ugrid.MeshLazy.time_eq(6)
       21.7±0.5μs       21.8±0.6μs     1.01  experimental.ugrid.MeshLazy.time_remove_connectivities(1000000)
       20.3±0.8μs       20.9±0.9μs     1.03  experimental.ugrid.MeshLazy.time_remove_connectivities(6)
       42.9±0.8μs       43.2±0.8μs     1.01  experimental.ugrid.MeshLazy.time_remove_coords(1000000)
       41.4±0.8μs       41.5±0.7μs     1.00  experimental.ugrid.MeshLazy.time_remove_coords(6)
              n/a              n/a      n/a  experimental.ugrid.UGridCommon.time_create(1000000)
              n/a              n/a      n/a  experimental.ugrid.UGridCommon.time_create(6)
          854±9ns          850±5ns     0.99  experimental.ugrid.regions_combine.CombineRegionsComputeRealData.time_compute_data(4)
          382±3ms          382±6ms     1.00  experimental.ugrid.regions_combine.CombineRegionsComputeRealData.time_compute_data(500)
              5.0              5.0     1.00  experimental.ugrid.regions_combine.CombineRegionsComputeRealData.track_addedmem_compute_data(4)
       54.6796875           57.375     1.05  experimental.ugrid.regions_combine.CombineRegionsComputeRealData.track_addedmem_compute_data(500)
      19.4±0.07ms       19.3±0.2ms     0.99  experimental.ugrid.regions_combine.CombineRegionsCreateCube.time_create_combined_cube(4)
       22.9±0.1ms       22.9±0.1ms     1.00  experimental.ugrid.regions_combine.CombineRegionsCreateCube.time_create_combined_cube(500)
              5.0              5.0     1.00  experimental.ugrid.regions_combine.CombineRegionsCreateCube.track_addedmem_create_combined_cube(4)
              5.0              5.0     1.00  experimental.ugrid.regions_combine.CombineRegionsCreateCube.track_addedmem_create_combined_cube(500)
          139±3ms        138±0.8ms     0.99  experimental.ugrid.regions_combine.CombineRegionsFileStreamedCalc.time_stream_file2file(4)
       1.09±0.08s       1.05±0.04s     0.97  experimental.ugrid.regions_combine.CombineRegionsFileStreamedCalc.time_stream_file2file(500)
              5.0              5.0     1.00  experimental.ugrid.regions_combine.CombineRegionsFileStreamedCalc.track_addedmem_stream_file2file(4)
       61.0390625        63.765625     1.04  experimental.ugrid.regions_combine.CombineRegionsFileStreamedCalc.track_addedmem_stream_file2file(500)
         65.4±1ms       65.1±0.9ms     1.00  experimental.ugrid.regions_combine.CombineRegionsSaveData.time_save(4)
         908±30ms         896±40ms     0.99  experimental.ugrid.regions_combine.CombineRegionsSaveData.time_save(500)
              5.0              5.0     1.00  experimental.ugrid.regions_combine.CombineRegionsSaveData.track_addedmem_save(4)
      61.05859375      63.77734375     1.04  experimental.ugrid.regions_combine.CombineRegionsSaveData.track_addedmem_save(500)
          0.03161          0.03161     1.00  experimental.ugrid.regions_combine.CombineRegionsSaveData.track_filesize_saved(4)
        216.01708        216.01708     1.00  experimental.ugrid.regions_combine.CombineRegionsSaveData.track_filesize_saved(500)
         850±10μs         844±10μs     0.99  import_iris.Iris.time__concatenate
          277±8μs         282±10μs     1.02  import_iris.Iris.time__constraints
          180±3μs          179±3μs     0.99  import_iris.Iris.time__data_manager
          161±5μs          161±3μs     1.00  import_iris.Iris.time__deprecation
          186±2μs          187±5μs     1.00  import_iris.Iris.time__lazy_data
      1.31±0.02ms      1.34±0.03ms     1.02  import_iris.Iris.time__merge
          117±2μs          124±3μs     1.06  import_iris.Iris.time__representation
         659±10μs          671±9μs     1.02  import_iris.Iris.time_analysis
          236±2μs          238±2μs     1.01  import_iris.Iris.time_analysis__area_weighted
          171±3μs          172±2μs     1.01  import_iris.Iris.time_analysis__grid_angles
          374±5μs          383±5μs     1.02  import_iris.Iris.time_analysis__interpolation
          275±3μs          277±5μs     1.01  import_iris.Iris.time_analysis__regrid
          182±4μs          184±2μs     1.01  import_iris.Iris.time_analysis__scipy_interpolate
          209±2μs          215±3μs     1.03  import_iris.Iris.time_analysis_calculus
          472±6μs          470±3μs     1.00  import_iris.Iris.time_analysis_cartography
          141±2μs          142±3μs     1.01  import_iris.Iris.time_analysis_geomerty
          355±4μs          357±5μs     1.00  import_iris.Iris.time_analysis_maths
          139±2μs          139±3μs     1.00  import_iris.Iris.time_analysis_stats
          288±3μs          295±5μs     1.03  import_iris.Iris.time_analysis_trajectory
         441±10μs         435±10μs     0.98  import_iris.Iris.time_aux_factory
          132±3μs          136±3μs     1.03  import_iris.Iris.time_common
          274±5μs          276±6μs     1.01  import_iris.Iris.time_common_lenient
      1.37±0.03ms      1.42±0.03ms     1.04  import_iris.Iris.time_common_metadata
          220±6μs          221±3μs     1.01  import_iris.Iris.time_common_mixin
      1.52±0.02ms      1.52±0.02ms     0.99  import_iris.Iris.time_common_resolve
          344±3μs          350±4μs     1.02  import_iris.Iris.time_config
          183±4μs        187±0.9μs     1.02  import_iris.Iris.time_coord_categorisation
         501±10μs         500±20μs     1.00  import_iris.Iris.time_coord_systems
      1.02±0.03ms      1.10±0.04ms     1.07  import_iris.Iris.time_coords
         779±30μs         778±50μs     1.00  import_iris.Iris.time_cube
          336±6μs          335±3μs     1.00  import_iris.Iris.time_exceptions
          119±2μs          123±2μs     1.03  import_iris.Iris.time_experimental
          314±2μs          317±3μs     1.01  import_iris.Iris.time_fileformats
          355±5μs          361±9μs     1.02  import_iris.Iris.time_fileformats__ff
      2.79±0.05ms       2.87±0.1ms     1.03  import_iris.Iris.time_fileformats__ff_cross_references
          120±2μs          124±2μs     1.04  import_iris.Iris.time_fileformats__pp_lbproc_pairs
          185±3μs          189±3μs     1.02  import_iris.Iris.time_fileformats_abf
         502±20μs         514±20μs     1.02  import_iris.Iris.time_fileformats_cf
         11.5±1ms         11.7±2ms     1.02  import_iris.Iris.time_fileformats_dot
          114±2μs          117±2μs     1.03  import_iris.Iris.time_fileformats_name
          373±2μs          380±2μs     1.02  import_iris.Iris.time_fileformats_name_loaders
         818±10μs         832±20μs     1.02  import_iris.Iris.time_fileformats_netcdf
          197±2μs          195±5μs     0.99  import_iris.Iris.time_fileformats_nimrod
          313±3μs          312±5μs     1.00  import_iris.Iris.time_fileformats_nimrod_load_rules
         952±30μs         957±30μs     1.01  import_iris.Iris.time_fileformats_pp
          271±3μs          276±4μs     1.02  import_iris.Iris.time_fileformats_pp_load_rules
          199±2μs          200±3μs     1.01  import_iris.Iris.time_fileformats_pp_save_rules
         712±10μs         719±10μs     1.01  import_iris.Iris.time_fileformats_rules
          343±4μs          353±8μs     1.03  import_iris.Iris.time_fileformats_structured_array_identification
          129±2μs          134±3μs     1.04  import_iris.Iris.time_fileformats_um
          271±4μs          275±5μs     1.02  import_iris.Iris.time_fileformats_um__fast_load
          232±7μs          239±5μs     1.03  import_iris.Iris.time_fileformats_um__fast_load_structured_fields
          117±3μs          120±1μs     1.03  import_iris.Iris.time_fileformats_um__ff_replacement
          134±2μs          136±2μs     1.01  import_iris.Iris.time_fileformats_um__optimal_array_structuring
      1.10±0.01ms      1.11±0.01ms     1.01  import_iris.Iris.time_fileformats_um_cf_map
          219±1μs          227±2μs     1.04  import_iris.Iris.time_io
          276±5μs          285±7μs     1.03  import_iris.Iris.time_io_format_picker
          318±2μs          324±4μs     1.02  import_iris.Iris.time_iris
          211±3μs          217±4μs     1.03  import_iris.Iris.time_iterate
      17.3±0.09ms       17.4±0.2ms     1.01  import_iris.Iris.time_palette
          454±5μs          455±4μs     1.00  import_iris.Iris.time_plot
          167±2μs          170±3μs     1.02  import_iris.Iris.time_quickplot
      2.12±0.05ms      2.12±0.06ms     1.00  import_iris.Iris.time_std_names
      3.55±0.06ms      3.62±0.07ms     1.02  import_iris.Iris.time_symbols
          120±8ms          121±7ms     1.01  import_iris.Iris.time_tests
          314±4μs          318±6μs     1.01  import_iris.Iris.time_third_party_cartopy
       7.95±0.3ms       8.04±0.4ms     1.01  import_iris.Iris.time_third_party_cf_units
          169±3μs          172±3μs     1.02  import_iris.Iris.time_third_party_cftime
       4.58±0.1ms      4.59±0.09ms     1.00  import_iris.Iris.time_third_party_matplotlib
         1.38±0ms      1.39±0.01ms     1.01  import_iris.Iris.time_third_party_numpy
      2.22±0.02ms      2.25±0.05ms     1.01  import_iris.Iris.time_third_party_scipy
          170±2μs          172±2μs     1.01  import_iris.Iris.time_time
          413±2μs          421±5μs     1.02  import_iris.Iris.time_util
          129±2μs          132±7μs     1.02  iterate.IZip.time_izip
      13.1±0.09ms       12.9±0.1ms     0.98  load.LoadAndRealise.time_load((1280, 960, 5), False, 'FF')
       42.5±0.6ms       42.4±0.7ms     1.00  load.LoadAndRealise.time_load((1280, 960, 5), False, 'NetCDF')
      14.3±0.06ms      14.2±0.08ms     1.00  load.LoadAndRealise.time_load((1280, 960, 5), False, 'PP')
      13.1±0.07ms      12.9±0.05ms     0.99  load.LoadAndRealise.time_load((1280, 960, 5), True, 'FF')
       42.4±0.6ms       42.3±0.5ms     1.00  load.LoadAndRealise.time_load((1280, 960, 5), True, 'NetCDF')
       14.3±0.1ms      14.1±0.05ms     0.99  load.LoadAndRealise.time_load((1280, 960, 5), True, 'PP')
        8.79±0.1s       8.68±0.04s     0.99  load.LoadAndRealise.time_load((2, 2, 1000), False, 'FF')
       40.6±0.7ms       40.2±0.6ms     0.99  load.LoadAndRealise.time_load((2, 2, 1000), False, 'NetCDF')
        9.13±0.2s       9.07±0.07s     0.99  load.LoadAndRealise.time_load((2, 2, 1000), False, 'PP')
       8.74±0.09s       8.72±0.04s     1.00  load.LoadAndRealise.time_load((2, 2, 1000), True, 'FF')
       40.6±0.5ms       40.4±0.4ms     0.99  load.LoadAndRealise.time_load((2, 2, 1000), True, 'NetCDF')
        9.06±0.2s       9.01±0.06s     0.99  load.LoadAndRealise.time_load((2, 2, 1000), True, 'PP')
       6.17±0.2ms       6.12±0.3ms     0.99  load.LoadAndRealise.time_load((2, 2, 2), False, 'FF')
       40.3±0.4ms       39.7±0.7ms     0.98  load.LoadAndRealise.time_load((2, 2, 2), False, 'NetCDF')
      6.54±0.03ms       6.38±0.1ms     0.97  load.LoadAndRealise.time_load((2, 2, 2), False, 'PP')
       6.08±0.1ms       5.91±0.2ms     0.97  load.LoadAndRealise.time_load((2, 2, 2), True, 'FF')
       40.2±0.8ms       40.4±0.8ms     1.00  load.LoadAndRealise.time_load((2, 2, 2), True, 'NetCDF')
       6.50±0.1ms       6.30±0.2ms     0.97  load.LoadAndRealise.time_load((2, 2, 2), True, 'PP')
         56.0±4ms         66.8±6ms     1.19  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'FF')
       41.8±0.3ms       42.1±0.3ms     1.01  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'NetCDF')
         16.2±1ms       16.4±0.7ms     1.01  load.LoadAndRealise.time_realise((1280, 960, 5), False, 'PP')
       31.4±0.9ms       31.5±0.8ms     1.00  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'FF')
        101±0.5ms        102±0.7ms     1.00  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'NetCDF')
         32.4±1ms         31.9±1ms     0.99  load.LoadAndRealise.time_realise((1280, 960, 5), True, 'PP')
          548±4ms          558±6ms     1.02  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'FF')
      4.13±0.06ms      4.07±0.05ms     0.98  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'NetCDF')
          552±4ms          559±1ms     1.01  load.LoadAndRealise.time_realise((2, 2, 1000), False, 'PP')
        561±0.7ms          569±6ms     1.01  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'FF')
      4.28±0.08ms      4.11±0.09ms     0.96  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'NetCDF')
          572±2ms          573±8ms     1.00  load.LoadAndRealise.time_realise((2, 2, 1000), True, 'PP')
       1.78±0.4ms       1.70±0.2ms     0.95  load.LoadAndRealise.time_realise((2, 2, 2), False, 'FF')
       4.06±0.1ms       4.06±0.2ms     1.00  load.LoadAndRealise.time_realise((2, 2, 2), False, 'NetCDF')
      1.49±0.02ms      1.52±0.03ms     1.02  load.LoadAndRealise.time_realise((2, 2, 2), False, 'PP')
      1.52±0.03ms      1.53±0.03ms     1.01  load.LoadAndRealise.time_realise((2, 2, 2), True, 'FF')
       4.18±0.1ms       4.11±0.1ms     0.98  load.LoadAndRealise.time_realise((2, 2, 2), True, 'NetCDF')
      1.50±0.03ms      1.52±0.03ms     1.01  load.LoadAndRealise.time_realise((2, 2, 2), True, 'PP')
          161±1ms          162±2ms     1.01  load.ManyVars.time_many_var_load
       13.3±0.1ms       13.1±0.2ms     0.99  load.STASHConstraint.time_stash_constraint((1280, 960, 5), 'FF')
      14.6±0.08ms       14.3±0.1ms     0.98  load.STASHConstraint.time_stash_constraint((1280, 960, 5), 'PP')
       8.70±0.06s       8.72±0.07s     1.00  load.STASHConstraint.time_stash_constraint((2, 2, 1000), 'FF')
        9.14±0.1s       9.03±0.06s     0.99  load.STASHConstraint.time_stash_constraint((2, 2, 1000), 'PP')
       6.28±0.3ms       6.20±0.2ms     0.99  load.STASHConstraint.time_stash_constraint((2, 2, 2), 'FF')
      6.72±0.04ms       6.43±0.2ms     0.96  load.STASHConstraint.time_stash_constraint((2, 2, 2), 'PP')
      13.1±0.08ms      13.0±0.09ms     0.99  load.StructuredFF.time_structured_load((1280, 960, 5), False)
      6.89±0.06ms      6.90±0.05ms     1.00  load.StructuredFF.time_structured_load((1280, 960, 5), True)
       8.80±0.09s       8.73±0.03s     0.99  load.StructuredFF.time_structured_load((2, 2, 1000), False)
          472±3ms          472±3ms     1.00  load.StructuredFF.time_structured_load((2, 2, 1000), True)
       6.21±0.2ms       6.01±0.1ms     0.97  load.StructuredFF.time_structured_load((2, 2, 2), False)
      5.36±0.06ms       5.32±0.1ms     0.99  load.StructuredFF.time_structured_load((2, 2, 2), True)
          225±2ms          224±2ms     1.00  load.TimeConstraint.time_time_constraint(20, 'FF')
       51.3±0.6ms       51.4±0.9ms     1.00  load.TimeConstraint.time_time_constraint(20, 'NetCDF')
          249±2ms          250±2ms     1.01  load.TimeConstraint.time_time_constraint(20, 'PP')
         47.4±1ms       46.4±0.5ms     0.98  load.TimeConstraint.time_time_constraint(3, 'FF')
       45.6±0.6ms       45.8±0.7ms     1.01  load.TimeConstraint.time_time_constraint(3, 'NetCDF')
       49.5±0.5ms       49.4±0.2ms     1.00  load.TimeConstraint.time_time_constraint(3, 'PP')
         41.8±1ms         42.5±1ms     1.02  load.ugrid.BasicLoading.time_load_file(1)
       44.0±0.1ms       45.8±0.7ms     1.04  load.ugrid.BasicLoading.time_load_file(200000)
       16.3±0.6ms       16.5±0.5ms     1.01  load.ugrid.BasicLoading.time_load_mesh(1)
       18.3±0.4ms       18.5±0.5ms     1.01  load.ugrid.BasicLoading.time_load_mesh(200000)
       41.9±0.9ms         42.3±1ms     1.01  load.ugrid.BasicLoadingTime.time_load_file(1)
       40.7±0.3ms         41.9±1ms     1.03  load.ugrid.BasicLoadingTime.time_load_file(200000)
       16.5±0.8ms       16.2±0.7ms     0.98  load.ugrid.BasicLoadingTime.time_load_mesh(1)
       15.0±0.2ms       15.0±0.2ms     0.99  load.ugrid.BasicLoadingTime.time_load_mesh(200000)
       55.9±0.5ms       56.3±0.4ms     1.01  load.ugrid.Callback.time_load_file_callback(1)
       59.1±0.5ms       59.3±0.3ms     1.00  load.ugrid.Callback.time_load_file_callback(200000)
         55.5±1ms         56.2±1ms     1.01  load.ugrid.CallbackTime.time_load_file_callback(1)
       55.3±0.7ms       56.0±0.4ms     1.01  load.ugrid.CallbackTime.time_load_file_callback(200000)
       4.44±0.2ms       4.46±0.2ms     1.00  load.ugrid.DataRealisation.time_realise_data(1)
       6.36±0.2ms       6.33±0.2ms     0.99  load.ugrid.DataRealisation.time_realise_data(200000)
       4.55±0.3ms       4.42±0.2ms     0.97  load.ugrid.DataRealisationTime.time_realise_data(1)
       1.73±0.03s       1.73±0.01s     1.00  load.ugrid.DataRealisationTime.time_realise_data(200000)
          181±5ns          179±7ns     0.98  metadata_manager_factory.MetadataManagerFactory.time_AncillaryVariableMetadata_fields
      1.20±0.01μs      1.23±0.02μs     1.02  metadata_manager_factory.MetadataManagerFactory.time_AncillaryVariableMetadata_values
          181±6ns          177±2ns     0.98  metadata_manager_factory.MetadataManagerFactory.time_BaseMetadata_fields
      1.21±0.01μs      1.23±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory.time_BaseMetadata_values
          185±4ns        178±0.8ns     0.96  metadata_manager_factory.MetadataManagerFactory.time_CellMeasuresMetadata_fields
      1.33±0.01μs      1.37±0.01μs     1.02  metadata_manager_factory.MetadataManagerFactory.time_CellMeasuresMetadata_values
          186±4ns          182±1ns     0.98  metadata_manager_factory.MetadataManagerFactory.time_CoordMetadata_fields
      1.46±0.01μs      1.47±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory.time_CoordMetadata_values
          184±5ns          176±1ns     0.96  metadata_manager_factory.MetadataManagerFactory.time_CubeMetadata_fields
      1.35±0.02μs      1.37±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory.time_CubeMetadata_values
          183±5ns          178±3ns     0.97  metadata_manager_factory.MetadataManagerFactory.time_DimCoordMetadata_fields
      1.54±0.02μs      1.56±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory.time_DimCoordMetadata_values
      1.64±0.01μs      1.64±0.01μs     1.00  metadata_manager_factory.MetadataManagerFactory__create.time_AncillaryVariableMetadata(1)
      11.0±0.04μs      11.1±0.04μs     1.00  metadata_manager_factory.MetadataManagerFactory__create.time_AncillaryVariableMetadata(10)
        105±0.5μs        105±0.4μs     1.00  metadata_manager_factory.MetadataManagerFactory__create.time_AncillaryVariableMetadata(100)
      1.63±0.01μs      1.64±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_BaseMetadata(1)
      11.0±0.04μs      11.0±0.05μs     1.00  metadata_manager_factory.MetadataManagerFactory__create.time_BaseMetadata(10)
        105±0.5μs        106±0.5μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_BaseMetadata(100)
      1.69±0.01μs      1.69±0.01μs     1.00  metadata_manager_factory.MetadataManagerFactory__create.time_CellMeasureMetadata(1)
      11.5±0.03μs      11.6±0.05μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CellMeasureMetadata(10)
        110±0.5μs        111±0.4μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CellMeasureMetadata(100)
      1.74±0.01μs      1.77±0.01μs     1.02  metadata_manager_factory.MetadataManagerFactory__create.time_CoordMetadata(1)
      12.1±0.06μs      12.3±0.04μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CoordMetadata(10)
        116±0.4μs        119±0.9μs     1.02  metadata_manager_factory.MetadataManagerFactory__create.time_CoordMetadata(100)
      1.69±0.01μs      1.71±0.01μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CubeMetadata(1)
      11.6±0.06μs      11.7±0.07μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CubeMetadata(10)
        111±0.5μs        111±0.4μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_CubeMetadata(100)
      1.82±0.01μs      1.84±0.03μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_DimCoordMetadata(1)
      12.8±0.05μs      12.8±0.05μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_DimCoordMetadata(10)
          123±1μs          124±1μs     1.01  metadata_manager_factory.MetadataManagerFactory__create.time_DimCoordMetadata(100)
          191±3ns          194±4ns     1.02  mixin.CFVariableMixin.time_get_attributes
          187±4ns          197±2ns     1.05  mixin.CFVariableMixin.time_get_long_name
      1.36±0.01μs      1.36±0.01μs     1.00  mixin.CFVariableMixin.time_get_metadata
          186±4ns          192±3ns     1.03  mixin.CFVariableMixin.time_get_standard_name
          188±2ns          197±1ns     1.05  mixin.CFVariableMixin.time_get_units
          188±4ns          196±3ns     1.04  mixin.CFVariableMixin.time_get_var_name
      1.10±0.01μs      1.11±0.01μs     1.01  mixin.CFVariableMixin.time_set_attributes
         241±10ns          254±5ns     1.05  mixin.CFVariableMixin.time_set_long_name
      5.74±0.04μs       5.77±0.2μs     1.00  mixin.CFVariableMixin.time_set_metadata__dict
       6.80±0.1μs       6.81±0.2μs     1.00  mixin.CFVariableMixin.time_set_metadata__metadata
      6.71±0.05μs       6.87±0.2μs     1.02  mixin.CFVariableMixin.time_set_metadata__tuple
         853±20ns          837±5ns     0.98  mixin.CFVariableMixin.time_set_standard_name
         837±10ns          834±5ns     1.00  mixin.CFVariableMixin.time_set_units
          830±6ns         838±30ns     1.01  mixin.CFVariableMixin.time_set_var_name
          429±3ms          429±5ms     1.00  plot.AuxSort.time_aux_sort
          459±9ms          458±3ms     1.00  regridding.HorizontalChunkedRegridding.time_regrid_area_w
         904±20ms          906±5ms     1.00  regridding.HorizontalChunkedRegridding.time_regrid_area_w_new_grid
       4.47±0.4ms       4.36±0.2ms     0.98  save.NetcdfSave.time_netcdf_save_cube(1, False)
       76.0±0.9ms       75.8±0.9ms     1.00  save.NetcdfSave.time_netcdf_save_cube(1, True)
         79.4±9ms         71.0±7ms     0.89  save.NetcdfSave.time_netcdf_save_cube(600, False)
         838±30ms         834±40ms     1.00  save.NetcdfSave.time_netcdf_save_cube(600, True)
          176±3ns          177±5ns     1.00  save.NetcdfSave.time_netcdf_save_mesh(1, False)
       59.1±0.8ms         58.3±1ms     0.99  save.NetcdfSave.time_netcdf_save_mesh(1, True)
          177±3ns          176±3ns     1.00  save.NetcdfSave.time_netcdf_save_mesh(600, False)
         839±70ms         824±30ms     0.98  save.NetcdfSave.time_netcdf_save_mesh(600, True)
              5.0              5.0     1.00  save.NetcdfSave.track_addedmem_netcdf_save(1, False)
              5.0              5.0     1.00  save.NetcdfSave.track_addedmem_netcdf_save(1, True)
              5.0              5.0     1.00  save.NetcdfSave.track_addedmem_netcdf_save(600, False)
      77.03515625        79.921875     1.04  save.NetcdfSave.track_addedmem_netcdf_save(600, True)
       39.6±0.5ms       40.1±0.3ms     1.01  trajectory.TrajectoryInterpolation.time_trajectory_linear
        102±0.6ms        102±0.3ms     1.00  trajectory.TrajectoryInterpolation.time_trajectory_nearest

</details>
 
Closes #4843

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
