### PR TITLE
Converted all unit/tests tests into PyTest

### DIFF
--- a/lib/iris/tests/integration/netcdf/test_ugrid_load.py
+++ b/lib/iris/tests/integration/netcdf/test_ugrid_load.py
@@ -4,10 +4,6 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Integration tests for NetCDF-UGRID file loading."""
 
-# Import iris.tests first so that some things can be initialised before
-# importing anything else.
-import iris.tests as tests  # isort:skip
-
 from collections.abc import Iterable
 
 import pytest
@@ -15,6 +11,7 @@ import pytest
 from iris import Constraint, load
 from iris.fileformats.netcdf.ugrid_load import load_mesh, load_meshes
 from iris.mesh import MeshXY
+from iris.tests import _shared_utils
 from iris.tests.stock.netcdf import (
     _file_from_cdl_template as create_file_from_cdl_template,
 )
@@ -45,167 +42,177 @@ def ugrid_load(uris, constraints=None, callback=None):
     return load(uris, constraints, callback)
 
 
-@tests.skip_data
-class TestBasic(tests.IrisTest):
-    def common_test(self, load_filename, assert_filename):
+@_shared_utils.skip_data
+class TestBasic:
+    def common_test(self, request, load_filename, assert_filename):
         cube_list = ugrid_load(
-            tests.get_data_path(["NetCDF", "unstructured_grid", load_filename]),
+            _shared_utils.get_data_path(["NetCDF", "unstructured_grid", load_filename]),
         )
-        self.assertEqual(1, len(cube_list))
+        assert 1 == len(cube_list)
         cube = cube_list[0]
-        self.assertCML(cube, ["mesh", assert_filename])
+        _shared_utils.assert_CML(request, cube, ["mesh", assert_filename])
 
-    def test_2D_1t_face_half_levels(self):
+    def test_2_d_1t_face_half_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_2D_1t_face_half_levels_main_conv_rain.nc",
             "2D_1t_face_half_levels.cml",
         )
 
-    def test_3D_1t_face_half_levels(self):
+    def test_3_d_1t_face_half_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_1t_half_level_face_grid_derived_theta_in_w3.nc",
             "3D_1t_face_half_levels.cml",
         )
 
-    def test_3D_1t_face_full_levels(self):
+    def test_3_d_1t_face_full_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_1t_full_level_face_grid_main_area_fraction_unit1.nc",
             "3D_1t_face_full_levels.cml",
         )
 
-    def test_2D_72t_face_half_levels(self):
+    def test_2_d_72t_face_half_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_2D_72t_face_half_levels_main_conv_rain.nc",
             "2D_72t_face_half_levels.cml",
         )
 
-    def test_3D_snow_pseudo_levels(self):
+    def test_3_d_snow_pseudo_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc",
             "3D_snow_pseudo_levels.cml",
         )
 
-    def test_3D_soil_pseudo_levels(self):
+    def test_3_d_soil_pseudo_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_soil_pseudo_levels_1t_face_half_levels_main_soil_temperature.nc",
             "3D_soil_pseudo_levels.cml",
         )
 
-    def test_3D_tile_pseudo_levels(self):
+    def test_3_d_tile_pseudo_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_tile_pseudo_levels_1t_face_half_levels_main_sw_up_tile.nc",
             "3D_tile_pseudo_levels.cml",
         )
 
-    def test_3D_veg_pseudo_levels(self):
+    def test_3_d_veg_pseudo_levels(self, request):
         self.common_test(
+            request,
             "lfric_ngvat_3D_veg_pseudo_levels_1t_face_half_levels_main_snowpack_density.nc",
             "3D_veg_pseudo_levels.cml",
         )
 
     def test_no_mesh(self):
         cube_list = load(
-            tests.get_data_path(
+            _shared_utils.get_data_path(
                 ["NetCDF", "unstructured_grid", "theta_nodal_not_ugrid.nc"]
             )
         )
-        self.assertTrue(all([cube.mesh is None for cube in cube_list]))
+        assert all([cube.mesh is None for cube in cube_list])
 
 
-@tests.skip_data
-class TestMultiplePhenomena(tests.IrisTest):
-    def test_multiple_phenomena(self):
+@_shared_utils.skip_data
+class TestMultiplePhenomena:
+    def test_multiple_phenomena(self, request):
         cube_list = ugrid_load(
-            tests.get_data_path(
+            _shared_utils.get_data_path(
                 ["NetCDF", "unstructured_grid", "lfric_surface_mean.nc"]
             ),
         )
-        self.assertCML(cube_list, ("mesh", "surface_mean.cml"))
+        _shared_utils.assert_CML(request, cube_list, ("mesh", "surface_mean.cml"))
 
 
 class TestTolerantLoading(XIOSFileMixin):
     # N.B. using parts of the XIOS-like file integration testing, to make
     # temporary netcdf files from stored CDL templates.
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()  # create cls.temp_dir = dir for test files
-
-    @classmethod
-    def tearDownClass(cls):
-        super().setUpClass()  # destroy temp dir
 
     # Create a testfile according to testcase-specific arguments.
     # NOTE: with this, parent "create_synthetic_test_cube" can load a cube.
     def create_synthetic_file(self, **create_kwargs):
         template_name = create_kwargs["template"]  # required kwarg
+        temp_dir = create_kwargs["temp_file_dir"]  # required kwarg
         testfile_name = "tmp_netcdf"
         template_subs = dict(NUM_NODES=7, NUM_FACES=3, DATASET_NAME=testfile_name)
         kwarg_subs = create_kwargs.get("subs", {})  # optional kwarg
         template_subs.update(kwarg_subs)
         filepath = create_file_from_cdl_template(
-            temp_file_dir=self.temp_dir,
+            temp_file_dir=temp_dir,
             dataset_name=testfile_name,
             dataset_type=template_name,
             template_subs=template_subs,
         )
         return str(filepath)  # N.B. Path object not usable in iris.load
 
-    def test_mesh_bad_topology_dimension(self):
+    def test_mesh_bad_topology_dimension(self, tmp_path):
         # Check that the load generates a suitable warning.
         warn_regex = r"topology_dimension.* ignoring"
         with pytest.warns(IrisCfWarning, match=warn_regex):
             template = "minimal_bad_topology_dim"
             dim_line = "mesh_var:topology_dimension = 1 ;"  # which is wrong !
             cube = self.create_synthetic_test_cube(
-                template=template, subs=dict(TOPOLOGY_DIM_DEFINITION=dim_line)
+                temp_file_dir=tmp_path,
+                template=template,
+                subs=dict(TOPOLOGY_DIM_DEFINITION=dim_line),
             )
 
         # Check that the result has topology-dimension of 2 (not 1).
-        self.assertEqual(cube.mesh.topology_dimension, 2)
+        assert cube.mesh.topology_dimension == 2
 
-    def test_mesh_no_topology_dimension(self):
+    def test_mesh_no_topology_dimension(self, tmp_path):
         # Check that the load generates a suitable warning.
         warn_regex = r"MeshXY variable.* has no 'topology_dimension'"
         with pytest.warns(IrisCfWarning, match=warn_regex):
             template = "minimal_bad_topology_dim"
             dim_line = ""  # don't create ANY topology_dimension property
             cube = self.create_synthetic_test_cube(
-                template=template, subs=dict(TOPOLOGY_DIM_DEFINITION=dim_line)
+                temp_file_dir=tmp_path,
+                template=template,
+                subs=dict(TOPOLOGY_DIM_DEFINITION=dim_line),
             )
 
         # Check that the result has the correct topology-dimension value.
-        self.assertEqual(cube.mesh.topology_dimension, 2)
+        assert cube.mesh.topology_dimension == 2
 
-    def test_mesh_bad_cf_role(self):
+    def test_mesh_bad_cf_role(self, tmp_path):
         # Check that the load generates a suitable warning.
         warn_regex = r"inappropriate cf_role"
         with pytest.warns(IrisCfWarning, match=warn_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = 'mesh_var:cf_role = "foo" ;'
             _ = self.create_synthetic_test_cube(
-                template=template, subs=dict(CF_ROLE_DEFINITION=dim_line)
+                temp_file_dir=tmp_path,
+                template=template,
+                subs=dict(CF_ROLE_DEFINITION=dim_line),
             )
 
-    def test_mesh_no_cf_role(self):
+    def test_mesh_no_cf_role(self, tmp_path):
         # Check that the load generates a suitable warning.
         warn_regex = r"no cf_role attribute"
         with pytest.warns(IrisCfWarning, match=warn_regex):
             template = "minimal_bad_mesh_cf_role"
             dim_line = ""
             _ = self.create_synthetic_test_cube(
-                template=template, subs=dict(CF_ROLE_DEFINITION=dim_line)
+                temp_file_dir=tmp_path,
+                template=template,
+                subs=dict(CF_ROLE_DEFINITION=dim_line),
             )
 
 
-@tests.skip_data
-class Test_load_mesh(tests.IrisTest):
+@_shared_utils.skip_data
+class Test_load_mesh:
     def common_test(self, file_name, mesh_var_name):
         mesh = load_mesh(
-            tests.get_data_path(["NetCDF", "unstructured_grid", file_name])
+            _shared_utils.get_data_path(["NetCDF", "unstructured_grid", file_name])
         )
         # NOTE: cannot use CML tests as this isn't supported for non-Cubes.
-        self.assertIsInstance(mesh, MeshXY)
-        self.assertEqual(mesh.var_name, mesh_var_name)
+        assert isinstance(mesh, MeshXY)
+        assert mesh.var_name == mesh_var_name
 
     def test_full_file(self):
         self.common_test(
@@ -218,12 +225,8 @@ class Test_load_mesh(tests.IrisTest):
 
     def test_no_mesh(self):
         meshes = load_meshes(
-            tests.get_data_path(
+            _shared_utils.get_data_path(
                 ["NetCDF", "unstructured_grid", "theta_nodal_not_ugrid.nc"]
             )
         )
-        self.assertDictEqual({}, meshes)
-
-
-if __name__ == "__main__":
-    tests.main()
+        assert {} == meshes

--- a/lib/iris/tests/integration/netcdf/test_ugrid_load.py
+++ b/lib/iris/tests/integration/netcdf/test_ugrid_load.py
@@ -151,10 +151,10 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_bad_topology_dimension(self, tmp_path):
         # Check that the load generates a suitable warning.
+        template = "minimal_bad_topology_dim"
+        dim_line = "mesh_var:topology_dimension = 1 ;"  # which is wrong !
         warn_regex = r"topology_dimension.* ignoring"
         with pytest.warns(IrisCfWarning, match=warn_regex):
-            template = "minimal_bad_topology_dim"
-            dim_line = "mesh_var:topology_dimension = 1 ;"  # which is wrong !
             cube = self.create_synthetic_test_cube(
                 temp_file_dir=tmp_path,
                 template=template,
@@ -166,10 +166,10 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_no_topology_dimension(self, tmp_path):
         # Check that the load generates a suitable warning.
+        template = "minimal_bad_topology_dim"
+        dim_line = ""  # don't create ANY topology_dimension property
         warn_regex = r"MeshXY variable.* has no 'topology_dimension'"
         with pytest.warns(IrisCfWarning, match=warn_regex):
-            template = "minimal_bad_topology_dim"
-            dim_line = ""  # don't create ANY topology_dimension property
             cube = self.create_synthetic_test_cube(
                 temp_file_dir=tmp_path,
                 template=template,
@@ -181,10 +181,10 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_bad_cf_role(self, tmp_path):
         # Check that the load generates a suitable warning.
+        template = "minimal_bad_mesh_cf_role"
+        dim_line = 'mesh_var:cf_role = "foo" ;'
         warn_regex = r"inappropriate cf_role"
         with pytest.warns(IrisCfWarning, match=warn_regex):
-            template = "minimal_bad_mesh_cf_role"
-            dim_line = 'mesh_var:cf_role = "foo" ;'
             _ = self.create_synthetic_test_cube(
                 temp_file_dir=tmp_path,
                 template=template,
@@ -193,10 +193,10 @@ class TestTolerantLoading(XIOSFileMixin):
 
     def test_mesh_no_cf_role(self, tmp_path):
         # Check that the load generates a suitable warning.
+        template = "minimal_bad_mesh_cf_role"
+        dim_line = ""
         warn_regex = r"no cf_role attribute"
         with pytest.warns(IrisCfWarning, match=warn_regex):
-            template = "minimal_bad_mesh_cf_role"
-            dim_line = ""
             _ = self.create_synthetic_test_cube(
                 temp_file_dir=tmp_path,
                 template=template,

--- a/lib/iris/tests/unit/tests/stock/test_netcdf.py
+++ b/lib/iris/tests/unit/tests/stock/test_netcdf.py
@@ -4,29 +4,12 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the :mod:`iris.tests.stock.netcdf` module."""
 
