### PR TITLE
address concatenate lazy comparison truthiness

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -13,6 +13,7 @@ from collections import defaultdict, namedtuple
 import dask.array as da
 import numpy as np
 
+from iris._lazy_data import as_concrete_data
 import iris.coords
 import iris.cube
 from iris.util import array_equal, guess_coord_axis
@@ -115,9 +116,13 @@ class _CoordMetaData(
             kwargs["circular"] = coord.circular
         if isinstance(coord, iris.coords.DimCoord):
             # Mix the monotonic ordering into the metadata.
-            if coord.core_points()[0] == coord.core_points()[-1]:
+            if as_concrete_data(
+                coord.core_points()[0] == coord.core_points()[-1]
+            ):
                 order = _CONSTANT
-            elif coord.core_points()[-1] > coord.core_points()[0]:
+            elif as_concrete_data(
+                coord.core_points()[-1] > coord.core_points()[0]
+            ):
                 order = _INCREASING
             else:
                 order = _DECREASING
@@ -776,17 +781,18 @@ class _CoordSignature:
         for coord, order in zip(self.dim_coords, self.dim_order):
             if order == _CONSTANT or order == _INCREASING:
                 points = _Extent(
-                    coord.core_points()[0], coord.core_points()[-1]
+                    as_concrete_data(coord.core_points()[0]),
+                    as_concrete_data(coord.core_points()[-1]),
                 )
                 if coord.core_bounds() is not None:
                     bounds = (
                         _Extent(
-                            coord.core_bounds()[0, 0],
-                            coord.core_bounds()[-1, 0],
+                            as_concrete_data(coord.core_bounds()[0, 0]),
+                            as_concrete_data(coord.core_bounds()[-1, 0]),
                         ),
                         _Extent(
-                            coord.core_bounds()[0, 1],
-                            coord.core_bounds()[-1, 1],
+                            as_concrete_data(coord.core_bounds()[0, 1]),
+                            as_concrete_data(coord.core_bounds()[-1, 1]),
                         ),
                     )
                 else:
@@ -794,17 +800,18 @@ class _CoordSignature:
             else:
                 # The order must be decreasing ...
                 points = _Extent(
-                    coord.core_points()[-1], coord.core_points()[0]
+                    as_concrete_data(coord.core_points()[-1]),
+                    as_concrete_data(coord.core_points()[0]),
                 )
                 if coord.core_bounds() is not None:
                     bounds = (
                         _Extent(
-                            coord.core_bounds()[-1, 0],
-                            coord.core_bounds()[0, 0],
+                            as_concrete_data(coord.core_bounds()[-1, 0]),
+                            as_concrete_data(coord.core_bounds()[0, 0]),
                         ),
                         _Extent(
-                            coord.core_bounds()[-1, 1],
-                            coord.core_bounds()[0, 1],
+                            as_concrete_data(coord.core_bounds()[-1, 1]),
+                            as_concrete_data(coord.core_bounds()[0, 1]),
                         ),
                     )
                 else:

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -13,7 +13,6 @@ from collections import defaultdict, namedtuple
 import dask.array as da
 import numpy as np
 
-from iris._lazy_data import as_concrete_data
 import iris.coords
 import iris.cube
 from iris.util import array_equal, guess_coord_axis
@@ -116,13 +115,9 @@ class _CoordMetaData(
             kwargs["circular"] = coord.circular
         if isinstance(coord, iris.coords.DimCoord):
             # Mix the monotonic ordering into the metadata.
-            if as_concrete_data(
-                coord.core_points()[0] == coord.core_points()[-1]
-            ):
+            if coord.points[0] == coord.points[-1]:
                 order = _CONSTANT
-            elif as_concrete_data(
-                coord.core_points()[-1] > coord.core_points()[0]
-            ):
+            elif coord.points[-1] > coord.points[0]:
                 order = _INCREASING
             else:
                 order = _DECREASING
@@ -780,39 +775,21 @@ class _CoordSignature:
         self.dim_extents = []
         for coord, order in zip(self.dim_coords, self.dim_order):
             if order == _CONSTANT or order == _INCREASING:
-                points = _Extent(
-                    as_concrete_data(coord.core_points()[0]),
-                    as_concrete_data(coord.core_points()[-1]),
-                )
-                if coord.core_bounds() is not None:
+                points = _Extent(coord.points[0], coord.points[-1])
+                if coord.bounds is not None:
                     bounds = (
-                        _Extent(
-                            as_concrete_data(coord.core_bounds()[0, 0]),
-                            as_concrete_data(coord.core_bounds()[-1, 0]),
-                        ),
-                        _Extent(
-                            as_concrete_data(coord.core_bounds()[0, 1]),
-                            as_concrete_data(coord.core_bounds()[-1, 1]),
-                        ),
+                        _Extent(coord.bounds[0, 0], coord.bounds[-1, 0]),
+                        _Extent(coord.bounds[0, 1], coord.bounds[-1, 1]),
                     )
                 else:
                     bounds = None
             else:
                 # The order must be decreasing ...
-                points = _Extent(
-                    as_concrete_data(coord.core_points()[-1]),
-                    as_concrete_data(coord.core_points()[0]),
-                )
-                if coord.core_bounds() is not None:
+                points = _Extent(coord.points[-1], coord.points[0])
+                if coord.bounds is not None:
                     bounds = (
-                        _Extent(
-                            as_concrete_data(coord.core_bounds()[-1, 0]),
-                            as_concrete_data(coord.core_bounds()[0, 0]),
-                        ),
-                        _Extent(
-                            as_concrete_data(coord.core_bounds()[-1, 1]),
-                            as_concrete_data(coord.core_bounds()[0, 1]),
-                        ),
+                        _Extent(coord.bounds[-1, 0], coord.bounds[0, 0]),
+                        _Extent(coord.bounds[-1, 1], coord.bounds[0, 1]),
                     )
                 else:
                     bounds = None

--- a/lib/iris/tests/unit/concatenate/__init__.py
+++ b/lib/iris/tests/unit/concatenate/__init__.py
@@ -5,6 +5,8 @@
 # licensing details.
 """Unit-test infrastructure for the :mod:`iris._concatenate` package."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
@@ -5,6 +5,8 @@
 # licensing details.
 """Unit-tests for :class:`iris._concatenate._CoordMetaData`."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
@@ -31,19 +31,23 @@ def check(actual: _CoordMetaData, expected: ExpectedItem) -> None:
 
 @pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
 @pytest.mark.parametrize("circular", [False, True])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
 def test_dim(
-    order: int, circular: bool, dtype: np.dtype, lazy: bool, with_bounds: bool
+    order: int,
+    circular: bool,
+    coord_dtype: np.dtype,
+    lazy: bool,
+    with_bounds: bool,
 ) -> None:
     """Test :class:`iris._concatenate._CoordMetaData` with dim coord."""
     metadata = create_metadata(
-        dim=True,
+        dim_coord=True,
         scalar=False,
         order=order,
         circular=circular,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )
@@ -52,19 +56,19 @@ def test_dim(
 
 
 @pytest.mark.parametrize("circular", [False, True])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
 def test_dim__scalar(
-    circular: bool, dtype: np.dtype, lazy: bool, with_bounds: bool
+    circular: bool, coord_dtype: np.dtype, lazy: bool, with_bounds: bool
 ) -> None:
     """Test :class:`iris._concatenate._CoordMetaData` with scalar dim coord."""
     metadata = create_metadata(
-        dim=True,
+        dim_coord=True,
         scalar=True,
         order=_CONSTANT,
         circular=circular,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )
@@ -73,19 +77,19 @@ def test_dim__scalar(
 
 
 @pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
 def test_aux(
-    order: int, dtype: np.dtype, lazy: bool, with_bounds: bool
+    order: int, coord_dtype: np.dtype, lazy: bool, with_bounds: bool
 ) -> None:
     """Test :class:`iris._concatenate._CoordMetaData` with aux coord."""
     metadata = create_metadata(
-        dim=False,
+        dim_coord=False,
         scalar=False,
         order=order,
         circular=None,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )
@@ -93,17 +97,19 @@ def test_aux(
     check(actual, metadata.expected)
 
 
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
-def test_aux__scalar(dtype: np.dtype, lazy: bool, with_bounds: bool) -> None:
+def test_aux__scalar(
+    coord_dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
     """Test :class:`iris._concatenate._CoordMetaData` with scalar aux coord."""
     metadata = create_metadata(
-        dim=False,
+        dim_coord=False,
         scalar=True,
         order=_CONSTANT,
         circular=None,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )

--- a/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordMetaData.py
@@ -1,0 +1,109 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit-tests for :class:`iris._concatenate._CoordMetaData`."""
+
+import numpy as np
+import pytest
+
+from iris._concatenate import (
+    _CONSTANT,
+    _DECREASING,
+    _INCREASING,
+    _CoordMetaData,
+)
+
+from . import ExpectedItem, create_metadata
+
+
+def check(actual: _CoordMetaData, expected: ExpectedItem) -> None:
+    """Assert actual and expected results."""
+    assert actual.defn == expected.defn
+    assert actual.dims == expected.dims
+    assert actual.points_dtype == expected.points_dtype
+    assert actual.bounds_dtype == expected.bounds_dtype
+    assert actual.kwargs == expected.kwargs
+
+
+@pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
+@pytest.mark.parametrize("circular", [False, True])
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_dim(
+    order: int, circular: bool, dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
+    """Test :class:`iris._concatenate._CoordMetaData` with dim coord."""
+    metadata = create_metadata(
+        dim=True,
+        scalar=False,
+        order=order,
+        circular=circular,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    actual = _CoordMetaData(coord=metadata.coord, dims=metadata.dims)
+    check(actual, metadata.expected)
+
+
+@pytest.mark.parametrize("circular", [False, True])
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_dim__scalar(
+    circular: bool, dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
+    """Test :class:`iris._concatenate._CoordMetaData` with scalar dim coord."""
+    metadata = create_metadata(
+        dim=True,
+        scalar=True,
+        order=_CONSTANT,
+        circular=circular,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    actual = _CoordMetaData(coord=metadata.coord, dims=metadata.dims)
+    check(actual, metadata.expected)
+
+
+@pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_aux(
+    order: int, dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
+    """Test :class:`iris._concatenate._CoordMetaData` with aux coord."""
+    metadata = create_metadata(
+        dim=False,
+        scalar=False,
+        order=order,
+        circular=None,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    actual = _CoordMetaData(coord=metadata.coord, dims=metadata.dims)
+    check(actual, metadata.expected)
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_aux__scalar(dtype: np.dtype, lazy: bool, with_bounds: bool) -> None:
+    """Test :class:`iris._concatenate._CoordMetaData` with scalar aux coord."""
+    metadata = create_metadata(
+        dim=False,
+        scalar=True,
+        order=_CONSTANT,
+        circular=None,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    actual = _CoordMetaData(coord=metadata.coord, dims=metadata.dims)
+    check(actual, metadata.expected)

--- a/lib/iris/tests/unit/concatenate/test__CoordSignature.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordSignature.py
@@ -42,18 +42,18 @@ class MockCubeSignature:
 
 
 @pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
 def test_dim(
-    order: int, dtype: np.dtype, lazy: bool, with_bounds: bool
+    order: int, coord_dtype: np.dtype, lazy: bool, with_bounds: bool
 ) -> None:
     """Test extent calculation of vector dimension coordinates."""
     metadata = create_metadata(
-        dim=True,
+        dim_coord=True,
         scalar=False,
         order=order,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )
@@ -64,7 +64,7 @@ def test_dim(
     coord_signature = _CoordSignature(cube_signature)
     assert len(coord_signature.dim_extents) == 1
     (actual,) = coord_signature.dim_extents
-    first, last = dtype(0), dtype((N_POINTS - 1) * SCALE_FACTOR)
+    first, last = coord_dtype(0), coord_dtype((N_POINTS - 1) * SCALE_FACTOR)
     if order == _CONSTANT:
         emsg = f"Expected 'order' of '{_DECREASING}' or '{_INCREASING}', got '{order}'."
         raise ValueError(emsg)
@@ -86,16 +86,18 @@ def test_dim(
     assert actual == expected
 
 
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("coord_dtype", [np.int32, np.float32])
 @pytest.mark.parametrize("lazy", [False, True])
 @pytest.mark.parametrize("with_bounds", [False, True])
-def test_dim__scalar(dtype: np.dtype, lazy: bool, with_bounds: bool) -> None:
+def test_dim__scalar(
+    coord_dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
     """Test extent calculation of scalar dimension coordinates."""
     metadata = create_metadata(
-        dim=True,
+        dim_coord=True,
         scalar=True,
         order=_CONSTANT,
-        dtype=dtype,
+        coord_dtype=coord_dtype,
         lazy=lazy,
         with_bounds=with_bounds,
     )
@@ -106,11 +108,11 @@ def test_dim__scalar(dtype: np.dtype, lazy: bool, with_bounds: bool) -> None:
     coord_signature = _CoordSignature(cube_signature)
     assert len(coord_signature.dim_extents) == 1
     (actual,) = coord_signature.dim_extents
-    point = dtype(1)
+    point = coord_dtype(1)
     points_extent = _Extent(min=point, max=point)
     bounds_extent = None
     if with_bounds:
-        first, last = dtype(0), dtype(2)
+        first, last = coord_dtype(0), coord_dtype(2)
         bounds_extent = (
             _Extent(min=first, max=first),
             _Extent(min=last, max=last),

--- a/lib/iris/tests/unit/concatenate/test__CoordSignature.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordSignature.py
@@ -1,0 +1,117 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit-tests for :class:`iris._concatenate._CoordSignature`."""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pytest
+
+from iris._concatenate import (
+    _CONSTANT,
+    _DECREASING,
+    _INCREASING,
+    _CoordExtent,
+    _CoordMetaData,
+    _CoordSignature,
+    _Extent,
+)
+from iris.coords import DimCoord
+
+from . import N_POINTS, SCALE_FACTOR, create_metadata
+
+
+@dataclass
+class MockCubeSignature:
+    """Simple mock of :class:`iris._concatenate._CubeSignature`."""
+
+    aux_coords_and_dims: bool | None = None
+    cell_measures_and_dims: bool | None = None
+    ancillary_variables_and_dims: bool | None = None
+    derived_coords_and_dims: bool | None = None
+    dim_coords: list[DimCoord, ...] = field(default_factory=list)
+    dim_mapping: bool | None = None
+    dim_extents: list[_Extent, ...] = field(default_factory=list)
+    dim_order: list[int, ...] = field(default_factory=list)
+    dim_metadata: list[_CoordMetaData, ...] = field(default_factory=list)
+
+
+@pytest.mark.parametrize("order", [_DECREASING, _INCREASING])
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_dim(
+    order: int, dtype: np.dtype, lazy: bool, with_bounds: bool
+) -> None:
+    """Test extent calculation of vector dimension coordinates."""
+    metadata = create_metadata(
+        dim=True,
+        scalar=False,
+        order=order,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    dim_metadata = [_CoordMetaData(metadata.coord, metadata.dims)]
+    cube_signature = MockCubeSignature(
+        dim_coords=[metadata.coord], dim_metadata=dim_metadata
+    )
+    coord_signature = _CoordSignature(cube_signature)
+    assert len(coord_signature.dim_extents) == 1
+    (actual,) = coord_signature.dim_extents
+    first, last = dtype(0), dtype((N_POINTS - 1) * SCALE_FACTOR)
+    if order == _CONSTANT:
+        emsg = f"Expected 'order' of '{_DECREASING}' or '{_INCREASING}', got '{order}'."
+        raise ValueError(emsg)
+    points_extent = _Extent(min=first, max=last)
+    bounds_extent = None
+    if with_bounds:
+        offset = SCALE_FACTOR // 2
+        if order == _INCREASING:
+            bounds_extent = (
+                _Extent(min=first - offset, max=last - offset),
+                _Extent(min=first + offset, max=last + offset),
+            )
+        else:
+            bounds_extent = (
+                _Extent(min=first + offset, max=last + offset),
+                _Extent(min=first - offset, max=last - offset),
+            )
+    expected = _CoordExtent(points=points_extent, bounds=bounds_extent)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("with_bounds", [False, True])
+def test_dim__scalar(dtype: np.dtype, lazy: bool, with_bounds: bool) -> None:
+    """Test extent calculation of scalar dimension coordinates."""
+    metadata = create_metadata(
+        dim=True,
+        scalar=True,
+        order=_CONSTANT,
+        dtype=dtype,
+        lazy=lazy,
+        with_bounds=with_bounds,
+    )
+    dim_metadata = [_CoordMetaData(metadata.coord, metadata.dims)]
+    cube_signature = MockCubeSignature(
+        dim_coords=[metadata.coord], dim_metadata=dim_metadata
+    )
+    coord_signature = _CoordSignature(cube_signature)
+    assert len(coord_signature.dim_extents) == 1
+    (actual,) = coord_signature.dim_extents
+    point = dtype(1)
+    points_extent = _Extent(min=point, max=point)
+    bounds_extent = None
+    if with_bounds:
+        first, last = dtype(0), dtype(2)
+        bounds_extent = (
+            _Extent(min=first, max=first),
+            _Extent(min=last, max=last),
+        )
+    expected = _CoordExtent(points=points_extent, bounds=bounds_extent)
+    assert actual == expected

--- a/lib/iris/tests/unit/concatenate/test__CoordSignature.py
+++ b/lib/iris/tests/unit/concatenate/test__CoordSignature.py
@@ -5,6 +5,8 @@
 # licensing details.
 """Unit-tests for :class:`iris._concatenate._CoordSignature`."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 import numpy as np


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR is a follow-on to #5142.

Lazy comparison will always yield a truthy value, therefore we require to realize the comparison. In this case, we're performing either lazy indexing for a single value or comparing lazy single values. Realizing the result won't undo the intent of #5142.

Great spot @trexfeathers :eyes: 

To do:

 - [x] Add a test case/s to highlight the issue and ratify adoption of `as_concrete_data` pattern, if possible

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
