### PR TITLE
Various linkcheck fixes and improvements

### DIFF
--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           fail: false
-          args: "--verbose './docs/**/*.rst' './docs/**/*.inc' './lib/**/*.py'"
+          args: "--verbose --max-concurrency 1 './docs/**/*.rst' './docs/**/*.inc' './lib/**/*.py'"
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0

--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -13,18 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Generate token"
-        uses: actions/create-github-app-token@v2
-        id: generate-token
-        with:
-          app-id: ${{ secrets.AUTH_APP_ID }}
-          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
-
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{secrets.GITHUB_TOKEN}}
           fail: false
           args: "--verbose './docs/**/*.rst' './docs/**/*.inc' './lib/**/*.py'"
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -26,6 +26,10 @@ https://geoport.whoi.edu:80/thredds/
 # catch (at least) github userids, of which many in whatsnews, too many --> "too many requests" failures
 https://github.com/[^/]*$
 
+# GitHub seems especially keen to rate-limit "blob" URLs.
+#  (maybe because these are especially associated with abuse?)
+https://github.com/[^/]*/[^/]*/blob/.*
+
 # nonfunctional example, used in docs/src/developers_guide/gitwash/development_workflow.rst
 https://github.com/your-user-name/iris
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

#6455 did not fix the GitHub rate limiting failures, and in the process made us more vulnerable by widening access to the `scitools-ci` token. I've investigated in more detail now; see comments below for explanations.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
