### PR TITLE
pytest migration ruff PT compliance for unit.concatenate

### DIFF
--- a/lib/iris/tests/unit/concatenate/test__CubeSignature.py
+++ b/lib/iris/tests/unit/concatenate/test__CubeSignature.py
@@ -19,7 +19,7 @@ from iris.util import new_axis
 
 
 class Test__coordinate_dim_metadata_equality:
-    @pytest.fixture
+    @pytest.fixture()
     def sample_data(self):
         # Return a standard set of test items, wrapped in a data object
         @dataclass

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -17,7 +17,7 @@ from iris.exceptions import ConcatenateError
 
 
 class TestEpoch:
-    @pytest.fixture
+    @pytest.fixture()
     def simple_1d_time_cubes(self):
         reftimes = [
             "hours since 1970-01-01 00:00:00",
@@ -49,7 +49,7 @@ class TestEpoch:
 
 
 class TestMessages:
-    @pytest.fixture
+    @pytest.fixture()
     def sample_cubes(self):
         # Construct and return a pair of identical cubes
         data = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
@@ -324,7 +324,7 @@ class TestOrder:
 
 
 class TestConcatenate__dask:
-    @pytest.fixture
+    @pytest.fixture()
     def sample_lazy_cubes(self):
         # Make a pair of concatenatable cubes, with dim points [1, 2] and [3, 4, 5]
         def build_lazy_cube(points):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

@pp-mo I've updated your changes so that they're `ruff check --select PT` ([flake8-pytest-style](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt)) compliant.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
