### PR TITLE
Fix for deprecated git `whatchanged`

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -83,11 +83,15 @@ This document explains the changes made to Iris for this release
    home-space is shared between multiple machines, as with some virtual desktop
    arrangements. (:pull:`6550`)
 
+#. `@melissaKG`_ upgraded Iris' tests to no longer use the deprecated
+   ``git whatchanged`` command. (:pull:`6672`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:
 
+.. _@melissaKG: https://github.com/melissaKG
 
 
 

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -219,11 +219,12 @@ class TestLicenseHeaders:
             msg = "{} is not a git repository."
             raise ValueError(msg.format(IRIS_REPO_DIRPATH))
 
-        # Call "git whatchanged" to get the details of all the files and when
+        # Call "git log" to get the details of all the files and when
         # they were last changed.
-        # TODO: whatchanged is deprecated, find an alternative Git command.
+        print("repo", IRIS_REPO_DIRPATH)
+        breakpoint()
         output = subprocess.check_output(
-            ["git", "whatchanged", "--pretty=TIME:%ct", "--i-still-use-this"],
+            ["git", "log", "--name-status", "--pretty=TIME:%ct"],
             cwd=IRIS_REPO_DIRPATH,
         )
 

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -221,8 +221,6 @@ class TestLicenseHeaders:
 
         # Call "git log" to get the details of all the files and when
         # they were last changed.
-        print("repo", IRIS_REPO_DIRPATH)
-        breakpoint()
         output = subprocess.check_output(
             ["git", "log", "--name-status", "--pretty=TIME:%ct"],
             cwd=IRIS_REPO_DIRPATH,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fix for https://github.com/SciTools/iris/issues/6667. Changes deprecated `git whatchanged` to `git log`. 


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
