### PR TITLE
Handle cases where `CFVariable` doesn't know its filename (e.g. NcData).

### DIFF
--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -88,8 +88,12 @@ class CFVariable(metaclass=ABCMeta):
         self.cf_data = data
         """NetCDF4 Variable data instance."""
 
-        self.filename = data.group().filepath()
+        self.filename: str
         """File source of the NetCDF content."""
+        try:
+            self.filename = data.group().filepath()
+        except AttributeError:
+            self.filename = "<unknown_filename>"
 
         self.cf_group = None
         """Collection of CF-netCDF variables associated with this variable."""


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Follow up to the changes in 03a5e72fe0dd33598c086a0c9063a181a59312a9 - it is not always possible to know the correct filename from the context of `CFVariable`.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
