### PR TITLE
minor refinement to release-do-nothing script

### DIFF
--- a/tools/release_do_nothing.py
+++ b/tools/release_do_nothing.py
@@ -720,6 +720,12 @@ def merge_back(
             f"{merge_commit}"
         )
         _wait_for_done(message)
+        message = (
+            f"Once the pull request is merged ensure that the {release_strings.branch} "
+            "release branch is restored.\n"
+            "GitHub automation rules may have automatically deleted the release branch."
+        )
+        _wait_for_done(message)
 
 
 def main():


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR introduces a minor improvement to the `release_do_nothing.py` script post v3.6.0 release.

We recently enabled automatic deletion of pull request head branches i.e.,

![image](https://github.com/SciTools/iris/assets/2051656/fc0baab9-5039-437c-a197-ca004704a3ed)

This automation is general useful for repo branch hygiene, but will result in the release branch being purged, which isn't necessarily what we want.

The `release_do_nothing.py` script now includes an additional step to ensure the release branch is **restored** from the GH GUI with a simple one button click.

As discussed with v3.6.0 release buddy @ESadek-MO off-line 👍 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
