### PR TITLE
add whatsnew for #5142

### DIFF
--- a/docs/src/whatsnew/3.6.rst
+++ b/docs/src/whatsnew/3.6.rst
@@ -63,6 +63,11 @@ This document explains the changes made to Iris for this release
    :icon: alert
    :animate: fade-in
 
+   📢 **Announcements**
+
+   Welcome and congratulations to `@sloosvel`_ who made their first contribution to
+   Iris! 🎉
+
    The patches in this release of Iris include:
 
    🐛 **Bugs Fixed**
@@ -70,6 +75,15 @@ This document explains the changes made to Iris for this release
    #. `@stephenworsley`_ fixed :meth:`~iris.cube.Cube.convert_units` to allow unit
       conversion of lazy data when using a `Distributed`_ scheduler.
       (:issue:`5347`, :pull:`5349`)
+
+   🚀 **Performance Enhancements**
+
+   #. `@sloosvel`_ improved :meth:`~iris.cube.CubeList.concatenate_cube` and
+      :meth:`~iris.cube.CubeList.concatenate` to ensure that lazy auxiliary coordinate
+      points and bounds are not realized. This change now allows cubes with
+      high-resolution auxiliary coordinates to concatenate successfully whilst using a
+      minimal in-core memory footprint.
+      (:issue:`5115`, :pull:`5142`)
 
 
 📢 Announcements
@@ -186,6 +200,7 @@ This document explains the changes made to Iris for this release
     core dev names are automatically included by the common_links.inc:
 
 .. _@fnattino: https://github.com/fnattino
+.. _@sloosvel: https://github.com/sloosvel
 
 
 .. comment


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR is a follow-on to #5142.

It adds an associated `whatsnew` entry for the forthcoming v3.6.1 patch release on the `v3.6.x` feature release branch.

Ping @sloosvel - you okay with this `whatsnew` entry? :smile: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
