### PR TITLE
Consider NaNs equal when comparing cubes

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,8 +91,10 @@ This document explains the changes made to Iris for this release
 💣 Incompatible Changes
 =======================
 
-#. `@bouweandela`_ updated cube comparison so cubes with data containing a
-   :obj:`numpy.nan` are now considered equal (:pull:`5713`)
+#. `@bouweandela`_ updated :class:`~iris.cube.Cube` comparison so equality is
+   now possible between cubes with data containing a :obj:`numpy.nan`.
+   e.g. ``Cube([np.nan, 1.0]) != Cube([np.nan, 2.0])``,
+   ``Cube([np.nan, 1.0]) == Cube([np.nan, 1.0])``. (:pull:`5713`)
 
 
 🚀 Performance Enhancements

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,7 +91,8 @@ This document explains the changes made to Iris for this release
 💣 Incompatible Changes
 =======================
 
-#. N/A
+#. `@bouweandela`_ updated cube comparison so cubes with data containing a
+   :obj:`numpy.nan` are now considered equal (:pull:`5713`)
 
 
 🚀 Performance Enhancements
@@ -112,6 +113,8 @@ This document explains the changes made to Iris for this release
    and also runs a little faster.  (:pull:`5638`)
 
 #. `@bouweandela`_ made comparing coordinates and arrays to themselves faster. (:pull:`5691`)
+
+#. `@bouweandela`_ made comparing cubes to themselves faster. (:pull:`5713`)
 
 
 🔥 Deprecations

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -91,10 +91,10 @@ This document explains the changes made to Iris for this release
 💣 Incompatible Changes
 =======================
 
-#. `@bouweandela`_ updated :class:`~iris.cube.Cube` comparison so equality is
-   now possible between cubes with data containing a :obj:`numpy.nan`.
-   e.g. ``Cube([np.nan, 1.0]) != Cube([np.nan, 2.0])``,
-   ``Cube([np.nan, 1.0]) == Cube([np.nan, 1.0])``. (:pull:`5713`)
+#. `@bouweandela`_ and  `@trexfeathers`_ (reviewer) updated :class:`~iris.cube.Cube`
+   comparison so equality is now possible between cubes with data containing a
+   :obj:`numpy.nan`. e.g. ``Cube([np.nan, 1.0]) == Cube([np.nan, 1.0])`` will now
+   evaluate to :obj:`True`, while previously this would have been :obj:`False`. (:pull:`5713`)
 
 
 🚀 Performance Enhancements
@@ -116,7 +116,8 @@ This document explains the changes made to Iris for this release
 
 #. `@bouweandela`_ made comparing coordinates and arrays to themselves faster. (:pull:`5691`)
 
-#. `@bouweandela`_ made comparing cubes to themselves faster. (:pull:`5713`)
+#. `@bouweandela`_ and  `@trexfeathers`_ (reviewer) made comparing cubes to
+   themselves faster. (:pull:`5713`)
 
 
 🔥 Deprecations

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3865,11 +3865,13 @@ class Cube(CFVariableMixin):
             if result:
                 # TODO: why do we use allclose() here, but strict equality in
                 #  _DimensionalMetadata (via util.array_equal())?
-                result = da.allclose(
-                    self.core_data(),
-                    other.core_data(),
-                    equal_nan=True,
-                ).compute()
+                result = bool(
+                    np.allclose(
+                        self.core_data(),
+                        other.core_data(),
+                        equal_nan=True,
+                    )
+                )
         return result
 
     # Must supply __ne__, Python does not defer to __eq__ for negative equality

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3824,6 +3824,9 @@ class Cube(CFVariableMixin):
 
     # START OPERATOR OVERLOADS
     def __eq__(self, other):
+        if other is self:
+            return True
+
         result = NotImplemented
 
         if isinstance(other, Cube):
@@ -3862,7 +3865,11 @@ class Cube(CFVariableMixin):
             if result:
                 # TODO: why do we use allclose() here, but strict equality in
                 #  _DimensionalMetadata (via util.array_equal())?
-                result = da.allclose(self.core_data(), other.core_data()).compute()
+                result = da.allclose(
+                    self.core_data(),
+                    other.core_data(),
+                    equal_nan=True,
+                ).compute()
         return result
 
     # Must supply __ne__, Python does not defer to __eq__ for negative equality

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -2841,9 +2841,18 @@ class Test_convert_units(tests.IrisTest):
 class Test__eq__data(tests.IrisTest):
     """Partial cube equality testing, for data type only."""
 
+    def test_cube_identical_to_itself(self):
+        cube = Cube([1.0])
+        self.assertTrue(cube == cube)
+
     def test_data_float_eq(self):
         cube1 = Cube([1.0])
         cube2 = Cube([1.0])
+        self.assertTrue(cube1 == cube2)
+
+    def test_data_float_nan_eq(self):
+        cube1 = Cube([np.nan, 1.0])
+        cube2 = Cube([np.nan, 1.0])
         self.assertTrue(cube1 == cube2)
 
     def test_data_float_eqtol(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Consider NaNs equal when comparing cubes and speed up comparing cubes to themselves.

Closes  #5705

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
