### PR TITLE
Improve handling of masks in concatenate

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -81,7 +81,7 @@ This document explains the changes made to Iris for this release
    may happen when there are very many or large auxiliary coordinates, derived
    coordinates, cell measures, or ancillary variables to be checked that span
    the concatenation axis. This issue can be avoided by disabling the
-   problematic check. (:pull:`5926`)
+   problematic check. (:pull:`5926` and :pull:`6187`)
 
 🔥 Deprecations
 ===============

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -310,7 +310,7 @@ def _hash_ndarray(a: np.ndarray) -> np.ndarray:
 
     # Hash the bytes representing the array data.
     hash.update(b"data=")
-    if isinstance(a, np.ma.MaskedArray):
+    if np.ma.is_masked(a):
         # Hash only the unmasked data
         hash.update(a.compressed().tobytes())
         # Hash the mask

--- a/lib/iris/tests/unit/concatenate/test_hashing.py
+++ b/lib/iris/tests/unit/concatenate/test_hashing.py
@@ -21,6 +21,8 @@ from iris import _concatenate
         (np.array([np.nan, 1.0]), np.array([np.nan, 1.0]), True),
         (np.ma.array([1, 2], mask=[0, 1]), np.ma.array([1, 2], mask=[0, 1]), True),
         (np.ma.array([1, 2], mask=[0, 1]), np.ma.array([1, 2], mask=[0, 0]), False),
+        (np.ma.array([1, 2], mask=[1, 1]), np.ma.array([1, 2], mask=[1, 1]), True),
+        (np.ma.array([1, 2], mask=[0, 0]), np.ma.array([1, 2], mask=[0, 0]), True),
         (da.arange(6).reshape((2, 3)), da.arange(6, chunks=1).reshape((2, 3)), True),
         (da.arange(20, chunks=1), da.arange(20, chunks=2), True),
         (
@@ -31,6 +33,21 @@ from iris import _concatenate
         (
             da.ma.masked_array([1, 2], mask=[0, 1]),
             da.ma.masked_array([1, 3], mask=[0, 1]),
+            True,
+        ),
+        (
+            np.arange(2),
+            da.ma.masked_array(np.arange(2), mask=[0, 0]),
+            True,
+        ),
+        (
+            np.arange(2),
+            da.ma.masked_array(np.arange(2), mask=[0, 1]),
+            False,
+        ),
+        (
+            da.ma.masked_array(np.arange(10), mask=np.zeros(10)),
+            da.ma.masked_array(np.arange(10), mask=np.ma.nomask),
             True,
         ),
         (


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The following arrays compare equal in `iris.util.array_equal`, so they should also compare equal in the hash function used by concatenate:
- `np.array([1, 2])` and `np.ma.array([1, 2], mask=np.ma.nomask)`
- `np.array([1, 2])` and `np.ma.array([1, 2], mask=[0, 0])`
- `np.ma.array([1, 2], mask=[0, 0])` and `np.ma.array([1, 2], mask=np.ma.nomask)`

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
