### PR TITLE
Normalise units of coordinate bounds

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -93,6 +93,10 @@ This document explains the changes made to Iris for this release
    :mod:`iris.fileformats._nc_load_rules.helpers` to lessen warning duplication.
    (:issue:`5536`, :pull:`5685`)
 
+#. `@bjlittle`_ fixed coordinate construction in the NetCDF loading pipeline to
+   ensure that bounds have the same units as the associated points.
+   (:issue:`1801`, :pull:`5746`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -1042,7 +1042,7 @@ def _normalise_bounds_units(
     If the bounds units are not convertible, a warning will be issued and
     the `bounds_data` will be ignored.
 
-    Bounds with invalid units will be gracefully left unconverted.
+    Bounds with invalid units will be gracefully left unconverted and passed through.
 
     Parameters
     ----------
@@ -1072,7 +1072,7 @@ def _normalise_bounds_units(
             else:
                 wmsg = (
                     f"Ignoring bounds on NetCDF variable {cf_bounds_var.cf_name!r}. "
-                    f"Expected {points_units.origin!r} units, got "
+                    f"Expected units compatible with {points_units.origin!r}, got "
                     f"{bounds_units.origin!r}."
                 )
                 warnings.warn(

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -904,8 +904,9 @@ def get_attr_units(cf_var, attributes):
         cf_units.as_unit(attr_units)
     except ValueError:
         # Using converted unicode message. Can be reverted with Python 3.
-        msg = "Ignoring netCDF variable {!r} invalid units {!r}".format(
-            cf_var.cf_name, attr_units
+        msg = (
+            f"Ignoring invalid units {attr_units!r} on netCDF variable "
+            f"{cf_var.cf_name!r}."
         )
         warnings.warn(
             msg,

--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -13,8 +13,10 @@ acquired an extra initial 'engine' argument, purely for consistency with other
 build routines, and which it does not use.
 
 """
+from __future__ import annotations
+
 import re
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 import warnings
 
 import cf_units
@@ -34,6 +36,12 @@ import iris.fileformats.netcdf
 from iris.fileformats.netcdf.loader import _get_cf_var_data
 import iris.std_names
 import iris.util
+
+if TYPE_CHECKING:
+    from numpy.ma import MaskedArray
+    from numpy.typing import ArrayLike
+
+    from iris.fileformats.cf import CFBoundaryVariable
 
 # TODO: should un-addable coords / cell measures / etcetera be skipped? iris#5068.
 
@@ -1025,6 +1033,57 @@ def reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var):
 
 
 ################################################################################
+def _normalise_bounds_units(
+    points_units: str, cf_bounds_var: CFBoundaryVariable, bounds_data: ArrayLike
+) -> Optional[MaskedArray]:
+    """Ensure bounds have units compatible with points.
+
+    If required, the `bounds_data` will be converted to the `points_units`.
+    If the bounds units are not convertible, a warning will be issued and
+    the `bounds_data` will be ignored.
+
+    Bounds with invalid units will be gracefully left unconverted.
+
+    Parameters
+    ----------
+    points_units : str
+        The units of the coordinate points.
+    cf_bounds_var : CFBoundaryVariable
+        The serialized NetCDF bounds variable.
+    bounds_data : MaskedArray
+        The pre-processed data of the bounds variable.
+
+    Returns
+    -------
+    MaskedArray or None
+        The bounds data with the same units as the points, or ``None``
+        if the bounds units are not convertible to the points units.
+
+    """
+    bounds_units = get_attr_units(cf_bounds_var, {})
+
+    if bounds_units != UNKNOWN_UNIT_STRING:
+        points_units = cf_units.Unit(points_units)
+        bounds_units = cf_units.Unit(bounds_units)
+
+        if bounds_units != points_units:
+            if bounds_units.is_convertible(points_units):
+                bounds_data = bounds_units.convert(bounds_data, points_units)
+            else:
+                wmsg = (
+                    f"Ignoring bounds on NetCDF variable {cf_bounds_var.cf_name!r}. "
+                    f"Expected {points_units.origin!r} units, got "
+                    f"{bounds_units.origin!r}."
+                )
+                warnings.warn(
+                    wmsg, category=iris.exceptions.IrisCfLoadWarning, stacklevel=2
+                )
+                bounds_data = None
+
+    return bounds_data
+
+
+################################################################################
 def build_dimension_coordinate(
     engine, cf_coord_var, coord_name=None, coord_system=None
 ):
@@ -1061,6 +1120,8 @@ def build_dimension_coordinate(
         # dimension names.
         if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
             bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
+
+        bounds_data = _normalise_bounds_units(attr_units, cf_bounds_var, bounds_data)
     else:
         bounds_data = None
 
@@ -1186,6 +1247,8 @@ def build_auxiliary_coordinate(
             # compatibility with array creators (i.e. dask)
             bounds_data = np.asarray(bounds_data)
             bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var, cf_coord_var)
+
+        bounds_data = _normalise_bounds_units(attr_units, cf_bounds_var, bounds_data)
     else:
         bounds_data = None
 

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test__normalise_bounds_units.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test__normalise_bounds_units.py
@@ -62,7 +62,7 @@ def test_invalid_units__pass_through() -> None:
     """Test bounds variable with invalid units."""
     units = "invalid"
     cf_bounds_var = _make_cf_bounds_var(units=units)
-    wmsg = f"Ignoring netCDF variable {CF_NAME!r} invalid units {units!r}"
+    wmsg = f"Ignoring invalid units {units!r} on netCDF variable {CF_NAME!r}"
     with pytest.warns(_WarnComboIgnoringCfLoad, match=wmsg):
         result = _normalise_bounds_units(None, cf_bounds_var, BOUNDS)
     assert result == BOUNDS

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test__normalise_bounds_units.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test__normalise_bounds_units.py
@@ -1,0 +1,102 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Test function :func:`iris.fileformats._nc_load_rules.helpers._normalise_bounds_units`."""
+
+# import iris tests first so that some things can be initialised before
+# importing anything else
+from typing import Optional
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from iris.exceptions import IrisCfLoadWarning
+from iris.fileformats._nc_load_rules.helpers import (
+    _normalise_bounds_units,
+    _WarnComboIgnoringCfLoad,
+)
+
+BOUNDS = mock.sentinel.bounds
+CF_NAME = "dummy_bnds"
+
+
+def _make_cf_bounds_var(
+    units: Optional[str] = None,
+    unitless: bool = False,
+) -> mock.MagicMock:
+    """Construct a mock CF bounds variable."""
+    if units is None:
+        units = "days since 1970-01-01"
+
+    cf_data = mock.Mock(spec=[])
+    # we want to mock the absence of flag attributes to helpers.get_attr_units
+    # see https://docs.python.org/3/library/unittest.mock.html#deleting-attributes
+    del cf_data.flag_values
+    del cf_data.flag_masks
+    del cf_data.flag_meanings
+
+    cf_var = mock.MagicMock(
+        cf_name=CF_NAME,
+        cf_data=cf_data,
+        units=units,
+        calendar=None,
+        dtype=float,
+    )
+
+    if unitless:
+        del cf_var.units
+
+    return cf_var
+
+
+def test_unitless() -> None:
+    """Test bounds variable with no units."""
+    cf_bounds_var = _make_cf_bounds_var(unitless=True)
+    result = _normalise_bounds_units(None, cf_bounds_var, BOUNDS)
+    assert result == BOUNDS
+
+
+def test_invalid_units__pass_through() -> None:
+    """Test bounds variable with invalid units."""
+    units = "invalid"
+    cf_bounds_var = _make_cf_bounds_var(units=units)
+    wmsg = f"Ignoring netCDF variable {CF_NAME!r} invalid units {units!r}"
+    with pytest.warns(_WarnComboIgnoringCfLoad, match=wmsg):
+        result = _normalise_bounds_units(None, cf_bounds_var, BOUNDS)
+    assert result == BOUNDS
+
+
+@pytest.mark.parametrize("units", ["unknown", "no_unit", "1", "kelvin"])
+def test_ignore_bounds(units) -> None:
+    """Test bounds variable with incompatible units compared to points."""
+    points_units = "km"
+    cf_bounds_var = _make_cf_bounds_var(units=units)
+    wmsg = (
+        f"Ignoring bounds on NetCDF variable {CF_NAME!r}. "
+        f"Expected units compatible with {points_units!r}"
+    )
+    with pytest.warns(IrisCfLoadWarning, match=wmsg):
+        result = _normalise_bounds_units(points_units, cf_bounds_var, BOUNDS)
+    assert result is None
+
+
+def test_compatible() -> None:
+    """Test bounds variable with compatible units requiring conversion."""
+    points_units, bounds_units = "days since 1970-01-01", "hours since 1970-01-01"
+    cf_bounds_var = _make_cf_bounds_var(units=bounds_units)
+    bounds = np.arange(10, dtype=float) * 24
+    result = _normalise_bounds_units(points_units, cf_bounds_var, bounds)
+    expected = bounds / 24
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_same_units() -> None:
+    """Test bounds variable with same units as points."""
+    units = "days since 1970-01-01"
+    cf_bounds_var = _make_cf_bounds_var(units=units)
+    bounds = np.arange(10, dtype=float)
+    result = _normalise_bounds_units(units, cf_bounds_var, bounds)
+    np.testing.assert_array_equal(result, bounds)
+    assert result is bounds

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_auxiliary_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_auxiliary_coordinate.py
@@ -232,6 +232,7 @@ class TestCoordConstruction(tests.IrisTest):
         )
 
         points = np.arange(6)
+        units = "days since 1970-01-01"
         self.cf_coord_var = mock.Mock(
             spec=threadsafe_nc.VariableWrapper,
             dimensions=("foo",),
@@ -241,7 +242,7 @@ class TestCoordConstruction(tests.IrisTest):
             cf_data=mock.MagicMock(chunking=mock.Mock(return_value=None), spec=[]),
             standard_name=None,
             long_name="wibble",
-            units="days since 1970-01-01",
+            units=units,
             calendar=None,
             shape=points.shape,
             size=np.prod(points.shape),
@@ -250,13 +251,20 @@ class TestCoordConstruction(tests.IrisTest):
         )
 
         bounds = np.arange(12).reshape(6, 2)
+        cf_data = mock.MagicMock(chunking=mock.Mock(return_value=None))
+        # we want to mock the absence of flag attributes to helpers.get_attr_units
+        # see https://docs.python.org/3/library/unittest.mock.html#deleting-attributes
+        del cf_data.flag_values
+        del cf_data.flag_masks
+        del cf_data.flag_meanings
         self.cf_bounds_var = mock.Mock(
             spec=threadsafe_nc.VariableWrapper,
             dimensions=("x", "nv"),
             scale_factor=1,
             add_offset=0,
             cf_name="wibble_bnds",
-            cf_data=mock.MagicMock(chunking=mock.Mock(return_value=None)),
+            cf_data=cf_data,
+            units=units,
             shape=bounds.shape,
             size=np.prod(bounds.shape),
             dtype=bounds.dtype,

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_dimension_coordinate.py
@@ -293,22 +293,22 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             standard_name=None,
             long_name="wibble",
             cf_data=mock.Mock(spec=[]),
-            units="m",
+            units="km",
             shape=points.shape,
             dtype=points.dtype,
             __getitem__=lambda self, key: points[key],
         )
 
-    def test_slowest_varying_vertex_dim(self):
+    def test_slowest_varying_vertex_dim__normalise_bounds(self):
         # Create the bounds cf variable.
-        bounds = np.arange(12).reshape(2, 6)
+        bounds = np.arange(12).reshape(2, 6) * 1000
         dimensions = ("nv", "foo")
         units = "m"
         self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
         # Expected bounds on the resulting coordinate should be rolled so that
         # the vertex dimension is at the end.
-        expected_bounds = bounds.transpose()
+        expected_bounds = bounds.transpose() / 1000
         expected_coord = DimCoord(
             self.cf_coord_var[:],
             long_name=self.cf_coord_var.long_name,
@@ -328,8 +328,8 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
             self.assertEqual(self.engine.cube_parts["coordinates"], expected_list)
 
-    def test_fastest_varying_vertex_dim(self):
-        bounds = np.arange(12).reshape(6, 2)
+    def test_fastest_varying_vertex_dim__normalise_bounds(self):
+        bounds = np.arange(12).reshape(6, 2) * 1000
         dimensions = ("foo", "nv")
         units = "m"
         self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
@@ -339,7 +339,7 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             long_name=self.cf_coord_var.long_name,
             var_name=self.cf_coord_var.cf_name,
             units=self.cf_coord_var.units,
-            bounds=bounds,
+            bounds=bounds / 1000,
         )
 
         # Asserts must lie within context manager because of deferred loading.
@@ -353,11 +353,11 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             expected_list = [(expected_coord, self.cf_coord_var.cf_name)]
             self.assertEqual(self.engine.cube_parts["coordinates"], expected_list)
 
-    def test_fastest_with_different_dim_names(self):
+    def test_fastest_with_different_dim_names__normalise_bounds(self):
         # Despite the dimension names 'x' differing from the coord's
         # which is 'foo' (as permitted by the cf spec),
         # this should still work because the vertex dim is the fastest varying.
-        bounds = np.arange(12).reshape(6, 2)
+        bounds = np.arange(12).reshape(6, 2) * 1000
         dimensions = ("x", "nv")
         units = "m"
         self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
@@ -367,7 +367,7 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
             long_name=self.cf_coord_var.long_name,
             var_name=self.cf_coord_var.cf_name,
             units=self.cf_coord_var.units,
-            bounds=bounds,
+            bounds=bounds / 1000,
         )
 
         # Asserts must lie within context manager because of deferred loading.

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_dimension_coordinate.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/helpers/test_build_dimension_coordinate.py
@@ -22,6 +22,26 @@ from iris.exceptions import CannotAddError
 from iris.fileformats._nc_load_rules.helpers import build_dimension_coordinate
 
 
+def _make_bounds_var(bounds, dimensions, units):
+    bounds = np.array(bounds)
+    cf_data = mock.Mock(spec=[])
+    # we want to mock the absence of flag attributes to helpers.get_attr_units
+    # see https://docs.python.org/3/library/unittest.mock.html#deleting-attributes
+    del cf_data.flag_values
+    del cf_data.flag_masks
+    del cf_data.flag_meanings
+    return mock.Mock(
+        dimensions=dimensions,
+        cf_name="wibble_bnds",
+        cf_data=cf_data,
+        units=units,
+        calendar=None,
+        shape=bounds.shape,
+        dtype=bounds.dtype,
+        __getitem__=lambda self, key: bounds[key],
+    )
+
+
 class RulesTestMixin:
     def setUp(self):
         # Create dummy pyke engine.
@@ -65,12 +85,9 @@ class TestCoordConstruction(tests.IrisTest, RulesTestMixin):
         RulesTestMixin.setUp(self)
 
         bounds = np.arange(12).reshape(6, 2)
-        self.cf_bounds_var = mock.Mock(
-            dimensions=("x", "nv"),
-            cf_name="wibble_bnds",
-            shape=bounds.shape,
-            __getitem__=lambda self, key: bounds[key],
-        )
+        dimensions = ("x", "nv")
+        units = "days since 1970-01-01"
+        self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
         self.bounds = bounds
 
         # test_dimcoord_not_added() and test_auxcoord_not_added have been
@@ -285,12 +302,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
     def test_slowest_varying_vertex_dim(self):
         # Create the bounds cf variable.
         bounds = np.arange(12).reshape(2, 6)
-        self.cf_bounds_var = mock.Mock(
-            dimensions=("nv", "foo"),
-            cf_name="wibble_bnds",
-            shape=bounds.shape,
-            __getitem__=lambda self, key: bounds[key],
-        )
+        dimensions = ("nv", "foo")
+        units = "m"
+        self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
         # Expected bounds on the resulting coordinate should be rolled so that
         # the vertex dimension is at the end.
@@ -316,12 +330,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
 
     def test_fastest_varying_vertex_dim(self):
         bounds = np.arange(12).reshape(6, 2)
-        self.cf_bounds_var = mock.Mock(
-            dimensions=("foo", "nv"),
-            cf_name="wibble_bnds",
-            shape=bounds.shape,
-            __getitem__=lambda self, key: bounds[key],
-        )
+        dimensions = ("foo", "nv")
+        units = "m"
+        self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
         expected_coord = DimCoord(
             self.cf_coord_var[:],
@@ -347,12 +358,9 @@ class TestBoundsVertexDim(tests.IrisTest, RulesTestMixin):
         # which is 'foo' (as permitted by the cf spec),
         # this should still work because the vertex dim is the fastest varying.
         bounds = np.arange(12).reshape(6, 2)
-        self.cf_bounds_var = mock.Mock(
-            dimensions=("x", "nv"),
-            cf_name="wibble_bnds",
-            shape=bounds.shape,
-            __getitem__=lambda self, key: bounds[key],
-        )
+        dimensions = ("x", "nv")
+        units = "m"
+        self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
         expected_coord = DimCoord(
             self.cf_coord_var[:],
@@ -396,12 +404,8 @@ class TestCircular(tests.IrisTest, RulesTestMixin):
         )
         if bounds:
             bounds = np.array(bounds).reshape(self.cf_coord_var.shape + (2,))
-            self.cf_bounds_var = mock.Mock(
-                dimensions=("x", "nv"),
-                cf_name="wibble_bnds",
-                shape=bounds.shape,
-                __getitem__=lambda self, key: bounds[key],
-            )
+            dimensions = ("x", "nv")
+            self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
     def _check_circular(self, circular, *args, **kwargs):
         if "coord_name" in kwargs:
@@ -483,12 +487,13 @@ class TestCircularScalar(tests.IrisTest, RulesTestMixin):
         # Note that for a scalar the shape of the array from
         # the cf var is (), rather than (1,).
         points = np.array([0.0])
+        units = "degrees"
         self.cf_coord_var = mock.Mock(
             dimensions=(),
             cf_name="wibble",
             standard_name=None,
             long_name="wibble",
-            units="degrees",
+            units=units,
             cf_data=mock.Mock(spec=[]),
             shape=(),
             dtype=points.dtype,
@@ -496,12 +501,8 @@ class TestCircularScalar(tests.IrisTest, RulesTestMixin):
         )
 
         bounds = np.array(bounds)
-        self.cf_bounds_var = mock.Mock(
-            dimensions=("bnds"),
-            cf_name="wibble_bnds",
-            shape=bounds.shape,
-            __getitem__=lambda self, key: bounds[key],
-        )
+        dimensions = ("bnds",)
+        self.cf_bounds_var = _make_bounds_var(bounds, dimensions, units)
 
     def _assert_circular(self, value):
         with self.deferred_load_patch, self.get_cf_bounds_var_patch:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull request ensures that during the NetCDF loading pipeline, coordinates are constructed with points and bounds equal to the units of the points.

This is to resolve the issue where coordinates can be constructed and attached to a cube, but the units of the points and bounds of the coordinate are encoded differently within the source NetCDF file.

The following cases are handled:

1. Bounds that have invalid units i.e., not recognised by `cf-units`, will result in a warning being raised and the bounds attached "as-is" to the coordinate. This provides the user to option to keep, remove or replace the bounds as they choose.
1. Bounds with units that are different but convertible to the units of the points will be automatically converted to the units of the points.
1. Bounds with units that are different and not convertible to the units of the points will result in a warning being raised and the bounds being ignored i.e., not attached to the coordinate.
1. Bounds with no associated NetCDF metadata specifying their units will be assumed to have the same units of the points i.e., they will be attached to the coordinate "as-is".

Note that, the `test_build_auxiliary_coordinate.TestBoundsVertexDim` and `test_build_dimension_coordinate.TestBoundsVertexDim`  tests have been extended to include test coverage of converting bounds to the units of the points, [2] above. This is to avoid heavy replication of boiler-plate mocking infrastructure.

TODO:
 - [x] Add `whatsnew` entry.

Finally, this one's for you @andreas-h.

Closes #1801 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
