### PR TITLE
ensure only .rst files are processed

### DIFF
--- a/docs/src/sphinxext/api_rst_formatting.py
+++ b/docs/src/sphinxext/api_rst_formatting.py
@@ -20,16 +20,17 @@ def main_api_rst_formatting(app):
     print(f"[{ntpath.basename(__file__)}] Processing RST files", end="")
 
     for file in src_dir.iterdir():
-        print(f".", end="")
+        if file.suffix == ".rst":
+            print(f".", end="")
 
-        with open(file, "r") as f:
-            lines = f.read()
+            with open(file, "r") as f:
+                lines = f.read()
 
-        lines = lines.replace(" package\n=", "\n")
-        lines = lines.replace(" module\n=", "\n")
+            lines = lines.replace(" package\n=", "\n")
+            lines = lines.replace(" module\n=", "\n")
 
-        with open(file, "w") as f:
-            f.write(lines)
+            with open(file, "w") as f:
+                f.write(lines)
     print("")
 
 def setup(app):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Minor improvement to ensure only ``.rst`` files are processed.  Non ``.rst`` files may be present especially when performing some manual testing or some temp files are left over.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
