### PR TITLE
Add bm_runner 'trialrun' subcommand.

### DIFF
--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -547,12 +547,7 @@ class TrialRun(_SubParserGenerator):
     epilog = (
         "e.g. python bm_runner.py trialrun "
         "MyBenchmarks.time_calc /tmp/testpython/bin/python"
-        "\n  NOTE: 'runpath' is also used for any data-generation, i.e. it"
-        "replaces $DATA_GEN_PYTHON during this run."
-        "\n  NOTE#2: setting $OVERRIDE_TEST_DATA_REPOSITORY avoids the runner "
-        "installing iris-test-data."
-        "\n  NOTE#3: setting $BENCHMARK_DATA may be desirable to specify "
-        "where is safe to create potentially large (Gb) test data."
+        "\n\nNOTE: 'runpath' also replaces $DATA_GEN_PYTHON during the run."
     )
 
     def add_arguments(self) -> None:
@@ -624,7 +619,20 @@ class GhPost(_SubParserGenerator):
 def main():
     parser = ArgumentParser(
         description="Run the Iris performance benchmarks (using Airspeed Velocity).",
-        epilog="More help is available within each sub-command.",
+        epilog=(
+            "More help is available within each sub-command."
+            "\n\nNOTE(1): iris-test-data is downloaded and cached within the "
+            "benchmarks code directory.\n   Set $OVERRIDE_TEST_DATA_REPOSITORY "
+            "to avoid the cost of this."
+            "\nNOTE(2): a separate python environment is created to write "
+            "benchmark test data.\n   Set $DATA_GEN_PYTHON to avoid the cost "
+            "of this."
+            "\nNOTE(3): test data is cached within the "
+            "benchmarks code directory, and uses a lot of disk space "
+            "of disk space (Gb).\n   Set $BENCHMARK_DATA to specify where this "
+            "space can be safely allocated."
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     subparsers = parser.add_subparsers(required=True)
 

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -546,7 +546,7 @@ class TrialRun(_SubParserGenerator):
     )
     epilog = (
         "e.g. python bm_runner.py trialrun "
-        "MyBenchmarks.time_calc /tmp/testpython/bin/python"
+        "MyBenchmarks.time_calc ${DATA_GEN_PYTHON}"
         "\n\nNOTE: 'runpath' also replaces $DATA_GEN_PYTHON during the run."
     )
 
@@ -621,12 +621,12 @@ def main():
         description="Run the Iris performance benchmarks (using Airspeed Velocity).",
         epilog=(
             "More help is available within each sub-command."
-            "\n\nNOTE(1): iris-test-data is downloaded and cached within the "
-            "benchmarks code directory.\n   Set $OVERRIDE_TEST_DATA_REPOSITORY "
-            "to avoid the cost of this."
-            "\nNOTE(2): a separate python environment is created to write "
-            "benchmark test data.\n   Set $DATA_GEN_PYTHON to avoid the cost "
+            "\n\nNOTE(1): a separate python environment is created to "
+            "construct test files.\n   Set $DATA_GEN_PYTHON to avoid the cost "
             "of this."
+            "\nNOTE(2): iris-test-data is downloaded and cached within the "
+            "data generation environment.\n   Set "
+            "$OVERRIDE_TEST_DATA_REPOSITORY to avoid the cost of this."
             "\nNOTE(3): test data is cached within the "
             "benchmarks code directory, and uses a lot of disk space "
             "of disk space (Gb).\n   Set $BENCHMARK_DATA to specify where this "

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -558,7 +558,7 @@ class TrialRun(_SubParserGenerator):
             help=(
                 "A benchmark name, possibly including wildcards, "
                 "as supported by the ASV '--benchmark' argument."
-            )
+            ),
         )
         self.subparser.add_argument(
             "runpath",
@@ -567,12 +567,11 @@ class TrialRun(_SubParserGenerator):
             help=(
                 "A path to an existing python environment, "
                 "to completely bypass environment building."
-            )
+            ),
         )
 
     @staticmethod
     def func(args: argparse.Namespace) -> None:
