### PR TITLE
Make the Coord.cell method lazy

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -100,6 +100,8 @@ This document explains the changes made to Iris for this release
    lazy data from file. This will also speed up coordinate comparison.
    (:pull:`5610`)
 
+#. `@bouweandela`_ changed :func:`iris.coords.Coord.cell` so it does not realize
+   all coordinate data and only loads a single cell instead. (:pull:`5693`)
 
 🔥 Deprecations
 ===============

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2092,7 +2092,7 @@ class Coord(_DimensionalMetadata):
         """
         index = iris.util._build_full_slice_given_keys(index, self.ndim)
 
-        point = tuple(np.array(self.points[index], ndmin=1).flatten())
+        point = tuple(np.array(self.core_points()[index], ndmin=1).flatten())
         if len(point) != 1:
             raise IndexError(
                 "The index %s did not uniquely identify a single "
@@ -2101,7 +2101,7 @@ class Coord(_DimensionalMetadata):
 
         bound = None
         if self.has_bounds():
-            bound = tuple(np.array(self.bounds[index], ndmin=1).flatten())
+            bound = tuple(np.array(self.core_bounds()[index], ndmin=1).flatten())
 
         if self.units.is_time_reference():
             point = self.units.num2date(point)

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -240,9 +240,12 @@ class Test_cell(tests.IrisTest):
         coord = mock.Mock(
             spec=Coord,
             ndim=1,
-            points=np.array([mock.sentinel.time]),
-            bounds=np.array([[mock.sentinel.lower, mock.sentinel.upper]]),
         )
+        coord.core_points = lambda: np.array([mock.sentinel.time])
+        coord.core_bounds = lambda: np.array(
+            [[mock.sentinel.lower, mock.sentinel.upper]]
+        )
+
         return coord
 
     def test_time_as_object(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This avoids loading all the coordinate data from disk if only a single cell is requested.

Closes #5692 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
