### PR TITLE
Generalise support for netcdf load+save of "special" attributes

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -72,7 +72,7 @@ This document explains the changes made to Iris for this release
    real data but will leave the :class:`iris.MeshCoord` (and attached mesh) lazy. (:issue:`4757`, :pull:`6405`)
 
 #. `@pp-mo`_ made it possible for the reference surfaces of derived coordinates, like orography, to be lazy.
-   (:pull: 6517).
+   (:pull:`6517`).
 
 #. `@HGWright`_ and `@pp-mo`_ enabled correct loading and saving of the bounds of CF
    parametric coordinates (that is, Iris derived coordinates).  This was previously
@@ -83,6 +83,11 @@ This document explains the changes made to Iris for this release
 #. `@bjlittle`_ extended ``zlib`` compression of :class:`~iris.cube.Cube` data payload when saving to NetCDF
    to also include any auxiliary coordinates and ancillary variables with the same ``shape``.
    (:issue:`6539`, :pull:`6552`)
+
+#. `@pp-mo`_ added support for saving and loading the special ``GRIB_PARAM`` attributes to netcdf, as used
+   by iris-grib to record the exact grib-file encoding of phenomenon types.  This means that data sourced
+   from GRIB grib files can be freely saved and re-loaded to netcdf without loss of information.
+   (`Issue Iris-grib#596 <https://github.com/SciTools/iris-grib/issues/596>`__, :pull:`6566`).
 
 
 🐛 Bugs Fixed
@@ -185,6 +190,10 @@ This document explains the changes made to Iris for this release
 #. `@DarkVoyager11`_ added a round trip integration test for NetCDF calendar attributes.
    (:issue:`2985`, :pull:`6562`)
 
+#. `@pp-mo`_ made a unified mechanism for 'managed' cube attributes: ones which get
+   converted between an iris-internal and an in-file form for saving/loading to netcdf,
+   such as STASH objects in a STASH attribute.
+   (:pull:`6566`).
 
 
 .. comment

--- a/lib/iris/fileformats/_nc_load_rules/actions.py
+++ b/lib/iris/fileformats/_nc_load_rules/actions.py
@@ -559,7 +559,7 @@ def action_all_managed_attributes(engine):
                 + "".join(f"\n  {name!r}: {val!r}" for name, val in matches)
                 + "\n- only the first of these is actioned."
             )
-            warnings.warn(msg)
+            warnings.warn(msg, category=_WarnComboLoadIgnoring)
 
         if len(matches) > 0:
             input_name, input_value = matches[0]
@@ -572,7 +572,7 @@ def action_all_managed_attributes(engine):
                     f"Iris '.{iris_name}' attribute is set to this untranslated raw "
                     "value -- which will not save out."
                 )
-                warnings.warn(msg)
+                warnings.warn(msg, category=iris.warnings.IrisLoadWarning)
 
             # process as a rule
             action_managed_attribute(engine, iris_name, iris_value)

--- a/lib/iris/fileformats/_nc_load_rules/actions.py
+++ b/lib/iris/fileformats/_nc_load_rules/actions.py
@@ -574,7 +574,7 @@ def action_all_managed_attributes(engine):
             # Take the first as priority
             input_name, input_value = matches[0]
             try:
-                iris_value = handler.decode_attribute(input_name, input_value)
+                iris_value = handler.decode_attribute(input_value)
                 # process as a rule
                 action_managed_attribute(engine, iris_name, iris_value)
 

--- a/lib/iris/fileformats/_nc_load_rules/actions.py
+++ b/lib/iris/fileformats/_nc_load_rules/actions.py
@@ -554,9 +554,9 @@ def action_all_managed_attributes(engine):
     var = engine.cf_var
     for handler in ATTRIBUTE_HANDLERS.values():
         # Each handler can have several match names, but ideally only 0 or 1 appears !
-        iris_name = handler.IrisIdentifyingName
+        iris_name = handler.iris_name
         matches = []
-        for match_name in handler.NetcdfIdentifyingNames:
+        for match_name in handler.netcdf_names:
             match_value = getattr(var, match_name, None)
             if match_value is not None:
                 matches.append((match_name, match_value))

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -32,10 +32,12 @@ class AttributeHandler(metaclass=ABCMeta):
     #: The storage name(s) which identify this type of data in actual files, which thus
     #  identify attributes which we should attempt to decode with this coder.
     # NOTES:
-    # (1) for save the attribute name is dynamically determined by the "encode" call.
-    # (2) for load, in (presumably extremely rare) case of multiples appearing, "the"
+    # (1) for load, in (presumably extremely rare) case of multiples appearing, "the"
     #  internal attribute is taken from the earliest appearing name: The other values
     #  are lost, and a warning will be issued.
