### PR TITLE
Added whatsnew notes on netcdf delayed saving and Distributed support.

### DIFF
--- a/docs/src/whatsnew/3.6.rst
+++ b/docs/src/whatsnew/3.6.rst
@@ -13,14 +13,37 @@ This document explains the changes made to Iris for this release
    :animate: fade-in
    :open:
 
-   We're so excited about our recent support for **delayed saving of lazy data
-   to netCDF** (:pull:`5191`) that we're celebrating this important step change
-   in behavour with its very own dedicated release 🥳
+We're so excited about our recent support for **delayed saving of lazy data
+to netCDF** (:pull:`5191`) that we're celebrating this important step change
+in behavour with its very own dedicated release 🥳
 
-   We're super keen for the community to leverage the benefit of this new
-   feature within Iris that we've brought this release forward several months.
-   As a result, this minor release of Iris is intentionally light in content.
-   However, there are some other goodies available for you to enjoy, such as:
+By using ``iris.save(..., compute=False)`` you can now save to multiple netcdf files
+in parallel.  See the new ``compute`` keyword in :func:`iris.fileformats.netcdf.save`.
+This can share and re-use any common (lazy) result computations, and it makes much
+better use of resources during any file-system waiting (i.e. it can use such periods to
+progress the *other* saves).
+
+Usage example::
+
+   # Create output files with delayed data saving.
+   delayeds = [
+       iris.save(cubes, filepath, compute=False)
+       for cubes, filepath in zip(output_cubesets, output_filepaths)
+   ]
+   # Complete saves in parallel.
+   dask.compute(delayeds)
+
+This advance also includes **another substantial benefit**, because netcdf saves can
+now use a
+`Dask.distributed scheduler <https://docs.dask.org/en/stable/scheduling.html>`_.
+With `Distributed <https://distributed.dask.org/en/stable/>`_ you can parallelise the
+saves across a whole cluster.  Whereas previously, the netcdf saving *only* worked with
+a "threaded" scheduler, limiting it to a single CPU.
+
+We're so super keen for the community to leverage the benefit of this new
+feature within Iris that we've brought this release forward several months.
+As a result, this minor release of Iris is intentionally light in content.
+However, there are some other goodies available for you to enjoy, such as:
 
    * Performing lazy arithmetic with an Iris :class:`~iris.cube.Cube` and a
      :class:`dask.array.Array`, and

--- a/docs/src/whatsnew/3.6.rst
+++ b/docs/src/whatsnew/3.6.rst
@@ -31,7 +31,7 @@ This document explains the changes made to Iris for this release
            for cubes, filepath in zip(output_cubesets, output_filepaths)
        ]
        # Complete saves in parallel.
-       dask.compute(delayeds)
+       dask.compute(*delayeds)
 
     This advance also includes **another substantial benefit**, because netcdf saves can
     now use a

--- a/docs/src/whatsnew/3.6.rst
+++ b/docs/src/whatsnew/3.6.rst
@@ -8,10 +8,10 @@ This document explains the changes made to Iris for this release
 
 
 .. dropdown:: v3.6 Release Highlights
-   :color: primary
-   :icon: info
-   :animate: fade-in
-   :open:
+    :color: primary
+    :icon: info
+    :animate: fade-in
+    :open:
 
     We're so excited about our recent support for **delayed saving of lazy data
     to netCDF** (:pull:`5191`) that we're celebrating this important step change
@@ -45,14 +45,14 @@ This document explains the changes made to Iris for this release
     As a result, this minor release of Iris is intentionally light in content.
     However, there are some other goodies available for you to enjoy, such as:
 
-   * Performing lazy arithmetic with an Iris :class:`~iris.cube.Cube` and a
-     :class:`dask.array.Array`, and
-   * Various improvements to our documentation resulting from adoption of
-     `sphinx-design`_ and `sphinx-apidoc`_.
+    * Performing lazy arithmetic with an Iris :class:`~iris.cube.Cube` and a
+      :class:`dask.array.Array`, and
+    * Various improvements to our documentation resulting from adoption of
+      `sphinx-design`_ and `sphinx-apidoc`_.
 
