### PR TITLE
FIX: weighted percentile works with 1D weights

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -39,6 +39,9 @@ This document explains the changes made to Iris for this release
 #. `@bouweandela`_ updated the ``chunktype`` of Dask arrays, so it corresponds
    to the array content. (:pull:`5801`)
 
+#. `@rcomer`_ made the :obj:`~iris.analysis.WPERCENTILE` aggregator work with
+   :func:`~iris.cube.Cube.rolling_window`.  (:issue:`5777`, :pull:`5825`)
+
 
 💣 Incompatible Changes
 =======================
@@ -70,7 +73,7 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. `@tkknight`_ removed the pin for ``sphinx <=5.3``, so the latest should 
+#. `@tkknight`_ removed the pin for ``sphinx <=5.3``, so the latest should
    now be used, currently being v7.2.6.
    (:pull:`5901`)
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -1467,7 +1467,8 @@ def _weighted_percentile(data, axis, weights, percent, returned=False, **kwargs)
     axis : int
         Axis to calculate percentiles over.
     weights : ndarray
-        Array with the weights.  Must have same shape as data.
+        Array with the weights.  Must have same shape as data or the shape of
+        data along axis.
     percent : float or sequence of floats
         Percentile rank/s at which to extract value/s.
     returned : bool, default=False
@@ -1475,12 +1476,18 @@ def _weighted_percentile(data, axis, weights, percent, returned=False, **kwargs)
         first element and the sum of the weights as the second element.
 
     """
-    # Ensure that data and weights arrays are same shape.
-    if data.shape != weights.shape:
-        raise ValueError("_weighted_percentile: weights wrong shape.")
+    # Ensure that weights array is the same shape as data, or the shape of data along
+    # axis.
+    if data.shape != weights.shape and data.shape[axis : axis + 1] != weights.shape:
+        raise ValueError(
+            f"For data array of shape {data.shape}, weights should be {data.shape} or {data.shape[axis : axis + 1]}"
+        )
     # Ensure that the target axis is the last dimension.
     data = np.rollaxis(data, axis, start=data.ndim)
-    weights = np.rollaxis(weights, axis, start=data.ndim)
+    if weights.ndim > 1:
+        weights = np.rollaxis(weights, axis, start=data.ndim)
+    elif data.ndim > 1:
+        weights = np.broadcast_to(weights, data.shape)
     quantiles = np.array(percent) / 100.0
     # Add data mask to weights if necessary.
     if ma.isMaskedArray(data):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #5777 by making the underlying `_weighted_percentile` function broadcast 1D weights if given.  Also improved the error message if `weights` is the wrong shape.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
