### PR TITLE
ensured ruff convention is numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ ignore = [
         "ALL",
     ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.setuptools]
 license-files = ["LICENSE"]
 zip-safe = false


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Ensured ruff convention is numpy, else ruff will  produce warnings for incompatible rules.

This augments https://github.com/SciTools/iris/pull/5623.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
