### PR TITLE
use explicit version for ci refresh-lockfiles gha

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -14,5 +14,5 @@ on:
 
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@main
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.2
     secrets: inherit


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Now that the [SciTools/workflows](https://github.com/SciTools/workflows/releases) is auto-released on PR merge, this PR uses an explicit version for the `refresh-lockfiles` GHA.

This should make it easy to pin the workflow to a last known working version in the event of a breaking release. Also, we should receive auto-updates from `dependabot` when new versions of our reusable GHAs are available.

Also see:

- https://github.com/SciTools/iris-grib/pull/331
- https://github.com/SciTools/python-stratify/pull/69

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
