### PR TITLE
configure dependabot for github composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@ version: 2
 updates:
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/workflows/composite/*"
     schedule:
       # Check later in the week - the upstream dependabot check in `workflows` runs deliberately early in the week.
       #  Therefore allowing time for the `workflows` update to be merged-and-released first.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request updates the `dependabot` configuration to include coverage of our composite GHAs.

Note that, `dependabot` has not updated the [actions/cache](https://github.com/actions/cache) GHA version used by the composite actions, which has been at `v4.0.2` since 19 Mar 2024.

As a result, the composite actions have been using a deprecated version of `node.js` and forced to run on `node20`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
