### PR TITLE
drop sphinxcontrib-napoleon

### DIFF
--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -46,7 +46,6 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx <=5.3
-  - sphinxcontrib-napoleon
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -45,7 +45,6 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx <=5.3
-  - sphinxcontrib-napoleon
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -45,7 +45,6 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx <=5.3
-  - sphinxcontrib-napoleon
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,6 @@ docs =
     sphinx<=5.3
     sphinx-copybutton
     sphinx-gallery>=0.11.0
-    sphinxcontrib-napoleon
     sphinx-design
     pydata-sphinx-theme>=0.13.0
 test =


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR drops the `sphinxcontrib-napolean` dependency, as of [sphinx 1.3](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html) (also see [PyPI](https://pypi.org/project/sphinxcontrib-napoleon/)) the `napoleon` extension is packaged under `sphinx.ext.napoleon` within `sphinx` itself i.e., we don't need this legacy package.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
