### PR TITLE
Simpler/faster data aggregation code in `aggregated_by`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -51,8 +51,7 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. N/A
-
+#. `@rcomer`_ made :meth:`~iris.cube.Cube.aggregated_by` faster. (:pull:`4970`)
 
 🔥 Deprecations
 ===============

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4240,6 +4240,11 @@ x            -              -
             aggregateby_weights = None
 
         aggregateby_data = stack(result, axis=dimension_to_groupby)
+        # Ensure plain ndarray is output if plain ndarray was input.
+        if ma.isMaskedArray(aggregateby_data) and not ma.isMaskedArray(
+            input_data
+        ):
+            aggregateby_data = ma.getdata(aggregateby_data)
 
         # Add the aggregation meta data to the aggregate-by cube.
         aggregator.update_metadata(

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4178,7 +4178,7 @@ x            -              -
         data_shape = list(self.shape + aggregator.aggregate_shape(**kwargs))
         data_shape[dimension_to_groupby] = len(groupby)
 
-        # Choose appropriate data and functions.
+        # Choose appropriate data and functions for data aggregation.
         if aggregator.lazy_func is not None and self.has_lazy_data():
             stack = da.stack
             input_data = self.lazy_data()

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4178,98 +4178,68 @@ x            -              -
         data_shape = list(self.shape + aggregator.aggregate_shape(**kwargs))
         data_shape[dimension_to_groupby] = len(groupby)
 
-        # Aggregate the group-by data.
+        # Choose appropriate data and functions.
         if aggregator.lazy_func is not None and self.has_lazy_data():
-            front_slice = (slice(None, None),) * dimension_to_groupby
-            back_slice = (slice(None, None),) * (
-                len(data_shape) - dimension_to_groupby - 1
-            )
-
-            # Create cube and weights slices
-            groupby_subcubes = map(
-                lambda groupby_slice: self[
-                    front_slice + (groupby_slice,) + back_slice
-                ].lazy_data(),
-                groupby.group(),
-            )
-            if weights is not None:
-                groupby_subweights = map(
-                    lambda groupby_slice: weights[
-                        front_slice + (groupby_slice,) + back_slice
-                    ],
-                    groupby.group(),
-                )
-            else:
-                groupby_subweights = (None for _ in range(len(groupby)))
-
-            agg = iris.analysis.create_weighted_aggregator_fn(
-                aggregator.lazy_aggregate, axis=dimension_to_groupby, **kwargs
-            )
-            result = list(map(agg, groupby_subcubes, groupby_subweights))
-
-            # If weights are returned, "result" is a list of tuples (each tuple
-            # contains two elements; the first is the aggregated data, the
-            # second is the aggregated weights). Convert these to two lists
-            # (one for the aggregated data and one for the aggregated weights)
-            # before combining the different slices.
-            if return_weights:
-                result, weights_result = list(zip(*result))
-                aggregateby_weights = da.stack(
-                    weights_result, axis=dimension_to_groupby
-                )
-            else:
-                aggregateby_weights = None
-            aggregateby_data = da.stack(result, axis=dimension_to_groupby)
+            stack = da.stack
+            input_data = self.lazy_data()
+            agg_method = aggregator.lazy_aggregate
         else:
-            cube_slice = [slice(None, None)] * len(data_shape)
-            for i, groupby_slice in enumerate(groupby.group()):
-                # Slice the cube with the group-by slice to create a group-by
-                # sub-cube.
-                cube_slice[dimension_to_groupby] = groupby_slice
-                groupby_sub_cube = self[tuple(cube_slice)]
+            input_data = self.data
+            # Note numpy.stack does not preserve masks.
+            stack = ma.stack if ma.isMaskedArray(input_data) else np.stack
+            agg_method = aggregator.aggregate
 
-                # Slice the weights
-                if weights is not None:
-                    groupby_sub_weights = weights[tuple(cube_slice)]
-                    kwargs["weights"] = groupby_sub_weights
+        # Create data and weights slices.
+        front_slice = (slice(None),) * dimension_to_groupby
+        back_slice = (slice(None),) * (
+            len(data_shape) - dimension_to_groupby - 1
+        )
 
-                # Perform the aggregation over the group-by sub-cube and
-                # repatriate the aggregated data into the aggregate-by cube
-                # data. If weights are also returned, handle them separately.
-                result = aggregator.aggregate(
-                    groupby_sub_cube.data, axis=dimension_to_groupby, **kwargs
-                )
-                if return_weights:
-                    weights_result = result[1]
-                    result = result[0]
-                else:
-                    weights_result = None
+        # Dask indexing doesn't cope with tuples but lists are OK.
+        slice_list = [
+            list(groupby_slice)
+            if isinstance(groupby_slice, tuple)
+            else groupby_slice
+            for groupby_slice in groupby.group()
+        ]
 
-                # Determine aggregation result data type for the aggregate-by
-                # cube data on first pass.
-                if i == 0:
-                    if ma.isMaskedArray(self.data):
-                        aggregateby_data = ma.zeros(
-                            data_shape, dtype=result.dtype
-                        )
-                    else:
-                        aggregateby_data = np.zeros(
-                            data_shape, dtype=result.dtype
-                        )
-                    if weights_result is not None:
-                        aggregateby_weights = np.zeros(
-                            data_shape, dtype=weights_result.dtype
-                        )
-                    else:
-                        aggregateby_weights = None
-                cube_slice[dimension_to_groupby] = i
-                aggregateby_data[tuple(cube_slice)] = result
-                if weights_result is not None:
-                    aggregateby_weights[tuple(cube_slice)] = weights_result
+        groupby_subarrs = map(
+            lambda groupby_slice: input_data[
+                front_slice + (groupby_slice,) + back_slice
+            ],
+            slice_list,
+        )
 
-            # Restore original weights.
-            if weights is not None:
-                kwargs["weights"] = weights
+        if weights is not None:
+            groupby_subweights = map(
+                lambda groupby_slice: weights[
+                    front_slice + (groupby_slice,) + back_slice
+                ],
+                slice_list,
+            )
+        else:
+            groupby_subweights = (None for _ in range(len(groupby)))
+
+        # Aggregate data slices.
+        agg = iris.analysis.create_weighted_aggregator_fn(
+            agg_method, axis=dimension_to_groupby, **kwargs
+        )
+        result = list(map(agg, groupby_subarrs, groupby_subweights))
+
+        # If weights are returned, "result" is a list of tuples (each tuple
+        # contains two elements; the first is the aggregated data, the
+        # second is the aggregated weights). Convert these to two lists
+        # (one for the aggregated data and one for the aggregated weights)
+        # before combining the different slices.
+        if return_weights:
+            result, weights_result = list(zip(*result))
+            aggregateby_weights = stack(
+                weights_result, axis=dimension_to_groupby
+            )
+        else:
+            aggregateby_weights = None
+
+        aggregateby_data = stack(result, axis=dimension_to_groupby)
 
         # Add the aggregation meta data to the aggregate-by cube.
         aggregator.update_metadata(

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4195,19 +4195,11 @@ x            -              -
             len(data_shape) - dimension_to_groupby - 1
         )
 
-        # Dask indexing doesn't cope with tuples but lists are OK.
-        slice_list = [
-            list(groupby_slice)
-            if isinstance(groupby_slice, tuple)
-            else groupby_slice
-            for groupby_slice in groupby.group()
-        ]
-
         groupby_subarrs = map(
-            lambda groupby_slice: input_data[
-                front_slice + (groupby_slice,) + back_slice
-            ],
-            slice_list,
+            lambda groupby_slice: iris.util._slice_data_with_keys(
+                input_data, front_slice + (groupby_slice,) + back_slice
+            )[1],
+            groupby.group(),
         )
 
         if weights is not None:
@@ -4215,7 +4207,7 @@ x            -              -
                 lambda groupby_slice: weights[
                     front_slice + (groupby_slice,) + back_slice
                 ],
-                slice_list,
+                groupby.group(),
             )
         else:
             groupby_subweights = (None for _ in range(len(groupby)))

