### PR TITLE
fix barb magnitude binning flip/flop

### DIFF
--- a/lib/iris/tests/integration/plot/test_vector_plots.py
+++ b/lib/iris/tests/integration/plot/test_vector_plots.py
@@ -197,6 +197,11 @@ class TestBarbs(MixinVectorPlotCases, _shared_utils.GraphicsTest):
         # use a scale factor that ensures the barb vector magnitudes fall
         # sufficiently within the default matplotlib barb bins in order to
         # avoid floating point issues where barbs flip/flop between bins.
+        #
+        # TODO: if the barb tests prove to be volatile to floating-point
+        # flip/flopping, then we could back-out this specialization and
+        # re-spin the barbs imagehash with a common scale_factor=30.1 for
+        # all TestBarbs tests.
         scale_factor = 30.1
 
         u_cube, v_cube = self._latlon_uv_cubes(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

:warning: This pull-request is targeting #6597.

Some of our barb integration tests are particularly sensitive to floating point rounding that may place the magnitude of a barb into a lower or higher bin. This flip/flop behaviour is being highlighted due to the test data, which unfortunately is within tolerance of a barb bin boundary for some samples.

We've previously seen these tests fail for similar reasons. In this case the root cause is the recent release of `cartopy` 0.25 ([PR#2590](https://github.com/SciTools/cartopy/pull/2509)) where the use of `numpy.hypot` was adopted within `cartopy.crs.transform_vectors`.

The migration to using `numpy.hypot` from `(u**2 + v**2)**0.5` is enough to trigger such a failure here for one particular test i.e., `test_vector_plots.py::TestBarbs::test_2d_plain_latlon_on_polar_map`.

To mitigate against this a custom `scale_factor` is used to place troublesome barbs safely with the range of barb bins, rather "around" the edge of two, which can result in floating point flip/flopping due to processing changes by third-parties.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
