### PR TITLE
Plugin support

### DIFF
--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -51,6 +51,7 @@
 .. _@ajdawson: https://github.com/ajdawson
 .. _@bjlittle: https://github.com/bjlittle
 .. _@bouweandela: https://github.com/bouweandela
+.. _@bsherratt: https://github.com/bsherratt
 .. _@corinnebosley: https://github.com/corinnebosley
 .. _@cpelley: https://github.com/cpelley
 .. _@djkirkham: https://github.com/djkirkham

--- a/docs/src/community/index.rst
+++ b/docs/src/community/index.rst
@@ -1,4 +1,5 @@
 .. include:: ../common_links.inc
+.. _namespace package: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
 
 .. todo:
     consider scientific-python.org
@@ -46,3 +47,23 @@ smoother interoperability:
    :hidden:
 
    iris_xarray
+
+Plugins
+-------
+
+Iris supports *plugins* under the `iris.plugins` `namespace package`_.  This
+allows packages that extend Iris' functionality to be developed and maintained
+independently, while still being installed into `iris.plugins` instead of a
+separate package.  For example, a plugin may provide loaders or savers for
+additional file formats, or alternative visualisation methods.
+
+Once a plugin is installed, it can be used either via the :func:`iris.use_plugin`
+function, or by importing it directly:
+
+.. code-block:: python
+
+    import iris
+
+    iris.use_plugin("my_plugin")
+    # OR
+    import iris.plugins.my_plugin

--- a/docs/src/community/index.rst
+++ b/docs/src/community/index.rst
@@ -1,5 +1,4 @@
 .. include:: ../common_links.inc
-.. _namespace package: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
 
 .. todo:
     consider scientific-python.org
@@ -51,19 +50,9 @@ smoother interoperability:
 Plugins
 -------
 
-Iris supports *plugins* under the `iris.plugins` `namespace package`_.  This
-allows packages that extend Iris' functionality to be developed and maintained
-independently, while still being installed into `iris.plugins` instead of a
-separate package.  For example, a plugin may provide loaders or savers for
-additional file formats, or alternative visualisation methods.
+Iris can be extended with **plugins**!  See below for further information:
 
-Once a plugin is installed, it can be used either via the :func:`iris.use_plugin`
-function, or by importing it directly:
+.. toctree::
+   :maxdepth: 2
 
-.. code-block:: python
-
-    import iris
-
-    iris.use_plugin("my_plugin")
-    # OR
-    import iris.plugins.my_plugin
+   plugins

--- a/docs/src/community/plugins.rst
+++ b/docs/src/community/plugins.rst
@@ -23,3 +23,44 @@ Once a plugin is installed, it can be used either via the
     iris.use_plugin("my_plugin")
     # OR
     import iris.plugins.my_plugin
+
+
+Creating plugins
+----------------
+
+The choice of a `namespace package`_ makes writing a plugin relatively
+straightforward: it simply needs to appear as a folder within ``iris/plugins``,
+then can be distributed in the same way as any other package.  An example
+repository layout:
+
+.. code-block:: plain
+
+    + lib
+      + iris
+        + plugins
+          + my_plugin
+            - __init__.py
+            - (more code...)
+    - README.md
+    - pyproject.toml
+    - setup.cfg
+    - (other project files...)
+
+In particular, note that there must **not** be any ``__init__.py`` files at
+higher levels than the plugin itself.
+
+The package name - how it is referred to by PyPI/conda, specified by
+``metadata.name`` in ``setup.cfg`` - is recommended to include both "iris" and
+the plugin name.  Continuing this example, its ``setup.cfg`` should include, at
+minimum:
+
+.. code-block:: ini
+
+    [metadata]
+    name = iris-my-plugin
+
+    [options]
+    packages = find_namespace:
+
+    [options.packages.find]
+    where = lib

--- a/docs/src/community/plugins.rst
+++ b/docs/src/community/plugins.rst
@@ -1,5 +1,7 @@
 .. _namespace package: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
 
+.. _community_plugins:
+
 Plugins
 =======
 

--- a/docs/src/community/plugins.rst
+++ b/docs/src/community/plugins.rst
@@ -33,7 +33,7 @@ straightforward: it simply needs to appear as a folder within ``iris/plugins``,
 then can be distributed in the same way as any other package.  An example
 repository layout:
 
