### PR TITLE
Fix Makefile for consequences of #5204.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 lockfiles:
-	python tools/update_lockfiles.py -o requirements/ci/nox.lock requirements/ci/py*.yml
+	python tools/update_lockfiles.py -o requirements/locks requirements/py*.yml


### PR DESCRIPTION
I just bumped into this problem.

FYI @trexfeathers 
I'm not clear if `Makefile` is still a worthwhile thing  (though I just used it!)
We could instead just rely on the command documented [here](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html?highlight=lockfile#github-actions-test-environment), and not bother with make since it only provides that one command.