### PR TITLE
Avoid using deprecated ContourSet attributes

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -84,6 +84,9 @@ This document explains the changes made to Iris for this release
    `"Xarray bridge" <https://github.com/SciTools/iris/issues/4994>`_ facility.
    (:pull:`5214`)
 
+#. `@rcomer`_ updated :func:`~iris.plot.contourf` to avoid using functionality
+   that is deprecated in Matplotlib v3.8 (:pull:`5405`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/tests/unit/plot/test_contourf.py
+++ b/lib/iris/tests/unit/plot/test_contourf.py
@@ -69,10 +69,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        mocker = mock.Mock(alpha=0, antialiased=False)
-        self.mpl_patch = self.patch(
-            "matplotlib.pyplot.contourf", return_value=mocker
-        )
+        mocker = mock.Mock(wraps=plt.contourf)
+        self.mpl_patch = self.patch("matplotlib.pyplot.contourf", mocker)
         self.draw_func = iplt.contourf
 
 

--- a/lib/iris/tests/unit/quickplot/test_contourf.py
+++ b/lib/iris/tests/unit/quickplot/test_contourf.py
@@ -11,6 +11,7 @@ import iris.tests as tests  # isort:skip
 
 from unittest import mock
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from iris.tests.stock import simple_2d
@@ -42,10 +43,8 @@ class TestCoords(tests.IrisTest, MixinCoords):
         self.bar_index = np.arange(self.bar.size)
         self.data = self.cube.data
         self.dataT = self.data.T
-        mocker = mock.Mock(alpha=0, antialiased=False)
-        self.mpl_patch = self.patch(
-            "matplotlib.pyplot.contourf", return_value=mocker
-        )
+        mocker = mock.Mock(wraps=plt.contourf)
+        self.mpl_patch = self.patch("matplotlib.pyplot.contourf", mocker)
         # Also need to mock the colorbar.
         self.patch("matplotlib.pyplot.colorbar")
         self.draw_func = qplt.contourf


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
For Matplotlib v3.8 the `ContourSet` class had a re-write (https://github.com/matplotlib/matplotlib/pull/25247) and various of its attributes will be deprecated in the upcoming release.  Relevant release notes are
https://matplotlib.org/devdocs/api/next_api_changes/deprecations/25138-AL.html
https://matplotlib.org/devdocs/api/next_api_changes/deprecations/25247-AL.html
https://matplotlib.org/devdocs/api/next_api_changes/deprecations/26399-REC.html


`iplt.contourf` uses some of these attributes so this PR updates it to work with the new `ContourSet`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