-import shutil
-import tempfile
-
 from iris import load_cube
-
-# Import iris.tests first so that some things can be initialised before
-# importing anything else.
-import iris.tests as tests  # isort:skip
 from iris.mesh import MeshCoord, MeshXY
 from iris.tests.stock import netcdf
 
 
-class XIOSFileMixin(tests.IrisTest):
-    @classmethod
-    def setUpClass(cls):
-        # Create a temp directory for transient test files.
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def tearDownClass(cls):
-        # Destroy the temp directory.
-        shutil.rmtree(cls.temp_dir)
-
+class XIOSFileMixin:
     def create_synthetic_file(self, **create_kwargs):
         # Should be overridden to invoke one of the create_file_ functions.
         # E.g.
@@ -42,86 +25,82 @@ class XIOSFileMixin(tests.IrisTest):
 
     def check_cube(self, cube, shape, location, level):
         # Basic checks on the primary data cube.
-        self.assertEqual(cube.var_name, "thing")
-        self.assertEqual(cube.long_name, "thingness")
-        self.assertEqual(cube.shape, shape)
+        assert cube.var_name == "thing"
+        assert cube.long_name == "thingness"
+        assert cube.shape == shape
 
         # Also a few checks on the attached mesh-related information.
         last_dim = cube.ndim - 1
