### PR TITLE
Corrected import of ESMPy module

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -41,7 +41,7 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ corrected the ESMF/ESMPy import in
    :mod:`iris.experimental.regrid_conservative` (the module was renamed to ESMPy
    in v8.4). Note that :mod:`~iris.experimental.regrid_conservative`
-   is already deprecated and will be removed in a future release. (:pull:`6641`)
+   is already deprecated and will be removed in a future release. (:pull:`6643`)
 
 
 💣 Incompatible Changes

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -30,8 +30,6 @@ This document explains the changes made to Iris for this release
 ✨ Features
 ===========
 
-#. N/A
-
 #. `@pp-mo`_ added a new utility function for making a test cube with a specified 2D
    horizontal grid.
    (:issue:`5770`, :pull:`6581`)
@@ -40,7 +38,10 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@trexfeathers`_ corrected the ESMF/ESMPy import in
+   :mod:`iris.experimental.regrid_conservative` (the module was renamed to ESMPy
+   in v8.4). Note that :mod:`~iris.experimental.regrid_conservative`
+   is already deprecated and will be removed in a future release. (:pull:`6641`)
 
 
 💣 Incompatible Changes

--- a/lib/iris/experimental/regrid_conservative.py
+++ b/lib/iris/experimental/regrid_conservative.py
@@ -71,7 +71,7 @@ def _make_esmpy_field(x_coord, y_coord, ref_name="field", data=None, mask=None):
 
     """
     # Lazy import so we can build the docs with no ESMF.
-    import ESMF
+    import esmpy as ESMF
 
     # Create a Grid object describing the coordinate cells.
     dims = [len(coord.points) for coord in (x_coord, y_coord)]
@@ -204,7 +204,7 @@ def regrid_conservative_via_esmpy(source_cube, grid_cube):
     warn_deprecated(wmsg)
 
     # Lazy import so we can build the docs with no ESMF.
-    import ESMF
+    import esmpy as ESMF
 
     # Get source + target XY coordinate pairs and check they are suitable.
     src_coords = get_xy_dim_coords(source_cube)

--- a/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_conservative_via_esmpy.py
@@ -14,7 +14,7 @@ from iris.tests import _shared_utils
 
 # Import ESMF if installed, else fail quietly + disable all the tests.
 try:
-    import ESMF
+    import esmpy as ESMF
 except ImportError:
     ESMF = None
 skip_esmf = pytest.mark.skipif(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The module was renamed to ESMPy in version 8.4. We didn't notice because the module using is deprecated in favour of iris-esmf-regrid, and because we have a test skipper from back when ESMPy wasn't always included in the development environment.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
