### PR TITLE
Split-attrs merge message

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -23,6 +23,9 @@ from iris._lazy_data import (
     multidim_lazy_stack,
 )
 from iris.common import CoordMetadata, CubeMetadata
+from iris.common._split_attribute_dicts import (
+    _convert_splitattrs_to_pairedkeys_dict as convert_splitattrs_to_pairedkeys_dict,
+)
 import iris.coords
 import iris.cube
 import iris.exceptions
@@ -391,8 +394,10 @@ class _CubeSignature(
                 )
             )
         if self_defn.attributes != other_defn.attributes:
-            diff_keys = set(self_defn.attributes.keys()) ^ set(
-                other_defn.attributes.keys()
+            attrs_1, attrs_2 = self_defn.attributes, other_defn.attributes
+            diff_keys = sorted(
+                set(attrs_1.globals) ^ set(attrs_2.globals)
+                | set(attrs_1.locals) ^ set(attrs_2.locals)
             )
             if diff_keys:
                 msgs.append(
@@ -400,14 +405,16 @@ class _CubeSignature(
                     + ", ".join(repr(key) for key in diff_keys)
                 )
             else:
-                diff_attrs = [
-                    repr(key)
-                    for key in self_defn.attributes
-                    if np.all(
-                        self_defn.attributes[key] != other_defn.attributes[key]
-                    )
+                attrs_1, attrs_2 = [
+                    convert_splitattrs_to_pairedkeys_dict(dic)
+                    for dic in (attrs_1, attrs_2)
                 ]
-                diff_attrs = ", ".join(diff_attrs)
+                diff_attrs = [
+                    repr(key[1])
+                    for key in attrs_1
+                    if np.all(attrs_1[key] != attrs_2[key])
+                ]
+                diff_attrs = ", ".join(sorted(diff_attrs))
                 msgs.append(
                     "cube.attributes values differ for keys: {}".format(
                         diff_attrs

--- a/lib/iris/tests/test_merge.py
+++ b/lib/iris/tests/test_merge.py
@@ -22,6 +22,7 @@ import iris
 from iris._lazy_data import as_lazy_data
 from iris.coords import AuxCoord, DimCoord
 import iris.cube
+from iris.cube import CubeAttrsDict
 import iris.exceptions
 import iris.tests.stock
 
@@ -1106,6 +1107,87 @@ class TestCubeMergeWithAncils(tests.IrisTest):
         cube2 = self._makecube(1)
         with self.assertRaisesRegex(iris.exceptions.MergeError, msg):
             _ = iris.cube.CubeList([cube1, cube2]).merge_cube()
+
+
+class TestCubeMerge__split_attributes__error_messages(tests.IrisTest):
+    """
+    Specific tests for the detection and wording of attribute-mismatch errors.
+
+    In particular, the adoption of 'split' attributes with the new
+    :class:`iris.cube.CubeAttrsDict` introduces some more subtle possible discrepancies
+    in attributes, where this has also impacted the messaging, so this aims to probe
+    those cases.
+    """
+
+    def _check_merge_error(self, attrs_1, attrs_2, expected_message):
+        """
+        Check the error from a merge failure caused by a mismatch of attributes.
+
+        Build a pair of cubes with given attributes, merge them + check for a match
+        to the expected error message.
+        """
+        cube_1 = iris.cube.Cube(
+            [0],
+            aux_coords_and_dims=[(AuxCoord([1], long_name="x"), None)],
+            attributes=attrs_1,
+        )
+        cube_2 = iris.cube.Cube(
+            [0],
+            aux_coords_and_dims=[(AuxCoord([2], long_name="x"), None)],
+            attributes=attrs_2,
+        )
+        with self.assertRaisesRegex(
+            iris.exceptions.MergeError, expected_message
+        ):
+            iris.cube.CubeList([cube_1, cube_2]).merge_cube()
+
+    def test_keys_differ__single(self):
+        self._check_merge_error(
+            attrs_1=dict(a=1, b=2),
+            attrs_2=dict(a=1),
+            # Note: matching key 'a' does *not* appear in the message
+            expected_message="cube.attributes keys differ: 'b'",
+        )
+
+    def test_keys_differ__multiple(self):
+        self._check_merge_error(
+            attrs_1=dict(a=1, b=2),
+            attrs_2=dict(a=1, c=2),
+            expected_message="cube.attributes keys differ: 'b', 'c'",
+        )
+
+    def test_values_differ__single(self):
+        self._check_merge_error(
+            attrs_1=dict(a=1, b=2),  # Note: matching key 'a' does not appear
+            attrs_2=dict(a=1, b=3),
+            expected_message="cube.attributes values differ for keys: 'b'",
+        )
+
+    def test_values_differ__multiple(self):
+        self._check_merge_error(
+            attrs_1=dict(a=1, b=2),
+            attrs_2=dict(a=12, b=22),
+            expected_message="cube.attributes values differ for keys: 'a', 'b'",
+        )
+
+    def test_splitattrs_keys_local_global_mismatch(self):
+        # Since Cube.attributes is now a "split-attributes" dictionary, it is now
+        # possible to have "cube1.attributes != cube1.attributes", but also
+        # "set(cube1.attributes.keys()) == set(cube2.attributes.keys())".
+        # I.E. it is now necessary to specifically compare ".globals" and ".locals" to
+        # see *what* differs between two attributes dictionaries.
+        self._check_merge_error(
+            attrs_1=CubeAttrsDict(globals=dict(a=1), locals=dict(b=2)),
+            attrs_2=CubeAttrsDict(locals=dict(a=2)),
+            expected_message="cube.attributes keys differ: 'a', 'b'",
+        )
+
+    def test_splitattrs_keys_local_match_masks_global_mismatch(self):
+        self._check_merge_error(
+            attrs_1=CubeAttrsDict(globals=dict(a=1), locals=dict(a=3)),
+            attrs_2=CubeAttrsDict(globals=dict(a=2), locals=dict(a=3)),
+            expected_message="cube.attributes values differ for keys: 'a'",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5585 

During consideration of #5585 with @trexfeathers, we realised that although the way merge compares attributes is OK,  the way it constructs a report of an attribute matching failure has some subtle problems in the "new world" of split attributes.
As stated in [part of the testing code](https://github.com/SciTools/iris/pull/5590/files#diff-39daed7858abd37d34b2611a269553d5fe4533e1db7e6ced6248ea811f752b3dR1174-R1178) here,
```
        # Since Cube.attributes is now a "split-attributes" dictionary, it is now
        # possible to have "cube1.attributes != cube1.attributes", but also
        # "set(cube1.attributes.keys()) == set(cube2.attributes.keys())".
        # I.E. it is now necessary to specifically compare ".globals" and ".locals" to
        # see *what* differs between two attributes dictionaries.
```

This also affects the code where it works out which keys are different in existence ([`"cube.attributes keys differ: "`](https://github.com/SciTools/iris/pull/5590/files#diff-b0fdcae9a793b3cacb90bb52be392ea27505b46f9672389bd6885a3bd8004cafR404)) or value ([`"cube.attributes values differ for keys:"`](https://github.com/SciTools/iris/pull/5590/files#diff-b0fdcae9a793b3cacb90bb52be392ea27505b46f9672389bd6885a3bd8004cafL412)) between two cubes whose attributes don't match.
Hence the changes here.

As so often, it was also useful to add some new tests to pin down existing behaviour,
When run against the prior feature-branch, behaviour looks like this :
```
$ pytest lib/iris/tests/test_merge_NEWSTUFF.py::TestCubeMerge__split_attributes__error_messages
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /net/home/h05/itpp/git/iris/iris_main
configfile: pyproject.toml
collected 6 items                                                                                                                                                                      

lib/iris/tests/test_merge_NEWSTUFF.py ..FF..                                                                                                                                     [100%]

======================================================================================= FAILURES =======================================================================================
______________________________________________ TestCubeMerge__split_attributes__error_messages.test_splitattrs_keys_local_global_mismatch ______________________________________________
iris.exceptions.MergeError: failed to merge into a single cube.
  cube.attributes keys differ: 'b'

During handling of the above exception, another exception occurred:

self = <iris.tests.test_merge_NEWSTUFF.TestCubeMerge__split_attributes__error_messages testMethod=test_splitattrs_keys_local_global_mismatch>

    def test_splitattrs_keys_local_global_mismatch(self):
        # Since Cube.attributes is now a "split-attributes" dictionary, it is now
        # possible to have "cube1.attributes != cube1.attributes", but also
        # "set(cube1.attributes.keys()) == set(cube2.attributes.keys())".
        # I.E. it is now necessary to specifically compare ".globals" and ".locals" to
        # see *what* differs between two attributes dictionaries.
>       self._check_merge_error(
            attrs_1=CubeAttrsDict(globals=dict(a=1), locals=dict(b=2)),
            attrs_2=CubeAttrsDict(locals=dict(a=2)),
            expected_message="cube.attributes keys differ: 'a', 'b'",
        )

lib/iris/tests/test_merge_NEWSTUFF.py:1179: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/iris/tests/test_merge_NEWSTUFF.py:1139: in _check_merge_error
    with self.assertRaisesRegex(
E   AssertionError: "cube.attributes keys differ: 'a', 'b'" does not match "failed to merge into a single cube.
E     cube.attributes keys differ: 'b'"
________________________________________ TestCubeMerge__split_attributes__error_messages.test_splitattrs_keys_local_match_masks_global_mismatch ________________________________________
iris.exceptions.MergeError: failed to merge into a single cube.
  cube.attributes values differ for keys: 

During handling of the above exception, another exception occurred:

self = <iris.tests.test_merge_NEWSTUFF.TestCubeMerge__split_attributes__error_messages testMethod=test_splitattrs_keys_local_match_masks_global_mismatch>

    def test_splitattrs_keys_local_match_masks_global_mismatch(self):
>       self._check_merge_error(
            attrs_1=CubeAttrsDict(globals=dict(a=1), locals=dict(a=3)),
            attrs_2=CubeAttrsDict(globals=dict(a=2), locals=dict(a=3)),
            expected_message="cube.attributes values differ for keys: 'a'",
        )

lib/iris/tests/test_merge_NEWSTUFF.py:1186: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/iris/tests/test_merge_NEWSTUFF.py:1139: in _check_merge_error
    with self.assertRaisesRegex(
E   AssertionError: "cube.attributes values differ for keys: 'a'" does not match "failed to merge into a single cube.
E     cube.attributes values differ for keys: "
=================================================================================== warnings summary ===================================================================================
lib/iris/tests/test_merge_NEWSTUFF.py::TestCubeMerge__split_attributes__error_messages::test_keys_differ__multiple
  <frozen importlib._bootstrap>:241: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== short test summary info ================================================================================
FAILED lib/iris/tests/test_merge_NEWSTUFF.py::TestCubeMerge__split_attributes__error_messages::test_splitattrs_keys_local_global_mismatch - AssertionError: "cube.attributes keys differ: 'a', 'b'" does not match "failed to merge into a single cube.
FAILED lib/iris/tests/test_merge_NEWSTUFF.py::TestCubeMerge__split_attributes__error_messages::test_splitattrs_keys_local_match_masks_global_mismatch - AssertionError: "cube.attributes values differ for keys: 'a'" does not match "failed to merge into a single cube.
======================================================================== 2 failed, 4 passed, 1 warning in 2.18s ========================================================================
```

**NOTE:** it was also noted in the above that sometimes the list of differing keys appears in a different order, due to use of set logic.
I have also now added `sorted` to fix that in a couple of places

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
