### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 # Defined by PEP 518
 requires = [
-  "setuptools>=64",
-  "setuptools_scm[toml]>=7.0",
+  "setuptools>=77.0.3",
+  "setuptools_scm[toml]>=8",
   "wheel",
 ]
 # Defined by PEP 517
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
@@ -48,7 +47,8 @@ keywords = [
     "ugrid",
     "visualisation",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "scitools-iris"
 requires-python = ">=3.11"
 
@@ -116,7 +116,6 @@ known-first-party = ["iris"]
 convention = "numpy"
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.dynamic]

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -7,8 +7,8 @@ dependencies:
   - python =3.11
 
 # Setup dependencies.
-  - setuptools >=64
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # Core dependencies.
   - cartopy >=0.21

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -7,8 +7,8 @@ dependencies:
   - python =3.12
 
 # Setup dependencies.
-  - setuptools >=64
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # Core dependencies.
   - cartopy >=0.21

--- a/requirements/py313.yml
+++ b/requirements/py313.yml
@@ -7,8 +7,8 @@ dependencies:
   - python =3.13
 
 # Setup dependencies.
-  - setuptools >=64
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # Core dependencies.
   - cartopy >=0.21


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request complies with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
