### PR TITLE
Speed up Cube.subset/Coord.intersect

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -76,6 +76,10 @@ This document explains the changes made to Iris for this release
    :meth:`iris.cube.Cube.subset`, and :meth:`iris.coords.Coord.intersect`.
    (:pull:`4969`)
 
+#. `@bouweandela`_ improved the speed of :meth:`iris.cube.Cube.subset` /
+   :meth:`iris.coords.Coord.intersect`.
+   (:pull:`4955`)
+
 🔥 Deprecations
 ===============
 

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -169,9 +169,35 @@ class TestCells(tests.IrisTest):
         self.assertTrue(self.e < 2)
 
     def test_cell_cell_cmp(self):
+        self.e = iris.coords.Cell(1)
+        self.f = iris.coords.Cell(1)
+
+        self.assertTrue(self.e == self.f)
+        self.assertEqual(hash(self.e), hash(self.f))
+
+        self.e = iris.coords.Cell(1)
+        self.f = iris.coords.Cell(1, [0, 2])
+
+        self.assertFalse(self.e == self.f)
+        self.assertNotEqual(hash(self.e), hash(self.f))
+
+        self.e = iris.coords.Cell(1, [0, 2])
+        self.f = iris.coords.Cell(1, [0, 2])
+
+        self.assertTrue(self.e == self.f)
+        self.assertEqual(hash(self.e), hash(self.f))
+
+        self.e = iris.coords.Cell(1, [0, 2])
+        self.f = iris.coords.Cell(1, [2, 0])
+
+        self.assertTrue(self.e == self.f)
+        self.assertEqual(hash(self.e), hash(self.f))
+
         self.e = iris.coords.Cell(0.7, [1.1, 1.9])
         self.f = iris.coords.Cell(0.8, [1.1, 1.9])
 
+        self.assertFalse(self.e == self.f)
+        self.assertNotEqual(hash(self.e), hash(self.f))
         self.assertFalse(self.e > self.f)
         self.assertTrue(self.e <= self.f)
         self.assertTrue(self.f >= self.e)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This speeds up `Cube.subset` / `Coord.intersect` by using a `dict` lookup instead of `list.index` to find the indices of the coordinate that should be used for subsetting the cube.

Here is some benchmark code:

```python
import iris.cube
import iris.coords
import numpy as np

lon = iris.coords.DimCoord(np.arange(0, 360, 0.5, dtype=np.float64), standard_name='longitude')
cube = iris.cube.Cube(np.arange(720, dtype=np.float32))
cube.add_dim_coord(lon, 0)
sublon = lon[(lon.points > 60) & (lon.points < 300)]

%timeit cube.subset(sublon)
```

The current `main` branch result is:
```
93.9 ms ± 4.51 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
and the result of running that code with this branch is:
```
13.5 ms ± 1.54 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
