### PR TITLE
DOCS: Removed broken git links.

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -390,7 +390,6 @@ linkcheck_ignore = [
     "https://docs.github.com",
     "https://github.com",
     "http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html",
-    "http://schacon.github.com/git",
     "http://scitools.github.com/cartopy",
     "http://www.wmo.int/pages/prog/www/DPFS/documents/485_Vol_I_en_colour.pdf",
     "https://software.ac.uk/how-cite-software",

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -74,7 +74,7 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     git checkout my-new-feature
 
 Generally, you will want to keep your feature branches on your public github_
-fork of `iris`_.  To do this, you `git push`_ this new branch up to your
+fork of `iris`_.  To do this, you ``git push`` this new branch up to your
 github repo.  Generally (if you followed the instructions in these pages, and by
 default), git will have a link to your github repo, called ``origin``.  You push
 up to your own repo on github with::
@@ -108,7 +108,7 @@ In More Detail
 --------------
 
 #. Make some changes
-#. See which files have changed with ``git status`` (see `git status`_).
+#. See which files have changed with ``git status``.
    You'll see a listing like this one::
 
      # On branch ny-new-feature
@@ -124,16 +124,15 @@ In More Detail
      #	INSTALL
      no changes added to commit (use "git add" and/or "git commit -a")
 
-#. Check what the actual changes are with ``git diff`` (`git diff`_).
-#. Add any new files to version control ``git add new_file_name`` (see
-   `git add`_).
+#. Check what the actual changes are with ``git diff``.
+#. Add any new files to version control ``git add new_file_name``.
 #. To commit all modified files into the local copy of your repo, do
    ``git commit -am 'A commit message'``.  Note the ``-am`` options to
    ``commit``. The ``m`` flag just signals that you're going to type a
    message on the command line.  The ``a`` flag will automatically stage
    all files that have been modified and deleted.
 #. To push the changes up to your forked repo on github, do a ``git
-   push`` (see `git push`_).
+   push``.
 
 
 Testing Your Changes

--- a/docs/src/developers_guide/gitwash/git_links.inc
+++ b/docs/src/developers_guide/gitwash/git_links.inc
@@ -13,20 +13,6 @@
 .. _github help: https://help.github.com
 .. _git documentation: https://git-scm.com/docs
 
-.. _git clone: http://schacon.github.com/git/git-clone.html
-.. _git checkout: http://schacon.github.com/git/git-checkout.html
-.. _git commit: http://schacon.github.com/git/git-commit.html
-.. _git push: http://schacon.github.com/git/git-push.html
-.. _git pull: http://schacon.github.com/git/git-pull.html
-.. _git add: http://schacon.github.com/git/git-add.html
-.. _git status: http://schacon.github.com/git/git-status.html
-.. _git diff: http://schacon.github.com/git/git-diff.html
-.. _git log: http://schacon.github.com/git/git-log.html
-.. _git branch: http://schacon.github.com/git/git-branch.html
-.. _git remote: http://schacon.github.com/git/git-remote.html
-.. _git rebase: http://schacon.github.com/git/git-rebase.html
-.. _git config: http://schacon.github.com/git/git-config.html
-
 .. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 
 .. |emdash| unicode:: U+02014

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,6 +91,8 @@ This document explains the changes made to Iris for this release
    links shown.  Also improved how the warning banner is implemented.
    (:pull:`5505` and :pull:`5508`)
 
+#. `@tkknight`_  removed broken git links. (:pull:`5569`)
+
 
 💼 Internal
 ===========


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Addresses https://github.com/SciTools/iris/issues/5336.

Removed broken git links, the user can still link to the git docs if needed.

Built docs: https://scitools-iris--5569.org.readthedocs.build/en/5569/developers_guide/gitwash/development_workflow.html


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