+    # (2) for save ,the attribute name is dynamically determined by the "encode" call.
+    #  On translation failure, however, we assume it is the last name listed -- since
+    #  it is so for StashHandler, the only one it currently matters for.
     NetcdfIdentifyingNames: List[str] = []
 
     @abstractmethod

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -1,0 +1,299 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""NetCDF attribute translations for Iris attributes with special convenience types.
+
+These are things which are stored differently in an Iris cube attribute from how they
+are actually stored in a netcdf file.  E.G. a STASH code is stored as a special object,
+but in a file it is just a string.
+
+These conversions are intended to be automatic and lossless, like a serialization.
+
+At present, there are 3 of these :
+  * "STASH": records/controls the exact file encoding of data loaded from or saved to
+     UM file formats (PP/FF).
+  * "GRIB_PARAM": does the same for GRIB data (using iris_grib).
+  * "ukmo__process_flags": internally a tuple of strings, but stored as a single string
+    with underscore separators.
+
+"""
+
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, List, Tuple
+
+
+class AttributeCodingObject(metaclass=ABCMeta):
+    #: The user-visible attribute name used within Iris, which identifies attributes
+    #  which we should attempt to encode with this coder.
+    IrisIdentifyingName: str = ""
+    #: The storage name(s) which identify this type of data in actual files, which thus
+    #  identify attributes which we should attempt to decode with this coder.
+    # NOTES:
+    # (1) for save the attribute name is dynamically determined by the "encode" call.
+    # (2) for load, in (presumably extremely rare) case of multiples appearing, "the"
+    #  internal attribute is taken from the earliest appearing name: The other values
+    #  are lost, and a warning will be issued.
+    NetcdfIdentifyingNames: List[str] = []
+
+    @staticmethod
+    @abstractmethod
+    def encode_object(content) -> Tuple[str, str]:
+        """Encode an object as an attribute name and value.
+
+        We already do change the name of STASH attributes to "um_stash_source" on save
+        (as-of Iris 3.12).  This structure also allows that we might produce different
+        names for different codes.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def decode_attribute(attr_name: str, attr_value: str) -> Any:
+        """Decode an attribute name and string to an attribute object."""
+        pass
+
+
+class StashCoder(AttributeCodingObject):
+    """Convert STASH object attribute to/from a netcdf string attribute."""
+
+    IrisIdentifyingName = "STASH"
+    # Note: two possible in-file attribute names, second one is a 'legacy' version.
+    NetcdfIdentifyingNames = ["um_stash_source", "ukmo__um_stash_source"]
+
+    @staticmethod
+    def encode_object(stash):
+        return StashCoder.NetcdfIdentifyingNames[0], str(stash)
+
+    @staticmethod
+    def decode_attribute(attr_name: str, attr_value: str):
+        # In this case the attribute name does not matter.
+        from iris.fileformats.pp import STASH
+
+        return STASH.from_msi(attr_value)
+
+
+class UkmoProcessCoder(AttributeCodingObject):
+    """Convert ukmo__process_flags tuple attribute to/from a netcdf string attribute."""
+
+    IrisIdentifyingName = "ukmo__process_flags"
+    NetcdfIdentifyingNames = ["ukmo__process_flags"]
+
+    @staticmethod
+    def encode_object(value):
+        def value_fix(value):
+            value = value.replace(" ", "_")
+            if value == "":
+                # Special handling for an empty string entry, which otherwise upsets
+                #  the split/join process.
+                value = "<EMPTY>"
+            return value
+
+        value = " ".join([value_fix(x) for x in value])
+        return UkmoProcessCoder.NetcdfIdentifyingNames[0], value
+
+    @staticmethod
+    def decode_attribute(attr_name: str, attr_value: str):
+        # In this case the attribute name does not matter.
+        def value_unfix(value):
+            value = value.replace("_", " ")
+            if value == "<EMPTY>":
+                # A placeholder flagging where the original was an empty string.
+                value = ""
+            return value
+
+        if attr_value == "":
+            flags = []
+        else:
+            flags = [value_unfix(x) for x in attr_value.split(" ")]
+
+        return tuple(flags)
+
+
+class GribParamCoder(AttributeCodingObject):
+    """Convert iris_grib GRIB_PARAM object attribute to/from a netcdf string attribute.
+
+    Use the mechanisms in iris_grib.
+    """
+
+    IrisIdentifyingName = "GRIB_PARAM"
+    NetcdfIdentifyingNames = ["GRIB_PARAM"]
+
+    @staticmethod
+    def encode_object(grib_param):
+        # grib_param should be an
+        #  iris_grib.grib_phenom_translation._gribcode.GenericConcreteGRIBCode
+        # Not typing this, as we need iris_grib to remain an optional import.
+        return GribParamCoder.NetcdfIdentifyingNames[0], repr(grib_param)
+
+    @staticmethod
+    def decode_attribute(attr_name: str, attr_value: str):
+        from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+
+        result = None
+        # Use the helper function to construct a suitable GenericConcreteGRIBCode object.
+        try:
+            result = GRIBCode(attr_value)
+        except (TypeError, ValueError):
+            pass
+        return result
+
+
+# Define the available attribute handlers.
+ATTRIBUTE_HANDLERS: Dict[str, AttributeCodingObject] = {}
+
+
+def _add_handler(handler: AttributeCodingObject):
+    ATTRIBUTE_HANDLERS[handler.IrisIdentifyingName] = handler
+
+
+# Always include the "STASH" and "ukmo__process_flags" handlers.
+_add_handler(StashCoder())
+_add_handler(UkmoProcessCoder())
+
+try:
+    import iris_grib  # noqa: F401
+
+    # If iris-grib is available, also include the "GRIB_PARAM" handler.
+    _add_handler(GribParamCoder())
+
+except ImportError:
+    pass
+
+
+#
+# Mechanism tests
+#
+def _decode_gribcode(grib_code: str):
+    return GribParamCoder.decode_attribute("x", grib_code)
+    # from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+    #
+    # result = None
+    # # Use the helper function to construct a suitable GenericConcreteGRIBCode object.
+    # try:
+    #     result = GRIBCode(grib_code)
+    # except (TypeError, ValueError):
+    #     pass
+    #
+    # return result
+
+
+def make_gribcode(*args, **kwargs):
+    from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+
+    return GRIBCode(*args, **kwargs)
+
+
+class TestGribDecode:
+    def test_grib_1(self):
+        assert _decode_gribcode(
+            "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        ) == make_gribcode(1, 2, 3, 4)
+
+    def test_grib_2(self):
+        assert _decode_gribcode("GRIBCode(2,5,7,13)") == make_gribcode(2, 5, 7, 13)
+
+    def test_grib_3(self):
+        assert _decode_gribcode(
+            "GRIBCode(2,5, number=13, centre_number=7)"
+        ) == make_gribcode(2, 5, 7, 13)
+
+    def test_grib_4(self):
+        assert _decode_gribcode("GRIBxXCode(2,5,7,13)") == make_gribcode(2, 5, 7, 13)
+
+    def test_grib_5(self):
+        assert _decode_gribcode("GRIBCode()") is None
+
+    def test_grib_6(self):
+        assert _decode_gribcode("GRIBCode(xxx)") is None
+
+    def test_grib_7(self):
+        assert _decode_gribcode(
+            "GRIBCode(xxx-any-junk..1, 2,qytw3dsa, 4)"
+        ) == make_gribcode(1, 2, 3, 4)
+
+
+def _sample_decode_rawlbproc(lbproc):
+    from iris.fileformats._pp_lbproc_pairs import LBPROC_MAP
+
+    return tuple(
+        sorted(
+            [
+                name
+                for value, name in LBPROC_MAP.items()
+                if isinstance(value, int) and lbproc & value
+            ]
+        )
+    )
+
+
+def _check_pf_roundtrip(contents):
+    print(f"original: {contents!r}")
+    name, val = UkmoProcessCoder.encode_object(contents)
+    reconstruct = UkmoProcessCoder.decode_attribute(name, val)
+    print(f"  -> encoded: {val!r}")
+    print(f"  -> reconstructed: {reconstruct!r}")
+    assert name == "ukmo__process_flags"
+    n_val = 0 if val == "" else len(val.split(" "))  # because split is odd
+    assert n_val == len(contents)
+    assert reconstruct == contents
+
+
+class TestProcessFlagsRoundtrip:
+    def test_pf_1(self):
+        sample = ("A example", "b", "another-thing with spaces")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_2(self):
+        sample = ("single",)
+        _check_pf_roundtrip(sample)
+
+    def test_pf_3(self):
+        sample = ("nonempty", "", "nonempty2")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_4(self):
+        sample = ()
+        _check_pf_roundtrip(sample)
+
+    def test_pf_5(self):
+        sample = ("a", "")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_6(self):
+        sample = ("", "b")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_7(self):
+        sample = ("",)
+        _check_pf_roundtrip(sample)
+
+    def test_pf_8(self):
+        sample = (" ",)
+        _check_pf_roundtrip(sample)
+
+    def test_pf_9(self):
+        sample = ("", "")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_10(self):
+        sample = (" a", "b")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_11(self):
+        sample = ("a ", "b")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_12(self):
+        sample = ("a", " b")
+        _check_pf_roundtrip(sample)
+
+    def test_pf_13(self):
+        sample = ("a", "b ")
+        _check_pf_roundtrip(sample)
+
+
+#
+# NOTE: also need to test both encode + decode separately, as there are corner cases.
+# LIKE: leading+trailing, empty entries ...
+#

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -58,8 +58,9 @@ class StashHandler(AttributeHandler):
     """Convert STASH object attribute to/from a netcdf string attribute."""
 
     IrisIdentifyingName = "STASH"
-    # Note: two possible in-file attribute names, second one is a 'legacy' version.
-    NetcdfIdentifyingNames = ["um_stash_source", "ukmo__um_stash_source"]
+    # Note: two possible in-file attribute names, the first one is a 'legacy' version
+    #  but takes priority in a conflict.
+    NetcdfIdentifyingNames = ["ukmo__um_stash_source", "um_stash_source"]
 
     def encode_object(self, stash):
         if isinstance(stash, STASH):
@@ -77,7 +78,8 @@ class StashHandler(AttributeHandler):
             raise TypeError(msg)
 
         msi_string = str(stash_object)  # convert to standard MSI string representation
-        return self.NetcdfIdentifyingNames[0], msi_string
+        # We always write "um_stash_source", not the legacy one.
+        return self.NetcdfIdentifyingNames[1], msi_string
 
     def decode_attribute(self, attr_name: str, attr_value):
         # In this case the attribute name does not matter.

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -20,7 +20,7 @@ At present, there are 3 of these :
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from iris.fileformats.pp import STASH
 
@@ -38,10 +38,10 @@ class AttributeHandler(metaclass=ABCMeta):
     # (2) for save ,the attribute name is dynamically determined by the "encode" call.
     #  On translation failure, however, we assume it is the last name listed -- since
     #  it is so for StashHandler, the only one it currently matters for.
-    NetcdfIdentifyingNames: List[str] = []
+    NetcdfIdentifyingNames: list[str] = []
 
     @abstractmethod
-    def encode_object(self, content) -> Tuple[str, str]:
+    def encode_object(self, content) -> tuple[str, str]:
         """Encode an object as an attribute name and value.
 
         We already do change the name of STASH attributes to "um_stash_source" on save
@@ -177,7 +177,7 @@ class GribParamHandler(AttributeHandler):
 
 
 # Define the available attribute handlers.
-ATTRIBUTE_HANDLERS: Dict[str, AttributeHandler] = {}
+ATTRIBUTE_HANDLERS: dict[str, AttributeHandler] = {}
 
 
 def _add_handler(handler: AttributeHandler):

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -87,7 +87,7 @@ class StashHandler(AttributeHandler):
         return STASH.from_msi(attr_value)
 
 
-class UkmoProcessHandler(AttributeHandler):
+class UkmoProcessFlagsHandler(AttributeHandler):
     """Convert ukmo__process_flags tuple attribute to/from a netcdf string attribute."""
 
     IrisIdentifyingName = "ukmo__process_flags"
@@ -183,7 +183,7 @@ def _add_handler(handler: AttributeHandler):
 
 # Always include the "STASH" and "ukmo__process_flags" handlers.
 _add_handler(StashHandler())
-_add_handler(UkmoProcessHandler())
+_add_handler(UkmoProcessFlagsHandler())
 
 try:
     import iris_grib  # noqa: F401
@@ -263,7 +263,7 @@ def _sample_decode_rawlbproc(lbproc):
 
 def _check_pf_roundtrip(contents):
     print(f"original: {contents!r}")
-    handler = UkmoProcessHandler()
+    handler = UkmoProcessFlagsHandler()
     name, val = handler.encode_object(contents)
     reconstruct = handler.decode_attribute(name, val)
     print(f"  -> encoded: {val!r}")

--- a/lib/iris/fileformats/netcdf/_attribute_handlers.py
+++ b/lib/iris/fileformats/netcdf/_attribute_handlers.py
@@ -56,7 +56,7 @@ class AttributeHandler(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def decode_attribute(self, attr_name: str, attr_value: Any) -> Any:
+    def decode_attribute(self, attr_value: Any) -> Any:
         """Decode an attribute name and value into the appropriate attribute object.
 
         The 'value' is typically a string, but possibly other attribute content types,
@@ -94,7 +94,7 @@ class StashHandler(AttributeHandler):
         # We always write "um_stash_source", not the legacy one.
         return self.NetcdfIdentifyingNames[1], msi_string
 
-    def decode_attribute(self, attr_name: str, attr_value: Any) -> Any:
+    def decode_attribute(self, attr_value: Any) -> Any:
         # In this case the attribute name does not matter.
         from iris.fileformats.pp import STASH
 
@@ -129,7 +129,7 @@ class UkmoProcessFlagsHandler(AttributeHandler):
         value = " ".join([value_fix(x) for x in value])
         return self.NetcdfIdentifyingNames[0], value
 
-    def decode_attribute(self, attr_name: str, attr_value: Any) -> Any:
+    def decode_attribute(self, attr_value: Any) -> Any:
         # In this case the attribute name does not matter.
         attr_value = str(attr_value)
 
@@ -179,7 +179,7 @@ class GribParamHandler(AttributeHandler):
         grib_string = repr(gribcode)
         return self.NetcdfIdentifyingNames[0], grib_string
 
-    def decode_attribute(self, attr_name: str, attr_value: Any) -> Any:
+    def decode_attribute(self, attr_value: Any) -> Any:
         from iris_grib.grib_phenom_translation._gribcode import GRIBCode
 
         # As above, a str() conversion is implied here.

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2427,7 +2427,7 @@ class Saver:
                         f"Invalid value in managed '{attr_name}' attribute: {value!r}. "
                         f"File attribute set to raw (string) value {string_value!r}."
                     )
