### PR TITLE
ruff rule D411 compliance.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -49,7 +49,7 @@ lint.ignore = [
     "D407",  # Missing dashed underline after section
     "D409",  # Section underline should match the length of its name
     "D410",  # Missing blank line after section
-    "D411",  # Missing blank line before section
+    #"D411",  # Missing blank line before section
     "D412",  # No blank lines allowed between a section header and its content 
 
     # pyupgrade (UP)

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -49,7 +49,6 @@ lint.ignore = [
     "D407",  # Missing dashed underline after section
     "D409",  # Section underline should match the length of its name
     "D410",  # Missing blank line after section
-    #"D411",  # Missing blank line before section
     "D412",  # No blank lines allowed between a section header and its content 
 
     # pyupgrade (UP)

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -988,6 +988,7 @@ def _create_cube(data, src, src_dims, tgt_coords, num_tgt_dims, regrid_callback)
     regrid_callback : callable
         The routine that will be used to calculate the interpolated
         values of any reference surfaces.
+
     Returns
     -------
     cube

--- a/lib/iris/common/resolve.py
+++ b/lib/iris/common/resolve.py
@@ -205,7 +205,7 @@ class Resolve:
         >>> resolver = Resolve(cube1, cube2)
         >>> results = [resolver.cube(data) for data in payload]
 
-    """  # noqa: D214
+    """  # noqa: D214, D411
 
     def __init__(self, lhs=None, rhs=None):
         """Resolve the provided ``lhs`` :class:`~iris.cube.Cube` operand and
@@ -2493,7 +2493,7 @@ class Resolve:
             >>> resolver.map_rhs_to_lhs
             False
 
-        """  # noqa: D214
+        """  # noqa: D214, D411
         result = None
         if self.mapping is not None:
             result = self._src_cube.ndim == len(self.mapping)
@@ -2554,5 +2554,5 @@ class Resolve:
             >>> Resolve(cube2, cube1).shape
             (240, 37, 49)
 
-        """  # noqa: D214
+        """  # noqa: D214, D411
         return self._broadcast_shape

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -4521,7 +4521,7 @@ x            -               -
             Notice that the forecast_period dimension now represents the 4
             possible windows of size 3 from the original cube.
 
-        """  # noqa: D214
+        """  # noqa: D214, D411
         # Update weights kwargs (if necessary) to handle different types of
         # weights
         weights_info = None

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -341,12 +341,12 @@ def _dot_node(indent, id, name, attributes):
     ----------
     id :
         The ID of the node.
-    name : 
+    name :
         The visual name of the node.
     attributes:
         An iterable of (name, value) attribute pairs.
 
-    """ # noqa: D411
+    """  # noqa: D411
     attributes = r"\n".join("%s: %s" % item for item in attributes)
     template = """%(indent)s"%(id)s" [
 %(indent)s    label = "%(name)s|%(attributes)s"

--- a/lib/iris/fileformats/dot.py
+++ b/lib/iris/fileformats/dot.py
@@ -337,16 +337,16 @@ def _coord_system_text(cs, uid):
 def _dot_node(indent, id, name, attributes):
     """Return a string containing the dot representation for a single node.
 
-    Args
-    ----
-    id
+    Parameters
+    ----------
+    id :
         The ID of the node.
-    name
+    name : 
         The visual name of the node.
-    attributes
+    attributes:
         An iterable of (name, value) attribute pairs.
 
-    """
+    """ # noqa: D411
     attributes = r"\n".join("%s: %s" % item for item in attributes)
     template = """%(indent)s"%(id)s" [
 %(indent)s    label = "%(name)s|%(attributes)s"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
PR solely for fixing `D411:  Missing blank line before section`

Continues work of https://github.com/SciTools/iris/issues/5625.

I used the `noqa` directive here as a few of the docstrings contain `Attributes:` in the docstest content and ruff thinks it is an over indented title, which it is not.  This will be a pattern for future docstrings that contains this.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
