### PR TITLE
Fix cube repr for scalar anc_var and cell measures

### DIFF
--- a/lib/iris/_representation/cube_printout.py
+++ b/lib/iris/_representation/cube_printout.py
@@ -260,6 +260,10 @@ class CubePrinter:
                 elif title in ("attributes:", "cell methods:", "mesh:"):
                     for title, value in zip(sect.names, sect.values):
                         add_scalar_row(title, value)
+                elif title == "scalar ancillary variables:":
+                    # These are just strings: nothing in the 'value' column.
+                    for name in sect.contents:
+                        add_scalar_row(name)
                 elif title == "scalar cell measures:":
                     # These are just strings: nothing in the 'value' column.
                     for name in sect.contents:

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -219,6 +219,12 @@ class ScalarCellMeasureSection(Section):
         self.contents = [cm.name() for cm in cell_measures]
 
 
+class ScalarAncillaryVariableSection(Section):
+    def __init__(self, title, ancillary_variables):
+        self.title = title
+        self.contents = [av.name() for av in ancillary_variables]
+
+
 class AttributeSection(Section):
     def __init__(self, title, attributes):
         self.title = title
@@ -274,7 +280,7 @@ class CubeSummary:
 
     """
 
-    def __init__(self, cube, shorten=False, name_padding=35):
+    def __init__(self, cube, name_padding=35):
         self.header = FullHeader(cube, name_padding)
 
         # Cache the derived coords so we can rely on consistent
@@ -314,13 +320,23 @@ class CubeSummary:
             if id(coord) not in scalar_coord_ids
         ]
 
-        # cell measures
-        vector_cell_measures = [
-            cm for cm in cube.cell_measures() if cm.shape != (1,)
-        ]
-
         # Ancillary Variables
-        vector_ancillary_variables = [av for av in cube.ancillary_variables()]
+        vector_ancillary_variables = []
+        scalar_ancillary_variables = []
+        for av, av_dims in cube._ancillary_variables_and_dims:
+            if av_dims:
+                vector_ancillary_variables.append(av)
+            else:
+                scalar_ancillary_variables.append(av)
+
+        # Cell Measures
+        vector_cell_measures = []
+        scalar_cell_measures = []
+        for cm, cm_dims in cube._cell_measures_and_dims:
+            if cm_dims:
+                vector_cell_measures.append(cm)
+            else:
+                scalar_cell_measures.append(cm)
 
         # Sort scalar coordinates by name.
         scalar_coords.sort(key=lambda coord: coord.name())
@@ -334,9 +350,6 @@ class CubeSummary:
         vector_derived_coords.sort(
             key=lambda coord: (cube.coord_dims(coord), coord.name())
         )
-        scalar_cell_measures = [
-            cm for cm in cube.cell_measures() if cm.shape == (1,)
-        ]
 
         self.vector_sections = {}
 
@@ -363,6 +376,11 @@ class CubeSummary:
 
         add_scalar_section(
             ScalarCoordSection, "Scalar coordinates:", cube, scalar_coords
+        )
+        add_scalar_section(
+            ScalarAncillaryVariableSection,
+            "Scalar ancillary variables:",
+            scalar_ancillary_variables,
         )
         add_scalar_section(
             ScalarCellMeasureSection,

--- a/lib/iris/tests/unit/representation/cube_printout/test_CubePrintout.py
+++ b/lib/iris/tests/unit/representation/cube_printout/test_CubePrintout.py
@@ -349,6 +349,20 @@ class TestCubePrintout__to_string(tests.IrisTest):
         ]
         self.assertEqual(rep, expected)
 
+    def test_section_vector_ancils_length_1(self):
+        # Check ancillary variables that map to a cube dimension of length 1
+        # are not interpreted as scalar ancillary variables.
+        cube = Cube(np.zeros((1, 3)), long_name="name", units=1)
+        cube.add_ancillary_variable(AncillaryVariable([0], long_name="av1"), 0)
+
+        rep = cube_replines(cube)
+        expected = [
+            "name / (1)                          (-- : 1; -- : 3)",
+            "    Ancillary variables:",
+            "        av1                             x       -",
+        ]
+        self.assertEqual(rep, expected)
+
     def test_section_vector_cell_measures(self):
         cube = Cube(np.zeros((2, 3)), long_name="name", units=1)
         cube.add_cell_measure(CellMeasure([0, 1, 2], long_name="cm"), 1)
@@ -356,6 +370,20 @@ class TestCubePrintout__to_string(tests.IrisTest):
         rep = cube_replines(cube)
         expected = [
             "name / (1)                          (-- : 2; -- : 3)",
+            "    Cell measures:",
+            "        cm                              -       x",
+        ]
+        self.assertEqual(rep, expected)
+
+    def test_section_vector_cell_measures_length_1(self):
+        # Check cell measures that map to a cube dimension of length 1 are not
+        # interpreted as scalar cell measures.
+        cube = Cube(np.zeros((2, 1)), long_name="name", units=1)
+        cube.add_cell_measure(CellMeasure([0], long_name="cm"), 1)
+
+        rep = cube_replines(cube)
+        expected = [
+            "name / (1)                          (-- : 2; -- : 1)",
             "    Cell measures:",
             "        cm                              -       x",
         ]
@@ -424,8 +452,8 @@ class TestCubePrintout__to_string(tests.IrisTest):
         rep = cube_replines(cube)
         expected = [
             "name / (1)                          (-- : 2; -- : 3)",
-            "    Ancillary variables:",
-            "        av                              -       -",
+            "    Scalar ancillary variables:",
+            "        av",
         ]
         self.assertEqual(rep, expected)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
I noticed that the cube printout wasn't handling scalar ancillary variables and cell measures correctly.

* There wasn't a section for scalar ancillary variables, so I've added that now
* If a cube had a dimension of length 1, and a cell measure that maps to this dimension, it was adding it to the "Scalar cell measures". 

Example to reproduce the second bullet point above:
```
cube = Cube(np.zeros((2, 1)), long_name="name", units=1)
cube.add_cell_measure(CellMeasure([0], long_name="cm"), 1)
```
print as

```
print(cube)
name / (1)                          (-- : 2; -- : 1)
    Scalar cell measures:
        cm
```

but it should print as

```
print(cube)
name / (1)                          (-- : 2; -- : 1)
    Scalar cell measures:
        cm                                  -        x               
    
```
---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
