### PR TITLE
Remove test timings

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -76,6 +76,9 @@ This document explains the changes made to Iris for this release
 #. `@fnattino`_ changed the order of ``ncgen`` arguments in the command to
    create NetCDF files for testing  (caused errors on OS X). (:pull:`5105`)
 
+#. `@rcomer`_ removed some old infrastructure that printed test timings.
+   (:pull:`5101`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -936,10 +936,6 @@ class IrisTest(unittest.TestCase):
         )
 
 
-def _method_path(meth, cls):
-    return ".".join([cls.__module__, cls.__name__, meth.__name__])
-
-
 get_data_path = IrisTest.get_data_path
 get_result_path = IrisTest.get_result_path
 

--- a/lib/iris/tests/graphics/README.md
+++ b/lib/iris/tests/graphics/README.md
@@ -24,7 +24,7 @@ perceived as it may be a simple pixel shift.
 
 ## Testing Strategy
 
-The `iris.tests.IrisTest_nometa.check_graphic` test routine calls out to
+The `iris.tests.IrisTest.check_graphic` test routine calls out to
 `iris.tests.graphics.check_graphic` which tests against the **acceptable**
 result. It does this using an image **hash** comparison technique which allows
 us to be robust against minor variations based on underlying library updates.

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -712,9 +712,8 @@ class CheckForWarningsMetaclass(type):
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
 class TestPcolorNoBounds(
-    tests.GraphicsTest_nometa, SliceMixin, metaclass=CheckForWarningsMetaclass
+    tests.GraphicsTest, SliceMixin, metaclass=CheckForWarningsMetaclass
 ):
     """
     Test the iris.plot.pcolor routine on a cube with coordinates
@@ -729,9 +728,8 @@ class TestPcolorNoBounds(
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
 class TestPcolormeshNoBounds(
-    tests.GraphicsTest_nometa, SliceMixin, metaclass=CheckForWarningsMetaclass
+    tests.GraphicsTest, SliceMixin, metaclass=CheckForWarningsMetaclass
 ):
     """
     Test the iris.plot.pcolormesh routine on a cube with coordinates

