### PR TITLE
Add mesh metas to the iris.common.metadata public API.

### DIFF
--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -28,6 +28,8 @@ __all__ = [
     "CoordMetadata",
     "CubeMetadata",
     "DimCoordMetadata",
+    "MeshCoordMetadata",
+    "MeshMetadata",
     "SERVICES",
     "SERVICES_COMBINE",
     "SERVICES_DIFFERENCE",


### PR DESCRIPTION
I think this should have happened in #6061 but I missed it.
