### PR TITLE
docs linkcheck ignore biggus rtd url

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -383,6 +383,7 @@ linkcheck_ignore = [
     "http://www.esrl.noaa.gov/psd/data/gridded/conventions/cdc_netcdf_standard.shtml",
     "http://www.nationalarchives.gov.uk/doc/open-government-licence",
     "https://www.metoffice.gov.uk/",
+    "https://biggus.readthedocs.io/",
 ]
 
 # list of sources to exclude from the build.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR adds a docs linkcheck ignore for `biggus` on RTD, which appears to be down or deleted.

See https://biggus.readthedocs.io/ :skull_and_crossbones: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
