### PR TITLE
set default 'unknown' version

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -101,7 +101,12 @@ import iris.config
 import iris.io
 
 from ._deprecation import IrisDeprecation, warn_deprecated
-from ._version import version as __version__  # noqa: F401
+
+try:
+    from ._version import version as __version__  # noqa: F401
+except ModuleNotFoundError:
+    __version__ = "unknown"
+
 
 try:
     import iris_sample_data


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Ever since we committed #4841, as developers we require the [setuptools-scm](https://github.com/pypa/setuptools_scm) generated `iris._version` file to be available to garner the `iris.__version__`.

If this file is **not** available, then the following traceback will be encountered by the developer whenever `import iris` is performed:

```bash
ModuleNotFoundError: No module named 'iris._version'
```

Thanks to our adoption of a [PEP-0518](https://peps.python.org/pep-0518/) build backend, as a developer you do **not** require to have the `setuptools-scm` package installed within your development environment to use `iris` (only do that if you care about getting the correct version). However, to generate the `iris._version` file without explicitly installing `setuptools-scm`, from the root source directory of `iris` simply:

```bash
> pip install --no-deps --editable .
```

It seems a shame to force developers to have to perform this step. Other packages which have adopted `setuptools-scm` default to the pattern of setting the `__version__ = "unknown"` to circumvent this situation as a convenience.

This PR introduces this pattern to `iris` as a similar developer convenience.

Ping @hsteptoe


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
