### PR TITLE
fix rtd version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,10 @@ build:
   os: ubuntu-20.04
   tools:
     python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
+      - git fetch --all
 
 conda:
   environment: requirements/ci/readthedocs.yml

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -87,6 +87,8 @@ author = "Iris Developers"
 # |version|, also used in various other places throughout the built documents.
 
 version = get_version("scitools-iris")
+if version.endswith("+dirty"):
+    version = version[: -len("+dirty")]
 autolog(f"Iris Version = {version}")
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## 🚀 Pull Request

### Description

This PR is a follow-up to PR #4841 by fixing the automatic discovery of the `iris` package version on readthedocs (RTD).

Essentially, the root cause of the issue is that when building the documentation on RTD, a **shallow clone** of the repository associated with the GitHub `push` or `pull_request` is performed i.e., RTD performs the following `git` command:

```bash
git clone --no-single-branch --depth 50 https://github.com/SciTools/iris .
```

The resulting shallow clone does not contain the **full** `git` history required by `setuptools-scm` to auto-discover the correct version of `iris`.

This can easily be remedied through RTD build customisation, see [unshallow clone](https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-clone) and more generically [extending the build process](https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process).

In addition to this, for documentation only we now parse the `version` to remove the `setuptools-scm` local-scheme `+dirty` tag, which although helpful to developers will most likely be confusing to community readers of the documentation.

Closes #4854


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
