### PR TITLE
ruff compliance for D106.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -29,7 +29,7 @@ lint.ignore = [
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
     "D104",  # Missing docstring in public package
-    "D106",  # Missing docstring in public nested class
+    #"D106",  # Missing docstring in public nested class
     # (D-3) Temporary, before an initial review, either fix ocurrences or move to (2).
     "D100",  # Missing docstring in public module
     "D103",  # Missing docstring in public function

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -29,7 +29,6 @@ lint.ignore = [
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
     "D104",  # Missing docstring in public package
-    #"D106",  # Missing docstring in public nested class
     # (D-3) Temporary, before an initial review, either fix ocurrences or move to (2).
     "D100",  # Missing docstring in public module
     "D103",  # Missing docstring in public function

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -662,7 +662,11 @@ def load_cubes(file_sources, callback=None, constraints=None):
 
 
 class ChunkControl(threading.local):
+    """Provide user control of Chunk Control."""
+
     class Modes(Enum):
+        """Modes Enums."""
+
         DEFAULT = auto()
         FROM_FILE = auto()
         AS_DASK = auto()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
PR solely for fixing `D106: Missing docstring in public nested class`

Continues work of https://github.com/SciTools/iris/issues/5625.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
