### PR TITLE
Converted all unit/io tests into pytest

### DIFF
--- a/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
+++ b/lib/iris/tests/unit/io/format_picker/test_FormatAgent.py
@@ -5,19 +5,14 @@
 """Unit tests for the `iris.io.format_picker.FormatAgent` class."""
 
 from iris.fileformats import FORMAT_AGENT
-import iris.tests as tests
 
 
-class TestFormatAgent(tests.IrisTest):
+class TestFormatAgent:
     def test_copy_is_equal(self):
         format_agent_copy = FORMAT_AGENT.copy()
-        self.assertEqual(format_agent_copy, FORMAT_AGENT)
+        assert format_agent_copy == FORMAT_AGENT
 
     def test_modified_copy_not_equal(self):
         format_agent_copy = FORMAT_AGENT.copy()
         format_agent_copy._format_specs.pop()
-        self.assertNotEqual(format_agent_copy, FORMAT_AGENT)
-
-
-if __name__ == "__main__":
-    tests.main()
+        assert format_agent_copy != FORMAT_AGENT

--- a/lib/iris/tests/unit/io/test__generate_cubes.py
+++ b/lib/iris/tests/unit/io/test__generate_cubes.py
@@ -4,33 +4,25 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the `iris.io._generate_cubes` function."""
 
-# Import iris.tests first so that some things can be initialised before
-# importing anything else.
-import iris.tests as tests  # isort:skip
-
 from pathlib import Path
 
 from iris.loading import _generate_cubes
 
 
-class TestGenerateCubes(tests.IrisTest):
-    def test_pathlib_paths(self):
+class TestGenerateCubes:
+    def test_pathlib_paths(self, mocker):
         test_variants = [
             ("string", "string"),
             (["string"], "string"),
             (Path("string"), Path("string")),
         ]
 
-        decode_uri_mock = self.patch(
+        decode_uri_mock = mocker.patch(
             "iris.iris.io.decode_uri", return_value=("file", None)
         )
-        self.patch("iris.iris.io.load_files")
+        mocker.patch("iris.iris.io.load_files")
 
         for gc_arg, du_arg in test_variants:
             decode_uri_mock.reset_mock()
             list(_generate_cubes(gc_arg, None, None))
             decode_uri_mock.assert_called_with(du_arg)
-
-
-if __name__ == "__main__":
-    tests.main()

--- a/lib/iris/tests/unit/io/test_expand_filespecs.py
+++ b/lib/iris/tests/unit/io/test_expand_filespecs.py
@@ -85,8 +85,7 @@ class TestExpandFilespecs:
             )
 
     def test_false_bool_absolute(self):
-        tempdir = self.tmpdir
-        msg = os.path.join(tempdir, "no_exist.txt")
+        msg = os.path.join(self.tmpdir, "no_exist.txt")
         (result,) = iio.expand_filespecs([msg], False)
         assert result == msg
 

--- a/lib/iris/tests/unit/io/test_save.py
+++ b/lib/iris/tests/unit/io/test_save.py
@@ -4,24 +4,19 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the `iris.io.save` function."""
 
-# Import iris.tests first so that some things can be initialised before
-# importing anything else.
-import iris.tests as tests  # isort:skip
-
 from pathlib import Path
-from unittest import mock
 
 import iris
 from iris.cube import Cube
 
 
-class TestSave(tests.IrisTest):
-    def test_pathlib_save(self):
-        file_mock = mock.Mock()
+class TestSave:
+    def test_pathlib_save(self, mocker):
+        file_mock = mocker.Mock()
         # Have to configure after creation because "name" is special
         file_mock.configure_mock(name="string")
 
-        find_saver_mock = self.patch(
+        find_saver_mock = mocker.patch(
             "iris.io.find_saver", return_value=(lambda *args, **kwargs: None)
         )
 
@@ -29,7 +24,7 @@ class TestSave(tests.IrisTest):
             return file_specs
 
         # does not expand filepaths due to patch
-        self.patch("iris.io.expand_filespecs", replace_expand)
+        mocker.patch("iris.io.expand_filespecs", replace_expand)
 
         test_variants = [
             ("string", "string"),
@@ -44,7 +39,3 @@ class TestSave(tests.IrisTest):
                 print("ValueError")
                 pass
             find_saver_mock.assert_called_with(fs_val)
-
-
-if __name__ == "__main__":
-    tests.main()


### PR DESCRIPTION
- [x] test__generate_cubes
- [x] test_expand_filespecs 
- [x] test_run_callback
- [x] test_save
- [x] format_picker/test_FormatAgent

**_Note for reviewer_**: I had a bit of a mission preventing myself from refactoring. `test_expand_filespecs` might need an extra beat (or might be perfectly fine, who knows).  