### PR TITLE
Disable navigation with keys for docs HTML theme

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -300,6 +300,7 @@ html_theme_options = {
     "footer_start": ["copyright", "sphinx-version"],
     "footer_end": ["custom_footer"],
     "navigation_depth": 3,
+    "navigation_with_keys": False,
     "show_toc_level": 2,
     "show_prev_next": True,
     "navbar_align": "content",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request avoids the following diagnostic issued by `pydata-sphinx-theme`:

```
The default value for `navigation_with_keys` will change to `False` in the next release.
If you wish to preserve the old behavior for your site, set `navigation_with_keys=True`
in the `html_theme_options` dict in your `conf.py` file. Be aware that `navigation_with_keys = True`
has negative accessibility implications: https://github.com/pydata/pydata-sphinx-theme/issues/1492
```

Reference:
- `pydata-sphinx-theme` [issue #1492](https://github.com/pydata/pydata-sphinx-theme/issues/1492)
- `sphinx` [HTML Theming](https://www.sphinx-doc.org/en/master/usage/theming.html).

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
