### PR TITLE
`v3.8.1` merge-back

### DIFF
--- a/docs/src/whatsnew/3.8.rst
+++ b/docs/src/whatsnew/3.8.rst
@@ -49,6 +49,7 @@ v3.8.1 (04 Mar 2024)
    :color: primary
    :icon: alert
    :animate: fade-in
+   :open:
 
    The patches in this release of Iris include:
 

--- a/docs/src/whatsnew/3.8.rst
+++ b/docs/src/whatsnew/3.8.rst
@@ -42,6 +42,21 @@ This document explains the changes made to Iris for this release
    any issues or feature requests for improving Iris. Enjoy!
 
 
+v3.8.1 (04 Mar 2024)
+====================
+
+.. dropdown:: v3.8.1 Patches
+   :color: primary
+   :icon: alert
+   :animate: fade-in
+
+   The patches in this release of Iris include:
+
+   #. `@stephenworsley`_ fixed a potential memory leak for Iris uses of
+      :func:`dask.array.map_blocks`; known specifically to be a problem in the
+      :class:`iris.analysis.AreaWeighted` regridder. (:pull:`5767`)
+
+
 📢 Announcements
 ================
 


### PR DESCRIPTION
Does not need to be a merge-commit since this is a 'manual' recreation of what the merge-back should be (no features are exclusive to the release branch, only What's New content).