### PR TITLE
Added link to UDUNITS-2 database to convert_units docstrings

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -75,6 +75,9 @@ This document explains the changes made to Iris for this release
    section into the user guide, containing advice and use cases to help users
    get the best out of Dask with Iris.
 
+#. `@acchamber`_ improved documentation for :meth:`~iris.cube.Cube.convert_units`
+   and :meth:`~iris.coords.Coord.convert_units` by including a link to the UDUNITS-2
+   documentation which contains lists of compatible units and aliases for them.
 
 💼 Internal
 ===========
@@ -89,7 +92,7 @@ This document explains the changes made to Iris for this release
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 .. _@rsdavies: https://github.com/rsdavies
-
+.. _@acchamber: https://github.com/acchamber 
 
 
 .. comment

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1862,6 +1862,8 @@ class Coord(_DimensionalMetadata):
         multiply each value in :attr:`~iris.coords.Coord.points` and
         :attr:`~iris.coords.Coord.bounds` by 180.0/:math:`\pi`.
 
+        Full list of supported units can be found in the UDUNITS-2 documentation
+        https://docs.unidata.ucar.edu/udunits/current/#Database
         """
         super().convert_units(unit=unit)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1134,6 +1134,9 @@ class Cube(CFVariableMixin):
         celsius and subtract 273.15 from each value in
         :attr:`~iris.cube.Cube.data`.
 
+        Full list of supported units can be found in the UDUNITS-2 documentation
+        https://docs.unidata.ucar.edu/udunits/current/#Database
+
         This operation preserves lazy data.
 
         """


### PR DESCRIPTION
## 🚀 Pull Request
To close #3945 
### Description

Adds a external hyperlink to convert_units methods for cube and coord to UDUNITS-2 documentation containing the information on what units and aliases for them are supported. 

The page in question has the information spread over 5 .xml files, but unless we want to recreate them in the cf-units documentation it's the closest we have to a list in the browser of supported units. 




