### PR TITLE
Support NetCDF v3 files in chunking control code.

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -44,7 +44,8 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@pp-mo`_ prevented the CHUNK_CONTROL feature from hitting an error when loading
+   from a NetCDF v3 file.  (:pull:`5897`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -243,6 +243,9 @@ def _get_cf_var_data(cf_var, filename):
                 result = as_lazy_data(proxy, chunks=None, dask_chunking=True)
             else:
                 chunks = cf_var.cf_data.chunking()
+                if chunks is None:
+                    # Occurs for non-version-4 netcdf
+                    chunks = "contiguous"
                 # In the "contiguous" case, pass chunks=None to 'as_lazy_data'.
                 if chunks == "contiguous":
                     if (

--- a/lib/iris/tests/unit/fileformats/netcdf/loader/test__chunk_control.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/loader/test__chunk_control.py
@@ -76,6 +76,15 @@ def test_default(tmp_filepath, save_cubelist_with_sigma):
     assert sigma.lazy_bounds().chunksize == (4, 2)
 
 
+def test_netcdf_v3():
+    # Just check that it does not fail when loading NetCDF v3 data
+    path = iris.tests.get_data_path(
+        ["NetCDF", "global", "xyt", "SMALL_total_column_co2.nc.k2"]
+    )
+    with CHUNK_CONTROL.set(time=-1):
+        iris.load(path)
+
+
 def test_control_global(tmp_filepath, save_cubelist_with_sigma):
     cube_varname, _ = save_cubelist_with_sigma
     with CHUNK_CONTROL.set(model_level_number=2):


### PR DESCRIPTION
Fixes #5864 
This supports when a netcdf variable ".chunking()" call returns `None`.

The added test fails without the fix.