### PR TITLE
Avoid cftime warnings on pp-load

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -47,6 +47,9 @@ This document explains the changes made to Iris for this release
 
 #. `@acchamber`_ removed some obsolete code that prevented extraction of time points
    from cubes with bounded times (:pull:`5175`)
+   
+#. `@rcomer`_ modified pp-loading to avoid a ``cftime`` warning for non-standard
+   calendars. (:pull:`5357`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1486,7 +1486,7 @@ class PPField2(PPField):
 
         """
         if not hasattr(self, "_t1"):
-            has_year_zero = self.lbyr == 0
+            has_year_zero = self.lbyr == 0 or None
             calendar = (
                 None if self.lbmon == 0 or self.lbdat == 0 else self.calendar
             )
@@ -1520,7 +1520,7 @@ class PPField2(PPField):
 
         """
         if not hasattr(self, "_t2"):
-            has_year_zero = self.lbyrd == 0
+            has_year_zero = self.lbyrd == 0 or None
             calendar = (
                 None if self.lbmond == 0 or self.lbdatd == 0 else self.calendar
             )
@@ -1567,7 +1567,7 @@ class PPField3(PPField):
 
         """
         if not hasattr(self, "_t1"):
-            has_year_zero = self.lbyr == 0
+            has_year_zero = self.lbyr == 0 or None
             calendar = (
                 None if self.lbmon == 0 or self.lbdat == 0 else self.calendar
             )
@@ -1602,7 +1602,7 @@ class PPField3(PPField):
 
         """
         if not hasattr(self, "_t2"):
-            has_year_zero = self.lbyrd == 0
+            has_year_zero = self.lbyrd == 0 or None
             calendar = (
                 None if self.lbmond == 0 or self.lbdatd == 0 else self.calendar
             )


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #5315.

I think we only care about the `has_year_zero` keyword if the `lbyr` or `lbyrd` is zero.  Otherwise, my solution is to leave it to cftime's default.  Different calendars have different defaults, see https://unidata.github.io/cftime/api.html#cftime.datetime.

I'm not sure whether this needs a test just to assert that we now don't get a warning.  In case we do, I have identified `aPPglob1/global.pp` as a suitable file.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
