### PR TITLE
Set benchmark runs to error if the subprocess errors

### DIFF
--- a/.github/workflows/benchmarks_run.yml
+++ b/.github/workflows/benchmarks_run.yml
@@ -112,6 +112,7 @@ jobs:
           gh issue create --title "$title" --body "$body" --label "Bot" --label "Type: Performance" --repo $GITHUB_REPOSITORY
 
       - name: Upload any benchmark reports
+        if: success() || steps.overnight.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: benchmark_reports

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -388,16 +388,20 @@ class Overnight(_SubParserGenerator):
         _setup_common()
 
         commit_range = f"{args.first_commit}^^.."
-        asv_command = shlex.split(ASV_HARNESS.format(posargs=commit_range))
-        _subprocess_runner([*asv_command, *args.asv_args], asv=True)
-
         # git rev-list --first-parent is the command ASV uses.
         git_command = shlex.split(
             f"git rev-list --first-parent {commit_range}"
         )
         commit_string = _subprocess_runner_capture(git_command)
         commit_list = commit_string.split("\n")
-        _asv_compare(*reversed(commit_list), overnight_mode=True)
+
+        asv_command = shlex.split(ASV_HARNESS.format(posargs=commit_range))
+        try:
+            _subprocess_runner([*asv_command, *args.asv_args], asv=True)
+        finally:
+            # Designed for long running - want to compare/post any valid
+            #  results even if some are broken.
+            _asv_compare(*reversed(commit_list), overnight_mode=True)
 
 
 class Branch(_SubParserGenerator):

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -51,6 +51,7 @@ def _subprocess_runner(args, asv=False, **kwargs):
         args.insert(0, "asv")
         kwargs["cwd"] = BENCHMARKS_DIR
     echo(" ".join(args))
+    kwargs.setdefault("check", True)
     return subprocess.run(args, **kwargs)
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -93,6 +93,9 @@ This document explains the changes made to Iris for this release
    an issue if the overnight run fails - this was previously an 'invisible'
    problem. (feature branch: :pull:`5432`)
 
+#. `@trexfeathers`_ set `bm_runner.py` to error when the called processes
+   error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
+   :pull`5434`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,


### PR DESCRIPTION
## 🚀 Pull Request

### Requires

- #5429 
- #5430 
- #5431 
- #5432 
- #5433 

Will need `git rebase upstream/FEATURE_benchmarks` once those are merged.

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Fixes an oversight introduced when we switched away from Nox (#5215). Called process errors in `bm_runner.py` should cause an error upstream. Without this: we have had some benchmarks erroring without us knowing about it.

Also included handling to allow the overnight run to report whatever results it has, before erroring.

### Demonstrations

I have temporarily created a different default branch on my fork: [`trexfeathers:demo_20230817_main`](https://github.com/trexfeathers/iris/tree/demo_20230817_main), which can simulate what would happen on `main`.

- [Previously missed benchmark errors](https://github.com/SciTools/iris/actions/runs/5884680662/job/15959841341#step:9:116) on `SciTools:main`
- Errors from benchmarks now reported: https://github.com/trexfeathers/iris/issues/80
- Benchmark results still reported even from a failed run: https://github.com/trexfeathers/iris/issues/81

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
