### PR TITLE
More accurate netcdf4 pin `<1.6.1`.

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -185,7 +185,7 @@ This document explains the changes made to Iris for this release
    (:pull:`4968`)
 
 #. `@trexfeathers`_ introduced the ``netcdf4<1.6.1`` pin to avoid a problem
-   with segfaults. (:pull:`4968`) (:issue:`5016`)
+   with segfaults. (:pull:`4968`, :pull:`5075`, :issue:`5016`)
 
 #. `@trexfeathers`_ updated the Matplotlib colormap registration in
    :mod:`iris.palette` in response to a deprecation warning. Using the new

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -121,7 +121,7 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ and `@trexfeathers`_ (reviewer) fixed an issue which prevented
    uncompressed PP fields with additional trailing padded words in the field
    data to be loaded and saved. (:pull:`5058`)
-   
+
 #. `@lbdreyer`_ and `@trexfeathers`_ (reviewer) fixed the handling of data when
    regridding with :class:`~iris.analysis.UnstructuredNearest` or calling
    :func:`~iris.analysis.trajectory.interpolate` such that the data type and mask is
@@ -184,8 +184,8 @@ This document explains the changes made to Iris for this release
    details.
    (:pull:`4968`)
 
-#. `@trexfeathers`_ introduced the ``netcdf4!=1.6.1`` pin to avoid a problem
-   with segfaults. (:pull:`4968`)
+#. `@trexfeathers`_ introduced the ``netcdf4<1.6.1`` pin to avoid a problem
+   with segfaults. (:pull:`4968`) (:issue:`5016`)
 
 #. `@trexfeathers`_ updated the Matplotlib colormap registration in
    :mod:`iris.palette` in response to a deprecation warning. Using the new

--- a/requirements/ci/py310.yml
+++ b/requirements/ci/py310.yml
@@ -16,7 +16,7 @@ dependencies:
   - cftime >=1.5
   - dask-core >=2.26
   - matplotlib >=3.5
-  - netcdf4 !=1.6.1
+  - netcdf4 <1.6.1
   - numpy >=1.19
   - python-xxhash
   - pyproj

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -16,7 +16,7 @@ dependencies:
   - cftime >=1.5
   - dask-core >=2.26
   - matplotlib >=3.5
-  - netcdf4 !=1.6.1
+  - netcdf4 <1.6.1
   - numpy >=1.19
   - python-xxhash
   - pyproj

--- a/requirements/ci/py39.yml
+++ b/requirements/ci/py39.yml
@@ -16,7 +16,7 @@ dependencies:
   - cftime >=1.5
   - dask-core >=2.26
   - matplotlib >=3.5
-  - netcdf4 !=1.6.1
+  - netcdf4 <1.6.1
   - numpy >=1.19
   - python-xxhash
   - pyproj

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     cftime>=1.5.0
     dask[array]>=2.26
     matplotlib>=3.5
-    netcdf4!=1.6.1
+    netcdf4<1.6.1
     numpy>=1.19
     scipy
     shapely!=1.8.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

See #5016. We're on the way to a proper fix in #5061 but in the meantime we need a netcdf4 pin that can account for future releases of the package, rather than being specific to avoiding one specific release.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
