### PR TITLE
Avoid realising auxiliary coordinates in `concatenate`

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -102,7 +102,7 @@ class _CoordMetaData(
         """
         defn = coord.metadata
         points_dtype = coord.core_points().dtype
-        bounds_dtype = coord.core_bounds().dtype if coord.bounds is not None else None
+        bounds_dtype = coord.core_bounds().dtype if coord.core_bounds() is not None else None
         kwargs = {}
         # Add scalar flag metadata.
         kwargs["scalar"] = coord.core_points().size == 1
@@ -623,14 +623,14 @@ class _CoordSignature:
 
         if candidate_axis:
             # Ensure both have equal availability of bounds.
-            result = (coord.bounds is None) == (other.bounds is None)
+            result = (coord.core_bounds() is None) == (other.core_bounds() is None)
         else:
-            if coord.bounds is not None and other.bounds is not None:
+            if coord.core_bounds() is not None and other.core_bounds() is not None:
                 # Ensure equality of bounds.
-                result = array_equal(coord.bounds, other.bounds)
+                result = array_equal(coord.core_bounds(), other.core_bounds())
             else:
                 # Ensure both have equal availability of bounds.
-                result = coord.bounds is None and other.bounds is None
+                result = coord.core_bounds() is None and other.core_bounds() is None
 
         return result, candidate_axis
 
@@ -682,20 +682,20 @@ class _CoordSignature:
         for coord, order in zip(self.dim_coords, self.dim_order):
             if order == _CONSTANT or order == _INCREASING:
                 points = _Extent(coord.core_points()[0], coord.core_points()[-1])
-                if coord.bounds is not None:
+                if coord.core_bounds() is not None:
                     bounds = (
-                        _Extent(coord.bounds[0, 0], coord.bounds[-1, 0]),
-                        _Extent(coord.bounds[0, 1], coord.bounds[-1, 1]),
+                        _Extent(coord.core_bounds()[0, 0], coord.core_bounds()[-1, 0]),
+                        _Extent(coord.core_bounds()[0, 1], coord.core_bounds()[-1, 1]),
                     )
                 else:
                     bounds = None
             else:
                 # The order must be decreasing ...
                 points = _Extent(coord.core_points()[-1], coord.core_points()[0])
-                if coord.bounds is not None:
+                if coord.core_bounds() is not None:
                     bounds = (
-                        _Extent(coord.bounds[-1, 0], coord.bounds[0, 0]),
-                        _Extent(coord.bounds[-1, 1], coord.bounds[0, 1]),
+                        _Extent(coord.core_bounds()[-1, 0], coord.core_bounds()[0, 0]),
+                        _Extent(coord.core_bounds()[-1, 1], coord.core_bounds()[0, 1]),
                     )
                 else:
                     bounds = None
@@ -976,7 +976,7 @@ class _ProtoCube:
                 bnds = None
                 if coord.has_bounds():
                     bnds = [
-                        skton.signature.aux_coords_and_dims[i].coord.bounds
+                        skton.signature.aux_coords_and_dims[i].coord.core_bounds()
                         for skton in skeletons
                     ]
                     bnds = np.concatenate(tuple(bnds), axis=dim)
@@ -1130,7 +1130,7 @@ class _ProtoCube:
         bounds = None
         if self._cube_signature.dim_coords[dim_ind].has_bounds():
             bounds = [
-                skeleton.signature.dim_coords[dim_ind].bounds
+                skeleton.signature.dim_coords[dim_ind].core_bounds()
                 for skeleton in skeletons
             ]
             bounds = np.concatenate(tuple(bounds))

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -16,7 +16,6 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
-from iris._lazy_data import as_lazy_data
 from iris.coords import AncillaryVariable, AuxCoord, CellMeasure, DimCoord
 import iris.cube
 import iris.tests.stock as stock

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -757,7 +757,7 @@ class Test2D(tests.IrisTest):
         self.assertTrue(cubes[1].coord("xy-aux").has_lazy_bounds())
         
         self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
-        self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
+        self.assertTrue(result[0].coord("xy-aux").has_lazy_bounds())
 
 
 class TestMulti2D(tests.IrisTest):

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -16,6 +16,7 @@ import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
+from iris._lazy_data import as_lazy_data
 from iris.coords import AncillaryVariable, AuxCoord, CellMeasure, DimCoord
 import iris.cube
 import iris.tests.stock as stock
@@ -745,10 +746,19 @@ class Test2D(tests.IrisTest):
         for cube in cubes:
             cube.data = cube.lazy_data()
             cube.coord("xy-aux").points = cube.coord("xy-aux").lazy_points()
+            bounds = da.arange(
+                4 * cube.coord("xy-aux").core_points().size).reshape(cube.shape + (4,))
+            cube.coord("xy-aux").bounds = bounds
         result = concatenate(cubes)
-        assert self.assertTrue(cubes[0].coord("xy-aux").has_lazy_points())
-        assert self.assertTrue(cubes[1].coord("xy-aux").has_lazy_points())
-        assert self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
+        
+        self.assertTrue(cubes[0].coord("xy-aux").has_lazy_points())
+        self.assertTrue(cubes[0].coord("xy-aux").has_lazy_bounds())
+        
+        self.assertTrue(cubes[1].coord("xy-aux").has_lazy_points())
+        self.assertTrue(cubes[1].coord("xy-aux").has_lazy_bounds())
+        
+        self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
+        self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
 
 
 class TestMulti2D(tests.IrisTest):

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -12,9 +12,11 @@ Test the cube concatenate mechanism.
 # before importing anything else.
 import iris.tests as tests  # isort:skip
 
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
+from iris._lazy_data import as_lazy_data
 from iris.coords import AncillaryVariable, AuxCoord, CellMeasure, DimCoord
 import iris.cube
 import iris.tests.stock as stock
@@ -228,7 +230,6 @@ def _make_cube_3d(x, y, z, data, aux=None, offset=0):
             cube.add_aux_coord(coord, (0, 1, 2))
 
     return cube
-
 
 def concatenate(cubes, order=None):
     """
@@ -735,6 +736,20 @@ class Test2D(tests.IrisTest):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].shape, (6, 2))
         self.assertEqual(result[0], com)
