### PR TITLE
added classification enums to qp

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -206,7 +206,8 @@ autodoc_default_options = {
     "undoc-members": True,
     "private-members": False,
     "special-members": False,
-    "inherited-members": True,
+    # Enums are most valuable when documented as concisely as possible.
+    "inherited-members": "Enum,IntEnum,ReprEnum,StrEnum",
     "show-inheritance": True,
 }
 

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -8,11 +8,14 @@ These routines work much like their :mod:`iris.plot` counterparts, but they
 automatically add a plot title, axis titles, and a colour bar when appropriate.
 
 These also have the optional kwarg ``footer``, which adds text to the bottom right of
-the plot figure.
+the plot figure. For security classifications, the enum :class:`Classifications`
+can be used for common usages.
 
 See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 
 """
+
+from enum import StrEnum
 
 import cf_units
 from matplotlib import patheffects
@@ -21,6 +24,13 @@ import matplotlib.pyplot as plt
 import iris.config
 import iris.coords
 import iris.plot as iplt
+
+
+class Classification(StrEnum):
+    official = "Official"
+    official_sensitive = "Official-Sensitive"
+    secret = "Secret"
+    top_secret = "Top Secret"
 
 
 def _use_symbol(units):

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -8,8 +8,8 @@ These routines work much like their :mod:`iris.plot` counterparts, but they
 automatically add a plot title, axis titles, and a colour bar when appropriate.
 
 These also have the optional kwarg ``footer``, which adds text to the bottom right of
-the plot figure. For security classifications, the enum :class:`Classifications`
-can be used for common usages.
+the plot figure. For UK government security classifications, the enum
+:class:`Classification` can be used for common usages.
 
 See also: :ref:`matplotlib <matplotlib:users-guide-index>`.
 
@@ -27,6 +27,11 @@ import iris.plot as iplt
 
 
 class Classification(StrEnum):
+    """Holds common UK security classifications, for convenience and consistency whilst using `footer`.
+
+    See `government documentation <https://assets.publishing.service.gov.uk/media/66b0d3c9ab418ab0555932d9/2024-08-05_-_2024_GSCP_UPDATE_.docx__1_.pdf>`__.
+    """
+
     official = "Official"
     official_sensitive = "Official-Sensitive"
     secret = "Secret"

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -283,9 +283,11 @@ class TestPlotHist(_shared_utils.GraphicsTest):
 
 @_shared_utils.skip_plot
 class TestFooter:
-    def test__footer(self):
-        text = "Example"
+    @pytest.mark.parametrize(
+        "text", [qplt.Classification.official_sensitive, "Example"]
+    )
+    def test__footer(self, text):
+        fig = plt.figure()
         qplt._footer(text)
-        fig = plt.gcf()
         footer_text = fig.texts[0].get_text()
         assert text == footer_text


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Added some convenience enums to quickplot, to supplement #6247.

```Python
from iris.quickplot import Classification

qplt.contour(cube, footer=Classification.official_sensitive)
iplot.show()
```
Which offers more consistency than:
```Python
qplt.contour(cube, footer="Official-Sensitive")
iplot.show()
```
