### PR TITLE
Replace references of `conda install build` to `conda install python-build`

### DIFF
--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -223,7 +223,7 @@ To do this perform the following steps.
 Create a conda environment with the appropriate conda packages to build the
 source distribution (``sdist``) and pure Python wheel (``bdist_wheel``)::
 
-    > conda create -n iris-pypi -c conda-forge --yes build twine
+    > conda create -n iris-pypi -c conda-forge --yes python-build twine
     > . activate iris-pypi
 
 Checkout the appropriate Iris ``<release>`` tag from the appropriate ``<repo>``.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
`build` is now called `python-build` on conda (it is still just `build` in pip). It seems that the [feedstock was archived August '24](https://github.com/conda-forge/build-feedstock), and nothing else has broken, so I don't think this is a problem for Iris' automated processes, outside of references to it. 

This PR changes instructions in the docs for doing a manual pypi release.

