### PR TITLE
Revert Cell.__hash__ fix

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -111,12 +111,6 @@ This document explains the changes made to Iris for this release
    to ``stderr`` when a :class:`~iris.fileformats.cf.CFReader` that fails to
    initialise is garbage collected. (:issue:`3312`, :pull:`4646`)
 
-#. `@stephenworsley`_ aligned the behaviour of :obj:`~iris.coords.Cell` equality
-   to match :obj:`~iris.coords.Coord` equality with respect to NaN values.
-   Two NaN valued Cells are now considered equal. This fixes :issue:`4681` and
-   causes NaN valued scalar coordinates to be able to merge be preserved during
-   cube merging. (:pull:`4701`)
-
 #. `@wjbenfold`_ fixed plotting of circular coordinates to extend kwarg arrays
    as well as the data. (:issue:`466`, :pull:`4649`)
 
@@ -139,10 +133,6 @@ This document explains the changes made to Iris for this release
    still be instantiated with ``calendar="gregorian"`` but their calendar
    attribute will be silently changed to "standard".  This may cause failures in
    code that explicitly checks the calendar attribute. (:pull:`4847`)
-
-#. `@bjlittle`_ accounted for the recent changes in ``python`` >=3.10.0 when
-   hashing a ``nan``. Specifically, a ``nan`` scalar coordinate will be
-   promoted to a vector ``nan`` coordinate during cube merge.
 
 
 🚀 Performance Enhancements

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -140,6 +140,10 @@ This document explains the changes made to Iris for this release
    attribute will be silently changed to "standard".  This may cause failures in
    code that explicitly checks the calendar attribute. (:pull:`4847`)
 
+#. `@bjlittle`_ accounted for the recent changes in ``python`` >=3.10.0 when
+   hashing a ``nan``. Specifically, a ``nan`` scalar coordinate will be
+   promoted to a vector ``nan`` coordinate during cube merge.
+
 
 🚀 Performance Enhancements
 ===========================

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -249,7 +249,7 @@ This document explains the changes made to Iris for this release
 
 #. `@bjlittle`_ and `@jamesp`_ (reviewer) and `@lbdreyer`_ (reviewer) extended
    the GitHub Continuous-Integration to cover testing on ``py38``, ``py39``,
