### PR TITLE
Add an auto-labeller to always benchmark lock file changes.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+# Make sure any dependency changes are benchmarked (only changes to the locks
+#  make a material difference - changes to the Conda YAML files are not
+#  benchmarked).
+benchmark_this:
+- changed-files:
+  - any-glob-to-any-file: 'requirements/locks/*.lock'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+# Reference
+#   - https://github.com/actions/labeler
+
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Dependency changes are the most common cause of performance regressions, but we often forget to benchmark these changes so things get missed.

#### To do

- [ ] What's New entry, once 3.8 has been cut.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
