### PR TITLE
enforce modern unittest usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,9 @@ repos:
     hooks:
     -   id: sort-all
         types: [file, python]
+
+-   repo: https://github.com/isidentical/teyit
+    rev: 0.4.3
+    hooks:
+    -   id: teyit
+        types: [file, python]

--- a/lib/iris/tests/integration/test_regridding.py
+++ b/lib/iris/tests/integration/test_regridding.py
@@ -156,14 +156,14 @@ class TestZonalMean_global(tests.IrisTest):
 
         # Ensure data remains unchanged.
         # (the same along each column)
-        self.assertTrue(
+        self.assertLess(
             np.array(
                 [
                     (res.data[:, 0] - res.data[:, i]).max()
                     for i in range(1, res.shape[1])
                 ]
-            ).max()
-            < 1e-10
+            ).max(),
+            1e-10,
         )
         self.assertArrayAlmostEqual(res.data[:, 0], self.src.data.reshape(-1))
 

--- a/lib/iris/tests/test_aggregate_by.py
+++ b/lib/iris/tests/test_aggregate_by.py
@@ -1279,7 +1279,7 @@ class TestAggregateBy(tests.IrisTest):
             returned=True,
             weights=self.weights_single,
         )
-        self.assertTrue(isinstance(aggregateby_output, tuple))
+        self.assertIsInstance(aggregateby_output, tuple)
 
         aggregateby_cube = aggregateby_output[0]
         self.assertCML(
@@ -1309,7 +1309,7 @@ class TestAggregateBy(tests.IrisTest):
             returned=True,
             weights=self.weights_multi,
         )
-        self.assertTrue(isinstance(aggregateby_output, tuple))
+        self.assertIsInstance(aggregateby_output, tuple)
 
         aggregateby_cube = aggregateby_output[0]
         self.assertCML(

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -1359,8 +1359,8 @@ class TestLatitudeWeightGeneration(tests.IrisTest):
         )
         cube.add_dim_coord(lat_coord, 0)
         weights = iris.analysis.cartography.cosine_latitude_weights(cube)
-        self.assertTrue(weights.max() <= 1)
-        self.assertTrue(weights.min() >= 0)
+        self.assertLessEqual(weights.max(), 1)
+        self.assertGreaterEqual(weights.min(), 0)
 
     def test_cosine_latitude_weights_0d(self):
         # 0d latitude dimension (scalar coordinate)

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -219,7 +219,7 @@ class TestBasicMaths(tests.IrisTest):
         a = self.cube
 
         b = iris.analysis.maths.add(a, self.cube, in_place=True)
-        self.assertTrue(b is a)
+        self.assertIs(b, a)
         self.assertCML(a, ("analysis", "addition_in_place.cml"))
 
     def test_addition_in_place_coord(self):
@@ -227,7 +227,7 @@ class TestBasicMaths(tests.IrisTest):
 
         # scalar is promoted to a coordinate internally
         b = iris.analysis.maths.add(a, 1000, in_place=True)
-        self.assertTrue(b is a)
+        self.assertIs(b, a)
         self.assertCML(a, ("analysis", "addition_in_place_coord.cml"))
 
     def test_addition_different_attributes(self):

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -691,7 +691,7 @@ class TestIteration(TestCube2d):
                 pass
 
     def test_not_iterable(self):
-        self.assertFalse(isinstance(self.t, collections.abc.Iterable))
+        self.assertNotIsInstance(self.t, collections.abc.Iterable)
 
 
 class Test2dSlicing(TestCube2d):

--- a/lib/iris/tests/test_cell.py
+++ b/lib/iris/tests/test_cell.py
@@ -87,40 +87,40 @@ class TestCells(tests.IrisTest):
 
     def test_in(self):
         c = iris.coords.Cell(4, None)
-        self.assertFalse(c in [3, 5])
-        self.assertTrue(c in [3, 4])
+        self.assertNotIn(c, [3, 5])
+        self.assertIn(c, [3, 4])
 
         c = iris.coords.Cell(4, [4, 5])
-        self.assertFalse(c in [3, 6])
-        self.assertTrue(c in [3, 4])
-        self.assertTrue(c in [3, 5])
+        self.assertNotIn(c, [3, 6])
+        self.assertIn(c, [3, 4])
+        self.assertIn(c, [3, 5])
 
         c = iris.coords.Cell(4, [4, 5])
         c1 = iris.coords.Cell(5, [4, 5])
         c2 = iris.coords.Cell(4, [3, 6])
 
-        self.assertTrue(c in [3, c])
-        self.assertFalse(c in [3, c1])
-        self.assertFalse(c in [3, c2])
+        self.assertIn(c, [3, c])
+        self.assertNotIn(c, [3, c1])
+        self.assertNotIn(c, [3, c2])
 
     def test_coord_equality(self):
         self.d = iris.coords.Cell(1.9, None)
-        self.assertTrue(self.d == 1.9)
-        self.assertFalse(self.d == [1.5, 1.9])
-        self.assertFalse(self.d != 1.9)
-        self.assertTrue(self.d >= 1.9)
-        self.assertTrue(self.d <= 1.9)
+        self.assertEqual(self.d, 1.9)
+        self.assertNotEqual(self.d, [1.5, 1.9])
+        self.assertEqual(self.d, 1.9)
+        self.assertGreaterEqual(self.d, 1.9)
+        self.assertLessEqual(self.d, 1.9)
         self.assertFalse(self.d > 1.9)
         self.assertFalse(self.d < 1.9)
