### PR TITLE
release_do_nothing script updates from v3.6.0rc0

### DIFF
--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -225,6 +225,11 @@ class TestLicenseHeaders(tests.IrisTest):
             ):
                 with open(full_fname) as fh:
                     content = fh.read()
+                    if content.startswith("#!"):
+                        # account for files with leading shebang directives
+                        # i.e., first strip out the shebang line before
+                        # then performing license header compliance checking
+                        content = "\n".join(content.split("\n")[1:])
                     if not content.startswith(LICENSE_TEMPLATE):
                         print(
                             "The file {} does not start with the required "

--- a/tools/release_do_nothing.py
+++ b/tools/release_do_nothing.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright Iris contributors
 #
 # This file is part of Iris and is released under the LGPL license.
@@ -281,6 +282,18 @@ def finalise_whats_new(
         _wait_for_done(message)
 
         message = (
+            f"In {rsts.release.name}: ensure the page title underline is "
+            "the exact same length as the page title text."
+        )
+        _wait_for_done(message)
+
+        dropdown_title = f"\n{release_strings.series} Release Highlights\n"
+        message = (
+            f"In {rsts.release.name}: set the sphinx-design dropdown title to:{dropdown_title}"
+        )
+        _wait_for_done(message)
+
+        message = (
             f"Review {rsts.release.name} to ensure it is a good reflection of "
             f"what is new in {release_strings.series}."
         )
@@ -355,8 +368,9 @@ def cut_release(
     if is_release_candidate:
         message = (
             "This is a release candidate - include the following instructions "
-            "for Conda-installing:\n"
-            "conda install -c conda-forge/label/rc_iris iris;"
+            "for installing with conda or pip:\n"
+            f"conda install -c conda-forge/label/rc_iris iris={release_strings.release}\n"
+            f"pip install scitools-iris=={release_strings.release}"
         )
         _wait_for_done(message)
 
@@ -378,6 +392,13 @@ def cut_release(
         "publishing to PyPI."
     )
     _break_print(message)
+
+    url = "https://github.com/SciTools/iris/actions/workflows/ci-wheels.yml"
+    message = (
+        f"Visit {url} to monitor the building, testing and publishing of "
+        "the Iris sdist and binary wheel to PyPI."
+    )
+    _wait_for_done(message)
 
 
 def check_rtd(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR makes some additive tweaks to the `tools/release_do_nothing.py` script, including making it directly executable from the CLI i.e., `> ./release_do_nothing.py`.

These suggested changes are within the context of performing an initial minor release candidate e.g., `v3.6.0rc0`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
