### PR TITLE
Add new Q+A issue, update author email

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,3 +4,6 @@ contact_links:
   -  name: 💬 Iris GitHub Discussions
      url: https://github.com/SciTools/iris/discussions
      about: Engage with the Iris community to discuss your issue
+  -  name: ❓ Usage Question
+     url: https://github.com/SciTools/iris/discussions/categories/q-a
+     About: Raise a question about how to use Iris in the Q&A section of Discussions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 author = SciTools Developers
-author_email = scitools-iris-dev@googlegroups.com
+author_email = scitools.pub@gmail.com
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Science/Research


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Part of #3860 

This is required to retire the google groups. Instead of raising questions about how to use iris on the [scitools-iris google group](https://groups.google.com/g/scitools-iris), we will instead point people at the Q&A discussions.

I did a search through the repo and couldn't find any other mention of google groups, other than the mention that it is a legacy support forum

I have also had to update the author name to the newly created scitools.pub@gmail.com

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
