### PR TITLE
Remove uses of logging.warn

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -79,6 +79,9 @@ This document explains the changes made to Iris for this release
    working properly. (Main pull request: :pull:`5437`, more detail:
    :pull:`5430`, :pull:`5431`, :pull:`5432`, :pull:`5434`, :pull:`5436`)
 
+#. `@trexfeathers`_ replaced all uses of the ``logging.WARNING`` level, in
+   favour of using Python warnings, following team agreement. (:pull:`5488`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/experimental/ugrid/cf.py
+++ b/lib/iris/experimental/ugrid/cf.py
@@ -10,14 +10,10 @@ Extensions to Iris' CF variable representation to represent CF UGrid variables.
 Eventual destination: :mod:`iris.fileformats.cf`.
 
 """
-import logging
+import warnings
 
-from ...config import get_logger
 from ...fileformats import cf
 from .mesh import Connectivity
-
-# Configure the logger.
-logger = get_logger(__name__, propagate=True, handler=False)
 
 
 class CFUGridConnectivityVariable(cf.CFVariable):
@@ -50,8 +46,6 @@ class CFUGridConnectivityVariable(cf.CFVariable):
     def identify(cls, variables, ignore=None, target=None, warn=True):
         result = {}
         ignore, target = cls._identify_common(variables, ignore, target)
-        # TODO: reconsider logging level when we have consistent practice.
-        log_level = logging.WARNING if warn else logging.DEBUG
 
         # Identify all CF-UGRID connectivity variables.
         for nc_var_name, nc_var in target.items():
@@ -70,11 +64,8 @@ class CFUGridConnectivityVariable(cf.CFVariable):
                                 f"{name}, referenced by netCDF variable "
                                 f"{nc_var_name}"
                             )
-                            logger.log(
-                                level=log_level,
-                                msg=message,
-                                extra=dict(cls=cls.__name__),
-                            )
+                            if warn:
+                                warnings.warn(message)
                         else:
                             # Restrict to non-string type i.e. not a
                             # CFLabelVariable.
@@ -88,11 +79,8 @@ class CFUGridConnectivityVariable(cf.CFVariable):
                                     f"as a CF-UGRID connectivity - is a "
                                     f"CF-netCDF label variable."
                                 )
-                                logger.log(
-                                    level=log_level,
-                                    msg=message,
-                                    extra=dict(cls=cls.__name__),
-                                )
+                                if warn:
+                                    warnings.warn(message)
 
         return result
 
@@ -131,8 +119,6 @@ class CFUGridAuxiliaryCoordinateVariable(cf.CFVariable):
     def identify(cls, variables, ignore=None, target=None, warn=True):
         result = {}
         ignore, target = cls._identify_common(variables, ignore, target)
-        # TODO: reconsider logging level when we have consistent practice.
-        log_level = logging.WARNING if warn else logging.DEBUG
 
         # Identify any CF-UGRID-relevant auxiliary coordinate variables.
         for nc_var_name, nc_var in target.items():
@@ -149,11 +135,8 @@ class CFUGridAuxiliaryCoordinateVariable(cf.CFVariable):
                                     f"variable {name}, referenced by netCDF "
                                     f"variable {nc_var_name}"
                                 )
-                                logger.log(
-                                    level=log_level,
-                                    msg=message,
-                                    extra=dict(cls=cls.__name__),
-                                )
+                                if warn:
+                                    warnings.warn(message)
                             else:
                                 # Restrict to non-string type i.e. not a
                                 # CFLabelVariable.
@@ -170,11 +153,8 @@ class CFUGridAuxiliaryCoordinateVariable(cf.CFVariable):
                                         f"auxiliary coordinate - is a "
                                         f"CF-netCDF label variable."
                                     )
-                                    logger.log(
-                                        level=log_level,
-                                        msg=message,
-                                        extra=dict(cls=cls.__name__),
-                                    )
+                                    if warn:
+                                        warnings.warn(message)
 
         return result
 
@@ -205,8 +185,6 @@ class CFUGridMeshVariable(cf.CFVariable):
     def identify(cls, variables, ignore=None, target=None, warn=True):
         result = {}
         ignore, target = cls._identify_common(variables, ignore, target)
-        # TODO: reconsider logging level when we have consistent practice.
-        log_level = logging.WARNING if warn else logging.DEBUG
 
         # Identify all CF-UGRID mesh variables.
         all_vars = target == variables
@@ -232,11 +210,8 @@ class CFUGridMeshVariable(cf.CFVariable):
                             f"Missing CF-UGRID mesh variable {name}, "
                             f"referenced by netCDF variable {nc_var_name}"
                         )
-                        logger.log(
-                            level=log_level,
-                            msg=message,
-                            extra=dict(cls=cls.__name__),
-                        )
+                        if warn:
+                            warnings.warn(message)
                     else:
                         # Restrict to non-string type i.e. not a
                         # CFLabelVariable.
@@ -250,11 +225,8 @@ class CFUGridMeshVariable(cf.CFVariable):
                                 f"CF-UGRID mesh - is a CF-netCDF label "
                                 f"variable."
                             )
-                            logger.log(
-                                level=log_level,
-                                msg=message,
-                                extra=dict(cls=cls.__name__),
-                            )
+                            if warn:
+                                warnings.warn(message)
 
         return result
 

--- a/lib/iris/experimental/ugrid/load.py
+++ b/lib/iris/experimental/ugrid/load.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from itertools import groupby
 from pathlib import Path
 import threading
+import warnings
 
 from ...config import get_logger
 from ...coords import AuxCoord
@@ -350,8 +351,7 @@ def _build_mesh(cf, mesh_var, file_path):
         )
     if cf_role_message:
         cf_role_message += " Correcting to 'mesh_topology'."
-        # TODO: reconsider logging level when we have consistent practice.
-        logger.warning(cf_role_message, extra=dict(cls=None))
+        warnings.warn(cf_role_message)
 
     if hasattr(mesh_var, "volume_node_connectivity"):
         topology_dimension = 3
@@ -369,8 +369,7 @@ def _build_mesh(cf, mesh_var, file_path):
             f" : *Assuming* topology_dimension={topology_dimension}"
             ", consistent with the attached connectivities."
         )
-        # TODO: reconsider logging level when we have consistent practice.
-        logger.warning(msg, extra=dict(cls=None))
+        warnings.warn(msg)
     else:
         quoted_topology_dimension = mesh_var.topology_dimension
         if quoted_topology_dimension != topology_dimension:
@@ -382,8 +381,7 @@ def _build_mesh(cf, mesh_var, file_path):
                 f"{quoted_topology_dimension}"
                 " -- ignoring this as it is inconsistent."
             )
-            # TODO: reconsider logging level when we have consistent practice.
-            logger.warning(msg=msg, extra=dict(cls=None))
+            warnings.warn(msg)
 
     node_dimension = None
     edge_dimension = getattr(mesh_var, "edge_dimension", None)

--- a/lib/iris/tests/integration/experimental/test_ugrid_load.py
+++ b/lib/iris/tests/integration/experimental/test_ugrid_load.py
@@ -169,8 +169,8 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_bad_topology_dimension(self):
         # Check that the load generates a suitable warning.
-        log_regex = r"topology_dimension.* ignoring"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = r"topology_dimension.* ignoring"
+        with pytest.warns(UserWarning, match=warn_regex):
             template = "minimal_bad_topology_dim"
             dim_line = "mesh_var:topology_dimension = 1 ;"  # which is wrong !
             cube = self.create_synthetic_test_cube(
@@ -182,8 +182,8 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_no_topology_dimension(self):
         # Check that the load generates a suitable warning.
-        log_regex = r"Mesh variable.* has no 'topology_dimension'"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = r"Mesh variable.* has no 'topology_dimension'"
+        with pytest.warns(UserWarning, match=warn_regex):
             template = "minimal_bad_topology_dim"
             dim_line = ""  # don't create ANY topology_dimension property
             cube = self.create_synthetic_test_cube(
@@ -195,8 +195,8 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_bad_cf_role(self):
         # Check that the load generates a suitable warning.
-        log_regex = r"inappropriate cf_role"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = r"inappropriate cf_role"
+        with pytest.warns(UserWarning, match=warn_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = 'mesh_var:cf_role = "foo" ;'
             _ = self.create_synthetic_test_cube(
@@ -205,8 +205,8 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_no_cf_role(self):
         # Check that the load generates a suitable warning.
-        log_regex = r"no cf_role attribute"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = r"no cf_role attribute"
+        with pytest.warns(UserWarning, match=warn_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = ""
             _ = self.create_synthetic_test_cube(

--- a/lib/iris/tests/integration/experimental/test_ugrid_load.py
+++ b/lib/iris/tests/integration/experimental/test_ugrid_load.py
@@ -16,8 +16,9 @@ import iris.tests as tests  # isort:skip
 
 from collections.abc import Iterable
 
+import pytest
+
 from iris import Constraint, load
-from iris.experimental.ugrid import logger
 from iris.experimental.ugrid.load import (
     PARSE_UGRID_ON_LOAD,
     load_mesh,
@@ -169,7 +170,7 @@ class TestTolerantLoading(XIOSFileMixin):
     def test_mesh_bad_topology_dimension(self):
         # Check that the load generates a suitable warning.
         log_regex = r"topology_dimension.* ignoring"
-        with self.assertLogs(logger, level="WARNING", msg_regex=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             template = "minimal_bad_topology_dim"
             dim_line = "mesh_var:topology_dimension = 1 ;"  # which is wrong !
             cube = self.create_synthetic_test_cube(
@@ -182,7 +183,7 @@ class TestTolerantLoading(XIOSFileMixin):
     def test_mesh_no_topology_dimension(self):
         # Check that the load generates a suitable warning.
         log_regex = r"Mesh variable.* has no 'topology_dimension'"
-        with self.assertLogs(logger, level="WARNING", msg_regex=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             template = "minimal_bad_topology_dim"
             dim_line = ""  # don't create ANY topology_dimension property
             cube = self.create_synthetic_test_cube(
@@ -195,7 +196,7 @@ class TestTolerantLoading(XIOSFileMixin):
     def test_mesh_bad_cf_role(self):
         # Check that the load generates a suitable warning.
         log_regex = r"inappropriate cf_role"
-        with self.assertLogs(logger, level="WARNING", msg_regex=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = 'mesh_var:cf_role = "foo" ;'
             _ = self.create_synthetic_test_cube(
@@ -205,7 +206,7 @@ class TestTolerantLoading(XIOSFileMixin):
     def test_mesh_no_cf_role(self):
         # Check that the load generates a suitable warning.
         log_regex = r"no cf_role attribute"
-        with self.assertLogs(logger, level="WARNING", msg_regex=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = ""
             _ = self.create_synthetic_test_cube(

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
@@ -14,12 +14,13 @@ todo: fold these tests into cf tests when experimental.ugrid is folded into
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-import numpy as np
+import re
+import warnings
 
-from iris.experimental.ugrid.cf import (
-    CFUGridAuxiliaryCoordinateVariable,
-    logger,
-)
+import numpy as np
+import pytest
+
+from iris.experimental.ugrid.cf import CFUGridAuxiliaryCoordinateVariable
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
 )
@@ -213,26 +214,30 @@ class TestIdentify(tests.IrisTest):
             "ref_source": ref_source,
         }
 
-        # The warn kwarg and expected corresponding log level.
-        warn_and_level = {True: "WARNING", False: "DEBUG"}
+        def operation(warn: bool):
+            warnings.warn("emit at least 1 warning")
+            result = CFUGridAuxiliaryCoordinateVariable.identify(
+                vars_all, warn=warn
+            )
+            self.assertDictEqual({}, result)
 
         # Missing warning.
         log_regex = rf"Missing CF-netCDF auxiliary coordinate variable {subject_name}.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                result = CFUGridAuxiliaryCoordinateVariable.identify(
-                    vars_all, warn=warn
-                )
-                self.assertDictEqual({}, result)
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []
 
         # String variable warning.
         log_regex = r".*is a CF-netCDF label variable.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                vars_all[subject_name] = netcdf_ugrid_variable(
-                    subject_name, "", np.bytes_
-                )
-                result = CFUGridAuxiliaryCoordinateVariable.identify(
-                    vars_all, warn=warn
-                )
-                self.assertDictEqual({}, result)
+        vars_all[subject_name] = netcdf_ugrid_variable(
+            subject_name, "", np.bytes_
+        )
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
@@ -223,7 +223,7 @@ class TestIdentify(tests.IrisTest):
 
         # Missing warning.
         log_regex = rf"Missing CF-netCDF auxiliary coordinate variable {subject_name}.*"
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
@@ -235,7 +235,7 @@ class TestIdentify(tests.IrisTest):
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridAuxiliaryCoordinateVariable.py
@@ -222,22 +222,22 @@ class TestIdentify(tests.IrisTest):
             self.assertDictEqual({}, result)
 
         # Missing warning.
-        log_regex = rf"Missing CF-netCDF auxiliary coordinate variable {subject_name}.*"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = rf"Missing CF-netCDF auxiliary coordinate variable {subject_name}.*"
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []
 
         # String variable warning.
-        log_regex = r".*is a CF-netCDF label variable.*"
+        warn_regex = r".*is a CF-netCDF label variable.*"
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(UserWarning, match=log_regex):
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
@@ -210,7 +210,7 @@ class TestIdentify(tests.IrisTest):
 
         # Missing warning.
         log_regex = rf"Missing CF-UGRID connectivity variable {subject_name}.*"
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
@@ -222,7 +222,7 @@ class TestIdentify(tests.IrisTest):
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
@@ -209,22 +209,24 @@ class TestIdentify(tests.IrisTest):
             self.assertDictEqual({}, result)
 
         # Missing warning.
-        log_regex = rf"Missing CF-UGRID connectivity variable {subject_name}.*"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = (
+            rf"Missing CF-UGRID connectivity variable {subject_name}.*"
+        )
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []
 
         # String variable warning.
-        log_regex = r".*is a CF-netCDF label variable.*"
+        warn_regex = r".*is a CF-netCDF label variable.*"
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(UserWarning, match=log_regex):
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridConnectivityVariable.py
@@ -14,9 +14,13 @@ todo: fold these tests into cf tests when experimental.ugrid is folded into
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-import numpy as np
+import re
+import warnings
 
-from iris.experimental.ugrid.cf import CFUGridConnectivityVariable, logger
+import numpy as np
+import pytest
+
+from iris.experimental.ugrid.cf import CFUGridConnectivityVariable
 from iris.experimental.ugrid.mesh import Connectivity
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
@@ -199,26 +203,28 @@ class TestIdentify(tests.IrisTest):
             "ref_source": ref_source,
         }
 
-        # The warn kwarg and expected corresponding log level.
-        warn_and_level = {True: "WARNING", False: "DEBUG"}
+        def operation(warn: bool):
+            warnings.warn("emit at least 1 warning")
+            result = CFUGridConnectivityVariable.identify(vars_all, warn=warn)
+            self.assertDictEqual({}, result)
 
         # Missing warning.
         log_regex = rf"Missing CF-UGRID connectivity variable {subject_name}.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                result = CFUGridConnectivityVariable.identify(
-                    vars_all, warn=warn
-                )
-                self.assertDictEqual({}, result)
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []
 
         # String variable warning.
         log_regex = r".*is a CF-netCDF label variable.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                vars_all[subject_name] = netcdf_ugrid_variable(
-                    subject_name, "", np.bytes_
-                )
-                result = CFUGridConnectivityVariable.identify(
-                    vars_all, warn=warn
-                )
-                self.assertDictEqual({}, result)
+        vars_all[subject_name] = netcdf_ugrid_variable(
+            subject_name, "", np.bytes_
+        )
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
@@ -252,22 +252,22 @@ class TestIdentify(tests.IrisTest):
             self.assertDictEqual({}, result)
 
         # Missing warning.
-        log_regex = rf"Missing CF-UGRID mesh variable {subject_name}.*"
-        with pytest.warns(UserWarning, match=log_regex):
+        warn_regex = rf"Missing CF-UGRID mesh variable {subject_name}.*"
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []
 
         # String variable warning.
-        log_regex = r".*is a CF-netCDF label variable.*"
+        warn_regex = r".*is a CF-netCDF label variable.*"
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(UserWarning, match=log_regex):
+        with pytest.warns(UserWarning, match=warn_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
         warn_list = [str(w.message) for w in record]
-        assert list(filter(re.compile(log_regex).match, warn_list)) == []
+        assert list(filter(re.compile(warn_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
@@ -14,9 +14,13 @@ todo: fold these tests into cf tests when experimental.ugrid is folded into
 # importing anything else.
 import iris.tests as tests  # isort:skip
 
-import numpy as np
+import re
+import warnings
 
-from iris.experimental.ugrid.cf import CFUGridMeshVariable, logger
+import numpy as np
+import pytest
+
+from iris.experimental.ugrid.cf import CFUGridMeshVariable
 from iris.tests.unit.experimental.ugrid.cf.test_CFUGridReader import (
     netcdf_ugrid_variable,
 )
@@ -242,22 +246,28 @@ class TestIdentify(tests.IrisTest):
             "ref_source": ref_source,
         }
 
-        # The warn kwarg and expected corresponding log level.
-        warn_and_level = {True: "WARNING", False: "DEBUG"}
+        def operation(warn: bool):
+            warnings.warn("emit at least 1 warning")
+            result = CFUGridMeshVariable.identify(vars_all, warn=warn)
+            self.assertDictEqual({}, result)
 
         # Missing warning.
         log_regex = rf"Missing CF-UGRID mesh variable {subject_name}.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                result = CFUGridMeshVariable.identify(vars_all, warn=warn)
-                self.assertDictEqual({}, result)
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []
 
         # String variable warning.
         log_regex = r".*is a CF-netCDF label variable.*"
-        for warn, level in warn_and_level.items():
-            with self.assertLogs(logger, level=level, msg_regex=log_regex):
-                vars_all[subject_name] = netcdf_ugrid_variable(
-                    subject_name, "", np.bytes_
-                )
-                result = CFUGridMeshVariable.identify(vars_all, warn=warn)
-                self.assertDictEqual({}, result)
+        vars_all[subject_name] = netcdf_ugrid_variable(
+            subject_name, "", np.bytes_
+        )
+        with pytest.warns(match=log_regex):
+            operation(warn=True)
+        with pytest.warns() as record:
+            operation(warn=False)
+        warn_list = [str(w.message) for w in record]
+        assert list(filter(re.compile(log_regex).match, warn_list)) == []

--- a/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
+++ b/lib/iris/tests/unit/experimental/ugrid/cf/test_CFUGridMeshVariable.py
@@ -253,7 +253,7 @@ class TestIdentify(tests.IrisTest):
 
         # Missing warning.
         log_regex = rf"Missing CF-UGRID mesh variable {subject_name}.*"
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)
@@ -265,7 +265,7 @@ class TestIdentify(tests.IrisTest):
         vars_all[subject_name] = netcdf_ugrid_variable(
             subject_name, "", np.bytes_
         )
-        with pytest.warns(match=log_regex):
+        with pytest.warns(UserWarning, match=log_regex):
             operation(warn=True)
         with pytest.warns() as record:
             operation(warn=False)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The development team has decided to embrace Python warnings, rather than Python logging, as the solution to user warnings.

Needed by #5472 - can't categorise warnings if they aren't warnings yet!

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
