### PR TITLE
nep29 drop numpy 1.22

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -113,6 +113,9 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ enforced the minimum pin of ``numpy>1.21`` in accordance with the `NEP29 Drop Schedule`_.
    (:pull:`5525`)
 
+#. `@bjlittle`_ enforced the minimum pin of ``numpy>1.22`` in accordance with the `NEP29 Drop Schedule`_.
+   (:pull:`5668`)
+
 
 📚 Documentation
 ================

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >1.21, !=1.24.3
+  - numpy >=1.23, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >1.21, !=1.24.3
+  - numpy >=1.23, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >1.21, !=1.24.3
+  - numpy >=1.23, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -5,7 +5,7 @@ dask[array]>=2022.9.0
 # libnetcdf!=4.9.1 (not available on PyPI)
 matplotlib>=3.5
 netcdf4
-numpy>1.21,!=1.24.3
+numpy>=1.23,!=1.24.3
 pyproj
 scipy
 shapely!=1.8.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces `nep29` and drops `numpy 1.22`, as scheduled.

See [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
