### PR TITLE
Unpin theme

### DIFF
--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -11,7 +11,7 @@
         <div id="slim-red-box-banner">
             You are viewing the <b>latest</b> unreleased documentation
             <b>v{{ version }}</b>. You can switch to a <b>stable</b> version
-            via the flyout menu in the bottom-right of the screen.
+            via the flyout menu in the bottom corner of the screen.
         </div>
         <p></p>
     {%- endif %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -324,7 +324,7 @@ html_context = {
     "github_user": "scitools",
     "github_version": "main",
     "doc_path": "docs/src",
-    # default theme.  Also disabled the button in ther html_theme_options.
+    # default theme.  Also disabled the button in the html_theme_options.
     # Info: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/light-dark.html#configure-default-theme-mode
     "default_mode": "light",
     # custom

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -310,6 +310,9 @@ html_theme_options = {
     ],
     "use_edit_page_button": True,
     "show_toc_level": 1,
+    # Omitted `theme-switcher` below to disable it
+    # Info: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/light-dark.html#configure-default-theme-mode
+    "navbar_end": ["navbar-icon-links"],
 }
 
 rev_parse = run(["git", "rev-parse", "--short", "HEAD"], capture_output=True)
@@ -321,6 +324,9 @@ html_context = {
     "github_user": "scitools",
     "github_version": "main",
     "doc_path": "docs/src",
+    # default theme.  Also disabled the button in ther html_theme_options.
+    # Info: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/light-dark.html#configure-default-theme-mode
+    "default_mode": "light",
     # custom
     "on_rtd": on_rtd,
     "rtd_version": rtd_version,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -68,6 +68,9 @@ This document explains the changes made to Iris for this release
 ================
 
 #. `@rcomer`_ clarified instructions for updating gallery tests. (:pull:`5100`)
+#. `@tkknight`_ unpinned ``pydata-sphinx-theme`` and set the default to use
+   the light version (not dark) while we make the docs dark mode friendly
+   (:pull:`????`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -70,7 +70,7 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ clarified instructions for updating gallery tests. (:pull:`5100`)
 #. `@tkknight`_ unpinned ``pydata-sphinx-theme`` and set the default to use
    the light version (not dark) while we make the docs dark mode friendly
-   (:pull:`????`)
+   (:pull:`5129`)
 
 
 💼 Internal

--- a/requirements/ci/py310.yml
+++ b/requirements/ci/py310.yml
@@ -48,7 +48,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-panels
-  - pydata-sphinx-theme = 0.8.1
+  - pydata-sphinx-theme
 
 # Temporary minimum pins.
 # See https://github.com/SciTools/iris/pull/5051

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -48,7 +48,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-panels
-  - pydata-sphinx-theme = 0.8.1
+  - pydata-sphinx-theme
 
 # Temporary minimum pins.
 # See https://github.com/SciTools/iris/pull/5051

--- a/requirements/ci/py39.yml
+++ b/requirements/ci/py39.yml
@@ -48,7 +48,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-panels
-  - pydata-sphinx-theme = 0.8.1
+  - pydata-sphinx-theme
 
 # Temporary minimum pins.
 # See https://github.com/SciTools/iris/pull/5051


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Unpinned `pydata-sphinx-theme` and set the default to use the `light` version (not dark).

We can enable the dark mode (and the switcher) once our docs are dark mode friendly.

See https://github.com/SciTools/iris/issues/4795

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
