### PR TITLE
Exempt major release label from stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -64,11 +64,11 @@ jobs:
 
           # Labels on issues exempted from stale.
           exempt-issue-labels:
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎, Release: Major"
 
           # Labels on prs exempted from stale.
           exempt-pr-labels:
-            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎"
+            "Status: Blocked,Status: Decision Required,Peloton 🚴‍♂️,Good First Issue, Dragon 🐉, Dragon Sub-Task 🦎, Release: Major"
 
           # Max number of operations per run.
           operations-per-run: 300


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
If we label something for a major release, it is reasonable/expected that it will hang around for a long time.  So I think it should be exempt from the stale GHA.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
