### PR TITLE
Save derived bounds

### DIFF
--- a/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_with_db.cdl
+++ b/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_with_db.cdl
@@ -1,0 +1,44 @@
+dimensions:
+	bnds = 2 ;
+	dim1 = 1 ;
+	dim2 = 1 ;
+	eta = 1 ;
+variables:
+	float temp(eta, dim1, dim2) ;
+		temp:standard_name = "air_temperature" ;
+		temp:units = "K" ;
+		temp:coordinates = "A B P0 PS ap" ;
+	double eta(eta) ;
+		eta:axis = "Z" ;
+		eta:bounds = "eta_bnds" ;
+		eta:standard_name = "atmosphere_hybrid_sigma_pressure_coordinate" ;
+		eta:long_name = "eta at full levels" ;
+		eta:positive = "down" ;
+	double eta_bnds(eta, bnds) ;
+	double P0 ;
+		P0:units = "Pa" ;
+	double PS(dim1, dim2) ;
+		PS:units = "Pa" ;
+	double A(eta) ;
+		A:bounds = "A_bnds" ;
+		A:units = "1" ;
+		A:long_name = "a coefficient for vertical coordinate at full levels" ;
+	double A_bnds(eta, bnds) ;
+	double B(eta) ;
+		B:bounds = "B_bnds" ;
+		B:units = "1" ;
+		B:long_name = "b coefficient for vertical coordinate at full levels" ;
+	double B_bnds(eta, bnds) ;
+	double ap(eta) ;
+		ap:bounds = "ap_bnds" ;
+		ap:units = "Pa" ;
+		ap:long_name = "vertical pressure" ;
+		ap:standard_name = "atmosphere_hybrid_sigma_pressure_coordinate" ;
+		ap:axis = "Z" ;
+		ap:formula_terms = "ap: ap b: B ps: PS" ;
+	double ap_bnds(eta, bnds) ;
+		ap_bnds:formula_terms = "ap: ap_bnds b: B_bnds ps: PS" ;
+
+// global attributes:
+		:Conventions = "CF-1.7" ;
+}

--- a/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_without_db.cdl
+++ b/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_without_db.cdl
@@ -1,0 +1,43 @@
+dimensions:
+	bnds = 2 ;
+	dim1 = 1 ;
+	dim2 = 1 ;
+	eta = 1 ;
+variables:
+	float temp(eta, dim1, dim2) ;
+		temp:standard_name = "air_temperature" ;
+		temp:units = "K" ;
+		temp:coordinates = "A B P0 PS ap" ;
+	double eta(eta) ;
+		eta:axis = "Z" ;
+		eta:bounds = "eta_bnds" ;
+		eta:standard_name = "atmosphere_hybrid_sigma_pressure_coordinate" ;
+		eta:long_name = "eta at full levels" ;
+		eta:positive = "down" ;
+	double eta_bnds(eta, bnds) ;
+	double P0 ;
+		P0:units = "Pa" ;
+	double PS(dim1, dim2) ;
+		PS:units = "Pa" ;
+	double A(eta) ;
+		A:bounds = "A_bnds" ;
+		A:units = "1" ;
+		A:long_name = "a coefficient for vertical coordinate at full levels" ;
+	double A_bnds(eta, bnds) ;
+	double B(eta) ;
+		B:bounds = "B_bnds" ;
+		B:units = "1" ;
+		B:long_name = "b coefficient for vertical coordinate at full levels" ;
+	double B_bnds(eta, bnds) ;
+	double ap(eta) ;
+		ap:bounds = "ap_bnds" ;
+		ap:units = "Pa" ;
+		ap:long_name = "vertical pressure" ;
+		ap:standard_name = "atmosphere_hybrid_sigma_pressure_coordinate" ;
+		ap:axis = "Z" ;
+		ap:formula_terms = "ap: ap b: B ps: PS" ;
+	double ap_bnds(eta, bnds) ;
+
+// global attributes:
+		:Conventions = "CF-1.7" ;
+}


### PR DESCRIPTION
Closes #6530

Note that the "proof" of the fix is to really compare 
https://github.com/SciTools/iris/blob/487cc7a96cb0e48256b48f5f9c7124e9f0dc671c/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_without_db.cdl
with
https://github.com/SciTools/iris/blob/487cc7a96cb0e48256b48f5f9c7124e9f0dc671c/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_with_db.cdl
so .. in the second case, we get [this magic extra line](https://github.com/SciTools/iris/blob/487cc7a96cb0e48256b48f5f9c7124e9f0dc671c/lib/iris/tests/results/integration/netcdf/derived_bounds/TestBoundsFiles/test_save_primary_with_db.cdl#L40)

-----
### Is this really ready to go ?
The main question there is, probably, more testing may be required - but **_can we think of any?_**
One thing to note : the new code is intentionally quite defensive
 \- i.e. things like "what if the named bounds-var doesn't exist", "what if the terms var doesn't exist" 
 \- but a lot of that is probably not worth testing, since it may be impossible to get the saver to actually produce those cases

