### PR TITLE
updating docs and stale comment

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -46,7 +46,7 @@ jobs:
             
             If you still care about this issue, then please either:
               * Re-open this issue, if you have sufficient permissions, or
-              * Add a comment pinging `@SciTools/iris-devs` who will re-open on your behalf.
+              * Add a comment stating that this is still relevant and someone will re-open it on your behalf.
 
           # Comment on the staled prs while closed.
           close-pr-message: |

--- a/docs/src/developers_guide/contributing_documentation_easy.rst
+++ b/docs/src/developers_guide/contributing_documentation_easy.rst
@@ -81,9 +81,9 @@ Describing what you've changed and why will help the person who reviews your cha
 .. tip::
 
    If you're not sure that you're making your pull request right, or have a
-   question, then make it anyway! You can then comment on it tagging
-   ``@SciTools/iris-devs`` to ask your question (then edit your pull request if
-   you need to).
+   question, then make it anyway! You can then comment on it to ask your
+   question, then someone from the dev team will be happy to help you out (then
+   edit your pull request if you need to).
 
 What Happens Next?
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Closes #4628. After a discussion at the Peloton it was decided that this was all that was required as we are already notified when people open and comment on issues and PR's. The lack of ability to ping SciTools-devs doesn't seem to have been a problem up to this point, so the docs and comment the stale bot makes have been updated to remove the mention of pinging the devs.

---
