### PR TITLE
Remove deprecated 'python setup.py test' support

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -88,6 +88,10 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ removed the obsolete ``setUpClass`` method from Iris testing.
    (:pull:`4927`)
 
+#. `@bjlittle`_ and `@lbdreyer`_ (reviewer) removed support for
+   ``python setup.py test``, which is a deprecated approach to executing
+   package tests, see `pypa/setuptools#1684`_. (:pull:`4948`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -97,10 +101,9 @@ This document explains the changes made to Iris for this release
 
 
 
-
 .. comment
     Whatsnew resources in alphabetical order:
 
-
 .. _NEP13: https://numpy.org/neps/nep-0013-ufunc-overrides.html
 .. _NEP18: https://numpy.org/neps/nep-0018-array-function-protocol.html
+.. _pypa/setuptools#1684: https://github.com/pypa/setuptools/issues/1684

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import os
 from shutil import copyfile
 import sys
@@ -6,30 +5,6 @@ import sys
 from setuptools import Command, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop as develop_cmd
-
-
-@contextmanager
-def temporary_path(directory):
-    """
-    Context manager that adds and subsequently removes the given directory
-    to sys.path
-
-    """
-    sys.path.insert(0, directory)
-    try:
-        yield
-    finally:
-        del sys.path[0]
-
-
-# Add full path so Python doesn't load any __init__.py in the intervening
-# directories, thereby saving setup.py from additional dependencies.
-with temporary_path("lib/iris/tests/runner"):
-    from _runner import TestRunner  # noqa:
-
-
-class SetupTestRunner(TestRunner, Command):
-    pass
 
 
 class BaseCommand(Command):
@@ -108,7 +83,6 @@ def custom_cmd(command_to_override, functions, help_doc=""):
 
 
 custom_commands = {
-    "test": SetupTestRunner,
     "develop": custom_cmd(develop_cmd, [build_std_names]),
     "build_py": custom_cmd(build_py, [build_std_names, copy_copyright]),
     "std_names": custom_cmd(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR performs some minor internal hygiene to purge support for the now deprecated pattern of invoking the `iris` tests with `python setup.py test`.

As a reference, see this `pytest` "[Do not run via setuptools](https://docs.pytest.org/en/latest/explanation/goodpractices.html#do-not-run-via-setuptools)" recommended Good Integration Practices.

Thankfully, there doesn't seem to be any references to this deprecated practice within our documentation, so there's no connective tissue to purge there :+1: 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
