### PR TITLE
Add format agent copy and equality methods

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -30,7 +30,9 @@ This document explains the changes made to Iris for this release
 ✨ Features
 ===========
 
-#. N/A
+#. `@jrackham-mo`_ added :meth:`~iris.io.format_picker.FormatAgent.copy` and
+   equality methods to :class:`iris.io.format_picker.FormatAgent`, as requested
+   in :issue:`6108`.
 
 
 🐛 Bugs Fixed
@@ -79,7 +81,7 @@ This document explains the changes made to Iris for this release
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
-
+.. _@jrackham-mo: https://github.com/jrackham-mo
 
 
 .. comment

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -32,7 +32,7 @@ This document explains the changes made to Iris for this release
 
 #. `@jrackham-mo`_ added :meth:`~iris.io.format_picker.FormatAgent.copy` and
    equality methods to :class:`iris.io.format_picker.FormatAgent`, as requested
-   in :issue:`6108`.
+   in :issue:`6108`, actioned in :pull:`6119`.
 
 
 🐛 Bugs Fixed

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -84,6 +84,12 @@ class FormatAgent:
             ["%s" % format_spec for format_spec in self._format_specs]
         )
 
+    def __eq__(self, other):
+        return self._format_specs == other._format_specs
+
+    def copy(self):
+        return FormatAgent(self._format_specs.copy())
+
     def get_spec(self, basename, buffer_obj):
         """Pick the first FormatSpecification.
 

--- a/lib/iris/io/format_picker.py
+++ b/lib/iris/io/format_picker.py
@@ -88,6 +88,13 @@ class FormatAgent:
         return self._format_specs == other._format_specs
 
     def copy(self):
+        """Return a copy of the format agent.
+
+        Returns
+        -------
+        FormatAgent
+            A copy of the format agent.
+        """
         return FormatAgent(self._format_specs.copy())
 
     def get_spec(self, basename, buffer_obj):

--- a/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
+++ b/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
@@ -1,0 +1,22 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the `iris.io.format_picker.FormatAgent` class."""
+from iris.fileformats import FORMAT_AGENT, FormatSpecification
+import iris.tests as tests
+
+
+class TestFormatAgent(tests.IrisTest):
+    def test_copy_is_equal(self):
+        format_agent_copy = FORMAT_AGENT.copy()
+        self.assertEqual(format_agent_copy, FORMAT_AGENT)
+
+    def test_modified_copy_not_equal(self):
+        format_agent_copy = FORMAT_AGENT.copy()
+        format_agent_copy._format_specs.pop()
+        self.assertNotEqual(format_agent_copy, FORMAT_AGENT)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
+++ b/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
@@ -3,7 +3,7 @@
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the `iris.io.format_picker.FormatAgent` class."""
-from iris.fileformats import FORMAT_AGENT, FormatSpecification
+from iris.fileformats import FORMAT_AGENT
 import iris.tests as tests
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Closes #6108.
Adds a copy method to `FormatAgent`, which creates a new `FormatAgent` from the format specs. Also adds an equality method which compares the format specs.

The use case for this is to temporarily modify the `FORMAT_AGENT` in a custom load, and then restore it so that we don't change standard `iris.load` behaviour outside of the custom load.