### PR TITLE
Allowed collapsing coordinates with `nbounds != (0, 2)`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -42,6 +42,11 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ and `@pp-mo`_ (reviewer) factored masking into the returned
    sum-of-weights calculation from :obj:`~iris.analysis.SUM`. (:pull:`4905`)
 
+#. `@schlunma`_ fixed a bug which prevented using
+   :meth:`iris.cube.Cube.collapsed` on coordinates whose number of bounds
+   differs from 0 or 2. This enables the use of this method on mesh
+   coordinates. (:issue:`4672`, :pull:`4870`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2215,12 +2215,24 @@ class Coord(_DimensionalMetadata):
                     "Metadata may not be fully descriptive for {!r}."
                 )
                 warnings.warn(msg.format(self.name()))
-            elif not self.is_contiguous():
-                msg = (
-                    "Collapsing a non-contiguous coordinate. "
-                    "Metadata may not be fully descriptive for {!r}."
-                )
-                warnings.warn(msg.format(self.name()))
+            else:
+                try:
+                    self._sanity_check_bounds()
+                except ValueError as exc:
+                    msg = (
+                        "Cannot check if coordinate is contiguous: {} "
+                        "Metadata may not be fully descriptive for {!r}. "
+                        "Ignoring bounds."
+                    )
+                    warnings.warn(msg.format(str(exc), self.name()))
+                    self.bounds = None
+                else:
+                    if not self.is_contiguous():
+                        msg = (
+                            "Collapsing a non-contiguous coordinate. "
+                            "Metadata may not be fully descriptive for {!r}."
+                        )
+                        warnings.warn(msg.format(self.name()))
 
             if self.has_bounds():
                 item = self.core_bounds()

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -481,7 +481,7 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         coord = AuxCoord(self.pts_real, bounds=self.bds_real, long_name="y")
 
         with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
