### PR TITLE
Fix attribute array comparison

### DIFF
--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -388,7 +388,16 @@ class _CubeSignature(
                 diff_attrs = [
                     repr(key[1])
                     for key in attrs_1
-                    if np.all(attrs_1[key] != attrs_2[key])
+                    if not np.array_equal(attrs_1[key], attrs_2[key])
+                    ## CB: Is the original line below really what was intended?
+                    ##     It only evaluates to true if ALL the values are different
+                    ##     in an array.
+                    ##     Surely it should be either:
+                    ##       np.any( attrs_1[key] != attrs_2[key] )
+                    ##     or
+                    ##       not np.all( attrs_1[key] == attrs_2[key] )
+                    ##
+                    #if np.all(attrs_1[key] != attrs_2[key])
                 ]
                 diff_attrs = ", ".join(sorted(diff_attrs))
                 msgs.append(

--- a/lib/iris/common/mixin.py
+++ b/lib/iris/common/mixin.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 from functools import wraps
 from typing import Any
 
+import numpy as np
 import cf_units
 
 import iris.std_names
@@ -104,11 +105,15 @@ class LimitedAttributeDict(dict):
         match = set(self.keys()) == set(other.keys())
         if match:
             for key, value in self.items():
-                match = value == other[key]
-                try:
-                    match = bool(match)
-                except ValueError:
-                    match = match.all()
+                match = np.array_equal(value, other[key])
+                # [CB] # match = value == other[key]
+
+# [CB] I don't think this try block is need now (was there for when numpy ==
+# operator would return a scalar bool if the arrays were not the same shape)
+#                try:
+#                    match = bool(match)
+#                except ValueError:
+#                    match = match.all()
                 if not match:
                     break
         return match

--- a/lib/iris/tests/unit/common/mixin/test_LimitedAttributeDict.py
+++ b/lib/iris/tests/unit/common/mixin/test_LimitedAttributeDict.py
@@ -42,6 +42,9 @@ class Test(tests.IrisTest):
         right = LimitedAttributeDict(**values)
         self.assertEqual(left, right)
         self.assertEqual(left, values)
+
+        # ChrisB: I am not sure the follow test is really valid. It is comparing
+        # a one-element numpy array with a scalar. Is that what we want?
         values = dict(one=np.arange(1), two=np.arange(1), three=np.arange(1))
         left = LimitedAttributeDict(dict(one=0, two=0, three=0))
         right = LimitedAttributeDict(**values)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fixes: #6027 

Logic for comparing arrays in attributes was relying on old numpy behaviour where an array compared to another any object would return a scalar `True` or `False`. Current numpy behaviour is to do a element-wise comparison which throws an error if the arrays are of different size.

Fix is to use the numpy function `array_eqaul`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

