### PR TITLE
fix setup.py std_names building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,9 @@ from setuptools.command.develop import develop
 
 
 class BaseCommand(Command):
-    """A valid no-op command for setuptools & distutils."""
+    """A minimal no-op setuptools command."""
 
     description: str = "A no-op command."
-    editable_mode: bool = True
     user_options: list = []
 
     def initialize_options(self):
@@ -23,32 +22,40 @@ class BaseCommand(Command):
         pass
 
 
-class DevelopCommand(develop):
-    editable_mode: bool = True
-
-
-def build_std_names(cmd, directory):
-    # Call out to tools/generate_std_names.py to build std_names module.
-
-    script_path = os.path.join("tools", "generate_std_names.py")
-    xml_path = os.path.join("etc", "cf-standard-name-table.xml")
-    module_path = os.path.join(directory, "iris", "std_names.py")
-    args = (sys.executable, script_path, xml_path, module_path)
-    cmd.spawn(args)
-
-
-def custom_cmd(klass, functions, help=""):
+def custom_command(cmd, help=""):
     """
-    Allows command specialisation to include calls to the given functions.
+    Factory function to generate a custom command that adds additional
+    behaviour to build the CF standard names module.
 
     """
 
-    class CustomCommand(klass):
-        description = help or klass.description
+    class CustomCommand(cmd):
+        description = help or cmd.description
+
+        def _build_std_names(self, directory):
+            # Call out to tools/generate_std_names.py to build std_names module.
+
+            script_path = os.path.join("tools", "generate_std_names.py")
+            xml_path = os.path.join("etc", "cf-standard-name-table.xml")
+            module_path = os.path.join(directory, "iris", "std_names.py")
+            args = (sys.executable, script_path, xml_path, module_path)
+            self.spawn(args)
+
+        def finalize_options(self):
+            # Execute the parent "cmd" class method.
+            cmd.finalize_options(self)
+
+            if (
+                not hasattr(self, "editable_mode")
+                or self.editable_mode is None
+            ):
+                # Default to editable i.e., applicable to "std_names" and
+                # and "develop" commands.
+                self.editable_mode = True
 
         def run(self):
-            # Run the original command to perform associated behaviour.
-            klass.run(self)
+            # Execute the parent "cmd" class method.
+            cmd.run(self)
 
             # Determine the target root directory
             if self.editable_mode:
@@ -62,20 +69,17 @@ def custom_cmd(klass, functions, help=""):
 
             print(f"\n[Running {msg}]")
 
-            # Run the custom command functions.
-            for func in functions:
-                func(self, target)
+            # Build the CF standard names.
+            self._build_std_names(target)
 
     return CustomCommand
 
 
 custom_commands = {
-    "develop": custom_cmd(DevelopCommand, [build_std_names]),
-    "build_py": custom_cmd(build_py, [build_std_names]),
-    "std_names": custom_cmd(
-        BaseCommand,
-        [build_std_names],
-        help="generate CF standard names module",
+    "develop": custom_command(develop),
+    "build_py": custom_command(build_py),
+    "std_names": custom_command(
+        BaseCommand, help="generate CF standard names"
     ),
 }
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds the `editable_mode` attribute (defaulting to `True`) to the [setuptools.command.develop.develop](https://github.com/pypa/setuptools/blob/main/setuptools/command/develop.py#L14) command subclass and custom `setup.BaseCommand` command class.

Closes #4951


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
