### PR TITLE
Convert ABF test to pytest.

### DIFF
--- a/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
+++ b/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
@@ -11,15 +11,14 @@ class Test_data:
         path = "0000000000000000jan00000"
         field = ABFField(path)
 
+        # Fake the file fetch operation
         fromfile = mocker.patch("iris.fileformats.abf.np.fromfile")
-        getattr = mocker.patch(
-            "iris.fileformats.abf.ABFField.__getattr__", wraps=field.__getattr__
-        )
-        read = mocker.patch("iris.fileformats.abf.ABFField._read", wraps=field._read)
+        # Spy on the '_read' operation
+        read = mocker.spy(field, "_read")
 
         # do the access
         field.data
 
+        # Check that _read was called, and np.fromfile.
         fromfile.assert_called_once_with(path, dtype=">u1")
-        assert getattr.call_count == 1
         assert read.call_count == 1

--- a/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
+++ b/lib/iris/tests/unit/fileformats/abf/test_ABFField.py
@@ -3,50 +3,23 @@
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the `iris.fileformats.abf.ABFField` class."""
-
-# Import iris.tests first so that some things can be initialised before
-# importing anything else.
-import iris.tests as tests  # isort:skip
-
-from unittest import mock
-
 from iris.fileformats.abf import ABFField
 
 
-class MethodCounter:
-    def __init__(self, method_name):
-        self.method_name = method_name
-        self.count = 0
-
-    def __enter__(self):
-        self.orig_method = getattr(ABFField, self.method_name)
-
-        def new_method(*args, **kwargs):
-            self.count += 1
-            self.orig_method(*args, **kwargs)
-
-        setattr(ABFField, self.method_name, new_method)
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        setattr(ABFField, self.method_name, self.orig_method)
-        return False
-
-
-class Test_data(tests.IrisTest):
-    def test_single_read(self):
+class Test_data:
+    def test_single_read(self, mocker):
         path = "0000000000000000jan00000"
         field = ABFField(path)
 
-        with mock.patch("iris.fileformats.abf.np.fromfile") as fromfile:
-            with MethodCounter("__getattr__") as getattr:
-                with MethodCounter("_read") as read:
-                    field.data
+        fromfile = mocker.patch("iris.fileformats.abf.np.fromfile")
+        getattr = mocker.patch(
+            "iris.fileformats.abf.ABFField.__getattr__", wraps=field.__getattr__
+        )
+        read = mocker.patch("iris.fileformats.abf.ABFField._read", wraps=field._read)
+
+        # do the access
+        field.data
 
         fromfile.assert_called_once_with(path, dtype=">u1")
-        self.assertEqual(getattr.count, 1)
-        self.assertEqual(read.count, 1)
-
-
-if __name__ == "__main__":
-    tests.main()
+        assert getattr.call_count == 1
+        assert read.call_count == 1


### PR DESCRIPTION
In this case I went a bit beyond the brief, and have converted the roll-your-own call counting to a reasonably standard approach using Mock.
Which is not strictly a pytest change (!)


**NOTE:**
@bjlittle suggested using "mocker.spy" instead, which does sound like the nicest way.
However, I found that "mocker.spy" does not work on a `__getattr__` call, even though "mock.patch" actually did.
So it looks like the implementation of "mocker.spy" is less obvious than you might expect (probably since it now it supports async methods, etc).

For the sake of simplicity, I just removed the check that `__getattr__` is called :   I think checking that `_read` was called is good enough in itself.
