### PR TITLE
ruff COM rule compliance

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -82,9 +82,9 @@ lint.ignore = [
     # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     "A",
 
-    # flake8-commas (COM)
-    # https://docs.astral.sh/ruff/rules/#flake8-commas-com
-    "COM",
+    # flake8-copyright (CPY)
+    # https://docs.astral.sh/ruff/rules/#flake8-copyright-cpy
+    "CPY",
 
     # flake8-comprehensions (C4)
     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ preview = false
 ignore = [
     # NOTE: Non-permanent exclusions should be added to the ".ruff.toml" file.
 
+    # flake8-commas (COM)
+    # https://docs.astral.sh/ruff/rules/#flake8-commas-com
+    "COM812",  # Trailing comma missing.
+    "COM819",  # Trailing comma prohibited.
+
     # flake8-implicit-str-concat (ISC)
     # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
     # NOTE: This rule may cause conflicts when used with "ruff format".


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces `ruff` [flake8-commas (COM)](https://docs.astral.sh/ruff/rules/#flake8-commas-com) compliance by:

- removing the `COM` rule from the `.ruff.toml`.
- adding `COM812` and `COM819` to the permanent ignores, as these rules can interfere with the `ruff` formatter.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
