### PR TITLE
Force pytest colour output on GitHub Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -136,6 +136,8 @@ jobs:
       - name: "iris ${{ matrix.session }}"
         env:
           PY_VER: ${{ matrix.python-version }}
+          # Force coloured output on GitHub Actions.
+          PY_COLORS: "1"
         run: |
           nox --session ${{ matrix.session }} -- --verbose ${{ matrix.coverage }}
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -104,6 +104,7 @@ This document explains the changes made to Iris for this release
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
+.. _@jfrost-mo: https://github.com/jfrost-mo
 
 
 
@@ -114,4 +115,3 @@ This document explains the changes made to Iris for this release
 .. _NPY002: https://docs.astral.sh/ruff/rules/numpy-legacy-random/
 .. _numpydoc validation: https://numpydoc.readthedocs.io/en/latest/validation.html#
 .. _Dask version 2024.2.1: https://docs.dask.org/en/stable/changelog.html#v2024-2-1
-.. _@jfrost-mo: https://github.com/jfrost-mo

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -98,6 +98,8 @@ This document explains the changes made to Iris for this release
    have been updated to comply and some rules have been ignored for now.
    (:pull:`5762`)
 
+#. `@jfrost-mo`_ enabled colour output for pytest on GitHub Actions. (:pull:`5895`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
@@ -112,3 +114,4 @@ This document explains the changes made to Iris for this release
 .. _NPY002: https://docs.astral.sh/ruff/rules/numpy-legacy-random/
 .. _numpydoc validation: https://numpydoc.readthedocs.io/en/latest/validation.html#
 .. _Dask version 2024.2.1: https://docs.dask.org/en/stable/changelog.html#v2024-2-1
+.. _@jfrost-mo: https://github.com/jfrost-mo


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This makes the output of pytest on GitHub Actions much more readable by breaking it up with colour.

It has to be forced on as GitHub Actions doesn't use a real TTY, which pytest uses for rich output detection.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
