### PR TITLE
Fix typo in dask best practice/cape docs

### DIFF
--- a/docs/src/further_topics/dask_best_practices/dask_parallel_loop.rst
+++ b/docs/src/further_topics/dask_best_practices/dask_parallel_loop.rst
@@ -42,7 +42,7 @@ We start out by loading cubes of pressure, temperature, dewpoint temperature and
 We set up the NumPy arrays we will be filling with the output data::
 
     output_arrays = [np.zeros(pressure.shape[0]) for _ in range(6)]
-    cape, cin, lcl, lfc, el, tpw = output_data
+    cape, cin, lcl, lfc, el, tpw = output_arrays
 
 Now we loop over the columns in the data to calculate the soundings::
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
I noticed a small typo in one of the examples in the dask best practice section: https://scitools-iris.readthedocs.io/en/v3.7.1/further_topics/dask_best_practices/dask_parallel_loop.html#original-code-with-loop

I have not checked the rest of the code works, but I thought it would be worth getting this typo fixed at least

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

