### PR TITLE
Make `slices_over` tests go faster

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -114,15 +114,17 @@ This document explains the changes made to Iris for this release
 #. `@pp-mo`_ reworked benchmark peak-memory measurement to use the
    `tracemalloc <https://docs.python.org/3.12/library/tracemalloc.html>`_
    package.
-   (:pull: `5948`)
+   (:pull:`5948`)
 
 #. `@pp-mo`_ added a benchmark 'trialrun' sub-command, to quickly test
-   benchmarks during development. (:pull: `5957`)
+   benchmarks during development. (:pull:`5957`)
 
 #. `@pp-mo`_ moved several memory-measurement benchmarks from 'on-demand' to
-   the standard set, in hopes that use of 'tracemalloc' (:pull: `5948`) makes
+   the standard set, in hopes that use of 'tracemalloc' (:pull:`5948`) makes
    the results consistent enough to monitor for performance changes.
-   (:pull: `5959`)
+   (:pull:`5959`)
+
+#. `@rcomer`_ made some ``slices_over`` tests go faster (:pull:`5973`)
 
 
 .. comment

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,7 +124,7 @@ This document explains the changes made to Iris for this release
    the results consistent enough to monitor for performance changes.
    (:pull:`5959`)
 
-#. `@rcomer`_ made some ``slices_over`` tests go faster (:pull:`5973`)
+#. `@rcomer`_ made some :meth:`~iris.cube.Cube.slices_over` tests go faster (:pull:`5973`)
 
 
 .. comment

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1051,10 +1051,10 @@ class Test_slices_dim_order(tests.IrisTest):
 @tests.skip_data
 class Test_slices_over(tests.IrisTest):
     def setUp(self):
-        self.cube = stock.realistic_4d()
+        self.cube = stock.realistic_4d()[:, :7, :10, :10]
         # Define expected iterators for 1D and 2D test cases.
         self.exp_iter_1d = range(len(self.cube.coord("model_level_number").points))
-        self.exp_iter_2d = np.ndindex(6, 70, 1, 1)
+        self.exp_iter_2d = np.ndindex(6, 7, 1, 1)
         # Define maximum number of interactions for particularly long
         # (and so time-consuming) iterators.
         self.long_iterator_max = 5
@@ -1154,7 +1154,7 @@ class Test_slices_over(tests.IrisTest):
         # cubes up to `self.long_iterator_max` to keep test runtime sensible.
         res = self.cube.slices_over("surface_altitude")
         # Define special ndindex iterator for the different dims sliced over.
-        nditer = np.ndindex(1, 1, 100, 100)
+        nditer = np.ndindex(1, 1, 10, 10)
         for ct in range(self.long_iterator_max):
             indices = list(next(nditer))
             # Replace the dimensions not iterated over with spanning slices.

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1090,7 +1090,7 @@ class Test_slices_over(tests.IrisTest):
             _ = self.cube.slices_over(self.cube.ndim + 1)
 
     def test_2d_slice_coord_given(self):
-        # Slicing over these two dimensions returns 420 2D cubes, so only check
+        # Slicing over these two dimensions returns 42 2D cubes, so only check
         # cubes up to `self.long_iterator_max` to keep test runtime sensible.
         res = self.cube.slices_over(
             [self.cube.coord("time"), self.cube.coord("model_level_number")]
@@ -1109,7 +1109,7 @@ class Test_slices_over(tests.IrisTest):
             )
 
     def test_2d_slice_coord_name_given(self):
-        # Slicing over these two dimensions returns 420 2D cubes, so only check
+        # Slicing over these two dimensions returns 42 2D cubes, so only check
         # cubes up to `self.long_iterator_max` to keep test runtime sensible.
         res = self.cube.slices_over(["time", "model_level_number"])
         for ct in range(self.long_iterator_max):
@@ -1124,7 +1124,7 @@ class Test_slices_over(tests.IrisTest):
             _ = self.cube.slices_over(["time", "wibble"])
 
     def test_2d_slice_dimension_given(self):
-        # Slicing over these two dimensions returns 420 2D cubes, so only check
+        # Slicing over these two dimensions returns 42 2D cubes, so only check
         # cubes up to `self.long_iterator_max` to keep test runtime sensible.
         res = self.cube.slices_over([0, 1])
         for ct in range(self.long_iterator_max):
@@ -1150,7 +1150,7 @@ class Test_slices_over(tests.IrisTest):
             _ = self.cube.slices_over([0, self.cube.ndim + 1])
 
     def test_multidim_slice_coord_given(self):
-        # Slicing over surface altitude returns 100x100 2D cubes, so only check
+        # Slicing over surface altitude returns 10x10 2D cubes, so only check
         # cubes up to `self.long_iterator_max` to keep test runtime sensible.
         res = self.cube.slices_over("surface_altitude")
         # Define special ndindex iterator for the different dims sliced over.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
I looked at #5969 and couldn't resist...

These slowest running tests are testing slicing over 70 model levels.  I assert that if the slicing does not go wrong for the first 7 levels, it is unlikely to go wrong for the next 63.  So let's just test with a smaller cube.  Locally, this simple change reduces the runtime of these tests by a factor of 9.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
