### PR TITLE
Splitattrs ncsave deprecation

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -33,9 +33,9 @@ This document explains the changes made to Iris for this release
    :class:`~iris.cube.Cube` :attr:`~iris.cube.Cube.attributes` handling to
    better preserve the distinction between dataset-level and variable-level
    attributes, allowing file-Cube-file round-tripping of NetCDF attributes. See
-   :class:`~iris.cube.CubeAttrsDict` and NetCDF
-   :func:`~iris.fileformats.netcdf.saver.save` for more. (:pull:`5152`,
-   `split attributes project`_)
+   :class:`~iris.cube.CubeAttrsDict`, NetCDF
+   :func:`~iris.fileformats.netcdf.saver.save` and :data:`~iris.Future` for more.
+   (:pull:`5152`, `split attributes project`_)
 
 #. `@rcomer`_ rewrote :func:`~iris.util.broadcast_to_shape` so it now handles
    lazy data. (:pull:`5307`)

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -27,6 +27,7 @@ import dask.array as da
 from dask.delayed import Delayed
 import numpy as np
 
+from iris._deprecation import warn_deprecated
 from iris._lazy_data import _co_realise_lazy_arrays, is_lazy_data
 from iris.aux_factory import (
     AtmosphereSigmaFactory,
@@ -2965,6 +2966,17 @@ def save(
     else:
         # Legacy mode: calculate "local_keys" to control which attributes are local
         # and which global.
+        # TODO: when iris.FUTURE.save_split_attrs is removed, this section can also be
+        # removed
+        message = (
+            "Saving to netcdf with legacy-style attribute handling for backwards "
+            "compatibility.\n"
+            "This mode is deprecated since Iris 3.8, and will eventually be removed.\n"
+            "Please consider enabling the new split-attributes handling mode, by "
+            "setting 'iris.FUTURE.save_split_attrs = True'."
+        )
+        warn_deprecated(message)
+
         if local_keys is None:
             local_keys = set()
         else:

--- a/lib/iris/tests/integration/netcdf/test_delayed_save.py
+++ b/lib/iris/tests/integration/netcdf/test_delayed_save.py
@@ -23,6 +23,13 @@ from iris.tests.stock import realistic_4d
 
 
 class Test__lazy_stream_data:
+    # Ensure all saves are done with split-atttribute saving,
+    # -- because some of these tests are sensitive to unexpected warnings.
+    @pytest.fixture(autouse=True)
+    def all_saves_with_split_attrs(self):
+        with iris.FUTURE.context(save_split_attrs=True):
+            yield
+
     @pytest.fixture(autouse=True)
     def output_path(self, tmp_path):
         # A temporary output netcdf-file path, **unique to each test call**.


### PR DESCRIPTION
Although we handled the split-attrs save control, we forgot to provide a deprecation warning.
So that's what this does.