### PR TITLE
More informative stack trace for benchmark data generation

### DIFF
--- a/benchmarks/benchmarks/generate_data/__init__.py
+++ b/benchmarks/benchmarks/generate_data/__init__.py
@@ -99,8 +99,6 @@ def run_function_elsewhere(func_to_run, *args, **kwargs):
     )
     python_string = "\n".join([func_string, func_call_string])
 
-    result = None
-    data_gen_traceback = None
     try:
         result = run(
             [DATA_GEN_PYTHON, "-c", python_string],
@@ -109,14 +107,11 @@ def run_function_elsewhere(func_to_run, *args, **kwargs):
             text=True,
         )
     except CalledProcessError as error_:
-        data_gen_traceback = error_.stderr
+        # From None 'breaks' the error chain - we don't want the original
+        #  traceback since it is long and confusing.
+        raise DataGenerationError(error_.stderr) from None
 
-    # Raise the error outside the original error chain - don't want the original
-    #  traceback since it is long and confusing.
-    if data_gen_traceback:
-        raise DataGenerationError(data_gen_traceback)
-    else:
-        return result.stdout
+    return result.stdout
 
 
 @contextmanager

--- a/benchmarks/benchmarks/generate_data/__init__.py
+++ b/benchmarks/benchmarks/generate_data/__init__.py
@@ -103,10 +103,13 @@ def run_function_elsewhere(func_to_run, *args, **kwargs):
     data_gen_traceback = None
     try:
         result = run(
-            [DATA_GEN_PYTHON, "-c", python_string], capture_output=True, check=True
+            [DATA_GEN_PYTHON, "-c", python_string],
+            capture_output=True,
+            check=True,
+            text=True,
         )
     except CalledProcessError as error_:
-        data_gen_traceback = error_.stderr.decode()
+        data_gen_traceback = error_.stderr
 
     # Raise the error outside the original error chain - don't want the original
     #  traceback since it is long and confusing.

--- a/benchmarks/benchmarks/generate_data/stock.py
+++ b/benchmarks/benchmarks/generate_data/stock.py
@@ -45,7 +45,7 @@ def _create_file__xios_common(func_name, **kwargs):
             temp_file_dir=str(BENCHMARK_DATA),
             **kwargs,
         )
-        Path(actual_path.decode()).replace(save_path)
+        Path(actual_path).replace(save_path)
     return save_path
 
 

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -98,6 +98,10 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ added a CI workflow to quickly validate that the
    benchmarking setup is still working. (:pull:`6496`)
 
