### PR TITLE
Rechunk derived

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -51,7 +51,8 @@ This document explains the changes made to Iris for this release
 🚀 Performance Enhancements
 ===========================
 
-#. N/A
+#. `@pp-mo`_ implemented automatic rechunking of hybrid (aka factory/derived)
+   coordinates to avoid excessive memory usage. (:issue:`6404`, :pull:`6516`)
 
 
 🔥 Deprecations

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -116,11 +116,12 @@ class AuxCoordFactory(CFVariableMixin, metaclass=ABCMeta):
         points array, and then again to make the bounds.
         """
         # Make an initial result calculation.
-        # First make all dependencies lazy, to ensure a lazy calculation and avoid
-        #  potentially spending a lot of time + memory.
+        # First make all dependencies (args) lazy, to ensure a lazy result calculation
+        #  and so avoid a greedy use of time + memory.
         lazy_deps = [
-            # Note: no attempt to make clever chunking choices here.  If needed it
-            #  should get fixed later.  Plus, single chunks keeps graph overhead small.
+            # Note: wrap real deps as single chunks here, no attempt at clever chunking.
+            #  If better is needed, this appears as too-big result chunks, which get
+            #  rechunked later.  For now, single chunks minimise the initial graph size.
             dep if is_lazy_data(dep) else da.from_array(dep, chunks=-1)
             for dep in dep_arrays
         ]

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -144,7 +144,7 @@ class AuxCoordFactory(CFVariableMixin, metaclass=ABCMeta):
                 #  chunksize, if smaller.
                 new_chunks = []
                 for dim_chunks, dim_max in zip(dep.chunks, adjusted_chunks):
-                    # N.B. dim_chunks is a list of the dep chunks in this dm, whereas
+                    # N.B. dim_chunks is a list of the dep chunks in this dim, whereas
                     #  dim_maxchunk is a single number (part of a chunksize).
                     if max(dim_chunks) <= dim_max:
                         dim_chunks = dim_chunks

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -121,7 +121,7 @@ class AuxCoordFactory(CFVariableMixin, metaclass=ABCMeta):
 
         # The dims of all the given components should be the same and, **presumably**,
         #  the same as the result ??
-        for i_dep, (dep, name) in enumerate(zip(dep_arrays, self.dependencies().keys())):
+        for i_dep, (dep, name) in enumerate(zip(dep_arrays, self.dependencies.keys())):
             if dep.ndim != result.ndim:
                 msg = (
                     f"Dependency #{i_dep}, '{name}' has ndims={dep.ndim}, "

--- a/lib/iris/tests/unit/aux_factory/test_AtmosphereSigmaFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AtmosphereSigmaFactory.py
@@ -135,21 +135,21 @@ class Test_dependencies:
 
 class Test__derive:
     def test_function_scalar(self):
-        assert AtmosphereSigmaFactory._derive(0, 0, 0) == 0
-        assert AtmosphereSigmaFactory._derive(3, 0, 0) == 3
-        assert AtmosphereSigmaFactory._derive(0, 5, 0) == 0
-        assert AtmosphereSigmaFactory._derive(0, 0, 7) == 0
-        assert AtmosphereSigmaFactory._derive(3, 5, 0) == -12
-        assert AtmosphereSigmaFactory._derive(3, 0, 7) == 3
-        assert AtmosphereSigmaFactory._derive(0, 5, 7) == 35
-        assert AtmosphereSigmaFactory._derive(3, 5, 7) == 23
+        assert AtmosphereSigmaFactory._calculate_array(0, 0, 0) == 0
+        assert AtmosphereSigmaFactory._calculate_array(3, 0, 0) == 3
+        assert AtmosphereSigmaFactory._calculate_array(0, 5, 0) == 0
+        assert AtmosphereSigmaFactory._calculate_array(0, 0, 7) == 0
+        assert AtmosphereSigmaFactory._calculate_array(3, 5, 0) == -12
+        assert AtmosphereSigmaFactory._calculate_array(3, 0, 7) == 3
+        assert AtmosphereSigmaFactory._calculate_array(0, 5, 7) == 35
+        assert AtmosphereSigmaFactory._calculate_array(3, 5, 7) == 23
 
     def test_function_array(self):
         ptop = 3
         sigma = np.array([2, 4])
         ps = np.arange(4).reshape(2, 2)
         np.testing.assert_equal(
-            AtmosphereSigmaFactory._derive(ptop, sigma, ps),
+            AtmosphereSigmaFactory._calculate_array(ptop, sigma, ps),
             [[-3, -5], [1, 3]],
         )
 

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -177,6 +177,7 @@ class Test_rechunk:
             self.y = make_co("y", (1, ny, 1))
             self.z = make_co("z", (1, 1, nz))
 
+        @property
         def dependencies(self):
             return {'x': self.x, "y": self.y, "z": self.z}
 

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -194,12 +194,12 @@ def chunkspecs(points: _Chunkspec, bounds: _Chunkspec) -> Tuple[_Chunks, _Chunks
     points, bounds : _Chunkspec
         A pair (points, bounds) of chunk specs.
         Each is a sequence of dimension specs, where each dim is either an int or an
-        iterable of int
+        iterable of int.
 
     Returns
     -------
-    chunks :
-        a pair of tuple of tuples, in the form of Dask chunks arguments.
+    points, bounds : _Chunks
+        a pair of array chunk descriptors, in the form of Dask chunks arguments.
 
     """
     pts_spec, bds_spec = [

--- a/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_AuxCoordFactory.py
@@ -165,21 +165,23 @@ class Test_lazy_aux_coords:
 
 class Test_rechunk:
     class TestAuxFact(AuxCoordFactory):
-        # A minimal AuxCoordFactory that enables us to test the re-chunking logic.
+        """A minimal AuxCoordFactory that enables us to test the re-chunking logic."""
+
         def __init__(self, nx, ny, nz):
             def make_co(name, dims):
                 dims = tuple(dims)
                 pts = da.ones(dims, dtype=np.int32, chunks=dims)
-                bds = np.stack([pts-0.5, pts+0.5], axis=-1)
+                bds = np.stack([pts - 0.5, pts + 0.5], axis=-1)
                 co = AuxCoord(pts, bounds=bds, long_name=name)
                 return co
+
             self.x = make_co("x", (nx, 1, 1))
             self.y = make_co("y", (1, ny, 1))
             self.z = make_co("z", (1, 1, nz))
 
         @property
         def dependencies(self):
-            return {'x': self.x, "y": self.y, "z": self.z}
+            return {"x": self.x, "y": self.y, "z": self.z}
 
         def _calculate_array(self, *dep_arrays, **other_args):
             x, y, z = dep_arrays
@@ -200,7 +202,7 @@ class Test_rechunk:
             )
             return result
 
