### PR TITLE
SUM, COUNT, PROPORTION: don't use dask on numpy arrays

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -32,14 +32,15 @@ This document explains the changes made to Iris for this release
 ===========
 
 #. `@ESadek-MO`_ edited :func:`~iris.io.expand_filespecs` to allow expansion of
-    non-existing paths, and added expansion functionality to :func:`~iris.io.save`.
-    (:issue:`4772`, :pull:`4913`)
+   non-existing paths, and added expansion functionality to :func:`~iris.io.save`.
+   (:issue:`4772`, :pull:`4913`)
 
 
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@rcomer`_ factored masking into the returned sum-of-weights calculation from
+   :obj:`~iris.analysis.SUM`. (:pull:`4905`)
 
 
 💣 Incompatible Changes
@@ -51,7 +52,9 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. N/A
+#. `@rcomer`_ increased aggregation speed for :obj:`~iris.analysis.SUM`,
+   :obj:`~iris.analysis.COUNT` and :obj:`~iris.analysis.PROPORTION` on real
+   data. (:pull:`4905`)
 
 
 🔥 Deprecations
@@ -63,7 +66,8 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@rcomer`_ introduced the ``dask >=2.26`` minimum pin, so that Iris can benefit
+   from Dask's support for `NEP13`_ and `NEP18`_. (:pull:`4905`)
 
 
 📚 Documentation
@@ -89,3 +93,5 @@ This document explains the changes made to Iris for this release
     Whatsnew resources in alphabetical order:
 
 
+.. _NEP13: https://numpy.org/neps/nep-0013-ufunc-overrides.html
+.. _NEP18: https://numpy.org/neps/nep-0018-array-function-protocol.html

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -39,8 +39,8 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. `@rcomer`_ factored masking into the returned sum-of-weights calculation from
-   :obj:`~iris.analysis.SUM`. (:pull:`4905`)
+#. `@rcomer`_ and `@pp-mo`_ (reviewer) factored masking into the returned
+   sum-of-weights calculation from :obj:`~iris.analysis.SUM`. (:pull:`4905`)
 
 
 💣 Incompatible Changes
