### PR TITLE
PP extra word fix

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -767,6 +767,18 @@ def _data_bytes_to_shaped_array(
 
     else:
         # Reform in row-column order
+        actual_length = np.prod(data.shape)
+        if (expected_length := np.prod(data_shape)) != actual_length:
+            if (expected_length < actual_length) and (data.ndim == 1):
+                # known use case where mule adds padding to data payload
+                # for a collapsed field.
+                data = data[:expected_length]
+            else:
+                emsg = (
+                    f"Expected field data word length {expected_length} does "
+                    f"not match actual field data word length {actual_length}."
+                )
+                raise ValueError(emsg)
         data.shape = data_shape
 
     # Mask the array

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -422,7 +422,13 @@ def _grid_and_pole_rules(cube, pp):
     lat_coord = vector_coord(cube, "latitude")
     grid_lat_coord = vector_coord(cube, "grid_latitude")
 
-    if lon_coord and not is_regular(lon_coord):
+    scalar_lon_coord = scalar_coord(cube, "longitude")
+
+    if lon_coord is None and grid_lon_coord is None and scalar_lon_coord:
+        pp.bdx = 360.0
+        pp.bzx = scalar_lon_coord.points[0] - pp.bdx
+        pp.lbnpt = scalar_lon_coord.shape[0]
+    elif lon_coord and not is_regular(lon_coord):
         pp.bzx = 0
         pp.bdx = 0
         pp.lbnpt = lon_coord.shape[0]

--- a/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__data_bytes_to_shaped_array.py
@@ -17,8 +17,51 @@ from unittest import mock
 
 import numpy as np
 import numpy.ma as ma
+import pytest
 
 import iris.fileformats.pp as pp
+
+
+@pytest.mark.parametrize(
+    "data_shape,expected_shape",
+    [
+        ((2, 3), (2, 3)),
+        ((2, 3), (3, 2)),
+        ((2, 3), (1, 3)),
+        ((2, 3), (2, 2)),
+        ((2, 3), (3, 3)),
+        ((2, 3), (2, 4)),
+    ],
+)
+def test_data_padding__no_compression(data_shape, expected_shape):
+    data_type = np.float32
+    data = np.empty(data_shape, dtype=data_type)
+
+    # create the field data buffer
+    buffer = io.BytesIO()
+    buffer.write(data)
+    buffer.seek(0)
+    data_bytes = buffer.read()
+
+    lbpack = pp.SplittableInt(0, dict(n1=0, n2=1))
+    boundary_packing = None
+    mdi = -1
+    args = (
+        data_bytes,
+        lbpack,
+        boundary_packing,
+        expected_shape,
+        data_type,
+        mdi,
+    )
+    data_length, expected_length = np.prod(data_shape), np.prod(expected_shape)
+
+    if expected_length <= data_length:
+        result = pp._data_bytes_to_shaped_array(*args)
+        assert result.shape == expected_shape
+    else:
+        with pytest.raises(ValueError):
+            _ = pp._data_bytes_to_shaped_array(*args)
 
 
 class Test__data_bytes_to_shaped_array__lateral_boundary_compression(

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -21,6 +21,17 @@ from iris.fileformats.pp_save_rules import _lbproc_rules, verify
 import iris.tests.stock as stock
 
 
+def test_grid_and_pole__scalar_dim_longitude():
+    cube = stock.lat_lon_cube()[:, -1:]
+    lon = cube.coord("longitude")
+
+    field = _pp_save_ppfield_values(cube)
+    bdx = 360.0
+    assert field.bdx == bdx
+    assert field.bzx == (lon.points[0] - bdx)
+    assert field.lbnpt == lon.points.size
+
+
 def _pp_save_ppfield_values(cube):
     """
     Emulate saving a cube as PP, and capture the resulting PP field values.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR addresses an issue with MULE altered PP files that include at least 1 extra word in the field data (specified by `lblrec`) as padding, causing the expected field data shape (specified by `lbrow` and `lbnpt`) to disagree with the payload data size.

This is limited to specific diagnostics, which have been reduced over `longitude`.

Normally, the fix would be within MULE, however there are now PP files in existence with this issue, and `iris` is unable to load and save them.

This PR addresses this for the specific use case that we are aware of; the solution has not been generalised. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
