### PR TITLE
DOC: remove advice to delete main branch

### DIFF
--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -14,8 +14,7 @@ Workflow Summary
 In what follows we'll refer to the upstream iris ``main`` branch, as
 "trunk".
 
-* Don't use your ``main`` (that is on your fork) branch for anything.
-  Consider deleting it.
+* Don't use your ``main`` (that is on your fork) branch for development.
 * When you are starting a new set of changes, fetch any changes from trunk,
   and start a new *feature branch* from that.
 * Make a new branch for each separable set of changes |emdash| "one task, one
@@ -33,13 +32,6 @@ This in turn makes it easier for project maintainers (that might be you) to see
 what you've done, and why you did it.
 
 See `linux git workflow`_ for some explanation.
-
-Consider Deleting Your Main Branch
-==================================
-
-It may sound strange, but deleting your own ``main`` branch can help reduce
-confusion about which branch you are on.  See `deleting master on github`_ for
-details.
 
 .. _update-mirror-trunk:
 

--- a/docs/src/developers_guide/gitwash/git_links.inc
+++ b/docs/src/developers_guide/gitwash/git_links.inc
@@ -28,6 +28,5 @@
 .. _git config: http://schacon.github.com/git/git-config.html
 
 .. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
-.. _deleting master on github: https://matthew-brett.github.io/pydagogue/gh_delete_master.html
 
 .. |emdash| unicode:: U+02014


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Our dev guide advocates deleting your main branch, with a link to this [pretty old page](https://matthew-brett.github.io/pydagogue/gh_delete_master.html).  I note that

* A quick browse of Iris core devs' forks suggests that not many of us ever followed this advice ourselves.
* The linked advice refers to `master` rather than `main`.  It may not be obvious for someone new to OSS that this is just an old name for the same thing.  Also there were good EDI reasons for dropping "master".
* The described procedure is fairly involved.  These days if you really wanted your default branch to be called something different, you could just rename it within GitHub.

So I think this advice is no longer useful.  Can we remove it?

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
