### PR TITLE
Ignore `flaticon.com` in linkchecks

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -400,6 +400,7 @@ linkcheck_ignore = [
     "https://stickler-ci.com/",
     "https://twitter.com/scitools_iris",
     "https://stackoverflow.com/questions/tagged/python-iris",
+    "https://www.flaticon.com/",
 ]
 
 # list of sources to exclude from the build.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Was getting repeated `broken` results in the linkcheck CI even though I could visit it manually, so would suggest there is a problem specific to the automation. In any case the link is not in a critical part of the documentation so seems safe to ignore.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