-        self.assertIsInstance(cube.mesh, MeshXY)
-        self.assertEqual(cube.mesh_dim(), last_dim)
-        self.assertEqual(cube.location, location)
+        assert isinstance(cube.mesh, MeshXY)
+        assert cube.mesh_dim() == last_dim
+        assert cube.location == location
         for coord_name in ("longitude", "latitude"):
             coord = cube.coord(coord_name)
-            self.assertIsInstance(coord, MeshCoord)
-            self.assertEqual(coord.shape, (shape[last_dim],))
-        self.assertTrue(cube.mesh.var_name.endswith(f"{level}_levels"))
+            assert isinstance(coord, MeshCoord)
+            assert coord.shape == (shape[last_dim],)
+        assert cube.mesh.var_name.endswith(f"{level}_levels")
 
 
 class Test_create_file__xios_2d_face_half_levels(XIOSFileMixin):
     def create_synthetic_file(self, **create_kwargs):
         return netcdf.create_file__xios_2d_face_half_levels(
-            temp_file_dir=self.temp_dir, dataset_name="mesh", **create_kwargs
+            dataset_name="mesh", **create_kwargs
         )
 
-    def test_basic_load(self):
-        cube = self.create_synthetic_test_cube()
+    def test_basic_load(self, tmp_path):
+        cube = self.create_synthetic_test_cube(temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 866), location="face", level="half")
 
