### PR TITLE
Removed deprecation when saving pp files. 

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,7 +86,7 @@ This document explains the changes made to Iris for this release
 
 #. `@acchamber`_ and `@ESadek-MO`_ resolved several deprecation to reduce
    number of warnings raised during tests.
-   (:pull:`5493`, :pull:`5511`)
+   (:pull:`5493`, :pull:`5511`, :pull:`5512`)
 
 #. `@trexfeathers`_ replaced all uses of the ``logging.WARNING`` level, in
    favour of using Python warnings, following team agreement. (:pull:`5488`)

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1227,13 +1227,12 @@ class PPField(metaclass=ABCMeta):
                 index = slice(pos[0], pos[-1] + 1)
                 if isinstance(header_elem, SplittableInt):
                     header_elem = int(header_elem)
-                lb[index] = header_elem
+                lb[index] = np.array(header_elem).astype("uint32")
             else:
                 index = slice(
                     pos[0] - NUM_LONG_HEADERS, pos[-1] - NUM_LONG_HEADERS + 1
                 )
-                b[index] = header_elem
-
+                b[index] = np.array(header_elem).astype("uint32")
         # Although all of the elements are now populated, we still need to
         # update some of the elements in case
         # things have changed (for example, the data length etc.)


### PR DESCRIPTION
## 🚀 Pull Request
Closes #5492.

I'm conscious this is somewhat fighting fires as they appear, it's hard to guess where the deprecation might be raised; in the tests currently it's only one place, though I've changed a similar operation just below as future bubblewrap. 

