### PR TITLE
Support dask arrays in binary operations

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -235,6 +235,7 @@ templates_path = ["_templates"]
 # See https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 intersphinx_mapping = {
     "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    "dask": ("https://docs.dask.org/en/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -35,6 +35,9 @@ This document explains the changes made to Iris for this release
    Also with significant input from `@fnattino`_.
    (:pull:`5191`)
 
+#. `@rcomer`_ tweaked binary operations so that dask arrays may safely be passed
+   to arithmetic operations and :func:`~iris.util.mask_cube`. (:pull:`4929`)
+
 
 🐛 Bugs Fixed
 =============

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -883,7 +883,9 @@ def _binary_op_common(
         rhs = other.core_data()
     else:
         # The rhs must be an array.
-        if not iris._lazy_data.is_lazy_data(other):
+        if iris._lazy_data.is_lazy_data(other):
+            rhs = other
+        else:
             rhs = np.asanyarray(other)
 
     def unary_func(lhs):

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -883,7 +883,8 @@ def _binary_op_common(
         rhs = other.core_data()
     else:
         # The rhs must be an array.
-        rhs = np.asanyarray(other)
+        if not iris._lazy_data.is_lazy_data(other):
+            rhs = np.asanyarray(other)
 
     def unary_func(lhs):
         data = operation_function(lhs, rhs)

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -225,33 +225,35 @@ def _assert_is_cube(cube):
 @_lenient_client(services=SERVICES)
 def add(cube, other, dim=None, in_place=False):
     """
-    Calculate the sum of two cubes, or the sum of a cube and a
-    coordinate or scalar value.
+    Calculate the sum of two cubes, or the sum of a cube and a coordinate or
+    array or scalar value.
 
-    When summing two cubes, they must both have the same coordinate
-    systems & data resolution.
+    When summing two cubes, they must both have the same coordinate systems and
+    data resolution.
 
-    When adding a coordinate to a cube, they must both share the same
-    number of elements along a shared axis.
+    When adding a coordinate to a cube, they must both share the same number of
+    elements along a shared axis.
 
-    Args:
+    Parameters
+    ----------
 
-    * cube:
-        An instance of :class:`iris.cube.Cube`.
-    * other:
-        An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
+    cube : iris.cube.Cube
+        First operand to add.
 
-    Kwargs:
+    other: iris.cube.Cube, iris.coords.Coord, number, numpy.ndarray or dask.array.Array
+        Second operand to add.
 
-    * dim:
-        If supplying a coord with no match on the cube, you must supply
-        the dimension to process.
-    * in_place:
-        Whether to create a new Cube, or alter the given "cube".
+    dim : int, optional
+        If `other` is a coord which does not exist on the cube, specify the
+        dimension to which it should be mapped.
 
-    Returns:
-        An instance of :class:`iris.cube.Cube`.
+    in_place : bool, default=False
+        If `True`, alters the input cube.  Otherwise a new cube is created.
+
+    Returns
+    -------
+
+    iris.cube.Cube
 
     Notes
     ------
@@ -280,32 +282,34 @@ def add(cube, other, dim=None, in_place=False):
 def subtract(cube, other, dim=None, in_place=False):
     """
     Calculate the difference between two cubes, or the difference between
-    a cube and a coordinate or scalar value.
+    a cube and a coordinate or array or scalar value.
 
-    When subtracting two cubes, they must both have the same coordinate
-    systems & data resolution.
+    When differencing two cubes, they must both have the same coordinate systems
+    and data resolution.
 
-    When subtracting a coordinate to a cube, they must both share the
-    same number of elements along a shared axis.
+    When subtracting a coordinate from a cube, they must both share the same
+    number of elements along a shared axis.
 
-    Args:
+    Parameters
+    ----------
 
-    * cube:
-        An instance of :class:`iris.cube.Cube`.
-    * other:
-        An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
+    cube : iris.cube.Cube
+        Cube from which to subtract.
 
-    Kwargs:
+    other: iris.cube.Cube, iris.coords.Coord, number, numpy.ndarray or dask.array.Array
+        Object to subtract from the cube.
 
-    * dim:
-        If supplying a coord with no match on the cube, you must supply
-        the dimension to process.
-    * in_place:
-        Whether to create a new Cube, or alter the given "cube".
+    dim : int, optional
+        If `other` is a coord which does not exist on the cube, specify the
+        dimension to which it should be mapped.
 
-    Returns:
-        An instance of :class:`iris.cube.Cube`.
+    in_place : bool, default=False
+        If `True`, alters the input cube.  Otherwise a new cube is created.
+
+    Returns
+    -------
+
+    iris.cube.Cube
 
     Notes
     ------
@@ -384,24 +388,35 @@ def _add_subtract_common(
 @_lenient_client(services=SERVICES)
 def multiply(cube, other, dim=None, in_place=False):
     """
-    Calculate the product of a cube and another cube or coordinate.
+    Calculate the product of two cubes, or the product of a cube and a coordinate
+    or array or scalar value.
 
-    Args:
+    When multiplying two cubes, they must both have the same coordinate systems
+    and data resolution.
 
-    * cube:
-        An instance of :class:`iris.cube.Cube`.
-    * other:
-        An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
+    When mulplying a cube by a coordinate, they must both share the same number
+    of elements along a shared axis.
 
-    Kwargs:
+    Parameters
+    ----------
 
-    * dim:
-        If supplying a coord with no match on the cube, you must supply
-        the dimension to process.
+    cube : iris.cube.Cube
+        First operand to multiply.
 
-    Returns:
-        An instance of :class:`iris.cube.Cube`.
+    other: iris.cube.Cube, iris.coords.Coord, number, numpy.ndarray or dask.array.Array
+        Second operand to multiply.
+
+    dim : int, optional
+        If `other` is a coord which does not exist on the cube, specify the
+        dimension to which it should be mapped.
+
+    in_place : bool, default=False
+        If `True`, alters the input cube.  Otherwise a new cube is created.
+
+    Returns
+    -------
+
+    iris.cube.Cube
 
     Notes
     ------
@@ -461,24 +476,35 @@ def _inplace_common_checks(cube, other, math_op):
 @_lenient_client(services=SERVICES)
 def divide(cube, other, dim=None, in_place=False):
     """
-    Calculate the division of a cube by a cube or coordinate.
+    Calculate the ratio of two cubes, or the ratio of a cube and a coordinate
+    or array or scalar value.
 
-    Args:
+    When dividing a cube by another cube, they must both have the same coordinate
+    systems and data resolution.
 
-    * cube:
-        An instance of :class:`iris.cube.Cube`.
-    * other:
-        An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
+    When dividing a cube by a coordinate, they must both share the same number
+    of elements along a shared axis.
 
-    Kwargs:
+    Parameters
+    ----------
 
-    * dim:
-        If supplying a coord with no match on the cube, you must supply
-        the dimension to process.
+    cube : iris.cube.Cube
+        Numerator.
 
-    Returns:
-        An instance of :class:`iris.cube.Cube`.
+    other: iris.cube.Cube, iris.coords.Coord, number, numpy.ndarray or dask.array.Array
+        Denominator.
+
+    dim : int, optional
+        If `other` is a coord which does not exist on the cube, specify the
+        dimension to which it should be mapped.
+
+    in_place : bool, default=False
+        If `True`, alters the input cube.  Otherwise a new cube is created.
+
+    Returns
+    -------
+
+    iris.cube.Cube
 
     Notes
     ------

--- a/lib/iris/analysis/maths.py
+++ b/lib/iris/analysis/maths.py
@@ -240,7 +240,7 @@ def add(cube, other, dim=None, in_place=False):
         An instance of :class:`iris.cube.Cube`.
     * other:
         An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray`.
+        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
 
     Kwargs:
 
@@ -294,7 +294,7 @@ def subtract(cube, other, dim=None, in_place=False):
         An instance of :class:`iris.cube.Cube`.
     * other:
         An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray`.
+        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
 
     Kwargs:
 
@@ -348,8 +348,8 @@ def _add_subtract_common(
     operation_name       - the public name of the operation (e.g. 'divide')
     cube                 - the cube whose data is used as the first argument
                            to `operation_function`
-    other                - the cube, coord, ndarray or number whose data is
-                           used as the second argument
+    other                - the cube, coord, ndarray, dask array or number whose
+                           data is used as the second argument
     new_dtype            - the expected dtype of the output. Used in the
                            case of scalar masked arrays
     dim                  - dimension along which to apply `other` if it's a
@@ -392,7 +392,7 @@ def multiply(cube, other, dim=None, in_place=False):
         An instance of :class:`iris.cube.Cube`.
     * other:
         An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray`.
+        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
 
     Kwargs:
 
@@ -469,7 +469,7 @@ def divide(cube, other, dim=None, in_place=False):
         An instance of :class:`iris.cube.Cube`.
     * other:
         An instance of :class:`iris.cube.Cube` or :class:`iris.coords.Coord`,
-        or a number or :class:`numpy.ndarray`.
+        or a number or :class:`numpy.ndarray` or :class:`dask.array.Array`.
 
     Kwargs:
 
@@ -842,8 +842,8 @@ def _binary_op_common(
     operation_name       - the public name of the operation (e.g. 'divide')
     cube                 - the cube whose data is used as the first argument
                            to `operation_function`
-    other                - the cube, coord, ndarray or number whose data is
-                           used as the second argument
+    other                - the cube, coord, ndarray, dask array or number whose
+                           data is used as the second argument
     new_dtype            - the expected dtype of the output. Used in the
                            case of scalar masked arrays
     new_unit             - unit for the resulting quantity
@@ -1197,7 +1197,7 @@ class IFunc:
         Kwargs:
 
         * other
-            A cube, coord, ndarray or number whose data is used as the
+            A cube, coord, ndarray, dask array or number whose data is used as the
             second argument to the data function.
 
         * new_name:

--- a/lib/iris/tests/unit/analysis/maths/test__arith__dask_array.py
+++ b/lib/iris/tests/unit/analysis/maths/test__arith__dask_array.py
@@ -1,0 +1,29 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for cube arithmetic with dask arrays."""
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests  # isort:skip
+
+from unittest import mock
+
+import dask
+import dask.array as da
+
+import iris.cube
+from iris.tests.unit.analysis.maths import MathsAddOperationMixin
+
+
+class TestArithDask(tests.IrisTest, MathsAddOperationMixin):
+    @mock.patch.object(dask.base, "compute", wraps=dask.base.compute)
+    def test_compute_not_called(self, mocked_compute):
+        # No data should be realised when adding a cube and a dask array.
+        cube = iris.cube.Cube(da.arange(4))
+        array = da.ones(4)
+
+        self.data_op(cube, array)
+        mocked_compute.assert_not_called()

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -1977,9 +1977,9 @@ def mask_cube(cube, points_to_mask, in_place=False, dim=None):
     """
     Masks any cells in the cube's data array which correspond to cells marked
     ``True`` (or non zero) in ``points_to_mask``.  ``points_to_mask`` may be
-    specified as a :class:`numpy.ndarray`, :class:`iris.coords.Coord` or
-    :class:`iris.cube.Cube`, following the same broadcasting approach as cube
-    arithmetic (see :ref:`cube maths`).
+    specified as a :class:`numpy.ndarray`, :class:`dask.array.Array`,
+    :class:`iris.coords.Coord` or :class:`iris.cube.Cube`, following the same
+    broadcasting approach as cube arithmetic (see :ref:`cube maths`).
 
     Parameters
     ----------
@@ -1987,7 +1987,7 @@ def mask_cube(cube, points_to_mask, in_place=False, dim=None):
     cube : iris.cube.Cube
         Cube containing data that requires masking.
 
-    points_to_mask : numpy.ndarray, iris.coords.Coord or iris.cube.Cube
+    points_to_mask : numpy.ndarray, dask.array.Array, iris.coords.Coord or iris.cube.Cube
         Specifies booleans (or ones and zeros) indicating which points will be masked.
 
     in_place : bool, default=False


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Currently, the various arithmetic functions state that their second operand may be a cube, a coordinate, a numpy array or a number.  There is nothing to stop you passing a dask array as the second operand, but it will be silently realised by the `numpy.asanyarray` call, which seems unhelpful to me.  I think it would be good to explicitly support passing a dask array, though there may be a better way to do it than my current change.

~In draft for now because a bunch of docstrings would need modifying and some tests adding, but I wanted to see if there is agreement in principle first.~

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
