### PR TITLE
raise dask min pin

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -151,6 +151,10 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ moved the benchmark runner conveniences from ``noxfile.py``
    to a dedicated ``benchmarks/bm_runner.py``. (:pull:`5215`)
 
+#. `@bjlittle`_ follow-up to :pull:`4972`, enforced ``dask>=2022.09.0`` minimum
+   pin for first use of `dask.array.ma.empty_like`_ and replaced `@tinyendian`_
+   workaround. (:pull:`5225`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -168,3 +172,4 @@ This document explains the changes made to Iris for this release
 
 .. _#ShowYourStripes: https://showyourstripes.info/s/globe/
 .. _README.md: https://github.com/SciTools/iris#-----
+.. _dask.array.ma.empty_like: https://docs.dask.org/en/stable/generated/dask.array.ma.empty_like.html

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -1244,12 +1244,8 @@ def rotate_winds(u_cube, v_cube, target_cs):
     if apply_mask:
         # Make masked arrays to accept masking.
         if lazy_output:
-            ut_cube = ut_cube.copy(
-                data=da.ma.masked_array(ut_cube.core_data())
-            )
-            vt_cube = vt_cube.copy(
-                data=da.ma.masked_array(vt_cube.core_data())
-            )
+            ut_cube = ut_cube.copy(data=da.ma.empty_like(ut_cube.core_data()))
+            vt_cube = vt_cube.copy(data=da.ma.empty_like(vt_cube.core_data()))
         else:
             ut_cube.data = ma.asanyarray(ut_cube.data)
             vt_cube.data = ma.asanyarray(vt_cube.data)

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.21
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2.26
+  - dask-core >=2022.9.0
   - matplotlib >=3.5
   - netcdf4
   - numpy >=1.19

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.21
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2.26
+  - dask-core >=2022.9.0
   - matplotlib >=3.5
   - netcdf4
   - numpy >=1.19

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy >=0.21
   - cf-units >=3.1
   - cftime >=1.5
-  - dask-core >=2.26
+  - dask-core >=2022.9.0
   - matplotlib >=3.5
   - netcdf4
   - numpy >=1.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     cartopy>=0.21
     cf-units>=3.1
     cftime>=1.5.0
-    dask[array]>=2.26
+    dask[array]>=2022.9.0
     matplotlib>=3.5
     netcdf4
     numpy>=1.19


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR is a follow-up to #4972, which introduces the use of `dask.array.ma.empty_like` to `iris`.

This feature was available from `dask` 2022.8.1. 

I've set the min pin to be `2022.9.0`, rather than the month point release.

Kudos to @rcomer who landed https://github.com/dask/dask/pull/9378 :love_you_gesture: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
