### PR TITLE
Faster dimension lookup for derived coordinates

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -80,6 +80,9 @@ This document explains the changes made to Iris for this release
    not break previously suggested code (instantiating and re-using an interpolator
    object remains possible), this is no longer an advertised feature. (:pull:`6084`)
 
+#. `@bouweandela`_ made coordinate dimension lookups faster for derived
+   coordinates. (:pull:`6337`)
+
 
 🔥 Deprecations
 ===============

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1873,14 +1873,6 @@ class Cube(CFVariableMixin):
             if match is None:
                 dims_by_id.update(aux_dims_by_id)
 
-        if match is None and not name_provided:
-            # We may have an equivalent coordinate but not the actual
-            # cube coordinate instance - so forced to perform coordinate
-            # lookup to attempt to retrieve it
-            coord = self.coord(coord)
-            # Check for id match - faster than equality
-            match = dims_by_id.get(id(coord))
-
         # Search derived aux coordinates
         if match is None:
             target_metadata = coord.metadata
@@ -1892,6 +1884,14 @@ class Cube(CFVariableMixin):
             matches = [factory.derived_dims(self.coord_dims) for factory in factories]
             if matches:
                 match = matches[0]
+
+        if match is None and not name_provided:
+            # We may have an equivalent coordinate but not the actual
+            # cube coordinate instance - so forced to perform coordinate
+            # lookup to attempt to retrieve it
+            coord = self.coord(coord)
+            # Check for id match - faster than equality
+            match = dims_by_id.get(id(coord))
 
         if match is None:
             raise iris.exceptions.CoordinateNotFoundError(coord.name())


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This makes looking up the dimensions of derived coordinates faster by first looking if the metadata of the requested coordinate matches that of an AuxFactory instead of creating the derived coordinate and then comparing the metadata. Creating a derived coordinate is a relatively slow operation.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
