### PR TITLE
Do not run CI stale bot on Dragon-labelled issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,7 +33,7 @@ jobs:
             Otherwise this issue will be automatically closed in 28 days time.
 
           # Comment on the staled prs.
-          stale-pr-message: | 
+          stale-pr-message: |
             In order to maintain a backlog of relevant PRs, we automatically label them as stale after 500 days of inactivity.
 
             If this PR is still important to you, then please comment on this PR and the stale label will be removed.
@@ -43,7 +43,7 @@ jobs:
           # Comment on the staled issues while closed.
           close-issue-message: |
             This stale issue has been automatically closed due to a lack of community activity.
-            
+
             If you still care about this issue, then please either:
               * Re-open this issue, if you have sufficient permissions, or
               * Add a comment pinging `@SciTools/iris-devs` who will re-open on your behalf.
@@ -51,12 +51,12 @@ jobs:
           # Comment on the staled prs while closed.
           close-pr-message: |
             This stale PR has been automatically closed due to a lack of community activity.
-            
+
             If you still care about this PR, then please either:
               * Re-open this PR, if you have sufficient permissions, or
               * Add a comment pinging `@SciTools/iris-devs` who will re-open on your behalf.
 
-          # Label to apply on staled issues. 
+          # Label to apply on staled issues.
           stale-issue-label: Stale
 
           # Label to apply on staled prs.
@@ -64,11 +64,11 @@ jobs:
 
           # Labels on issues exempted from stale.
           exempt-issue-labels:
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎"
 
           # Labels on prs exempted from stale.
           exempt-pr-labels:
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎"
 
           # Max number of operations per run.
           operations-per-run: 300


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR exempts issues and PRs with the `Dragon 🐉` and `Dragon Sub-Task 🐉` labels from being marked as stale via the `stale.yml` workflow.

Closes #5411 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
