### PR TITLE
Hard-code conda channel into asv_delegated_conda.py

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -4,7 +4,6 @@
     "project_url": "https://github.com/SciTools/iris",
     "repo": "..",
     "environment_type": "conda-delegated",
-    "conda_channels": ["conda-forge", "defaults"],
     "show_commit_url": "http://github.com/scitools/iris/commit/",
     "branches": ["upstream/main"],
 

--- a/benchmarks/asv_delegated_conda.py
+++ b/benchmarks/asv_delegated_conda.py
@@ -66,6 +66,8 @@ class CondaDelegated(Conda):
             ignored.append("`requirements`")
         if tagged_env_vars:
             ignored.append("`tagged_env_vars`")
+        if conf.conda_channels:
+            ignored.append("conda_channels")
         if conf.conda_environment_file:
             ignored.append("`conda_environment_file`")
         message = (
@@ -75,6 +77,8 @@ class CondaDelegated(Conda):
         log.warning(message)
         requirements = {}
         tagged_env_vars = {}
+        # All that is required to create ASV's bare-bones environment.
+        conf.conda_channels = ["defaults"]
         conf.conda_environment_file = None
 
         super().__init__(conf, python, requirements, tagged_env_vars)

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,6 +97,9 @@ This document explains the changes made to Iris for this release
    error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
    :pull`5434`)
 
+#. `@trexfeathers`_ set `bm_runner.py` to error when the called processes
+   error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
+   :pull`5434`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,9 +97,6 @@ This document explains the changes made to Iris for this release
    error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
    :pull`5434`)
 
-#. `@trexfeathers`_ set `bm_runner.py` to error when the called processes
-   error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
-   :pull`5434`)
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,6 +97,7 @@ This document explains the changes made to Iris for this release
    error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
    :pull`5434`)
 
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:


### PR DESCRIPTION
## 🚀 Pull Request

### Requires:

- #5429 
- #5430 
- #5431 
- #5432 
- #5433 
- #5434

Will need `git rebase upstream/FEATURE_benchmarks` once those are merged.

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Since the `asv_delegated_conda.py` plugin is the only reason we need specified `conda_channels` (https://github.com/SciTools/iris/issues/5280#issuecomment-1525802077), I decided it was more appropriate / less misleading to hard-code the Conda channel into the plugin script itself.

No What's New entry since this is so small and internal.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
