### PR TITLE
Adding a CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: "If Iris played an important part in your research then please add us to your reference list by using one of the references below."
+authors:
+    - name: "Met Office"
+    address: "Exeter, Devon"
+title: "Iris"
+abstract: "A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
+version: 3.4
+date-released: 2022-12-01
+licence: LGPL-3.0
+doi: 10.5281/zenodo.7386117
+url: "http://scitools.org.uk/"
+repository-code: "https://github.com/SciTools/iris"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,3 +11,4 @@ licence: LGPL-3.0
 doi: 10.5281/zenodo.7386117
 url: "http://scitools.org.uk/"
 repository-code: "https://github.com/SciTools/iris"
+type: software

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,13 +2,13 @@ cff-version: 1.2.0
 message: "If Iris played an important part in your research then please add us to your reference list by using one of the references below."
 authors:
     - name: "Met Office"
-    address: "Exeter, Devon"
+      address: "Exeter, Devon"
 title: "Iris"
 abstract: "A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
-version: 3.4
-date-released: 2022-12-01
-licence: LGPL-3.0
-doi: 10.5281/zenodo.7386117
+version: "3.4"
+date-released: "2022-12-01"
+licence: "LGPL-3.0"
+doi: "10.5281/zenodo.7386117"
 url: "http://scitools.org.uk/"
 repository-code: "https://github.com/SciTools/iris"
-type: software
+type: "software"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,10 @@
 cff-version: 1.2.0
-message: "If Iris played an important part in your research then please add us to your reference list by using one of the references below."
+message: "If Iris played an important part in your research then please add us to your reference list by using the references below."
 authors:
     - name: "Met Office"
       address: "Exeter, Devon"
-title: "Iris: A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
+title: "Iris"
+abstract: "A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
 version: "3.4"
 date-released: "2022-12-01"
 license: "LGPL-3.0"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,11 +3,10 @@ message: "If Iris played an important part in your research then please add us t
 authors:
     - name: "Met Office"
       address: "Exeter, Devon"
-title: "Iris"
-abstract: "A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
+title: "Iris: A powerful, format-agnostic, and community-driven Python package for analysing and visualising Earth science data"
 version: "3.4"
 date-released: "2022-12-01"
-licence: "LGPL-3.0"
+license: "LGPL-3.0"
 doi: "10.5281/zenodo.7386117"
 url: "http://scitools.org.uk/"
 repository-code: "https://github.com/SciTools/iris"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

I have written the CITATION.cff file for Iris using the information from the [citation page](https://scitools-iris.readthedocs.io/en/latest/userguide/citation.html) of the documentation.

This pull request is a WIP and will require changes based on the answers to some questions that I have below.

resolves #5118

### Questions for @SciTools/iris-devs

1. In the documentation, currently the BibTeX entry begins with @manual tag. When looking through the old PR's #389 and #5116, I cannot find any consideration being given to the @software tag even though to me this seems like the most natural fit. Could you let me know the reasons behind this choice, and I can update the CITATION.cff to reflect @manual if you feel that is still the best fit.

2. With the existence of this file, what should become of the existing citation page of the documentation?
- My thought is that the documentation should in some way link to or reference the github to obtain the references rather than also manually listing them out in the documentation as currently it would be a duplication and so both would need to be maintained.

3. Where would be the best place for this in the 'What's New' section of the documentation?
- 3.5 Given the potential overhaul of the citation page in the documentation what should happen to the existing entry in the documentation section of the 'What's New' "3. [@jonseddon](https://github.com/jonseddon) updated the citation to a more recent version of Iris. ([PR #5116](https://github.com/SciTools/iris/pull/5116))".

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
