### PR TITLE
Make further topics obviously different

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -291,7 +291,6 @@ html_sidebars = {
 html_theme_options = {
     "footer_start": ["copyright", "sphinx-version"],
     "footer_end": ["custom_footer"],
-    "collapse_navigation": True,
     "navigation_depth": 3,
     "show_prev_next": True,
     "navbar_align": "content",

--- a/docs/src/further_topics/index.rst
+++ b/docs/src/further_topics/index.rst
@@ -1,8 +1,8 @@
 .. _further_topics_index:
 
 
-➕ Further Topics
-=================
+Further Topics
+===============
 
 Extra information on specific technical issues.
 

--- a/docs/src/further_topics/index.rst
+++ b/docs/src/further_topics/index.rst
@@ -1,8 +1,8 @@
 .. _further_topics_index:
 
 
-Further Topics
-===============
+➕ Further Topics
+=================
 
 Extra information on specific technical issues.
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -142,6 +142,13 @@ This document explains the changes made to Iris for this release
 
 #. `@bouweandela`_ updated all hyperlinks to https. (:pull:`5621`)
 
+#. `@ESadek-MO`_ created an index page for :ref:`further_topics_index`, and
+   relocated all 'Technical Papers' into
+   :ref:`further_topics_index`. (:pull:`5602`)
+
+#. `@trexfeathers`_ made drop-down icons visible to show which pages link to
+   'sub-pages'. (:pull:`5684`)
+
 
 💼 Internal
 ===========


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

A very simple way to make it obvious in a TOC-tree that `Further Topics` is not just a page, but a subsection of its own.

I chose to edit the title itself, rather than an alias in the existing TOC-tree, so that this will also apply if included in other TOC-trees. I also kinda like the title being this way 😁

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
