### PR TITLE
Fix axes replacement on subfigures

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -39,7 +39,10 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@rcomer`_ enabled automatic replacement of a Matplotlib
+   :class:`~matplotlib.axes.Axes` with a Cartopy
+   :class:`~cartopy.mpl.geoaxes.GeoAxes` when the ``Axes`` is on a
+   :class:`~matplotlib.figure.SubFigure`. (:issue:`5282`, :pull:`5288`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -904,7 +904,7 @@ def _replace_axes_with_cartopy_axes(cartopy_proj):
 
     ax = plt.gca()
     if not isinstance(ax, cartopy.mpl.geoaxes.GeoAxes):
-        fig = plt.gcf()
+        fig = ax.get_figure()
         if isinstance(ax, matplotlib.axes.SubplotBase):
             _ = fig.add_subplot(
                 ax.get_subplotspec(),

--- a/lib/iris/tests/unit/plot/test__replace_axes_with_cartopy_axes.py
+++ b/lib/iris/tests/unit/plot/test__replace_axes_with_cartopy_axes.py
@@ -37,6 +37,13 @@ class Test_replace_axes_with_cartopy_axes(tests.IrisTest):
             expected.get_position().bounds, result.get_position().bounds
         )
 
+    def test_ax_on_subfigure(self):
+        subfig, _ = self.fig.subfigures(nrows=2)
+        subfig.subplots()
+        _replace_axes_with_cartopy_axes(ccrs.PlateCarree())
+        result = plt.gca()
+        self.assertIs(result.get_figure(), subfig)
+
     def tearDown(self):
         plt.close(self.fig)
 


### PR DESCRIPTION
## 🚀 Pull Request



### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #5282

We just needed to get hold of the SubFigure rather than the parent Figure.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
