### PR TITLE
Whats new updates for v3.7.0 .

### DIFF
--- a/docs/src/whatsnew/3.7.rst
+++ b/docs/src/whatsnew/3.7.rst
@@ -18,18 +18,19 @@ This document explains the changes made to Iris for this release
    we have made a number of improvements for user-experience and usability,
    notably :
 
-   * improved messaging for :ref:`CubeList.concatenate() <concat_warnings>`
-     and  :ref:`Cube.convert_units() <convert_docs>`.
+   * We added :ref:`Dark mode support <docs_dark>` for the documentation.
 
-   * avoid warnings which may occur in :ref:`pp loading <cftime_warnings>`
-     and :ref:`contourf <contour_future>`.
-
-   * :ref:`documentation supports Dark mode <docs_dark>`.
-
-   * :ref:`added a "Dask Best Practices" guide <dask_guide>`
+   * We :ref:`added a "Dask Best Practices" guide <dask_guide>`
      ( :ref:`here <dask best practices>` ) .
 
-   * :ref:`improved the Installation Guide <installdocs_update>`.
+   * We :ref:`improved the Installation Guide <installdocs_update>`.
+
+   * We improved the information in
+     :ref:`warnings from CubeList.concatenate() <concat_warnings>`
+     and :ref:`documentation of Cube.convert_units() <convert_docs>`.
+
+   * We prevented some warnings occurring in :ref:`pp loading <cftime_warnings>`
+     and :ref:`contourf <contour_future>`.
 
    Please do get in touch with us on :issue:`GitHub<new/choose>` if you have
    any issues or feature requests for improving Iris. Enjoy!

--- a/docs/src/whatsnew/3.7.rst
+++ b/docs/src/whatsnew/3.7.rst
@@ -1,7 +1,7 @@
 .. include:: ../common_links.inc
 
-v3.7 (16 Aug 2023) [release candidate]
-**************************************
+v3.7 (31 Aug 2023)
+******************
 
 This document explains the changes made to Iris for this release
 (:doc:`View all changes <index>`.)


### PR DESCRIPTION
Readying the whatsnew for actual release.
Note that, since v3.7.0rc0 was cut, we did merge  [some fixes to the formatting of the whatsnew document](https://github.com/SciTools/iris/pull/5427).

@HGWright **please re-check the docs build on this PR !**

