### PR TITLE
PP Proleptic Gregorian

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1078,7 +1078,7 @@ class PPField(metaclass=ABCMeta):
     def calendar(self):
         """Return the calendar of the field."""
         # TODO #577 What calendar to return when ibtim.ic in [0, 3]
-        calendar = cf_units.CALENDAR_STANDARD
+        calendar = cf_units.CALENDAR_PROLEPTIC_GREGORIAN
         if self.lbtim.ic == 2:
             calendar = cf_units.CALENDAR_360_DAY
         elif self.lbtim.ic == 4:

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -503,6 +503,11 @@ def _new_coord_and_dims(
         a new (coordinate, dims) pair.
 
     """
+    if (
+        units.is_time_reference()
+        and units.calendar == cf_units.CALENDAR_PROLEPTIC_GREGORIAN
+    ):
+        units = units.change_calendar(cf_units.CALENDAR_STANDARD)
     bounds = lower_and_upper_bounds
     if is_vector_operation:
         dims, points, bounds = _reduce_points_and_bounds(points, bounds)
@@ -548,7 +553,7 @@ def _epoch_date_hours_internals(epoch_hours_unit, datetime):
         if m == 0:
             # Add a 'January', by changing month=0 to 1.
             m = 1
-            if calendar == cf_units.CALENDAR_STANDARD:
+            if calendar == cf_units.CALENDAR_PROLEPTIC_GREGORIAN:
                 days_offset += 31
             elif calendar == cf_units.CALENDAR_360_DAY:
                 days_offset += 30
@@ -561,7 +566,7 @@ def _epoch_date_hours_internals(epoch_hours_unit, datetime):
         if y == 0:
             # Add a 'Year 0', by changing year=0 to 1.
             y = 1
-            if calendar == cf_units.CALENDAR_STANDARD:
+            if calendar == cf_units.CALENDAR_PROLEPTIC_GREGORIAN:
                 days_in_year_0 = 366
             elif calendar == cf_units.CALENDAR_360_DAY:
                 days_in_year_0 = 360

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -507,7 +507,9 @@ def _new_coord_and_dims(
         units.is_time_reference()
         and units.calendar == cf_units.CALENDAR_PROLEPTIC_GREGORIAN
     ):
-        units = units.change_calendar(cf_units.CALENDAR_STANDARD)
+        units = cf_units.Unit(
+            "hours since epoch", calendar=cf_units.CALENDAR_STANDARD
+        )
     bounds = lower_and_upper_bounds
     if is_vector_operation:
         dims, points, bounds = _reduce_points_and_bounds(points, bounds)

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -143,7 +143,7 @@ class Test_calendar(tests.IrisTest):
     def test_greg(self):
         field = DummyPPField()
         field.lbtim = SplittableInt(1, {"ia": 2, "ib": 1, "ic": 0})
-        self.assertEqual(field.calendar, "standard")
+        self.assertEqual(field.calendar, "proleptic_gregorian")
 
     def test_360(self):
         field = DummyPPField()

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
@@ -13,7 +13,12 @@ Unit tests for
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-from cf_units import CALENDAR_360_DAY, CALENDAR_PROLEPTIC_GREGORIAN, Unit
+from cf_units import (
+    CALENDAR_360_DAY,
+    CALENDAR_PROLEPTIC_GREGORIAN,
+    CALENDAR_STANDARD,
+    Unit,
+)
 from cftime import datetime as nc_datetime
 import numpy as np
 
@@ -38,9 +43,10 @@ def _lbcode(value=None, ix=None, iy=None):
     return result
 
 
-_EPOCH_HOURS_UNIT = Unit(
+_EPOCH_HOURS_UNIT_IN = Unit(
     "hours since epoch", calendar=CALENDAR_PROLEPTIC_GREGORIAN
 )
+_EPOCH_HOURS_UNIT_OUT = Unit("hours since epoch", calendar=CALENDAR_STANDARD)
 _HOURS_UNIT = Unit("hours")
 
 
@@ -63,7 +69,7 @@ class TestLBTIMx0x_SingleTimepoint(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -74,7 +80,7 @@ class TestLBTIMx0x_SingleTimepoint(TestField):
                     DimCoord(
                         24 * 0.25,
                         standard_name="time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                     ),
                     None,
                 )
@@ -104,7 +110,7 @@ class TestLBTIMx1x_Forecast(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -123,7 +129,7 @@ class TestLBTIMx1x_Forecast(TestField):
                     DimCoord(
                         24 * 9.25,
                         standard_name="time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                     ),
                     None,
                 ),
@@ -131,7 +137,7 @@ class TestLBTIMx1x_Forecast(TestField):
                     DimCoord(
                         24 * 8.125,
                         standard_name="forecast_reference_time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                     ),
                     None,
                 ),
@@ -156,7 +162,7 @@ class TestLBTIMx1x_Forecast(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=_lbcode(1),
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=None,
@@ -173,7 +179,7 @@ class TestLBTIMx1x_Forecast(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=_lbcode(1),
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=None,
@@ -194,7 +200,7 @@ class TestLBTIMx2x_TimePeriod(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -205,7 +211,7 @@ class TestLBTIMx2x_TimePeriod(TestField):
                     DimCoord(
                         24 * 9.125 - 2.0,
                         standard_name="forecast_reference_time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                     ),
                     None,
                 ),
@@ -221,7 +227,7 @@ class TestLBTIMx2x_TimePeriod(TestField):
                 (
                     DimCoord(
                         standard_name="time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                         points=[24 * 8.625],
                         bounds=[24 * 8.125, 24 * 9.125],
                     ),
@@ -253,7 +259,7 @@ class TestLBTIMx3x_YearlyAggregation(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -267,7 +273,7 @@ class TestLBTIMx3x_YearlyAggregation(TestField):
                     DimCoord(
                         [t2_hours - lbft],
                         standard_name="forecast_reference_time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                     ),
                     None,
                 ),
@@ -283,7 +289,7 @@ class TestLBTIMx3x_YearlyAggregation(TestField):
                 (
                     DimCoord(
                         standard_name="time",
-                        units=_EPOCH_HOURS_UNIT,
+                        units=_EPOCH_HOURS_UNIT_OUT,
                         points=[t2_hours],
                         bounds=[t1_hours, t2_hours],
                     ),
@@ -314,7 +320,7 @@ class TestLBTIMx2x_ZeroYear(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -332,7 +338,7 @@ class TestLBTIMxxx_Unhandled(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -355,7 +361,7 @@ class TestLBCODE3xx(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -366,7 +372,7 @@ class TestLBCODE3xx(TestField):
                 DimCoord(
                     [t2_hours - lbft],
                     standard_name="forecast_reference_time",
-                    units=_EPOCH_HOURS_UNIT,
+                    units=_EPOCH_HOURS_UNIT_OUT,
                 ),
                 None,
             )
@@ -391,7 +397,7 @@ class TestArrayInputWithLBTIM_0_0_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_OUT,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -400,7 +406,9 @@ class TestArrayInputWithLBTIM_0_0_1(TestField):
 
         # Expected coords.
         time_coord = DimCoord(
-            (24 * 8) + 3 + hours, standard_name="time", units=_EPOCH_HOURS_UNIT
+            (24 * 8) + 3 + hours,
+            standard_name="time",
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [(time_coord, (0,))]
         self.assertCoordsAndDimsListsMatch(coords_and_dims, expected)
@@ -427,7 +435,7 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -443,12 +451,12 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         time_coord = DimCoord(
             (24 * 8) + 3 + forecast_period_in_hours,
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         fref_time_coord = DimCoord(
             (24 * 8) + 3,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0,)),
@@ -480,7 +488,7 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -497,12 +505,12 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         time_coord = DimCoord(
             (24 * 8) + 3 + forecast_period_in_hours,
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         fref_time_coord = DimCoord(
             (24 * 8) + 3,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0,)),
@@ -530,7 +538,7 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -548,13 +556,13 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         )
         points = (years - 1970) * 24 * 365 + (24 * 8) + 12
         time_coord = DimCoord(
-            points, standard_name="time", units=_EPOCH_HOURS_UNIT
+            points, standard_name="time", units=_EPOCH_HOURS_UNIT_OUT
         )
         points = (24 * 8) + hours
         fref_time_coord = DimCoord(
             points,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0, 1)),  # Spans dims 0 and 1.
@@ -587,7 +595,7 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -612,12 +620,12 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
                 for year in years
             ],
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         fref_time_coord = DimCoord(
             (24 * 8) + 3,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0, 1)),
@@ -651,7 +659,7 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -668,12 +676,12 @@ class TestArrayInputWithLBTIM_0_1_1(TestField):
         time_coord = DimCoord(
             (24 * 8) + 3 + forecast_period_in_hours,
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         fref_time_coord = DimCoord(
             (24 * 8) + 3,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0,)),
@@ -698,7 +706,7 @@ class TestArrayInputWithLBTIM_0_2_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -723,14 +731,14 @@ class TestArrayInputWithLBTIM_0_2_1(TestField):
         time_coord = AuxCoord(
             points,
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
             bounds=bounds,
         )
         points = 10 * 24 + 9 - lbft
         fref_time_coord = DimCoord(
             points,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0,)),
@@ -755,7 +763,7 @@ class TestArrayInputWithLBTIM_0_3_1(TestField):
         coords_and_dims = _convert_time_coords(
             lbcode=lbcode,
             lbtim=lbtim,
-            epoch_hours_unit=_EPOCH_HOURS_UNIT,
+            epoch_hours_unit=_EPOCH_HOURS_UNIT_IN,
             t1=t1,
             t2=t2,
             lbft=lbft,
@@ -786,13 +794,13 @@ class TestArrayInputWithLBTIM_0_3_1(TestField):
         time_coord = AuxCoord(
             points,
             standard_name="time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
             bounds=bounds,
         )
         fref_time_coord = DimCoord(
             points - lbft,
             standard_name="forecast_reference_time",
-            units=_EPOCH_HOURS_UNIT,
+            units=_EPOCH_HOURS_UNIT_OUT,
         )
         expected = [
             (fp_coord, (0,)),

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__convert_time_coords.py
@@ -13,7 +13,7 @@ Unit tests for
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-from cf_units import CALENDAR_360_DAY, CALENDAR_STANDARD, Unit
+from cf_units import CALENDAR_360_DAY, CALENDAR_PROLEPTIC_GREGORIAN, Unit
 from cftime import datetime as nc_datetime
 import numpy as np
 
@@ -38,14 +38,24 @@ def _lbcode(value=None, ix=None, iy=None):
     return result
 
 
-_EPOCH_HOURS_UNIT = Unit("hours since epoch", calendar=CALENDAR_STANDARD)
+_EPOCH_HOURS_UNIT = Unit(
+    "hours since epoch", calendar=CALENDAR_PROLEPTIC_GREGORIAN
+)
 _HOURS_UNIT = Unit("hours")
 
 
 class TestLBTIMx0x_SingleTimepoint(TestField):
     def _check_timepoint(self, lbcode, expect_match=True):
         lbtim = _lbtim(ib=0, ic=1)
-        t1 = nc_datetime(1970, 1, 1, hour=6, minute=0, second=0)
+        t1 = nc_datetime(
+            1970,
+            1,
+            1,
+            hour=6,
+            minute=0,
+            second=0,
+            calendar="proleptic_gregorian",
+        )
         t2 = nc_datetime(
             0, 0, 0, calendar=None, has_year_zero=True
         )  # not used in result

--- a/lib/iris/tests/unit/fileformats/pp_load_rules/test__epoch_date_hours.py
+++ b/lib/iris/tests/unit/fileformats/pp_load_rules/test__epoch_date_hours.py
@@ -30,7 +30,7 @@ from iris.fileformats.pp_load_rules import (
 
 class TestEpochHours__standard(tests.IrisTest):
     def setUp(self):
-        self.calendar = cf_units.CALENDAR_STANDARD
+        self.calendar = cf_units.CALENDAR_PROLEPTIC_GREGORIAN
         self.hrs_unit = Unit("hours since epoch", calendar=self.calendar)
 
     def test_1970_1_1(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
A proposal to resolve #3561, hopefully without creating breaking changes for the user.  Quoting myself from that issue:

> Noting that
>
>* 1st January 1970 is the same date in the Proleptic Gregorian and Standard calendars
>* Any time point expressed as _hours since_ 1st January 1970 is also therefore the same in the Proleptic Gregorian and Standard calendars
>
>So, once we have converted our pp time headers into a coordinate with unit "hours since 1970-01-01 00:00:00", it is somewhat arbitrary whether we label it "proleptic_gregorian" or "standard".  Would it therefore be reasonable to use the Proleptic Gregorian calendar to do the conversion from pp-header to coordinate, but still label the coordinate with the "standard" calendar?  It would be a bit of a fudge, but would mean any change in behaviour would be limited to dates before 15th October 1582, and therefore a bugfix.

Similarly, when saving we can convert a standard calendar unit to Proleptic Gregorian with the `cf_units.Unit.change_calendar` method, and then use that new unit to do the `date2num` conversion.

I've done a fair bit of test wrangling.  I think the last few failures reflect that the years 0 and 1 are genuinely different in the two calendars, so the expected values could just be updated.  Leaving that for now and opening as draft to see what people think.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
