### PR TITLE
Switch order of options and parameter in `ncgen` command

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -73,14 +73,15 @@ This document explains the changes made to Iris for this release
 💼 Internal
 ===========
 
-#. N/A
+#. `@fnattino`_ changed the order of ``ncgen`` arguments in the command to
+   create NetCDF files for testing  (caused errors on OS X). (:pull:`5105`)
 
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
-
+.. _@fnattino: https://github.com/fnattino
 
 
 .. comment

--- a/lib/iris/tests/stock/netcdf.py
+++ b/lib/iris/tests/stock/netcdf.py
@@ -51,7 +51,7 @@ def ncgen_from_cdl(
             f_out.write(cdl_str)
     if cdl_path:
         # Create netcdf from stored CDL file.
-        call_args = [NCGEN_PATHSTR, cdl_path, "-k3", "-o", nc_path]
+        call_args = [NCGEN_PATHSTR, "-k3", "-o", nc_path, cdl_path]
         call_kwargs = {}
     else:
         # No CDL file : pipe 'cdl_str' directly into the ncgen program.


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Switch order of options and parameter in the call to `ncgen` (current order leads to error on OS X). Closes #5097.  