-   As always, get in touch with us on :issue:`GitHub<new/choose>`, particularly
-   if you have any feedback with regards to delayed saving, or have any issues
-   or feature requests for improving Iris. Enjoy!
+    As always, get in touch with us on :issue:`GitHub<new/choose>`, particularly
+    if you have any feedback with regards to delayed saving, or have any issues
+    or feature requests for improving Iris. Enjoy!
 
 
 📢 Announcements

--- a/docs/src/whatsnew/3.6.rst
+++ b/docs/src/whatsnew/3.6.rst
@@ -13,37 +13,37 @@ This document explains the changes made to Iris for this release
    :animate: fade-in
    :open:
 
-We're so excited about our recent support for **delayed saving of lazy data
-to netCDF** (:pull:`5191`) that we're celebrating this important step change
-in behavour with its very own dedicated release 🥳
+    We're so excited about our recent support for **delayed saving of lazy data
+    to netCDF** (:pull:`5191`) that we're celebrating this important step change
+    in behavour with its very own dedicated release 🥳
 
-By using ``iris.save(..., compute=False)`` you can now save to multiple netcdf files
-in parallel.  See the new ``compute`` keyword in :func:`iris.fileformats.netcdf.save`.
-This can share and re-use any common (lazy) result computations, and it makes much
-better use of resources during any file-system waiting (i.e. it can use such periods to
-progress the *other* saves).
+    By using ``iris.save(..., compute=False)`` you can now save to multiple netcdf files
+    in parallel.  See the new ``compute`` keyword in :func:`iris.fileformats.netcdf.save`.
+    This can share and re-use any common (lazy) result computations, and it makes much
+    better use of resources during any file-system waiting (i.e. it can use such periods to
+    progress the *other* saves).
 
-Usage example::
+    Usage example::
 
-   # Create output files with delayed data saving.
-   delayeds = [
-       iris.save(cubes, filepath, compute=False)
-       for cubes, filepath in zip(output_cubesets, output_filepaths)
-   ]
-   # Complete saves in parallel.
-   dask.compute(delayeds)
+       # Create output files with delayed data saving.
+       delayeds = [
+           iris.save(cubes, filepath, compute=False)
+           for cubes, filepath in zip(output_cubesets, output_filepaths)
+       ]
+       # Complete saves in parallel.
+       dask.compute(delayeds)
 
-This advance also includes **another substantial benefit**, because netcdf saves can
-now use a
-`Dask.distributed scheduler <https://docs.dask.org/en/stable/scheduling.html>`_.
-With `Distributed <https://distributed.dask.org/en/stable/>`_ you can parallelise the
-saves across a whole cluster.  Whereas previously, the netcdf saving *only* worked with
-a "threaded" scheduler, limiting it to a single CPU.
+    This advance also includes **another substantial benefit**, because netcdf saves can
+    now use a
+    `Dask.distributed scheduler <https://docs.dask.org/en/stable/scheduling.html>`_.
+    With `Distributed <https://distributed.dask.org/en/stable/>`_ you can parallelise the
+    saves across a whole cluster.  Whereas previously, the netcdf saving *only* worked with
+    a "threaded" scheduler, limiting it to a single CPU.
 
-We're so super keen for the community to leverage the benefit of this new
-feature within Iris that we've brought this release forward several months.
-As a result, this minor release of Iris is intentionally light in content.
-However, there are some other goodies available for you to enjoy, such as:
+    We're so super keen for the community to leverage the benefit of this new
+    feature within Iris that we've brought this release forward several months.
+    As a result, this minor release of Iris is intentionally light in content.
+    However, there are some other goodies available for you to enjoy, such as:
 
    * Performing lazy arithmetic with an Iris :class:`~iris.cube.Cube` and a
      :class:`dask.array.Array`, and


### PR DESCRIPTION
Here's my suggestion explaining the benefits of delayed saves, and Distributed.

We _could_ consider a new UserGuide section for this, but I think we can still argue that this is a special usage + doesn't belong there.