### PR TITLE
WSTARBAR is upward velocity

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -95,6 +95,10 @@ This document explains the changes made to Iris for this release
 
 #. `@stephenworsley`_ fixed a bug which caused derived coordinates to be realised
    after calling :meth:`iris.cube.Cube.aggregated_by`. (:issue:`3637`, :pull:`4947`)
+   
+#. `@rcomer`_ corrected the ``standard_name`` mapping from UM stash code ``m01s30i311``
+   to indicate that this is the upward, rather than northward part of the flow.
+   (:pull:`5060`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/fileformats/um_cf_map.py
+++ b/lib/iris/fileformats/um_cf_map.py
@@ -906,7 +906,7 @@ STASH_TO_CF = {
     'm01s30i301': CFName(None, 'Heavyside function on pressure levels', '1'),
     'm01s30i302': CFName('virtual_temperature', None, 'K'),
     'm01s30i310': CFName('northward_transformed_eulerian_mean_air_velocity', None, 'm s-1'),
-    'm01s30i311': CFName('northward_transformed_eulerian_mean_air_velocity', None, 'm s-1'),
+    'm01s30i311': CFName('upward_transformed_eulerian_mean_air_velocity', None, 'm s-1'),
     'm01s30i312': CFName('northward_eliassen_palm_flux_in_air', None, 'kg s-2'),
     'm01s30i313': CFName('upward_eliassen_palm_flux_in_air', None, 'kg s-2'),
     'm01s30i314': CFName('tendency_of_eastward_wind_due_to_eliassen_palm_flux_divergence', None, 'm s-2'),


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
STASH diagnostic 30311 is listed in the [UM STASHmaster metadata file](https://code.metoffice.gov.uk/trac/um/browser/main/trunk/rose-meta/um-atmos/HEAD/etc/stash/STASHmaster/STASHmaster-meta.conf?order=name) as "RESIDUAL MN MERID. CIRC. WSTARBAR".  I have checked with Steve Hardiman (who originally implemented these diagnostics in the UM) and Martin Andrews (who has used these diagnostics a lot more than I have) and they agree that this should map to "upward" rather than "northward" in Iris.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
