### PR TITLE
Handle derived coordinates correctly in `concatenate`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -57,6 +57,9 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
+#. `@schlunma`_ fixed :meth:`iris.cube.CubeList.concatenate` so that it
+   preserves derived coordinates. (:issue:`2478`, :pull:`5096`)
+
 #. `@trexfeathers`_ and `@pp-mo`_ made Iris' use of the `netCDF4`_ library
    thread-safe. (:pull:`5095`)
 

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -160,6 +160,39 @@ class _CoordMetaData(
         return self.defn.name()
 
 
+class _DerivedCoordAndDims(
+    namedtuple("DerivedCoordAndDims", ["coord", "dims", "aux_factory"])
+):
+    """
+    Container for a derived coordinate, the associated AuxCoordFactory, and the
+    associated data dimension(s) spanned over a :class:`iris.cube.Cube`.
+
+    Args:
+
+    * coord:
+        A :class:`iris.coords.DimCoord` or :class:`iris.coords.AuxCoord`
+        coordinate instance.
+
+    * dims:
+        A tuple of the data dimension(s) spanned by the coordinate.
+
+    * aux_factory:
+        A :class:`iris.aux_factory.AuxCoordFactory` instance.
+
+    """
+
+    __slots__ = ()
+
+    def __eq__(self, other):
+        """Do not take aux factories into account for equality."""
+        result = NotImplemented
+        if isinstance(other, _DerivedCoordAndDims):
+            equal_coords = self.coord == other.coord
+            equal_dims = self.dims == other.dims
+            result = equal_coords and equal_dims
+        return result
+
+
 class _OtherMetaData(namedtuple("OtherMetaData", ["defn", "dims"])):
     """
     Container for the metadata that defines a cell measure or ancillary
@@ -280,6 +313,7 @@ def concatenate(
     check_aux_coords=True,
     check_cell_measures=True,
     check_ancils=True,
+    check_derived_coords=False,
 ):
     """
     Concatenate the provided cubes over common existing dimensions.
@@ -295,6 +329,26 @@ def concatenate(
     * error_on_mismatch:
         If True, raise an informative
         :class:`~iris.exceptions.ContatenateError` if registration fails.
+
+    * check_aux_coords
+        Checks if the points and bounds of auxiliary coordinates of the cubes
+        match. This check is not applied to auxiliary coordinates that span the
+        dimension the concatenation is occurring along.  Defaults to True.
+
+    * check_cell_measures
+        Checks if the data of cell measures of the cubes match. This check is
+        not applied to cell measures that span the dimension the concatenation
+        is occurring along. Defaults to True.
+
+    * check_ancils
+        Checks if the data of ancillary variables of the cubes match. This
+        check is not applied to ancillary variables that span the dimension the
+        concatenation is occurring along. Defaults to True.
+
+    * check_derived_coords
+        Checks if the points and bounds of derived coordinates of the cubes
+        match. This check is not applied to derived coordinates that span the
+        dimension the concatenation is occurring along.  Defaults to True.
 
     Returns:
         A :class:`iris.cube.CubeList` of concatenated :class:`iris.cube.Cube`
@@ -321,6 +375,7 @@ def concatenate(
                 check_aux_coords,
                 check_cell_measures,
                 check_ancils,
+                check_derived_coords,
             )
             if registered:
                 axis = proto_cube.axis
@@ -378,6 +433,8 @@ class _CubeSignature:
         self.cm_metadata = []
         self.ancillary_variables_and_dims = []
         self.av_metadata = []
+        self.derived_coords_and_dims = []
+        self.derived_metadata = []
         self.dim_mapping = []
 
         # Determine whether there are any anonymous cube dimensions.
@@ -436,6 +493,17 @@ class _CubeSignature:
             self.av_metadata.append(metadata)
             av_and_dims = _CoordAndDims(av, tuple(dims))
             self.ancillary_variables_and_dims.append(av_and_dims)
+
+        def name_key_func(factory):
+            return factory.name()
+
+        for factory in sorted(cube.aux_factories, key=name_key_func):
+            coord = factory.make_coord(cube.coord_dims)
+            dims = cube.coord_dims(coord)
+            metadata = _CoordMetaData(coord, dims)
+            self.derived_metadata.append(metadata)
+            coord_and_dims = _DerivedCoordAndDims(coord, tuple(dims), factory)
+            self.derived_coords_and_dims.append(coord_and_dims)
 
     def _coordinate_differences(self, other, attr, reason="metadata"):
         """
@@ -597,6 +665,7 @@ class _CoordSignature:
         self.ancillary_variables_and_dims = (
             cube_signature.ancillary_variables_and_dims
         )
+        self.derived_coords_and_dims = cube_signature.derived_coords_and_dims
         self.dim_coords = cube_signature.dim_coords
         self.dim_mapping = cube_signature.dim_mapping
         self.dim_extents = []
@@ -779,6 +848,11 @@ class _ProtoCube:
             # Concatenate the new ancillary variables
             ancillary_variables_and_dims = self._build_ancillary_variables()
 
+            # Concatenate the new aux factories
+            aux_factories = self._build_aux_factories(
+                dim_coords_and_dims, aux_coords_and_dims
+            )
+
             # Concatenate the new data payload.
             data = self._build_data()
 
@@ -790,6 +864,7 @@ class _ProtoCube:
                 aux_coords_and_dims=aux_coords_and_dims,
                 cell_measures_and_dims=cell_measures_and_dims,
                 ancillary_variables_and_dims=ancillary_variables_and_dims,
+                aux_factories=aux_factories,
                 **kwargs,
             )
         else:
@@ -807,6 +882,7 @@ class _ProtoCube:
         check_aux_coords=False,
         check_cell_measures=False,
         check_ancils=False,
+        check_derived_coords=False,
     ):
         """
         Determine whether the given source-cube is suitable for concatenation
@@ -826,6 +902,28 @@ class _ProtoCube:
 
         * error_on_mismatch:
             If True, raise an informative error if registration fails.
+
+        * check_aux_coords
+            Checks if the points and bounds of auxiliary coordinates of the
+            cubes match. This check is not applied to auxiliary coordinates
+            that span the dimension the concatenation is occurring along.
+            Defaults to True.
+
+        * check_cell_measures
+            Checks if the data of cell measures of the cubes match. This check
+            is not applied to cell measures that span the dimension the
+            concatenation is occurring along. Defaults to True.
+
+        * check_ancils
+            Checks if the data of ancillary variables of the cubes match. This
+            check is not applied to ancillary variables that span the dimension
+            the concatenation is occurring along. Defaults to True.
+
+        * check_derived_coords
+            Checks if the points and bounds of derived coordinates of the cubes
+            match. This check is not applied to derived coordinates that span
+            the dimension the concatenation is occurring along.  Defaults to
+            True.
 
         Returns:
             Boolean.
@@ -898,6 +996,21 @@ class _ProtoCube:
                     cube_signature.ancillary_variables_and_dims,
                 ):
                     # AncillaryVariables that span the candidate axis can differ
+                    if (
+                        candidate_axis not in coord_a.dims
+                        or candidate_axis not in coord_b.dims
+                    ):
+                        if not coord_a == coord_b:
+                            match = False
+
+        # Check for compatible derived coordinates.
+        if match:
+            if check_derived_coords:
+                for coord_a, coord_b in zip(
+                    self._cube_signature.derived_coords_and_dims,
+                    cube_signature.derived_coords_and_dims,
+                ):
+                    # Derived coords that span the candidate axis can differ
                     if (
                         candidate_axis not in coord_a.dims
                         or candidate_axis not in coord_b.dims
@@ -1087,6 +1200,64 @@ class _ProtoCube:
             ancillary_variables_and_dims.append((av.copy(), dims))
 
         return ancillary_variables_and_dims
+
+    def _build_aux_factories(self, dim_coords_and_dims, aux_coords_and_dims):
+        """
+        Generate the aux factories for the new concatenated cube.
+
+        Args:
+
+        * dim_coords_and_dims:
+            A list of dimension coordinate and dimension tuple pairs from the
+            concatenated cube.
+
+        * aux_coords_and_dims:
+            A list of auxiliary coordinates and dimension(s) tuple pairs from
+            the concatenated cube.
+
+        Returns:
+            A list of :class:`iris.aux_factory.AuxCoordFactory`.
+
+        """
+        # Setup convenience hooks.
+        cube_signature = self._cube_signature
+        old_dim_coords = cube_signature.dim_coords
+        old_aux_coords = [a[0] for a in cube_signature.aux_coords_and_dims]
+        new_dim_coords = [d[0] for d in dim_coords_and_dims]
+        new_aux_coords = [a[0] for a in aux_coords_and_dims]
+        scalar_coords = cube_signature.scalar_coords
+
+        aux_factories = []
+
+        # Generate all the factories for the new concatenated cube.
+        for i, (coord, dims, factory) in enumerate(
+            cube_signature.derived_coords_and_dims
+        ):
+            # Check whether the derived coordinate of the factory spans the
+            # nominated dimension of concatenation.
+            if self.axis in dims:
+                # Update the dependencies of the factory with coordinates of
+                # the concatenated cube. We need to check all coordinate types
+                # here (dim coords, aux coords, and scalar coords).
+                new_dependencies = {}
+                for (dep_name, old_dependency) in factory.dependencies.items():
+                    if old_dependency in old_dim_coords:
+                        dep_idx = old_dim_coords.index(old_dependency)
+                        new_dependency = new_dim_coords[dep_idx]
+                    elif old_dependency in old_aux_coords:
+                        dep_idx = old_aux_coords.index(old_dependency)
+                        new_dependency = new_aux_coords[dep_idx]
+                    else:
+                        dep_idx = scalar_coords.index(old_dependency)
+                        new_dependency = scalar_coords[dep_idx]
+                    new_dependencies[dep_name] = new_dependency
+
+                # Create new factory with the updated dependencies.
+                factory = factory.__class__(**new_dependencies)
+
+            aux_factories.append(factory)
+
+        return aux_factories
 
     def _build_data(self):
         """

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -313,7 +313,7 @@ def concatenate(
     check_aux_coords=True,
     check_cell_measures=True,
     check_ancils=True,
-    check_derived_coords=False,
+    check_derived_coords=True,
 ):
     """
     Concatenate the provided cubes over common existing dimensions.
@@ -919,17 +919,17 @@ class _ProtoCube:
             Checks if the points and bounds of auxiliary coordinates of the
             cubes match. This check is not applied to auxiliary coordinates
             that span the dimension the concatenation is occurring along.
-            Defaults to True.
+            Defaults to False.
 
         * check_cell_measures
             Checks if the data of cell measures of the cubes match. This check
             is not applied to cell measures that span the dimension the
-            concatenation is occurring along. Defaults to True.
+            concatenation is occurring along. Defaults to False.
 
         * check_ancils
             Checks if the data of ancillary variables of the cubes match. This
             check is not applied to ancillary variables that span the dimension
-            the concatenation is occurring along. Defaults to True.
+            the concatenation is occurring along. Defaults to False.
 
         * check_derived_coords
             Checks if the points and bounds of derived coordinates of the cubes
@@ -938,7 +938,7 @@ class _ProtoCube:
             differences in scalar coordinates and dimensional coordinates used
             to derive the coordinate are still checked. Checks for auxiliary
             coordinates used to derive the coordinates can be ignored with
-            `check_aux_coords`. Defaults to True.
+            `check_aux_coords`. Defaults to False.
 
         Returns:
             Boolean.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -573,8 +573,11 @@ class CubeList(list):
         * check_derived_coords
             Checks if the points and bounds of derived coordinates of the cubes
             match. This check is not applied to derived coordinates that span
-            the dimension the concatenation is occurring along.  Defaults to
-            True.
+            the dimension the concatenation is occurring along. Note that
+            differences in scalar coordinates and dimensional coordinates used
+            to derive the coordinate are still checked. Checks for auxiliary
+            coordinates used to derive the coordinates can be ignored with
+            `check_aux_coords`. Defaults to True.
 
         .. note::
 
@@ -648,8 +651,11 @@ class CubeList(list):
         * check_derived_coords
             Checks if the points and bounds of derived coordinates of the cubes
             match. This check is not applied to derived coordinates that span
-            the dimension the concatenation is occurring along.  Defaults to
-            True.
+            the dimension the concatenation is occurring along. Note that
+            differences in scalar coordinates and dimensional coordinates used
+            to derive the coordinate are still checked. Checks for auxiliary
+            coordinates used to derive the coordinates can be ignored with
+            `check_aux_coords`. Defaults to True.
 
         Returns:
             A new :class:`iris.cube.CubeList` of concatenated

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -542,6 +542,7 @@ class CubeList(list):
         check_aux_coords=True,
         check_cell_measures=True,
         check_ancils=True,
+        check_derived_coords=True,
     ):
         """
         Return the concatenated contents of the :class:`CubeList` as a single
@@ -554,19 +555,26 @@ class CubeList(list):
         Kwargs:
 
         * check_aux_coords
-            Checks the auxiliary coordinates of the cubes match. This check
-            is not applied to auxiliary coordinates that span the dimension
-            the concatenation is occurring along. Defaults to True.
+            Checks if the points and bounds of auxiliary coordinates of the
+            cubes match. This check is not applied to auxiliary coordinates
+            that span the dimension the concatenation is occurring along.
+            Defaults to True.
 
         * check_cell_measures
-            Checks the cell measures of the cubes match. This check
-            is not applied to cell measures that span the dimension
-            the concatenation is occurring along. Defaults to True.
+            Checks if the data of cell measures of the cubes match. This check
+            is not applied to cell measures that span the dimension the
+            concatenation is occurring along. Defaults to True.
 
         * check_ancils
-            Checks the ancillary variables of the cubes match. This check
-            is not applied to ancillary variables that span the dimension
+            Checks if the data of ancillary variables of the cubes match. This
+            check is not applied to ancillary variables that span the dimension
             the concatenation is occurring along. Defaults to True.
+
+        * check_derived_coords
+            Checks if the points and bounds of derived coordinates of the cubes
+            match. This check is not applied to derived coordinates that span
+            the dimension the concatenation is occurring along.  Defaults to
+            True.
 
         .. note::
 
@@ -587,6 +595,7 @@ class CubeList(list):
                 check_aux_coords=check_aux_coords,
                 check_cell_measures=check_cell_measures,
                 check_ancils=check_ancils,
+                check_derived_coords=check_derived_coords,
             )
             n_res_cubes = len(res)
             if n_res_cubes == 1:
@@ -613,6 +622,7 @@ class CubeList(list):
         check_aux_coords=True,
         check_cell_measures=True,
         check_ancils=True,
+        check_derived_coords=True,
     ):
         """
         Concatenate the cubes over their common dimensions.
@@ -620,19 +630,26 @@ class CubeList(list):
         Kwargs:
 
         * check_aux_coords
-            Checks the auxiliary coordinates of the cubes match. This check
-            is not applied to auxiliary coordinates that span the dimension
-            the concatenation is occurring along. Defaults to True.
+            Checks if the points and bounds of auxiliary coordinates of the
+            cubes match. This check is not applied to auxiliary coordinates
+            that span the dimension the concatenation is occurring along.
+            Defaults to True.
 
         * check_cell_measures
-            Checks the cell measures of the cubes match. This check
-            is not applied to cell measures that span the dimension
-            the concatenation is occurring along. Defaults to True.
+            Checks if the data of cell measures of the cubes match. This check
+            is not applied to cell measures that span the dimension the
+            concatenation is occurring along. Defaults to True.
 
         * check_ancils
-            Checks the ancillary variables of the cubes match. This check
-            is not applied to ancillary variables that span the dimension
+            Checks if the data of ancillary variables of the cubes match. This
+            check is not applied to ancillary variables that span the dimension
             the concatenation is occurring along. Defaults to True.
+
+        * check_derived_coords
+            Checks if the points and bounds of derived coordinates of the cubes
+            match. This check is not applied to derived coordinates that span
+            the dimension the concatenation is occurring along.  Defaults to
+            True.
 
         Returns:
             A new :class:`iris.cube.CubeList` of concatenated
@@ -718,6 +735,7 @@ class CubeList(list):
             check_aux_coords=check_aux_coords,
             check_cell_measures=check_cell_measures,
             check_ancils=check_ancils,
+            check_derived_coords=check_derived_coords,
         )
 
     def realise_data(self):