-    @pytest.mark.parametrize('nz', [10, 100, 1000])
+    @pytest.mark.parametrize("nz", [10, 100, 1000])
     def test_rechunk(self, nz):
         # Test calculation which forms (NX, 1, 1) * (1, NY, 1) * (1, 1, NZ)
         #  at different NZ sizes eventually needing to rechunk on both Y and X


### PR DESCRIPTION
Closes #6404 

Automatic rechunking of derived coordinates

Investigation of the #6404 problem reveals that the points/bounds arrays of our derived (aka factory)  coords have arrays which are mostly single chunks, which could thus be very large.

This was due to the fact that they tend to be like a broadcast product of several simple one-dimensional coords (dim or aux), each spanning a different dim or two, which themselves are quite small and so tend to be all single chunks.  
When these are broadcast together, the result then tends to be one massive chunk, which can blow memory.

**For example:** 
a result formed like A * B * C, 
where these might have dims (T, Z, Y, X) of:
  - A: (NT, 1, 1, 1),  
  - B: (1, NZ, 1, 1),  
  - C: (1, 1, NY, NX), 

which are all relatively small, and so can be single chunks.  

Say  NT, NZ, NY, NX = 100, 70, 1000, 500.
then the result is (100 * 70 * 1000 * 500) -> 3.5Gpoints.
If element size is a typical 4 bytes, and dask chunksize is a typical 200Mb, then we expect a chunk ~50M array elements.
An array of this size, loaded from an input netcdf file, might get chunked (1, 70, 1000, 500)  ~35M elements, or 140Mb.
But our derived coord will have the _whole_ array, 3,500 Melements --> **~14Gb in a single chunk**.

It seems likely that this problem has been noticed more recently because, since #5369, we now have derived coordinates which are time-dependent, so that is multiplying up the total size where before it did not.
However even before this, we were potentially mutliplying e.g. the size of a field * the number of model levels, which already lead to single-chunk arrays larger than ideal.  Typical numbers : 70 * 1024 * 768 * 4 = 220Mib, already reaching the standard Dask chunksize of 200Mib (so hi-res fields or double resolution will clearly exceed).

### Todo:
  * [x] more testing to ensure coverage of all new code
  * [ ]  when this is agreed + passing :
    * [ ] agree on #6517
    * [ ] merge that in here
    * [ ] check it doesn't break this
    * [ ] when+if all good, merge this