### PR TITLE
Trial tracemalloc as memory tracker (replacement v2 PR)

### DIFF
--- a/benchmarks/benchmarks/memtrace_evaluation/__init__.py
+++ b/benchmarks/benchmarks/memtrace_evaluation/__init__.py
@@ -29,11 +29,11 @@ class MemcheckCommon:
         nblocks = params["nblocks"]
         nworkers = params["nworkers"]
 
-        nyfull = ysize // nblocks
+        ny_task = ysize // nblocks
         use_processes = {"threads": False, "processes": True}[runtype]
         self.task = SampleParallelTask(
             n_blocks=nblocks,
-            outerdim=nyfull // nblocks,
+            outerdim=ny_task,
             innerdim=nx,
             n_workers=nworkers,
             use_process_workers=use_processes,
@@ -111,6 +111,12 @@ class MemcheckBlocksAndWorkers(MemcheckCommon):
     @memory_units_mib
     def track_addmem_calc(self, nblocks, nworkers):
         return self.run_addedmem_calc()
+
+
+class MemcheckBlocksAndWorkers_processes(MemcheckBlocksAndWorkers):
+    def setup(self, nblocks, nworkers):
+        self.default_params["runtype"] = "processes"
+        super().setup(nblocks, nworkers)
 
 
 class MemcheckBlocksAndWorkers_Rss(MemcheckBlocksAndWorkers):

--- a/benchmarks/benchmarks/memtrace_evaluation/__init__.py
+++ b/benchmarks/benchmarks/memtrace_evaluation/__init__.py
@@ -1,0 +1,113 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Benchmarks to evaluate tracemalloc/rss methods of memory measurement."""
+
+from .. import TrackAddedMemoryAllocation
+from .memory_exercising_task import SampleParallelTask
+
+
+class MemcheckCommon:
+    # Basic controls over the test calculation
+    default_params = {
+        "measure": "tracemalloc",  # alternate: "rss"
+        "runtype": "threads",  # alternate: "processes"
+        "ysize": 10000,
+        "nx": 2000,
+        "nblocks": 6,
+        "nworkers": 4,
+    }
+
+    def _setup(self, **kwargs):
+        params = self.default_params.copy()
+        params.update(kwargs)
+        measure = params["measure"]
+        runtype = params["runtype"]
+        ysize = params["ysize"]
+        nx = params["nx"]
+        nblocks = params["nblocks"]
+        nworkers = params["nworkers"]
+
+        nyfull = ysize // nblocks
+        use_processes = {"threads": False, "processes": True}[runtype]
+        self.task = SampleParallelTask(
+            n_blocks=nblocks,
+            outerdim=nyfull // nblocks,
+            innerdim=nx,
+            n_workers=nworkers,
+            use_process_workers=use_processes,
+        )
+        self.use_tracemalloc = {"tracemalloc": True, "rss": False}[measure]
+
+    def run_time_calc(self):
+        # This usage is a bit crap, as we don't really care about the runtype.
+        self.task.perform()
+
+    def run_addedmem_calc(self):
+        with TrackAddedMemoryAllocation(
+            use_tracemalloc=self.use_tracemalloc,
+            result_min_mb=0.0,
+        ) as tracer:
+            self.task.perform()
+        return tracer.addedmem_mb()
+
+
+def memory_units_mib(func):
+    func.unit = "Mib"
+    return func
+
+
+class MemcheckRunstyles(MemcheckCommon):
+    # only some are parametrised, or it's just too complicated!
+    param_names = [
+        "measure",
+        "runtype",
+        "ysize",
+    ]
+    params = [
+        # measure
+        ["tracemalloc", "rss"],
+        # runtype
+        ["threads", "processes"],
+        # ysize
+        [10000, 40000],
+    ]
+
+    def setup(self, measure, runtype, ysize):
+        self._setup(measure=measure, runtype=runtype, ysize=ysize)
+
+    def time_calc(self, measure, runtype, ysize):
+        self.run_time_calc()
+
+    @memory_units_mib
+    def track_addmem_calc(self, measure, runtype, ysize):
+        return self.run_addedmem_calc()
+
+
+class MemcheckBlocksAndWorkers(MemcheckCommon):
+    # only some are parametrised, or it's just too complicated!
+    param_names = [
+        "nblocks",
+        "nworkers",
+    ]
+    params = [
+        # nblocks
+        [1, 4, 9],
+        # nworkers
+        [1, 4, 9],
+    ]
+
+    def setup(self, nblocks, nworkers):
+        self.default_params["ysize"] = 20000
+        self._setup(
+            nblocks=nblocks,
+            nworkers=nworkers,
+        )
+
+    def time_calc(self, nblocks, nworkers):
+        self.run_time_calc()
+
+    @memory_units_mib
+    def track_addmem_calc(self, nblocks, nworkers):
+        return self.run_addedmem_calc()

--- a/benchmarks/benchmarks/memtrace_evaluation/__init__.py
+++ b/benchmarks/benchmarks/memtrace_evaluation/__init__.py
@@ -16,7 +16,7 @@ class MemcheckCommon:
         "ysize": 10000,
         "nx": 2000,
         "nblocks": 6,
-        "nworkers": 4,
+        "nworkers": 3,
     }
 
     def _setup(self, **kwargs):
@@ -95,7 +95,7 @@ class MemcheckBlocksAndWorkers(MemcheckCommon):
         # nblocks
         [1, 4, 9],
         # nworkers
-        [1, 4, 9],
+        [1, 2, 3, 4],
     ]
 
     def setup(self, nblocks, nworkers):
@@ -111,3 +111,12 @@ class MemcheckBlocksAndWorkers(MemcheckCommon):
     @memory_units_mib
     def track_addmem_calc(self, nblocks, nworkers):
         return self.run_addedmem_calc()
+
+
+class MemcheckBlocksAndWorkers_Rss(MemcheckBlocksAndWorkers):
+    def setup(self, nblocks, nworkers):
+        self.default_params["measure"] = "rss"
+        super().setup(
+            nblocks=nblocks,
+            nworkers=nworkers,
+        )

--- a/benchmarks/benchmarks/memtrace_evaluation/memory_exercising_task.py
+++ b/benchmarks/benchmarks/memtrace_evaluation/memory_exercising_task.py
@@ -1,0 +1,94 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Provide a standard parallel calculation for testing the memory tracing."""
+
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import numpy as np
+
+"""
+the basic operation is to for each worker to construct a (NY, NX) numpy
+random array, of which it calculates and returns the mean(axis=0)
+  --> (NX,) result
+The results are then collected --> (N_BLOCKS, NX),
+and a mean over all calculated --> (NX,)
+The final (single-value) result is the *minimum* of that.
+"""
+
+# _SHOW_DEBUG = True
+_SHOW_DEBUG = False
+
+
+def debug(msg):
+    if _SHOW_DEBUG:
+        print(msg)
+
+
+def subtask_operation(arg):
+    i_task, ny, nx = arg
+    debug(f"\nRunning #{i_task}({ny}, {nx}) ..")
+    data = np.random.uniform(0.0, 1.0, size=(ny, nx))  # noqa: NPY002
+    sub_result = data.mean(axis=0)
+    debug(f"\n.. completed #{i_task}")
+    return sub_result
+
+
+class SampleParallelTask:
+    def __init__(
+        self,
+        n_blocks=5,
+        outerdim=1000,
+        innerdim=250,
+        n_workers=4,
+        use_process_workers=False,
+    ):
+        self.n_blocks = n_blocks
+        self.outerdim = outerdim
+        self.innerdim = innerdim
+        self.n_workers = n_workers
+        if use_process_workers:
+            self.pool_type = ProcessPoolExecutor
+        else:
+            self.pool_type = ThreadPoolExecutor
+        self._setup_calc()
+
+    def _setup_calc(self):
+        self._pool = self.pool_type(self.n_workers)
+
+    def perform(self):
+        partial_results = self._pool.map(
+            subtask_operation,
+            [
+                (i_task + 1, self.outerdim, self.innerdim)
+                for i_task in range(self.n_blocks)
+            ],
+        )
+        combined = np.stack(list(partial_results))
+        result = np.mean(combined, axis=0)
+        result = result.min()
+        return result
+
+
+if __name__ == "__main__":
+    nb = 12
+    nw = 3
+    ny, nx = 1000, 200
+    dims = (ny, nx)
+    use_processes = False
+    typ = "process" if use_processes else "thread"
+    msg = f"Starting: blocks={nb} workers={nw} size={dims} type={typ}"
+    print(msg)
+    calc = SampleParallelTask(
+        n_blocks=nb,
+        outerdim=ny,
+        innerdim=nx,
+        n_workers=nw,
+        use_process_workers=use_processes,
+    )
+    debug("Created.")
+    debug("Run..")
+    result = calc.perform()
+    debug("\n.. Run DONE.")
+    debug(f"result = {result}")


### PR DESCRIPTION
# ***WIP DO NOT MERGE THIS, EVER***

Some modified code for memory benchmarks, evaluating "tracemalloc" against our existing Linux process-RSS measuring technique.


### Additional context : sample output from a desktop run
```
$ asv run -b Memcheck* --quick -e -E existing:/tmp/persistent/newconda-envs/iris3/bin/python 
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
· Ignoring ASV setting(s): `python`. Benchmark environment management is delegated to third party script(s).
· Discovering benchmarks
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_tmp_persistent_newconda-envs_iris3_bin_python
[ 0.00%] ··· Importing benchmark suite produced output:
[ 0.00%] ···· /net/home/h05/itpp/git/iris/iris_main/benchmarks/benchmarks/generate_data/__init__.py:52: UserWarning: No BENCHMARK_DATA env var, defaulting to /net/home/h05/itpp/git/iris/iris_main/benchmarks/.data. Note that some benchmark files are GB in size.
              warn(message)

[12.50%] ··· memtrace_evaluation.MemcheckBlocksAndWorkers.time_calc                                                                                                                                 ok
[12.50%] ··· ========= ========== ========= =========
             --                   nworkers           
             --------- ------------------------------
              nblocks      1          4         9    
             ========= ========== ========= =========
                 1      568±0ms    543±0ms   514±0ms 
                 4      144±0ms    181±0ms   151±0ms 
                 9      55.9±0ms   116±0ms   109±0ms 
             ========= ========== ========= =========

[25.00%] ··· memtrace_evaluation.MemcheckBlocksAndWorkers.track_addmem_calc                                                                                                                         ok
[25.00%] ··· ========= ======= ======= =======
             --                nworkers       
             --------- -----------------------
              nblocks     1       4       9   
             ========= ======= ======= =======
                 1      305.3   305.3   305.3 
                 4       19.2    76.4    76.4 
                 9       4.0     15.2    33.9 
             ========= ======= ======= =======

[37.50%] ··· memtrace_evaluation.MemcheckRunstyles.time_calc                                                                                                                                        ok
[37.50%] ··· ============= ================= ================= =================== ===================
             --                                          runtype / ysize                              
             ------------- ---------------------------------------------------------------------------
                measure     threads / 10000   threads / 40000   processes / 10000   processes / 40000 
             ============= ================= ================= =================== ===================
              tracemalloc       91.2±0ms          228±0ms            40.2±0ms            82.4±0ms     
                  rss           87.0±0ms          222±0ms            45.5±0ms            81.5±0ms     
             ============= ================= ================= =================== ===================

[50.00%] ··· memtrace_evaluation.MemcheckRunstyles.track_addmem_calc                                                                                                                                ok
[50.00%] ··· ============= ================= ================= =================== ===================
             --                                          runtype / ysize                              
             ------------- ---------------------------------------------------------------------------
                measure     threads / 10000   threads / 40000   processes / 10000   processes / 40000 
             ============= ================= ================= =================== ===================
              tracemalloc         17.0              67.9               0.2                 0.2        
                  rss             9.1               34.4               0.9                 0.9        
             ============= ================= ================= =================== ===================
```
