### PR TITLE
removed redundant timeattr check and added tests to ensure datetime/c…

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -1510,14 +1510,6 @@ class Cell(namedtuple("Cell", ["point", "bound"])):
         """
         if self.bound is None:
             raise ValueError("Point cannot exist inside an unbounded cell.")
-        if hasattr(point, "timetuple") or np.any(
-            [hasattr(val, "timetuple") for val in self.bound]
-        ):
-            raise TypeError(
-                "Cannot determine whether a point lies within "
-                "a bounded region for datetime-like objects."
-            )
-
         return np.min(self.bound) <= point <= np.max(self.bound)
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Solving #5175, this removes the restriction against comparing datetime objects, as the only ones Iris should deal with are datetime.datetime, cftime.datetime, and PartialDateTime. Adds various new tests for checking combinations of those act as they should. 
