### PR TITLE
DOCS: add pin for pydata-sphinx-theme

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -291,7 +291,6 @@ html_sidebars = {
 html_theme_options = {
     "footer_start": ["copyright", "sphinx-version"],
     "footer_end": ["custom_footer"],
-    "collapse_navigation": True,
     "navigation_depth": 3,
     "show_prev_next": True,
     "navbar_align": "content",

--- a/docs/src/developers_guide/contributing_getting_involved.rst
+++ b/docs/src/developers_guide/contributing_getting_involved.rst
@@ -59,7 +59,5 @@ If you are new to using GitHub we recommend reading the
    :caption: Reference
    :hidden:
 
-   ../generated/api/iris
-   ../whatsnew/index
    ../copyright
    ../voted_issues

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -142,6 +142,13 @@ This document explains the changes made to Iris for this release
 
 #. `@bouweandela`_ updated all hyperlinks to https. (:pull:`5621`)
 
+#. `@ESadek-MO`_ created an index page for :ref:`further_topics_index`, and
+   relocated all 'Technical Papers' into
+   :ref:`further_topics_index`. (:pull:`5602`)
+
+#. `@trexfeathers`_ made drop-down icons visible to show which pages link to
+   'sub-pages'. (:pull:`5684`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -120,6 +120,9 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ enforced the minimum pin of ``numpy>1.22`` in accordance with the `NEP29 Drop Schedule`_.
    (:pull:`5668`)
 
+#. `@tkknight`_ enforced the temporary pin of ``pydata-sphinx-theme==0.14.4`` to fix
+   the missing toctree in the sidebar. (:pull:`5694`)
+
 
 📚 Documentation
 ================

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -24,7 +24,7 @@ This document explains the changes made to Iris for this release
 📢 Announcements
 ================
 
-#. `@lbdreyer`_ relicensed Iris from LGPL-3 to BSD-3. (:pull: `5577`)
+#. `@lbdreyer`_ relicensed Iris from LGPL-3 to BSD-3. (:pull:`5577`)
 
 #. `@HGWright`_, `@bjlittle`_ and `@trexfeathers`_ (reviewers) added a
    CITATION.cff file to Iris and updated the :ref:`citation documentation <Citing_Iris>`

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -47,13 +47,14 @@ dependencies:
   - requests
 
 # Documentation dependencies.
-  - sphinx <=5.3
+  - pydata-sphinx-theme == 0.14.4  # See https://github.com/SciTools/iris/issues/5698
+  - sphinx <=5.3                   # See https://github.com/SciTools/iris/issues/5123
   - sphinxcontrib-apidoc
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  - pydata-sphinx-theme >=0.13.0
 
-# Temporary minimum pins.
+# Temporary pins.
 # See https://github.com/SciTools/iris/pull/5051
   - graphviz >=6.0.0
+  

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -47,13 +47,14 @@ dependencies:
   - requests
 
 # Documentation dependencies.
-  - sphinx <=5.3
+  - pydata-sphinx-theme == 0.14.4  # See ??????
+  - sphinx <=5.3                   # See https://github.com/SciTools/iris/issues/5123
   - sphinxcontrib-apidoc
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  - pydata-sphinx-theme >=0.13.0
 
-# Temporary minimum pins.
+
+# Temporary pins.
 # See https://github.com/SciTools/iris/pull/5051
   - graphviz >=6.0.0

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -47,7 +47,7 @@ dependencies:
   - requests
 
 # Documentation dependencies.
-  - pydata-sphinx-theme == 0.14.4  # See ??????
+  - pydata-sphinx-theme == 0.14.4  # See https://github.com/SciTools/iris/issues/5698
   - sphinx <=5.3                   # See https://github.com/SciTools/iris/issues/5123
   - sphinxcontrib-apidoc
   - sphinx-copybutton

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -54,7 +54,7 @@ dependencies:
   - sphinx-gallery >=0.11.0
   - sphinx-design
 
-
 # Temporary pins.
 # See https://github.com/SciTools/iris/pull/5051
   - graphviz >=6.0.0
+  

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -46,13 +46,13 @@ dependencies:
   - requests
 
 # Documentation dependencies.
-  - sphinx <=5.3
+  - pydata-sphinx-theme == 0.14.4  # See https://github.com/SciTools/iris/issues/5698
+  - sphinx <=5.3                   # See https://github.com/SciTools/iris/issues/5123
   - sphinxcontrib-apidoc
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  - pydata-sphinx-theme >=0.13.0
 
-# Temporary minimum pins.
+# Temporary pins.
 # See https://github.com/SciTools/iris/pull/5051
   - graphviz >=6.0.0


### PR DESCRIPTION
## 🚀 Pull Request

### Description

* Add a pin for ``pydata-sphinx-theme`` to address #5686.
* Add links to issues/prs for the pins for easy reference
* Remove 2 links from the developers guide sidebar - this cause issues with it expanding the toc instead of going to the page direct.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
