### PR TITLE
Bugfix for #3696

### DIFF
--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -650,6 +650,13 @@ class _CubeSignature:
                     "Data types", "", self.data_type, other.data_type
                 )
             )
+        # Check cube overlap.
+        # if self.something != other.something:
+        #     msgs.append(
+        #         msg_template.format(
+        #             "Cube extent", "",
+        #         )
+        #     )
 
         match = not bool(msgs)
         if error_on_mismatch and not match:
@@ -992,6 +999,9 @@ class _ProtoCube:
             match = self._sequence(
                 coord_signature.dim_extents[dim_ind], candidate_axis
             )
+            if error_on_mismatch and not match:
+                msg = "Dimensional coordinate extents differ"
+                raise iris.exceptions.ConcatenateError(msg)
 
         # Check for compatible AuxCoords.
         if match:

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -9,6 +9,7 @@ Automatic concatenation of multiple cubes over one or more existing dimensions.
 """
 
 from collections import defaultdict, namedtuple
+import warnings
 
 import dask.array as da
 import numpy as np
@@ -650,13 +651,6 @@ class _CubeSignature:
                     "Data types", "", self.data_type, other.data_type
                 )
             )
-        # Check cube overlap.
-        # if self.something != other.something:
-        #     msgs.append(
-        #         msg_template.format(
-        #             "Cube extent", "",
-        #         )
-        #     )
 
         match = not bool(msgs)
         if error_on_mismatch and not match:
@@ -1000,8 +994,11 @@ class _ProtoCube:
                 coord_signature.dim_extents[dim_ind], candidate_axis
             )
             if error_on_mismatch and not match:
-                msg = "Dimensional coordinate extents differ"
+                msg = ["Dimensional coordinate extents differ"]
                 raise iris.exceptions.ConcatenateError(msg)
+            elif not match:
+                msg = f"Found cubes with overlap on concatenate axis {candidate_axis}, skipping concatenation for these cubes"
+                warnings.warm()
 
         # Check for compatible AuxCoords.
         if match:

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -242,6 +242,15 @@ class TestMessages(tests.IrisTest):
         with self.assertRaisesRegex(ConcatenateError, exc_regexp):
             _ = concatenate([cube_1, cube_2], True)
 
+    def test_dim_coords_overlap_message(self):
+        cube_1 = self.cube
+        cube_2 = cube_1.copy()
+        cube_2.coord("time").points = np.arange(1, 3, dtype=np.float32)
+        exc_regexp = "Dimensional coordinate extents differ .*"
+        # import pdb ; pdb.set_trace()
+        with self.assertRaisesRegex(ConcatenateError, exc_regexp):
+            _ = concatenate([cube_1, cube_2], True)
+
 
 class TestOrder(tests.IrisTest):
     def _make_cube(self, points, bounds=None):

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -246,8 +246,7 @@ class TestMessages(tests.IrisTest):
         cube_1 = self.cube
         cube_2 = cube_1.copy()
         cube_2.coord("time").points = np.arange(1, 3, dtype=np.float32)
-        exc_regexp = "Dimensional coordinate extents differ .*"
-        # import pdb ; pdb.set_trace()
+        exc_regexp = "Dimensional coordinate extents differ"
         with self.assertRaisesRegex(ConcatenateError, exc_regexp):
             _ = concatenate([cube_1, cube_2], True)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Following #3696, which left the user confused about how concatenation interfaced with cube overlap, added a more explicit error message if you try to use concatenate_cube to concatenate two cubes with overlapping coordinates and added warning if you use regular concatenate so the user understands why they remain separate. 

New test added for the error message and all tests pass. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
