### PR TITLE
Gallery: show colour bar stealing space from multiple axes

### DIFF
--- a/.github/workflows/benchmarks_run.yml
+++ b/.github/workflows/benchmarks_run.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       IRIS_TEST_DATA_LOC_PATH: benchmarks
       IRIS_TEST_DATA_PATH: benchmarks/iris-test-data
-      IRIS_TEST_DATA_VERSION: "2.19"
+      IRIS_TEST_DATA_VERSION: "2.21"
       # Lets us manually bump the cache to rebuild
       ENV_CACHE_BUILD: "0"
       TEST_DATA_CACHE_BUILD: "2"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,7 +50,7 @@ jobs:
             session: "tests"
 
     env:
-      IRIS_TEST_DATA_VERSION: "2.19"
+      IRIS_TEST_DATA_VERSION: "2.21"
       ENV_NAME: "ci-tests"
 
     steps:

--- a/docs/gallery_code/meteorology/plot_COP_maps.py
+++ b/docs/gallery_code/meteorology/plot_COP_maps.py
@@ -24,7 +24,6 @@ References
 
 import os.path
 
-import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -150,9 +149,7 @@ def main():
     colors = np.stack([red, green, blue], axis=1)
 
     # Make a wider than normal figure to house two maps side-by-side.
-    fig, ax_array = plt.subplots(
-        1, 2, figsize=(12, 5), subplot_kw=dict(projection=ccrs.PlateCarree())
-    )
+    fig, ax_array = plt.subplots(1, 2, figsize=(12, 5))
 
     # Loop over our scenarios to make a plot for each.
     for ax, experiment, label in zip(
@@ -167,15 +164,20 @@ def main():
         exp_anom_cube = exp_cube - preindustrial
 
         # Plot this anomaly.
+        plt.sca(ax)
         ax.set_title(f"HadGEM2 {label} Scenario", fontsize=10)
         contour_result = iplt.contourf(
-            exp_anom_cube, levels, colors=colors, extend="both", axes=ax
+            exp_anom_cube, levels, colors=colors, extend="both"
         )
-        ax.coastlines()
+        plt.gca().coastlines()
 
-    # Now add a colour bar which spans the two plots.
+    # Now add a colour bar which spans the two plots.  Here we pass Figure.axes
+    # which is a list of all (two) axes currently on the figure.  Note that
+    # these are different to the contents of ax_array, because those were
+    # standard Matplotlib Axes that Iris automatically replaced those with
+    # Cartopy GeoAxes.
     cbar = plt.colorbar(
-        contour_result, ax=ax_array, aspect=60, orientation="horizontal"
+        contour_result, ax=fig.axes, aspect=60, orientation="horizontal"
     )
 
     # Label the colour bar and add ticks.

--- a/docs/gallery_code/meteorology/plot_COP_maps.py
+++ b/docs/gallery_code/meteorology/plot_COP_maps.py
@@ -174,8 +174,8 @@ def main():
     # Now add a colour bar which spans the two plots.  Here we pass Figure.axes
     # which is a list of all (two) axes currently on the figure.  Note that
     # these are different to the contents of ax_array, because those were
-    # standard Matplotlib Axes that Iris automatically replaced those with
-    # Cartopy GeoAxes.
+    # standard Matplotlib Axes that Iris automatically replaced with Cartopy
+    # GeoAxes.
     cbar = plt.colorbar(
         contour_result, ax=fig.axes, aspect=60, orientation="horizontal"
     )

--- a/docs/gallery_code/meteorology/plot_COP_maps.py
+++ b/docs/gallery_code/meteorology/plot_COP_maps.py
@@ -24,6 +24,7 @@ References
 
 import os.path
 
+import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -149,7 +150,9 @@ def main():
     colors = np.stack([red, green, blue], axis=1)
 
     # Make a wider than normal figure to house two maps side-by-side.
-    fig, ax_array = plt.subplots(1, 2, figsize=(12, 5))
+    fig, ax_array = plt.subplots(
+        1, 2, figsize=(12, 5), subplot_kw=dict(projection=ccrs.PlateCarree())
+    )
 
     # Loop over our scenarios to make a plot for each.
     for ax, experiment, label in zip(
@@ -164,30 +167,15 @@ def main():
         exp_anom_cube = exp_cube - preindustrial
 
         # Plot this anomaly.
-        plt.sca(ax)
         ax.set_title(f"HadGEM2 {label} Scenario", fontsize=10)
         contour_result = iplt.contourf(
-            exp_anom_cube, levels, colors=colors, extend="both"
+            exp_anom_cube, levels, colors=colors, extend="both", axes=ax
         )
-        plt.gca().coastlines()
+        ax.coastlines()
 
-    # Now add a colourbar who's leftmost point is the same as the leftmost
-    # point of the left hand plot and rightmost point is the rightmost
-    # point of the right hand plot.
-
-    # Get the positions of the 2nd plot and the left position of the 1st plot.
-    left, bottom, width, height = ax_array[1].get_position().bounds
-    first_plot_left = ax_array[0].get_position().bounds[0]
-
-    # The width of the colorbar should now be simple.
-    width = left - first_plot_left + width
-
-    # Add axes to the figure, to place the colour bar.
-    colorbar_axes = fig.add_axes([first_plot_left, 0.18, width, 0.03])
-
-    # Add the colour bar.
+    # Now add a colour bar which spans the two plots.
     cbar = plt.colorbar(
-        contour_result, colorbar_axes, orientation="horizontal"
+        contour_result, ax=ax_array, aspect=60, orientation="horizontal"
     )
 
     # Label the colour bar and add ticks.

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -76,7 +76,7 @@ This document explains the changes made to Iris for this release
    Iris. See :ref:`filtering-warnings`. (:pull:`5509`)
 
 #. `@rcomer`_ updated the "Global average annual temperature maps" to show how
-   a colourbar may steal space from multiple axes. (:pull:`5093`)
+   a colourbar may steal space from multiple axes. (:pull:`5537`)
 
 
 💼 Internal

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -75,6 +75,9 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ documented the intended use of warnings filtering with
    Iris. See :ref:`filtering-warnings`. (:pull:`5509`)
 
+#. `@rcomer`_ updated the "Global average annual temperature maps" to show how
+   a colourbar may steal space from multiple axes. (:pull:`5093`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -75,7 +75,8 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ documented the intended use of warnings filtering with
    Iris. See :ref:`filtering-warnings`. (:pull:`5509`)
 
-#. `@rcomer`_ updated the "Global average annual temperature maps" to show how
+#. `@rcomer`_ updated the
+   :ref:`sphx_glr_generated_gallery_meteorology_plot_COP_maps.py` to show how
    a colourbar may steal space from multiple axes. (:pull:`5537`)
 
 

--- a/lib/iris/tests/results/imagerepo.json
+++ b/lib/iris/tests/results/imagerepo.json
@@ -1,6 +1,6 @@
 {
     "gallery_tests.test_plot_COP_1d.0": "aefec91c3601249cc9b3336dc4c8cdb31a64c6d997b3c0eccb5932d285e42f33",
-    "gallery_tests.test_plot_COP_maps.0": "ea9130db95668524913e6ac168991f0d956e917ec76396b96a853dcf94696935",
+    "gallery_tests.test_plot_COP_maps.0": "ea91789995668566913e43474adb6a917e8d947c4b46957ec6716a91958e6f81",
     "gallery_tests.test_plot_SOI_filtering.0": "fa56f295c5e0694a3c17a58d95e8da536233da99984c5af4c6739b4a9a444eb4",
     "gallery_tests.test_plot_TEC.0": "e5a761b69a589a4bc46f9e48c65c6631ce61d1ce3982c13739b33193c0ee3f8c",
     "gallery_tests.test_plot_anomaly_log_colouring.0": "ec4464e384a39b13931a9b1c85696da968d5e6e63e26847bdbd399938d3c5a4c",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
It was embarrassingly recent that I realised you can get Matplotlib to automatically place a colour bar across multiple axes.  Probably because I originally came to the Iris gallery to learn this sort of thing.  This PR modifies one example to show such placement rather than manually placing a colour bar axes.  Note that we also have the [GloSea example](https://scitools-iris.readthedocs.io/en/latest/generated/gallery/meteorology/plot_lagged_ensemble.html#sphx-glr-generated-gallery-meteorology-plot-lagged-ensemble-py) showing manual colour bar placement.

I have two versions of this in the two commits.  In the first commit, I created Cartopy GeoAxes up front so that I could pass the original array of axes to `colorbar`.  I the second commit, I reverted that and found a different way to get hold of the GeoAxes that Iris auto-creates.  I am in two minds which is the right version to keep:  I think the first version is Better Object Oriented Code, but the second version better illustrates Iris' capabilities (and gotchas).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