-        self.assertFalse(self.d in [1.5, 3.5])
-        self.assertTrue(self.d in [1.5, 1.9])
+        self.assertNotIn(self.d, [1.5, 3.5])
+        self.assertIn(self.d, [1.5, 1.9])
 
-        self.assertTrue(self.d != 1)
-        self.assertFalse(self.d == 1)
+        self.assertNotEqual(self.d, 1)
+        self.assertNotEqual(self.d, 1)
         self.assertFalse(self.d >= 2)
         self.assertFalse(self.d <= 1)
-        self.assertTrue(self.d > 1)
-        self.assertTrue(self.d < 2)
+        self.assertGreater(self.d, 1)
+        self.assertLess(self.d, 2)
 
         # Ensure the Cell's operators return NotImplemented.
         class Terry:
@@ -152,72 +152,72 @@ class TestCells(tests.IrisTest):
 
     def test_coord_bounds_cmp(self):
         self.e = iris.coords.Cell(0.7, [1.1, 1.9])
-        self.assertTrue(self.e == 1.6)
-        self.assertFalse(self.e != 1.6)
-        self.assertTrue(self.e >= 1.9)
-        self.assertTrue(self.e <= 1.9)
+        self.assertEqual(self.e, 1.6)
+        self.assertEqual(self.e, 1.6)
+        self.assertGreaterEqual(self.e, 1.9)
+        self.assertLessEqual(self.e, 1.9)
         self.assertFalse(self.e > 1.9)
         self.assertFalse(self.e < 1.9)
 
-        self.assertFalse(self.e in [1.0, 3.5])
-        self.assertTrue(self.e in [1.5, 1.9])
-        self.assertTrue(self.e != 1)
-        self.assertFalse(self.e == 1)
+        self.assertNotIn(self.e, [1.0, 3.5])
+        self.assertIn(self.e, [1.5, 1.9])
+        self.assertNotEqual(self.e, 1)
+        self.assertNotEqual(self.e, 1)
         self.assertFalse(self.e >= 2)
         self.assertFalse(self.e <= 1)
-        self.assertTrue(self.e > 1)
-        self.assertTrue(self.e < 2)
+        self.assertGreater(self.e, 1)
+        self.assertLess(self.e, 2)
 
     def test_cell_cell_cmp(self):
         self.e = iris.coords.Cell(1)
         self.f = iris.coords.Cell(1)
 
-        self.assertTrue(self.e == self.f)
+        self.assertEqual(self.e, self.f)
         self.assertEqual(hash(self.e), hash(self.f))
 
         self.e = iris.coords.Cell(1)
         self.f = iris.coords.Cell(1, [0, 2])
 
-        self.assertFalse(self.e == self.f)
+        self.assertNotEqual(self.e, self.f)
         self.assertNotEqual(hash(self.e), hash(self.f))
 
         self.e = iris.coords.Cell(1, [0, 2])
         self.f = iris.coords.Cell(1, [0, 2])
 
-        self.assertTrue(self.e == self.f)
+        self.assertEqual(self.e, self.f)
         self.assertEqual(hash(self.e), hash(self.f))
 
         self.e = iris.coords.Cell(1, [0, 2])
         self.f = iris.coords.Cell(1, [2, 0])
 
-        self.assertTrue(self.e == self.f)
+        self.assertEqual(self.e, self.f)
         self.assertEqual(hash(self.e), hash(self.f))
 
         self.e = iris.coords.Cell(0.7, [1.1, 1.9])
         self.f = iris.coords.Cell(0.8, [1.1, 1.9])
 
-        self.assertFalse(self.e == self.f)
+        self.assertNotEqual(self.e, self.f)
         self.assertNotEqual(hash(self.e), hash(self.f))
         self.assertFalse(self.e > self.f)
-        self.assertTrue(self.e <= self.f)
-        self.assertTrue(self.f >= self.e)
+        self.assertLessEqual(self.e, self.f)
+        self.assertGreaterEqual(self.f, self.e)
         self.assertFalse(self.f < self.e)
 
         self.e = iris.coords.Cell(0.9, [2, 2.1])
         self.f = iris.coords.Cell(0.8, [1.1, 1.9])
 
-        self.assertTrue(self.e > self.f)
+        self.assertGreater(self.e, self.f)
         self.assertFalse(self.e <= self.f)
         self.assertFalse(self.f >= self.e)
-        self.assertTrue(self.f < self.e)
+        self.assertLess(self.f, self.e)
 
     def test_cmp_contig(self):
         # Test cells that share an edge
         a = iris.coords.Cell(point=1054440.0, bound=(1054080.0, 1054800.0))
         b = iris.coords.Cell(point=1055160.0, bound=(1054800.0, 1055520.0))
