### PR TITLE
Fix gitwash URL linkcheck

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -57,3 +57,6 @@ https://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html
 
 # nonfunctional, found in some code examples
 https://www.somehost.com
+
+# FLAKY: used in developers_guide/gitwash
+https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds a `lychee` exception to the recently flaky `gitwash` mail-archive URL. 

Closes #6679.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
