### PR TITLE
Temporary fix for airspeed-velocity/asv#1396

### DIFF
--- a/benchmarks/asv_delegated_conda.py
+++ b/benchmarks/asv_delegated_conda.py
@@ -192,6 +192,11 @@ class CondaDelegated(Conda):
             # Record new environment information in properties.
             self._update_info()
 
+    def _run_conda(self, args, env=None):
+        # TODO: remove after airspeed-velocity/asv#1397 is merged and released.
+        args = ["--yes" if arg == "--force" else arg for arg in args]
+        super()._run_conda(args, env)
+
     def checkout_project(self, repo: Repo, commit_hash: str) -> None:
         """Check out the working tree of the project at given commit hash."""
         super().checkout_project(repo, commit_hash)

--- a/benchmarks/asv_delegated_conda.py
+++ b/benchmarks/asv_delegated_conda.py
@@ -195,7 +195,7 @@ class CondaDelegated(Conda):
     def _run_conda(self, args, env=None):
         # TODO: remove after airspeed-velocity/asv#1397 is merged and released.
         args = ["--yes" if arg == "--force" else arg for arg in args]
-        super()._run_conda(args, env)
+        return super()._run_conda(args, env)
 
     def checkout_project(self, repo: Repo, commit_hash: str) -> None:
         """Check out the working tree of the project at given commit hash."""

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -90,6 +90,10 @@ This document explains the changes made to Iris for this release
 #. `@bouweandela`_ removed a workaround in :meth:`~iris.cube.CubeList.merge` for an
    issue with :func:`dask.array.stack` which has been solved since 2017. (:pull:`5923`)
 
+#. `@trexfeathers`_ introduced a temporary fix for Airspeed Velocity's
+   deprecated use of the ``conda --force`` argument. To be removed once
+   `airspeed-velocity/asv#1397`_ is merged and released. (:pull:`5931`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -100,3 +104,5 @@ This document explains the changes made to Iris for this release
 
 .. comment
     Whatsnew resources in alphabetical order:
+
+.. _airspeed-velocity/asv#1397: https://github.com/airspeed-velocity/asv/pull/1397


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

See airspeed-velocity/asv#1396. The fix has been proposed in airspeed-velocity/asv#1397 but it is uncertain how quickly that might progress. We need the benchmarks working for an upcoming sprint, including in places where we cannot pin the Conda version appropriately, so I am proposing this temporary override in our existing subclass.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
