### PR TITLE
Remove `setUpClass` from Iris tests.

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -75,7 +75,8 @@ This document explains the changes made to Iris for this release
 💼 Internal
 ===========
 
-#. N/A
+#. `@rcomer`_ removed the obsolete ``setUpClass`` method from Iris testing.
+   (:pull:`4927`)
 
 
 .. comment

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -213,11 +213,6 @@ class IrisTest_nometa(unittest.TestCase):
 
     _assertion_counts = collections.defaultdict(int)
 
-    @classmethod
-    def setUpClass(cls):
-        # Ensure that the CF profile if turned-off for testing.
-        iris.site_configuration["cf_profile"] = None
-
     def _assert_str_same(
         self,
         reference_str,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #4891.

I have tested locally with my `iris-dev` environment, and I do not see any errors or failures without this `setUpClass`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
