### PR TITLE
DOCS: add links to scitools-classroom repo.

### DIFF
--- a/docs/src/userguide/index.rst
+++ b/docs/src/userguide/index.rst
@@ -18,6 +18,12 @@ they may serve as a useful reference for future exploration.
    sequentially using the ``next`` and ``previous`` links at the bottom
    of each page.
 
+.. note:: 
+   
+   There is also useful learning material held in the
+   https://github.com/scitools-classroom repo, including tutorials, courses
+   and presentations.
+
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Add a link to the https://github.com/scitools-classroom repo from the user guide.

- [Current](https://scitools-iris.readthedocs.io/en/latest/userguide/index.html)
- [This PR](https://scitools-iris--5609.org.readthedocs.build/en/5609/userguide/index.html)

Addresses https://github.com/SciTools/iris/issues/5486.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
