### PR TITLE
Remove "on-demand" from some benchmarks

### DIFF
--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -71,8 +71,8 @@ class TrackAddedMemoryAllocation:
 
     """
 
-    RESULT_MINIMUM_MB = 1.0
-    RESULT_ROUND_DP = 1
+    RESULT_MINIMUM_MB = 0.2
+    RESULT_ROUND_DP = 1  # I.E. to nearest 0.1 Mb
 
     def __enter__(self):
         tracemalloc.start()

--- a/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
+++ b/benchmarks/benchmarks/experimental/ugrid/regions_combine.py
@@ -18,7 +18,7 @@ from iris import load, load_cube, save
 from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 from iris.experimental.ugrid.utils import recombine_submeshes
 
-from ... import TrackAddedMemoryAllocation, on_demand_benchmark
+from ... import TrackAddedMemoryAllocation
 from ...generate_data.ugrid import make_cube_like_2d_cubesphere
 
 
@@ -183,7 +183,6 @@ class CombineRegionsComputeRealData(MixinCombineRegions):
         _ = self.recombined_cube.data
 
     # Vulnerable to noise, so disabled by default.
-    @on_demand_benchmark
     @TrackAddedMemoryAllocation.decorator
     def track_addedmem_compute_data(self, n_cubesphere):
         _ = self.recombined_cube.data
@@ -204,7 +203,6 @@ class CombineRegionsSaveData(MixinCombineRegions):
         save(self.recombined_cube, "tmp.nc")
 
     # Vulnerable to noise, so disabled by default.
-    @on_demand_benchmark
     @TrackAddedMemoryAllocation.decorator
     def track_addedmem_save(self, n_cubesphere):
         save(self.recombined_cube, "tmp.nc")
@@ -234,7 +232,6 @@ class CombineRegionsFileStreamedCalc(MixinCombineRegions):
         save(self.recombined_cube, "tmp.nc")
 
     # Vulnerable to noise, so disabled by default.
-    @on_demand_benchmark
     @TrackAddedMemoryAllocation.decorator
     def track_addedmem_stream_file2file(self, n_cubesphere):
         save(self.recombined_cube, "tmp.nc")

--- a/benchmarks/benchmarks/save.py
+++ b/benchmarks/benchmarks/save.py
@@ -38,8 +38,6 @@ class NetcdfSave:
         if is_unstructured:
             self._save_mesh(self.cube)
 
-    # Vulnerable to noise, so disabled by default.
-    @on_demand_benchmark
     @TrackAddedMemoryAllocation.decorator
     def track_addedmem_netcdf_save(self, n_cubesphere, is_unstructured):
         # Don't need to copy the cube here since track_ benchmarks don't


### PR DESCRIPTION
Since we believe the new [tracemalloc memory measurement method](https://github.com/SciTools/iris/pull/5948)  (TMMM :tm:) ought to deliver more stable results, 
Let's see what happens if we put those back in the standard set.

There are a lot more in cperf/sperf, but I think we [decided to remove all of those from the standard set](https://github.com/SciTools/iris/pull/4621).
I'd be open to reconsidering that -- if anyone thinks appropriate, @trexfeathers ?