### PR TITLE
DOCS: Use tabs for the install info

### DIFF
--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -19,45 +19,48 @@ Iris can be installed using conda or pip.
 .. note:: This documentation was built using Python |python_version|.
 
 
-.. _installing_using_conda:
+.. _installing_a_released_version:
 
-Installing a Released Version Using Conda
------------------------------------------
+Installing a Released Version
+-----------------------------
 
-To install Iris using conda, you must first download and install conda,
-for example from https://docs.conda.io/en/latest/miniconda.html.
+.. tab-set::
 
-Once conda is installed, you can install Iris using conda with the following
-command::
+    .. tab-item:: conda-forge
 
-  conda install -c conda-forge iris
+        To install Iris using conda, you must first download and install conda,
+        for example from https://docs.conda.io/en/latest/miniconda.html.
 
-If you wish to run any of the code in the gallery you will also
-need the Iris sample data. This can also be installed using conda::
+        Once conda is installed, you can install Iris using conda with the following
+        command::
 
-  conda install -c conda-forge iris-sample-data
+          conda install -c conda-forge iris
 
-Further documentation on using conda and the features it provides can be found
-at https://docs.conda.io/projects/conda/en/latest/index.html.
+        If you wish to run any of the code in the gallery you will also
+        need the Iris sample data. This can also be installed using conda::
 
-.. _installing_using_pip:
+          conda install -c conda-forge iris-sample-data
 
-Installing a Released Version Using Pip
----------------------------------------
+        Further documentation on using conda and the features it provides can be found
+        at https://docs.conda.io/projects/conda/en/latest/index.html.
 
-Iris is also available from https://pypi.org/ so can be installed with ``pip``::
+    .. tab-item:: PyPI
 
-  pip install scitools-iris
+        Iris is also available from https://pypi.org/ so can be installed with ``pip``::
 
-If you wish to run any of the code in the gallery you will also
-need the Iris sample data. This can also be installed using pip::
+          pip install scitools-iris
 
-  pip install iris-sample-data
+        If you wish to run any of the code in the gallery you will also
+        need the Iris sample data. This can also be installed using pip::
+
+          pip install iris-sample-data
+
+
 
 .. _installing_from_source:
 
-Installing a Development Version from a Git Checkout
-----------------------------------------------------
+Installing a Development Version
+--------------------------------
 
 The latest Iris source release is available from
 https://github.com/SciTools/iris.


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Minor change to the installation instructions to use **tabs** in the docs.  The content under the conda and pypi tabs is the same as before, just in a tab.

Inspiration taken from the [geovista docs](https://geovista--828.org.readthedocs.build/en/828/installation.html#stable). (this is in a PR atm).

### Current  - [Link](https://scitools-iris.readthedocs.io/en/latest/installing.html#installing-a-released-version-using-conda)
![image](https://github.com/SciTools/iris/assets/2108488/52ee05ce-76cd-47e7-beca-8ffef3cc9750)


### New - [Link](https://scitools-iris--6013.org.readthedocs.build/en/6013/installing.html#installing-a-released-version)
![image](https://github.com/SciTools/iris/assets/2108488/44c852f3-6365-47cb-8641-f438eff89dad)


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
