### PR TITLE
NEP29 and NumPy v2 pins

### DIFF
--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.23, !=1.24.3
+  - numpy >=1.24, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.24, !=1.24.3
+  - numpy >=1.24, !=1.24.3, <2
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.23, !=1.24.3
+  - numpy >=1.24, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.24, !=1.24.3
+  - numpy >=1.24, !=1.24.3, <2
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.23, !=1.24.3
+  - numpy >=1.24, !=1.24.3
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -18,7 +18,7 @@ dependencies:
   - libnetcdf !=4.9.1
   - matplotlib-base >=3.5
   - netcdf4
-  - numpy >=1.24, !=1.24.3
+  - numpy >=1.24, !=1.24.3, <2
   - python-xxhash
   - pyproj
   - scipy

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -5,7 +5,7 @@ dask[array]>=2022.9.0
 # libnetcdf!=4.9.1 (not available on PyPI)
 matplotlib>=3.5
 netcdf4
-numpy>=1.23,!=1.24.3
+numpy>=1.24,!=1.24.3,<2
 pyproj
 scipy
 shapely!=1.8.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

- [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html)
  - `2024-06-22`: NumPy `>=1.24`
  - 0289e5680b208d02015be3a76715e8435002c4c0
- [NumPy v2](https://numpy.org/doc/stable/release/2.0.0-notes.html)
  - #6035 has proven that it will be a medium/large task to get all our tests supporting NumPy v2
  - We expect to have some slots to work on this for Iris v3.11 - #5571
  - So we need a pin in the meantime, and I expect also a patch release

The lock files already fit between these two pins so I have not refreshed those.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
