### PR TITLE
Better handle `setuptools_scm` versioning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,12 @@ build:
       # to allow setuptools-scm to correctly auto-discover the version.
       - git fetch --unshallow
       - git fetch --all
+    # Need to stash the local changes that Read the Docs makes so that
+    #  setuptools_scm can generate the correct Iris version.
+    pre_install:
+      - git stash
+    post_install:
+      - git stash apply
 
 conda:
   environment: requirements/ci/readthedocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ build:
     pre_install:
       - git stash
     post_install:
-      - git stash apply
+      - git stash pop
 
 conda:
   environment: requirements/ci/readthedocs.yml

--- a/docs/src/_templates/custom_sidebar_logo_version.html
+++ b/docs/src/_templates/custom_sidebar_logo_version.html
@@ -7,15 +7,20 @@
         <span title="stable version">
             <img src="https://img.shields.io/badge/✨️_version_('stable')-{{ version }}-green?style=flat">
         </span>
-    {% else %}
-        {# Covers builds for any specific versions/commits, including RC's. #}
+    {% elif rtd_version_type == 'tag' %}
+        {# Covers builds for specific tags, including RC's. #}
         <span title="archived version (not 'stable' or 'latest')">
             <img src="https://img.shields.io/badge/🔒_version_(archived)-{{ version }}-red?style=?style=flat">
+        </span>
+    {% else %}
+        {# Anything else build by RTD will be the HEAD of an activated branch #}
+        <span title="non-tagged branch commit">
+            <img src="https://img.shields.io/badge/🚧_branch-{{ rtd_version }}_@_{{ commit_sha }}-blue?style=?style=flat">
         </span>
     {% endif %}
 {%- else %}
     {# not on rtd #}
-    <span title="development version">
-        <img src="https://img.shields.io/badge/✏️_version_(dev)-{{ version }}-blue?style=?style=flat">
+    <span title="non-tagged development commit">
+        <img src="https://img.shields.io/badge/🚧_commit_SHA-{{ commit_sha }}-blue?style=?style=flat">
     </span>
 {%- endif %}

--- a/docs/src/_templates/custom_sidebar_logo_version.html
+++ b/docs/src/_templates/custom_sidebar_logo_version.html
@@ -1,20 +1,21 @@
 {% if on_rtd %}
     {% if rtd_version == 'latest' %}
         <span title="latest development version">
-            <img src="https://img.shields.io/badge/latest_version-{{ version }}-orange?style=flat">
+            <img src="https://img.shields.io/badge/⚠️_version='latest'-{{ version }}-gold?style=flat">
         </span>
     {% elif rtd_version == 'stable' %}
         <span title="stable version">
-            <img src="https://img.shields.io/badge/stable_version-{{ version }}-green?style=flat">
+            <img src="https://img.shields.io/badge/✨️_version='stable'-{{ version }}-green?style=flat">
         </span>
     {% else %}
-        <span title="old version (not stable or latest)">
-            <img src="https://img.shields.io/badge/old_version-{{ version }}-red?style=?style=flat">
+        {# Covers builds for any specific versions/commits, including RC's. #}
+        <span title="fixed version (not 'stable' or 'latest')">
+            <img src="https://img.shields.io/badge/🔒_version=fixed-{{ version }}-red?style=?style=flat">
         </span>
     {% endif %}
 {%- else %}
     {# not on rtd #}
     <span title="development version">
-        <img src="https://img.shields.io/badge/dev_version-{{ version }}-blue?style=?style=flat">
+        <img src="https://img.shields.io/badge/✏️_version=dev-{{ version }}-blue?style=?style=flat">
     </span>
 {%- endif %}

--- a/docs/src/_templates/custom_sidebar_logo_version.html
+++ b/docs/src/_templates/custom_sidebar_logo_version.html
@@ -1,21 +1,21 @@
 {% if on_rtd %}
     {% if rtd_version == 'latest' %}
         <span title="latest development version">
-            <img src="https://img.shields.io/badge/⚠️_version='latest'-{{ version }}-gold?style=flat">
+            <img src="https://img.shields.io/badge/⚠️_version_('latest')-{{ version }}-gold?style=flat">
         </span>
     {% elif rtd_version == 'stable' %}
         <span title="stable version">
-            <img src="https://img.shields.io/badge/✨️_version='stable'-{{ version }}-green?style=flat">
+            <img src="https://img.shields.io/badge/✨️_version_('stable')-{{ version }}-green?style=flat">
         </span>
     {% else %}
         {# Covers builds for any specific versions/commits, including RC's. #}
-        <span title="fixed version (not 'stable' or 'latest')">
-            <img src="https://img.shields.io/badge/🔒_version=fixed-{{ version }}-red?style=?style=flat">
+        <span title="archived version (not 'stable' or 'latest')">
+            <img src="https://img.shields.io/badge/🔒_version_(archived)-{{ version }}-red?style=?style=flat">
         </span>
     {% endif %}
 {%- else %}
     {# not on rtd #}
     <span title="development version">
-        <img src="https://img.shields.io/badge/✏️_version=dev-{{ version }}-blue?style=?style=flat">
+        <img src="https://img.shields.io/badge/✏️_version_(dev)-{{ version }}-blue?style=?style=flat">
     </span>
 {%- endif %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -86,9 +86,16 @@ author = "Iris Developers"
 # The version info for the project you're documenting, acts as replacement for
 # |version|, also used in various other places throughout the built documents.
 
-version = get_version("scitools-iris")
-if version.endswith("+dirty"):
-    version = version[: -len("+dirty")]
+if on_rtd:
+    # Get the version string that was generated when RTD installed Iris - RTD
+    #  later modifies Iris' source, causing setuptools_scm to advance the
+    #  version string away from its correct value.
+    from iris._version import __version__
+
+    version = __version__
+else:
+    version = get_version("scitools-iris")
+
 release = version
 autolog(f"Iris Version = {version}")
 autolog(f"Iris Release = {release}")

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import re
 from subprocess import run
 import sys
+from urllib.parse import quote
 import warnings
 
 
@@ -43,9 +44,11 @@ on_rtd = os.environ.get("READTHEDOCS") == "True"
 
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
-# Make rtd_version safe for use in shields.io badges.
-rtd_version = rtd_version.replace("_", "__")
-rtd_version = rtd_version.replace("-", "--")
+if rtd_version is not None:
+    # Make rtd_version safe for use in shields.io badges.
+    rtd_version = rtd_version.replace("_", "__")
+    rtd_version = rtd_version.replace("-", "--")
+    rtd_version = quote(rtd_version)
 
 # branch, tag, external (for pull request builds), or unknown.
 rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE")

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -25,6 +25,7 @@ import ntpath
 import os
 from pathlib import Path
 import re
+from subprocess import run
 import sys
 import warnings
 
@@ -43,10 +44,15 @@ on_rtd = os.environ.get("READTHEDOCS") == "True"
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
 
+# branch, tag, external (for pull request builds), or unknown.
+rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE")
+
 # For local testing purposes we can force being on RTD and the version
 # on_rtd = True           # useful for testing
 # rtd_version = "latest"  # useful for testing
 # rtd_version = "stable"  # useful for testing
+# rtd_version_type = "tag"  # useful for testing
+# rtd_version = "my_branch"   # useful for testing
 
 if on_rtd:
     autolog("Build running on READTHEDOCS server")
@@ -300,6 +306,9 @@ html_theme_options = {
     "show_toc_level": 1,
 }
 
+rev_parse = run(["git", "rev-parse", "--short", "HEAD"], capture_output=True)
+commit_sha = rev_parse.stdout.decode().strip()
+
 html_context = {
     # pydata_theme
     "github_repo": "iris",
@@ -309,9 +318,11 @@ html_context = {
     # custom
     "on_rtd": on_rtd,
     "rtd_version": rtd_version,
+    "rtd_version_type": rtd_version_type,
     "version": version,
     "copyright_years": copyright_years,
     "python_version": build_python_version,
+    "commit_sha": commit_sha,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,6 +43,9 @@ on_rtd = os.environ.get("READTHEDOCS") == "True"
 
 # This is the rtd reference to the version, such as: latest, stable, v3.0.1 etc
 rtd_version = os.environ.get("READTHEDOCS_VERSION")
+# Make rtd_version safe for use in shields.io badges.
+rtd_version = rtd_version.replace("_", "__")
+rtd_version = rtd_version.replace("-", "--")
 
 # branch, tag, external (for pull request builds), or unknown.
 rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE")

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -85,17 +85,7 @@ author = "Iris Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version|, also used in various other places throughout the built documents.
-
-if on_rtd:
-    # Get the version string that was generated when RTD installed Iris - RTD
-    #  later modifies Iris' source, causing setuptools_scm to advance the
-    #  version string away from its correct value.
-    from iris._version import __version__
-
-    version = __version__
-else:
-    version = get_version("scitools-iris")
-
+version = get_version("scitools-iris")
 release = version
 autolog(f"Iris Version = {version}")
 autolog(f"Iris Release = {release}")

--- a/docs/src/whatsnew/3.3.rst
+++ b/docs/src/whatsnew/3.3.rst
@@ -318,6 +318,9 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ and `@wjbenfold`_ (reviewer) used ``pytest`` parametrization to
    streamline the gallery test code. (:pull:`4792`)
 
+#. `@trexfeathers`_ improved settings to better working with
+   ``setuptools_scm``. (:pull:`4925`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "lib/iris/_version.py"
 local_scheme = "dirty-tag"
+version_scheme = "release-branch-semver"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

* Uses the correct `version_scheme` setting for our release branch strategy.
* Properly copes with the conflict between `setuptools_scm` and Read the Docs.
* Changes the RTD version badge to better reflect all fixed-version builds.

[Here's a rendered example for the fictitious `5.6.9` version](https://trexfeathers-iris.readthedocs.io/en/5.6.9/)

Here are the five badges I'm proposing:
- ![latest development version](https://img.shields.io/badge/⚠️_version_('latest')-5.6.10dev49-gold?style=flat) - whenever RTD labels a build as `latest`.
- ![stable version](https://img.shields.io/badge/✨️_version_('stable')-5.6.9-green?style=flat) - whenever RTD labels a build as `stable`.
- ![archived version (not 'stable' or 'latest')](https://img.shields.io/badge/🔒_version_(archived)-5.6.8-red?style=?style=flat) - all other builds of tags, which we typically only use for the release tags.
- ![non-tagged branch commit](https://img.shields.io/badge/🚧_branch-mybranch_@_abcd1234-blue?style=?style=flat) - everything else built by RTD, which is currently just any branches that we mark for building, and in future could include PR's too.
- ![non-tagged development commit](https://img.shields.io/badge/🚧_commit_SHA-abcd1234-blue?style=?style=flat) - all non-RTD builds.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
