### PR TITLE
DOCS: remove --force option as it is not present in conda (only mamba)

### DIFF
--- a/docs/src/installing.rst
+++ b/docs/src/installing.rst
@@ -72,15 +72,8 @@ Once conda is installed, you can create a development environment for Iris
 using conda and then activate it.  The example commands below assume you are in
 the root directory of your local copy of Iris::
 
-  conda env create --force --file=requirements/iris.yml
+  conda env create --file=requirements/iris.yml
   conda activate iris-dev
-
-.. note::
-
-  The ``--force`` option, used when creating the environment, first removes
-  any previously existing ``iris-dev`` environment of the same name. This is
-  particularly useful when rebuilding your environment due to a change in
-  requirements.
 
 The ``requirements/iris.yml`` file defines the Iris development conda
 environment *name* and all the relevant *top level* `conda-forge` package


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Remove reference to `--force` when using conda.  It is only available when using mamba.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
