### PR TITLE
Various ruff rule compliance (W, CPY, ISC, AIR)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -11,7 +11,6 @@ lint.ignore = [
     # pycodestyle (E, W)
     # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "E",
-    "W",
 
     # mccabe (C90)
     # https://docs.astral.sh/ruff/rules/#mccabe-c90

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -178,10 +178,6 @@ lint.ignore = [
     # https://docs.astral.sh/ruff/rules/#flynt-fly
     "FLY",
 
-    # Airflow (AIR)
-    # https://docs.astral.sh/ruff/rules/#airflow-air
-    "AIR",
-
     # Perflint (PERF)
     # https://docs.astral.sh/ruff/rules/#perflint-perf
     "PERF",

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -70,10 +70,6 @@ lint.ignore = [
     # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     "A",
 
-    # flake8-copyright (CPY)
-    # https://docs.astral.sh/ruff/rules/#flake8-copyright-cpy
-    "CPY",
-
     # flake8-comprehensions (C4)
     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "C4",

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -86,10 +86,6 @@ lint.ignore = [
     # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
     "FA",
 
-    # flake8-implicit-str-concat (ISC)
-    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
-    "ISC",
-
     # flake8-logging-format (G)
     # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
     "G",

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -257,8 +257,8 @@ def _gh_create_reports(commit_sha: str, results_full: str, results_shifts: str) 
                 * commit {commit_sha} ({pr_tag}).
 
                 <p>
-                Please review the report below and 
-                take corrective/congratulatory action as appropriate 
+                Please review the report below and
+                take corrective/congratulatory action as appropriate
                 :slightly_smiling_face:
                 </p>
                 """


### PR DESCRIPTION
## 🚀 Pull Request

### Description
PR solely for fixing:

* `pycodestyle (W)` - This is the only one that needed a code change.
* `flake8-copyright (CPY)`
* `flake8-implicit-str-concat (ISC)`
* `Airflow (AIR)`

Continues work of https://github.com/SciTools/iris/issues/5625.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
