### PR TITLE
Splitattrs cube metadata

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -784,6 +784,12 @@ class _ProtoCube:
 
             # Build the new cube.
             kwargs = cube_signature.defn._asdict()
+            # Hack for now just to make this work, since we added a "global_attributes"
+            # field to CubeMetadata, which we are not yet using, but we have no matching
+            # keyword in the Cube constructor call.
+            kwargs.pop("global_attributes")
+            # TODO-splitattrs: in future we will provide some way of passing separate
+            #  local+global attributes into the Cube constructor.  Fix this properly then.
             cube = iris.cube.Cube(
                 data,
                 dim_coords_and_dims=dim_coords_and_dims,

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -391,6 +391,9 @@ class _CubeSignature(
                 )
             )
         if self_defn.attributes != other_defn.attributes:
+            # TODO-splitattrs: this needs to change to handle both global + local
+            #  attributes, when they are in active use. We probably *ought* to be using
+            #  metadata.difference for this.
             diff_keys = set(self_defn.attributes.keys()) ^ set(
                 other_defn.attributes.keys()
             )
@@ -1594,6 +1597,12 @@ class ProtoCube:
             for coord, dims in self._aux_coords_and_dims
         ]
         kwargs = dict(zip(CubeMetadata._fields, signature.defn))
+        # Hack for now just to make this work, since we added a "global_attributes"
+        # field to CubeMetadata, which we are not yet using, but we have no matching
+        # keyword in the Cube constructor call.
+        kwargs.pop("global_attributes")
+        # TODO-splitattrs: in future we will provide some way of passing separate
+        #  local+global attributes into the Cube constructor.  Fix this properly then.
 
         cms_and_dims = [
             (deepcopy(cm), dims) for cm, dims in self._cell_measures_and_dims

--- a/lib/iris/common/mixin.py
+++ b/lib/iris/common/mixin.py
@@ -242,4 +242,8 @@ class CFVariableMixin:
 
             # Ensure to always set state through the individual mixin/container
             # setter functions.
-            setattr(self, field, value)
+            # Since we don't have a 'global_attributes' cube property, we need to avoid
+            # setting a property that doesn't exist.
+            # TODO - splitattrs: fix this properly later.
+            if hasattr(self, field):
+                setattr(self, field, value)

--- a/lib/iris/experimental/stratify.py
+++ b/lib/iris/experimental/stratify.py
@@ -172,7 +172,10 @@ def relevel(cube, src_levels, tgt_levels, axis=None, interpolator=None):
     new_data = interpolator(tgt_levels, src_data, cube_data, axis=axis)
 
     # Create a result cube with the correct shape and metadata.
-    result = Cube(new_data, **cube.copy().metadata._asdict())
+    # TODO-splitattrs: fix this
+    kwargs = cube.metadata._asdict()
+    kwargs.pop("global_attributes")
+    result = Cube(new_data, **kwargs)
 
     # Copy across non z-dimension coordinates from the source cube
     # to the result cube.

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -950,7 +950,15 @@ class TestCubeAPI(TestCube2d):
         self.assertEqual(self.t.cell_methods, ())
 
     def test_metadata_tuple(self):
-        metadata = ("air_pressure", "foo", "bar", "", {"random": "12"}, ())
+        metadata = (
+            "air_pressure",
+            "foo",
+            "bar",
+            "",
+            {"random": "12"},
+            (),
+            {"extra": 4},
+        )
         self.t.metadata = metadata
         self.assertEqual(self.t.standard_name, "air_pressure")
         self.assertEqual(self.t.long_name, "foo")
@@ -989,7 +997,7 @@ class TestCubeAPI(TestCube2d):
         metadata.units = ""
         metadata.attributes = {"random": "12"}
         metadata.cell_methods = ()
-        metadata.cell_measures_and_dims = []
+        metadata.global_attributes = {"extra": 4}
         self.t.metadata = metadata
         self.assertEqual(self.t.standard_name, "air_pressure")
         self.assertEqual(self.t.long_name, "foo")
@@ -998,7 +1006,6 @@ class TestCubeAPI(TestCube2d):
         self.assertEqual(self.t.attributes, metadata.attributes)
         self.assertIsNot(self.t.attributes, metadata.attributes)
         self.assertEqual(self.t.cell_methods, ())
-        self.assertEqual(self.t._cell_measures_and_dims, [])
 
     def test_metadata_fail(self):
         with self.assertRaises(TypeError):

--- a/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
+++ b/lib/iris/tests/unit/common/mixin/test_CFVariableMixin.py
@@ -314,10 +314,12 @@ class Test__metadata_setter(tests.IrisTest):
 
     def test_class_cubemetadata(self):
         self.args["cell_methods"] = None
+        self.args["global_attributes"] = None
         metadata = CubeMetadata(**self.args)
         self.item.metadata = metadata
         expected = metadata._asdict()
         del expected["cell_methods"]
+        del expected["global_attributes"]
         self.assertEqual(self.item._metadata_manager.values, expected)
         self.assertIsNot(
             self.item._metadata_manager.attributes, metadata.attributes

--- a/lib/iris/tests/unit/common/resolve/test_Resolve.py
+++ b/lib/iris/tests/unit/common/resolve/test_Resolve.py
@@ -4466,6 +4466,7 @@ class Test_cube(tests.IrisTest):
             units=Unit("K"),
             attributes={},
             cell_methods=(),
+            global_attributes=None,  # TODO-splitattrs: should be {}, when implemented
         )
         lhs_cube = Cube(self.data)
         lhs_cube.metadata = self.cube_metadata


### PR DESCRIPTION
Addresses #4982 

This implements the basics of adding a separate `.global_attributes` field to a `CubeMetadata`,
and tests that it behaves exactly the same as the `.attributes` field.

NB this field is not yet accessible from the cube itself, so no behaviour changes should result.
That awaits #4983, which will replace the implemenation of `cube.attributes` and add `cube.attributes.local` and `cube.attributes.global`.

