### PR TITLE
Splitattrs ncload

### DIFF
--- a/docs/src/further_topics/metadata.rst
+++ b/docs/src/further_topics/metadata.rst
@@ -131,7 +131,7 @@ We can easily get all of the associated metadata of the :class:`~iris.cube.Cube`
 using the ``metadata`` property:
 
     >>> cube.metadata
-    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={}, locals={'Conventions': 'CF-1.5', 'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
+    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={'Conventions': 'CF-1.5'}, locals={'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
 
 We can also inspect the ``metadata`` of the ``longitude``
 :class:`~iris.coords.DimCoord` attached to the :class:`~iris.cube.Cube` in the same way:
@@ -676,7 +676,7 @@ For example, consider the following :class:`~iris.common.metadata.CubeMetadata`,
 .. doctest:: metadata-combine
 
     >>> cube.metadata
-    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={}, locals={'Conventions': 'CF-1.5', 'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
+    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={'Conventions': 'CF-1.5'}, locals={'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
 
 We can perform the **identity function** by comparing the metadata with itself,
 
@@ -811,7 +811,7 @@ the ``from_metadata`` class method. For example, given the following
 .. doctest:: metadata-convert
 
     >>> cube.metadata
-    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={}, locals={'Conventions': 'CF-1.5', 'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
+    CubeMetadata(standard_name='air_temperature', long_name=None, var_name='air_temperature', units=Unit('K'), attributes=CubeAttrsDict(globals={'Conventions': 'CF-1.5'}, locals={'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}), cell_methods=(CellMethod(method='mean', coord_names=('time',), intervals=('6 hour',), comments=()),))
 
 We can easily convert it to a :class:`~iris.common.metadata.DimCoordMetadata` instance
 using ``from_metadata``,

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -435,7 +435,7 @@ def build_cube_metadata(engine):
         try:
             cube.attributes.globals[str(attr_name)] = attr_value
         except ValueError as e:
-            msg = "Skipping global attribute {!r}: {}"
+            msg = "Skipping disallowed global attribute {!r}: {}"
             warnings.warn(msg.format(attr_name, str(e)))
 
 

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -433,7 +433,7 @@ def build_cube_metadata(engine):
     # Set the cube global attributes.
     for attr_name, attr_value in cf_var.cf_group.global_attributes.items():
         try:
-            cube.attributes[str(attr_name)] = attr_value
+            cube.attributes.globals[str(attr_name)] = attr_value
         except ValueError as e:
             msg = "Skipping global attribute {!r}: {}"
             warnings.warn(msg.format(attr_name, str(e)))

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -159,8 +159,13 @@ def _add_unused_attributes(iris_object, cf_var):
         return item[0] not in _CF_ATTRS
 
     tmpvar = filter(attribute_predicate, cf_var.cf_attrs_unused())
+    attrs_dict = iris_object.attributes
+    if hasattr(attrs_dict, "locals"):
+        # Treat cube attributes (i.e. a CubeAttrsDict) as a special case.
+        # These attrs are "local" (i.e. on the variable), so record them as such.
+        attrs_dict = attrs_dict.locals
     for attr_name, attr_value in tmpvar:
-        _set_attributes(iris_object.attributes, attr_name, attr_value)
+        _set_attributes(attrs_dict, attr_name, attr_value)
 
 
 def _get_actual_dtype(cf_var):

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_cube_metadata.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_cube_metadata.py
@@ -42,7 +42,7 @@ def _make_engine(global_attributes=None, standard_name=None, long_name=None):
     return engine
 
 
-class TestInvalidGlobalAttributes(tests.IrisTest):
+class TestGlobalAttributes(tests.IrisTest):
     def test_valid(self):
         global_attributes = {
             "Conventions": "CF-1.5",
@@ -51,7 +51,7 @@ class TestInvalidGlobalAttributes(tests.IrisTest):
         engine = _make_engine(global_attributes)
         build_cube_metadata(engine)
         expected = global_attributes
-        self.assertEqual(engine.cube.attributes, expected)
+        self.assertEqual(engine.cube.attributes.globals, expected)
 
     def test_invalid(self):
         global_attributes = {
@@ -65,13 +65,14 @@ class TestInvalidGlobalAttributes(tests.IrisTest):
         # Check for a warning.
         self.assertEqual(warn.call_count, 1)
         self.assertIn(
-            "Skipping global attribute 'calendar'", warn.call_args[0][0]
+            "Skipping disallowed global attribute 'calendar'",
+            warn.call_args[0][0],
         )
         # Check resulting attributes. The invalid entry 'calendar'
         # should be filtered out.
         global_attributes.pop("calendar")
         expected = global_attributes
-        self.assertEqual(engine.cube.attributes, expected)
+        self.assertEqual(engine.cube.attributes.globals, expected)
 
 
 class TestCubeName(tests.IrisTest):


### PR DESCRIPTION
Changes netcdf loading code to specifically load into `cube.attributes.globals` and `cube.attributes.locals`
Since the same attributes are then appearing in 'cube.attributes', this in itself (i.e. without changes to saving) should have no effect.
-- **_Except_** in some minor corner cases, where an attribute is present as _both_ a local (variable-attribute)) + global (file-attribute).

So, I think that this is (almost) fully backwards-compatible, and **_does not require a control switch like a FUTURE flag_** (but reviewer may think differently).
( N.B. I **_am_** intending to create a FUTURE flag for the new split-attributes saving behaviour, since that will definitely change behaviour quite significantly. Covered in #4986 )

The actual changes in loading code are pretty small (https://github.com/SciTools/iris/commit/f736c4baa56bbf14a6a90d1e21175ada7c008ac7)

I have had to modify change some of the existing tests from #4960, by replacing `cube.attributes == <expected-result-dictionary>` with `dict(cube.attributes) == <expected-result-dictionary>`.  In principle I could have done that first, to prove pre-existing behaviour, but I think the argument is pretty solid as it is.

( Note : replaces older version  #5048 )