-        self.assertTrue(a < b)
-        self.assertTrue(a <= b)
-        self.assertFalse(a == b)
+        self.assertLess(a, b)
+        self.assertLessEqual(a, b)
+        self.assertNotEqual(a, b)
         self.assertFalse(a >= b)
         self.assertFalse(a > b)
 

--- a/lib/iris/tests/test_cf.py
+++ b/lib/iris/tests/test_cf.py
@@ -35,21 +35,21 @@ class TestCaching(tests.IrisTest):
         # cf_var.
         # NB. Can't use hasattr() because that triggers the attribute
         # to be created!
-        self.assertTrue("coordinates" not in cf_var.__dict__)
+        self.assertNotIn("coordinates", cf_var.__dict__)
         _ = cf_var.coordinates
         self.assertEqual(nc_var.ncattrs.call_count, 1)
-        self.assertTrue("coordinates" in cf_var.__dict__)
+        self.assertIn("coordinates", cf_var.__dict__)
 
         # Trying again results in no change.
         _ = cf_var.coordinates
         self.assertEqual(nc_var.ncattrs.call_count, 1)
-        self.assertTrue("coordinates" in cf_var.__dict__)
+        self.assertIn("coordinates", cf_var.__dict__)
 
         # Trying another attribute results in just a new attribute.
-        self.assertTrue("standard_name" not in cf_var.__dict__)
+        self.assertNotIn("standard_name", cf_var.__dict__)
         _ = cf_var.standard_name
         self.assertEqual(nc_var.ncattrs.call_count, 1)
-        self.assertTrue("standard_name" in cf_var.__dict__)
+        self.assertIn("standard_name", cf_var.__dict__)
 
 
 @tests.skip_data

--- a/lib/iris/tests/test_coord_api.py
+++ b/lib/iris/tests/test_coord_api.py
@@ -32,12 +32,12 @@ class TestCoordSlicing(tests.IrisTest):
         a = self.lat
         b = a.copy()
         self.assertEqual(a, b)
-        self.assertFalse(a is b)
+        self.assertIsNot(a, b)
 
         a = self.lat
         b = a[:]
         self.assertEqual(a, b)
-        self.assertFalse(a is b)
+        self.assertIsNot(a, b)
 
     def test_slice_multiple_indices(self):
         aux_lat = iris.coords.AuxCoord.from_coord(self.lat)

--- a/lib/iris/tests/test_coordsystem.py
+++ b/lib/iris/tests/test_coordsystem.py
@@ -316,8 +316,8 @@ class Test_GeogCS_mutation(tests.IrisTest):
         # CRS changes
         cs = GeogCS(6543210, 6500000)
         _ = cs.as_cartopy_crs()
-        self.assertTrue("_globe" in cs.__dict__)
-        self.assertTrue("_crs" in cs.__dict__)
+        self.assertIn("_globe", cs.__dict__)
+        self.assertIn("_crs", cs.__dict__)
         self.assertEqual(cs.semi_major_axis, 6543210)
         cs.datum = "OSGB 1936"
         self.assertEqual(cs.as_cartopy_crs().datum, "OSGB 1936")

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -632,7 +632,7 @@ class TestDimSelection(tests.IrisTest):
         )
         self.assertIsInstance(cube.coord("a"), AuxCoord)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.dim_coords)
+        self.assertIn(cube.coord("b"), cube.dim_coords)
 
     def test_string_b_with_aux(self):
         templates = ((0, "a"), (1, "b"), (2, "c"), (3, "d"))
@@ -642,7 +642,7 @@ class TestDimSelection(tests.IrisTest):
             cube, ("merge", "string_b_with_aux.cml"), checksum=False
         )
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.dim_coords)
+        self.assertIn(cube.coord("a"), cube.dim_coords)
         self.assertIsInstance(cube.coord("b"), AuxCoord)
 
     def test_string_a_with_dim(self):
@@ -654,7 +654,7 @@ class TestDimSelection(tests.IrisTest):
         )
         self.assertIsInstance(cube.coord("a"), AuxCoord)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.dim_coords)
+        self.assertIn(cube.coord("b"), cube.dim_coords)
 
     def test_string_b_with_dim(self):
         templates = ((0, "a"), (1, "b"), (2, "c"), (3, "d"))
@@ -664,7 +664,7 @@ class TestDimSelection(tests.IrisTest):
             cube, ("merge", "string_b_with_dim.cml"), checksum=False
         )
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.dim_coords)
+        self.assertIn(cube.coord("a"), cube.dim_coords)
         self.assertIsInstance(cube.coord("b"), AuxCoord)
 
     def test_string_a_b(self):
@@ -681,9 +681,9 @@ class TestDimSelection(tests.IrisTest):
         cube = iris.cube.CubeList(cubes).merge()[0]
         self.assertCML(cube, ("merge", "a_aux_b_aux.cml"), checksum=False)
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.dim_coords)
+        self.assertIn(cube.coord("a"), cube.dim_coords)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.aux_coords)
+        self.assertIn(cube.coord("b"), cube.aux_coords)
 
     def test_a_aux_b_dim(self):
         templates = ((0, 10), (1, 11), (2, 12), (3, 13))