-    def test_scale_mesh(self):
-        cube = self.create_synthetic_test_cube(n_faces=10)
+    def test_scale_mesh(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_faces=10, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 10), location="face", level="half")
 
-    def test_scale_time(self):
-        cube = self.create_synthetic_test_cube(n_times=3)
+    def test_scale_time(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_times=3, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(3, 866), location="face", level="half")
 
 
 class Test_create_file__xios_3d_face_half_levels(XIOSFileMixin):
     def create_synthetic_file(self, **create_kwargs):
         return netcdf.create_file__xios_3d_face_half_levels(
-            temp_file_dir=self.temp_dir, dataset_name="mesh", **create_kwargs
+            dataset_name="mesh", **create_kwargs
         )
 
-    def test_basic_load(self):
-        cube = self.create_synthetic_test_cube()
+    def test_basic_load(self, tmp_path):
+        cube = self.create_synthetic_test_cube(temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 38, 866), location="face", level="half")
 
-    def test_scale_mesh(self):
-        cube = self.create_synthetic_test_cube(n_faces=10)
+    def test_scale_mesh(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_faces=10, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 38, 10), location="face", level="half")
 
-    def test_scale_time(self):
-        cube = self.create_synthetic_test_cube(n_times=3)
+    def test_scale_time(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_times=3, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(3, 38, 866), location="face", level="half")
 
