### PR TITLE
pip pin for sphinx<5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ where = lib
 
 [options.extras_require]
 docs =
-    sphinx
+    sphinx<5
     sphinx-copybutton
     sphinx-gallery>=0.11.0
     sphinx_rtd_theme


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR temporarily resolves the existing documentation build failure on RTD i.e., see [here](https://readthedocs.org/api/v2/build/19061195.txt)

There are a couple of factors in play here:

1. The `sphinx-panels` package is no longer maintained (#5121) and is pinning back the `sphinx` package from >=v6.0.0 to v4.5.0 on `conda-forge`
2. The `pydata-sphinx-theme` is pinned to v0.8.1 (latest version available is >=v0.12.0), and this is causing the additional `pip install` step on RTD to pull the `sphinx` package **way down** to v3.5.3 which is incompatible and, I suspect, causing the following traceback:
```shell
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/__main__.py", line 13, in <module>
    from sphinx.cmd.build import main
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/cmd/build.py", line 25, in <module>
    from sphinx.application import Sphinx
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/application.py", line 32, in <module>
    from sphinx.config import Config
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/config.py", line 23, in <module>
    from sphinx.util import logging
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/util/__init__.py", line 35, in <module>
    from sphinx.util import smartypants  # noqa
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/util/smartypants.py", line 33, in <module>
    from sphinx.util.docutils import __version_info__ as docutils_version
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/util/docutils.py", line 31, in <module>
    from sphinx.util.typing import RoleFunction
  File "/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/site-packages/sphinx/util/typing.py", line 34, in <module>
    from types import Union as types_Union
ImportError: cannot import name 'Union' from 'types' (/home/docs/checkouts/readthedocs.org/user_builds/scitools-iris/conda/latest/lib/python3.10/types.py)
```

We can circumvent this dependency carnage (no thanks to `pip`) by introducing the **temporary** maximum pin `sphinx<5` within the `setup.cfg`, which prevent the `pip` dependency resolver "stuffing up" :tm:, and maintaining the compatible dependencies resolved and installed by `conda`.

However, as a follow-up, I strongly recommend that we address:
- #5121 to unpin `sphinx`
- #4795 work to resolve the dark-mode issues pinning the `pydata-sphinx-theme` back at v0.8.1

The documentation built by this PR can be viewed [here](https://bjlittle-iris.readthedocs.io/en/latest/) and the RTD raw build output is available [here](https://readthedocs.org/api/v2/build/19062285.txt).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
