### PR TITLE
remove extra-requirements from rtd config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,5 +29,3 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR mops up after #5262, and removes the now defunct PyPI `docs` optional dependencies reference within the `.readthedocs.yml`. 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
