### PR TITLE
pytest verbosity

### DIFF
--- a/lib/iris/tests/runner/_runner.py
+++ b/lib/iris/tests/runner/_runner.py
@@ -130,7 +130,6 @@ class TestRunner:
 
         args = [
             None,
-            "-v",
             f"-n={self.num_processors}",
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ skip_gitignore = "True"
 verbose = "False"
 
 [tool.pytest.ini_options]
-addopts = "-ra -q"
+addopts = "-ra"
 testpaths = "lib/iris"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
We are currently both increasing and decreasing the verbosity of pytest in our CI, because we set the `-v` and `-q` flags in different places.  If we remove these flags

* I think the CI output will be the same (can check in a minute!)
* Developers who want more verbose output when running locally may use the `-v` flag.  Currently it doesn't work because the `-q` setting in the `pyproject.toml` is picked up, and the settings cancel each other out.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
