### PR TITLE
Splitattrs ncsave redo commonmeta

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -182,7 +182,7 @@ class Future(threading.local):
         # self.__dict__['example_future_flag'] = example_future_flag
         self.__dict__["datum_support"] = datum_support
         self.__dict__["pandas_ndim"] = pandas_ndim
-        self.__dict__["save_split_attrs"] = pandas_ndim
+        self.__dict__["save_split_attrs"] = save_split_attrs
 
     def __repr__(self):
         # msg = ('Future(example_future_flag={})')

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -142,7 +142,9 @@ NameConstraint = iris._constraints.NameConstraint
 class Future(threading.local):
     """Run-time configuration controller."""
 
-    def __init__(self, datum_support=False, pandas_ndim=False):
+    def __init__(
+        self, datum_support=False, pandas_ndim=False, save_split_attrs=False
+    ):
         """
         A container for run-time options controls.
 
@@ -164,6 +166,11 @@ class Future(threading.local):
         pandas_ndim : bool, default=False
             See :func:`iris.pandas.as_data_frame` for details - opts in to the
             newer n-dimensional behaviour.
+        save_split_attrs : bool, default=False
+            Save "global" and "local" cube attributes to netcdf in appropriately
+            different ways :  "global" ones are saved as dataset attributes, where
+            possible, while "local" ones are saved as data-variable attributes.
+            See :func:`iris.fileformats.netcdf.saver.save`.
 
         """
         # The flag 'example_future_flag' is provided as a reference for the
@@ -175,12 +182,15 @@ class Future(threading.local):
         # self.__dict__['example_future_flag'] = example_future_flag
         self.__dict__["datum_support"] = datum_support
         self.__dict__["pandas_ndim"] = pandas_ndim
+        self.__dict__["save_split_attrs"] = pandas_ndim
 
     def __repr__(self):
         # msg = ('Future(example_future_flag={})')
         # return msg.format(self.example_future_flag)
-        msg = "Future(datum_support={}, pandas_ndim={})"
-        return msg.format(self.datum_support, self.pandas_ndim)
+        msg = "Future(datum_support={}, pandas_ndim={}, save_split_attrs={})"
+        return msg.format(
+            self.datum_support, self.pandas_ndim, self.save_split_attrs
+        )
 
     # deprecated_options = {'example_future_flag': 'warning',}
     deprecated_options = {}

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# Copyright Iris contributors
+    # Copyright Iris contributors
 #
 # This file is part of Iris and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
@@ -930,19 +930,19 @@ class CubeAttrsDict(MutableMapping):
         return attributes
 
     @property
-    def locals(self):
+    def locals(self) -> LimitedAttributeDict:
         return self._locals
 
     @locals.setter
-    def locals(self, attributes):
+    def locals(self, attributes: Optional[Mapping]):
         self._locals = self._normalise_attrs(attributes)
 
     @property
-    def globals(self):
+    def globals(self) -> LimitedAttributeDict:
         return self._globals
 
     @globals.setter
-    def globals(self, attributes):
+    def globals(self, attributes: Optional[Mapping]):
         self._globals = self._normalise_attrs(attributes)
 
     #
@@ -1335,8 +1335,12 @@ class Cube(CFVariableMixin):
     #
     # Ensure that .attributes is always a :class:`CubeAttrsDict`.
     #
-    @CFVariableMixin.attributes.setter
-    def attributes(self, attributes):
+    @property
+    def attributes(self) -> CubeAttrsDict:
+        return super().attributes
+
+    @attributes.setter
+    def attributes(self, attributes: Optional[Mapping]):
         """
         An override to CfVariableMixin.attributes.setter, which ensures that Cube
         attributes are stored in a way which distinguishes global + local ones.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-    # Copyright Iris contributors
+# Copyright Iris contributors
 #
 # This file is part of Iris and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2626,7 +2626,7 @@ def save(
       dictionaries on each cube in the saved cube list will be compared, and common
       attributes saved as NetCDF global attributes where appropriate.
 
-      Or, **when split-attribute saving is enabled**, then `cube.attributes.locals``
+      Or, **when split-attribute saving is enabled**, then ``cube.attributes.locals``
       are always saved as attributes of data-variables, and ``cube.attributes.globals``
       are saved as global (dataset) attributes, where possible.
       Since the 2 types are now distinguished : see :class:`~iris.cube.CubeAttrsDict`.
@@ -2887,12 +2887,10 @@ def save(
                             f'of cube "{cube.name()}" were not saved, overlaid '
                             "by existing local attributes with the same names."
                         )
-                    for attr in demote_attrs:
-                        if attr not in blocked_attrs:
-                            cube.attributes.locals[
-                                attr
-                            ] = cube.attributes.globals[attr]
-                        cube.attributes.globals.pop(attr)
+                    for attr in set(demote_attrs) - set(blocked_attrs):
+                        # move global to local
+                        value = cube.attributes.globals.pop(attr)
+                        cube.attributes.locals[attr] = value
 
     else:
         # Determine the attribute keys that are common across all cubes and

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2893,9 +2893,8 @@ def save(
                         cube.attributes.locals[attr] = value
 
     else:
-        # Determine the attribute keys that are common across all cubes and
-        # thereby extend the collection of local_keys for attributes
-        # that should be attributes on data variables.
+        # Legacy mode: calculate "local_keys" to control which attributes are local
+        # and which global.
         if local_keys is None:
             local_keys = set()
         else:
@@ -2913,22 +2912,6 @@ def save(
             different_value_keys = []
             for key in common_keys:
                 if np.any(attributes[key] != cube.attributes[key]):
-                    different_value_keys.append(key)
-            common_keys.difference_update(different_value_keys)
-            local_keys.update(different_value_keys)
-
-        common_attr_values = None
-        for cube in cubes:
-            cube_attributes = cube.attributes
-            keys = set(cube_attributes)
-            if common_attr_values is None:
-                common_attr_values = cube_attributes.copy()
-                common_keys = keys.copy()
-            local_keys.update(keys.symmetric_difference(common_keys))
-            common_keys.intersection_update(keys)
-            different_value_keys = []
-            for key in common_keys:
-                if np.any(common_attr_values[key] != cube_attributes[key]):
                     different_value_keys.append(key)
             common_keys.difference_update(different_value_keys)
             local_keys.update(different_value_keys)

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2826,7 +2826,8 @@ def save(
             for attrname in global_names
             if not all(
                 attr_values_equal(
-                    cube.attributes[attrname], cube0.attributes[attrname]
+                    cube.attributes.globals.get(attrname),
+                    cube0.attributes.globals.get(attrname),
                 )
                 for cube in cubes[1:]
             )
@@ -2834,15 +2835,15 @@ def save(
 
         # Establish all the global attributes which we will write to the file (at end).
         global_attributes = {
-            attr: cube0.attributes.globals[attr]
+            attr: cube0.attributes.globals.get(attr)
             for attr in global_names
             if attr not in invalid_globals
         }
         if invalid_globals:
             # Some cubes have different global attributes: modify cubes as required.
             warnings.warn(
-                f"Saving the cube global attributes {invalid_globals} as local"
-                "(i.e. data-variable) attributes, where possible, since they are not '"
+                f"Saving the cube global attributes {invalid_globals} as local "
+                "(i.e. data-variable) attributes, where possible, since they are not "
                 "the same on all input cubes."
             )
             cubes = list(cubes)  # avoiding modifying the actual input arg.

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -540,7 +540,9 @@ class Saver:
             An interable of cube attribute keys. Any cube attributes with
             matching keys will become attributes on the data variable rather
             than global attributes.
-            .. note:
+
+            .. Note::
+
                 Has no effect if :attr:`iris.FUTURE.save_split_attrs` is ``True``.
 
         * unlimited_dimensions (iterable of strings and/or

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -724,10 +724,6 @@ class Saver:
 
             # Add global attributes taking into account local_keys.
             cube_attributes = cube.attributes
-            if iris.FUTURE.save_split_attrs:
-                # In this case, do *not* promote any 'local' attributes to global ones,
-                # only "global" cube attrs may be written as global file attributes
-                cube_attributes = cube_attributes.globals
             global_attributes = {
                 k: v
                 for k, v in cube_attributes.items()

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -540,6 +540,8 @@ class Saver:
             An interable of cube attribute keys. Any cube attributes with
             matching keys will become attributes on the data variable rather
             than global attributes.
+            .. note:
+                Has no effect if :attr:`iris.FUTURE.save_split_attrs` is ``True``.
 
         * unlimited_dimensions (iterable of strings and/or
            :class:`iris.coords.Coord` objects):
@@ -709,20 +711,27 @@ class Saver:
         # aux factory in the cube.
         self._add_aux_factories(cube, cf_var_cube, cube_dimensions)
 
-        # Add data variable-only attribute names to local_keys.
-        if local_keys is None:
-            local_keys = set()
-        else:
-            local_keys = set(local_keys)
-        local_keys.update(_CF_DATA_ATTRS, _UKMO_DATA_ATTRS)
+        if not iris.FUTURE.save_split_attrs:
+            # In the "old" way, we update global attributes as we go.
+            # Add data variable-only attribute names to local_keys.
+            if local_keys is None:
+                local_keys = set()
+            else:
+                local_keys = set(local_keys)
+            local_keys.update(_CF_DATA_ATTRS, _UKMO_DATA_ATTRS)
 
-        # Add global attributes taking into account local_keys.
-        global_attributes = {
-            k: v
-            for k, v in cube.attributes.items()
-            if (k not in local_keys and k.lower() != "conventions")
-        }
-        self.update_global_attributes(global_attributes)
+            # Add global attributes taking into account local_keys.
+            cube_attributes = cube.attributes
+            if iris.FUTURE.save_split_attrs:
+                # In this case, do *not* promote any 'local' attributes to global ones,
+                # only "global" cube attrs may be written as global file attributes
+                cube_attributes = cube_attributes.globals
+            global_attributes = {
+                k: v
+                for k, v in cube_attributes.items()
+                if (k not in local_keys and k.lower() != "conventions")
+            }
+            self.update_global_attributes(global_attributes)
 
         if cf_profile_available:
             cf_patch = iris.site_configuration.get("cf_patch")
@@ -778,6 +787,9 @@ class Saver:
             CF global attributes to be updated.
 
         """
