### PR TITLE
DOC: clarify save_pairs_from_cube docstring

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -42,7 +42,10 @@ This document explains the changes made to Iris for this release
 💣 Incompatible Changes
 =======================
 
-#. N/A
+#. `@rcomer`_ removed the *target* parameter from
+   :func:`~iris.fileformats.pp.as_fields` and
+   :func:`~iris.fileformats.pp.save_pairs_from_cube` because it had no effect.
+   (:pull:`5783`)
 
 
 🚀 Performance Enhancements

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2177,11 +2177,11 @@ def save(cube, target, append=False, field_coords=None):
     of cubes to be saved to a PP file.
 
     """
-    fields = as_fields(cube, field_coords, target)
+    fields = as_fields(cube, field_coords)
     save_fields(fields, target, append=append)
 
 
-def save_pairs_from_cube(cube, field_coords=None, target=None):
+def save_pairs_from_cube(cube, field_coords=None):
     """Use the PP saving rules to generate (2D cube, PP field) pairs from a cube.
 
     Parameters
@@ -2193,8 +2193,6 @@ def save_pairs_from_cube(cube, field_coords=None, target=None):
         reducing the given cube into 2d slices, which will ultimately
         determine the x and y coordinates of the resulting fields.
         If None, the final two  dimensions are chosen for slicing.
-    target : optional
-        A filename or open file handle.
 
     Yields
     ------
@@ -2300,7 +2298,7 @@ def save_pairs_from_cube(cube, field_coords=None, target=None):
         yield (slice2D, pp_field)
 
 
-def as_fields(cube, field_coords=None, target=None):
+def as_fields(cube, field_coords=None):
     """Use the PP saving rules to convert a cube to an iterable of PP fields.
 
     Use the PP saving rules (and any user rules) to convert a cube to
@@ -2314,16 +2312,9 @@ def as_fields(cube, field_coords=None, target=None):
         reducing the given cube into 2d slices, which will ultimately
         determine the x and y coordinates of the resulting fields.
         If None, the final two  dimensions are chosen for slicing.
-    target : optional
-        A filename or open file handle.
 
     """
-    return (
-        field
-        for cube, field in save_pairs_from_cube(
-            cube, field_coords=field_coords, target=target
-        )
-    )
+    return (field for _, field in save_pairs_from_cube(cube, field_coords=field_coords))
 
 
 def save_fields(fields, target, append: bool = False):

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2182,10 +2182,7 @@ def save(cube, target, append=False, field_coords=None):
 
 
 def save_pairs_from_cube(cube, field_coords=None, target=None):
-    """Use the PP saving rules to convert a cube.
-
-    Use the PP saving rules to convert a cube or
-    iterable of cubes to an iterable of (2D cube, PP field) pairs.
+    """Use the PP saving rules to generate (2D cube, PP field) pairs from a cube.
 
     Parameters
     ----------
@@ -2198,6 +2195,11 @@ def save_pairs_from_cube(cube, field_coords=None, target=None):
         If None, the final two  dimensions are chosen for slicing.
     target : optional
         A filename or open file handle.
+
+    Yields
+    ------
+    :class:`iris.cube.Cube`, :class:`iris.fileformats.pp.PPField`.
+        A 2-dimensional slice of the input cube together with its associated pp-field.
 
     """
     # Open issues

--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2199,7 +2199,7 @@ def save_pairs_from_cube(cube, field_coords=None, target=None):
     Yields
     ------
     :class:`iris.cube.Cube`, :class:`iris.fileformats.pp.PPField`.
-        A 2-dimensional slice of the input cube together with its associated pp-field.
+        2-dimensional slices of the input cube together with their associated pp-fields.
 
     """
     # Open issues


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
I'm glad this function exists publicly as it was the solution to my problem today but I found the docstring confusing: because it said it could convert an iterable of cubes, I tried passing a cubelist, which failed because cubelists have no `shape` attribute.

I also note that the `target` parameter does not appear to be used for anything, but I don't think I want to pull on that thread right now...

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