--- a/lib/iris/tests/unit/analysis/maths/test__arith__derived_coords.py
+++ b/lib/iris/tests/unit/analysis/maths/test__arith__derived_coords.py
@@ -16,9 +16,8 @@ from iris.tests.unit.analysis.maths import (
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
 class TestBroadcastingDerived(
-    tests.IrisTest_nometa,
+    tests.IrisTest,
     MathsAddOperationMixin,
     CubeArithmeticBroadcastingTestMixin,
 ):

--- a/lib/iris/tests/unit/analysis/maths/test__arith__meshcoords.py
+++ b/lib/iris/tests/unit/analysis/maths/test__arith__meshcoords.py
@@ -54,9 +54,8 @@ class MeshLocationsMixin:
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
 class TestBroadcastingWithMesh(
-    tests.IrisTest_nometa,
+    tests.IrisTest,
     MeshLocationsMixin,
     MathsAddOperationMixin,
     CubeArithmeticBroadcastingTestMixin,
@@ -71,9 +70,8 @@ class TestBroadcastingWithMesh(
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
 class TestBroadcastingWithMeshAndDerived(
-    tests.IrisTest_nometa,
+    tests.IrisTest,
     MeshLocationsMixin,
     MathsAddOperationMixin,
     CubeArithmeticBroadcastingTestMixin,

--- a/lib/iris/tests/unit/analysis/maths/test_add.py
+++ b/lib/iris/tests/unit/analysis/maths/test_add.py
@@ -21,10 +21,7 @@ from iris.tests.unit.analysis.maths import (
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
-class TestBroadcasting(
-    tests.IrisTest_nometa, CubeArithmeticBroadcastingTestMixin
-):
+class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):
         return operator.add
@@ -34,8 +31,7 @@ class TestBroadcasting(
         return add
 
 
-@tests.iristest_timing_decorator
-class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+class TestMasking(tests.IrisTest, CubeArithmeticMaskingTestMixin):
     @property
     def data_op(self):
         return operator.add
@@ -57,9 +53,8 @@ class TestCoordMatch(CubeArithmeticCoordsTest):
             add(cube1, cube2)
 
 
-@tests.iristest_timing_decorator
 class TestMaskedConstant(
-    tests.IrisTest_nometa, CubeArithmeticMaskedConstantTestMixin
+    tests.IrisTest, CubeArithmeticMaskedConstantTestMixin
 ):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/maths/test_divide.py
+++ b/lib/iris/tests/unit/analysis/maths/test_divide.py
@@ -23,10 +23,7 @@ from iris.tests.unit.analysis.maths import (
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
-class TestBroadcasting(
-    tests.IrisTest_nometa, CubeArithmeticBroadcastingTestMixin
-):
+class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):
         return operator.truediv
@@ -36,8 +33,7 @@ class TestBroadcasting(
         return divide
 
 
-@tests.iristest_timing_decorator
-class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+class TestMasking(tests.IrisTest, CubeArithmeticMaskingTestMixin):
     @property
     def data_op(self):
         return operator.truediv

--- a/lib/iris/tests/unit/analysis/maths/test_multiply.py
+++ b/lib/iris/tests/unit/analysis/maths/test_multiply.py
@@ -21,10 +21,7 @@ from iris.tests.unit.analysis.maths import (
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
-class TestBroadcasting(
-    tests.IrisTest_nometa, CubeArithmeticBroadcastingTestMixin
-):
+class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):
         return operator.mul
@@ -34,8 +31,7 @@ class TestBroadcasting(
         return multiply
 
 
-@tests.iristest_timing_decorator
-class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+class TestMasking(tests.IrisTest, CubeArithmeticMaskingTestMixin):
     @property
     def data_op(self):
         return operator.mul
@@ -57,9 +53,8 @@ class TestCoordMatch(CubeArithmeticCoordsTest):
             multiply(cube1, cube2)
 
 
-@tests.iristest_timing_decorator
 class TestMaskedConstant(
-    tests.IrisTest_nometa, CubeArithmeticMaskedConstantTestMixin
+    tests.IrisTest, CubeArithmeticMaskedConstantTestMixin
 ):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/analysis/maths/test_subtract.py
+++ b/lib/iris/tests/unit/analysis/maths/test_subtract.py
@@ -21,10 +21,7 @@ from iris.tests.unit.analysis.maths import (
 
 
 @tests.skip_data
-@tests.iristest_timing_decorator
-class TestBroadcasting(
-    tests.IrisTest_nometa, CubeArithmeticBroadcastingTestMixin
-):
+class TestBroadcasting(tests.IrisTest, CubeArithmeticBroadcastingTestMixin):
     @property
     def data_op(self):
         return operator.sub
@@ -34,8 +31,7 @@ class TestBroadcasting(
         return subtract
 
 
-@tests.iristest_timing_decorator
-class TestMasking(tests.IrisTest_nometa, CubeArithmeticMaskingTestMixin):
+class TestMasking(tests.IrisTest, CubeArithmeticMaskingTestMixin):
     @property
     def data_op(self):
         return operator.sub
@@ -57,9 +53,8 @@ class TestCoordMatch(CubeArithmeticCoordsTest):
             subtract(cube1, cube2)
 
 
-@tests.iristest_timing_decorator
 class TestMaskedConstant(
-    tests.IrisTest_nometa, CubeArithmeticMaskedConstantTestMixin
+    tests.IrisTest, CubeArithmeticMaskedConstantTestMixin
 ):
     @property
     def data_op(self):

--- a/lib/iris/tests/unit/merge/test_ProtoCube.py
+++ b/lib/iris/tests/unit/merge/test_ProtoCube.py
@@ -77,8 +77,7 @@ class Mixin_register(metaclass=ABCMeta):
             self.assertTrue(result)
 
 
-@tests.iristest_timing_decorator
-class Test_register__match(Mixin_register, tests.IrisTest_nometa):
+class Test_register__match(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return []
@@ -88,8 +87,7 @@ class Test_register__match(Mixin_register, tests.IrisTest_nometa):
         return example_cube()
 
 
-@tests.iristest_timing_decorator
-class Test_register__standard_name(Mixin_register, tests.IrisTest_nometa):
+class Test_register__standard_name(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.standard_name", "air_temperature", "air_density"]
@@ -101,8 +99,7 @@ class Test_register__standard_name(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__long_name(Mixin_register, tests.IrisTest_nometa):
+class Test_register__long_name(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.long_name", "screen_air_temp", "Belling"]
@@ -114,8 +111,7 @@ class Test_register__long_name(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__var_name(Mixin_register, tests.IrisTest_nometa):
+class Test_register__var_name(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.var_name", "'airtemp'", "'airtemp2'"]
@@ -127,8 +123,7 @@ class Test_register__var_name(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__units(Mixin_register, tests.IrisTest_nometa):
+class Test_register__units(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.units", "'K'", "'C'"]
@@ -140,8 +135,7 @@ class Test_register__units(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__attributes_unequal(Mixin_register, tests.IrisTest_nometa):
+class Test_register__attributes_unequal(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.attributes", "'mint'"]
@@ -153,10 +147,7 @@ class Test_register__attributes_unequal(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__attributes_unequal_array(
-    Mixin_register, tests.IrisTest_nometa
-):
+class Test_register__attributes_unequal_array(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.attributes", "'mint'"]
@@ -174,10 +165,7 @@ class Test_register__attributes_unequal_array(
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__attributes_superset(
-    Mixin_register, tests.IrisTest_nometa
-):
+class Test_register__attributes_superset(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.attributes", "'stuffed'"]
@@ -189,10 +177,7 @@ class Test_register__attributes_superset(
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__attributes_multi_diff(
-    Mixin_register, tests.IrisTest_nometa
-):
+class Test_register__attributes_multi_diff(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.attributes", "'sam'", "'mint'"]
@@ -215,8 +200,7 @@ class Test_register__attributes_multi_diff(
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__cell_method(Mixin_register, tests.IrisTest_nometa):
+class Test_register__cell_method(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.cell_methods"]
@@ -228,8 +212,7 @@ class Test_register__cell_method(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__data_shape(Mixin_register, tests.IrisTest_nometa):
+class Test_register__data_shape(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube.shape", "(2,)", "(3,)"]
@@ -241,8 +224,7 @@ class Test_register__data_shape(Mixin_register, tests.IrisTest_nometa):
         return cube
 
 
-@tests.iristest_timing_decorator
-class Test_register__data_dtype(Mixin_register, tests.IrisTest_nometa):
+class Test_register__data_dtype(Mixin_register, tests.IrisTest):
     @property
     def fragments(self):
         return ["cube data dtype", "int32", "int8"]

--- a/lib/iris/tests/unit/tests/test_IrisTest.py
+++ b/lib/iris/tests/unit/tests/test_IrisTest.py
@@ -66,8 +66,7 @@ class _MaskedArrayEquality(metaclass=ABCMeta):
             self._func(self.arr1, arr2, strict=False)
 
 
-@tests.iristest_timing_decorator
-class Test_assertMaskedArrayEqual(_MaskedArrayEquality, tests.IrisTest_nometa):
+class Test_assertMaskedArrayEqual(_MaskedArrayEquality, tests.IrisTest):
     @property
     def _func(self):
         return self.assertMaskedArrayEqual
@@ -114,10 +113,7 @@ class Test_assertMaskedArrayEqual__Nonmaasked(tests.IrisTest):
         self.assertMaskedArrayEqual(arr1, arr2)
 
 
-@tests.iristest_timing_decorator
-class Test_assertMaskedArrayAlmostEqual(
-    _MaskedArrayEquality, tests.IrisTest_nometa
-):
+class Test_assertMaskedArrayAlmostEqual(_MaskedArrayEquality, tests.IrisTest):
     @property
     def _func(self):
         return self.assertMaskedArrayAlmostEqual


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Here is some more Iris functionality that I did not know existed, until @pp-mo mentioned it the other day.  Described by the removed comment
https://github.com/SciTools/iris/blob/6eb0401011a8edce51a942a176e2feb06f4b3f09/lib/iris/tests/__init__.py#L940-L946

I tried to run this with `unittest discover` as the comment recommends, but got errors, particularly from [test_pandas.py](https://github.com/SciTools/iris/blob/main/lib/iris/tests/unit/pandas/test_pandas.py).  I found that this functionality can be used with `pytest -s -v`, so if we do want to keep the functionality we should probably document that.  I'm unsure if it can be made to work with `pytest-xdist`.

In any case, pytest provides its own functionality to tell you the timings of the slowest running tests via the `--durations` flag, and of course we now have some `pytest` tests which don't inherit from `IrisTest`, so won't work with the bespoke functionality unless we go through and add the decorator.

More generally, the more we can simplify these test classes, the better chance we have of eventually ditching `unittest` altogether.

This functionality was added at #2372.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
