### PR TITLE
Add pytest-mock dependency

### DIFF
--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -43,6 +43,7 @@ dependencies:
   - psutil
   - pytest
   - pytest-cov
+  - pytest-mock
   - pytest-xdist
   - requests
 

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -43,6 +43,7 @@ dependencies:
   - psutil
   - pytest
   - pytest-cov
+  - pytest-mock
   - pytest-xdist
   - requests
 

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -42,6 +42,7 @@ dependencies:
   - pre-commit
   - psutil
   - pytest
+  - pytest-mock
   - pytest-xdist
   - requests
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds the [pytest-mock](https://github.com/pytest-dev/pytest-mock) package dependency to the conda YAML spec files.

It is not necessary to include this dependency for `pip`, as only `scitools-iris` core dependencies require to be configured.

When this pull-request is merged, the follow-up action is to refresh the lockfiles for the targeted `FEATURE_pytest_conversion` feature branch.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