@@ -691,9 +691,9 @@ class TestDimSelection(tests.IrisTest):
         cube = iris.cube.CubeList(cubes).merge()[0]
         self.assertCML(cube, ("merge", "a_aux_b_dim.cml"), checksum=False)
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.aux_coords)
+        self.assertIn(cube.coord("a"), cube.aux_coords)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.dim_coords)
+        self.assertIn(cube.coord("b"), cube.dim_coords)
 
     def test_a_dim_b_aux(self):
         templates = ((0, 10), (1, 11), (2, 12), (3, 13))
@@ -701,9 +701,9 @@ class TestDimSelection(tests.IrisTest):
         cube = iris.cube.CubeList(cubes).merge()[0]
         self.assertCML(cube, ("merge", "a_dim_b_aux.cml"), checksum=False)
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.dim_coords)
+        self.assertIn(cube.coord("a"), cube.dim_coords)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.aux_coords)
+        self.assertIn(cube.coord("b"), cube.aux_coords)
 
     def test_a_dim_b_dim(self):
         templates = ((0, 10), (1, 11), (2, 12), (3, 13))
@@ -713,9 +713,9 @@ class TestDimSelection(tests.IrisTest):
         cube = iris.cube.CubeList(cubes).merge()[0]
         self.assertCML(cube, ("merge", "a_dim_b_dim.cml"), checksum=False)
         self.assertIsInstance(cube.coord("a"), DimCoord)
-        self.assertTrue(cube.coord("a") in cube.dim_coords)
+        self.assertIn(cube.coord("a"), cube.dim_coords)
         self.assertIsInstance(cube.coord("b"), DimCoord)
-        self.assertTrue(cube.coord("b") in cube.aux_coords)
+        self.assertIn(cube.coord("b"), cube.aux_coords)
 
 
 class TestTimeTripleMerging(tests.IrisTest):

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -661,8 +661,9 @@ class TestNetCDFSave(tests.IrisTest):
             # Test NETCDF4_64BIT file format saving.
             iris.save(cube, file_out, netcdf_format="NETCDF3_64BIT")
             ds = _thread_safe_nc.DatasetWrapper(file_out)
