### PR TITLE
Add memory benchmarks

### DIFF
--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -114,6 +114,33 @@ class TrackAddedMemoryAllocation:
         decorated_func.unit = "Mb"
         return _wrapper
 
+    @staticmethod
+    def decorator_repeating(repeats=3):
+        """Benchmark to track growth in resident memory during execution.
+
+        Tracks memory for repeated calls of decorated function.
+
+        Intended for use on ASV ``track_`` benchmarks. Applies the
+        :class:`TrackAddedMemoryAllocation` context manager to the benchmark
+        code, sets the benchmark ``unit`` attribute to ``Mb``.
+
+        """
+
+        def decorator(decorated_func):
+            def _wrapper(*args, **kwargs):
+                assert decorated_func.__name__[:6] == "track_"
+                # Run the decorated benchmark within the added memory context
+                # manager.
+                with TrackAddedMemoryAllocation() as mb:
+                    for _ in range(repeats):
+                        decorated_func(*args, **kwargs)
+                return mb.addedmem_mb()
+
+            decorated_func.unit = "Mb"
+            return _wrapper
+
+        return decorator
+
 
 def on_demand_benchmark(benchmark_object):
     """Disable these benchmark(s) unless ON_DEMAND_BENCHARKS env var is set.

--- a/benchmarks/benchmarks/merge_concat.py
+++ b/benchmarks/benchmarks/merge_concat.py
@@ -34,7 +34,7 @@ class Merge:
     def time_merge(self):
         _ = self.cube_list.merge_cube()
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_mem_merge(self):
         _ = self.cube_list.merge_cube()
 
@@ -56,6 +56,6 @@ class Concatenate:
     def time_concatenate(self):
         _ = self.cube_list.concatenate_cube()
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_mem_merge(self):
         _ = self.cube_list.concatenate_cube()

--- a/benchmarks/benchmarks/merge_concat.py
+++ b/benchmarks/benchmarks/merge_concat.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from iris.cube import CubeList
 
+from . import TrackAddedMemoryAllocation
 from .generate_data.stock import realistic_4d_w_everything
 
 
@@ -33,6 +34,10 @@ class Merge:
     def time_merge(self):
         _ = self.cube_list.merge_cube()
 
+    @TrackAddedMemoryAllocation.decorator
+    def track_mem_merge(self):
+        _ = self.cube_list.merge_cube()
+
 
 class Concatenate:
     # TODO: Improve coverage.
@@ -49,4 +54,8 @@ class Concatenate:
         self.cube_list = CubeList([source_cube, second_cube])
 
     def time_concatenate(self):
+        _ = self.cube_list.concatenate_cube()
+
+    @TrackAddedMemoryAllocation.decorator
+    def track_mem_merge(self):
         _ = self.cube_list.concatenate_cube()

--- a/benchmarks/benchmarks/regridding.py
+++ b/benchmarks/benchmarks/regridding.py
@@ -53,7 +53,6 @@ class HorizontalChunkedRegridding:
         # Realise data
         out.data
 
-
     @TrackAddedMemoryAllocation.decorator
     def track_mem_regrid_area_w(self) -> None:
         for _ in range(3):
@@ -62,7 +61,6 @@ class HorizontalChunkedRegridding:
             # Realise data
             out.data
 
-
     @TrackAddedMemoryAllocation.decorator
     def track_mem_regrid_area_w_new_grid(self) -> None:
         for _ in range(3):
@@ -70,6 +68,7 @@ class HorizontalChunkedRegridding:
             out = self.chunked_cube.regrid(self.template_cube, self.scheme_area_w)
             # Realise data
             out.data
+
 
 class CurvilinearRegridding:
     def setup(self) -> None:

--- a/benchmarks/benchmarks/regridding.py
+++ b/benchmarks/benchmarks/regridding.py
@@ -14,6 +14,8 @@ import iris
 from iris.analysis import AreaWeighted, PointInCell
 from iris.coords import AuxCoord
 
+from . import TrackAddedMemoryAllocation
+
 
 class HorizontalChunkedRegridding:
     def setup(self) -> None:
@@ -51,6 +53,23 @@ class HorizontalChunkedRegridding:
         # Realise data
         out.data
 
+
+    @TrackAddedMemoryAllocation.decorator
+    def track_mem_regrid_area_w(self) -> None:
+        for _ in range(3):
+            # Regrid the chunked cube
+            out = self.cube.regrid(self.template_cube, self.scheme_area_w)
+            # Realise data
+            out.data
+
+
+    @TrackAddedMemoryAllocation.decorator
+    def track_mem_regrid_area_w_new_grid(self) -> None:
+        for _ in range(3):
+            # Regrid the chunked cube
+            out = self.chunked_cube.regrid(self.template_cube, self.scheme_area_w)
+            # Realise data
+            out.data
 
 class CurvilinearRegridding:
     def setup(self) -> None:
@@ -93,3 +112,11 @@ class CurvilinearRegridding:
         out = self.cube.regrid(self.template_cube, self.scheme_pic)
         # Realise the data
         out.data
+
+    @TrackAddedMemoryAllocation.decorator
+    def track_mem_regrid_pic(self) -> None:
+        for _ in range(3):
+            # Regrid the cube onto the template.
+            out = self.cube.regrid(self.template_cube, self.scheme_pic)
+            # Realise the data
+            out.data

--- a/benchmarks/benchmarks/regridding.py
+++ b/benchmarks/benchmarks/regridding.py
@@ -53,21 +53,19 @@ class HorizontalChunkedRegridding:
         # Realise data
         out.data
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_mem_regrid_area_w(self) -> None:
-        for _ in range(3):
-            # Regrid the chunked cube
-            out = self.cube.regrid(self.template_cube, self.scheme_area_w)
-            # Realise data
-            out.data
+        # Regrid the chunked cube
+        out = self.cube.regrid(self.template_cube, self.scheme_area_w)
+        # Realise data
+        out.data
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_mem_regrid_area_w_new_grid(self) -> None:
-        for _ in range(3):
-            # Regrid the chunked cube
-            out = self.chunked_cube.regrid(self.template_cube, self.scheme_area_w)
-            # Realise data
-            out.data
+        # Regrid the chunked cube
+        out = self.chunked_cube.regrid(self.template_cube, self.scheme_area_w)
+        # Realise data
+        out.data
 
 
 class CurvilinearRegridding:
@@ -112,10 +110,9 @@ class CurvilinearRegridding:
         # Realise the data
         out.data
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_mem_regrid_pic(self) -> None:
-        for _ in range(3):
-            # Regrid the cube onto the template.
-            out = self.cube.regrid(self.template_cube, self.scheme_pic)
-            # Realise the data
-            out.data
+        # Regrid the cube onto the template.
+        out = self.cube.regrid(self.template_cube, self.scheme_pic)
+        # Realise the data
+        out.data

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -41,6 +41,7 @@ class PearsonR:
             cube.data = cube.lazy_data()
 
         result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
+        result.data
 
     @TrackAddedMemoryAllocation.decorator_repeating()
     def track_lazy(self):
@@ -48,4 +49,4 @@ class PearsonR:
             cube.data = cube.lazy_data()
 
         result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
-            result.data
+        result.data

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -32,10 +32,9 @@ class PearsonR:
     def time_real(self):
         pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_real(self):
-        for _ in range(3):
-            pearsonr(self.cube_a, self.cube_b, weights=self.weights)
+        pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
     def time_lazy(self):
         for cube in self.cube_a, self.cube_b:
@@ -43,11 +42,10 @@ class PearsonR:
 
         result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_lazy(self):
-        for _ in range(3):
-            for cube in self.cube_a, self.cube_b:
-                cube.data = cube.lazy_data()
+        for cube in self.cube_a, self.cube_b:
+            cube.data = cube.lazy_data()
 
-            result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
+        result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
             result.data

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -8,6 +8,8 @@ import iris
 from iris.analysis.stats import pearsonr
 import iris.tests
 
+from . import TrackAddedMemoryAllocation
+
 
 class PearsonR:
     def setup(self):
@@ -30,9 +32,22 @@ class PearsonR:
     def time_real(self):
         pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
+    @TrackAddedMemoryAllocation.decorator
+    def time_real(self):
+        for _ in range(3):
+            pearsonr(self.cube_a, self.cube_b, weights=self.weights)
+
     def time_lazy(self):
         for cube in self.cube_a, self.cube_b:
             cube.data = cube.lazy_data()
 
         result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
-        result.data
+
+    @TrackAddedMemoryAllocation.decorator
+    def time_lazy(self):
+        for _ in range(3):
+            for cube in self.cube_a, self.cube_b:
+                cube.data = cube.lazy_data()
+
+            result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
+            result.data

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -33,7 +33,7 @@ class PearsonR:
         pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
     @TrackAddedMemoryAllocation.decorator
-    def time_real(self):
+    def track_real(self):
         for _ in range(3):
             pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
@@ -44,7 +44,7 @@ class PearsonR:
         result = pearsonr(self.cube_a, self.cube_b, weights=self.weights)
 
     @TrackAddedMemoryAllocation.decorator
-    def time_lazy(self):
+    def track_lazy(self):
         for _ in range(3):
             for cube in self.cube_a, self.cube_b:
                 cube.data = cube.lazy_data()

--- a/benchmarks/benchmarks/trajectory.py
+++ b/benchmarks/benchmarks/trajectory.py
@@ -13,6 +13,8 @@ import numpy as np
 import iris
 from iris.analysis.trajectory import interpolate
 
+from . import TrackAddedMemoryAllocation
+
 
 class TrajectoryInterpolation:
     def setup(self) -> None:
@@ -33,8 +35,24 @@ class TrajectoryInterpolation:
         # Realise the data
         out_cube.data
 
+    @TrackAddedMemoryAllocation.decorator
+    def track_trajectory_linear(self) -> None:
+        for _ in range(3):
+            # Regrid the cube onto the template.
+            out_cube = interpolate(self.cube, self.sample_points, method="linear")
+            # Realise the data
+            out_cube.data
+
     def time_trajectory_nearest(self) -> None:
         # Regrid the cube onto the template.
         out_cube = interpolate(self.cube, self.sample_points, method="nearest")
         # Realise the data
         out_cube.data
+
+    @TrackAddedMemoryAllocation.decorator
+    def track_trajectory_nearest(self) -> None:
+        for _ in range(3):
+            # Regrid the cube onto the template.
+            out_cube = interpolate(self.cube, self.sample_points, method="nearest")
+            # Realise the data
+            out_cube.data

--- a/benchmarks/benchmarks/trajectory.py
+++ b/benchmarks/benchmarks/trajectory.py
@@ -35,13 +35,12 @@ class TrajectoryInterpolation:
         # Realise the data
         out_cube.data
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_trajectory_linear(self) -> None:
-        for _ in range(3):
-            # Regrid the cube onto the template.
-            out_cube = interpolate(self.cube, self.sample_points, method="linear")
-            # Realise the data
-            out_cube.data
+        # Regrid the cube onto the template.
+        out_cube = interpolate(self.cube, self.sample_points, method="linear")
+        # Realise the data
+        out_cube.data
 
     def time_trajectory_nearest(self) -> None:
         # Regrid the cube onto the template.
@@ -49,10 +48,9 @@ class TrajectoryInterpolation:
         # Realise the data
         out_cube.data
 
-    @TrackAddedMemoryAllocation.decorator
+    @TrackAddedMemoryAllocation.decorator_repeating()
     def track_trajectory_nearest(self) -> None:
-        for _ in range(3):
-            # Regrid the cube onto the template.
-            out_cube = interpolate(self.cube, self.sample_points, method="nearest")
-            # Realise the data
-            out_cube.data
+        # Regrid the cube onto the template.
+        out_cube = interpolate(self.cube, self.sample_points, method="nearest")
+        # Realise the data
+        out_cube.data


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Extends existing benchmarks by adding a version which tracks memory for functions where iris may be responsible for memory handling (e.g. by calling dask in a specific way, as resolved in #5767). Memory benchmarks are repeated so that memory leaks may be better detected.
