### PR TITLE
Sphinx reset modules

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -368,6 +368,11 @@ sphinx_gallery_conf = {
     "ignore_pattern": r"__init__\.py",
     # force gallery building, unless overridden (see src/Makefile)
     "plot_gallery": "'True'",
+    # force re-registering of nc-time-axis with matplotlib for each example,
+    # required for sphinx-gallery>=0.11.0
+    "reset_modules": (
+        lambda gallery_conf, fname: sys.modules.pop("nc_time_axis", None),
+    ),
 }
 
 # -----------------------------------------------------------------------------

--- a/docs/src/developers_guide/contributing_documentation_full.rst
+++ b/docs/src/developers_guide/contributing_documentation_full.rst
@@ -147,7 +147,7 @@ can exclude the module from the API documentation.  Add the entry to the
 Gallery
 ~~~~~~~
 
-The Iris :ref:`sphx_glr_generated_gallery` uses a sphinx extension named
+The Iris :ref:`gallery_index` uses a sphinx extension named
 `sphinx-gallery <https://sphinx-gallery.github.io/stable/>`_
 that auto generates reStructuredText (rst) files based upon a gallery source
 directory that abides directory and filename convention.

--- a/requirements/ci/py310.yml
+++ b/requirements/ci/py310.yml
@@ -45,6 +45,6 @@ dependencies:
   - sphinx
   - sphinxcontrib-napoleon
   - sphinx-copybutton
-  - sphinx-gallery
+  - sphinx-gallery >=0.11.0
   - sphinx-panels
   - pydata-sphinx-theme = 0.8.1

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -45,6 +45,6 @@ dependencies:
   - sphinx
   - sphinxcontrib-napoleon
   - sphinx-copybutton
-  - sphinx-gallery
+  - sphinx-gallery >=0.11.0
   - sphinx-panels
   - pydata-sphinx-theme = 0.8.1

--- a/requirements/ci/py39.yml
+++ b/requirements/ci/py39.yml
@@ -45,6 +45,6 @@ dependencies:
   - sphinx
   - sphinxcontrib-napoleon
   - sphinx-copybutton
-  - sphinx-gallery
+  - sphinx-gallery >=0.11.0
   - sphinx-panels
   - pydata-sphinx-theme = 0.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ where = lib
 docs =
     sphinx
     sphinx-copybutton
-    sphinx-gallery
+    sphinx-gallery>=0.11.0
     sphinx_rtd_theme
     sphinxcontrib-napoleon
     sphinx-panels


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR resolves the issue of the documentation failing to build on RTD.

This is related to the recent release of `sphinx-gallery` 0.11.0.

Also see:

- https://github.com/sphinx-gallery/sphinx-gallery/pull/890
- https://github.com/matplotlib/matplotlib/pull/23514

Thanks @rcomer :+1: 

TODO:

- [x] ~Resolve the conda lockfiles as part of this PR~

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
