### PR TITLE
removed double reference of typehints and enhancements

### DIFF
--- a/docs/src/whatsnew/3.11.rst
+++ b/docs/src/whatsnew/3.11.rst
@@ -22,10 +22,6 @@ This document explains the changes made to Iris for this release
      coordinates, e.g. a time-varying orography.  This is controlled by the
      :meth:`~iris.LOAD_POLICY` object : see :class:`~iris.LoadPolicy`.
 
-   * We now have type hints in :class:`~iris.cube.Cube`, and
-     :meth:`iris.cube.CubeList.concatenate` is in places almost an order of
-     magnitude faster!
-
    * `@bouweandela`_ added type hints for :class:`~iris.cube.Cube`.
 
    * Checkout the significant performance enhancements section for a couple of


### PR DESCRIPTION
The 3.11 whatsnew currently double mentions type hints and enhancements. I've removed the offending line. 

This should go into the 3.11 branch, and then a mergeback. 