+            coord.collapsed()
 
         msg = (
             "Collapsing a multi-dimensional coordinate. "
@@ -494,7 +494,7 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         coord = AuxCoord(self.pts_lazy, bounds=self.bds_lazy, long_name="y")
 
         with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
+            coord.collapsed()
 
         msg = (
             "Collapsing a multi-dimensional coordinate. "
@@ -507,7 +507,7 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         coord = AuxCoord(self.pts_real, bounds=self.bds_real, long_name="y")
 
         with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
+            coord.collapsed()
 
         msg = (
             "Collapsing a non-contiguous coordinate. "
@@ -520,7 +520,7 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         coord = AuxCoord(self.pts_lazy, bounds=self.bds_lazy, long_name="y")
 
         with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
+            coord.collapsed()
 
         msg = (
             "Collapsing a non-contiguous coordinate. "

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -474,6 +474,76 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         self.assertArrayEqual(collapsed_coord.points, da.array([55]))
         self.assertArrayEqual(collapsed_coord.bounds, da.array([[-2, 112]]))
 
+    def test_numeric_3_bounds_warning(self):
+        points = np.array([2.0])
+        bounds = np.array([[1.0, 0.0, 3.0]])
+
+        coord = AuxCoord(points, bounds=bounds, long_name="x")
+
+        msg = (
+            r"Cannot check if coordinate is contiguous: Invalid operation "
+            r"for 'x', with 3 bound\(s\). Contiguous bounds are only "
+            r"defined for 1D coordinates with 2 bounds. Metadata may not "
+            r"be fully descriptive for 'x'. Ignoring bounds."
+        )
+        with warnings.catch_warnings():
+            # Cause all warnings to raise Exceptions
+            warnings.simplefilter("error")
+            with self.assertRaisesRegex(UserWarning, msg):
+                coord.collapsed()
+
+    def test_lazy_3_bounds_warning(self):
+        points = da.arange(1)
+        bounds = da.arange(1 * 3).reshape(1, 3)
+
+        coord = AuxCoord(points, bounds=bounds, long_name="y")
+
+        msg = (
+            r"Cannot check if coordinate is contiguous: Invalid operation "
+            r"for 'y', with 3 bound\(s\). Contiguous bounds are only "
+            r"defined for 1D coordinates with 2 bounds. Metadata may not "
+            r"be fully descriptive for 'y'. Ignoring bounds."
+        )
+        with warnings.catch_warnings():
+            # Cause all warnings to raise Exceptions
+            warnings.simplefilter("error")
+            with self.assertRaisesRegex(UserWarning, msg):
+                coord.collapsed()
+
+    def test_numeric_3_bounds(self):
+
+        points = np.array([2.0, 6.0, 4.0])
+        bounds = np.array([[1.0, 0.0, 3.0], [5.0, 4.0, 7.0], [3.0, 2.0, 5.0]])
+
+        coord = AuxCoord(points, bounds=bounds)
+
+        collapsed_coord = coord.collapsed()
+
+        self.assertFalse(collapsed_coord.has_lazy_points())
+        self.assertFalse(collapsed_coord.has_lazy_bounds())
+
+        self.assertArrayAlmostEqual(collapsed_coord.points, np.array([4.0]))
+        self.assertArrayAlmostEqual(
+            collapsed_coord.bounds, np.array([[2.0, 6.0]])
+        )
+
+    def test_lazy_3_bounds(self):
+
+        points = da.arange(3) * 2.0
+        bounds = da.arange(3 * 3).reshape(3, 3)
+
+        coord = AuxCoord(points, bounds=bounds)
+
+        collapsed_coord = coord.collapsed()
+
+        self.assertTrue(collapsed_coord.has_lazy_points())
+        self.assertTrue(collapsed_coord.has_lazy_bounds())
+
+        self.assertArrayAlmostEqual(collapsed_coord.points, da.array([2.0]))
+        self.assertArrayAlmostEqual(
+            collapsed_coord.bounds, da.array([[0.0, 4.0]])
+        )
+
 
 class Test_is_compatible(tests.IrisTest):
     def setUp(self):

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -332,9 +332,8 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         )
         for units in ["unknown", "no_unit", 1, "K"]:
             coord.units = units
-            with mock.patch("warnings.warn") as warn:
+            with self.assertNoWarningsRegexp():
                 collapsed_coord = coord.collapsed()
-            warn.assert_not_called()
             self.assertArrayEqual(
                 collapsed_coord.points, np.mean(coord.points)
             )
@@ -480,53 +479,45 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         self.setupTestArrays((3, 4))
         coord = AuxCoord(self.pts_real, bounds=self.bds_real, long_name="y")
 
-        with mock.patch("warnings.warn") as warn:
-            coord.collapsed()
-
         msg = (
             "Collapsing a multi-dimensional coordinate. "
             "Metadata may not be fully descriptive for 'y'."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            coord.collapsed()
 
     def test_lazy_nd_multidim_bounds_warning(self):
         self.setupTestArrays((3, 4))
         coord = AuxCoord(self.pts_lazy, bounds=self.bds_lazy, long_name="y")
 
-        with mock.patch("warnings.warn") as warn:
-            coord.collapsed()
-
         msg = (
             "Collapsing a multi-dimensional coordinate. "
             "Metadata may not be fully descriptive for 'y'."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            coord.collapsed()
 
     def test_numeric_nd_noncontiguous_bounds_warning(self):
         self.setupTestArrays((3))
         coord = AuxCoord(self.pts_real, bounds=self.bds_real, long_name="y")
 
-        with mock.patch("warnings.warn") as warn:
-            coord.collapsed()
-
         msg = (
             "Collapsing a non-contiguous coordinate. "
             "Metadata may not be fully descriptive for 'y'."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            coord.collapsed()
 
     def test_lazy_nd_noncontiguous_bounds_warning(self):
         self.setupTestArrays((3))
         coord = AuxCoord(self.pts_lazy, bounds=self.bds_lazy, long_name="y")
 
-        with mock.patch("warnings.warn") as warn:
-            coord.collapsed()
-
         msg = (
             "Collapsing a non-contiguous coordinate. "
             "Metadata may not be fully descriptive for 'y'."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            coord.collapsed()
 
     def test_numeric_3_bounds(self):
 
@@ -535,16 +526,14 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
 
         coord = AuxCoord(points, bounds=bounds, long_name="x")
 
-        with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
-
         msg = (
-            "Cannot check if coordinate is contiguous: Invalid operation for "
-            "'x', with 3 bound(s). Contiguous bounds are only defined for 1D "
-            "coordinates with 2 bounds. Metadata may not be fully descriptive "
-            "for 'x'. Ignoring bounds."
+            r"Cannot check if coordinate is contiguous: Invalid operation for "
+            r"'x', with 3 bound\(s\). Contiguous bounds are only defined for "
+            r"1D coordinates with 2 bounds. Metadata may not be fully "
+            r"descriptive for 'x'. Ignoring bounds."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            collapsed_coord = coord.collapsed()
 
         self.assertFalse(collapsed_coord.has_lazy_points())
         self.assertFalse(collapsed_coord.has_lazy_bounds())
@@ -561,16 +550,14 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
 
         coord = AuxCoord(points, bounds=bounds, long_name="x")
 
-        with mock.patch("warnings.warn") as warn:
-            collapsed_coord = coord.collapsed()
-
         msg = (
-            "Cannot check if coordinate is contiguous: Invalid operation for "
-            "'x', with 3 bound(s). Contiguous bounds are only defined for 1D "
-            "coordinates with 2 bounds. Metadata may not be fully descriptive "
-            "for 'x'. Ignoring bounds."
+            r"Cannot check if coordinate is contiguous: Invalid operation for "
+            r"'x', with 3 bound\(s\). Contiguous bounds are only defined for "
+            r"1D coordinates with 2 bounds. Metadata may not be fully "
+            r"descriptive for 'x'. Ignoring bounds."
         )
-        self.assertEqual([mock.call(msg)], warn.call_args_list)
+        with self.assertWarnsRegex(UserWarning, msg):
+            collapsed_coord = coord.collapsed()
 
         self.assertTrue(collapsed_coord.has_lazy_points())
         self.assertTrue(collapsed_coord.has_lazy_bounds())

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -474,50 +474,23 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         self.assertArrayEqual(collapsed_coord.points, da.array([55]))
         self.assertArrayEqual(collapsed_coord.bounds, da.array([[-2, 112]]))
 
-    def test_numeric_3_bounds_warning(self):
-        points = np.array([2.0])
-        bounds = np.array([[1.0, 0.0, 3.0]])
-
-        coord = AuxCoord(points, bounds=bounds, long_name="x")
-
-        msg = (
-            r"Cannot check if coordinate is contiguous: Invalid operation "
-            r"for 'x', with 3 bound\(s\). Contiguous bounds are only "
-            r"defined for 1D coordinates with 2 bounds. Metadata may not "
-            r"be fully descriptive for 'x'. Ignoring bounds."
-        )
-        with warnings.catch_warnings():
-            # Cause all warnings to raise Exceptions
-            warnings.simplefilter("error")
-            with self.assertRaisesRegex(UserWarning, msg):
-                coord.collapsed()
-
-    def test_lazy_3_bounds_warning(self):
-        points = da.arange(1)
-        bounds = da.arange(1 * 3).reshape(1, 3)
-
-        coord = AuxCoord(points, bounds=bounds, long_name="y")
-
-        msg = (
-            r"Cannot check if coordinate is contiguous: Invalid operation "
-            r"for 'y', with 3 bound\(s\). Contiguous bounds are only "
-            r"defined for 1D coordinates with 2 bounds. Metadata may not "
-            r"be fully descriptive for 'y'. Ignoring bounds."
-        )
-        with warnings.catch_warnings():
-            # Cause all warnings to raise Exceptions
-            warnings.simplefilter("error")
-            with self.assertRaisesRegex(UserWarning, msg):
-                coord.collapsed()
-
     def test_numeric_3_bounds(self):
 
         points = np.array([2.0, 6.0, 4.0])
         bounds = np.array([[1.0, 0.0, 3.0], [5.0, 4.0, 7.0], [3.0, 2.0, 5.0]])
 
-        coord = AuxCoord(points, bounds=bounds)
+        coord = AuxCoord(points, bounds=bounds, long_name="x")
 
-        collapsed_coord = coord.collapsed()
+        with mock.patch("warnings.warn") as warn:
+            collapsed_coord = coord.collapsed()
+
+        msg = (
+            "Cannot check if coordinate is contiguous: Invalid operation for "
+            "'x', with 3 bound(s). Contiguous bounds are only defined for 1D "
+            "coordinates with 2 bounds. Metadata may not be fully descriptive "
+            "for 'x'. Ignoring bounds."
+        )
+        self.assertEqual([mock.call(msg)], warn.call_args_list)
 
         self.assertFalse(collapsed_coord.has_lazy_points())
         self.assertFalse(collapsed_coord.has_lazy_bounds())
@@ -532,9 +505,18 @@ class Test_collapsed(tests.IrisTest, CoordTestMixin):
         points = da.arange(3) * 2.0
         bounds = da.arange(3 * 3).reshape(3, 3)
 
-        coord = AuxCoord(points, bounds=bounds)
+        coord = AuxCoord(points, bounds=bounds, long_name="x")
 
-        collapsed_coord = coord.collapsed()
+        with mock.patch("warnings.warn") as warn:
+            collapsed_coord = coord.collapsed()
+
+        msg = (
+            "Cannot check if coordinate is contiguous: Invalid operation for "
+            "'x', with 3 bound(s). Contiguous bounds are only defined for 1D "
+            "coordinates with 2 bounds. Metadata may not be fully descriptive "
+            "for 'x'. Ignoring bounds."
+        )
+        self.assertEqual([mock.call(msg)], warn.call_args_list)
 
         self.assertTrue(collapsed_coord.has_lazy_points())
         self.assertTrue(collapsed_coord.has_lazy_bounds())


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull request allows collapsing coordinates with number of bounds different from 0 or 2 (e.g., mesh dimensions). For this, it first checks if `self.is_contiguous()` (that is just used to issue a warning during the collapsing of coordinates) raises an error before actually calling it. If it raises an error, issue a different warning and remove the bounds before continuing.

Closes #4672.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
