### PR TITLE
DOC: improve gallery test instructions

### DIFF
--- a/docs/src/developers_guide/contributing_documentation_full.rst
+++ b/docs/src/developers_guide/contributing_documentation_full.rst
@@ -87,6 +87,8 @@ pattern matching, e.g.::
 
     pytest -v -k plot_coriolis docs/gallery_tests/test_gallery_examples.py
 
+If a gallery test fails, follow the instructions in :ref:`testing.graphics`.
+
 The ``make`` commands shown below can be run in the ``docs`` or ``docs/src``
 directory.
 
@@ -165,13 +167,13 @@ The code for the gallery entries are in ``docs/gallery_code``.
 Each sub directory in this directory is a sub section of the gallery.  The
 respective ``README.rst`` in each folder is included in the gallery output.
 
-For each gallery entry there must be a corresponding test script located in
-``docs/gallery_tests``.
-
 To add an entry to the gallery simple place your python code into the
 appropriate sub directory and name it with a prefix of ``plot_``.  If your
 gallery entry does not fit into any existing sub directories then create a new
-directory and place it in there.
+directory and place it in there.  A test for the gallery entry will be
+automatically generated (see Testing_ for how to run it).  To add a new
+reference image for this test, follow the instructions in
+:ref:`testing.graphics`.
 
 The reStructuredText (rst) output of the gallery is located in
 ``docs/src/generated/gallery``.

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -67,7 +67,7 @@ This document explains the changes made to Iris for this release
 📚 Documentation
 ================
 
-#. N/A
+#. `@rcomer`_ clarified instructions for updating gallery tests. (:pull:`5100`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Since #4792, it is no longer necessary to add a test file with each new gallery entry, because we generate them using `glob`:
https://github.com/SciTools/iris/blob/dfbc5c2aef0c64918061a4e312f66d94b0beb525/docs/gallery_tests/test_gallery_examples.py#L18-L22

I also added some links from the gallery testing instructions to the image testing instructions, as I was struggling to find my way around when recently wanting to update a gallery test image file.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
