### PR TITLE
TST: make image comparison fail nicely

### DIFF
--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -804,10 +804,10 @@ class TestPlotCoordinatesGiven(_shared_utils.GraphicsTest):
             try:
                 self.check_graphic()
             except AssertionError as err:
-                self.fail(
-                    "Draw method %r failed with coords: %r. "
-                    "Assertion message: %s" % (draw_method, rcoords, err)
+                err.add_note(
+                    f"Draw method {draw_method!r} failed with coords: {rcoords!r}."
                 )
+                raise
 
     def run_tests_1d(self, cube, results):
         # there is a different calling convention for 1d plots
@@ -816,10 +816,10 @@ class TestPlotCoordinatesGiven(_shared_utils.GraphicsTest):
             try:
                 self.check_graphic()
             except AssertionError as err:
-                msg = (
-                    "Draw method {!r} failed with coords: {!r}. Assertion message: {!s}"
+                err.add_note(
+                    f"Draw method {draw_method!r} failed with coords: {rcoords!r}."
                 )
-                self.fail(msg.format(draw_method, rcoords, err))
+                raise
 
     def test_yx(self):
         test_cube = self.cube[0, 0, :, :]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #6393.  I assume this `fail` method existed to expand the error message but got removed somewhere along the way.  I just learned about the [add_note](https://docs.python.org/3/library/exceptions.html#BaseException.add_note) method, which seems a nice simple way to achieve this.

Failure messages now look like

`run_tests_1D`
```
E                           AssertionError: Image comparison failed: Bad phash a2ffb6127f0dc9992085d960c6748d369b121ca69d6a9b048df34ce789ff7205 with hamming distance 4 for test iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_y.0.
E                           Draw method iris.quickplot.plot failed with coords: ['grid_latitude'].
```

`run_tests`
```
E                           AssertionError: Image comparison failed: Bad phash ead77a0cf751c5acb40195acd56999e2952899f2d5ec0bf2982c6a536a57b700 with hamming distance 6 for test iris.tests.test_quickplot.TestQuickplotCoordinatesGiven.test_tx.5.
E                           Draw method iris.quickplot.points failed with coords: ['grid_longitude', 'time'].
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