-            self.assertTrue(
-                ds.file_format in ["NETCDF3_64BIT", "NETCDF3_64BIT_OFFSET"],
+            self.assertIn(
+                ds.file_format,
+                ["NETCDF3_64BIT", "NETCDF3_64BIT_OFFSET"],
                 "Failed to save as NETCDF3_64BIT format",
             )
             ds.close()
@@ -1374,11 +1375,11 @@ class TestCFStandardName(tests.IrisTest):
 
     def test_std_name_lookup_pass(self):
         # Test performing a CF standard name look-up hit.
-        self.assertTrue("time" in iris.std_names.STD_NAMES)
+        self.assertIn("time", iris.std_names.STD_NAMES)
 
     def test_std_name_lookup_fail(self):
         # Test performing a CF standard name look-up miss.
-        self.assertFalse("phenomenon_time" in iris.std_names.STD_NAMES)
+        self.assertNotIn("phenomenon_time", iris.std_names.STD_NAMES)
 
 
 @tests.skip_data
@@ -1398,8 +1399,9 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
                 cube = iris.load_cube(temp_filename)
 
                 # Check correct number and type of flags
-                self.assertTrue(
-                    len(cube.attributes["ukmo__process_flags"]) == 1,
+                self.assertEqual(
+                    len(cube.attributes["ukmo__process_flags"]),
+                    1,
                     "Mismatch in number of process flags.",
                 )
                 process_flag = cube.attributes["ukmo__process_flags"][0]
@@ -1427,8 +1429,9 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
 
                 # Check correct number and type of flags
                 process_flags = cube.attributes["ukmo__process_flags"]
-                self.assertTrue(
-                    len(process_flags) == len(bits),
+                self.assertEqual(
+                    len(process_flags),
+                    len(bits),
                     "Mismatch in " "number of process flags.",
                 )
                 self.assertEqual(set(process_flags), set(descriptions))

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -365,16 +365,16 @@ class TestSplittableInt(tests.IrisTest):
         self.assertEqual(t, 400033)
         self.assertNotEqual(t, 33)
 
-        self.assertTrue(t >= 400033)
+        self.assertGreaterEqual(t, 400033)
         self.assertFalse(t >= 400034)
 
-        self.assertTrue(t <= 400033)
+        self.assertLessEqual(t, 400033)
         self.assertFalse(t <= 400032)
 
-        self.assertTrue(t > 400032)
+        self.assertGreater(t, 400032)
         self.assertFalse(t > 400034)
 
-        self.assertTrue(t < 400034)
+        self.assertLess(t, 400034)
         self.assertFalse(t < 400032)
 
     def test_name_mapping(self):

--- a/lib/iris/tests/test_util.py
+++ b/lib/iris/tests/test_util.py
@@ -106,8 +106,9 @@ class TestClipString(tests.IrisTest):
         )
 
         # Also test the rider was added
-        self.assertTrue(
-            self.rider in result,
+        self.assertIn(
+            self.rider,
+            result,
             "Rider was not added to the string when it should have been.",
         )
 
@@ -125,8 +126,9 @@ class TestClipString(tests.IrisTest):
         )
 
         # Also test that no rider was added on the end if the string was not clipped
-        self.assertFalse(
-            self.rider in result,
+        self.assertNotIn(
+            self.rider,
+            result,
             "Rider was adding to the string when it should not have been.",
         )
 

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -486,7 +486,7 @@ class Test___call___lazy(tests.IrisTest):
         result = self.lazy_regridder(self.lazy_cube)
         self.assertTrue(result.has_lazy_data())
         expected = self.regridder(self.cube)
-        self.assertTrue(result == expected)
+        self.assertEqual(result, expected)
 
 
 class Test___call____invalid_types(tests.IrisTest):

--- a/lib/iris/tests/unit/common/lenient/test__Lenient.py
+++ b/lib/iris/tests/unit/common/lenient/test__Lenient.py
@@ -389,7 +389,7 @@ class Test___setitem__(tests.IrisTest):
         self.lenient.__dict__[client] = None
         self.lenient[client] = True
         self.assertTrue(self.lenient.__dict__[client])
-        self.assertFalse(isinstance(self.lenient.__dict__[client], Iterable))
+        self.assertNotIsInstance(self.lenient.__dict__[client], Iterable)
 
     def test_callable_in_value_bool(self):
         def client():
@@ -399,8 +399,8 @@ class Test___setitem__(tests.IrisTest):
         self.lenient.__dict__[qualname_client] = None
         self.lenient[client] = True
         self.assertTrue(self.lenient.__dict__[qualname_client])
-        self.assertFalse(
-            isinstance(self.lenient.__dict__[qualname_client], Iterable)
+        self.assertNotIsInstance(
+            self.lenient.__dict__[qualname_client], Iterable
         )
 
     def test_in_value_iterable(self):
@@ -709,7 +709,7 @@ class Test_register_service(tests.IrisTest):
         self.assertNotIn(service, self.lenient.__dict__)
         self.lenient.register_service(service)
         self.assertIn(service, self.lenient.__dict__)
-        self.assertFalse(isinstance(self.lenient.__dict__[service], Iterable))
+        self.assertNotIsInstance(self.lenient.__dict__[service], Iterable)
         self.assertTrue(self.lenient.__dict__[service])
 
     def test_callable(self):
@@ -720,8 +720,8 @@ class Test_register_service(tests.IrisTest):
         self.assertNotIn(qualname_service, self.lenient.__dict__)
         self.lenient.register_service(service)
         self.assertIn(qualname_service, self.lenient.__dict__)
-        self.assertFalse(
-            isinstance(self.lenient.__dict__[qualname_service], Iterable)
+        self.assertNotIsInstance(
+            self.lenient.__dict__[qualname_service], Iterable
         )
         self.assertTrue(self.lenient.__dict__[qualname_service])
 

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -214,7 +214,7 @@ class Test_extract(tests.IrisTest):
         constraint = iris.Constraint(name="a2")
         cube = Cube(1, long_name="a1")
         res = cube.extract(constraint)
-        self.assertIs(res, None)
+        self.assertIsNone(res)
 
     def test_scalar_cube_coord_match(self):
         # Ensure that extract is able to extract a scalar cube according to
@@ -234,7 +234,7 @@ class Test_extract(tests.IrisTest):
         coord = iris.coords.AuxCoord(0, long_name="scalar_coord")
         cube.add_aux_coord(coord, None)
         res = cube.extract(constraint)
-        self.assertIs(res, None)
+        self.assertIsNone(res)
 
     def test_1d_cube_exists(self):
         # Ensure that extract is able to extract from a 1d cube.
@@ -248,7 +248,7 @@ class Test_extract(tests.IrisTest):
         constraint = iris.Constraint(name="a2")
         cube = Cube([1], long_name="a1")
         res = cube.extract(constraint)
-        self.assertIs(res, None)
+        self.assertIsNone(res)
 
 
 class Test_xml(tests.IrisTest):
@@ -3019,7 +3019,7 @@ class Test__eq__data(tests.IrisTest):
     def test_data_float_eq(self):
         cube1 = Cube([1.0])
         cube2 = Cube([1.0])
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_data_float_eqtol(self):
         val1 = np.array(1.0, dtype=np.float32)
@@ -3029,35 +3029,35 @@ class Test__eq__data(tests.IrisTest):
         cube1 = Cube([val1])
         cube2 = Cube([val2])
         self.assertNotEqual(val1, val2)
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_data_float_not_eq(self):
         val1 = 1.0
         val2 = 1.0 + 1.0e-4
         cube1 = Cube([1.0, val1])
         cube2 = Cube([1.0, val2])
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_data_int_eq(self):
         cube1 = Cube([1, 2, 3])
         cube2 = Cube([1, 2, 3])
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_data_int_not_eq(self):
         cube1 = Cube([1, 2, 3])
         cube2 = Cube([1, 2, 0])
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     # NOTE: since numpy v1.18, boolean array subtract is deprecated.
     def test_data_bool_eq(self):
         cube1 = Cube([True, False])
         cube2 = Cube([True, False])
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_data_bool_not_eq(self):
         cube1 = Cube([True, False])
         cube2 = Cube([True, True])
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
 
 class Test__eq__meta(tests.IrisTest):
@@ -3066,7 +3066,7 @@ class Test__eq__meta(tests.IrisTest):
         cube2 = Cube([0, 1])
         avr = AncillaryVariable([2, 3], long_name="foo")
         cube2.add_ancillary_variable(avr, 0)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_ancillary_reorder(self):
         cube1 = Cube([0, 1])
@@ -3079,7 +3079,7 @@ class Test__eq__meta(tests.IrisTest):
         cube1.add_ancillary_variable(avr2, 0)
         cube2.add_ancillary_variable(avr2, 0)
         cube2.add_ancillary_variable(avr1, 0)
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_ancillary_diff_data(self):
         cube1 = Cube([0, 1])
@@ -3088,14 +3088,14 @@ class Test__eq__meta(tests.IrisTest):
         avr2 = AncillaryVariable([4, 5], long_name="foo")
         cube1.add_ancillary_variable(avr1, 0)
         cube2.add_ancillary_variable(avr2, 0)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_cell_measure_fail(self):
         cube1 = Cube([0, 1])
         cube2 = Cube([0, 1])
         cms = CellMeasure([2, 3], long_name="foo")
         cube2.add_cell_measure(cms, 0)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_cell_measure_reorder(self):
         cube1 = Cube([0, 1])
@@ -3108,7 +3108,7 @@ class Test__eq__meta(tests.IrisTest):
         cube1.add_cell_measure(cms2, 0)
         cube2.add_cell_measure(cms2, 0)
         cube2.add_cell_measure(cms1, 0)
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
     def test_cell_measure_diff_data(self):
         cube1 = Cube([0, 1])
@@ -3117,14 +3117,14 @@ class Test__eq__meta(tests.IrisTest):
         cms2 = CellMeasure([4, 5], long_name="foo")
         cube1.add_cell_measure(cms1, 0)
         cube2.add_cell_measure(cms2, 0)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_cell_method_fail(self):
         cube1 = Cube([0, 1])
         cube2 = Cube([0, 1])
         cmth = CellMethod("mean", "time", "6hr")
         cube2.add_cell_method(cmth)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     # Unlike cell measures, cell methods are order sensitive.
     def test_cell_method_reorder_fail(self):
@@ -3138,7 +3138,7 @@ class Test__eq__meta(tests.IrisTest):
         cube1.add_cell_method(cmth2)
         cube2.add_cell_method(cmth2)
         cube2.add_cell_method(cmth1)
-        self.assertFalse(cube1 == cube2)
+        self.assertNotEqual(cube1, cube2)
 
     def test_cell_method_correct_order(self):
         cube1 = Cube([0, 1])
@@ -3151,7 +3151,7 @@ class Test__eq__meta(tests.IrisTest):
         cube1.add_cell_method(cmth2)
         cube2.add_cell_method(cmth1)
         cube2.add_cell_method(cmth2)
-        self.assertTrue(cube1 == cube2)
+        self.assertEqual(cube1, cube2)
 
 
 @pytest.fixture

--- a/lib/iris/tests/unit/cube/test_Cube__aggregated_by.py
+++ b/lib/iris/tests/unit/cube/test_Cube__aggregated_by.py
@@ -327,7 +327,7 @@ class Test_aggregated_by(tests.IrisTest):
             "simple_agg", self.mock_weighted_agg, returned=True
         )
 
-        self.assertTrue(isinstance(output, tuple))
+        self.assertIsInstance(output, tuple)
         self.assertEqual(len(output), 2)
         self.assertEqual(output[0].shape, (2, 11))
         self.assertEqual(output[1].shape, (2, 11))
@@ -526,11 +526,11 @@ class Test_aggregated_by__lazy(tests.IrisTest):
 
         self.assertTrue(self.cube.has_lazy_data())
 
-        self.assertTrue(isinstance(output, tuple))
+        self.assertIsInstance(output, tuple)
         self.assertEqual(len(output), 2)
 
         cube = output[0]
-        self.assertTrue(isinstance(cube, Cube))
+        self.assertIsInstance(cube, Cube)
         self.assertTrue(cube.has_lazy_data())
         self.assertEqual(cube.shape, (2, 11))
         row_0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]

--- a/lib/iris/tests/unit/cube/test_Cube__operators.py
+++ b/lib/iris/tests/unit/cube/test_Cube__operators.py
@@ -154,7 +154,7 @@ class Test_lazy_maths__scalar_cube(tests.IrisTest):
     def check_common(self, c1, c2, math_op):
         cube = math_op(c1, c2)
         data = cube.data
-        self.assertTrue(isinstance(data, np.ndarray))
+        self.assertIsInstance(data, np.ndarray)
         self.assertEqual(data.shape, ())
 
     def test_add_scalar__int(self):

--- a/lib/iris/tests/unit/data_manager/test_DataManager.py
+++ b/lib/iris/tests/unit/data_manager/test_DataManager.py
@@ -63,18 +63,18 @@ class Test___eq__(tests.IrisTest):
     def test_real_with_real_failure(self):
         dm1 = DataManager(self.real_array)
         dm2 = DataManager(np.ones(self.shape))
-        self.assertFalse(dm1 == dm2)
+        self.assertNotEqual(dm1, dm2)
 
     def test_real_with_real__dtype_failure(self):
         dm1 = DataManager(self.real_array)
         dm2 = DataManager(self.real_array.astype(int))
-        self.assertFalse(dm1 == dm2)
+        self.assertNotEqual(dm1, dm2)
 
     def test_real_with_lazy_failure(self):
         dm1 = DataManager(self.real_array)
         dm2 = DataManager(as_lazy_data(self.real_array))
-        self.assertFalse(dm1 == dm2)
-        self.assertFalse(dm2 == dm1)
+        self.assertNotEqual(dm1, dm2)
+        self.assertNotEqual(dm2, dm1)
 
     def test_lazy_with_lazy(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
@@ -84,16 +84,16 @@ class Test___eq__(tests.IrisTest):
     def test_lazy_with_lazy_failure(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
         dm2 = DataManager(as_lazy_data(self.real_array) * 10)
-        self.assertFalse(dm1 == dm2)
+        self.assertNotEqual(dm1, dm2)
 
     def test_lazy_with_lazy__dtype_failure(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
         dm2 = DataManager(as_lazy_data(self.real_array).astype(int))
-        self.assertFalse(dm1 == dm2)
+        self.assertNotEqual(dm1, dm2)
 
     def test_non_DataManager_failure(self):
         dm = DataManager(np.array(0))
-        self.assertFalse(dm == 0)
+        self.assertNotEqual(dm, 0)
 
 
 class Test___ne__(tests.IrisTest):
@@ -110,7 +110,7 @@ class Test___ne__(tests.IrisTest):
     def test_real_with_real_failure(self):
         dm1 = DataManager(self.real_array)
         dm2 = DataManager(self.real_array.copy())
-        self.assertFalse(dm1 != dm2)
+        self.assertEqual(dm1, dm2)
 
     def test_real_with_real__dtype(self):
         dm1 = DataManager(self.real_array)
@@ -131,7 +131,7 @@ class Test___ne__(tests.IrisTest):
     def test_lazy_with_lazy_failure(self):
         dm1 = DataManager(as_lazy_data(self.real_array))
         dm2 = DataManager(as_lazy_data(self.real_array))
-        self.assertFalse(dm1 != dm2)
+        self.assertEqual(dm1, dm2)
 
     def test_lazy_with_lazy__dtype(self):
         dm1 = DataManager(as_lazy_data(self.real_array))

--- a/lib/iris/tests/unit/experimental/ugrid/mesh/test_MeshCoord.py
+++ b/lib/iris/tests/unit/experimental/ugrid/mesh/test_MeshCoord.py
@@ -495,7 +495,7 @@ class Test_cube_containment(tests.IrisTest):
         # The resulting coord is an AuxCoord instead of a MeshCoord, but the
         # values match.
         co2 = cube2.coord(meshcoord.name())
-        self.assertFalse(isinstance(co2, MeshCoord))
+        self.assertNotIsInstance(co2, MeshCoord)
         self.assertIsInstance(co2, AuxCoord)
         self.assertArrayAllClose(co2.points, meshcoord.points[:1])
         self.assertArrayAllClose(co2.bounds, meshcoord.bounds[:1])

--- a/lib/iris/tests/unit/fileformats/pp/test_PPField.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_PPField.py
@@ -166,12 +166,12 @@ class Test_coord_system(tests.IrisTest):
             result = field.coord_system()
         if not rotated:
             # It should return a standard unrotated CS.
-            self.assertTrue(mock_cs_mod.GeogCS.call_count == 1)
+            self.assertEqual(mock_cs_mod.GeogCS.call_count, 1)
             self.assertEqual(result, mock_cs_mod.GeogCS())
         else:
             # It should return a rotated CS with the correct makeup.
-            self.assertTrue(mock_cs_mod.GeogCS.call_count == 1)
-            self.assertTrue(mock_cs_mod.RotatedGeogCS.call_count == 1)
+            self.assertEqual(mock_cs_mod.GeogCS.call_count, 1)
+            self.assertEqual(mock_cs_mod.RotatedGeogCS.call_count, 1)
             self.assertEqual(result, mock_cs_mod.RotatedGeogCS())
             self.assertEqual(
                 mock_cs_mod.RotatedGeogCS.call_args_list[0],

--- a/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save_fields.py
@@ -34,16 +34,16 @@ class TestSaveFields(tests.IrisTest):
         m = mock.mock_open()
         with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], "foo.pp")
-        self.assertTrue(mock.call("foo.pp", "wb") in m.mock_calls)
-        self.assertTrue(mock.call().write("saved") in m.mock_calls)
+        self.assertIn(mock.call("foo.pp", "wb"), m.mock_calls)
+        self.assertIn(mock.call().write("saved"), m.mock_calls)
 
     def test_save_append(self):
         open_func = "builtins.open"
         m = mock.mock_open()
         with mock.patch(open_func, m, create=True):
             pp.save_fields([self.pp_field], "foo.pp", append=True)
-        self.assertTrue(mock.call("foo.pp", "ab") in m.mock_calls)
-        self.assertTrue(mock.call().write("saved") in m.mock_calls)
+        self.assertIn(mock.call("foo.pp", "ab"), m.mock_calls)
+        self.assertIn(mock.call().write("saved"), m.mock_calls)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/unit/time/test_PartialDateTime.py
+++ b/lib/iris/tests/unit/time/test_PartialDateTime.py
@@ -226,12 +226,12 @@ class Test___eq__(tests.IrisTest, _Test_operator):
     def test_cftime_equal(self):
         pdt = PartialDateTime(month=3, second=2)
         other = cftime.datetime(year=2013, month=3, day=20, second=2)
-        self.assertTrue(pdt == other)
+        self.assertEqual(pdt, other)
 
     def test_cftime_not_equal(self):
         pdt = PartialDateTime(month=3, second=2)
         other = cftime.datetime(year=2013, month=4, day=20, second=2)
-        self.assertFalse(pdt == other)
+        self.assertNotEqual(pdt, other)
 
 
 class Test___ne__(tests.IrisTest, _Test_operator):
@@ -248,7 +248,7 @@ class Test___gt__(tests.IrisTest, _Test_operator):
     def test_cftime_greater(self):
         pdt = PartialDateTime(month=3, microsecond=2)
         other = cftime.datetime(year=2013, month=2, day=20, second=3)
-        self.assertTrue(pdt > other)
+        self.assertGreater(pdt, other)
 
     def test_cftime_not_greater(self):
         pdt = PartialDateTime(month=3, microsecond=2)

--- a/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
+++ b/lib/iris/tests/unit/util/test_demote_dim_coord_to_aux_coord.py
@@ -45,7 +45,7 @@ class Test(tests.IrisTest):
         cube_a = stock.hybrid_height()
         cube_b = cube_a.copy()
         demote_dim_coord_to_aux_coord(cube_b, "level_height")
-        self.assertTrue(cube_a.coord("level_height") in cube_b.aux_coords)
+        self.assertIn(cube_a.coord("level_height"), cube_b.aux_coords)
 
     def test_coord_of_that_name_does_not_exist(self):
         cube_a = stock.simple_2d_w_multidim_and_scalars()

--- a/lib/iris/tests/unit/util/test_mask_cube.py
+++ b/lib/iris/tests/unit/util/test_mask_cube.py
@@ -67,7 +67,7 @@ class TestArrayMask(tests.IrisTest, MaskCubeMixin):
         returned = mask_cube(cube, discontiguity_array, in_place=True)
         np.testing.assert_array_equal(expected.data.mask, cube.data.mask)
         self.assertOriginalMetadata(cube, "full2d_global")
-        self.assertIs(returned, None)
+        self.assertIsNone(returned)
 
     def test_mask_cube_2d_not_in_place(self):
         # This tests the masking of a 2d data array
@@ -96,7 +96,7 @@ class TestArrayMask(tests.IrisTest, MaskCubeMixin):
         for subcube in cube.slices("foo"):
             # Mask should have been broadcast across "bar" dimension.
             np.testing.assert_array_equal(subcube.data.mask, mask)
-        self.assertIs(returned, None)
+        self.assertIsNone(returned)
 
 
 class TestCoordMask(tests.IrisTest, MaskCubeMixin):
@@ -153,7 +153,7 @@ class TestCubeMask(tests.IrisTest, MaskCubeMixin):
         for subcube in self.cube.slices("bar"):
             # Mask should have been broadcast across 'foo' dimension.
             np.testing.assert_array_equal(subcube.data.mask, mask.data)
-        self.assertIs(returned, None)
+        self.assertIsNone(returned)
 
     def test_mask_cube_2d_create_new_dim(self):
         mask = iris.cube.Cube(
@@ -183,7 +183,7 @@ class TestCubeMask(tests.IrisTest, MaskCubeMixin):
         cube = simple_1d()
         mask = cube.copy(da.from_array([0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1]))
         returned = mask_cube(cube, mask, in_place=True)
-        self.assertIs(returned, None)
+        self.assertIsNone(returned)
         self.assertTrue(cube.has_lazy_data())
         # Touch the data so lazyness status doesn't interfere with CML check.
         cube.data

--- a/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
+++ b/lib/iris/tests/unit/util/test_promote_aux_coord_to_dim_coord.py
@@ -29,7 +29,7 @@ class Test(tests.IrisTest):
         cube_a = stock.hybrid_height()
         cube_b = cube_a.copy()
         promote_aux_coord_to_dim_coord(cube_b, "model_level_number")
-        self.assertTrue(cube_a.coord("level_height") in cube_b.aux_coords)
+        self.assertIn(cube_a.coord("level_height"), cube_b.aux_coords)
 
     @tests.skip_data
     def test_argument_is_coord_instance(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR uses the [teyit](https://github.com/isidentical/teyit) tool to enforce modern `unittest` patterns.

Ideally, we would drop our use of `unittest` in preference for `pytest`, but that's dealing with a huge amount of tech debt... the next best thing is to ensure that we're not using deprecated parts of `unittest`, which is happening in the forthcoming [python 3.12](https://docs.python.org/dev/whatsnew/3.12.html#removed) release.

`teyit` is written and maintained by [Batuhan Taskaya](https://github.com/isidentical), who is a [Python Software Foundation](https://www.python.org/psf-landing/) fellow and a `python` core developer.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