-                    warnings.warn(msg)
+                    warnings.warn(msg, category=iris.warnings.IrisSaveWarning)
                     # Resolve by setting the expected attr to the "raw" string repr
                     attr_name = handler.NetcdfIdentifyingNames[0]
                     value = string_value

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2428,9 +2428,9 @@ class Saver:
                         f"File attribute set to raw (string) value {string_value!r}."
                     )
                     warnings.warn(msg, category=iris.warnings.IrisSaveWarning)
-                    # Resolve by setting the expected attr to the "raw" string repr
+                    # Resolve by setting the **Iris** attr-name to the "raw" string repr
                     # NB we expect the default written name to be the last listed
-                    attr_name = handler.NetcdfIdentifyingNames[-1]
+                    attr_name = handler.IrisIdentifyingName
                     value = string_value
 
             if attr_name in _CF_GLOBAL_ATTRS:

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2429,7 +2429,8 @@ class Saver:
                     )
                     warnings.warn(msg, category=iris.warnings.IrisSaveWarning)
                     # Resolve by setting the expected attr to the "raw" string repr
-                    attr_name = handler.NetcdfIdentifyingNames[0]
+                    # NB we expect the default written name to be the last listed
+                    attr_name = handler.NetcdfIdentifyingNames[-1]
                     value = string_value
 
             if attr_name in _CF_GLOBAL_ATTRS:

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -2430,7 +2430,7 @@ class Saver:
                     warnings.warn(msg, category=iris.warnings.IrisSaveWarning)
                     # Resolve by setting the **Iris** attr-name to the "raw" string repr
                     # NB we expect the default written name to be the last listed
-                    attr_name = handler.IrisIdentifyingName
+                    attr_name = handler.iris_name
                     value = string_value
 
             if attr_name in _CF_GLOBAL_ATTRS:

