### PR TITLE
Configure pytest-mock as pytest required-plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ version_scheme = "release-branch-semver"
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+required_plugins = "pytest-mock"
 testpaths = "lib/iris"
 
 [tool.coverage.run]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request configures the `pytest-mock` plugin for `pytest`, thus making the `mocker` fixture available.

See https://pytest-mock.readthedocs.io/en/latest/ for further details.

Note that, through the `mocker` fixture, we have access to vanilla `mock` module as we know and (un-)love.

![image](https://github.com/SciTools/iris/assets/2051656/1e3a8a45-a0b1-4d68-8105-12e55747f629)


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
