### PR TITLE
updated installing instructions to use pip

### DIFF
--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -107,10 +107,10 @@ all the packages from the `testing` and `documentation` sections.
 
 .. _requirements: https://github.com/scitools/iris/tree/main/requirements
 
-Finally you need to run the command to configure your shell environment
-to find your local Iris code::
+Finally you need to run the command to configure your environment
+to find your local Iris code.  From your Iris directory run::
 
-  python setup.py develop
+  pip install --no-deps --editable .
 
 
 Running the Tests

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -81,7 +81,7 @@ This document explains the changes made to Iris for this release
    during development. (:pull:`5258`)
 
 #. `@tkknight`_ updated the :ref:`installing_from_source` instructions to use
-   ``pip``.  (:pull:`????`)
+   ``pip``.  (:pull:`5273`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -67,7 +67,7 @@ This document explains the changes made to Iris for this release
    3.11. (:pull:`5226`)
 
 #. `@rcomer`_ dropped support for python 3.8, in accordance with the NEP29_
-   recommendations (:pull:`5226`) 
+   recommendations (:pull:`5226`)
 
 
 📚 Documentation
@@ -79,6 +79,9 @@ This document explains the changes made to Iris for this release
 #. `@tkknight`_ updated the ``make`` target for ``help`` and added
    ``livehtml`` to auto generate the documentation when changes are detected
    during development. (:pull:`5258`)
+
+#. `@tkknight`_ updated the :ref:`installing_from_source` instructions to use
+   ``pip``.  (:pull:`????`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Updated the installing instructions to use:

`pip install --no-deps --editable .`

instead of:

`python setup.py develop`

Using pip is considered better practice, also the old way shows a couple of strong warnings:

```
/home/theuser/projects/iris
$ python setup.py develop
/home/theuser/.conda/envs/iris-dev/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:66: _BetaConfiguration: Support for [tool.setuptools] in pyproject.toml is still *beta*.
  config = read_configuration(filepath, True, ignore_option_errors, dist)
running develop
/home/theuser/.conda/envs/iris-dev/lib/python3.11/site-packages/setuptools/command/develop.py:40: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` and ``easy_install``.
        Instead, use pypa/build, pypa/installer, pypa/build or
        other standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  easy_install.initialize_options(self)
/home/theuser/.conda/envs/iris-dev/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer, pypa/build or
        other standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
running egg_info
writing lib/scitools_iris.egg-info/PKG-INFO
writing dependency_links to lib/scitools_iris.egg-info/dependency_links.txt
writing requirements to lib/scitools_iris.egg-info/requires.txt
writing top-level names to lib/scitools_iris.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
<SNIP>
```


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