-.. code-block:: plain
+.. code-block:: text
 
     + lib
       + iris

--- a/docs/src/community/plugins.rst
+++ b/docs/src/community/plugins.rst
@@ -1,0 +1,25 @@
+.. _namespace package: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
+
+Plugins
+=======
+
+Iris supports **plugins** under the ``iris.plugins`` `namespace package`_.
+This allows packages that extend Iris' functionality to be developed and
+maintained independently, while still being installed into ``iris.plugins``
+instead of a separate package.  For example, a plugin may provide loaders or
+savers for additional file formats, or alternative visualisation methods.
+
+
+Using plugins
+-------------
+
+Once a plugin is installed, it can be used either via the
+:func:`iris.use_plugin` function, or by importing it directly:
+
+.. code-block:: python
+
+    import iris
+
+    iris.use_plugin("my_plugin")
+    # OR
+    import iris.plugins.my_plugin

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -32,7 +32,9 @@ This document explains the changes made to Iris for this release
 ✨ Features
 ===========
 
-#. N/A
+#. `@bsherratt`_ added support for plugins - see the corresponding
+   :ref:`documentation page<community_plugins>` for further information.
+   (:pull:`5144`)
 
 
 🐛 Bugs Fixed

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -478,6 +478,14 @@ def use_plugin(plugin_name):
     """
     Convenience function to import a plugin
 
+    For example::
+
+        use_plugin("my_plugin")
+
+    is equivalent to::
+
+        import iris.plugins.my_plugin
+
     This is useful for plugins that are not used directly, but instead do all
     their setup on import.  In this case, style checkers would not know the
     significance of the import statement and warn that it is an unused import.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -91,6 +91,7 @@ All the load functions share very similar arguments:
 
 import contextlib
 import glob
+import importlib
 import itertools
 import os.path
 import pathlib
@@ -470,3 +471,14 @@ def sample_data_path(*path_to_join):
             "appropriate for general file access.".format(target)
         )
     return target
+
+
+def use_plugin(plugin_name):
+    """
+    Convenience function to import a plugin
+
+    This is useful for plugins that are not used directly, but instead do all
+    their setup on import.  In this case, style checkers would not know the
+    significance of the import statement and warn that it is an unused import.
+    """
+    importlib.import_module(f"iris.plugins.{plugin_name}")

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -130,6 +130,7 @@ __all__ = [
     "sample_data_path",
     "save",
     "site_configuration",
+    "use_plugin",
 ]
 
 

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -134,8 +134,9 @@ class FormatAgent:
                 value = value[:50] + "..."
             printable_values[key] = value
         msg = (
-            "No format specification could be found for the given buffer."
-            " File element cache:\n {}".format(printable_values)
+            "No format specification could be found for the given buffer. "
+            "Perhaps a plugin is missing or has not been loaded. "
+            "File element cache:\n {}".format(printable_values)
         )
         raise ValueError(msg)
 

--- a/lib/iris/plugins/README.md
+++ b/lib/iris/plugins/README.md
@@ -1,4 +1,10 @@
 # Iris plugins
 
-`iris.plugins` is a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
-allowing arbitrary plugins to be installed alongside Iris.
+`iris.plugins` is a [namespace package] allowing arbitrary plugins to be
+installed alongside Iris.
+
+See [the Iris documentation][plugins] for more information.
+
+
+[namespace package]: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
+[plugins]: https://scitools-iris.readthedocs.io/en/latest/community/plugins.html

--- a/lib/iris/plugins/README.md
+++ b/lib/iris/plugins/README.md
@@ -1,0 +1,4 @@
+# Iris plugins
+
+`iris.plugins` is a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
+allowing arbitrary plugins to be installed alongside Iris.


### PR DESCRIPTION
## 🚀 Pull Request

Plugins! cf #4798 and the older proof of concept #3657.

It uses the same approach of namespace packages, but as `iris.plugins` instead of limiting ourselves to `iris.io.plugins`, and does not try to discover which plugins are available (should it..?)

This has been successfully used to separate out the NAME loader, although that will be a separate PR once we're happy with the approach to plugins.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
