### PR TITLE
PP saver: correctly set `bplon` for LAM domains

### DIFF
--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -44,6 +44,13 @@ def _basic_coord_system_rules(cube, pp):
     if cube.coord_system("GeogCS") is not None or cube.coord_system(None) is None:
         pp.bplat = 90
         pp.bplon = 0
+        try:
+            # LAMs should have bplon of 180
+            if not cube.coord(axis="x").circular or not cube.coord(axis="x").circular:
+                pp.bplon = 180.0
+        except iris.exceptions.CoordinateNotFoundError:
+            pass
+
     elif cube.coord_system("RotatedGeogCS") is not None:
         pp.bplat = cube.coord_system("RotatedGeogCS").grid_north_pole_latitude
         pp.bplon = cube.coord_system("RotatedGeogCS").grid_north_pole_longitude


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fixes: #3560 

When saving cube to PP format the `lblon` PP field (rotated pole longitude) should be set to 180.0 if the domain is a Local Area Model (LAM)

Global domains should have it set to 0.0, as per the previous behaviour.