-   and ``py310``. (:pull:`4840` and :pull:`4852`)
+   and ``py310``. (:pull:`4840`)
 
 #. `@bjlittle`_ and `@trexfeathers`_ (reviewer) adopted `setuptools-scm`_ for
    automated ``iris`` package versioning. (:pull:`4841`)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1353,27 +1353,14 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         compared.
 
         """
-
-        def nan_equality(x, y):
-            return (
-                isinstance(x, (float, np.number))
-                and np.isnan(x)
-                and isinstance(y, (float, np.number))
-                and np.isnan(y)
-            )
-
         if isinstance(other, (int, float, np.number)) or hasattr(
             other, "timetuple"
         ):
             if self.bound is not None:
                 return self.contains_point(other)
-            elif nan_equality(self.point, other):
-                return True
             else:
                 return self.point == other
         elif isinstance(other, Cell):
-            if nan_equality(self.point, other.point):
-                return True
             return (self.point == other.point) and (
                 self.bound == other.bound or self.bound == other.bound[::-1]
             )

--- a/lib/iris/tests/integration/merge/test_merge.py
+++ b/lib/iris/tests/integration/merge/test_merge.py
@@ -54,14 +54,16 @@ class TestNaNs(tests.IrisTest):
         cubes = CubeList(cube1.slices_over("x"))
         cube2 = cubes.merge_cube()
 
-        # Account for change in behaviour for py310+ when hashing NaN
+        # Account for change in behaviour for py310+ when hashing a NaN
         # Reference https://github.com/SciTools/iris/pull/4874
         version = (
             f"{version_info.major}.{version_info.minor}.{version_info.micro}"
         )
         if parse_version(version) >= parse_version("3.10.0"):
+            # vector coordinate
             expected = np.array([np.nan] * cube1.shape[0])
         else:
+            # scalar coordinate
             expected = nan_coord1.points
 
         self.assertArrayEqual(

--- a/lib/iris/tests/integration/merge/test_merge.py
+++ b/lib/iris/tests/integration/merge/test_merge.py
@@ -12,9 +12,7 @@ Integration tests for merging cubes.
 # before importing anything else.
 import iris.tests as tests  # isort:skip
 
-import numpy as np
-
-from iris.coords import AuxCoord, DimCoord
+from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 
 
@@ -33,46 +31,6 @@ class TestContiguous(tests.IrisTest):
         self.assertTrue(coord2.is_contiguous())
         self.assertArrayEqual(coord2.points, [1, 2, 3])
         self.assertArrayEqual(coord2.bounds, coord1.bounds[::-1, ::-1])
-
-
-class TestNaNs(tests.IrisTest):
-    def test_merge_nan_coords(self):
-        from sys import version_info
-
-        from pkg_resources import parse_version
-
-        # Test that nan valued coordinates merge together.
-        cube1 = Cube(np.ones([3, 4]), "air_temperature", units="K")
-        coord1 = DimCoord([1, 2, 3], long_name="x")
-        coord2 = DimCoord([0, 1, 2, 3], long_name="y")
-        nan_coord1 = AuxCoord(np.nan, long_name="nan1")
-        nan_coord2 = AuxCoord([np.nan] * 4, long_name="nan2")
-        cube1.add_dim_coord(coord1, 0)
-        cube1.add_dim_coord(coord2, 1)
-        cube1.add_aux_coord(nan_coord1)
-        cube1.add_aux_coord(nan_coord2, 1)
-        cubes = CubeList(cube1.slices_over("x"))
-        cube2 = cubes.merge_cube()
-
-        # Account for change in behaviour for py310+ when hashing a NaN
-        # Reference https://github.com/SciTools/iris/pull/4874
-        version = (
-            f"{version_info.major}.{version_info.minor}.{version_info.micro}"
-        )
-        if parse_version(version) >= parse_version("3.10.0"):
-            # vector coordinate
-            expected = np.array([np.nan] * cube1.shape[0])
-        else:
-            # scalar coordinate
-            expected = nan_coord1.points
-
-        self.assertArrayEqual(
-            np.isnan(expected), np.isnan(cube2.coord("nan1").points)
-        )
-        self.assertArrayEqual(
-            np.isnan(nan_coord2.points),
-            np.isnan(cube2.coord("nan2").points),
-        )
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -155,24 +155,6 @@ class Test___eq__(tests.IrisTest):
         self.assertEqual(cell1, cell2)
 
 
-class Test___hash__(tests.IrisTest):
-    def test_nan__hash(self):
-        cell = Cell(np.nan, None)
-        self.assertEqual(cell._hash, 0)
-
-    def test_nan___hash__(self):
-        cell = Cell(np.nan, None)
-        self.assertEqual(cell.__hash__(), 0)
-
-    def test_non_nan__hash(self):
-        cell = Cell(1, None)
-        self.assertNotEqual(cell._hash, 0)
-
-    def test_non_nan___hash__(self):
-        cell = Cell("two", ("one", "three"))
-        self.assertNotEqual(cell.__hash__(), 0)
-
-
 class Test_contains_point(tests.IrisTest):
     def test_datetimelike_bounded_cell(self):
         point = object()

--- a/lib/iris/tests/unit/coords/test_Cell.py
+++ b/lib/iris/tests/unit/coords/test_Cell.py
@@ -146,14 +146,6 @@ class Test___eq__(tests.IrisTest):
         self.assertNotEqual(cell, PartialDateTime(month=3, hour=12))
         self.assertNotEqual(cell, PartialDateTime(month=4))
 
-    def test_nan_other(self):
-        # Check that nans satisfy equality.
-        cell1 = Cell(np.nan)
-        cell2 = Cell(np.nan)
-        self.assertEqual(cell1, np.nan)
-        self.assertEqual(np.nan, cell1)
-        self.assertEqual(cell1, cell2)
-
 
 class Test_contains_point(tests.IrisTest):
     def test_datetimelike_bounded_cell(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR reverts the fix targeting the change in behaviour of `Cell.__hash__` when dealing with NaNs due to the performance regression that it introduces.

This fix is only applicable to a change in behaviour for `py310`.

See:
- #4840 
- #4852

Reference:
- https://bugs.python.org/issue43475
- https://github.com/numpy/numpy/issues/18833
- https://github.com/numpy/numpy/pull/18908
- https://github.com/numpy/numpy/issues/21210

Closes #4843

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
