### PR TITLE
pypi: use trusted publishing for binary wheels

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -129,6 +129,10 @@ jobs:
     needs: test-wheel
     name: "publish to test.pypi"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: test-pypi
+
     # upload to Test PyPI for every commit on main branch
     # and check for the SciTools repo
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'SciTools'
@@ -138,18 +142,20 @@ jobs:
         name: pypi-artifacts
         path: ${{ github.workspace }}/dist
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-        print_hash: true
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        print-hash: true
 
   publish-artifacts-pypi:
     needs: test-wheel
     name: "publish to pypi"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: pypi
+
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && github.repository_owner == 'SciTools'
     steps:
@@ -158,8 +164,6 @@ jobs:
         name: pypi-artifacts
         path: ${{ github.workspace }}/dist
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        print_hash: true
+        print-hash: true

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -142,6 +142,11 @@ This document explains the changes made to Iris for this release
    benchmark data generation, showing developers the root problem at-a-glance
    without needing local replication. (:pull:`6524`)
 
+#. `@bjlittle`_ added support for `Trusted Publishing`_ of source distributions
+   and binary wheels to PyPI and Test PyPI. (:pull:`6543`)
+
+
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
@@ -152,3 +157,5 @@ This document explains the changes made to Iris for this release
 
 .. comment
     Whatsnew resources in alphabetical order:
+
+.. _Trusted Publishing: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

[PyPI](https://pypi.org/) now supports **Trusted Publishing**, which is an OIDC-based "tokenless" authentication mechanism for uploading to the index from within a CI/CD workflow.

This "tokenless" flow has significant security benefits over a traditional manually configured API token, and should be preferred wherever supported and possible.

This pull-request also requires PyPI (and Test PyPI) to be configured for Trusted Publishing for the `scitools-iris` project, which has already been performed. 

Reference:

- [Trusted Publishers for all Package Repositories](https://repos.openssf.org/trusted-publishers-for-all-package-repositories.html)
- [Publishing to PyPI with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/)