+#. `@trexfeathers`_ improved the stack trace for errors that occur during
+   benchmark data generation, showing developers the root problem at-a-glance
+   without needing local replication. (:pull:`6524`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The current setup produces a long and confusing trace. Due to our use of `subprocess` to run a _separate_ Python instance, the information is provides is close to meaningless - a big block of text with the function definition, but no information about what went wrong when running the function.

<details><summary>Example from the current setup</summary>

```
               For parameters: 2
               Traceback (most recent call last):
                 File "/home/runner/work/iris/iris/benchmarks/.asv/env/e35ec55c4ba4ad9d53b3b315a88cda8c/delegated_env/lib/python3.13/site-packages/asv_runner/server.py", line 179, in _run_server
                   _run(run_args)
                   ~~~~^^^^^^^^^^
                 File "/home/runner/work/iris/iris/benchmarks/.asv/env/e35ec55c4ba4ad9d53b3b315a88cda8c/delegated_env/lib/python3.13/site-packages/asv_runner/run.py", line 65, in _run
                   skip = benchmark.do_setup()
                 File "/home/runner/work/iris/iris/benchmarks/.asv/env/e35ec55c4ba4ad9d53b3b315a88cda8c/delegated_env/lib/python3.13/site-packages/asv_runner/benchmarks/time.py", line 80, in do_setup
                   result = Benchmark.do_setup(self)
                 File "/home/runner/work/iris/iris/benchmarks/.asv/env/e35ec55c4ba4ad9d53b3b315a88cda8c/delegated_env/lib/python3.13/site-packages/asv_runner/benchmarks/_base.py", line 632, in do_setup
                   setup(*self._current_params)
                   ~~~~~^^^^^^^^^^^^^^^^^^^^^^^
                 File "/home/runner/work/iris/iris/benchmarks/benchmarks/__init__.py", line 68, in setup
                   (self.file_path,) = create_um_files(
                                       ~~~~~~~~~~~~~~~^
                       param, param, param, param, False, ["NetCDF"]
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   ).values()
                   ^
                 File "/home/runner/work/iris/iris/benchmarks/benchmarks/generate_data/um_files.py", line 184, in create_um_files
                   _ = run_function_elsewhere(
                       _create_um_files, len_x, len_y, len_z, len_t, compress, save_paths
                   )
                 File "/home/runner/work/iris/iris/benchmarks/benchmarks/generate_data/__init__.py", line 95, in run_function_elsewhere
                   result = run(
                       [DATA_GEN_PYTHON, "-c", python_string], capture_output=True, check=True
                   )
                 File "/home/runner/work/iris/iris/benchmarks/.asv/env/e35ec55c4ba4ad9d53b3b315a88cda8c/delegated_env/lib/python3.13/subprocess.py", line 577, in run
                   raise CalledProcessError(retcode, process.args,
                                            output=stdout, stderr=stderr)
               subprocess.CalledProcessError: Command '['/home/runner/work/iris/iris/.nox/tests-3-13/bin/python3.13', '-c', 'def _create_um_files(\n    len_x: int, len_y: int, len_z: int, len_t: int, compress, save_paths: dict\n) -> None:\n    """Generate an FF object of given shape and compression, save to FF/PP/NetCDF.\n\n    This is run externally\n    (:func:`benchmarks.generate_data.run_function_elsewhere`), so all imports\n    are self-contained and input parameters are simple types.\n    """\n    from copy import deepcopy\n    from datetime import datetime\n    from tempfile import NamedTemporaryFile\n\n    from mule import ArrayDataProvider, Field3, FieldsFile\n    from mule.pp import fields_to_pp_file\n    import numpy as np\n\n    from iris import load_cube\n    from iris import save as save_cube\n\n    template = {\n        "fixed_length_header": {"dataset_type": 3, "grid_staggering": 3},\n        "integer_constants": {\n            "num_p_levels": len_z,\n            "num_cols": len_x,\n            "num_rows": len_y,\n        },\n        "real_constants": {},\n        "level_dependent_constants": {"dims": (len_z + 1, None)},\n    }\n    new_ff = FieldsFile.from_template(deepcopy(template))\n\n    data_array = np.arange(len_x * len_y).reshape(len_x, len_y)\n    array_provider = ArrayDataProvider(data_array)\n\n    def add_field(level_: int, time_step_: int) -> None:\n        """Add a minimal field to the new :class:`~mule.FieldsFile`.\n\n        Includes the minimum information to allow Mule saving and Iris\n        loading, as well as incrementation for vertical levels and time\n        steps to allow generation of z and t dimensions.\n        """\n        new_field = Field3.empty()\n        # To correspond to the header-release 3 class used.\n        new_field.lbrel = 3\n        # Mule uses the first element of the lookup to test for\n        #  unpopulated fields (and skips them), so the first element should\n        #  be set to something. The year will do.\n        new_field.raw[1] = datetime.now().year\n\n        # Horizontal.\n        new_field.lbcode = 1\n        new_field.lbnpt = len_x\n        new_field.lbrow = len_y\n        new_field.bdx = new_ff.real_constants.col_spacing\n        new_field.bdy = new_ff.real_constants.row_spacing\n        new_field.bzx = new_ff.real_constants.start_lon - 0.5 * new_field.bdx\n        new_field.bzy = new_ff.real_constants.start_lat - 0.5 * new_field.bdy\n\n        # Hemisphere.\n        new_field.lbhem = 32\n        # Processing.\n        new_field.lbproc = 0\n\n        # Vertical.\n        # Hybrid height values by simulating sequences similar to those in a\n        #  theta file.\n        new_field.lbvc = 65\n        if level_ == 0:\n            new_field.lblev = 9999\n        else:\n            new_field.lblev = level_\n\n        level_1 = level_ + 1\n        six_rec = 20 / 3\n        three_rec = six_rec / 2\n\n        new_field.blev = level_1**2 * six_rec - six_rec\n        new_field.brsvd1 = level_1**2 * six_rec + (six_rec * level_1) - three_rec\n\n        brsvd2_simulated = np.linspace(0.995, 0, len_z)\n        shift = min(len_z, 2)\n        bhrlev_simulated = np.concatenate([np.ones(shift), brsvd2_simulated[:-shift]])\n        new_field.brsvd2 = brsvd2_simulated[level_]\n        new_field.bhrlev = bhrlev_simulated[level_]\n\n        # Time.\n        new_field.lbtim = 11\n\n        new_field.lbyr = time_step_\n        for attr_name in ["lbmon", "lbdat", "lbhr", "lbmin", "lbsec"]:\n            setattr(new_field, attr_name, 0)\n\n        new_field.lbyrd = time_step_ + 1\n        for attr_name in ["lbmond", "lbdatd", "lbhrd", "lbmind", "lbsecd"]:\n            setattr(new_field, attr_name, 0)\n\n        # Data and packing.\n        new_field.lbuser1 = 1\n        new_field.lbpack = int(compress)\n        new_field.bacc = 0\n        new_field.bmdi = -1\n        new_field.lbext = 0\n        new_field.set_data_provider(array_provider)\n\n        new_ff.fields.append(new_field)\n\n    for time_step in range(len_t):\n        for level in range(len_z):\n            add_field(level, time_step + 1)\n\n    ff_path = save_paths.get("FF", None)\n    pp_path = save_paths.get("PP", None)\n    nc_path = save_paths.get("NetCDF", None)\n\n    if ff_path:\n        new_ff.to_file(ff_path)\n    if pp_path:\n        fields_to_pp_file(str(pp_path), new_ff.fields)\n    if nc_path:\n        temp_ff_path = None\n        # Need an Iris Cube from the FF content.\n        if ff_path:\n            # Use the existing file.\n            ff_cube = load_cube(ff_path)\n        else:\n            # Make a temporary file.\n            temp_ff_path = NamedTemporaryFile()\n            new_ff.to_file(temp_ff_path.name)\n            ff_cube = load_cube(temp_ff_path.name)\n\n        save_cube(ff_cube, nc_path, zlib=compress)\n        if temp_ff_path:\n            temp_ff_path.close()\n\n_create_um_files(2,2,2,2,False,{\'NetCDF\': \'/home/runner/work/iris/iris/benchmarks/.data/UM_2_2_2_2/False.nc\'})']' returned non-zero exit status 1.
```

</details>

The proposed setup suppresses the original trace, instead raising its own deliberately constructed error derived from the `stderr` of the `subprocess` call.

<details><summary>Example from the proposed setup</summary>

```
              For parameters: 2
              Traceback (most recent call last):
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/asv_runner/server.py", line 179, in _run_server
                  _run(run_args)
                  ~~~~^^^^^^^^^^
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/asv_runner/run.py", line 65, in _run
                  skip = benchmark.do_setup()
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/asv_runner/benchmarks/time.py", line 80, in do_setup
                  result = Benchmark.do_setup(self)
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/asv_runner/benchmarks/_base.py", line 632, in do_setup
                  setup(*self._current_params)
                  ~~~~~^^^^^^^^^^^^^^^^^^^^^^^
                File "/home/users/martin.yeo/repos/iris/benchmarks/benchmarks/__init__.py", line 68, in setup
                  (self.file_path,) = create_um_files(
                                      ~~~~~~~~~~~~~~~^
                      param, param, param, param, False, ["NetCDF"]
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  ).values()
                  ^
                File "/home/users/martin.yeo/repos/iris/benchmarks/benchmarks/generate_data/um_files.py", line 184, in create_um_files
                  _ = run_function_elsewhere(
                      _create_um_files, len_x, len_y, len_z, len_t, compress, save_paths
                  )
                File "/home/users/martin.yeo/repos/iris/benchmarks/benchmarks/generate_data/__init__.py", line 112, in run_function_elsewhere
                  raise DataGenerationError(error_.stderr) from None
              benchmarks.generate_data.DataGenerationError: Traceback (most recent call last):
                File "<string>", line 136, in <module>
                  _create_um_files(2,2,2,2,False,{'NetCDF': '/home/users/martin.yeo/repos/iris/benchmarks/.data/UM_2_2_2_2/False.nc'})
                  ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "<string>", line 129, in _create_um_files
                  new_ff.to_file(temp_ff_path.name)
                  ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/mule/__init__.py", line 1412, in to_file
                  self._write_to_file(output_file)
                  ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/mule/ff.py", line 496, in _write_to_file
                  super(FieldsFile, self)._write_to_file(output_file)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/mule/__init__.py", line 1738, in _write_to_file
                  data_bytes, data_size = write_operator.to_bytes(field)
                                          ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
                File "/home/users/martin.yeo/repos/iris/.nox/tests-3-13/lib/python3.13/site-packages/mule/ff.py", line 315, in to_bytes
                  return data.tostring(), data.size
                         ^^^^^^^^^^^^^
              AttributeError: 'numpy.ndarray' object has no attribute 'tostring'
              asv: benchmark failed (exit status 1)

```

</details>

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
