### PR TITLE
fix for ruff rule D214.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -40,7 +40,6 @@ lint.ignore = [
     "D208",  # Docstring is over-indented
     "D209",  # Multi-line docstring closing quotes should be on a separate line
     "D211",  # No blank lines allowed before class docstring
-    "D214",  # Section is over-indented
     "D300",  # triple double quotes `""" / Use triple single quotes `'''`
     "D400",  # First line should end with a period
     "D401",  # First line of docstring should be in imperative mood: ...

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -205,7 +205,7 @@ class Resolve:
         >>> resolver = Resolve(cube1, cube2)
         >>> results = [resolver.cube(data) for data in payload]
 
-    """
+    """  # noqa: D214
 
     def __init__(self, lhs=None, rhs=None):
         """Resolve the provided ``lhs`` :class:`~iris.cube.Cube` operand and
@@ -2493,7 +2493,7 @@ class Resolve:
             >>> resolver.map_rhs_to_lhs
             False
 
-        """
+        """  # noqa: D214
         result = None
         if self.mapping is not None:
             result = self._src_cube.ndim == len(self.mapping)
@@ -2554,5 +2554,5 @@ class Resolve:
             >>> Resolve(cube2, cube1).shape
             (240, 37, 49)
 
-        """
+        """  # noqa: D214
         return self._broadcast_shape

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4521,7 +4521,7 @@ x            -               -
             Notice that the forecast_period dimension now represents the 4
             possible windows of size 3 from the original cube.
 
-        """
+        """  # noqa: D214
         # Update weights kwargs (if necessary) to handle different types of
         # weights
         weights_info = None


### PR DESCRIPTION
## 🚀 Pull Request

### Description
PR solely for fixing `D214:  Section is over-indented`

Continues work of https://github.com/SciTools/iris/issues/5625.

I used the `noqa` directive here as a few of the docstrings contain `Attributes:` in the docstest content and ruff thinks it is an over indented title, which it is not.  This will be a pattern for future docstrings that contains this.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
