### PR TITLE
Recommend `pytest` in developer guide

### DIFF
--- a/docs/src/developers_guide/contributing_running_tests.rst
+++ b/docs/src/developers_guide/contributing_running_tests.rst
@@ -5,9 +5,17 @@
 Running the Tests
 *****************
 
-You can run the tests in an environment you created yourself, or you can use ``nox``
-to test in an automatically generated environment, consistent with our GitHub
-continuous integration.  For the latter, see :ref:`using nox`.
+There are two options for running the tests:
+
+* Use an environment you created yourself.  This requires more manual steps to
+  set up, but gives you more flexibility.  For example, you can run a subset of
+  the tests or use ``python`` interactively to investigate any issues.  See
+  :ref:`using manual env`.
+
+* Use ``nox``.  This will automatically generate an environment and run test
+  sessions consistent with our GitHub continuous integration.  See :ref:`using nox`.
+
+.. _using manual env:
 
 Using a Manually Created Environment for Testing Iris
 =====================================================

--- a/docs/src/developers_guide/contributing_running_tests.rst
+++ b/docs/src/developers_guide/contributing_running_tests.rst
@@ -10,15 +10,15 @@ There are two options for running the tests:
 * Use an environment you created yourself.  This requires more manual steps to
   set up, but gives you more flexibility.  For example, you can run a subset of
   the tests or use ``python`` interactively to investigate any issues.  See
-  :ref:`using manual env`.
+  :ref:`test manual env`.
 
 * Use ``nox``.  This will automatically generate an environment and run test
   sessions consistent with our GitHub continuous integration.  See :ref:`using nox`.
 
-.. _using manual env:
+.. _test manual env:
 
-Using a Manually Created Environment for Testing Iris
-=====================================================
+Testing Iris in a Manually Created Environment
+==============================================
 
 To create a suitable environment for running the tests, see :ref:`installing_from_source`.
 
@@ -46,7 +46,7 @@ All the Iris tests may be run from the root ``iris`` project directory using
 
    pytest -n 2
 
-will run the tests on two processors.  For more options, use the command
+will run the tests across two processes.  For more options, use the command
 ``pytest -h``.  Below is a trimmed example of the output::
 
    ============================= test session starts ==============================

--- a/docs/src/developers_guide/contributing_running_tests.rst
+++ b/docs/src/developers_guide/contributing_running_tests.rst
@@ -5,13 +5,14 @@
 Running the Tests
 *****************
 
-Using setuptools for Testing Iris
-=================================
+You can run the tests in an environment you created yourself, or you can use ``nox``
+to test in an automatically generated environment, consistent with our GitHub
+continuous integration.  For the latter, see :ref:`using nox`.
 
-.. warning:: The `setuptools`_ ``test`` command was deprecated in `v41.5.0`_. See :ref:`using nox`.
+Using a Manually Created Environment for Testing Iris
+=====================================================
 
-A prerequisite of running the tests is to have the Python environment
-setup.  For more information on this see :ref:`installing_from_source`.
+To create a suitable environment for running the tests, see :ref:`installing_from_source`.
 
 Many Iris tests will use data that may be defined in the test itself, however
 this is not always the case as sometimes example files may be used.  Due to
@@ -32,11 +33,56 @@ The example command below uses ``~/projects`` as the parent directory::
    git clone git@github.com:SciTools/iris-test-data.git
    export OVERRIDE_TEST_DATA_REPOSITORY=~/projects/iris-test-data/test_data
 
-All the Iris tests may be run from the root ``iris`` project directory via::
+All the Iris tests may be run from the root ``iris`` project directory using
+``pytest``.  For example::
 
-   python setup.py test
+   pytest -n 2
 
-You can also run a specific test, the example below runs the tests for
+will run the tests on two processors.  For more options, use the command
+``pytest -h``.  Below is a trimmed example of the output::
+
+   ============================= test session starts ==============================
+   platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0
+   rootdir: /path/to/git/clone/iris, configfile: pyproject.toml, testpaths: lib/iris
+   plugins: xdist-2.5.0, forked-1.4.0
+   gw0 I / gw1 I
+   gw0 [6361] / gw1 [6361] 
+
+   ........................................................................ [  1%]
+   ........................................................................ [  2%]
+   ........................................................................ [  3%]
+   ...
+   .......................ssssssssssssssssss............................... [ 99%]
+   ........................                                                 [100%]
+   =============================== warnings summary ===============================
+   ...
+   -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+   =========================== short test summary info ============================
+   SKIPPED [1] lib/iris/tests/experimental/test_raster.py:152: Test requires 'gdal'.
+   SKIPPED [1] lib/iris/tests/experimental/test_raster.py:155: Test requires 'gdal'.
+   ...
+   ========= 6340 passed, 21 skipped, 1659 warnings in 193.57s (0:03:13) ==========
+
+There may be some tests that have been **skipped**.  This is due to a Python
+decorator being present in the test script that will intentionally skip a test
+if a certain condition is not met.  In the example output above there are
+**21** skipped tests. At the point in time when this was run this was due to an
+experimental dependency not being present.
+
+.. tip::
+
+   The most common reason for tests to be skipped is when the directory for the
+   ``iris-test-data`` has not been set which would shows output such as::
+
+      SKIPPED [1] lib/iris/tests/unit/fileformats/test_rules.py:157: Test(s) require external data.
+      SKIPPED [1] lib/iris/tests/unit/fileformats/pp/test__interpret_field.py:97: Test(s) require external data.
+      SKIPPED [1] lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py:29: Test(s) require external data.
+      
+   All Python decorators that skip tests will be defined in
+   ``lib/iris/tests/__init__.py`` with a function name with a prefix of
+   ``skip_``.
+
+You can also run a specific test module.  The example below runs the tests for
 mapping::
 
    cd lib/iris/tests
