### PR TITLE
Ignore sticklerci

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -384,6 +384,7 @@ linkcheck_ignore = [
     "http://www.nationalarchives.gov.uk/doc/open-government-licence",
     "https://www.metoffice.gov.uk/",
     "https://biggus.readthedocs.io/",
+    "https://stickler-ci.com/",
 ]
 
 # list of sources to exclude from the build.


### PR DESCRIPTION
Linkcheck is now broken because https://stickler-ci.com/ is down.

It looks like that website has now been shutdown:
![image](https://github.com/SciTools/iris/assets/8101163/8ba67686-15f5-4427-925c-edeeb858671b)


