### PR TITLE
Make roundtrip checking more precise + improve some tests accordingly.

### DIFF
--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -546,8 +546,8 @@ class TestRoundtrip(MixinAttrsTesting):
             )
 
         if (
-                local_attr in ('missing_value', 'standard_error_multiplier')
-                and origin_style == "input_local"
+            local_attr in ("missing_value", "standard_error_multiplier")
+            and origin_style == "input_local"
         ):
             # These ones are actually discarded by roundtrip.
             # Not clear why, but for now this captures the facts.


### PR DESCRIPTION
This provides an important tweak to the split-attrs feature branch, which really needs to be shown working with the main-branch code **_prior_** to the adoption of split attributes in cube content and loading (as already merged)

