### PR TITLE
Tweak indents to fix list numbering.

### DIFF
--- a/docs/src/whatsnew/3.7.rst
+++ b/docs/src/whatsnew/3.7.rst
@@ -47,7 +47,7 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ rewrote :func:`~iris.util.broadcast_to_shape` so it now handles
    lazy data. (:pull:`5307`)
    
-.. _concat_warnings:
+   .. _concat_warnings:
 
 #. `@acchamber`_   added error and warning messages about coordinate overlaps to
    :func:`~iris.cube.CubeList.concatenate` to improve the concatenation process.
@@ -74,7 +74,7 @@ This document explains the changes made to Iris for this release
 #. `@acchamber`_ removed some obsolete code that prevented extraction of time points
    from cubes with bounded times (:pull:`5175`)
    
-.. _cftime_warnings:
+   .. _cftime_warnings:
 
 #. `@rcomer`_ modified pp-loading to avoid a ``cftime`` warning for non-standard
    calendars. (:pull:`5357`)
@@ -104,34 +104,32 @@ This document explains the changes made to Iris for this release
 
 #. N/A
 
-
 📚 Documentation
 ================
-
 .. _docs_dark:
 
 #. `@tkknight`_ prepared the documentation for dark mode and enable the option
    to use it.  By default the theme will be based on the users system settings,
    defaulting to ``light`` if no system setting is found.  (:pull:`5299`)
 
-.. _dask_guide:
+   .. _dask_guide:
 
 #. `@HGWright`_ added a :doc:`/further_topics/dask_best_practices/index`
    section into the user guide, containing advice and use cases to help users
    get the best out of Dask with Iris.  (:pull:`5190`)
 
-.. _convert_docs:
+   .. _convert_docs:
 
 #. `@acchamber`_ improved documentation for :meth:`~iris.cube.Cube.convert_units`
    and :meth:`~iris.coords.Coord.convert_units` by including a link to the UDUNITS-2
    documentation which contains lists of compatible units and aliases for them.
    (:pull:`5388`)
 
-
-.. _installdocs_update:
+   .. _installdocs_update:
 
 #. `@rcomer`_ updated the :ref:`Installation Guide<installing_iris>` to reflect
    that some things are now simpler.  (:pull:`5416`)
+
 
 💼 Internal
 ===========
@@ -141,7 +139,7 @@ This document explains the changes made to Iris for this release
    `"Xarray bridge" <https://github.com/SciTools/iris/issues/4994>`_ facility.
    (:pull:`5214`, :pull:`5212`)
 
-.. _contour_future:
+   .. _contour_future:
 
 #. `@rcomer`_ updated :func:`~iris.plot.contourf` to avoid using functionality
    that is deprecated in Matplotlib v3.8 (:pull:`5405`)


### PR DESCRIPTION
This should fix a problem with the 3.7.0rc0 docs that was pointed out : the numbering of the lists of items in the whatsnew section was messed up by the insertion of anchor points for the 'feature items' para.

I think this fixes that.
We will include it in the main release, and in any subsequent bugfixes, but we won't make a bugfix release for this alone.
So for now, I'll include it here and, when this is agreed, it will also go into the v3.7.x mergeback to main.