### PR TITLE
Correct wrong type of equality check in benchmark GHA.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run overnight benchmarks
         run: |
           first_commit=${{ inputs.first_commit }}
-          if [ "$first_commit" != "" ]
+          if [ "$first_commit" == "" ]
           then
             first_commit=$(git log --after="$(date -d "1 day ago" +"%Y-%m-%d") 23:00:00" --pretty=format:"%h" | tail -n 1)
           fi


### PR DESCRIPTION
# 😳

In #5001 I intended to generate `first_commit` ONLY IF it was not already provided by the `workflow_dispatch`, but I got my equality the wrong way round.