### PR TITLE
Simplify and lazify broadcast_to_shape

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -30,7 +30,8 @@ This document explains the changes made to Iris for this release
 ✨ Features
 ===========
 
-#. N/A
+#. `@rcomer`_ rewrote :func:`~iris.util.broadcast_to_shape` so it now handles
+   lazy data. (:pull:`5307`)
 
 
 🐛 Bugs Fixed

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -47,6 +47,15 @@ def is_lazy_data(data):
     return result
 
 
+def is_lazy_masked_data(data):
+    """
+    Return True if the argument is both an Iris 'lazy' data array and the
+    underlying array is of masked type.  Otherwise return False.
+
+    """
+    return is_lazy_data(data) and ma.isMA(da.utils.meta_from_array(data))
+
+
 @lru_cache
 def _optimum_chunksize_internals(
     chunks,

--- a/lib/iris/tests/unit/lazy_data/test_is_lazy_masked_data.py
+++ b/lib/iris/tests/unit/lazy_data/test_is_lazy_masked_data.py
@@ -1,0 +1,27 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Test function :func:`iris._lazy data.is_lazy_masked_data`."""
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from iris._lazy_data import is_lazy_masked_data
+
+real_arrays = [
+    np.arange(3),
+    np.ma.array(range(3)),
+    np.ma.array(range(3), mask=[0, 1, 1]),
+]
+lazy_arrays = [da.from_array(arr) for arr in real_arrays]
+
+
+@pytest.mark.parametrize(
+    "arr, expected", zip(real_arrays + lazy_arrays, [False] * 4 + [True] * 2)
+)
+def test_is_lazy_masked_data(arr, expected):
+    result = is_lazy_masked_data(arr)
+    assert result is expected

--- a/lib/iris/tests/unit/util/test_broadcast_to_shape.py
+++ b/lib/iris/tests/unit/util/test_broadcast_to_shape.py
@@ -50,6 +50,7 @@ class Test_broadcast_to_shape(tests.IrisTest):
         # transposed
         a = da.random.random([2, 3])
         b = broadcast_to_shape(a, (5, 3, 4, 2), (3, 1))
+        mocked_compute.assert_not_called()
         for i in range(5):
             for j in range(4):
                 self.assertArrayEqual(b[i, :, j, :].T.compute(), a.compute())

--- a/lib/iris/tests/unit/util/test_broadcast_to_shape.py
+++ b/lib/iris/tests/unit/util/test_broadcast_to_shape.py
@@ -9,6 +9,10 @@
 # importing anything else
 import iris.tests as tests  # isort:skip
 
+from unittest import mock
+
+import dask
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
 
@@ -40,6 +44,16 @@ class Test_broadcast_to_shape(tests.IrisTest):
             for j in range(4):
                 self.assertArrayEqual(b[i, :, j, :].T, a)
 
+    @mock.patch.object(dask.base, "compute", wraps=dask.base.compute)
+    def test_lazy_added_dimensions_transpose(self, mocked_compute):
+        # adding dimensions and having the dimensions of the input
+        # transposed
+        a = da.random.random([2, 3])
+        b = broadcast_to_shape(a, (5, 3, 4, 2), (3, 1))
+        for i in range(5):
+            for j in range(4):
+                self.assertArrayEqual(b[i, :, j, :].T.compute(), a.compute())
+
     def test_masked(self):
         # masked arrays are also accepted
         a = np.random.random([2, 3])
@@ -48,6 +62,19 @@ class Test_broadcast_to_shape(tests.IrisTest):
         for i in range(5):
             for j in range(4):
                 self.assertMaskedArrayEqual(b[i, :, j, :].T, m)
+
+    @mock.patch.object(dask.base, "compute", wraps=dask.base.compute)
+    def test_lazy_masked(self, mocked_compute):
+        # masked arrays are also accepted
+        a = np.random.random([2, 3])
+        m = da.ma.masked_array(a, mask=[[0, 1, 0], [0, 1, 1]])
+        b = broadcast_to_shape(m, (5, 3, 4, 2), (3, 1))
+        mocked_compute.assert_not_called()
+        for i in range(5):
+            for j in range(4):
+                self.assertMaskedArrayEqual(
+                    b[i, :, j, :].compute().T, m.compute()
+                )
 
     def test_masked_degenerate(self):
         # masked arrays can have degenerate masks too

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -23,7 +23,7 @@ import numpy as np
 import numpy.ma as ma
 
 from iris._deprecation import warn_deprecated
-from iris._lazy_data import as_concrete_data, is_lazy_data
+from iris._lazy_data import as_concrete_data, is_lazy_data, is_lazy_masked_data
 from iris.common import SERVICES
 from iris.common.lenient import _lenient_client
 import iris.exceptions
@@ -92,6 +92,12 @@ def broadcast_to_shape(array, shape, dim_map):
         else:
             new_mask = np.broadcast_to(mask, shape)
         new_array = ma.array(new_array, mask=new_mask)
+
+    elif is_lazy_masked_data(array):
+        # broadcast_to strips masks so we need to handle them explicitly.
+        mask = da.ma.getmaskarray(array)
+        new_mask = da.broadcast_to(mask, shape)
+        new_array = da.ma.masked_array(new_array, new_mask)
 
     return new_array
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -34,8 +34,7 @@ def broadcast_to_shape(array, shape, dim_map):
     Broadcast an array to a given shape.
 
     Each dimension of the array must correspond to a dimension in the
-    given shape. Striding is used to repeat the array until it matches
-    the desired shape, returning repeated views on the original array.
+    given shape. The result is a read-only view (see :func:`numpy.broadcast_to`).
     If you need to write to the resulting array, make a copy first.
 
     Args:

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -76,19 +76,12 @@ def broadcast_to_shape(array, shape, dim_map):
     See more at :doc:`/userguide/real_and_lazy_data`.
 
     """
-    n_new_dims = len(shape) - len(array.shape)
+    n_orig_dims = len(array.shape)
+    n_new_dims = len(shape) - n_orig_dims
     array = array.reshape(array.shape + (1,) * n_new_dims)
 
-    # Map current dims to their target dims.
-    map_dims = tuple(dim_map) + tuple(
-        n for n in range(len(shape)) if n not in dim_map
-    )
-    # transpose needs the inverse mapping.  Keep this as a tuple as dask's transpose
-    # breaks if this is an array.
-    inverse_map_dims = tuple(np.argsort(map_dims))
-
     # Get dims in required order.
-    array = np.transpose(array, inverse_map_dims)
+    array = np.moveaxis(array, range(n_orig_dims), dim_map)
     new_array = np.broadcast_to(array, shape)
 
     if ma.isMA(array):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Attempt to resolve #5295, following my own suggestion at https://github.com/SciTools/iris/issues/5295#issuecomment-1532791248.  It turned out I didn't need to use `da.broadcast_to` directly - this is automatic due to dask's support for NEP13/18.  We *do* still need to handle masked arrays separately because they don't (yet) support NEP13/18.

This is still not working for the case where the array is both lazy and masked (see failing new test) because the mask gets ignored by `da.broadcast_to`.  We could apply a similar approach to that for the numpy masked arrays, but you can't tell whether a dask array is masked until you realise it.  This seems like it must be a common problem.  Anyone know a solution before I attempt to re-invent the wheel?

#### Performance Note

For a simple array I found this new implementation takes nearly twice as long as `main`.  However we are only talking about ~4 microseconds, and it does not appear to depend on array size, so maybe it's OK?

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