--- a/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
@@ -1,0 +1,207 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Integration tests for netcdf loading of attributes with "special" handling."""
+
+import warnings
+
+from iris_grib.grib_phenom_translation._gribcode import (
+    GenericConcreteGRIBCode,
+    GRIBCode,
+)
+import netCDF4 as nc
+import numpy as np
+import pytest
+
+import iris
+from iris.cube import Cube
+from iris.fileformats.pp import STASH
+
+
+@pytest.fixture(autouse=True, scope="session")
+def iris_futures():
+    iris.FUTURE.save_split_attrs = True
+
+
+class LoadTestCommon:
+    @pytest.fixture(autouse=True)
+    def tmp_filepath(self, tmp_path_factory):
+        tmp_dir = tmp_path_factory.mktemp("tmp_nc")
+        # We can reuse the same path all over, as it is recreated for each test.
+        self.tmp_ncpath = tmp_dir / "tmp.nc"
+        yield
+
+    def _check_load_inner(self, iris_name, nc_name, value):
+        # quickly create a valid netcdf file with a simple cube in it.
+        cube = Cube([1], var_name="x")
+        # Save : NB can fail
+        iris.save(cube, self.tmp_ncpath)
+        # Reopen for updating with netcdf
+        ds = nc.Dataset(self.tmp_ncpath, "r+")
+        # Add the test attribute content.
+        ds.variables["x"].setncattr(nc_name, value)
+        ds.close()
+        # Now load back + see what Iris loader makes of the attribute value.
+        cube = iris.load_cube(self.tmp_ncpath, "x")
+        # NB can be absent -> None result.
+        result = cube.attributes.get(iris_name)
+        return result
+
+    _LOAD_FAIL_MSG = "Invalid content for attribute.* set to.* untranslated raw value"
+
+
+class TestStash(LoadTestCommon):
+    def _check_load(self, value):
+        return self._check_load_inner("STASH", "um_stash_source", value)
+
+    def test_simple_object(self):
+        stash_string = "m01s02i324"
+        result = self._check_load(stash_string)
+        assert isinstance(result, STASH)
+        assert result == STASH(1, 2, 324)
+
+    def test_alternate_format(self):
+        stash_string = "  m1s2i3  "  # slight tolerance in STASH conversion function
+        result = self._check_load(stash_string)
+        assert isinstance(result, STASH)
+        assert result == STASH(1, 2, 3)
+
+    def test_bad_string__fail(self):
+        stash_string = "xxx"
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(stash_string)
+        assert result == "xxx"
+
+    def test_empty_string__fail(self):
+        stash_string = ""
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(stash_string)
+        assert result == ""
+
+    def test_numeric_value__fail(self):
+        value = 3
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(value)
+        # written directly, comes back as an array scalar of int64
+        assert result.dtype == np.int64
+        assert result == 3
+
+    def test_tuple_value__fail(self):
+        # As they cast to arrays, we expect lists to behave the same
+        value = (2, 3, 7)
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(value)
+        # written directly, comes back as an array of int64, shape (3,)
+        assert result.dtype == np.int64
+        assert result.shape == (3,)
+        assert np.all(result == value)
+
+
+class TestUkmoProcessFlags(LoadTestCommon):
+    def _check_load(self, value):
+        return self._check_load_inner(
+            "ukmo__process_flags", "ukmo__process_flags", value
+        )
+
+    def test_simple_string(self):
+        flag_string = "one two"
+        result = self._check_load(flag_string)
+        assert isinstance(result, tuple)
+        assert result == ("one", "two")
+
+    def test_alternate_string(self):
+        string = " one two  t   hree "  # merges multiple separators
+        result = self._check_load(string)
+        assert result == ("", "one", "two", "", "t", "", "", "hree", "")
+
+    def test_special_elements(self):
+        string = "one <EMPTY> two_three"
+        result = self._check_load(string)
+        assert result == ("one", "", "two three")
+
+    def test_empty_string(self):
+        string = ""
+        # This is NOT an error
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = self._check_load(string)
+        assert result == ()
+
+    def test_numeric_value__fail(self):
+        value = 3
+        # Note: not a failure, because conversion forces to a string ...
+        result = self._check_load(value)
+        # ... but the answer isn't what you might want.
+        assert result == ("3",)
+
+    def test_tuple_value__fail(self):
+        value = (2, 3, 7)
+        result = self._check_load(value)
+        # force to a string, the result is not pretty !
+        assert result == ("[2", "3", "7]")
+
+
+class TestGribParam(LoadTestCommon):
+    def _check_load(self, value):
+        return self._check_load_inner("GRIB_PARAM", "GRIB_PARAM", value)
+
+    def test_standard_string(self):
+        string = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        result = self._check_load(string)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == GRIBCode(1, 2, 3, 4)
+
+    def test_confused_string(self):
+        string = "GRIBCode(edition=1, centre=2, nonsense=3, table_version=4)"
+        result = self._check_load(string)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == GRIBCode(1, 2, 3, 4)
+
+    def test_alternate_format_string(self):
+        string = "grib(1, 2, 3, 4)"
+        result = self._check_load(string)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == GRIBCode(1, 2, 3, 4)
+
+    def test_minimal_string(self):
+        string = "1 2 3 4"
+        result = self._check_load(string)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == GRIBCode(1, 2, 3, 4)
+
+    def test_invalid_string__fail(self):
+        string = "grib(1, 2, 3)"
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(string)
+        assert result == string
+
+    def test_junk_string__fail(self):
+        string = "xxx"
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(string)
+        assert result == string
+
+    def test_empty_string__fail(self):
+        string = ""
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(string)
+        assert result == string
+
+    def test_numeric_value__fail(self):
+        value = 3
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(value)
+        # written directly, comes back as an array scalar of int64
+        assert result.dtype == np.int64
+        assert result == 3
+
+    def test_tuple_value__fail(self):
+        # As they cast to arrays, we expect lists to behave the same
+        value = (2, 3, 7)
+        with pytest.warns(UserWarning, match=self._LOAD_FAIL_MSG):
+            result = self._check_load(value)
+        # written directly, comes back as an array of int64, shape (3,)
+        assert result.dtype == np.int64
+        assert result.shape == (3,)
+        assert np.all(result == value)

--- a/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
@@ -26,11 +26,6 @@ from iris.fileformats.pp import STASH
 from iris.warnings import IrisLoadWarning
 
 
-@pytest.fixture(autouse=True, scope="session")
-def iris_futures():
-    iris.FUTURE.save_split_attrs = True
-
-
 class LoadTestCommon:
     @pytest.fixture(autouse=True)
     def tmp_filepath(self, tmp_path_factory):
@@ -43,7 +38,9 @@ class LoadTestCommon:
         # quickly create a valid netcdf file with a simple cube in it.
         cube = Cube([1], var_name="x")
         # Save : NB can fail
-        iris.save(cube, self.tmp_ncpath)
+        with iris.FUTURE.context(save_split_attrs=True):
+            iris.save(cube, self.tmp_ncpath)
+
         # Reopen for updating with netcdf
         ds = NcDataset(self.tmp_ncpath, "r+")
         # Add the test attribute content.

--- a/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
@@ -7,11 +7,15 @@
 # Annoyingly, this import is *not* redundant, as pytest import fails without it.
 import warnings
 
-import iris_grib  # noqa: F401
-from iris_grib.grib_phenom_translation._gribcode import (
-    GenericConcreteGRIBCode,
-    GRIBCode,
-)
+try:
+    import iris_grib  # noqa: F401
+    from iris_grib.grib_phenom_translation._gribcode import (
+        GenericConcreteGRIBCode,
+        GRIBCode,
+    )
+except ImportError:
+    iris_grib = None
+
 import numpy as np
 import pytest
 
@@ -178,6 +182,7 @@ class TestUkmoProcessFlags(LoadTestCommon):
         assert result == ("[2", "3", "7]")
 
 
+@pytest.mark.skipif(iris_grib is None, reason="iris_grib is not available")
 class TestGribParam(LoadTestCommon):
     def _check_load(self, value):
         return self._check_load_inner("GRIB_PARAM", "GRIB_PARAM", value)

--- a/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_load_managed_attributes.py
@@ -4,9 +4,9 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Integration tests for netcdf loading of attributes with "special" handling."""
 
+# Annoyingly, this import is *not* redundant, as pytest import fails without it.
 import warnings
 
