### PR TITLE
build wheel from sdist, not src

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -35,9 +35,7 @@ jobs:
     - name: "building"
       shell: bash
       run: |
-        # require build with explicit --sdist and --wheel in order to
-        # get correct version associated with sdist and bdist artifacts
-        pipx run build --sdist --wheel
+        pipx run build
 
     - uses: actions/upload-artifact@v3
       with:

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -92,6 +92,9 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ and `@trexfeathers`_ (reviewer) migrated ``setup.cfg`` to
    ``pyproject.toml``, as motivated by `PEP-0621`_. (:pull:`5262`)
 
+#. `@bjlittle`_ adopted `pypa/build`_ recommended best practice to build a
+   binary ``wheel`` from the ``sdist``. (:pull:`5266`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -107,3 +110,4 @@ This document explains the changes made to Iris for this release
 .. _sphinx-design: https://github.com/executablebooks/sphinx-design
 .. _check-manifest: https://github.com/mgedmin/check-manifest
 .. _PEP-0621: https://peps.python.org/pep-0621/
+.. _pypa/build: https://pypa-build.readthedocs.io/en/stable/


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR adopts the [pypa/build](https://pypa-build.readthedocs.io/en/stable/) recommended best practice to build the binary `wheel` from the `sdist`, as opposed to from the `src`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
