### PR TITLE
nep29 drop table schedule numpy>1.21

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -66,7 +66,8 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@bjlittle`_ enforced the minimum pin of ``numpy>1.21`` in accordance with the `NEP29 Drop Schedule`_.
+   (:pull:`5525`)
 
 
 📚 Documentation
@@ -117,3 +118,6 @@ This document explains the changes made to Iris for this release
 
 .. comment
     Whatsnew resources in alphabetical order:
+
+.. _NEP29 Drop Schedule: https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule
+

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib >=3.5
   - netcdf4
-  - numpy >=1.21, !=1.24.3
+  - numpy >1.21, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib >=3.5
   - netcdf4
-  - numpy >=1.21, !=1.24.3
+  - numpy >1.21, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib >=3.5
   - netcdf4
-  - numpy >=1.21, !=1.24.3
+  - numpy >1.21, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -5,7 +5,7 @@ dask[array]>=2022.9.0
 # libnetcdf!=4.9.1 (not available on PyPI)
 matplotlib>=3.5
 netcdf4
-numpy>=1.21,!=1.24.3
+numpy>1.21,!=1.24.3
 pyproj
 scipy
 shapely!=1.8.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
The pull-request bumps the minimum `numpy` version to `>1.21`, according to the [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
