### PR TITLE
List 25 slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ local_scheme = "dirty-tag"
 version_scheme = "release-branch-semver"
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra --durations=25"
 testpaths = "lib/iris"
 
 [tool.coverage.run]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Running the iris test suite feels a bit slow when developing. This pull request adds a pytest option that causes the 25 slowest tests to be displayed with every test run. This will make test run times more visible to developers and in that way encourage writing faster tests.

Examples
========

In CI: https://github.com/SciTools/iris/actions/runs/9186913624/job/25263500853?pr=5969#step:12:1646

Locally:
```
$ pytest lib/iris/tests/unit/cube/test_Cube.py
============================================================================ test session starts ============================================================================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/bandela/src/scitools/iris
configfile: pyproject.toml
plugins: cov-5.0.0, xdist-3.5.0
collected 354 items                                                                                                                                                         

lib/iris/tests/unit/cube/test_Cube.py ............................................................................................................................... [ 35%]
..................................................................................................................................................................... [ 82%]
..............................................................                                                                                                        [100%]

============================================================================= warnings summary ==============================================================================
lib/iris/tests/unit/cube/test_Cube.py::Test___init___data::test_matrix
  /home/bandela/src/scitools/iris/lib/iris/tests/unit/cube/test_Cube.py:68: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    data = np.matrix([[1, 2, 3], [4, 5, 6]])

lib/iris/tests/unit/cube/test_Cube.py: 41 warnings
  /home/bandela/src/scitools/iris/lib/iris/coords.py:2153: IrisVagueMetadataWarning: Cannot check if coordinate is contiguous: Invalid operation for 'y', with 0 bound(s). Contiguous bounds are only defined for 1D coordinates with 2 bounds. Metadata may not be fully descriptive for 'y'. Ignoring bounds.
    warnings.warn(

lib/iris/tests/unit/cube/test_Cube.py: 22 warnings
  /home/bandela/src/scitools/iris/lib/iris/coords.py:2153: IrisVagueMetadataWarning: Cannot check if coordinate is contiguous: Invalid operation for 'x', with 0 bound(s). Contiguous bounds are only defined for 1D coordinates with 2 bounds. Metadata may not be fully descriptive for 'x'. Ignoring bounds.
    warnings.warn(

lib/iris/tests/unit/cube/test_Cube.py: 26 warnings
  /home/bandela/src/scitools/iris/lib/iris/coords.py:2140: IrisVagueMetadataWarning: Collapsing a multi-dimensional coordinate. Metadata may not be fully descriptive for 'full_x'.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================== slowest 25 durations ============================================================================
2.26s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_dimension_given
2.25s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_coord_name_given
2.22s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_coord_given
2.21s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_duplicate_coordinate_given
2.21s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_non_orthogonal_coordinates_given
0.91s call     lib/iris/tests/unit/cube/test_Cube.py::Test_convert_units::test_unit_multiply
0.20s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_multidim_slice_coord_given
0.15s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_coord_given
0.15s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_reversed_dimension_given
0.15s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_coord_name_given
0.15s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_dimension_given
0.08s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_nodimension
0.06s call     lib/iris/tests/unit/cube/test_Cube.py::Test_xml::test_ancils
0.02s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_dim_order::test_all_permutations
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test__init__mesh::test_meshcoords_equal_meshes
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_nonexistent_dimension_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test__init__mesh::test_fail_meshcoords_different_meshes
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_nonexistent_coord_name_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_nonexistent_coord_name_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_nonexistent_dimension_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_1d_slice_nonexistent_coord_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_intersection__Metadata::test_metadata_wrapped
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_slices_over::test_2d_slice_nonexistent_coord_given
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test__add_aux_coord__mesh::test_fail_different_dimension
0.01s call     lib/iris/tests/unit/cube/test_Cube.py::Test_collapsed__multidim_weighted_with_dim_metadata::test_weighted_fullweights_lazy_x
===================================================================== 354 passed, 90 warnings in 14.03s =====================================================================
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