-        print(args)
         if args.runpath:
             # Shortcut creation of a data-gen environment
             # - which is also the trial-run env.
@@ -591,7 +590,8 @@ class TrialRun(_SubParserGenerator):
             # show any errors
             "-e",
             # do not build a unique env : run test in data-gen environment
-            "--environment", f"existing:{python_path}"
+            "--environment",
+            f"existing:{python_path}",
         ] + args.asv_args
         _subprocess_runner(asv_command, asv=True)
 

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -547,8 +547,8 @@ class TrialRun(_SubParserGenerator):
     epilog = (
         "e.g. python bm_runner.py trialrun "
         "MyBenchmarks.time_calc /tmp/testpython/bin/python"
-        "\n\n  NOTE#1: setting $DATA_GEN_PYTHON is equivalent to the "
-        "'runpath' argument."
+        "\n  NOTE: 'runpath' is also used for any data-generation, i.e. it"
+        "replaces $DATA_GEN_PYTHON during this run."
         "\n  NOTE#2: setting $OVERRIDE_TEST_DATA_REPOSITORY avoids the runner "
         "installing iris-test-data."
         "\n  NOTE#3: setting $BENCHMARK_DATA may be desirable to specify "
@@ -567,7 +567,6 @@ class TrialRun(_SubParserGenerator):
         self.subparser.add_argument(
             "runpath",
             type=str,
-            nargs="?",
             help=(
                 "A path to an existing python executable, "
                 "to completely bypass environment building."

--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -325,7 +325,7 @@ class _SubParserGenerator(ABC):
     def add_asv_arguments(self) -> None:
         self.subparser.add_argument(
             "asv_args",
-            nargs="*",
+            nargs=argparse.REMAINDER,
             help="Any number of arguments to pass down to the ASV benchmark command.",
         )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -313,5 +313,5 @@ def benchmarks(session: nox.sessions.Session):
         )
         session.error(message)
     session.install("asv", "nox")
-    with session.chdir(Path(__file__).parent / "benchmarks"):
-        session.run("python", "bm_runner.py", *session.posargs)
+    bm_runner_path = Path(__file__).parent / "benchmarks" / "bm_runner.py"
+    session.run("python", bm_runner_path, *session.posargs)


### PR DESCRIPTION
Closes #5944

Notes: I tried to make this as foolproof and self-contained as possible. 
so it sets up DATA_GEN_PYTHON and ON_DEMAND_BENCHMARKS.

However you must still provide iris-test-data, via **OVERRIDE_TEST_DATA_REPOSITORY** (at least for most benchmarks).
If you don't, the resulting error is not that obvious (!) -- see below
You may also need to set **BENCHMARK_DATA** if you don't want to overfill your homespace or /tmp/persistent (here at MetOffice).
So, this is potentially still tricky to use, and even dangerous if you total your disk quota!

You may also provide a suitable environment, to prevent it creating one.
Omitting this does work, but can be slow as although we can build a suitable test env, we still don't have a reliable way of automatically caching + re-using them.
**If the "Speed up environment prep" task currently on the board comes good, it might improve that case ?**


### Detail of error report due to missing test-data 
```
$ nox -s benchmarks -- trialrun CubeCreation /tmp/persistent/newconda-envs/iris3/bin/python
nox > Running session benchmarks
nox > Re-using existing virtual environment at .nox/benchmarks.
nox > python -m pip install asv nox
nox > cd /tmp/persistent/git/iris/benchmarks
nox > python bm_runner.py trialrun CubeCreation /tmp/persistent/newconda-envs/iris3/bin/python
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
BM_RUNNER DEBUG: Using existing data generation environment.
BM_RUNNER DEBUG: Setting up ASV ...
BM_RUNNER DEBUG: asv machine --yes
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
I will now ask you some questions about this machine to identify it in the benchmarks.
  . . .
BM_RUNNER DEBUG: Setup complete.
BM_RUNNER DEBUG: asv run --bench CubeCreation --quick -e --environment existing:/tmp/persistent/newconda-envs/iris3/bin/python
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
· Ignoring ASV setting(s): `python`. Benchmark environment management is delegated to third party script(s).
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_tmp_persistent_newconda-envs_iris3_bin_python
[50.00%] ··· cube.CubeCreation.time_create                                                                                                                                              failed
[50.00%] ··· =============== ============= ===========
             --                Cube creation strategy 
             --------------- -------------------------
              Cube has mesh   instantiate   construct 
             =============== ============= ===========
                  False          failed       failed  
                   True          failed       failed  
             =============== ============= ===========
             For parameters: False, 'instantiate'
             Traceback (most recent call last):

<<multiple tracebacks like this ...>>
              For parameters: True, 'construct'
              Traceback (most recent call last):
                File "/tmp/persistent/newconda-envs/iris3/lib/python3.11/site-packages/asv_runner/server.py", line 179, in _run_server
                  _run(run_args)
                File "/tmp/persistent/newconda-envs/iris3/lib/python3.11/site-packages/asv_runner/run.py", line 65, in _run
                  skip = benchmark.do_setup()
                         ^^^^^^^^^^^^^^^^^^^^
                File "/tmp/persistent/newconda-envs/iris3/lib/python3.11/site-packages/asv_runner/benchmarks/time.py", line 80, in do_setup
                  result = Benchmark.do_setup(self)
                           ^^^^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/persistent/newconda-envs/iris3/lib/python3.11/site-packages/asv_runner/benchmarks/_base.py", line 632, in do_setup
                  setup(*self._current_params)
                File "/tmp/persistent/git/iris/benchmarks/benchmarks/cube.py", line 21, in setup
                  source_cube = realistic_4d_w_everything(w_mesh=w_mesh)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/persistent/git/iris/benchmarks/benchmarks/generate_data/stock.py", line 182, in realistic_4d_w_everything
                  _ = run_function_elsewhere(_external, w_mesh_=w_mesh, save_path_=str(save_path))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/persistent/git/iris/benchmarks/benchmarks/generate_data/__init__.py", line 95, in run_function_elsewhere
                  result = run(
                           ^^^^
                File "/tmp/persistent/newconda-envs/iris3/lib/python3.11/subprocess.py", line 571, in run
                  raise CalledProcessError(retcode, process.args,
              subprocess.CalledProcessError: Command '['/tmp/persistent/newconda-envs/iris3/bin/python', '-c', "def _external(w_mesh_: str, save_path_: str):\n    import iris\n    from iris.tests.stock import realistic_4d_w_everything\n\n    cube = realistic_4d_w_everything(w_mesh=bool(w_mesh_))\n    iris.save(cube, save_path_)\n\n_external(w_mesh_=True,save_path_='/data/users/itpp/benchmarks_testdata/realistic_4d_w_everything_True.nc')"]' returned non-zero exit status 1.
              asv: benchmark failed (exit status 1)

Traceback (most recent call last):
  File "/tmp/persistent/git/iris/benchmarks/bm_runner.py", line 636, in <module>
    main()
  File "/tmp/persistent/git/iris/benchmarks/bm_runner.py", line 632, in main
    parsed.func(parsed)
  File "/tmp/persistent/git/iris/benchmarks/bm_runner.py", line 596, in func
    _subprocess_runner(asv_command, asv=True)
  File "/tmp/persistent/git/iris/benchmarks/bm_runner.py", line 49, in _subprocess_runner
    return subprocess.run(args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/persistent/newconda-envs/tp_asvtst/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['asv', 'run', '--bench', 'CubeCreation', '--quick', '-e', '--environment', 'existing:/tmp/persistent/newconda-envs/iris3/bin/python']' returned non-zero exit status 2.
nox > Command python bm_runner.py trialrun CubeCreation /tmp/persistent/newconda-envs/iris3/bin/python failed with exit code 1
nox > Session benchmarks failed.
```