@@ -52,9 +52,9 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. `@rcomer`_ increased aggregation speed for :obj:`~iris.analysis.SUM`,
-   :obj:`~iris.analysis.COUNT` and :obj:`~iris.analysis.PROPORTION` on real
-   data. (:pull:`4905`)
+#. `@rcomer`_ and `@pp-mo`_ (reviewer) increased aggregation speed for
+   :obj:`~iris.analysis.SUM`, :obj:`~iris.analysis.COUNT` and
+   :obj:`~iris.analysis.PROPORTION` on real data. (:pull:`4905`)
 
 
 🔥 Deprecations

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1621,7 +1621,7 @@ def _sum(array, **kwargs):
                 )
         else:
             weights = al.ma.masked_array(
-                weights_in, mask=da.ma.getmaskarray(array)
+                weights_in, mask=al.ma.getmaskarray(array)
             )
         rvalue = (wsum, np.sum(weights, axis=axis_in))
     else:

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1499,14 +1499,12 @@ def _weighted_percentile(
         return result
 
 
-@_build_dask_mdtol_function
-def _lazy_count(array, **kwargs):
-    array = iris._lazy_data.as_lazy_data(array)
+def _count(array, **kwargs):
     func = kwargs.pop("function", None)
     if not callable(func):
         emsg = "function must be a callable. Got {}."
         raise TypeError(emsg.format(type(func)))
-    return da.sum(func(array), **kwargs)
+    return np.sum(func(array), **kwargs)
 
 
 def _proportion(array, function, axis, **kwargs):
@@ -1740,9 +1738,9 @@ def _peak(array, **kwargs):
 #
 COUNT = Aggregator(
     "count",
-    iris._lazy_data.non_lazy(_lazy_count),
+    _count,
     units_func=lambda units: 1,
-    lazy_func=_lazy_count,
+    lazy_func=_build_dask_mdtol_function(_count),
 )
 """
 An :class:`~iris.analysis.Aggregator` instance that counts the number

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1500,6 +1500,12 @@ def _weighted_percentile(
 
 
 def _count(array, **kwargs):
+    """
+    Counts the number of points along the axis that satisfy the condition
+    specified by ``function``.  Uses Dask's support for NEP13/18 to work as
+    either a lazy or a real function.
+
+    """
     func = kwargs.pop("function", None)
     if not callable(func):
         emsg = "function must be a callable. Got {}."
@@ -1602,7 +1608,11 @@ def _lazy_rms(array, axis, **kwargs):
 
 
 def _sum(array, **kwargs):
-    # weighted or scaled sum
+    """
+    Weighted or scaled sum.  Uses Dask's support for NEP13/18 to work as either
+    a lazy or a real function.
+
+    """
     axis_in = kwargs.get("axis", None)
     weights_in = kwargs.pop("weights", None)
     returned_in = kwargs.pop("returned", False)

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1611,14 +1611,18 @@ def _sum(array, **kwargs):
     else:
         wsum = np.sum(array, **kwargs)
     if returned_in:
+        al = da if iris._lazy_data.is_lazy_data(array) else np
         if weights_in is None:
-            weights = np.ones_like(array)
-            if iris._lazy_data.is_lazy_data(weights):
+            weights = al.ones_like(array)
+            if al is da:
+                # Dask version of ones_like does not preserve masks. See dask#9301.
                 weights = da.ma.masked_array(
                     weights, da.ma.getmaskarray(array)
                 )
         else:
-            weights = weights_in  # TODO should this also be masked?
+            weights = al.ma.masked_array(
+                weights_in, mask=da.ma.getmaskarray(array)
+            )
         rvalue = (wsum, np.sum(weights, axis=axis_in))
     else:
         rvalue = wsum

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1508,7 +1508,6 @@ def _count(array, **kwargs):
 
 
 def _proportion(array, function, axis, **kwargs):
-    count = iris._lazy_data.non_lazy(_lazy_count)
     # if the incoming array is masked use that to count the total number of
     # values
     if ma.isMaskedArray(array):
@@ -1519,7 +1518,7 @@ def _proportion(array, function, axis, **kwargs):
             # case pass the array shape instead of the mask:
             total_non_masked = array.shape[axis]
         else:
-            total_non_masked = count(
+            total_non_masked = _count(
                 array.mask, axis=axis, function=np.logical_not, **kwargs
             )
             total_non_masked = ma.masked_equal(total_non_masked, 0)
@@ -1532,7 +1531,7 @@ def _proportion(array, function, axis, **kwargs):
     # a dtype for its data that is different to the dtype of the fill-value,
     # which can cause issues outside this function.
     # Reference - tests/unit/analyis/test_PROPORTION.py Test_masked.test_ma
-    numerator = count(array, axis=axis, function=function, **kwargs)
+    numerator = _count(array, axis=axis, function=function, **kwargs)
     result = ma.asarray(numerator / total_non_masked)
 
     return result
@@ -1615,7 +1614,9 @@ def _sum(array, **kwargs):
         if weights_in is None:
             weights = np.ones_like(array)
             if iris._lazy_data.is_lazy_data(weights):
-                weights = da.ma.masked_array(weights, da.ma.getmaskarray(array))
+                weights = da.ma.masked_array(
+                    weights, da.ma.getmaskarray(array)
+                )
         else:
             weights = weights_in  # TODO should this also be masked?
         rvalue = (wsum, np.sum(weights, axis=axis_in))

--- a/lib/iris/tests/unit/analysis/test_SUM.py
+++ b/lib/iris/tests/unit/analysis/test_SUM.py
@@ -9,6 +9,7 @@
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
@@ -91,6 +92,16 @@ class Test_weights_and_returned(tests.IrisTest):
         self.assertArrayEqual(data, [14, 9, 11, 13, 15])
         self.assertArrayEqual(weights, [4, 2, 2, 2, 2])
 
+    def test_masked_weights_and_returned(self):
+        array = ma.array(
+            self.cube_2d.data, mask=[[0, 0, 1, 0, 0], [0, 0, 0, 1, 0]]
+        )
+        data, weights = SUM.aggregate(
+            array, axis=0, weights=self.weights, returned=True
+        )
+        self.assertArrayEqual(data, [14, 9, 8, 4, 15])
+        self.assertArrayEqual(weights, [4, 2, 1, 1, 2])
+
 
 class Test_lazy_weights_and_returned(tests.IrisTest):
     def setUp(self):
@@ -127,6 +138,17 @@ class Test_lazy_weights_and_returned(tests.IrisTest):
         self.assertTrue(is_lazy_data(lazy_data))
         self.assertArrayEqual(lazy_data.compute(), [14, 9, 11, 13, 15])
         self.assertArrayEqual(weights, [4, 2, 2, 2, 2])
+
+    def test_masked_weights_and_returned(self):
+        array = da.ma.masked_array(
+            self.cube_2d.lazy_data(), mask=[[0, 0, 1, 0, 0], [0, 0, 0, 1, 0]]
+        )
+        lazy_data, weights = SUM.lazy_aggregate(
+            array, axis=0, weights=self.weights, returned=True
+        )
+        self.assertTrue(is_lazy_data(lazy_data))
+        self.assertArrayEqual(lazy_data.compute(), [14, 9, 8, 4, 15])
+        self.assertArrayEqual(weights, [4, 2, 1, 1, 2])
 
 
 class Test_aggregate_shape(tests.IrisTest):

--- a/requirements/ci/py310.yml
+++ b/requirements/ci/py310.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.20
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2
+  - dask-core >=2.26
   - matplotlib
   - netcdf4
   - numpy >=1.19

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.20
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2
+  - dask-core >=2.26
   - matplotlib
   - netcdf4
   - numpy >=1.19

--- a/requirements/ci/py39.yml
+++ b/requirements/ci/py39.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.20
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2
+  - dask-core >=2.26
   - matplotlib
   - netcdf4
   - numpy >=1.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     cartopy>=0.20
     cf-units>=3.1
     cftime>=1.5.0
-    dask[array]>=2
+    dask[array]>=2.26
     matplotlib
     netcdf4
     numpy>=1.19


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
We have a few aggregators that are implemented purely in dask, and the "real" version works by converting the numpy array to a dask array, passing it through the dask functions, and then realising the data.  This appears to have been done at #3168 in response to a review request to reduce code repetition.  However, it is slow compared to just working directly with numpy.  Consider the following:

```python
import timeit

import iris.analysis
import numpy as np

def get_array():
    return np.random.random(10000).reshape(100, 100)

def over_half(a):
    return a > 0.5

setup = """
import iris
from __main__ import get_array, over_half
arr = get_array()
"""

print("COUNT", timeit.timeit(
    'iris.analysis.COUNT.aggregate(arr, 1, function=over_half)',
    setup=setup, number=500))

print("PROPORTION", timeit.timeit(
    'iris.analysis.PROPORTION.aggregate(arr, 1, function=over_half)',
    setup=setup, number=500))  

print("SUM", timeit.timeit(
    'iris.analysis.SUM.aggregate(arr, 1)',
    setup=setup, number=500))
```

On my local machine with `main`, this gives
```
COUNT 1.7456789941061288
PROPORTION 1.7775695940945297
SUM 1.26268538297154
```
With my branch it gives
```
COUNT 0.008400967926718295
PROPORTION 0.014432693016715348
SUM 0.004979556077159941
```

Note that https://github.com/dask/dask/pull/6393 introduced the `__array_function__` and `__array_ufunc__` methods to dask arrays so that, since [it was included at version 2.26](https://docs.dask.org/en/stable/changelog.html#id137), `numpy.sum` will automatically use `dask.array.sum` if it finds a dask array.

```python
import numpy
import dask
import dask.array as da

for package in [numpy, dask]:
    print(package.__name__, package.__version__)
    
array = da.array(range(5))
print(numpy.sum(array))
```
```
numpy 1.19.5
dask 2.26.0
dask.array<sum-aggregate, shape=(), dtype=int64, chunksize=(), chunktype=numpy.ndarray>
```
I have therefore updated the dask minimum pin to version 2.26.

One other aggregator, `MAX_RUN` is also implemented in the dask-only way.  However, since it's rather more complicated than these, I've left it for now.  Could be investigated separately.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
