### PR TITLE
Replace testing helper function

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -245,7 +245,8 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ and `@pp-mo`_ improved generation of stock NetCDF files.
    (:pull:`4827`, :pull:`4836`)
 
-#. `@rcomer`_ removed some now redundant testing methods. (:pull:`4838`)
+#. `@rcomer`_ removed some now redundant testing functions. (:pull:`4838`,
+   :pull:`4878`)
 
 #. `@bjlittle`_ and `@jamesp`_ (reviewer) and `@lbdreyer`_ (reviewer) extended
    the GitHub Continuous-Integration to cover testing on ``py38``, ``py39``,

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -588,31 +588,18 @@ class IrisTest_nometa(unittest.TestCase):
         self.assertFalse(matches, msg)
 
     def _assertMaskedArray(self, assertion, a, b, strict, **kwargs):
-        # Define helper function to extract unmasked values as a 1d
-        # array.
-        def unmasked_data_as_1d_array(array):
-            array = ma.asarray(array)
-            if array.ndim == 0:
-                if array.mask:
-                    data = np.array([])
-                else:
-                    data = np.array([array.data])
-            else:
-                data = array.data[~ma.getmaskarray(array)]
-            return data
-
-        # Compare masks. This will also check that the array shapes
-        # match, which is not tested when comparing unmasked values if
-        # strict is False.
+        # Compare masks.
         a_mask, b_mask = ma.getmaskarray(a), ma.getmaskarray(b)
         np.testing.assert_array_equal(a_mask, b_mask)
 
         if strict:
+            # Compare all data values.
             assertion(a.data, b.data, **kwargs)
         else:
+            # Compare only unmasked data values.
             assertion(
-                unmasked_data_as_1d_array(a),
-                unmasked_data_as_1d_array(b),
+                ma.compressed(a),
+                ma.compressed(b),
                 **kwargs,
             )
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Unless I'm missing something, `unmasked_data_as_1d_array` does the same as [numpy.ma.compressed](https://numpy.org/doc/stable/reference/generated/numpy.ma.compressed.html?highlight=compressed#numpy.ma.compressed).  So we could just replace it.

Fewer lines :+1: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