--- a/lib/iris/tests/unit/cube/test_Cube__aggregated_by.py
+++ b/lib/iris/tests/unit/cube/test_Cube__aggregated_by.py
@@ -67,9 +67,7 @@ class Test_aggregated_by(tests.IrisTest):
 
         self.mock_agg = mock.Mock(spec=Aggregator)
         self.mock_agg.cell_method = []
-        self.mock_agg.aggregate = mock.Mock(
-            return_value=mock.Mock(dtype="object")
-        )
+        self.mock_agg.aggregate = mock.Mock(return_value=np.arange(4))
         self.mock_agg.aggregate_shape = mock.Mock(return_value=())
         self.mock_agg.lazy_func = None
         self.mock_agg.post_process = mock.Mock(side_effect=lambda x, y, z: x)
@@ -79,8 +77,8 @@ class Test_aggregated_by(tests.IrisTest):
 
         def mock_weighted_aggregate(*_, **kwargs):
             if kwargs.get("returned", False):
-                return (mock.Mock(dtype="object"), mock.Mock(dtype="object"))
-            return mock.Mock(dtype="object")
+                return (np.arange(11), np.ones(11))
+            return np.arange(4)
 
         self.mock_weighted_agg.aggregate = mock.Mock(
             side_effect=mock_weighted_aggregate


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
The code currently used for the lazy case in `aggregated_by` just needs a few tweaks to also use it for the real case.  So we can have fewer lines, and the McCabe complexity of the method is reduced from 27 to 20.

Edit: it turns out this also makes it faster (https://github.com/SciTools/iris/pull/4970#issuecomment-1263663273).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
