### PR TITLE
Fix pp save of realization coordinate

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -51,6 +51,9 @@ This document explains the changes made to Iris for this release
 #. `@acchamber`_ and `@rcomer`_ modified 2D plots so that time axes and their
    ticks have more sensible default labels.  (:issue:`5426`, :pull:`5561`)
 
+#. `@rcomer`_ added handling for realization coordinates when saving pp files
+   (:issue:`4747`, :pull:`5568`)
+
 
 💣 Incompatible Changes
 =======================

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -51,8 +51,8 @@ This document explains the changes made to Iris for this release
 #. `@acchamber`_ and `@rcomer`_ modified 2D plots so that time axes and their
    ticks have more sensible default labels.  (:issue:`5426`, :pull:`5561`)
 
-#. `@rcomer`_ added handling for realization coordinates when saving pp files
-   (:issue:`4747`, :pull:`5568`)
+#. `@rcomer`_ and `@trexfeathers`_ (reviewer) added handling for realization
+   coordinates when saving pp files (:issue:`4747`, :pull:`5568`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -615,7 +615,7 @@ def _non_std_cross_section_rules(cube, pp):
 
 def _lbproc_rules(cube, pp):
     """
-    Rules for setting the horizontal grid and pole location of the PP field.
+    Rules for setting the time processing information of the PP field.
 
     Note: `pp.lbproc` must be set to 0 before these rules are run.
 
@@ -845,7 +845,7 @@ def _vertical_rules(cube, pp):
 
 def _all_other_rules(cube, pp):
     """
-    Rules for setting the horizontal grid and pole location of the PP field.
+    Rules for setting the field code and ensemble member number of the PP field.
 
     Args:
         cube: the cube being saved as a series of PP fields.
@@ -860,12 +860,17 @@ def _all_other_rules(cube, pp):
     if check_items in CF_TO_LBFC:
         pp.lbfc = CF_TO_LBFC[check_items]
 
-    # Set STASH code.
+    # Set field code.
     if (
         "STASH" in cube.attributes
         and str(cube.attributes["STASH"]) in STASH_TRANS
     ):
         pp.lbfc = STASH_TRANS[str(cube.attributes["STASH"])].field_code
+
+    # Set ensemble member number.
+    real_coord = scalar_coord(cube, "realization")
+    if real_coord is not None:
+        pp.lbrsvd[3] = real_coord.points[0]
 
     return pp
 

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -615,7 +615,7 @@ def _non_std_cross_section_rules(cube, pp):
 
 def _lbproc_rules(cube, pp):
     """
-    Rules for setting the time processing information of the PP field.
+    Rules for setting the processing code of the PP field.
 
     Note: `pp.lbproc` must be set to 0 before these rules are run.
 
@@ -845,7 +845,10 @@ def _vertical_rules(cube, pp):
 
 def _all_other_rules(cube, pp):
     """
-    Rules for setting the field code and ensemble member number of the PP field.
+    Fields currently managed by these rules:
+
+    * lbfc (field code)
+    * lbrsvd[3] (ensemble member number)
 
     Args:
         cube: the cube being saved as a series of PP fields.

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -44,6 +44,18 @@ def test_grid_and_pole__scalar_dim_longitude(unit, modulus):
     assert field.lbnpt == lon.points.size
 
 
+def test_realization():
+    cube = stock.lat_lon_cube()
+    real_coord = DimCoord(42, standard_name="realization", units=1)
+    cube.add_aux_coord(real_coord)
+    with mock.patch("iris.fileformats.pp.PPField3", autospec=True) as pp_field:
+        pp_field.lbrsvd = list(range(6))
+        verify(cube, pp_field)
+        member_number = pp_field.lbrsvd[3]
+
+    assert member_number == 42
+
+
 def _pp_save_ppfield_values(cube):
     """
     Emulate saving a cube as PP, and capture the resulting PP field values.

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -49,7 +49,7 @@ def test_realization():
     real_coord = DimCoord(42, standard_name="realization", units=1)
     cube.add_aux_coord(real_coord)
     with mock.patch("iris.fileformats.pp.PPField3", autospec=True) as pp_field:
-        pp_field.lbrsvd = list(range(6))
+        pp_field.lbrsvd = list(range(4))
         verify(cube, pp_field)
         member_number = pp_field.lbrsvd[3]
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #4747 by adding some handling for the "realization" coordinate in `pp_save_rules.py`.

I followed the pattern of `_general_time_rules` in this module, and found the relevant field attribute by looking at the load code:
https://github.com/SciTools/iris/blob/e0850ebc73824c929f48d51067f88c3c2067b7fb/lib/iris/fileformats/pp_load_rules.py#L947-L950

Also updated some docstrings and comments.  There seem to have been some copypasta errors going on.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
