### PR TITLE
purge unnecessary setup.py copy_copyright function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-from shutil import copyfile
 import sys
 
 from setuptools import Command, setup
@@ -21,13 +20,6 @@ class BaseCommand(Command):
 
     def run(self):
         pass
-
-
-def copy_copyright(cmd, directory):
-    # Copy the COPYRIGHT information into the package root
-    iris_build_dir = os.path.join(directory, "iris")
-    for fname in ["COPYING", "COPYING.LESSER"]:
-        copyfile(fname, os.path.join(iris_build_dir, fname))
 
 
 def build_std_names(cmd, directory):
@@ -70,7 +62,7 @@ def custom_cmd(command_to_override, functions, help_doc=""):
 
 custom_commands = {
     "develop": custom_cmd(develop_cmd, [build_std_names]),
-    "build_py": custom_cmd(build_py, [build_std_names, copy_copyright]),
+    "build_py": custom_cmd(build_py, [build_std_names]),
     "std_names": custom_cmd(
         BaseCommand,
         [build_std_names],


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR performs yet more `setup.py` hygiene by removing the `copy_copyright` function, which copies the `COPYING` and `COPYING.LESSER` license files down into the `iris` package source root when building the `iris` distribution.

IMHO this is unnecessary, and I don't know of any other open source packages that do this.

The license files are already packaged in our PyPI `sdist` and binary `wheels` metadata, and also as part of our conda-forge `iris` conda package tarball, as per all other open source packages which follow recommended package distribution good practice.

Additionally bundling the license files within the `iris` package root source seems unnecessary.

Reference: This change was introduced in #2891 (with no explanation/reason) and first became part of `iris` 2.0.0. To be fair, I reviewed and merged that PR, and didn't challenge it's introduction... now I am :wink: 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