-# Annoyingly, this import is *not* redundant, as pytest import fails without it.
 import iris_grib  # noqa: F401
 from iris_grib.grib_phenom_translation._gribcode import (
     GenericConcreteGRIBCode,

--- a/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
@@ -5,11 +5,11 @@
 """Integration tests for netcdf saving of attributes with "special" handling."""
 
 from iris_grib.grib_phenom_translation._gribcode import GRIBCode
-import netCDF4 as nc
 import pytest
 
 import iris
 from iris.cube import Cube
+from iris.fileformats.netcdf._thread_safe_nc import DatasetWrapper as NcDataset
 from iris.fileformats.pp import STASH
 
 
@@ -30,7 +30,7 @@ class SaveTestCommon:
         cube = Cube([1], var_name="x", attributes={iris_name: value})
         # Save : NB can fail
         iris.save(cube, self.tmp_ncpath)
-        ds = nc.Dataset(self.tmp_ncpath)
+        ds = NcDataset(self.tmp_ncpath)
         result = ds.variables["x"].getncattr(nc_name)
         return result
 

--- a/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
@@ -4,9 +4,12 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Integration tests for netcdf saving of attributes with "special" handling."""
 
-# Unfortunately not redundant since pytest fails to import iris_grib without it.
-import iris_grib  # noqa: F401
-from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+try:
+    import iris_grib
+    from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+except ImportError:
+    iris_grib = None
+
 import pytest
 
 import iris
@@ -127,6 +130,7 @@ class TestUkmoProcessFlags(SaveTestCommon):
         assert result == "None"
 
 
+@pytest.mark.skipif(iris_grib is None, reason="iris_grib is not available")
 class TestGribParam(SaveTestCommon):
     def _check_save(self, value):
         return self._check_save_inner("GRIB_PARAM", "GRIB_PARAM", value)

--- a/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
@@ -18,11 +18,6 @@ from iris.fileformats.netcdf._thread_safe_nc import DatasetWrapper as NcDataset
 from iris.fileformats.pp import STASH
 
 
-@pytest.fixture(autouse=True, scope="session")
-def iris_futures():
-    iris.FUTURE.save_split_attrs = True
-
-
 class SaveTestCommon:
     @pytest.fixture(autouse=True)
     def tmp_filepath(self, tmp_path_factory):
@@ -34,7 +29,9 @@ class SaveTestCommon:
     def _check_save_inner(self, iris_name, nc_name, value):
         cube = Cube([1], var_name="x", attributes={iris_name: value})
         # Save : NB can fail
-        iris.save(cube, self.tmp_ncpath)
+        with iris.FUTURE.context(save_split_attrs=True):
+            iris.save(cube, self.tmp_ncpath)
+
         ds = NcDataset(self.tmp_ncpath)
         result = ds.variables["x"].getncattr(nc_name)
         return result

--- a/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
+++ b/lib/iris/tests/integration/netcdf/test_save_managed_attributes.py
@@ -1,0 +1,167 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Integration tests for netcdf saving of attributes with "special" handling."""
+
+from iris_grib.grib_phenom_translation._gribcode import GRIBCode
+import netCDF4 as nc
+import pytest
+
+import iris
+from iris.cube import Cube
+from iris.fileformats.pp import STASH
+
+
+@pytest.fixture(autouse=True, scope="session")
+def iris_futures():
+    iris.FUTURE.save_split_attrs = True
+
+
+class SaveTestCommon:
+    @pytest.fixture(autouse=True)
+    def tmp_filepath(self, tmp_path_factory):
+        tmp_dir = tmp_path_factory.mktemp("tmp_nc")
+        # We can reuse the same path all over, as it is recreated for each test.
+        self.tmp_ncpath = tmp_dir / "tmp.nc"
+        yield
+
+    def _check_save_inner(self, iris_name, nc_name, value):
+        cube = Cube([1], var_name="x", attributes={iris_name: value})
+        # Save : NB can fail
+        iris.save(cube, self.tmp_ncpath)
+        ds = nc.Dataset(self.tmp_ncpath)
+        result = ds.variables["x"].getncattr(nc_name)
+        return result
+
+
+class TestStash(SaveTestCommon):
+    def _check_save(self, value):
+        return self._check_save_inner("STASH", "um_stash_source", value)
+
+    def test_simple_object(self):
+        stash = STASH(1, 2, 324)
+        result = self._check_save(stash)
+        assert result == "m01s02i324"
+
+    def test_simple_string(self):
+        stash_str = "m1s2i324"
+        result = self._check_save(stash_str)
+        assert result == "m01s02i324"
+
+    def test_bad_string__fail(self):
+        bad_str = "xxx"
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save(bad_str)
+        assert result == "xxx"
+
+    def test_empty_string__fail(self):
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save("")
+        assert result == ""
+
+    def test_bad_object__fail(self):
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save({})
+        assert result == "{}"
+
+    def test_none_object__fail(self):
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save(None)
+        assert result == "None"
+
+
+class TestUkmoProcessFlags(SaveTestCommon):
+    def _check_save(self, value):
+        return self._check_save_inner(
+            "ukmo__process_flags", "ukmo__process_flags", value
+        )
+
+    def test_simple_object(self):
+        flags = ("one", "two")
+        result = self._check_save(flags)
+        assert result == "one two"
+
+    def test_simple_string(self):
+        string = "one two three"
+        result = self._check_save(string)
+        assert result == string
+
+    def test_empty_tuple(self):
+        obj = ()
+        result = self._check_save(obj)
+        assert result == ""
+
+    def test_string_w_spaces(self):
+        obj = ("one", "two three")
+        result = self._check_save(obj)
+        assert result == "one two_three"
+
+    def test_string_w_underscores(self):
+        obj = ("one", "two_three")
+        result = self._check_save(obj)
+        assert result == "one two_three"
+
+    def test_tuple_w_empty_string(self):
+        obj = ("one", "", "two")
+        result = self._check_save(obj)
+        assert result == "one <EMPTY> two"
+
+    def test_bad_object(self):
+        obj = {}
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save(obj)
+        assert result == "{}"
+
+    def test_none_object(self):
+        obj = None
+        with pytest.warns(UserWarning, match="Invalid value in managed.* attribute"):
+            result = self._check_save(obj)
+        assert result == "None"
+
+
+class TestGribParam(SaveTestCommon):
+    def _check_save(self, value):
+        return self._check_save_inner("GRIB_PARAM", "GRIB_PARAM", value)
+
+    def test_simple_object(self):
+        code = GRIBCode(1, 2, 3, 4)
+        result = self._check_save(code)
+        assert (
+            result == "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        )
+
+    def test_simple_string(self):
+        code_string = "1, 2, 3,,,  4"  # the converter is highly tolerant
+        result = self._check_save(code_string)
+        assert (
+            result == "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        )
+
+    _encode_fail_msg = (
+        r"Invalid value in managed.* attribute.* set to raw \(string\) value"
+    )
+
+    def test_bad_string_toofew__fail(self):
+        code_string = "1, 2,  3"
+        with pytest.warns(UserWarning, match=self._encode_fail_msg):
+            result = self._check_save(code_string)
+        assert result == "1, 2,  3"
+
+    def test_bad_string_junk__fail(self):
+        code_string = "xxx"
+        with pytest.warns(UserWarning, match=self._encode_fail_msg):
+            result = self._check_save(code_string)
+        assert result == "xxx"
+
+    def test_bad_object__fail(self):
+        obj = {}
+        with pytest.warns(UserWarning, match=self._encode_fail_msg):
+            result = self._check_save(obj)
+        assert result == "{}"
+
+    def test_none_object__fail(self):
+        obj = None
+        with pytest.warns(UserWarning, match=self._encode_fail_msg):
+            result = self._check_save(obj)
+        assert result == "None"

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -71,7 +71,13 @@ _LOCAL_TEST_ATTRS = (
 )
 # Don't test iris_extended_grid_mapping, as it is a special attribute that
 # is not expected to always roundtrip.
-_LOCAL_TEST_ATTRS = [a for a in _LOCAL_TEST_ATTRS if a != "iris_extended_grid_mapping"]
+# Also, let's simply exclude "ukmo__process_flags", as the required value structure is
+# weird and doesn't fit our general testing structure.
+_LOCAL_TEST_ATTRS = [
+    a
+    for a in _LOCAL_TEST_ATTRS
+    if a not in ("iris_extended_grid_mapping", "ukmo__process_flags")
+]
 
 
 # Define a fixture to parametrise over the 'local-style' test attributes.
@@ -979,12 +985,9 @@ class TestRoundtrip(MixinAttrsTesting):
         if local_attr == "missing_value":
             # Special-cases : 'missing_value' type must be compatible with the variable
             attrval = 303
-        elif local_attr == "ukmo__process_flags":
-            # What this does when a GLOBAL attr seems to be weird + unintended.
-            # 'this' --> 't h i s'
-            attrval = "process"
-            # NOTE: it's also supposed to handle vector values - which we are not
-            # testing.
+        elif local_attr == "STASH":
+            # Provide a valid content.
+            attrval = "m01s02i123"
 
         # NOTE: results *should* be the same whether the original attribute is written
         # as global or a variable attribute
@@ -1477,51 +1480,43 @@ class TestSave(MixinAttrsTesting):
             [None, "value", "value", None], expected_warnings=msg_regexp
         )
 
+    def _teststr_safevalue(self, attrname, value, offset=0):
+        if attrname == "STASH":
+            value = f"m01s02i{213 + offset}"
+        return value
+
     def test_localstyle__single(self, local_attr):
-        self.run_save_testcase_legacytype(local_attr, ["value"])
+        value_single = self._teststr_safevalue(local_attr, "value-single")
+        self.run_save_testcase_legacytype(local_attr, [value_single])
 
         # Defaults to local
-        expected_results = [None, "value"]
-        # .. but a couple of special cases
-        if local_attr == "ukmo__process_flags":
-            # A particular, really weird case
-            expected_results = [None, "v a l u e"]
-        elif local_attr == "STASH":
+        expected_results = [None, value_single]
+        # .. but a special case
+        if local_attr == "STASH":
             # A special case : the stored name is different
             self.attrname = "um_stash_source"
 
         self.check_save_results(expected_results)
 
     def test_localstyle__multiple_same(self, local_attr):
-        self.run_save_testcase_legacytype(local_attr, ["value-same", "value-same"])
+        value_same = self._teststr_safevalue(local_attr, "value-same")
+        self.run_save_testcase_legacytype(local_attr, [value_same, value_same])
 
         # They remain separate + local
-        expected_results = [None, "value-same", "value-same"]
-        if local_attr == "ukmo__process_flags":
-            # A particular, really weird case
-            expected_results = [
-                None,
-                "v a l u e - s a m e",
-                "v a l u e - s a m e",
-            ]
-        elif local_attr == "STASH":
+        expected_results = [None, value_same, value_same]
+        if local_attr == "STASH":
             # A special case : the stored name is different
             self.attrname = "um_stash_source"
 
         self.check_save_results(expected_results)
 
     def test_localstyle__multiple_different(self, local_attr):
-        self.run_save_testcase_legacytype(local_attr, ["value-A", "value-B"])
+        value_a = self._teststr_safevalue(local_attr, "value-A", 1)
+        value_b = self._teststr_safevalue(local_attr, "value-B", 2)
+        self.run_save_testcase_legacytype(local_attr, [value_a, value_b])
         # Different values are treated just the same as matching ones.
-        expected_results = [None, "value-A", "value-B"]
-        if local_attr == "ukmo__process_flags":
-            # A particular, really weird case
-            expected_results = [
-                None,
-                "v a l u e - A",
-                "v a l u e - B",
-            ]
-        elif local_attr == "STASH":
+        expected_results = [None, value_a, value_b]
+        if local_attr == "STASH":
             # A special case : the stored name is different
             self.attrname = "um_stash_source"
         self.check_save_results(expected_results)

--- a/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
+++ b/lib/iris/tests/integration/test_netcdf__loadsaveattrs.py
@@ -69,14 +69,15 @@ _LOCAL_TEST_ATTRS = (
     iris.fileformats.netcdf.saver._CF_DATA_ATTRS
     + iris.fileformats.netcdf.saver._UKMO_DATA_ATTRS
 )
-# Don't test iris_extended_grid_mapping, as it is a special attribute that
-# is not expected to always roundtrip.
-# Also, let's simply exclude "ukmo__process_flags", as the required value structure is
-# weird and doesn't fit our general testing structure.
+# For simplicity, we exclude several special cases that don't act with "standard"
+#  behaviour (because they translate in special ways):
+#   * "iris_extended_grid_mapping" : not expected to always roundtrip
+#   * "ukmo__process_flags" : has an odd value structure
+#   * "um_stash_source" : should only occur in files, not in Iris attribute dicts
 _LOCAL_TEST_ATTRS = [
     a
     for a in _LOCAL_TEST_ATTRS
-    if a not in ("iris_extended_grid_mapping", "ukmo__process_flags")
+    if a not in ("iris_extended_grid_mapping", "ukmo__process_flags", "um_stash_source")
 ]
 
 

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -1332,7 +1332,7 @@ class TestNetCDFUKmoProcessFlags(tests.IrisTest):
 
         # Maps lbproc value to the process flags that should be created
         multiple_map = {
-            bits: [iris.fileformats.pp.lbproc_map[bit] for bit in bits]
+            bits: tuple([iris.fileformats.pp.lbproc_map[bit] for bit in bits])
             for bits in multiple_bit_values
         }
 

--- a/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__miscellaneous.py
+++ b/lib/iris/tests/unit/fileformats/nc_load_rules/actions/test__miscellaneous.py
@@ -81,13 +81,19 @@ netcdf test {{
 
     def test_stash_empty(self):
         value = ""
-        cube = self.run_testcase(ukmo__um_stash_source=value)
+        cube = self.run_testcase(
+            ukmo__um_stash_source=value,
+            warning_regex="Invalid content for managed attribute name 'um_stash_source'",
+        )
         self.assertNotIn("STASH", cube.attributes)
         self.assertEqual(cube.attributes["ukmo__um_stash_source"], value)
 
     def test_stash_invalid(self):
         value = "XXX"
-        cube = self.run_testcase(ukmo__um_stash_source="XXX")
+        cube = self.run_testcase(
+            ukmo__um_stash_source="XXX",
+            warning_regex="Invalid content for managed attribute name 'um_stash_source'",
+        )
         self.assertNotIn("STASH", cube.attributes)
         self.assertEqual(cube.attributes["ukmo__um_stash_source"], value)
 
@@ -103,7 +109,7 @@ netcdf test {{
 
     def test_processflags_empty(self):
         cube = self.run_testcase(ukmo__process_flags="")
-        expected_result = [""]  # May seem odd, but that's what it does.
+        expected_result = ()
         self.check_result(cube, processflags=expected_result)
 
 

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/__init__.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the :mod:`iris.fileformats._attribute_handlers` module."""

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
@@ -77,14 +77,14 @@ class TestDecodeAttribute:
 
     def test_grib1(self):
         test_string = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
-        result = GP_HANDLER.decode_attribute("", test_string)
+        result = GP_HANDLER.decode_attribute(test_string)
         expected = GRIBCode(1, 2, 3, 4)
         assert isinstance(result, GenericConcreteGRIBCode)
         assert result == expected
 
     def test_grib2(self):
         test_string = "GRIBCode(edition=2, discipline=3, category=4, number=5)"
-        result = GP_HANDLER.decode_attribute("", test_string)
+        result = GP_HANDLER.decode_attribute(test_string)
         expected = GRIBCode(2, 3, 4, 5)
         assert isinstance(result, GenericConcreteGRIBCode)
         assert result == expected
@@ -92,7 +92,7 @@ class TestDecodeAttribute:
     def test_odd_array_case(self):
         test_value = np.array([1.7, 5.4])
         # Bizarrely, this converts to a string which *will* parse
-        result = GP_HANDLER.decode_attribute("", test_value)
+        result = GP_HANDLER.decode_attribute(test_value)
         expected = GRIBCode(1, 7, 5, 4)
         assert isinstance(result, GenericConcreteGRIBCode)
         assert result == expected
@@ -105,4 +105,4 @@ class TestDecodeAttribute:
     def test_badvalue__fail(self, badval):
         # It can convert random values to strings, but they mostly won't satisfy.
         with pytest.raises(ValueError):
-            GP_HANDLER.decode_attribute("", badval)
+            GP_HANDLER.decode_attribute(badval)

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
@@ -1,0 +1,106 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for :class:`iris.fileformats.netcdf._attribute_handlers.StashHandler`."""
+
+from iris_grib.grib_phenom_translation._gribcode import (
+    GenericConcreteGRIBCode,
+    GRIBCode,
+)
+import numpy as np
+import pytest
+
+from iris.fileformats.netcdf._attribute_handlers import ATTRIBUTE_HANDLERS
+
+GP_HANDLER = ATTRIBUTE_HANDLERS["GRIB_PARAM"]
+
+
+class TestEncodeObject:
+    """Test how GRIB_PARAM attributes convert to strings for storage in netcdf files."""
+
+    def test_edition1_codeobject(self):
+        test_code = GRIBCode(1, 2, 3, 4)
+        result = GP_HANDLER.encode_object(test_code)
+        expected = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        assert result == ("GRIB_PARAM", expected)
+
+    def test_edition1_minimal_string(self):
+        test_string = "1 2 3 4"
+        result = GP_HANDLER.encode_object(test_string)
+        expected = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        assert result == ("GRIB_PARAM", expected)
+
+    def test_edition1_alternate_string(self):
+        test_string = "##1-a22bb33@z!44##"
+        result = GP_HANDLER.encode_object(test_string)
+        expected = "GRIBCode(edition=1, table_version=22, centre_number=33, number=44)"
+        assert result == ("GRIB_PARAM", expected)
+
+    def test_bad_string__toofew__fail(self):
+        test_string = "1, 2, 3"
+        msg = "Invalid argument for GRIBCode creation.*requires 4 numbers"
+        with pytest.raises(ValueError, match=msg):
+            GP_HANDLER.encode_object(test_string)
+
+    def test_edition1_string_toomany(self):
+        """No objection to extra numbers -- ignored."""
+        test_string = "1, 2, 3, 4, 5, 6"
+        result = GP_HANDLER.encode_object(test_string)
+        expected = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        assert result == ("GRIB_PARAM", expected)
+
+    def test_bad_edition(self):
+        test_string = "7,1,2,3"
+        msg = "Invalid grib edition.*for GRIBcode : can only be 1 or 2"
+        with pytest.raises(ValueError, match=msg):
+            GP_HANDLER.encode_object(test_string)
+
+    def test_edition2_codeobject(self):
+        test_code = GRIBCode(2, 3, 4, 5)
+        result = GP_HANDLER.encode_object(test_code)
+        expected = "GRIBCode(edition=2, discipline=3, category=4, number=5)"
+        assert result == ("GRIB_PARAM", expected)
+
+    def test_string_edition2(self):
+        """A STASH object is converted to its 'str'."""
+        test_code = "2, 3, 4, 5"
+        result = GP_HANDLER.encode_object(test_code)
+        expected = "GRIBCode(edition=2, discipline=3, category=4, number=5)"
+        assert result == ("GRIB_PARAM", expected)
+
+
+class TestDecodeAttribute:
+    """Test how GRIB_PARAM attributes convert back to GRIBCode objects."""
+
+    def test_grib1(self):
+        test_string = "GRIBCode(edition=1, table_version=2, centre_number=3, number=4)"
+        result = GP_HANDLER.decode_attribute("", test_string)
+        expected = GRIBCode(1, 2, 3, 4)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == expected
+
+    def test_grib2(self):
+        test_string = "GRIBCode(edition=2, discipline=3, category=4, number=5)"
+        result = GP_HANDLER.decode_attribute("", test_string)
+        expected = GRIBCode(2, 3, 4, 5)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == expected
+
+    def test_odd_array_case(self):
+        test_value = np.array([1.7, 5.4])
+        # Bizarrely, this converts to a string which *will* parse
+        result = GP_HANDLER.decode_attribute("", test_value)
+        expected = GRIBCode(1, 7, 5, 4)
+        assert isinstance(result, GenericConcreteGRIBCode)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "badval",
+        [np.array(1), 2.5, np.array([9.3, 5, 2.4])],
+        ids=["int", "float", "array"],
+    )
+    def test_badvalue__fail(self, badval):
+        # It can convert random values to strings, but they mostly won't satisfy.
+        with pytest.raises(ValueError):
+            GP_HANDLER.decode_attribute("", badval)

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
@@ -4,6 +4,8 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for :class:`iris.fileformats.netcdf._attribute_handlers.StashHandler`."""
 
+# Unfortunately not redundant since pytest fails to import iris_grib without it.
+import iris_grib  # noqa: F401
 from iris_grib.grib_phenom_translation._gribcode import (
     GenericConcreteGRIBCode,
     GRIBCode,

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_GribParamHandler.py
@@ -4,14 +4,14 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for :class:`iris.fileformats.netcdf._attribute_handlers.StashHandler`."""
 
-# Unfortunately not redundant since pytest fails to import iris_grib without it.
-import iris_grib  # noqa: F401
+import pytest
+
+iris_grib = pytest.importorskip("iris_grib")
 from iris_grib.grib_phenom_translation._gribcode import (
     GenericConcreteGRIBCode,
     GRIBCode,
 )
 import numpy as np
-import pytest
 
 from iris.fileformats.netcdf._attribute_handlers import ATTRIBUTE_HANDLERS
 

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_StashHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_StashHandler.py
@@ -56,23 +56,23 @@ class TestDecodeAttribute:
     def test_standard(self):
         """Test valid MSI string."""
         test_string = "m01s02i213"
-        result = STASH_HANDLER.decode_attribute("", test_string)
+        result = STASH_HANDLER.decode_attribute(test_string)
         expected = STASH(1, 2, 213)
         assert result == expected
 
     def test_alternate_format(self):
         """Test the slight tolerances in formatting."""
         test_string = "  m1S002i3  "
-        result = STASH_HANDLER.decode_attribute("", test_string)
+        result = STASH_HANDLER.decode_attribute(test_string)
         expected = STASH(1, 2, 3)
         assert result == expected
 
     def test_invalid(self):
         test_string = "xxx"
         with pytest.raises(ValueError, match="Expected STASH code MSI"):
-            STASH_HANDLER.decode_attribute("", test_string)
+            STASH_HANDLER.decode_attribute(test_string)
 
     def test_empty(self):
         test_string = ""
         with pytest.raises(ValueError, match="Expected STASH code MSI"):
-            STASH_HANDLER.decode_attribute("", test_string)
+            STASH_HANDLER.decode_attribute(test_string)

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_StashHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_StashHandler.py
@@ -1,0 +1,78 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for :class:`iris.fileformats.netcdf._attribute_handlers.StashHandler`."""
+
+import pytest
+
+from iris.fileformats.netcdf._attribute_handlers import ATTRIBUTE_HANDLERS
+from iris.fileformats.pp import STASH
+
+STASH_HANDLER = ATTRIBUTE_HANDLERS["STASH"]
+
+
+class TestEncodeObject:
+    """Test how STASH attributes convert to strings for storage in actual netcdf files.
+
+    These are mostly STASH objects, but we must also allow correctly formed STASH
+    strings, and error other types of content.
+    """
+
+    def test_stash_object(self):
+        """A STASH object is converted to its 'str'."""
+        test_stash = STASH(3, 5, 123)
+        result = STASH_HANDLER.encode_object(test_stash)
+        expected = ("um_stash_source", str(test_stash))
+        assert result == expected
+
+    def test_stash_string(self):
+        """A STASH-convertible str is regularised."""
+        test_string = "m2s5i23"
+        result = STASH_HANDLER.encode_object(test_string)
+        expected = ("um_stash_source", "m02s05i023")  # Numbers filled to N digits
+        assert result == expected
+
+    def test_invalid_string__fail(self):
+        with pytest.raises(ValueError, match="Expected STASH code MSI string"):
+            STASH_HANDLER.encode_object("xxx")
+
+    def test_empty_string__fail(self):
+        with pytest.raises(ValueError, match="Expected STASH code MSI string"):
+            STASH_HANDLER.encode_object("")
+
+    def test_none_object__fail(self):
+        with pytest.raises(TypeError, match="Invalid STASH attribute"):
+            STASH_HANDLER.encode_object(None)
+
+    def test_nonstash_object__fail(self):
+        with pytest.raises(TypeError, match="Invalid STASH attribute"):
+            STASH_HANDLER.encode_object({})
+
+
+class TestDecodeAttribute:
+    """Test how STASH string attributes convert back to STASH objects."""
+
+    def test_standard(self):
+        """Test valid MSI string."""
+        test_string = "m01s02i213"
+        result = STASH_HANDLER.decode_attribute("", test_string)
+        expected = STASH(1, 2, 213)
+        assert result == expected
+
+    def test_alternate_format(self):
+        """Test the slight tolerances in formatting."""
+        test_string = "  m1S002i3  "
+        result = STASH_HANDLER.decode_attribute("", test_string)
+        expected = STASH(1, 2, 3)
+        assert result == expected
+
+    def test_invalid(self):
+        test_string = "xxx"
+        with pytest.raises(ValueError, match="Expected STASH code MSI"):
+            STASH_HANDLER.decode_attribute("", test_string)
+
+    def test_empty(self):
+        test_string = ""
+        with pytest.raises(ValueError, match="Expected STASH code MSI"):
+            STASH_HANDLER.decode_attribute("", test_string)

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_UkmoProcessFlagsHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_UkmoProcessFlagsHandler.py
@@ -1,0 +1,126 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for
+:class:`iris.fileformats.netcdf._attribute_handlers.UkmoProcessFlagsHandler`.
+"""
+
+import numpy as np
+import pytest
+
+from iris.fileformats.netcdf._attribute_handlers import ATTRIBUTE_HANDLERS
+
+UPF_HANDLER = ATTRIBUTE_HANDLERS["ukmo__process_flags"]
+
+
+class TestEncodeObject:
+    """Test how 'ukmo__process_flags' attributes convert to tuples in netcdf files."""
+
+    def test_basic_tuple(self):
+        """A tuple of strings converts to a single string."""
+        test_tuple = ("one", "two", "three")
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = "one two three"
+        assert result == ("ukmo__process_flags", expected)
+
+    def test_single(self):
+        test_tuple = ("one",)
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = "one"
+        assert result == ("ukmo__process_flags", expected)
+
+    def test_0_tuple(self):
+        test_tuple = ()
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = ""
+        assert result == ("ukmo__process_flags", expected)
+
+    def test_empty_element(self):
+        test_tuple = ("one", "", "two")
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = "one <EMPTY> two"
+        assert result == ("ukmo__process_flags", expected)
+
+    def test_spaced_element(self):
+        test_tuple = ("one", "two three")
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = "one two_three"
+        assert result == ("ukmo__process_flags", expected)
+
+    def test_underscores(self):
+        """Can't distinguish original underscores and spaces. Doesn't really matter."""
+        test_tuple = ("_", " ", "a_b", "a b")
+        result = UPF_HANDLER.encode_object(test_tuple)
+        expected = "_ _ a_b a_b"
+        assert result == ("ukmo__process_flags", expected)
+
+    @pytest.mark.parametrize(
+        "badval",
+        ["this", 1, ("a", 1, "b"), ("a", None), ["a", "b"], None],
+        ids=["string", "int", "tuplewithInt", "tuplewithNone", "listofStr", "none"],
+    )
+    def test_non_tuple__fail(self, badval):
+        """Won't convert anything but a tuple of strings."""
+        with pytest.raises(TypeError, match="Invalid 'ukmo__process_flags' attribute"):
+            UPF_HANDLER.encode_object(badval)
+
+
+class TestDecodeAttribute:
+    """Test how 'ukmo__process_flags' converts from file string back to a tuple."""
+
+    def test_standard(self):
+        test_string = "one two"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ("one", "two")
+
+    def test_empty(self):
+        test_string = ""
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ()
+
+    def test_empty_element(self):
+        test_string = "<EMPTY>"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ("",)
+
+    def test_empty_among_elements(self):
+        test_string = "a <EMPTY> b"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ("a", "", "b")
+
+    def test_embedded_spaces(self):
+        """Extra spaces result in additional empty elements. Never mind!."""
+        test_string = "a  b   c"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ("a", "", "b", "", "", "c")
+
+    def test_underscores(self):
+        """Extra spaces result in additional empty elements. Never mind!."""
+        test_string = "_a b_c _ d_"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == (" a", "b c", " ", "d ")
+
+    def test_junk_string(self):
+        """There's no such thing as an undecodable string."""
+        test_string = "xxx"
+        result = UPF_HANDLER.decode_attribute("", test_string)
+        assert result == ("xxx",)
+
+    @pytest.mark.parametrize("badtype", ("int", "intarray", "floatarray"))
+    def test_numeric_values(self, badtype):
+        """Even array attributes get converted to a string + split."""
+        if badtype == "int":
+            test_value = 1
+            expected = ("1",)
+        elif badtype == "intarray":
+            test_value = np.array([1, 2])
+            expected = ("[1", "2]")
+        elif badtype == "floatarray":
+            test_value = np.array([1.2, 2.5, 3.7])
+            expected = ("[1.2", "2.5", "3.7]")
+        else:
+            raise ValueError(f"Unrecognised param : {badtype}")
+
+        result = UPF_HANDLER.decode_attribute("", test_value)
+        assert result == expected

--- a/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_UkmoProcessFlagsHandler.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/attribute_handlers/test_UkmoProcessFlagsHandler.py
@@ -71,40 +71,40 @@ class TestDecodeAttribute:
 
     def test_standard(self):
         test_string = "one two"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ("one", "two")
 
     def test_empty(self):
         test_string = ""
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ()
 
     def test_empty_element(self):
         test_string = "<EMPTY>"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ("",)
 
     def test_empty_among_elements(self):
         test_string = "a <EMPTY> b"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ("a", "", "b")
 
     def test_embedded_spaces(self):
         """Extra spaces result in additional empty elements. Never mind!."""
         test_string = "a  b   c"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ("a", "", "b", "", "", "c")
 
     def test_underscores(self):
         """Extra spaces result in additional empty elements. Never mind!."""
         test_string = "_a b_c _ d_"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == (" a", "b c", " ", "d ")
 
     def test_junk_string(self):
         """There's no such thing as an undecodable string."""
         test_string = "xxx"
-        result = UPF_HANDLER.decode_attribute("", test_string)
+        result = UPF_HANDLER.decode_attribute(test_string)
         assert result == ("xxx",)
 
     @pytest.mark.parametrize("badtype", ("int", "intarray", "floatarray"))
@@ -122,5 +122,5 @@ class TestDecodeAttribute:
         else:
             raise ValueError(f"Unrecognised param : {badtype}")
 
-        result = UPF_HANDLER.decode_attribute("", test_value)
+        result = UPF_HANDLER.decode_attribute(test_value)
         assert result == expected


### PR DESCRIPTION
Closes https://github.com/SciTools/iris-grib/issues/596 and https://github.com/SciTools/iris-grib/issues/674

Ties together the handling of STASH, GRIB_PARAM and "ukmo__process_flags" attributes, 
which all require special handling on netcdf load+save.

By design, should preserve existing behaviour.
But I have tried to generalise the handling, 
( and also rationalise behaviour a wee bit, at least for "ukmo__process_flags" -- though that one is quite obscure ).

TODO:
  - [x] ?probably? ditch the `@staticmethod` + use `self` more
  - [x] make sure all types _also_ support the "plain" string formats (as found in the files) _inside_ Iris, as well as the 'convenience' forms
     - e.g. in place of a STASH object, can have just the string like "m01s02i123" (str form) or "STASH(model=...)" (repr form) . 
     - ... and similar for the other 2 types
  - [x] testing (TBD) ...

(but first, just let's see if it breaks anything I haven't already tried)