### PR TITLE
Add support for Geostationary coord_system

### DIFF
--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -825,7 +825,7 @@ class RectilinearRegridder:
         return data
 
     def _check_units(self, coord):
-        from iris.coord_systems import GeogCS, RotatedGeogCS
+        from iris.coord_systems import GeogCS, RotatedGeogCS, Geostationary
 
         if coord.coord_system is None:
             # No restriction on units.
@@ -840,6 +840,16 @@ class RectilinearRegridder:
                 msg = (
                     "Unsupported units for coordinate system. "
                     "Expected 'degrees' got {!r}.".format(coord.units)
+                )
+                raise ValueError(msg)
+        elif isinstance(
+            coord.coord_system,
+            Geostationary,
+        ):
+            if coord.units != "radians":
+                msg = (
+                    "Unsupported units for coordinate system. "
+                    "Expected 'radians' got {!r}.".format(coord.units)
                 )
                 raise ValueError(msg)
         else:

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -825,7 +825,7 @@ class RectilinearRegridder:
         return data
 
     def _check_units(self, coord):
-        from iris.coord_systems import GeogCS, RotatedGeogCS, Geostationary
+        from iris.coord_systems import GeogCS, Geostationary, RotatedGeogCS
 
         if coord.coord_system is None:
             # No restriction on units.

--- a/lib/iris/fileformats/_nc_load_rules/actions.py
+++ b/lib/iris/fileformats/_nc_load_rules/actions.py
@@ -235,6 +235,10 @@ def action_provides_coordinate(engine, dimcoord_fact):
         coord_type = "projection_x"
     elif hh.is_projection_y_coordinate(engine, var_name):
         coord_type = "projection_y"
+    elif hh.is_projection_x_angular_coordinate(engine, var_name):
+        coord_type = "projection_x_angular"
+    elif hh.is_projection_y_angular_coordinate(engine, var_name):
+        coord_type = "projection_y_angular"
 
     if coord_type is None:
         # Not identified as a specific known coord_type.
@@ -274,6 +278,8 @@ _COORDTYPE_GRIDTYPES_AND_COORDNAMES = {
     ),
     "projection_x": ("projected", hh.CF_VALUE_STD_NAME_PROJ_X),
     "projection_y": ("projected", hh.CF_VALUE_STD_NAME_PROJ_Y),
+    "projection_x_angular": ("projected", hh.CF_VALUE_STD_NAME_PROJ_X_ANGULAR),
+    "projection_y_angular": ("projected", hh.CF_VALUE_STD_NAME_PROJ_Y_ANGULAR),
     "time": (None, None),
     "time_period": (None, None),
     "miscellaneous": (None, None),

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -183,6 +183,8 @@ CF_VALUE_STD_NAME_GRID_LAT = "grid_latitude"
 CF_VALUE_STD_NAME_GRID_LON = "grid_longitude"
 CF_VALUE_STD_NAME_PROJ_X = "projection_x_coordinate"
 CF_VALUE_STD_NAME_PROJ_Y = "projection_y_coordinate"
+CF_VALUE_STD_NAME_PROJ_X_ANGULAR = "projection_x_angular_coordinate"
+CF_VALUE_STD_NAME_PROJ_Y_ANGULAR = "projection_y_angular_coordinate"
 
 
 ################################################################################
@@ -1414,6 +1416,16 @@ def is_projection_x_coordinate(engine, cf_name):
 
 
 ################################################################################
+def is_projection_x_angular_coordinate(engine, cf_name):
+    """Determine whether the CF coordinate variable is a projection_x_angular_coordinate variable."""
+    cf_var = engine.cf_var.cf_group[cf_name]
+    attr_name = getattr(cf_var, CF_ATTR_STD_NAME, None) or getattr(
+        cf_var, CF_ATTR_LONG_NAME, None
+    )
+    return attr_name == CF_VALUE_STD_NAME_PROJ_X_ANGULAR
+
+
+################################################################################
 def is_projection_y_coordinate(engine, cf_name):
     """Determine whether the CF coordinate variable is a projection_y_coordinate variable."""
     cf_var = engine.cf_var.cf_group[cf_name]
@@ -1421,6 +1433,16 @@ def is_projection_y_coordinate(engine, cf_name):
         cf_var, CF_ATTR_LONG_NAME, None
     )
     return attr_name == CF_VALUE_STD_NAME_PROJ_Y
+
+
+################################################################################
+def is_projection_y_angular_coordinate(engine, cf_name):
+    """Determine whether the CF coordinate variable is a projection_y_angular_coordinate variable."""
+    cf_var = engine.cf_var.cf_group[cf_name]
+    attr_name = getattr(cf_var, CF_ATTR_STD_NAME, None) or getattr(
+        cf_var, CF_ATTR_LONG_NAME, None
+    )
+    return attr_name == CF_VALUE_STD_NAME_PROJ_Y_ANGULAR
 
 
 ################################################################################

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -219,6 +219,7 @@ def _can_draw_map(coords):
         ["latitude", "longitude"],
         ["grid_latitude", "grid_longitude"],
         ["projection_y_coordinate", "projection_x_coordinate"],
+        ["projection_y_angular_coordinate", "projection_x_angular_coordinate"],
     ]
     return std_names in valid_std_names
 
@@ -797,6 +798,8 @@ def _draw_1d_from_points(draw_method_name, arg_func, *args, **kwargs):
         if draw_method_name == "plot" and u_object.standard_name not in (
             "projection_x_coordinate",
             "projection_y_coordinate",
+            "projection_x_angular_coordinate",
+            "projection_y_angular_coordinate",
         ):
             u = _shift_plot_sections(u_object, u, v)
 

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -262,12 +262,14 @@ def guess_coord_axis(coord):
         "longitude",
         "grid_longitude",
         "projection_x_coordinate",
+        "projection_x_angular_coordinate",
     ):
         axis = "X"
     elif coord.standard_name in (
         "latitude",
         "grid_latitude",
         "projection_y_coordinate",
+        "projection_y_angular_coordinate",
     ):
         axis = "Y"
     elif coord.units.is_convertible("hPa") or coord.attributes.get("positive") in (


### PR DESCRIPTION
Closes #5485 

Supports the cannonical coordinates of the Geostationary coord system (`projection_x_angular_coordinate`, `projection_y_angular_coordinate`) and their cannonical unit (radians).