### PR TITLE
Add a pytest-unittest translator to the conversion guide  

### DIFF
--- a/docs/src/developers_guide/contributing_pytest_conversions.rst
+++ b/docs/src/developers_guide/contributing_pytest_conversions.rst
@@ -41,7 +41,7 @@ Conversion Checklist
 
 #. Check for references to ``@tests``. These should be changed to ``@_shared_utils``.
 #. Check for references to ``with mock.patch("...")``. These should be replaced with
-   ``mocker.patch("...")``, which can be passed into functions as a fixture.
+   ``mocker.patch("...")``. ``mocker`` is a fixture, and can be passed into functions.
 #. Check for ``np.testing.assert...``. This can usually be swapped for
    ``_shared_utils.assert...``.
 #. Check for references to ``super()``. Most test classes used to inherit from

--- a/docs/src/developers_guide/contributing_pytest_conversions.rst
+++ b/docs/src/developers_guide/contributing_pytest_conversions.rst
@@ -41,7 +41,7 @@ Conversion Checklist
 
 #. Check for references to ``@tests``. These should be changed to ``@_shared_utils``.
 #. Check for references to ``with mock.patch("...")``. These should be replaced with
-   ``mocker.patch("...")``.
+   ``mocker.patch("...")``, which and be passed into functions as a fixture.
 #. Check for ``np.testing.assert...``. This can usually be swapped for
    ``_shared_utils.assert...``.
 #. Check for references to ``super()``. Most test classes used to inherit from

--- a/docs/src/developers_guide/contributing_pytest_conversions.rst
+++ b/docs/src/developers_guide/contributing_pytest_conversions.rst
@@ -41,7 +41,7 @@ Conversion Checklist
 
 #. Check for references to ``@tests``. These should be changed to ``@_shared_utils``.
 #. Check for references to ``with mock.patch("...")``. These should be replaced with
-   ``mocker.patch("...")``, which and be passed into functions as a fixture.
+   ``mocker.patch("...")``, which can be passed into functions as a fixture.
 #. Check for ``np.testing.assert...``. This can usually be swapped for
    ``_shared_utils.assert...``.
 #. Check for references to ``super()``. Most test classes used to inherit from

--- a/docs/src/developers_guide/contributing_pytest_conversions.rst
+++ b/docs/src/developers_guide/contributing_pytest_conversions.rst
@@ -41,7 +41,7 @@ Conversion Checklist
 
 #. Check for references to ``@tests``. These should be changed to ``@_shared_utils``.
 #. Check for references to ``with mock.patch("...")``. These should be replaced with
-   ``mocker.patch("...")``. Note, ``mocker.patch("...")`` is NOT a context manager.
+   ``mocker.patch("...")``.
 #. Check for ``np.testing.assert...``. This can usually be swapped for
    ``_shared_utils.assert...``.
 #. Check for references to ``super()``. Most test classes used to inherit from
@@ -53,4 +53,24 @@ Conversion Checklist
    ``pytest.warns(match=message)``.
 #. Check the file against https://github.com/astral-sh/ruff , using ``pip install ruff`` ->
    ``ruff check --select PT <file>``.
+
+Common Translations
+-------------------
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - ``unittest`` method
+     - ``pytest`` equivalent
+   * - ``assertTrue(x)``
+     - ``assert x``
+   * - ``assertFalse(x)``
+     - ``assert not x``
+   * - ``assertRegex(x, y)``
+     - ``assert re.match(y, x)``
+   * - ``assertRaisesRegex(cls, msg_re)``
+     - ``with pytest.raises(cls, match=msg_re):``
+   * - ``mock.patch(...)``
+     - ``mocker.patch(...)``
 


### PR DESCRIPTION
Added a translation guide, as suggested in https://github.com/SciTools/iris/issues/5690#issuecomment-1988712822.

Additionally, corrected myself; ``mocker`` has the same api as ``mock``, and can be used as a context manager. In the example I based that judgement off, it was just decided it wasn't needed. 

See https://pytest-mock.readthedocs.io/en/latest/usage.html
