### PR TITLE
ruff compliance for D404.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,7 +37,6 @@ lint.ignore = [
     "D202",  # No blank lines allowed after function docstring
     "D205",  # 1 blank line required between summary line and description
     "D401",  # First line of docstring should be in imperative mood: ...
-    "D404",  # First word of the docstring should not be "This"
     "D406",  # Section name should end with a newline
 
     # pyupgrade (UP)

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -259,7 +259,7 @@ class CellMethodSection(Section):
 
 
 class CubeSummary:
-    """This class provides a structure for output representations of an Iris cube."""
+    """Provide a structure for output representations of an Iris cube."""
 
     def __init__(self, cube, name_padding=35):
         self.header = FullHeader(cube, name_padding)

--- a/lib/iris/analysis/_area_weighted.py
+++ b/lib/iris/analysis/_area_weighted.py
@@ -18,7 +18,7 @@ from iris.util import _meshgrid
 
 
 class AreaWeightedRegridder:
-    """This class provides support for performing area-weighted regridding."""
+    """Provide support for performing area-weighted regridding."""
 
     def __init__(self, src_grid_cube, target_grid_cube, mdtol=1):
         """Create an area-weighted regridder for conversions between the source

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -164,7 +164,9 @@ def snapshot_grid(cube):
 
 
 class RectilinearInterpolator:
-    """This class provides support for performing nearest-neighbour or
+    """Provide support for performing nearest-neighbour or linear interpolation.
+
+    This class provides support for performing nearest-neighbour or
     linear interpolation over one or more orthogonal dimensions.
 
     """

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -369,7 +369,9 @@ def _regrid_weighted_curvilinear_to_rectilinear__perform(src_cube, regrid_info):
 
 
 class CurvilinearRegridder:
-    """This class provides support for performing point-in-cell regridding
+    """Provides support for performing point-in-cell regridding.
+
+    This class provides support for performing point-in-cell regridding
     between a curvilinear source grid and a rectilinear target grid.
 
     """
@@ -485,7 +487,9 @@ class CurvilinearRegridder:
 
 
 class RectilinearRegridder:
-    """This class provides support for performing nearest-neighbour or
+    """Provides support for performing nearest-neighbour or linear regridding.
+
+    This class provides support for performing nearest-neighbour or
     linear regridding between source and target grids.
 
     """

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -200,7 +200,9 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
 
 
 class PointInCell:
-    """This class describes the point-in-cell regridding scheme for use
+    """Describe the point-in-cell regridding scheme.
+
+    This class describes the point-in-cell regridding scheme for use
     typically with :meth:`iris.cube.Cube.regrid()`.
 
     .. warning::
@@ -234,7 +236,7 @@ class PointInCell:
 
 
 class _ProjectedUnstructuredRegridder:
-    """This class provides regridding that uses scipy.interpolate.griddata."""
+    """Regridding that uses scipy.interpolate.griddata."""
 
     def __init__(self, src_cube, tgt_grid_cube, method, projection=None):
         """Create a regridder for conversions between the source
@@ -601,7 +603,9 @@ class _ProjectedUnstructuredRegridder:
 
 
 class ProjectedUnstructuredLinear:
-    """This class describes the linear regridding scheme which uses the
+    """Describe the linear regridding scheme.
+
+    This class describes the linear regridding scheme which uses the
     scipy.interpolate.griddata to regrid unstructured data on to a grid.
 
     The source cube and the target cube will be projected into a common
@@ -677,7 +681,9 @@ class ProjectedUnstructuredLinear:
 
 
 class ProjectedUnstructuredNearest:
-    """This class describes the nearest regridding scheme which uses the
+    """Describe the nearest regridding scheme which uses scipy.interpolate.griddata.
+
+    This class describes the nearest regridding scheme which uses the
     scipy.interpolate.griddata to regrid unstructured data on to a grid.
 
     The source cube and the target cube will be projected into a common

--- a/lib/iris/experimental/ugrid/cf.py
+++ b/lib/iris/experimental/ugrid/cf.py
@@ -267,7 +267,9 @@ class CFUGridGroup(cf.CFGroup):
 
 
 class CFUGridReader(cf.CFReader):
-    """This class allows the contents of a netCDF file to be interpreted according
+    """Allows the contents of a netCDF file to be.
+
+    This class allows the contents of a netCDF file to be interpreted according
     to the 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 
     Specialisation of :class:`~iris.fileformats.cf.CFReader` that can also

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -1007,7 +1007,9 @@ class CFGroup(MutableMapping):
 
 ################################################################################
 class CFReader:
-    """This class allows the contents of a netCDF file to be interpreted according
+    """Allows the contents of a netCDF file to be interpreted.
+
+    This class allows the contents of a netCDF file to be interpreted according
     to the 'NetCDF Climate and Forecast (CF) Metadata Conventions'.
 
     """

--- a/lib/iris/fileformats/pp_load_rules.py
+++ b/lib/iris/fileformats/pp_load_rules.py
@@ -929,7 +929,9 @@ def convert(f):
 
 
 def _all_other_rules(f):
-    """This deals with all the other rules that have not been factored into any of
+    """Deals with all the other rules.
+
+    Deals with all the other rules that have not been factored into any of
     the other convert_scalar_coordinate functions above.
 
     """

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -810,7 +810,9 @@ def _draw_1d_from_points(draw_method_name, arg_func, *args, **kwargs):
 
 
 def _draw_two_1d_from_points(draw_method_name, arg_func, *args, **kwargs):
-    """This function is equivalend to _draw_two_1d_from_points but expects two
+    """Draw two 1d frompoints (expects two y-axis variables rather than one).
+
+    This function is equivalend to _draw_two_1d_from_points but expects two
     y-axis variables rather than one (such as is required for .fill_between). It
     can't be used where the y-axis variables are string coordinates. The y-axis
     variable provided first has precedence where the two differ on whether the

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -803,7 +803,9 @@ class IrisTest(unittest.TestCase):
         self.assertArrayAllClose(result.data.std(), std_dev, rtol=rtol)
 
     def assertDictEqual(self, lhs, rhs, msg=None):
-        """This method overrides unittest.TestCase.assertDictEqual (new in Python3.1)
+        """Dictionary Comparison.
+
+        This method overrides unittest.TestCase.assertDictEqual (new in Python3.1)
         in order to cope with dictionary comparison where the value of a key may
         be a numpy array.
 

--- a/lib/iris/tests/system_test.py
+++ b/lib/iris/tests/system_test.py
@@ -4,7 +4,10 @@
 # See LICENSE in the root of the repository for full licensing details.
 
 
-"""This system test module is useful to identify if some of the key components required for Iris are available.
+"""System test module.
+
+System test module is useful to identify if some of the key components required for
+Iris are available.
 
 The system tests can be run with ``python setup.py test --system-tests``.
 

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -64,7 +64,9 @@ def test_netcdf4_import():
 
 
 def test_python_versions():
-    """This test is designed to fail whenever Iris' supported Python versions are
+    """Test Python Versions.
+
+    Test is designed to fail whenever Iris' supported Python versions are
     updated, insisting that versions are updated EVERYWHERE in-sync.
     """
     latest_supported = "3.11"

--- a/lib/iris/tests/test_pp_cf.py
+++ b/lib/iris/tests/test_pp_cf.py
@@ -68,7 +68,7 @@ class TestAll(tests.IrisTest, pp.PPTest):
     _ref_dir = ("usecases", "pp_to_cf_conversion")
 
     def _test_file(self, name):
-        """This is the main test routine that is called for each of the files listed below."""
+        """Main test routine that is called for each of the files listed below."""
         pp_path = self._src_pp_path(name)
 
         # 1) Load the PP and check the Cube

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -956,7 +956,9 @@ class Test_rolling_window(tests.IrisTest):
 
 
 class Test_slices_dim_order(tests.IrisTest):
-    """This class tests the capability of iris.cube.Cube.slices(), including its
+    """Test the capability of iris.cube.Cube.slices().
+
+    Test the capability of iris.cube.Cube.slices(), including its
     ability to correctly re-order the dimensions.
     """
 

--- a/lib/iris/tests/unit/fileformats/netcdf/loader/test__chunk_control.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/loader/test__chunk_control.py
@@ -178,7 +178,9 @@ def test_no_chunks_from_file(tmp_filepath, save_cubelist_with_sigma):
 
 
 def test_as_dask(tmp_filepath, save_cubelist_with_sigma):
-    """This does not test return values, as we can't be sure
+    """Test as dask.
+
+    No return values, as we can't be sure
     dask chunking behaviour won't change, or that it will differ
     from our own chunking behaviour.
     """


### PR DESCRIPTION
## 🚀 Pull Request

### Description
PR solely for fixing `D404: First word of the docstring should not be "This"`

Continues work of https://github.com/SciTools/iris/issues/5625.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
