### PR TITLE
#5180 do not run publish-to-test-pypi on forks

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -153,7 +153,7 @@ jobs:
     name: "publish to pypi"
     runs-on: ubuntu-latest
     # upload to PyPI for every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && github.repository-owner == 'SciTools'
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -132,7 +132,8 @@ jobs:
     name: "publish to test.pypi"
     runs-on: ubuntu-latest
     # upload to Test PyPI for every commit on main branch
-    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    # and check for the SciTools repo
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository-owner == 'SciTools'
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -26,7 +26,8 @@ This document explains the changes made to Iris for this release
 ================
 
 #. Congratulations to `@ESadek-MO`_ who has become a core developer for Iris! 🎉
-#. Welcome and congratulations to `@HGWright`_ and `@scottrobinson02`_ who made their first contributions to Iris! 🎉
+#. Welcome and congratulations to `@HGWright`_, `@scottrobinson02`_ and
+   `@agriyakhetarpal`_ who made their first contributions to Iris! 🎉
 
 
 ✨ Features
@@ -140,6 +141,9 @@ This document explains the changes made to Iris for this release
 #. `@lbdreyer`_ removed the Iris TestRunner. Tests are now run via nox or
    pytest. (:pull:`5205`)
 
+#. `@agriyakhetarpal`_ prevented the GitHub action for publishing releases to
+   PyPI from running in forks. (:pull:`5220`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -148,6 +152,7 @@ This document explains the changes made to Iris for this release
 .. _@fnattino: https://github.com/fnattino
 .. _@ed-hawkins: https://github.com/ed-hawkins
 .. _@scottrobinson02: https://github.com/scottrobinson02
+.. _@agriyakhetarpal: https://github.com/agriyakhetarpal
 
 .. comment
     Whatsnew resources in alphabetical order:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Checks for 'SciTools' as the repository owner such that `ci_wheels.yml` does not run the `"publish to test.pypi"` step in forks, fixes #5180 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
