### PR TITLE
updated layout of top navbar

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -294,7 +294,9 @@ html_theme_options = {
     "collapse_navigation": True,
     "navigation_depth": 3,
     "show_prev_next": True,
-    "navbar_align": "left",
+    "navbar_align": "content",
+    # removes the search box from the top bar
+    "navbar_persistent": [],
     # TODO: review if 6 links is too crowded.
     "header_links_before_dropdown": 6,
     "github_url": "https://github.com/SciTools/iris",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
With the recent release of pydata-sphinx-theme [v0.14.1](https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.14.1) we can make some minor improvements.

Changes top navbar alignment to be `content` and not `left`.  Also disabled the **search box** as we already have one in the left sidebar, this allows for more links to be shown in full.

### TODO

- [x] Check the RTD build pulls in the latest theme and renders ok.

### Current NavBar
![image](https://github.com/SciTools/iris/assets/2108488/9189871a-e9e3-4970-9cbb-20b21e5c7603)


### New NavBar (this PR)
![image](https://github.com/SciTools/iris/assets/2108488/787b66b1-84af-4608-b301-9d2eaa840b6c)

A whatsnew will be done in a separate PR.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