@@ -50,56 +96,6 @@ using the commands ``python test_mapping.py -h`` or
           matplotlib_ figures as the tests are run.  For example::
 
              python test_mapping.py -d
-
-          You can also use the ``-d`` command line option when running all
-          the tests but this will take a while to run and will require the
-          manual closing of each of the figures for the tests to continue.
-
-The output from running the tests is verbose as it will run ~5000 separate
-tests.  Below is a trimmed example of the output::
-
-   running test
-   Running test suite(s): default
-
-   Running test discovery on iris.tests with 2 processors.
-   test_circular_subset (iris.tests.experimental.regrid.test_regrid_area_weighted_rectilinear_src_and_grid.TestAreaWeightedRegrid) ... ok
-   test_cross_section (iris.tests.experimental.regrid.test_regrid_area_weighted_rectilinear_src_and_grid.TestAreaWeightedRegrid) ... ok
-   test_different_cs (iris.tests.experimental.regrid.test_regrid_area_weighted_rectilinear_src_and_grid.TestAreaWeightedRegrid) ... ok
-   ...
-   ...
-   test_ellipsoid (iris.tests.unit.experimental.raster.test_export_geotiff.TestProjection) ... SKIP: Test requires 'gdal'.
-   test_no_ellipsoid (iris.tests.unit.experimental.raster.test_export_geotiff.TestProjection) ... SKIP: Test requires 'gdal'.
-   ...
-   ...
-   test_slice (iris.tests.test_util.TestAsCompatibleShape) ... ok
-   test_slice_and_transpose (iris.tests.test_util.TestAsCompatibleShape) ... ok
-   test_transpose (iris.tests.test_util.TestAsCompatibleShape) ... ok
-
-   ----------------------------------------------------------------------
-   Ran 4762 tests in 238.649s
-
-   OK (SKIP=22)
-
-There may be some tests that have been **skipped**.  This is due to a Python
-decorator being present in the test script that will intentionally skip a test
-if a certain condition is not met.  In the example output above there are
-**22** skipped tests, at the point in time when this was run this was primarily
-due to an experimental dependency not being present.
-
-
-.. tip::
-
-   The most common reason for tests to be skipped is when the directory for the
-   ``iris-test-data`` has not been set which would shows output such as::
-
-      test_coord_coord_map (iris.tests.test_plot.Test1dScatter) ... SKIP: Test(s) require external data.
-      test_coord_coord (iris.tests.test_plot.Test1dScatter) ... SKIP: Test(s) require external data.
-      test_coord_cube (iris.tests.test_plot.Test1dScatter) ... SKIP: Test(s) require external data.
-
-   All Python decorators that skip tests will be defined in
-   ``lib/iris/tests/__init__.py`` with a function name with a prefix of
-   ``skip_``.
-
 
 .. _using nox:
 

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -119,7 +119,7 @@ Running the Tests
 To ensure your setup is configured correctly you can run the test suite using
 the command::
 
-    python setup.py test
+    pytest
 
 For more information see :ref:`developer_running_tests`.
 

--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -121,7 +121,7 @@ the command::
 
     pytest
 
-For more information see :ref:`developer_running_tests`.
+For more information see :ref:`test manual env`.
 
 
 Custom Site Configuration


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This is the culmination of my cunning plan from #4199!

Removes the instructions for using the deprecated `python setup.py test`, and instead gives instructions for `pytest`.

I have retained the instructions for running a module directly with e.g. `python my/test/file.py`, because I have not found a way to use our extra options (e.g. `-d` for displaying figures) under `pytest`.

Also added a little about the pros and cons of testing in your own `iris-dev` environment vs using `nox`, thanks to @bsherratt's suggestion at https://github.com/SciTools/iris/discussions/4199#discussioncomment-1447095.

See here for how this page renders:
https://www-hc/~hadru/iris-dev/developers_guide/contributing_running_tests.html

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