--- a/lib/iris/tests/integration/concatenate/test_concatenate.py
+++ b/lib/iris/tests/integration/concatenate/test_concatenate.py
@@ -16,12 +16,41 @@ import iris.tests as tests  # isort:skip
 import cf_units
 import numpy as np
 
-from iris._concatenate import concatenate
+from iris._concatenate import _DerivedCoordAndDims, concatenate
 import iris.aux_factory
 import iris.coords
 import iris.cube
 import iris.tests.stock as stock
 from iris.util import unify_time_units
+
+
+class Test_DerivedCoordAndDims:
+    def test_equal(self):
+        assert _DerivedCoordAndDims(
+            "coord", "dims", "aux_factory"
+        ) == _DerivedCoordAndDims("coord", "dims", "aux_factory")
+
+    def test_non_equal_coord(self):
+        assert _DerivedCoordAndDims(
+            "coord_0", "dims", "aux_factory"
+        ) != _DerivedCoordAndDims("coord_1", "dims", "aux_factory")
+
+    def test_non_equal_dims(self):
+        assert _DerivedCoordAndDims(
+            "coord", "dims_0", "aux_factory"
+        ) != _DerivedCoordAndDims("coord", "dims_1", "aux_factory")
+
+    def test_non_equal_aux_factory(self):
+        # Note: aux factories are not taken into account for equality!
+        assert _DerivedCoordAndDims(
+            "coord", "dims", "aux_factory_0"
+        ) == _DerivedCoordAndDims("coord", "dims", "aux_factory_1")
+
+    def test_non_equal_types(self):
+        assert (
+            _DerivedCoordAndDims("coord", "dims", "aux_factory")
+            != "I am not a _DerivedCoordAndDims"
+        )
 
 
 class Test_concatenate__epoch(tests.IrisTest):
@@ -287,7 +316,7 @@ class Test_cubes_with_derived_coord(tests.IrisTest):
         cube_b.coord("time").points = [12, 18]
         cube_b.coord("ps").points = [10.0, 20.0]
 
-        result = concatenate([cube_a, cube_b])
+        result = concatenate([cube_a, cube_b], check_aux_coords=False)
         self.assertEqual(len(result), 2)
 
     def test_ignore_diff_air_pressure(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This fixes the issue that the result of `iris.cube.CubeList.concatenate` loses any derived coordinate present in the input cubes. Here, this is fixed for all derived coordinates (for those that span the concatenated dimensions and for those that don't).

### Todo

- [x] Add tests
- [x] ~~Redo the same for `merge` if easily possible~~ EDIT: this is not necessary, it's already working as expected.

Closes #2478 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
