### PR TITLE
Inflate benchmark data to ensure laziness

### DIFF
--- a/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
+++ b/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
@@ -30,7 +30,7 @@ from ...generate_data.ugrid import make_cube_like_2d_cubesphere
 class MixinCombineRegions:
     # Characterise time taken + memory-allocated, for various stages of combine
     # operations on cubesphere-like test data.
-    params = [4, 500]
+    params = [50, 500]
     param_names = ["cubesphere-N"]
 
     def _parametrised_cache_filename(self, n_cubesphere, content_name):

--- a/benchmarks/benchmarks/load/__init__.py
+++ b/benchmarks/benchmarks/load/__init__.py
@@ -27,7 +27,7 @@ class LoadAndRealise:
     # For data generation
     timeout = 600.0
     params = [
-        [(2, 2, 2), (1280, 960, 5), (2, 2, 1000)],
+        [(50, 50, 2), (1280, 960, 5), (2, 2, 1000)],
         [False, True],
         ["FF", "PP", "NetCDF"],
     ]

--- a/benchmarks/benchmarks/load/ugrid.py
+++ b/benchmarks/benchmarks/load/ugrid.py
@@ -77,7 +77,7 @@ class DataRealisation:
     warmup_time = 0.0
     timeout = 300.0
 
-    params = [1, int(2e5)]
+    params = [int(1e4), int(2e5)]
     param_names = ["number of faces"]
 
     def setup_common(self, **kwargs):

--- a/benchmarks/benchmarks/save.py
+++ b/benchmarks/benchmarks/save.py
@@ -21,7 +21,7 @@ from .generate_data.ugrid import make_cube_like_2d_cubesphere
 
 
 class NetcdfSave:
-    params = [[1, 600], [False, True]]
+    params = [[50, 600], [False, True]]
     param_names = ["cubesphere-N", "is_unstructured"]
 
     def setup(self, n_cubesphere, is_unstructured):

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -97,6 +97,9 @@ This document explains the changes made to Iris for this release
    error. This fixes an oversight introduced in :pull:`5215`. (feature branch:
    :pull`5434`)
 
+#. `@trexfeathers`_ inflated some benchmark data sizes to compensate for
+   :pull:`5229`. (feature branch: :pull:`5436`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,


### PR DESCRIPTION
## 🚀 Pull Request

### Requires

- #5429 
- #5430 
- #5431 
- #5432 
- #5433 
- #5434 
- #5435

Will need `git rebase upstream/FEATURE_benchmarks` once those are merged.

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Inflates some of the data sizes for benchmarks to make sure Iris still handles them as lazy data since #5229.

### Demonstrations

- [Example of error that previously occurred](https://github.com/SciTools/iris/actions/runs/5884680662/job/15959841341#step:9:116)
- [A demo benchmark run that includes this PR's code](https://github.com/trexfeathers/iris/actions/runs/5900705016/job/16005475350) - no laziness failures

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
