### PR TITLE
Avoid using mutable default.

### DIFF
--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1096,7 +1096,7 @@ def format_array(arr):
     return result
 
 
-def new_axis(src_cube, scalar_coord=None, expand_extras=[]):
+def new_axis(src_cube, scalar_coord=None, expand_extras=()):
     """
     Create a new axis as the leading dimension of the cube, promoting a scalar
     coordinate if specified.
@@ -1111,10 +1111,10 @@ def new_axis(src_cube, scalar_coord=None, expand_extras=[]):
     * scalar_coord (:class:`iris.coord.Coord` or 'string')
         Scalar coordinate to promote to a dimension coordinate.
 
-    * expand_extras (list)
-        List of auxiliary coordinates, ancillary variables and cell measures
-        that will be expanded so that they map to the new dimension as well
-        as the existing dimensions.
+    * expand_extras (iterable)
+        Auxiliary coordinates, ancillary variables and cell measures which will
+        be expanded so that they map to the new dimension as well as the
+        existing dimensions.
 
     Returns:
         A new :class:`iris.cube.Cube` instance with one extra leading dimension


### PR DESCRIPTION
I noticed a tiny problem with the recently-merged extension to new-axis, in that it is using a mutable default argument.

As it is, the routine never modifies the argument, and in fact always replaces it [here](https://github.com/SciTools/iris/blob/505dca8ca5d7fbe5b45d2e24180280cd62ebfab8/lib/iris/util.py#L1180-L1182).
But I think it's accepted that this is not good practice generally.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
