### PR TITLE
TESTING - DO NOT MERGE.  Added sphinx_search.extension

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,3 +29,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -164,6 +164,7 @@ extensions = [
 ]
 
 if on_rtd:
+    # search as you type on readthedocs only.
     extensions.extend(["sphinx_search.extension"])
 
 if skip_api == "1":

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -163,6 +163,9 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
 ]
 
+if on_rtd:
+    extensions.extend(["sphinx_search.extension"])
+
 if skip_api == "1":
     autolog("Skipping the API docs generation (SKIP_API=1)")
 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ readme = {file = "README.md", content-type = "text/markdown"}
 include = ["iris*"]
 where = ["lib"]
 
+[tool.setuptools.dynamic.optional-dependencies]
+docs = {file = ["requirements/pypi-optional-docs.txt"]}
+
 [tool.setuptools_scm]
 write_to = "lib/iris/_version.py"
 local_scheme = "dirty-tag"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dynamic = [
     "dependencies",
+    "optional-dependencies",
     "readme",
     "version",
 ]
@@ -66,12 +67,13 @@ zip-safe = false
 dependencies = {file = "requirements/pypi-core.txt"}
 readme = {file = "README.md", content-type = "text/markdown"}
 
+[tool.setuptools.dynamic.optional-dependencies]
+docs = {file = ["requirements/pypi-optional-docs.txt"]}
+
+
 [tool.setuptools.packages.find]
 include = ["iris*"]
 where = ["lib"]
-
-[tool.setuptools.dynamic.optional-dependencies]
-docs = {file = ["requirements/pypi-optional-docs.txt"]}
 
 [tool.setuptools_scm]
 write_to = "lib/iris/_version.py"

--- a/requirements/pypi-optional-docs.txt
+++ b/requirements/pypi-optional-docs.txt
@@ -1,0 +1,1 @@
+readthedocs-sphinx-search


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Added support for search as you type via the [readthedocs-sphinx-search](https://readthedocs-sphinx-search.readthedocs.io/en/latest/index.html) package.

The change only includes the extension if it is running on the read the docs servers, it will not run in a local dev environment (but could if installed via pip).

This change may help users find what they want as the results are more interactive.

**TESTING - DO NOT MERGE.**

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
