### PR TITLE
Remove `iris.plot.outline` workaround

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,6 +124,8 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ adapted the benchmark for importing :mod:`iris.palette` to
    cope with new colormap behaviour in Matplotlib `v3.6`. (:pull:`4998`)
 
+#. `@rcomer`_ removed a now redundant workaround for an old matplotlib bug,
+   highlighted by :issue:`4090`.  (:pull:`4999`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -1344,11 +1344,6 @@ def outline(cube, coords=None, color="k", linewidth=None, axes=None):
         axes=axes,
     )
 
-    # set the _is_stroked property to get a single color grid.
-    # See https://github.com/matplotlib/matplotlib/issues/1302
-    result._is_stroked = False
-    if hasattr(result, "_wrapped_collection_fix"):
-        result._wrapped_collection_fix._is_stroked = False
     return result
 
 

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -242,12 +242,6 @@ class TestLimitedAreaCube(tests.GraphicsTest):
         iplt.pcolormesh(self.cube)
         self.check_graphic()
 
-    def test_grid(self):
-        iplt.pcolormesh(self.cube, facecolors="none", edgecolors="blue")
-        # the result is a graphic which has coloured edges. This is a mpl bug,
-        # see https://github.com/matplotlib/matplotlib/issues/1302
-        self.check_graphic()
-
     def test_outline(self):
         iplt.outline(self.cube)
         self.check_graphic()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
`iplt.outline` contains an ancient workaround for a Matplotlib bug raised at https://github.com/matplotlib/matplotlib/issues/1302 and fixed by https://github.com/matplotlib/matplotlib/pull/18480, which was included in Matplotlib v3.4.  Since Matplotlib is now pinned to >=3.5 (#4998), we can safely remove the workaround.  I also here remove a test which expected the old behaviour, and failed when we tested against mpl v3.4.1 (#4090).

Closes #4090.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
