### PR TITLE
Bugfix array equality

### DIFF
--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -9,6 +9,7 @@ import operator
 
 import numpy as np
 
+from iris.common.metadata import hexdigest
 import iris.exceptions
 
 
@@ -531,10 +532,9 @@ class AttributeConstraint(Constraint):
         super().__init__(cube_func=self._cube_func)
 
     def __eq__(self, other):
-        eq = (
-            isinstance(other, AttributeConstraint)
-            and self._attributes == other._attributes
-        )
+        hex_self = {(k, hexdigest(v)) for k, v in self._attributes.items()}
+        hex_other = {(k, hexdigest(v)) for k, v in other._attributes.items()}
+        eq = isinstance(other, AttributeConstraint) and hex_self == hex_other
         return eq
 
     def __hash__(self):

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -3386,8 +3386,8 @@ class Cube(CFVariableMixin):
             # Condition1: The two blocks don't themselves wrap
             #             (inside_indices is contiguous).
             # Condition2: Are we chunked at either extreme edge.
-            edge_wrap = (
-                index_of_second_chunk == inside_indices[end_of_first_chunk] + 1
+            edge_wrap = np.array_equal(
+                index_of_second_chunk, inside_indices[end_of_first_chunk] + 1
             ) and index_of_second_chunk in (final_index, 1)
             subsets = None
             if edge_wrap:


### PR DESCRIPTION
Elementwise comparison is no longer permitted when NumPy shapes cannot be broadcast (I need to find an official reference for this).

Much of Iris is already protected behind various `array_equal` calls, this PR mops up the remaining ones.

Targetting `v3.12.x` as this is required as an urgent bugfix for some users of Iris 3.12. Can propagate afterwards as necessary.