-    def test_scale_levels(self):
-        cube = self.create_synthetic_test_cube(n_levels=10)
+    def test_scale_levels(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_levels=10, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 10, 866), location="face", level="half")
 
 
 class Test_create_file__xios_3d_face_full_levels(XIOSFileMixin):
     def create_synthetic_file(self, **create_kwargs):
         return netcdf.create_file__xios_3d_face_full_levels(
-            temp_file_dir=self.temp_dir, dataset_name="mesh", **create_kwargs
+            dataset_name="mesh", **create_kwargs
         )
 
-    def test_basic_load(self):
-        cube = self.create_synthetic_test_cube()
+    def test_basic_load(self, tmp_path):
+        cube = self.create_synthetic_test_cube(temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 39, 866), location="face", level="full")
 
-    def test_scale_mesh(self):
-        cube = self.create_synthetic_test_cube(n_faces=10)
+    def test_scale_mesh(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_faces=10, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 39, 10), location="face", level="full")
 
-    def test_scale_time(self):
-        cube = self.create_synthetic_test_cube(n_times=3)
+    def test_scale_time(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_times=3, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(3, 39, 866), location="face", level="full")
 
-    def test_scale_levels(self):
-        cube = self.create_synthetic_test_cube(n_levels=10)
+    def test_scale_levels(self, tmp_path):
+        cube = self.create_synthetic_test_cube(n_levels=10, temp_file_dir=tmp_path)
         self.check_cube(cube, shape=(1, 10, 866), location="face", level="full")
-
-
-if __name__ == "__main__":
-    tests.main()