+        # TODO: when we no longer support combined attribute saving, this routine will
+        # only be called once: it can reasonably be renamed "_set_global_attributes",
+        # and the 'kwargs' argument can be removed.
         if attributes is not None:
             # Handle sequence e.g. [('fruit', 'apple'), ...].
             if not hasattr(attributes, "keys"):
@@ -2219,6 +2231,8 @@ class Saver:
             The newly created CF-netCDF data variable.
 
         """
+        # TODO: when iris.FUTURE.save_split_attrs is removed, the 'local_keys' arg can
+        # be removed.
         # Get the values in a form which is valid for the file format.
         data = self._ensure_valid_dtype(cube.core_data(), "cube", cube)
 
@@ -2307,16 +2321,20 @@ class Saver:
         if cube.units.calendar:
             _setncattr(cf_var, "calendar", cube.units.calendar)
 
-        # Add data variable-only attribute names to local_keys.
-        if local_keys is None:
-            local_keys = set()
+        if iris.FUTURE.save_split_attrs:
+            attr_names = cube.attributes.locals.keys()
         else:
-            local_keys = set(local_keys)
-        local_keys.update(_CF_DATA_ATTRS, _UKMO_DATA_ATTRS)
+            # Add data variable-only attribute names to local_keys.
+            if local_keys is None:
+                local_keys = set()
+            else:
+                local_keys = set(local_keys)
+            local_keys.update(_CF_DATA_ATTRS, _UKMO_DATA_ATTRS)
 
-        # Add any cube attributes whose keys are in local_keys as
-        # CF-netCDF data variable attributes.
-        attr_names = set(cube.attributes).intersection(local_keys)
+            # Add any cube attributes whose keys are in local_keys as
+            # CF-netCDF data variable attributes.
+            attr_names = set(cube.attributes).intersection(local_keys)
+
         for attr_name in sorted(attr_names):
             # Do not output 'conventions' attribute.
             if attr_name.lower() == "conventions":
@@ -2781,26 +2799,117 @@ def save(
     else:
         cubes = cube
 
-    if local_keys is None:
+    if iris.FUTURE.save_split_attrs:
+        # We don't actually use 'local_keys' in this case.
+        # TODO: can remove this when the iris.FUTURE.save_split_attrs is removed.
         local_keys = set()
-    else:
-        local_keys = set(local_keys)
 
-    # Determine the attribute keys that are common across all cubes and
-    # thereby extend the collection of local_keys for attributes
-    # that should be attributes on data variables.
-    attributes = cubes[0].attributes
-    common_keys = set(attributes)
-    for cube in cubes[1:]:
-        keys = set(cube.attributes)
-        local_keys.update(keys.symmetric_difference(common_keys))
-        common_keys.intersection_update(keys)
-        different_value_keys = []
-        for key in common_keys:
-            if np.any(attributes[key] != cube.attributes[key]):
-                different_value_keys.append(key)
-        common_keys.difference_update(different_value_keys)
-        local_keys.update(different_value_keys)
+        # Find any collisions in the cube global attributes and "demote" all those to
+        # local attributes (where possible, else warn they are lost).
+        # N.B. "collision" includes when not all cubes *have* that attribute.
+        global_names = set()
+        for cube in cubes:
+            global_names |= set(cube.attributes.globals.keys())
+
+        # Fnd any global attributes which are not the same on *all* cubes.
+        def attr_values_equal(val1, val2):
+            # An equality test which also works when some values are numpy arrays (!)
+            # As done in :meth:`iris.common.mixin.LimitedAttributeDict.__eq__`.
+            match = val1 == val2
+            try:
+                match = bool(match)
+            except ValueError:
+                match = match.all()
+            return match
+
+        cube0 = cubes[0]
+        invalid_globals = [
+            attrname
+            for attrname in global_names
+            if not all(
+                attr_values_equal(
+                    cube.attributes[attrname], cube0.attributes[attrname]
+                )
+                for cube in cubes[1:]
+            )
+        ]
+
+        # Establish all the global attributes which we will write to the file (at end).
+        global_attributes = {
+            attr: cube0.attributes.globals[attr]
+            for attr in global_names
+            if attr not in invalid_globals
+        }
+        if invalid_globals:
+            # Some cubes have different global attributes: modify cubes as required.
+            warnings.warn(
+                f"Saving the cube global attributes {invalid_globals} as local"
+                "(i.e. data-variable) attributes, where possible, since they are not '"
+                "the same on all input cubes."
+            )
+            cubes = list(cubes)  # avoiding modifying the actual input arg.
+            for i_cube in range(len(cubes)):
+                # We iterate over cube *index*, so we can replace the list entries with
+                # with cube *copies* -- just to avoid changing our call args.
+                cube = cubes[i_cube]
+                demote_attrs = [
+                    attr
+                    for attr in cube.attributes.globals
+                    if attr in invalid_globals
+                ]
+                if any(demote_attrs):
+                    # This cube contains some 'demoted' global attributes.
+                    # Replace the input cube with a copy, so we can modify attributes.
+                    cube = cube.copy()
+                    cubes[i_cube] = cube
+                    # Catch any demoted attrs where there is already a local version
+                    blocked_attrs = [
+                        attrname
+                        for attrname in demote_attrs
+                        if attrname in cube.attributes.locals
+                    ]
+                    if blocked_attrs:
+                        warnings.warn(
+                            f"Global cube attributes {blocked_attrs} "
+                            f'of cube "{cube.name()}" have been lost, overlaid '
+                            "by existing local attributes with the same names."
+                        )
+                    for attr in demote_attrs:
+                        if attr not in blocked_attrs:
+                            cube.attributes.locals[
+                                attr
+                            ] = cube.attributes.globals[attr]
+                        cube.attributes.globals.pop(attr)
+
+    else:
+        # Determine the attribute keys that are common across all cubes and
+        # thereby extend the collection of local_keys for attributes
+        # that should be attributes on data variables.
+        # NOTE: in 'legacy' mode, this code derives a common value for 'local_keys', which
+        # is employed in saving each cube.
+        # However, in `split_attrs` mode, this considers ONLY global attributes, and the
+        # resulting 'common_keys' is the fixed result : each cube is then saved like ...
+        # "sman.write(... localkeys=list(cube.attributes) - common_keys, ...)"
+        if local_keys is None:
+            local_keys = set()
+        else:
+            local_keys = set(local_keys)
+
+        common_attr_values = None
+        for cube in cubes:
+            cube_attributes = cube.attributes
+            keys = set(cube_attributes)
+            if common_attr_values is None:
+                common_attr_values = cube_attributes.copy()
+                common_keys = keys.copy()
+            local_keys.update(keys.symmetric_difference(common_keys))
+            common_keys.intersection_update(keys)
+            different_value_keys = []
+            for key in common_keys:
+                if np.any(common_attr_values[key] != cube_attributes[key]):
+                    different_value_keys.append(key)
+            common_keys.difference_update(different_value_keys)
+            local_keys.update(different_value_keys)
 
     def is_valid_packspec(p):
         """Only checks that the datatype is valid."""
@@ -2902,7 +3011,12 @@ def save(
                 warnings.warn(msg)
 
         # Add conventions attribute.
-        sman.update_global_attributes(Conventions=conventions)
+        if iris.FUTURE.save_split_attrs:
+            # In the "new way", we just create all the global attributes at once.
+            global_attributes["Conventions"] = conventions
+            sman.update_global_attributes(global_attributes)
+        else:
+            sman.update_global_attributes(Conventions=conventions)
 
     if compute:
         # No more to do, since we used Saver(compute=True).

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2600,9 +2600,15 @@ def save(
     Save cube(s) to a netCDF file, given the cube and the filename.
 
     * Iris will write CF 1.7 compliant NetCDF files.
-    * The attributes dictionaries on each cube in the saved cube list
-      will be compared and common attributes saved as NetCDF global
-      attributes where appropriate.
+    * If **split-attribute saving is disabled**, i.e.
+      :attr:`iris.FUTURE.save_split_attrs` is ``False``, then attributes dictionaries
+      on each cube in the saved cube list will be compared and common attributes saved
+      as NetCDF global attributes where appropriate.
+
+      Or, **when **split-attribute saving is enabled**, then `cube.attributes.locals``
+      are always saved as attributes of data-variables, and ``cube.attributes.globals``
+      are saved as global (dataset) attributes, where possible.
+      Since the 2 types are now distinguished : see :class:`~iris.cube.CubeAttrsDict`.
     * Keyword arguments specifying how to save the data are applied
       to each cube. To use different settings for different cubes, use
       the NetCDF Context manager (:class:`~Saver`) directly.
@@ -2635,6 +2641,8 @@ def save(
         An interable of cube attribute keys. Any cube attributes with
         matching keys will become attributes on the data variable rather
         than global attributes.
+        **NOTE:** this is *ignored* if 'split-attribute saving' is **enabled**,
+        i.e. when ``iris.FUTURE.save_split_attrs`` is ``True``.
 
     * unlimited_dimensions (iterable of strings and/or
        :class:`iris.coords.Coord` objects):

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -186,7 +186,8 @@ class MixinAttrsTesting:
                 cubes.append(cube)
                 dimco = DimCoord(np.arange(3.0), var_name="x")
                 cube.add_dim_coord(dimco, 0)
-                cube.attributes.globals[attr_name] = global_value
+                if global_value is not None:
+                    cube.attributes.globals[attr_name] = global_value
                 if local_value is not None:
                     cube.attributes.locals[attr_name] = local_value
             return cubes

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -77,7 +77,7 @@ class MixinAttrsTesting:
         Search up the callstack for a function named "test_*", and return the name for
         use as a test identifier.
 
-        Idea borrowed from :meth:`iris.tests.IrisTest_nometa.result_path`.
+        Idea borrowed from :meth:`iris.tests.IrisTest.result_path`.
 
         Returns
         -------

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -383,7 +383,7 @@ class TestRoundtrip(MixinAttrsTesting):
         files and run a save-load roundtrip to produce the output file.
 
         The name of the attribute, and the input and output temporary filepaths are
-        stored on the instance, where "self.check_roundtrip_results_OLDSTYLE()" can get them.
+        stored on the instance, where "self.check_roundtrip_results()" can get them.
 
         """
         self.run_testcase(
@@ -859,16 +859,10 @@ class TestLoad(MixinAttrsTesting):
         if origin_style == "input_global":
             # Record in source as a global attribute
             values = [attrval, None]
-            # (cube,) = self.create_load_testcase_OLDSTYLE(
-            #     attr_name=local_attr, global_value_file1=attrval
-            # )
         else:
             assert origin_style == "input_local"
             # Record in source as a variable-local attribute
             values = [None, attrval]
-            # (cube,) = self.create_load_testcase_OLDSTYLE(
-            #     attr_name=local_attr, vars_values_file1=attrval
-            # )
 
         self.run_load_testcase(attr_name=local_attr, values=values)
 
@@ -935,7 +929,7 @@ class TestSave(MixinAttrsTesting):
         # It is stored as a *global* by default.
         self.check_save_results(["value-x", None])
 
-    def test_02_userstyle__multiple_same_NEWSTYLE(self):
+    def test_02_userstyle__multiple_same(self):
         self.run_save_testcase_legacytype("random", ["value-x", "value-x"])
         self.check_save_results(["value-x", None, None])
 

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -964,52 +964,52 @@ class TestSave(MixinAttrsTesting):
         results = self.fetch_results(filepath=self.result_filepath)
         assert results == expected
 
-    def test_01_userstyle__single(self):
+    def test_userstyle__single(self):
         self.run_save_testcase_legacytype("random", "value-x")
         # It is stored as a *global* by default.
         self.check_save_results(["value-x", None])
 
-    def test_02_userstyle__multiple_same(self):
+    def test_userstyle__multiple_same(self):
         self.run_save_testcase_legacytype("random", ["value-x", "value-x"])
         self.check_save_results(["value-x", None, None])
 
-    def test_03_userstyle__multiple_different(self):
+    def test_userstyle__multiple_different(self):
         # Clashing values are stored as locals on the individual variables.
         self.run_save_testcase_legacytype("random", ["value-A", "value-B"])
         self.check_save_results([None, "value-A", "value-B"])
 
-    def test_04_Conventions__single(self):
+    def test_Conventions__single(self):
         self.run_save_testcase_legacytype("Conventions", "x")
         # Always discarded + replaced by a single global setting.
         self.check_save_results(["CF-1.7", None])
 
-    def test_05_Conventions__multiple_same(self):
+    def test_Conventions__multiple_same(self):
         self.run_save_testcase_legacytype(
             "Conventions", ["same-value", "same-value"]
         )
         # Always discarded + replaced by a single global setting.
         self.check_save_results(["CF-1.7", None, None])
 
-    def test_06_Conventions__multiple_different(self):
+    def test_Conventions__multiple_different(self):
         self.run_save_testcase_legacytype(
             "Conventions", ["value-A", "value-B"]
         )
         # Always discarded + replaced by a single global setting.
         self.check_save_results(["CF-1.7", None, None])
 
-    def test_07_globalstyle__single(self, global_attr):
+    def test_globalstyle__single(self, global_attr):
         self.run_save_testcase_legacytype(global_attr, ["value"])
         # Defaults to global
         self.check_save_results(["value", None])
 
-    def test_08_globalstyle__multiple_same(self, global_attr):
+    def test_globalstyle__multiple_same(self, global_attr):
         # Multiple user-type with same values are promoted to global.
         self.run_save_testcase_legacytype(
             global_attr, ["value-same", "value-same"]
         )
         self.check_save_results(["value-same", None, None])
 
-    def test_09_globalstyle__multiple_different(self, global_attr):
+    def test_globalstyle__multiple_different(self, global_attr):
         # Multiple user-type with different values remain local.
         msg_regexp = (
             f"'{global_attr}' is being added as CF data variable attribute,"
@@ -1021,7 +1021,7 @@ class TestSave(MixinAttrsTesting):
         # *Only* stored as locals when there are differing values.
         self.check_save_results([None, "value-A", "value-B"])
 
-    def test_10_localstyle__single(self, local_attr):
+    def test_localstyle__single(self, local_attr):
         self.run_save_testcase_legacytype(local_attr, ["value"])
 
         # Defaults to local
@@ -1036,7 +1036,7 @@ class TestSave(MixinAttrsTesting):
 
         self.check_save_results(expected_results)
 
-    def test_11_localstyle__multiple_same(self, local_attr):
+    def test_localstyle__multiple_same(self, local_attr):
         self.run_save_testcase_legacytype(
             local_attr, ["value-same", "value-same"]
         )
@@ -1056,7 +1056,7 @@ class TestSave(MixinAttrsTesting):
 
         self.check_save_results(expected_results)
 
-    def test_12_localstyle__multiple_different(self, local_attr):
+    def test_localstyle__multiple_different(self, local_attr):
         self.run_save_testcase_legacytype(local_attr, ["value-A", "value-B"])
         # Different values are treated just the same as matching ones.
         expected_results = [None, "value-A", "value-B"]

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -39,6 +39,7 @@ import iris.fileformats.netcdf._thread_safe_nc as threadsafe_nc4
 
 # A list of "global-style" attribute names : those which should be global attributes by
 # default (i.e. file- or group-level, *not* attached to a variable).
+
 _GLOBAL_TEST_ATTRS = set(iris.fileformats.netcdf.saver._CF_GLOBAL_ATTRS)
 # Remove this one, which has peculiar behaviour + is tested separately
 # N.B. this is not the same as 'Conventions', but is caught in the crossfire when that
@@ -263,16 +264,15 @@ class TestRoundtrip(MixinAttrsTesting):
         else:
             assert self.attrname in ds.ncattrs()
             assert ds.getncattr(self.attrname) == global_attr_value
-        if var_attr_vals:
-            var_attr_vals = self._default_vars_and_attrvalues(var_attr_vals)
-            for var_name, value in var_attr_vals.items():
-                assert var_name in ds.variables
-                v = ds.variables[var_name]
-                if value is None:
-                    assert self.attrname not in v.ncattrs()
-                else:
-                    assert self.attrname in v.ncattrs()
-                    assert v.getncattr(self.attrname) == value
+        var_attr_vals = self._default_vars_and_attrvalues(var_attr_vals)
+        for var_name, value in var_attr_vals.items():
+            assert var_name in ds.variables
+            v = ds.variables[var_name]
+            if value is None:
+                assert self.attrname not in v.ncattrs()
+            else:
+                assert self.attrname in v.ncattrs()
+                assert v.getncattr(self.attrname) == value
 
     #######################################################
     # Tests on "user-style" attributes.
@@ -302,7 +302,7 @@ class TestRoundtrip(MixinAttrsTesting):
         # It results in a "promoted" global attribute.
         self.create_roundtrip_testcase(
             attr_name="myname",  # A generic "user" attribute with no special handling
-            vars_values_file1={"myvar": "single-value"},
+            vars_values_file1="single-value",
         )
         self.check_roundtrip_results(
             global_attr_value="single-value",  # local values eclipse the global ones
@@ -545,10 +545,12 @@ class TestRoundtrip(MixinAttrsTesting):
                 attr_name=local_attr, vars_values_file1=attrval
             )
 
-        if local_attr in iris.fileformats.netcdf.saver._CF_DATA_ATTRS:
-            # These ones are simply discarded on loading.
-            # By experiment, this overlap between _CF_ATTRS and _CF_DATA_ATTRS
-            # currently contains only 'missing_value' and 'standard_error_multiplier'.
+        if (
+                local_attr in ('missing_value', 'standard_error_multiplier')
+                and origin_style == "input_local"
+        ):
+            # These ones are actually discarded by roundtrip.
+            # Not clear why, but for now this captures the facts.
             expect_global = None
             expect_var = None
         else:

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -1250,7 +1250,7 @@ class TestSave(MixinAttrsTesting):
         if do_split:
             expected = [None, "value", "value"]
             expected_warning = (
-                "Saving the cube global attributes \\['userattr'\\] as local"
+                r"Saving the cube global attributes \['userattr'\] as local"
             )
         else:
             # N.B. legacy code sees only two equal values (and promotes).
@@ -1266,7 +1266,7 @@ class TestSave(MixinAttrsTesting):
         )
         if do_split:
             warning = (
-                "Saving the cube global attributes \\['userattr'\\] as local"
+                r"Saving the cube global attributes \['userattr'\] as local"
             )
         else:
             # N.B. legacy code does not warn of global-to-local "demotion".

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -82,7 +82,8 @@ def check_captured_warnings(
     Compare captured warning messages with a list of regexp-matches.
 
     We allow them to occur in any order, and replace each actual result in the list
-    with the matching regexp as this makes failure reports much easier to comprehend.
+    with its matching regexp, if any, as this makes failure results much easier to
+    comprehend.
 
     """
     if expected_keys is None:
@@ -94,16 +95,16 @@ def check_captured_warnings(
     found_results = [str(warning.message) for warning in captured_warnings]
     remaining_keys = expected_keys.copy()
     for i_message, message in enumerate(found_results.copy()):
-        i_found = None
-        for i_key, key in enumerate(remaining_keys):
+        for key in remaining_keys:
             if key.search(message):
-                # Hit : remove one + only one matching warning from the list
-                i_found = i_message
+                # Hit : replace one message in the list with its matching "key"
+                found_results[i_message] = key
+                # remove the matching key
+                remaining_keys.remove(key)
+                # skip on to next message
                 break
-        if i_found is not None:
-            found_results[i_found] = key
-            remaining_keys.remove(key)
-    assert found_results == expected_keys
+
+    assert set(found_results) == set(expected_keys)
 
 
 class MixinAttrsTesting:

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -1095,17 +1095,14 @@ class TestSave(MixinAttrsTesting):
         self.run_save_testcase_legacytype("random", ["value-A", "value-B"])
         self.check_save_results([None, "value-A", "value-B"])
 
-    def test_userstyle__multiple_onemissing(self, global_attr):
+    def test_userstyle__multiple_onemissing(self):
         # Multiple user-type, with one missing, behave like different values.
         self.run_save_testcase_legacytype(
-            global_attr,
+            "random",
             ["value", None],
         )
         # Stored as locals when there are differing values.
-        self.check_save_results(
-            [None, "value", None],
-            expected_warnings="should only be a CF global attribute",
-        )
+        self.check_save_results([None, "value", None])
 
     def test_Conventions__single(self):
         self.run_save_testcase_legacytype("Conventions", "x")

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -19,13 +19,15 @@ might be recorded either globally or locally.
 
 """
 import inspect
-from typing import Iterable, Optional, Union
+from typing import Optional, Union
 
+import numpy as np
 import pytest
 
 import iris
 import iris.coord_systems
-from iris.cube import Cube, CubeAttrsDict
+from iris.coords import DimCoord
+from iris.cube import Cube
 import iris.fileformats.netcdf
 import iris.fileformats.netcdf._thread_safe_nc as threadsafe_nc4
 
@@ -129,13 +131,14 @@ class MixinAttrsTesting:
             vars_and_attrvalues = {"var": vars_and_attrvalues}
         return vars_and_attrvalues
 
-    def create_testcase_files(
+    def create_testcase_files_or_cubes(
         self,
         attr_name: str,
         global_value_file1: Optional[str] = None,
         var_values_file1: Union[None, str, dict] = None,
         global_value_file2: Optional[str] = None,
         var_values_file2: Union[None, str, dict] = None,
+        cubes=False,
     ):
         """
         Create temporary input netcdf files with specific content.
@@ -148,9 +151,13 @@ class MixinAttrsTesting:
         created, with an attribute = the dictionary value, *except* that a dictionary
         value of None means that a local attribute is _not_ created on the variable.
         """
-        # Make some input file paths.
-        filepath1 = self._testfile_path("testfile")
-        filepath2 = self._testfile_path("testfile2")
+        # save attribute on the instance
+        self.attrname = attr_name
+
+        if not cubes:
+            # Make some input file paths.
+            filepath1 = self._testfile_path("testfile")
+            filepath2 = self._testfile_path("testfile2")
 
         def make_file(
             filepath: str, global_value=None, var_values=None
@@ -170,24 +177,155 @@ class MixinAttrsTesting:
             ds.close()
             return filepath
 
-        # Create one input file (always).
-        filepaths = [
-            make_file(
-                filepath1,
-                global_value=global_value_file1,
-                var_values=var_values_file1,
+        def make_cubes(var_name, global_value=None, var_values=None):
+            cubes = []
+            var_values = self._default_vars_and_attrvalues(var_values)
+            for varname, local_value in var_values.items():
+                cube = Cube(np.arange(3.0), var_name=var_name)
+                cubes.append(cube)
+                dimco = DimCoord(np.arange(3.0), var_name="x")
+                cube.add_dim_coord(dimco, 0)
+                cube.attributes.globals[attr_name] = global_value
+                if local_value is not None:
+                    cube.attributes.locals[attr_name] = local_value
+            return cubes
+
+        if cubes:
+            results = make_cubes("v1", global_value_file1, var_values_file1)
+            if global_value_file2 is not None or var_values_file2 is not None:
+                results.extend(
+                    make_cubes("v2", global_value_file2, var_values_file2)
+                )
+        else:
+            results = [
+                make_file(filepath1, global_value_file1, var_values_file1)
+            ]
+            if global_value_file2 is not None or var_values_file2 is not None:
+                # Make a second testfile and add it to files-to-be-loaded.
+                results.append(
+                    make_file(filepath2, global_value_file2, var_values_file2)
+                )
+
+        # Save results on the instance
+        if cubes:
+            self.input_cubes = results
+        else:
+            self.input_filepaths = results
+        return results
+
+    def run_testcase(self, attr_name, values, create_cubes_or_files="files"):
+        # Save common attribute-name on the instance
+        self.attrname = attr_name
+
+        # Standardise input to a list-of-lists, each inner list = [global, *locals]
+        assert isinstance(values, list)
+        if not isinstance(values[0], list):
+            values = [values]
+        assert len(values) in (1, 2)
+        assert len(values[0]) > 1
+
+        # Decode into global1, *locals1, and optionally global2, *locals2
+        global1 = values[0][0]
+        vars1 = {}
+        i_var = 0
+        for value in values[0][1:]:
+            vars1[f"var_{i_var}"] = value
+            i_var += 1
+        if len(values) == 1:
+            global2 = None
+            vars2 = None
+        else:
+            assert len(values) == 2
+            global2 = values[1][0]
+            vars2 = {}
+            for value in values[1][1:]:
+                vars2[f"var_{i_var}"] = value
+                i_var += 1
+
+        # Create test files or cubes (and store data on the instance)
+        assert create_cubes_or_files in ("cubes", "files")
+        make_cubes = create_cubes_or_files == "cubes"
+        self.create_testcase_files_or_cubes(
+            attr_name=attr_name,
+            global_value_file1=global1,
+            var_values_file1=vars1,
+            global_value_file2=global2,
+            var_values_file2=vars2,
+            cubes=make_cubes,
+        )
+
+    def fetch_results(
+        self, filepath=None, cubes=None, oldstyle_combined=False
+    ):
+        """
+        Return testcase results from an output file or cubes in a standardised form.
+
+        Unpick the global+local values of an attribute resulting from an operation.
+        A file result is always [global_value, *local_values]
+        A cubes result is [*[global_value, *local_values]] (over different global vals)
+
+        When "oldstyle_combined" simulate the "legacy" result, when each cube had a
+        single combined attribute dictionary.  This enables us to check against former
+        behaviour (and behaviour of results treated as a single dictionary).
+        If results are from a *file*, this has no effect.
+
+        """
+        attr_name = self.attrname
+        if filepath is not None:
+            # Fetch global and local values from a file
+            try:
+                ds = threadsafe_nc4.DatasetWrapper(filepath)
+                global_result = (
+                    ds.getncattr(attr_name)
+                    if attr_name in ds.ncattrs()
+                    else None
+                )
+                # Fetch local attr value from all data variables (except dimcoord vars)
+                local_vars_results = [
+                    (
+                        var.name,
+                        (
+                            var.getncattr(attr_name)
+                            if attr_name in var.ncattrs()
+                            else None
+                        ),
+                    )
+                    for var in ds.variables.values()
+                    if var.name not in ds.dimensions
+                ]
+            finally:
+                ds.close()
+            # This version always returns a single result set [global, local1[, local2]]
+            # Return global, plus locals sorted by varname
+            local_vars_results = sorted(local_vars_results, key=lambda x: x[0])
+            results = [global_result] + [val for _, val in local_vars_results]
+        else:
+            assert cubes is not None
+            # Sort result cubes according to a standard ordering.
+            cubes = sorted(cubes, key=lambda cube: cube.name())
+            # Fetch globals and locals from cubes.
+            if oldstyle_combined:
+                # Replace cubes attributes with all-combined dictionaries
+                cubes = [cube.copy() for cube in cubes]
+                for cube in cubes:
+                    combined = dict(cube.attributes)
+                    cube.attributes.clear()
+                    cube.attributes.locals = combined
+            global_values = set(
+                cube.attributes.globals.get(attr_name, None) for cube in cubes
             )
-        ]
-        if global_value_file2 is not None or var_values_file2 is not None:
-            # Make a second testfile and add it to files-to-be-loaded.
-            filepaths.append(
-                make_file(
-                    filepath2,
-                    global_value=global_value_file2,
-                    var_values=var_values_file2,
-                ),
-            )
-        return filepaths
+            # This way returns *multiple* result 'sets', one for each global value
+            results = [
+                [globalval]
+                + [
+                    cube.attributes.locals.get(attr_name, None)
+                    for cube in cubes
+                    if cube.attributes.globals.get(attr_name, None)
+                    == globalval
+                ]
+                for globalval in sorted(global_values)
+            ]
+        return results
 
 
 class TestRoundtrip(MixinAttrsTesting):
@@ -206,73 +344,37 @@ class TestRoundtrip(MixinAttrsTesting):
 
     """
 
-    def _roundtrip_load_and_save(
-        self, input_filepaths: Union[str, Iterable[str]], output_filepath: str
-    ) -> None:
-        """
-        Load netcdf input file(s) and re-write all to a given output file.
-        """
-        # Do a load+save to produce a testable output result in a new file.
-        cubes = iris.load(input_filepaths)
-        iris.save(cubes, output_filepath)
-
-    def create_roundtrip_testcase(
-        self,
-        attr_name,
-        global_value_file1=None,
-        vars_values_file1=None,
-        global_value_file2=None,
-        vars_values_file2=None,
-    ):
+    def run_roundtrip_testcase(self, attr_name, values):
         """
         Initialise the testcase from the passed-in controls, configure the input
         files and run a save-load roundtrip to produce the output file.
 
         The name of the attribute, and the input and output temporary filepaths are
-        stored on the instance, where "self.check_roundtrip_results()" can get them.
+        stored on the instance, where "self.check_roundtrip_results_OLDSTYLE()" can get them.
 
         """
-        self.attrname = attr_name
-        self.input_filepaths = self.create_testcase_files(
-            attr_name=attr_name,
-            global_value_file1=global_value_file1,
-            var_values_file1=vars_values_file1,
-            global_value_file2=global_value_file2,
-            var_values_file2=vars_values_file2,
+        self.run_testcase(
+            attr_name=attr_name, values=values, create_cubes_or_files="files"
         )
         self.result_filepath = self._testfile_path("result")
-        self._roundtrip_load_and_save(
-            self.input_filepaths, self.result_filepath
-        )
+        # Do a load+save to produce a testable output result in a new file.
+        cubes = iris.load(self.input_filepaths)
+        iris.save(cubes, self.result_filepath)
 
-    def check_roundtrip_results(
-        self, global_attr_value=None, var_attr_vals=None
-    ):
+    def check_roundtrip_results(self, expected):
         """
         Run checks on the generated output file.
 
-        The counterpart to create_testcase, with similar control arguments.
-        Check existence (or not) of : a global attribute, named variables, and their
-        local attributes.  Values of 'None' mean to check that the relevant global/local
-        attribute does *not* exist.
+        The counterpart to create_roundtrip_testcase_OLDSTYLE, with similar control arguments.
+        Check existence (or not) of a global attribute, and a number of local
+        (variable) attributes.
+        Values of 'None' mean to check that the relevant global/local attribute does
+        *not* exist.
         """
         # N.B. there is only ever one result-file, but it can contain various variables
         # which came from different input files.
-        ds = threadsafe_nc4.DatasetWrapper(self.result_filepath)
-        if global_attr_value is None:
-            assert self.attrname not in ds.ncattrs()
-        else:
-            assert self.attrname in ds.ncattrs()
-            assert ds.getncattr(self.attrname) == global_attr_value
-        var_attr_vals = self._default_vars_and_attrvalues(var_attr_vals)
-        for var_name, value in var_attr_vals.items():
-            assert var_name in ds.variables
-            v = ds.variables[var_name]
-            if value is None:
-                assert self.attrname not in v.ncattrs()
-            else:
-                assert self.attrname in v.ncattrs()
-                assert v.getncattr(self.attrname) == value
+        results = self.fetch_results(filepath=self.result_filepath)
+        assert results == expected
 
     #######################################################
     # Tests on "user-style" attributes.
@@ -281,94 +383,60 @@ class TestRoundtrip(MixinAttrsTesting):
     #
 
     def test_01_userstyle_single_global(self):
-        self.create_roundtrip_testcase(
-            attr_name="myname",  # A generic "user" attribute with no special handling
-            global_value_file1="single-value",
-            vars_values_file1={
-                "myvar": None
-            },  # the variable has no such attribute
+        self.run_roundtrip_testcase(
+            attr_name="myname", values=["single-value", None]
         )
         # Default behaviour for a general global user-attribute.
         # It simply remains global.
-        self.check_roundtrip_results(
-            global_attr_value="single-value",  # local values eclipse the global ones
-            var_attr_vals={
-                "myvar": None
-            },  # the variable has no such attribute
-        )
+        self.check_roundtrip_results(["single-value", None])
 
     def test_02_userstyle_single_local(self):
         # Default behaviour for a general local user-attribute.
         # It results in a "promoted" global attribute.
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="myname",  # A generic "user" attribute with no special handling
-            vars_values_file1="single-value",
+            values=[None, "single-value"],
         )
-        self.check_roundtrip_results(
-            global_attr_value="single-value",  # local values eclipse the global ones
-            # N.B. the output var has NO such attribute
-        )
+        self.check_roundtrip_results(["single-value", None])
 
     def test_03_userstyle_multiple_different(self):
         # Default behaviour for general user-attributes.
         # The global attribute is lost because there are local ones.
-        vars1 = {"f1_v1": "f1v1", "f1_v2": "f2v2"}
-        vars2 = {"f2_v1": "x1", "f2_v2": "x2"}
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="random",  # A generic "user" attribute with no special handling
-            global_value_file1="global_file1",
-            vars_values_file1=vars1,
-            global_value_file2="global_file2",
-            vars_values_file2=vars2,
+            values=[
+                ["common_global", "f1v1", "f1v2"],
+                ["common_global", "x1", "x2"],
+            ],
         )
-        # combine all 4 vars in one dict
-        all_vars_and_attrs = vars1.copy()
-        all_vars_and_attrs.update(vars2)
-        # TODO: replace with "|", when we drop Python 3.8
-        # see: https://peps.python.org/pep-0584/
         # just check they are all there and distinct
-        assert len(all_vars_and_attrs) == len(vars1) + len(vars2)
-        self.check_roundtrip_results(
-            global_attr_value=None,  # local values eclipse the global ones
-            var_attr_vals=all_vars_and_attrs,
-        )
+        self.check_roundtrip_results([None, "f1v1", "f1v2", "x1", "x2"])
 
     def test_04_userstyle_matching_promoted(self):
         # matching local user-attributes are "promoted" to a global one.
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="random",
-            global_value_file1="global_file1",
-            vars_values_file1={"v1": "same-value", "v2": "same-value"},
+            values=["global_file1", "same-value", "same-value"],
         )
-        self.check_roundtrip_results(
-            global_attr_value="same-value",
-            var_attr_vals={"v1": None, "v2": None},
-        )
+        self.check_roundtrip_results(["same-value", None, None])
 
     def test_05_userstyle_matching_crossfile_promoted(self):
         # matching user-attributes are promoted, even across input files.
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="random",
-            global_value_file1="global_file1",
-            vars_values_file1={"v1": "same-value", "v2": "same-value"},
-            vars_values_file2={"f2_v1": "same-value", "f2_v2": "same-value"},
+            values=[
+                ["global_file1", "same-value", "same-value"],
+                [None, "same-value", "same-value"],
+            ],
         )
-        self.check_roundtrip_results(
-            global_attr_value="same-value",
-            var_attr_vals={x: None for x in ("v1", "v2", "f2_v1", "f2_v2")},
-        )
+        self.check_roundtrip_results(["same-value", None, None, None, None])
 
     def test_06_userstyle_nonmatching_remainlocal(self):
         # Non-matching user attributes remain 'local' to the individual variables.
-        self.create_roundtrip_testcase(
-            attr_name="random",
-            global_value_file1="global_file1",
-            vars_values_file1={"v1": "value-1", "v2": "value-2"},
+        self.run_roundtrip_testcase(
+            attr_name="random", values=["global_file1", "value-1", "value-2"]
         )
-        self.check_roundtrip_results(
-            global_attr_value=None,  # NB it still destroys the global one !!
-            var_attr_vals={"v1": "value-1", "v2": "value-2"},
-        )
+        self.check_roundtrip_results([None, "value-1", "value-2"])
 
     #######################################################
     # Tests on "Conventions" attribute.
@@ -383,63 +451,50 @@ class TestRoundtrip(MixinAttrsTesting):
     def test_07_conventions_var_local(self):
         # What happens if 'Conventions' appears as a variable-local attribute.
         # N.B. this is not good CF, but we'll see what happens anyway.
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="Conventions",
-            global_value_file1=None,
-            vars_values_file1="user_set",
+            values=[None, "user_set"],
         )
-        self.check_roundtrip_results(
-            global_attr_value="CF-1.7",  # standard content from Iris save
-            var_attr_vals=None,
-        )
+        self.check_roundtrip_results(["CF-1.7", None])
 
     def test_08_conventions_var_both(self):
         # What happens if 'Conventions' appears as both global + local attribute.
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name="Conventions",
-            global_value_file1="global-setting",
-            vars_values_file1="local-setting",
+            values=["global-setting", "local-setting"],
         )
-        self.check_roundtrip_results(
-            global_attr_value="CF-1.7",  # standard content from Iris save
-            var_attr_vals=None,
-        )
+        # standard content from Iris save
+        self.check_roundtrip_results(["CF-1.7", None])
 
     #######################################################
     # Tests on "global" style attributes
     #  = those specific ones which 'ought' only to be global (except on collisions)
     #
-
     def test_09_globalstyle__global(self, global_attr):
         attr_content = f"Global tracked {global_attr}"
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name=global_attr,
-            global_value_file1=attr_content,
+            values=[attr_content, None],
         )
-        self.check_roundtrip_results(global_attr_value=attr_content)
+        self.check_roundtrip_results([attr_content, None])
 
     def test_10_globalstyle__local(self, global_attr):
         # Strictly, not correct CF, but let's see what it does with it.
         attr_content = f"Local tracked {global_attr}"
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name=global_attr,
-            vars_values_file1=attr_content,
+            values=[None, attr_content],
         )
-        self.check_roundtrip_results(
-            global_attr_value=attr_content
-        )  # "promoted"
+        self.check_roundtrip_results([attr_content, None])
 
     def test_11_globalstyle__both(self, global_attr):
         attr_global = f"Global-{global_attr}"
         attr_local = f"Local-{global_attr}"
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name=global_attr,
-            global_value_file1=attr_global,
-            vars_values_file1=attr_local,
+            values=[attr_global, attr_local],
         )
-        self.check_roundtrip_results(
-            global_attr_value=attr_local  # promoted local setting "wins"
-        )
+        self.check_roundtrip_results([attr_local, None])
 
     def test_12_globalstyle__multivar_different(self, global_attr):
         # Multiple *different* local settings are retained, not promoted
@@ -449,26 +504,20 @@ class TestRoundtrip(MixinAttrsTesting):
             UserWarning, match="should only be a CF global attribute"
         ):
             # A warning should be raised when writing the result.
-            self.create_roundtrip_testcase(
+            self.run_roundtrip_testcase(
                 attr_name=global_attr,
-                vars_values_file1={"v1": attr_1, "v2": attr_2},
+                values=[None, attr_1, attr_2],
             )
-        self.check_roundtrip_results(
-            global_attr_value=None,
-            var_attr_vals={"v1": attr_1, "v2": attr_2},
-        )
+        self.check_roundtrip_results([None, attr_1, attr_2])
 
     def test_13_globalstyle__multivar_same(self, global_attr):
         # Multiple *same* local settings are promoted to a common global one
         attrval = f"Locally-defined-{global_attr}"
-        self.create_roundtrip_testcase(
+        self.run_roundtrip_testcase(
             attr_name=global_attr,
-            vars_values_file1={"v1": attrval, "v2": attrval},
+            values=[None, attrval, attrval],
         )
-        self.check_roundtrip_results(
-            global_attr_value=attrval,
-            var_attr_vals={"v1": None, "v2": None},
-        )
+        self.check_roundtrip_results([attrval, None, None])
 
     def test_14_globalstyle__multifile_different(self, global_attr):
         # Different global attributes from multiple files are retained as local ones
@@ -478,34 +527,23 @@ class TestRoundtrip(MixinAttrsTesting):
             UserWarning, match="should only be a CF global attribute"
         ):
             # A warning should be raised when writing the result.
-            self.create_roundtrip_testcase(
-                attr_name=global_attr,
-                global_value_file1=attr_1,
-                vars_values_file1={"v1": None},
-                global_value_file2=attr_2,
-                vars_values_file2={"v2": None},
+            self.run_roundtrip_testcase(
+                attr_name=global_attr, values=[[attr_1, None], [attr_2, None]]
             )
-        self.check_roundtrip_results(
-            # Combining them "demotes" the common global attributes to local ones
-            var_attr_vals={"v1": attr_1, "v2": attr_2}
-        )
+        self.check_roundtrip_results([None, attr_1, attr_2])
 
     def test_15_globalstyle__multifile_same(self, global_attr):
         # Matching global-type attributes in multiple files are retained as global
         attrval = f"Global-{global_attr}"
-        self.create_roundtrip_testcase(
-            attr_name=global_attr,
-            global_value_file1=attrval,
-            vars_values_file1={"v1": None},
-            global_value_file2=attrval,
-            vars_values_file2={"v2": None},
+        self.run_roundtrip_testcase(
+            attr_name=global_attr, values=[[attrval, None], [attrval, None]]
         )
-        self.check_roundtrip_results(
-            # The attribute remains as a common global setting
-            global_attr_value=attrval,
-            # The individual variables do *not* have an attribute of this name
-            var_attr_vals={"v1": None, "v2": None},
-        )
+        #     # The attribute remains as a common global setting
+        #     global_attr_value=attrval,
+        #     # The individual variables do *not* have an attribute of this name
+        #     var_attr_vals={"v1": None, "v2": None},
+        # )
+        self.check_roundtrip_results([attrval, None, None])
 
     #######################################################
     # Tests on "local" style attributes
@@ -535,19 +573,16 @@ class TestRoundtrip(MixinAttrsTesting):
         # as global or a variable attribute
         if origin_style == "input_global":
             # Record in source as a global attribute
-            self.create_roundtrip_testcase(
-                attr_name=local_attr, global_value_file1=attrval
-            )
+            values = [attrval, None]
         else:
             assert origin_style == "input_local"
             # Record in source as a variable-local attribute
-            self.create_roundtrip_testcase(
-                attr_name=local_attr, vars_values_file1=attrval
-            )
+            values = [None, attrval]
+        self.run_roundtrip_testcase(attr_name=local_attr, values=values)
 
         if (
-                local_attr in ('missing_value', 'standard_error_multiplier')
-                and origin_style == "input_local"
+            local_attr in ("missing_value", "standard_error_multiplier")
+            and origin_style == "input_local"
         ):
             # These ones are actually discarded by roundtrip.
             # Not clear why, but for now this captures the facts.
@@ -569,11 +604,7 @@ class TestRoundtrip(MixinAttrsTesting):
         if local_attr == "STASH":
             # A special case, output translates this to a different attribute name.
             self.attrname = "um_stash_source"
-
-        self.check_roundtrip_results(
-            global_attr_value=expect_global,
-            var_attr_vals=expect_var,
-        )
+        self.check_roundtrip_results([expect_global, expect_var])
 
 
 class TestLoad(MixinAttrsTesting):
@@ -590,33 +621,20 @@ class TestLoad(MixinAttrsTesting):
 
     """
 
-    def create_load_testcase(
-        self,
-        attr_name,
-        global_value_file1=None,
-        vars_values_file1=None,
-        global_value_file2=None,
-        vars_values_file2=None,
-    ) -> iris.cube.CubeList:
-        """
-        Initialise the testcase from the passed-in controls, configure the input
-        files and run a save-load roundtrip to produce the output file.
-
-        The name of the tested attribute and all the temporary filepaths are stored
-        on the instance, from where "self.check_load_results()" can get them.
-
-        """
-        self.attrname = attr_name
-        self.input_filepaths = self.create_testcase_files(
-            attr_name=attr_name,
-            global_value_file1=global_value_file1,
-            var_values_file1=vars_values_file1,
-            global_value_file2=global_value_file2,
-            var_values_file2=vars_values_file2,
+    def run_load_testcase(self, attr_name, values):
+        self.run_testcase(
+            attr_name=attr_name, values=values, create_cubes_or_files="files"
         )
+
+    def check_load_results(self, expected, oldstyle_combined=False):
         result_cubes = iris.load(self.input_filepaths)
-        result_cubes = sorted(result_cubes, key=lambda cube: cube.name())
-        return result_cubes
+        results = self.fetch_results(
+            cubes=result_cubes, oldstyle_combined=oldstyle_combined
+        )
+        assert isinstance(expected, list)
+        if not isinstance(expected[0], list):
+            expected = [expected]
+        assert results == expected
 
     #######################################################
     # Tests on "user-style" attributes.
@@ -625,83 +643,58 @@ class TestLoad(MixinAttrsTesting):
     #
 
     def test_01_userstyle_single_global(self):
-        cube1, cube2 = self.create_load_testcase(
-            attr_name="myname",  # A generic "user" attribute with no special handling
-            global_value_file1="single-value",
-            vars_values_file1={
-                "myvar": None,
-                "myvar2": None,
-            },  # the variable has no such attribute
+        self.run_load_testcase(
+            attr_name="myname", values=["single_value", None, None]
         )
-        # Default behaviour for a general global user-attribute.
-        # It is attached to all loaded cubes.
-
-        expected_dict = {"myname": "single-value"}
-        for cube in (cube1, cube2):
-            # #1 : legacy results, for cube.attributes **viewed as a plain dictionary**.
-            assert dict(cube1.attributes) == expected_dict
-            # #2 : exact expected result, viewed as newstyle split-attributes
-            assert cube1.attributes == CubeAttrsDict(globals=expected_dict)
+        # Legacy-equivalent result check (single attributes dict per cube)
+        self.check_load_results(
+            [None, "single_value", "single_value"],
+            oldstyle_combined=True,
+        )
+        # Full new-style results check
+        self.check_load_results(["single_value", None, None])
 
     def test_02_userstyle_single_local(self):
         # Default behaviour for a general local user-attribute.
         # It is attached to only the specific cube.
-        cube1, cube2 = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name="myname",  # A generic "user" attribute with no special handling
-            vars_values_file1={"myvar1": "single-value", "myvar2": None},
+            values=[None, "single-value", None],
         )
-        assert cube1.attributes == {"myname": "single-value"}
-        assert cube2.attributes == {}
+        self.check_load_results(
+            [None, "single-value", None], oldstyle_combined=True
+        )
+        self.check_load_results([None, "single-value", None])
 
     def test_03_userstyle_multiple_different(self):
         # Default behaviour for differing local user-attributes.
         # The global attribute is simply lost, because there are local ones.
-        vars1 = {"f1_v1": "f1v1", "f1_v2": "f1v2"}
-        vars2 = {"f2_v1": "x1", "f2_v2": "x2"}
-        cube1, cube2, cube3, cube4 = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name="random",  # A generic "user" attribute with no special handling
-            global_value_file1="global_file1",
-            vars_values_file1=vars1,
-            global_value_file2="global_file2",
-            vars_values_file2=vars2,
+            values=[
+                ["global_file1", "f1v1", "f1v2"],
+                ["global_file2", "x1", "x2"],
+            ],
         )
-
-        # (#1) : legacy equivalence : for cube.attributes viewed as a plain 'dict'
-        assert dict(cube1.attributes) == {"random": "f1v1"}
-        assert dict(cube2.attributes) == {"random": "f1v2"}
-        assert dict(cube3.attributes) == {"random": "x1"}
-        assert dict(cube4.attributes) == {"random": "x2"}
-
-        # (#1) : exact results check, for newstyle "split" cube attrs
-        assert cube1.attributes == CubeAttrsDict(
-            globals={"random": "global_file1"}, locals={"random": "f1v1"}
+        self.check_load_results(
+            [None, "f1v1", "f1v2", "x1", "x2"],
+            oldstyle_combined=True,
         )
-        assert cube2.attributes == CubeAttrsDict(
-            globals={"random": "global_file1"}, locals={"random": "f1v2"}
-        )
-        assert cube3.attributes == CubeAttrsDict(
-            globals={"random": "global_file2"}, locals={"random": "x1"}
-        )
-        assert cube4.attributes == CubeAttrsDict(
-            globals={"random": "global_file2"}, locals={"random": "x2"}
+        self.check_load_results(
+            [["global_file1", "f1v1", "f1v2"], ["global_file2", "x1", "x2"]]
         )
 
     def test_04_userstyle_multiple_same(self):
         # Nothing special to note in this case
         # TODO: ??remove??
-        cube1, cube2 = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name="random",
-            global_value_file1="global_file1",
-            vars_values_file1={"v1": "same-value", "v2": "same-value"},
+            values=["global_file1", "same-value", "same-value"],
         )
-        for cube in (cube1, cube2):
-            # (#1): legacy values, for cube.attributes viewed as a single dict
-            assert dict(cube.attributes) == {"random": "same-value"}
-            # (#2): exact results, with newstyle "split" cube attrs
-            assert cube2.attributes == CubeAttrsDict(
-                globals={"random": "global_file1"},
-                locals={"random": "same-value"},
-            )
+        self.check_load_results(
+            oldstyle_combined=True, expected=[None, "same-value", "same-value"]
+        )
+        self.check_load_results(["global_file1", "same-value", "same-value"])
 
     #######################################################
     # Tests on "Conventions" attribute.
@@ -716,28 +709,27 @@ class TestLoad(MixinAttrsTesting):
     def test_07_conventions_var_local(self):
         # What happens if 'Conventions' appears as a variable-local attribute.
         # N.B. this is not good CF, but we'll see what happens anyway.
-        (cube,) = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name="Conventions",
-            global_value_file1=None,
-            vars_values_file1="user_set",
+            values=[None, "user_set"],
         )
-        assert cube.attributes == {"Conventions": "user_set"}
+        # Legacy result
+        self.check_load_results([None, "user_set"], oldstyle_combined=True)
+        # Newstyle result
+        self.check_load_results([None, "user_set"])
 
     def test_08_conventions_var_both(self):
         # What happens if 'Conventions' appears as both global + local attribute.
-        # = the global version gets lost.
-        (cube,) = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name="Conventions",
-            global_value_file1="global-setting",
-            vars_values_file1="local-setting",
+            values=["global-setting", "local-setting"],
         )
-        # (#1): legacy values, for cube.attributes viewed as a single dict
-        assert dict(cube.attributes) == {"Conventions": "local-setting"}
-        # (#2): exact results, with newstyle "split" cube attrs
-        assert cube.attributes == CubeAttrsDict(
-            globals={"Conventions": "global-setting"},
-            locals={"Conventions": "local-setting"},
+        # (#1): legacy result : the global version gets lost.
+        self.check_load_results(
+            [None, "local-setting"], oldstyle_combined=True
         )
+        # (#2): newstyle results : retain both.
+        self.check_load_results(["global-setting", "local-setting"])
 
     #######################################################
     # Tests on "global" style attributes
@@ -746,74 +738,67 @@ class TestLoad(MixinAttrsTesting):
 
     def test_09_globalstyle__global(self, global_attr):
         attr_content = f"Global tracked {global_attr}"
-        (cube,) = self.create_load_testcase(
-            attr_name=global_attr,
-            global_value_file1=attr_content,
+        self.run_load_testcase(
+            attr_name=global_attr, values=[attr_content, None]
         )
-        assert cube.attributes == {global_attr: attr_content}
+        # (#1) legacy
+        self.check_load_results([None, attr_content], oldstyle_combined=True)
+        # (#2) newstyle : global status preserved.
+        self.check_load_results([attr_content, None])
 
     def test_10_globalstyle__local(self, global_attr):
         # Strictly, not correct CF, but let's see what it does with it.
-        # = treated the same as a global setting
         attr_content = f"Local tracked {global_attr}"
-        (cube,) = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name=global_attr,
-            vars_values_file1=attr_content,
+            values=[None, attr_content],
         )
-        # (#1): legacy values, for cube.attributes viewed as a single dict
-        assert dict(cube.attributes) == {global_attr: attr_content}
-        # (#2): exact results, with newstyle "split" cube attrs
-        assert cube.attributes == CubeAttrsDict(
-            locals={global_attr: attr_content}
+        # (#1): legacy result = treated the same as a global setting
+        self.check_load_results([None, attr_content], oldstyle_combined=True)
+        # (#2): newstyle result : remains local
+        self.check_load_results(
+            [None, attr_content],
         )
 
     def test_11_globalstyle__both(self, global_attr):
         attr_global = f"Global-{global_attr}"
         attr_local = f"Local-{global_attr}"
-        (cube,) = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name=global_attr,
-            global_value_file1=attr_global,
-            vars_values_file1=attr_local,
+            values=[attr_global, attr_local],
         )
-        # promoted local setting "wins"
-        # (#1): legacy values, for cube.attributes viewed as a single dict
-        assert dict(cube.attributes) == {global_attr: attr_local}
-        # (#2): exact results, with newstyle "split" cube attrs
-        assert cube.attributes == CubeAttrsDict(
-            globals={global_attr: attr_global},
-            locals={global_attr: attr_local},
-        )
+        # (#1) legacy result : promoted local setting "wins"
+        self.check_load_results([None, attr_local], oldstyle_combined=True)
+        # (#2) newstyle result : both retained
+        self.check_load_results([attr_global, attr_local])
 
     def test_12_globalstyle__multivar_different(self, global_attr):
         # Multiple *different* local settings are retained
         attr_1 = f"Local-{global_attr}-1"
         attr_2 = f"Local-{global_attr}-2"
-        cube1, cube2 = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name=global_attr,
-            vars_values_file1={"v1": attr_1, "v2": attr_2},
+            values=[None, attr_1, attr_2],
         )
         # (#1): legacy values, for cube.attributes viewed as a single dict
-        assert dict(cube1.attributes) == {global_attr: attr_1}
-        assert dict(cube2.attributes) == {global_attr: attr_2}
+        self.check_load_results([None, attr_1, attr_2], oldstyle_combined=True)
         # (#2): exact results, with newstyle "split" cube attrs
-        assert cube1.attributes == CubeAttrsDict(locals={global_attr: attr_1})
-        assert cube2.attributes == CubeAttrsDict(locals={global_attr: attr_2})
+        self.check_load_results([None, attr_1, attr_2])
 
     def test_14_globalstyle__multifile_different(self, global_attr):
-        # Different global attributes from multiple files are retained as local ones
+        # Different global attributes from multiple files
         attr_1 = f"Global-{global_attr}-1"
         attr_2 = f"Global-{global_attr}-2"
-        cube1, cube2, cube3, cube4 = self.create_load_testcase(
+        self.run_load_testcase(
             attr_name=global_attr,
-            global_value_file1=attr_1,
-            vars_values_file1={"f1v1": None, "f1v2": None},
-            global_value_file2=attr_2,
-            vars_values_file2={"f2v1": None, "f2v2": None},
+            values=[[attr_1, None, None], [attr_2, None, None]],
         )
-        assert cube1.attributes == {global_attr: attr_1}
-        assert cube2.attributes == {global_attr: attr_1}
-        assert cube3.attributes == {global_attr: attr_2}
-        assert cube4.attributes == {global_attr: attr_2}
+        # (#1) legacy : multiple globals retained as local ones
+        self.check_load_results(
+            [None, attr_1, attr_1, attr_2, attr_2], oldstyle_combined=True
+        )
+        # (#1) newstyle : result same as input
+        self.check_load_results([[attr_1, None, None], [attr_2, None, None]])
 
     #######################################################
     # Tests on "local" style attributes
@@ -839,38 +824,45 @@ class TestLoad(MixinAttrsTesting):
         # Create testfiles and load them, which should always produce a single cube.
         if origin_style == "input_global":
             # Record in source as a global attribute
-            (cube,) = self.create_load_testcase(
-                attr_name=local_attr, global_value_file1=attrval
-            )
+            values = [attrval, None]
+            # (cube,) = self.create_load_testcase_OLDSTYLE(
+            #     attr_name=local_attr, global_value_file1=attrval
+            # )
         else:
             assert origin_style == "input_local"
             # Record in source as a variable-local attribute
-            (cube,) = self.create_load_testcase(
-                attr_name=local_attr, vars_values_file1=attrval
-            )
+            values = [None, attrval]
+            # (cube,) = self.create_load_testcase_OLDSTYLE(
+            #     attr_name=local_attr, vars_values_file1=attrval
+            # )
+
+        self.run_load_testcase(attr_name=local_attr, values=values)
 
         # Work out the expected result.
-        # NOTE: generally, result will be the same whether the original attribute is
-        # provided as a global or variable attribute ...
-        expected_result = {local_attr: attrval}
-        # ... but there are some special cases
+        result_value = attrval
+        # ... there are some special cases
         if origin_style == "input_local":
             if local_attr == "ukmo__process_flags":
                 # Some odd special behaviour here.
-                expected_result = {local_attr: ("process",)}
+                result_value = (result_value,)
             elif local_attr in ("standard_error_multiplier", "missing_value"):
                 # For some reason, these ones never appear on the cube
-                expected_result = {}
+                result_value = None
 
+        # NOTE: **legacy** result is the same, whether the original attribute was
+        # provided as a global or local attribute ...
+        expected_result_legacy = [None, result_value]
+
+        # While 'newstyle' results preserve the input type local/global.
         if origin_style == "input_local":
-            expected_result_newstyle = CubeAttrsDict(expected_result)
+            expected_result_newstyle = [None, result_value]
         else:
-            expected_result_newstyle = CubeAttrsDict(globals=expected_result)
+            expected_result_newstyle = [result_value, None]
 
         # (#1): legacy values, for cube.attributes viewed as a single dict
-        assert dict(cube.attributes) == expected_result
+        self.check_load_results(expected_result_legacy, oldstyle_combined=True)
         # (#2): exact results, with newstyle "split" cube attrs
-        assert cube.attributes == expected_result_newstyle
+        self.check_load_results(expected_result_newstyle)
 
 
 class TestSave(MixinAttrsTesting):
@@ -879,120 +871,108 @@ class TestSave(MixinAttrsTesting):
 
     """
 
-    def create_save_testcase(self, attr_name, value1, value2=None):
-        """
-        Test attribute saving for cube(s) with given value(s).
-
-        Create cubes(s) and save to temporary file, then return the global and all
-        variable-local attributes of that name (or None-s) from the file.
-        """
-        self.attrname = (
-            attr_name  # Required for common testfile-naming function.
+    def run_save_testcase(self, attr_name, values):
+        self.run_testcase(
+            attr_name=attr_name, values=values, create_cubes_or_files="cubes"
         )
-        if value2 is None:
-            n_cubes = 1
-            values = [value1]
-        else:
-            n_cubes = 2
-            values = [value1, value2]
-        cube_names = [f"cube_{i_cube}" for i_cube in range(n_cubes)]
-        cubes = [
-            Cube([0], long_name=cube_name, attributes={attr_name: attr_value})
-            for cube_name, attr_value in zip(cube_names, values)
-        ]
         self.result_filepath = self._testfile_path("result")
-        iris.save(cubes, self.result_filepath)
-        # Get the global+local attribute values directly from the file with netCDF4
-        if attr_name == "STASH":
-            # A special case : the stored name is different
-            attr_name = "um_stash_source"
-        try:
-            ds = threadsafe_nc4.DatasetWrapper(self.result_filepath)
-            global_result = (
-                ds.getncattr(attr_name) if attr_name in ds.ncattrs() else None
-            )
-            local_results = [
-                (
-                    var.getncattr(attr_name)
-                    if attr_name in var.ncattrs()
-                    else None
-                )
-                for var in ds.variables.values()
-            ]
-        finally:
-            ds.close()
-        return [global_result] + local_results
+        iris.save(self.input_cubes, self.result_filepath)
+
+    def run_save_testcase_legacytype(self, attr_name: str, values: list):
+        """
+        Legacy-type means : before cubes had split attributes.
+
+        This just means we have only one "set" of cubes, with ***no*** distinct global
+        attribute.
+        """
+        if not isinstance(values, list):
+            # Translate single input value to list-of-1
+            values = [values]
+        self.run_save_testcase(attr_name, [None] + values)
+
+    def check_save_results(self, expected: list):
+        results = self.fetch_results(filepath=self.result_filepath)
+        assert results == expected
 
     def test_01_userstyle__single(self):
-        results = self.create_save_testcase("random", "value-x")
+        self.run_save_testcase_legacytype("random", "value-x")
         # It is stored as a *global* by default.
-        assert results == ["value-x", None]
+        self.check_save_results(["value-x", None])
 
-    def test_02_userstyle__multiple_same(self):
-        results = self.create_save_testcase("random", "value-x", "value-x")
-        # As above.
-        assert results == ["value-x", None, None]
+    def test_02_userstyle__multiple_same_NEWSTYLE(self):
+        self.run_save_testcase_legacytype("random", ["value-x", "value-x"])
+        self.check_save_results(["value-x", None, None])
 
     def test_03_userstyle__multiple_different(self):
-        results = self.create_save_testcase("random", "value-A", "value-B")
         # Clashing values are stored as locals on the individual variables.
-        assert results == [None, "value-A", "value-B"]
+        self.run_save_testcase_legacytype("random", ["value-A", "value-B"])
+        self.check_save_results([None, "value-A", "value-B"])
 
     def test_04_Conventions__single(self):
-        results = self.create_save_testcase("Conventions", "x")
+        self.run_save_testcase_legacytype("Conventions", "x")
         # Always discarded + replaced by a single global setting.
-        assert results == ["CF-1.7", None]
+        self.check_save_results(["CF-1.7", None])
 
     def test_05_Conventions__multiple_same(self):
-        results = self.create_save_testcase(
-            "Conventions", "same-value", "same-value"
+        self.run_save_testcase_legacytype(
+            "Conventions", ["same-value", "same-value"]
         )
         # Always discarded + replaced by a single global setting.
-        assert results == ["CF-1.7", None, None]
+        self.check_save_results(["CF-1.7", None, None])
 
     def test_06_Conventions__multiple_different(self):
-        results = self.create_save_testcase(
-            "Conventions", "value-A", "value-B"
+        self.run_save_testcase_legacytype(
+            "Conventions", ["value-A", "value-B"]
         )
         # Always discarded + replaced by a single global setting.
-        assert results == ["CF-1.7", None, None]
+        self.check_save_results(["CF-1.7", None, None])
 
     def test_07_globalstyle__single(self, global_attr):
-        results = self.create_save_testcase(global_attr, "value")
+        self.run_save_testcase_legacytype(global_attr, ["value"])
         # Defaults to global
-        assert results == ["value", None]
+        self.check_save_results(["value", None])
 
     def test_08_globalstyle__multiple_same(self, global_attr):
-        results = self.create_save_testcase(
-            global_attr, "value-same", "value-same"
+        # Multiple user-type with same values are promoted to global.
+        self.run_save_testcase_legacytype(
+            global_attr, ["value-same", "value-same"]
         )
-        assert results == ["value-same", None, None]
+        self.check_save_results(["value-same", None, None])
 
     def test_09_globalstyle__multiple_different(self, global_attr):
+        # Multiple user-type with different values remain local.
         msg_regexp = (
             f"'{global_attr}' is being added as CF data variable attribute,"
             f".* should only be a CF global attribute."
         )
         with pytest.warns(UserWarning, match=msg_regexp):
-            results = self.create_save_testcase(
-                global_attr, "value-A", "value-B"
+            self.run_save_testcase_legacytype(
+                global_attr, ["value-A", "value-B"]
             )
         # *Only* stored as locals when there are differing values.
-        assert results == [None, "value-A", "value-B"]
+        # assert results == [None, "value-A", "value-B"]
+        self.check_save_results([None, "value-A", "value-B"])
 
     def test_10_localstyle__single(self, local_attr):
-        results = self.create_save_testcase(local_attr, "value")
+        self.run_save_testcase_legacytype(local_attr, ["value"])
+
         # Defaults to local
         expected_results = [None, "value"]
+        # .. but a couple of special cases
         if local_attr == "ukmo__process_flags":
             # A particular, really weird case
             expected_results = [None, "v a l u e"]
-        assert results == expected_results
+        elif local_attr == "STASH":
+            # A special case : the stored name is different
+            self.attrname = "um_stash_source"
+
+        self.check_save_results(expected_results)
 
     def test_11_localstyle__multiple_same(self, local_attr):
-        results = self.create_save_testcase(
-            local_attr, "value-same", "value-same"
+        self.run_save_testcase_legacytype(
+            local_attr, ["value-same", "value-same"]
         )
+
         # They remain separate + local
         expected_results = [None, "value-same", "value-same"]
         if local_attr == "ukmo__process_flags":
@@ -1002,10 +982,14 @@ class TestSave(MixinAttrsTesting):
                 "v a l u e - s a m e",
                 "v a l u e - s a m e",
             ]
-        assert results == expected_results
+        elif local_attr == "STASH":
+            # A special case : the stored name is different
+            self.attrname = "um_stash_source"
+
+        self.check_save_results(expected_results)
 
     def test_12_localstyle__multiple_different(self, local_attr):
-        results = self.create_save_testcase(local_attr, "value-A", "value-B")
+        self.run_save_testcase_legacytype(local_attr, ["value-A", "value-B"])
         # Different values are treated just the same as matching ones.
         expected_results = [None, "value-A", "value-B"]
         if local_attr == "ukmo__process_flags":
@@ -1015,4 +999,7 @@ class TestSave(MixinAttrsTesting):
                 "v a l u e - A",
                 "v a l u e - B",
             ]
-        assert results == expected_results
+        elif local_attr == "STASH":
+            # A special case : the stored name is different
+            self.attrname = "um_stash_source"
+        self.check_save_results(expected_results)

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -76,7 +76,7 @@ def local_attr(request):
 
 
 def check_captured_warnings(
-    expected_keys: List[str], captured_warnings: List[warnings]
+    expected_keys: List[str], captured_warnings: List[warnings.WarningMessage]
 ):
     if expected_keys is None:
         expected_keys = []

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -530,8 +530,8 @@ class TestRoundtrip(MixinAttrsTesting):
             # warnings about the clash
             expected_warnings = [
                 "Saving.* global attributes.* as local",
-                'attributes.* of cube "var_0" have been lost',
-                'attributes.* of cube "var_1" have been lost',
+                'attributes.* of cube "var_0" were not saved',
+                'attributes.* of cube "var_1" were not saved',
             ]
         else:
             # oldstyle saves: matching locals promoted, override original global
@@ -1280,8 +1280,8 @@ class TestSave(MixinAttrsTesting):
             expected = [None, "valueB", "valueB"]
             expected_warnings = [
                 "Saving.* global attributes.* as local",
-                'attributes.* of cube "v1" have been lost',
-                'attributes.* of cube "v2" have been lost',
+                'attributes.* of cube "v1" were not saved',
+                'attributes.* of cube "v2" were not saved',
             ]
         else:
             # N.B. legacy code sees only the locals, and promotes them.

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -339,7 +339,8 @@ class MixinAttrsTesting:
                     if attr_name in ds.ncattrs()
                     else None
                 )
-                # Fetch local attr value from all data variables (except dimcoord vars)
+                # Fetch local attr value from all data variables :  In our testcases,
+                # that is all *except* dimcoords (ones named after dimensions).
                 local_vars_results = [
                     (
                         var.name,
@@ -688,11 +689,6 @@ class TestRoundtrip(MixinAttrsTesting):
         self.run_roundtrip_testcase(
             attr_name=global_attr, values=[[attrval, None], [attrval, None]]
         )
-        #     # The attribute remains as a common global setting
-        #     global_attr_value=attrval,
-        #     # The individual variables do *not* have an attribute of this name
-        #     var_attr_vals={"v1": None, "v2": None},
-        # )
         self.check_roundtrip_results([attrval, None, None])
 
     #######################################################


### PR DESCRIPTION
**MISTAKE** - replaced by https://github.com/pp-mo/iris/pull/77


just testing
provisional changes to common-metadata to accommodate split attribute dictionaries

No new function yet -- just to see if it breaks any existing tests
Will need additional tests for how this actually functions with split-attr testcases


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