+    
+    def test_concat_lazy_aux_coords(self):
+        cubes = []
+        y = (0, 2)
+        cube = _make_cube((2, 4), y, 2, aux="xy")
+        cubes.append(cube)
+        cubes.append(_make_cube((0, 2), y, 1, aux="xy"))
+        for cube in cubes:
+            cube.data = cube.lazy_data()
+            cube.coord("xy-aux").points = cube.coord("xy-aux").lazy_points()
+        result = concatenate(cubes)
+        assert self.assertTrue(cubes[0].coord("xy-aux").has_lazy_points())
+        assert self.assertTrue(cubes[1].coord("xy-aux").has_lazy_points())
+        assert self.assertTrue(result[0].coord("xy-aux").has_lazy_points())
 
 
 class TestMulti2D(tests.IrisTest):

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -337,7 +337,12 @@ class TestConcatenate__dask(tests.IrisTest):
         cube.add_dim_coord(lat, 0)
         cube.add_dim_coord(lon, 1)
         if aux_coords:
-            aux_coord = iris.coords.AuxCoord(data, var_name="aux_coord")
+            bounds = np.arange(len(points) * nx * 4).reshape(len(points), nx, 4)
+            bounds = as_lazy_data(bounds)
+            aux_coord = iris.coords.AuxCoord(
+                data,
+                var_name="aux_coord",
+                bounds=bounds)
             cube.add_aux_coord(aux_coord, (0, 1))
         return cube
 
@@ -353,8 +358,11 @@ class TestConcatenate__dask(tests.IrisTest):
         c2 = self.build_lazy_cube([3, 4, 5], aux_coords=True)
         (result, ) = concatenate([c1, c2])
         self.assertTrue(c1.coord("aux_coord").has_lazy_points())
+        self.assertTrue(c1.coord("aux_coord").has_lazy_bounds())
         self.assertTrue(c2.coord("aux_coord").has_lazy_points())
+        self.assertTrue(c2.coord("aux_coord").has_lazy_bounds())
         self.assertTrue(result.coord("aux_coord").has_lazy_points())
+        self.assertTrue(result.coord("aux_coord").has_lazy_bounds())
 
     def test_lazy_concatenate_masked_array_mixed_deferred(self):
         c1 = self.build_lazy_cube([1, 2])

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -328,7 +328,7 @@ class TestOrder(tests.IrisTest):
 
 
 class TestConcatenate__dask(tests.IrisTest):
-    def build_lazy_cube(self, points, bounds=None, nx=4):
+    def build_lazy_cube(self, points, bounds=None, nx=4, aux_coords=False):
         data = np.arange(len(points) * nx).reshape(len(points), nx)
         data = as_lazy_data(data)
         cube = iris.cube.Cube(data, standard_name="air_temperature", units="K")
@@ -336,6 +336,9 @@ class TestConcatenate__dask(tests.IrisTest):
         lon = iris.coords.DimCoord(np.arange(nx), "longitude")
         cube.add_dim_coord(lat, 0)
         cube.add_dim_coord(lon, 1)
+        if aux_coords:
+            aux_coord = iris.coords.AuxCoord(data, var_name="aux_coord")
+            cube.add_aux_coord(aux_coord, (0, 1))
         return cube
 
     def test_lazy_concatenate(self):
@@ -344,6 +347,14 @@ class TestConcatenate__dask(tests.IrisTest):
         (cube,) = concatenate([c1, c2])
         self.assertTrue(cube.has_lazy_data())
         self.assertFalse(ma.isMaskedArray(cube.data))
+    
+    def test_lazy_concatenate_aux_coords(self):
+        c1 = self.build_lazy_cube([1, 2], aux_coords=True)
+        c2 = self.build_lazy_cube([3, 4, 5], aux_coords=True)
+        (result, ) = concatenate([c1, c2])
+        self.assertTrue(c1.coord("aux_coord").has_lazy_points())
+        self.assertTrue(c2.coord("aux_coord").has_lazy_points())
+        self.assertTrue(result.coord("aux_coord").has_lazy_points())
 
     def test_lazy_concatenate_masked_array_mixed_deferred(self):
         c1 = self.build_lazy_cube([1, 2])

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -357,10 +357,13 @@ class TestConcatenate__dask(tests.IrisTest):
         c1 = self.build_lazy_cube([1, 2], aux_coords=True)
         c2 = self.build_lazy_cube([3, 4, 5], aux_coords=True)
         (result, ) = concatenate([c1, c2])
+
         self.assertTrue(c1.coord("aux_coord").has_lazy_points())
         self.assertTrue(c1.coord("aux_coord").has_lazy_bounds())
+
         self.assertTrue(c2.coord("aux_coord").has_lazy_points())
         self.assertTrue(c2.coord("aux_coord").has_lazy_bounds())
+
         self.assertTrue(result.coord("aux_coord").has_lazy_points())
         self.assertTrue(result.coord("aux_coord").has_lazy_bounds())
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
---
This PR changes the call from `coord.points` and `coord.bounds` to `coord.core_points()` and `coord.core_bounds()` respectively in order to avoid realising auxiliary coordinates when concatenating cubes.

Closes #5115 

[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
