### PR TITLE
Remove unnecessary `global` declarations

### DIFF
--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -211,7 +211,6 @@ def _get_cf_var_data(cf_var, filename):
     unnecessarily slow + wasteful of memory.
 
     """
-    global CHUNK_CONTROL
     if hasattr(cf_var, "_data_array"):
         # The variable is not an actual netCDF4 file variable, but an emulating
         # object with an attached data array (either numpy or dask), which can be
@@ -353,8 +352,6 @@ class _OrderedAddableList(list):
 
 
 def _load_cube(engine, cf, cf_var, filename):
-    global CHUNK_CONTROL
-
     # Translate dimension chunk-settings specific to this cube (i.e. named by
     # it's data-var) into global ones, for the duration of this load.
     # Thus, by default, we will create any AuxCoords, CellMeasures et al with

--- a/lib/iris/palette.py
+++ b/lib/iris/palette.py
@@ -227,7 +227,7 @@ def _load_palette():
 
     """
     # Reference these module level namespace variables.
-    global CMAP_BREWER, _CMAP_BY_SCHEME, _CMAP_BY_KEYWORD, _CMAP_BY_STD_NAME
+    global _CMAP_BY_SCHEME, _CMAP_BY_KEYWORD, _CMAP_BY_STD_NAME
 
     _CMAP_BY_SCHEME = {}
     _CMAP_BY_KEYWORD = {}


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Remove several `global` variable declarations that were unnecessary due to the variables never being **assigned** to in their declared scope (accessing them is not ambiguous in the namespace scope).

This was highlighted by the flake8 linter in a recent pre-commit hook update.

Unblocks: #6396 
