### PR TITLE
Make the `Cube` class available from Iris root

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -104,6 +104,7 @@ from iris._combine import COMBINE_POLICY as _COMBINE_POLICY
 from iris._combine import CombineOptions
 import iris._constraints
 import iris.config
+from iris.cube import Cube
 import iris.io
 from iris.io import save
 from iris.loading import (


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Closes #891

- [x] Circular imports - didn't happen
- [x] Documentation - importing, but not including in `__all__`, adds the convenience without polluting the documentation. Precedent comes from `geovista.GeoPlotter` ([undocumented](https://geovista.readthedocs.io/en/latest/reference/generated/api/geovista/index.html)), which actually comes from `geovista.geoplotter.GeoPlotter` ([documented](https://geovista.readthedocs.io/en/latest/reference/generated/api/geovista/geoplotter/index.html#geovista.geoplotter.GeoPlotter))
- [ ] Performance regressions - tested locally, but just confirming via CI...

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
