### PR TITLE
Remove `setup.py develop` command

### DIFF
--- a/benchmarks/asv_delegated.py
+++ b/benchmarks/asv_delegated.py
@@ -41,6 +41,24 @@ class Delegated(_DelegatedABC):
         # The project checkout.
         build_dir = Path(self._build_root) / self._repo_subdir
 
+        # Older iterations of setup.py are incompatible with setuptools>=80.
+        #  (Most dependencies are protected by lock-files, but build
+        #   dependencies in pyproject.toml are independent).
+        setup_py = build_dir / "setup.py"
+        pyproject = build_dir / "pyproject.toml"
+        if setup_py.is_file() and "setuptools.command.develop" in setup_py.read_text():
+            with pyproject.open("r+") as file_write:
+                lines = file_write.readlines()
+                for i, line in enumerate(lines):
+                    if line == "requires = [\n":
+                        next_line = lines[i + 1]
+                        indent = next_line[: len(next_line) - len(next_line.lstrip())]
+
+                        lines.insert(i + 1, f'{indent}"setuptools<80",\n')
+                        break
+                file_write.seek(0)
+                file_write.writelines(lines)
+
         class Mode(enum.Enum):
             """The scenarios where the correct env setup script is known."""
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -36,7 +36,10 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@trexfeathers`_ removed the custom ``setup.py develop`` command, since
+   Setuptools are deprecating ``develop``; developers should instead
+   use ``pip install -e .``. See `Running setuptools commands`_ for more.
+   (:pull:`6424`)
 
 
 💣 Incompatible Changes
@@ -75,11 +78,6 @@ This document explains the changes made to Iris for this release
 #. `@pp-mo`_ replaced the PR-based linkchecks with a daily scheduled link checker based
    on `lychee <https://github.com/lycheeverse/lychee-action>`__.
    (:issue:`4140`, :pull:`6386`)
-
-#. `@trexfeathers`_ removed the custom ``setup.py develop`` command, since
-   Setuptools are deprecating ``develop``; developers should instead
-   use ``pip install -e .``. See `Running setuptools commands`_ for more.
-   (:pull:`6424`)
 
 
 .. comment

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -76,6 +76,11 @@ This document explains the changes made to Iris for this release
    on `lychee <https://github.com/lycheeverse/lychee-action>`__.
    (:issue:`4140`, :pull:`6386`)
 
+#. `@trexfeathers`_ removed the custom ``setup.py develop`` command, since
+   Setuptools are deprecating ``develop``; developers should instead
+   use ``pip install -e .``. See `Running setuptools commands`_ for more.
+   (:pull:`6424`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -86,3 +91,5 @@ This document explains the changes made to Iris for this release
 
 .. comment
     Whatsnew resources in alphabetical order:
+
+.. _Running setuptools commands: https://setuptools.pypa.io/en/latest/deprecated/commands.html

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import sys
 
 from setuptools import Command, setup
 from setuptools.command.build_py import build_py
-from setuptools.command.develop import develop
 
 
 class BaseCommand(Command):
@@ -49,8 +48,7 @@ def custom_command(cmd, help=""):
             cmd.finalize_options(self)
 
             if not hasattr(self, "editable_mode") or self.editable_mode is None:
-                # Default to editable i.e., applicable to "std_names" and
-                # and "develop" commands.
+                # Default to editable i.e., applicable to "std_names".
                 self.editable_mode = True
 
         def run(self):
@@ -76,7 +74,6 @@ def custom_command(cmd, help=""):
 
 
 custom_commands = {
-    "develop": custom_command(develop),
     "build_py": custom_command(build_py),
     "std_names": custom_command(BaseCommand, help="generate CF standard names"),
 }


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This is deprecated behaviour and can easily be achieved using `pip install -e .` instead.

#### More info

- [Running `setuptools` commands](https://setuptools.pypa.io/en/latest/deprecated/commands.html)
- [v80.0.0 deprecations and removals](https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals)

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
