### PR TITLE
ruff rule D208 compliance.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,7 +37,6 @@ lint.ignore = [
     "D200",  # One-line docstring should fit on one line
     "D202",  # No blank lines allowed after function docstring
     "D205",  # 1 blank line required between summary line and description
-    "D208",  # Docstring is over-indented
     "D209",  # Multi-line docstring closing quotes should be on a separate line
     "D211",  # No blank lines allowed before class docstring
     "D300",  # triple double quotes `""" / Use triple single quotes `'''`

--- a/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
+++ b/lib/iris/tests/unit/analysis/geometry/test_geometry_area_weights.py
@@ -2,10 +2,7 @@
 #
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Unit tests for the :func:`iris.analysis.geometry.geometry_area_weights`
-function.
-
- """
+"""Unit tests for the :func:`iris.analysis.geometry.geometry_area_weights` function."""
 
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
PR solely for fixing `D208:  Docstring is over-indented`

Continues work of https://github.com/SciTools/iris/issues/5625.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
