### PR TITLE
Speed up operations that use the `Coord.cells` method for time coordinates

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -71,7 +71,7 @@ This document explains the changes made to Iris for this release
    :obj:`~iris.analysis.SUM`, :obj:`~iris.analysis.COUNT` and
    :obj:`~iris.analysis.PROPORTION` on real data. (:pull:`4905`)
 
-#. `@bouweandela` made :meth:`iris.coords.Coord.cells` faster for time
+#. `@bouweandela`_ made :meth:`iris.coords.Coord.cells` faster for time
    coordinates. This also affects :meth:`iris.cube.Cube.extract`,
    :meth:`iris.cube.Cube.subset`, and :meth:`iris.coords.Coord.intersect`.
    (:pull:`4969`)

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -50,7 +50,7 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ and `@lbdreyer`_ (reviewer) fixed the building of the CF
    Standard Names module ``iris.std_names`` for the ``setup.py`` commands
    ``develop`` and ``std_names``. (:issue:`4951`, :pull:`4952`)
-   
+
 #. `@lbdreyer`_ and `@pp-mo`_ (reviewer) fixed the cube print out such that
    scalar ancillary variables are displayed in a dedicated section rather than
    being added to the vector ancillary variables section. Further, ancillary
@@ -71,6 +71,10 @@ This document explains the changes made to Iris for this release
    :obj:`~iris.analysis.SUM`, :obj:`~iris.analysis.COUNT` and
    :obj:`~iris.analysis.PROPORTION` on real data. (:pull:`4905`)
 
+#. `@bouweandela` made :meth:`iris.coords.Coord.cells` faster for time
+   coordinates. This also affects :meth:`iris.cube.Cube.extract`,
+   :meth:`iris.cube.Cube.subset`, and :meth:`iris.coords.Coord.intersect`.
+   (:pull:`4969`)
 
 🔥 Deprecations
 ===============

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1898,12 +1898,12 @@ class Coord(_DimensionalMetadata):
         if self.ndim != 1:
             raise iris.exceptions.CoordinateMultiDimError(self)
 
-        points = self.core_points()
-        bounds = self.core_bounds()
+        points = self.points
+        bounds = self.bounds
         if self.units.is_time_reference():
-            points = self.units.num2date(self.core_points())
+            points = self.units.num2date(points)
             if self.has_bounds():
-                bounds = self.units.num2date(self.core_bounds())
+                bounds = self.units.num2date(bounds)
 
         if self.has_bounds():
             for point, bound in zip(points, bounds):

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1895,7 +1895,22 @@ class Coord(_DimensionalMetadata):
               ...
 
         """
-        return _CellIterator(self)
+        if self.ndim != 1:
+            raise iris.exceptions.CoordinateMultiDimError(self)
+
+        points = self.core_points()
+        bounds = self.core_bounds()
+        if self.units.is_time_reference():
+            points = self.units.num2date(self.core_points())
+            if self.has_bounds():
+                bounds = self.units.num2date(self.core_bounds())
+
+        if self.has_bounds():
+            for point, bound in zip(points, bounds):
+                yield Cell(point, bound)
+        else:
+            for point in points:
+                yield Cell(point)
 
     def _sanity_check_bounds(self):
         if self.ndim == 1:
@@ -3135,22 +3150,6 @@ class CellMethod(iris.util._OrderedHashable):
                 cellMethod_xml_element.appendChild(coord_xml_element)
 
         return cellMethod_xml_element
-
-
-# See Coord.cells() for the description/context.
-class _CellIterator(Iterator):
-    def __init__(self, coord):
-        self._coord = coord
-        if coord.ndim != 1:
-            raise iris.exceptions.CoordinateMultiDimError(coord)
-        self._indices = iter(range(coord.shape[0]))
-
-    def __next__(self):
-        # NB. When self._indices runs out it will raise StopIteration for us.
-        i = next(self._indices)
-        return self._coord.cell(i)
-
-    next = __next__
 
 
 # See ExplicitCoord._group() for the description/context.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This speeds up functions that make use of the `Coord.cells` method to generate many cells describing a time coordinate. This affects for example `Cube.extract`, `Cube.subset`, and `Coord.intersection`.

Here is a script that demonstrates this:

```python
import cf_units
import iris.cube
import iris.coords
import iris.time
import numpy as np

time_units = cf_units.Unit('days since 1850-01-01', calendar='standard')
time = iris.coords.DimCoord(np.arange(10000, dtype=np.float64), standard_name='time', units=time_units)
cube = iris.cube.Cube(np.arange(10000, dtype=np.float32))
cube.add_dim_coord(time, 0)
pdt1 = iris.time.PartialDateTime(year=1852)
pdt2 = iris.time.PartialDateTime(year=1854)
constraint = iris.Constraint(time=lambda cell: pdt1 <= cell.point < pdt2)

%timeit cube.extract(constraint)
```

Before:
```
1.4 s ± 15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
36.7 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Note that the changes in this pull request do slow down the case where only a few cells are actually generated:

Before:
```python
%timeit time.cells()
```
```
1.24 µs ± 20.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
```python
%timeit next(time.cells())
```
```
140 µs ± 1.07 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
After:
```python
%timeit time.cells()
```
```
216 ns ± 7.68 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
```python
%timeit next(time.cells())
```
```
16.8 ms ± 395 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
but you can still use `Coord.cell` if you need just a few cells.

Closes #4957.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
