### PR TITLE
purge unused setup.py clean_source custom command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,20 +48,6 @@ class BaseCommand(Command):
         pass
 
 
-class CleanSource(BaseCommand):
-    description = "clean orphaned pyc/pyo files from the source directory"
-
-    def run(self):
-        for root_path, dir_names, file_names in os.walk("lib"):
-            for file_name in file_names:
-                if file_name.endswith("pyc") or file_name.endswith("pyo"):
-                    compiled_path = os.path.join(root_path, file_name)
-                    source_path = compiled_path[:-1]
-                    if not os.path.exists(source_path):
-                        print("Cleaning", compiled_path)
-                        os.remove(compiled_path)
-
-
 def copy_copyright(cmd, directory):
     # Copy the COPYRIGHT information into the package root
     iris_build_dir = os.path.join(directory, "iris")
@@ -116,7 +102,6 @@ custom_commands = {
         [build_std_names],
         help_doc="generate CF standard name module",
     ),
-    "clean_source": CleanSource,
 }
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR performs more `setup.py` hygiene by removing the archaic and redundant `clean_source` custom command.

IMHO it's simply not necessary, and to my knowledge has never been used as part of our workflow, ever. Even as a developer convenience I've simply never used it. 

Sounds harsh, but AFAIK this is classic deadwood infrastructure code that can be purged.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
