### PR TITLE
Replaced `NotImplementedError` with `NotImplemented`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -112,6 +112,7 @@ This document explains the changes made to Iris for this release
 
 .. _@scottrobinson02: https://github.com/scottrobinson02
 .. _@acchamber: https://github.com/acchamber
+.. _@fazledyn-or: https://github.com/fazledyn-or
 
 
 .. comment

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -102,6 +102,9 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ adapted benchmarking to work with ASV ``>=v0.6`` by no
    longer using the ``--strict`` argument. (:pull:`5496`)
 
+#. `@fazledyn-or`_ replaced ``NotImplementedError`` with ``NotImplemented`` as
+   a proper method call. (:pull:`5544`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -3119,7 +3119,7 @@ class CellMethod(iris.util._OrderedHashable):
 
     def __add__(self, other):
         # Disable the default tuple behaviour of tuple concatenation
-        raise NotImplementedError()
+        return NotImplemented
 
     def xml_element(self, doc):
         """


### PR DESCRIPTION
This PR is made against https://github.com/SciTools/iris/discussions/5521

## 🚀 Pull Request

### Description
- This PR replaces the usage of `NotImplementedError` with `NotImplemented`

#### More Info
In file: [coords.py](https://github.com/SciTools/iris/blob/main/lib/iris/coords.py#L3122), class: CellMethod, there is a special method __add__ that raises a NotImplementedError. If a special method supporting a [binary operation is not implemented it should return NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that [derived classes should override those methods. ](https://docs.python.org/3/library/exceptions.html#NotImplementedError)iCR suggested that the special method __add__ should return NotImplemented instead of raising an exception.

An example of how NotImplemented helps the [interpreter support a binary operation is here.](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations)


---
### CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


### Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

