### PR TITLE
Use https for opendap.org link, as http no longer supported.

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -396,6 +396,7 @@ linkcheck_ignore = [
     "https://www.metoffice.gov.uk/",
     "https://biggus.readthedocs.io/",
     "https://stickler-ci.com/",
+    "https://twitter.com/scitools_iris",
 ]
 
 # list of sources to exclude from the build.

--- a/docs/src/whatsnew/1.4.rst
+++ b/docs/src/whatsnew/1.4.rst
@@ -58,7 +58,7 @@ Features
 
 * Use the latest release of Cartopy, v0.8.0.
 
-.. _OPeNDAP: http://www.opendap.org
+.. _OPeNDAP: https://www.opendap.org
 .. _exp-regrid:
 
 Experimental Regridding Enhancements


### PR DESCRIPTION
Should fix #5619 CI linkcheck failure