--- a/lib/iris/tests/unit/tests/test__shared_utils.py
+++ b/lib/iris/tests/unit/tests/test__shared_utils.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Unit tests for the :mod:`iris.tests._shared_utils`."""
+"""Unit tests for :mod:`iris.tests._shared_utils`."""
 
 from abc import ABCMeta, abstractmethod
 

--- a/lib/iris/tests/unit/tests/test__shared_utils.py
+++ b/lib/iris/tests/unit/tests/test__shared_utils.py
@@ -1,0 +1,125 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the :mod:`iris.tests._shared_utils`."""
+
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+import pytest
+
+from iris.tests import _shared_utils
+
+
+class _MaskedArrayEquality(metaclass=ABCMeta):
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.arr1 = np.ma.array([1, 2, 3, 4], mask=[False, True, True, False])
+        self.arr2 = np.ma.array([1, 3, 2, 4], mask=[False, True, True, False])
+
+    @property
+    @abstractmethod
+    def _func(self):
+        pass
+
+    def test_strict_comparison(self):
+        # Comparing both mask and data array completely.
+        with pytest.raises(AssertionError):
+            self._func(self.arr1, self.arr2, strict=True)
+
+    def test_non_strict_comparison(self):
+        # Checking masked array equality and all unmasked array data values.
+        self._func(self.arr1, self.arr2, strict=False)
+
+    def test_default_strict_arg_comparison(self):
+        self._func(self.arr1, self.arr2)
+
+    def test_nomask(self):
+        # Test that an assertion is raised when comparing a masked array
+        # containing masked and unmasked values with a masked array with
+        # 'nomask'.
+        arr1 = np.ma.array([1, 2, 3, 4])
+        with pytest.raises(AssertionError):
+            self._func(arr1, self.arr2, strict=False)
+
+    def test_nomask_unmasked(self):
+        # Ensure that a masked array with 'nomask' can compare with an entirely
+        # unmasked array.
+        arr1 = np.ma.array([1, 2, 3, 4])
+        arr2 = np.ma.array([1, 2, 3, 4], mask=False)
+        self._func(arr1, arr2, strict=False)
+
+    def test_different_mask_strict(self):
+        # Differing masks, equal data
+        arr2 = self.arr1.copy()
+        arr2[0] = np.ma.masked
+        with pytest.raises(AssertionError):
+            self._func(self.arr1, arr2, strict=True)
+
+    def test_different_mask_nonstrict(self):
+        # Differing masks, equal data
+        arr2 = self.arr1.copy()
+        arr2[0] = np.ma.masked
+        with pytest.raises(AssertionError):
+            self._func(self.arr1, arr2, strict=False)
+
+
+class Test_assert_masked_array_equal(_MaskedArrayEquality):
+    @property
+    def _func(self):
+        return _shared_utils.assert_masked_array_equal
+
+
+class Test_assert_masked_array_equal__Nonmaasked:
+    def test_nonmasked_same(self):
+        # Masked test can be used on non-masked arrays.
+        arr1 = np.array([1, 2])
+        _shared_utils.assert_masked_array_equal(arr1, arr1)
+
+    def test_masked_nonmasked_same(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=None.
+        arr1 = np.ma.masked_array([1, 2])
+        arr2 = np.array([1, 2])
+        _shared_utils.assert_masked_array_equal(arr1, arr2)
+
+    def test_masked_nonmasked_different(self):
+        arr1 = np.ma.masked_array([1, 2])
+        arr2 = np.array([1, 3])
+        with pytest.raises(AssertionError, match="Arrays are not equal"):
+            _shared_utils.assert_masked_array_equal(arr1, arr2)
+
+    def test_nonmasked_masked_same(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=None.
+        arr1 = np.array([1, 2])
+        arr2 = np.ma.masked_array([1, 2])
+        _shared_utils.assert_masked_array_equal(arr1, arr2)
+
+    def test_masked_nonmasked_same_falsemask(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=False.
+        arr1 = np.ma.masked_array([1, 2], mask=False)
+        arr2 = np.array([1, 2])
+        _shared_utils.assert_masked_array_equal(arr1, arr2)
+
+    def test_masked_nonmasked_same_emptymask(self):
+        # Masked test can be used between masked + non-masked arrays, and will
+        # consider them equal, when mask=zeros.
+        arr1 = np.ma.masked_array([1, 2], mask=[False, False])
+        arr2 = np.array([1, 2])
+        _shared_utils.assert_masked_array_equal(arr1, arr2)
+
+
+class Test_assert_masked_array_almost_equal(_MaskedArrayEquality):
+    @property
+    def _func(self):
+        return _shared_utils.assert_masked_array_almost_equal
+
+    def test_decimal(self):
+        emsg = r"Arrays are not almost equal to 3 decimals"
+        arr1, arr2 = np.ma.array([100.0]), np.ma.array([100.003])
+        _shared_utils.assert_masked_array_almost_equal(arr1, arr2, decimal=2)
+        with pytest.raises(AssertionError, match=emsg):
+            _shared_utils.assert_masked_array_almost_equal(arr1, arr2, decimal=3)


### PR DESCRIPTION
- [x] `stock/test_netcdf`
- [x] `test__shared_utils`

Note: I have intentionally not converted `test_IrisTests`, as this is explicitly a unittest file and awaits deprecation.

- [x] `integration/netcdf/test_ugrid_load`

I've done this integration test as changes to test/netcdf were breaking it. Originally I only wanted to change calls, but that was breaking enough that I decided to just convert the whole thing.
