### PR TITLE
Reduce default number of benchmark rounds

### DIFF
--- a/benchmarks/bm_runner.py
+++ b/benchmarks/bm_runner.py
@@ -27,7 +27,7 @@ ROOT_DIR = BENCHMARKS_DIR.parent
 GH_REPORT_DIR = ROOT_DIR.joinpath(".github", "workflows", "benchmark_reports")
 
 # Common ASV arguments for all run_types except `custom`.
-ASV_HARNESS = "run {posargs} --attribute rounds=4 --interleave-rounds --show-stderr"
+ASV_HARNESS = "run {posargs} --attribute rounds=3 --interleave-rounds --show-stderr"
 
 
 def echo(echo_string: str):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Recent experience has shown that benchmarks run on GitHub actions are very accurate. I originally set the default of 4 rounds to compensate for an assumed _inaccuracy_ of GHA (given it's a shared resource). I would like to try with 3, and if that's still accurate I might consider dropping to 2.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
