### PR TITLE
Impose a definite key ordering on results of metadata combine+difference

### DIFF
--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -386,9 +386,13 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
         [dsleft.pop(key) for key in keys]
         [dsright.pop(key) for key in keys]
         # Now bring the result together.
-        result = {k: left[k] for k, _ in common}
-        result.update({k: left[k] for k in dsleft.keys()})
-        result.update({k: right[k] for k in dsright.keys()})
+        # NB result keys order is : first common keys (in left order) ; then left-only ;
+        # then right-only.
+        result = {
+            k: left[k] for k in left if any(key == k for key, hsh in common)
+        }
+        result.update({k: left[k] for k in left if k in dsleft})
+        result.update({k: right[k] for k in right if k in dsright})
 
         return result
 
@@ -406,7 +410,8 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
         # Intersection of common items.
         common = sleft & sright
         # Now bring the result together.
-        result = {k: left[k] for k, _ in common}
+        # N.B. key order matches 'left'.
+        result = {k: left[k] for k in left if k in common}
 
         return result
 
@@ -562,8 +567,9 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
             result = None
         else:
             # Replace hash-rvalue with original rvalue.
-            dsleft = {k: left[k] for k in dsleft.keys()}
-            dsright = {k: right[k] for k in dsright.keys()}
+            # NB key orders match the originals
+            dsleft = {k: left[k] for k in left if k in dsleft}
+            dsright = {k: right[k] for k in right if k in dsright}
             result = (dsleft, dsright)
 
         return result
@@ -585,8 +591,9 @@ class BaseMetadata(metaclass=_NamedTupleMeta):
             result = None
         else:
             # Replace hash-rvalue with original rvalue.
-            dsleft = {k: left[k] for k in dsleft.keys()}
-            dsright = {k: right[k] for k in dsright.keys()}
+            # NB key orders match the originals
+            dsleft = {k: left[k] for k in left if k in dsleft}
+            dsright = {k: right[k] for k in right if k in dsright}
             result = (dsleft, dsright)
 
         return result


### PR DESCRIPTION
**WIP** just testing, for now

I found that the results of some common metadata operation, both "difference" and "combine",  are not deterministic, 
since the use of set logic produces results in a varying results  -- specifically, in the order of dictionary keys.
Which I think is why we have some doctest skips, e.g. [here in the metadata docs](https://github.com/SciTools/iris/blame/421e193d9a73d767c64d989550c816cebdebecab/docs/src/further_topics/metadata.rst#L604-L605)

So I'm aiming to fix that.

The problem is that these ops produce genuinely non-deterministic results.
For ref, we had to address a similar problem [here in the netcdf loader](https://github.com/SciTools/iris/blob/v3.4.0/lib/iris/fileformats/netcdf/loader.py#L135-L150)

So, we could use 'OrderedSet's, but there is no such standard class (and various competing solutions none of which are entirely great).  So instead, I am aiming to determine result key order from the inputs in a hopefully natural way.
