### PR TITLE
Fix merge: assign cell measures and ancillary variables to correct dimensions

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -43,6 +43,11 @@ This document explains the changes made to Iris for this release
    in v8.4). Note that :mod:`~iris.experimental.regrid_conservative`
    is already deprecated and will be removed in a future release. (:pull:`6643`)
 
+#. `@rcomer`_ fixed a bug in merging cubes with cell measures or ancillary
+   variables. The merged cube now has the cell measures and ancillary variables
+   on the correct dimensions, and merge no longer fails when trying to add
+   them to a dimension of the wrong length. (:issue:`2076`, :pull:`6688`)
+
 
 💣 Incompatible Changes
 =======================

--- a/lib/iris/_merge.py
+++ b/lib/iris/_merge.py
@@ -1532,6 +1532,14 @@ class ProtoCube:
             tuple([dim + offset for dim in item.dims])
             for item in vector_aux_coords_and_dims
         ]
+        self._cell_measures_and_dims = [
+            (cm, tuple([dim + offset for dim in dims]))
+            for cm, dims in self._cell_measures_and_dims
+        ]
+        self._ancillary_variables_and_dims = [
+            (av, tuple([dim + offset for dim in dims]))
+            for av, dims in self._ancillary_variables_and_dims
+        ]
 
         # Now factor in the vector payload shape. Note that, for
         # deferred loading, this does NOT change the shape.

--- a/lib/iris/tests/unit/merge/test_merge.py
+++ b/lib/iris/tests/unit/merge/test_merge.py
@@ -301,16 +301,24 @@ class TestCubeMergeWithAncils:
     def test_merge_with_cell_measure(self):
         cube1 = self._makecube(0, cm=True)
         cube2 = self._makecube(1, cm=True)
-        cubes = iris.cube.CubeList([cube1, cube2]).merge()
+        cube3 = self._makecube(2, cm=True)
+        cubes = iris.cube.CubeList([cube1, cube2, cube3]).merge()
         assert len(cubes) == 1
         assert cube1.cell_measures() == cubes[0].cell_measures()
+        # The cell measure should be on the second (non merged) dimension.
+        (cm,) = cube1.cell_measures()
+        assert cubes[0].cell_measure_dims(cm) == (1,)
 
     def test_merge_with_ancillary_variable(self):
         cube1 = self._makecube(0, av=True)
         cube2 = self._makecube(1, av=True)
-        cubes = iris.cube.CubeList([cube1, cube2]).merge()
+        cube3 = self._makecube(2, av=True)
+        cubes = iris.cube.CubeList([cube1, cube2, cube3]).merge()
         assert len(cubes) == 1
         assert cube1.ancillary_variables() == cubes[0].ancillary_variables()
+        # The ancillary variable should be on the second (non merged) dimension.
+        (av,) = cube1.ancillary_variables()
+        assert cubes[0].ancillary_variable_dims(av) == (1,)
 
     def test_cell_measure_error_msg(self):
         msg = "cube.cell_measures differ"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #2076 

The problem was that merge tries to add the cell measure to the same dimension that it had on the input cubes.   This is wrong, because the new dimension[s] are added to the start.  So we need to add an offset in the same way that is already done for coordinates.  The problem was not picked up by the tests because the output cube there was square (2 by 2) and there was no check for which dimension the cell measure was on.  By adding a third cube in the test input, we reproduce the error shown in the issue.

Also made equivalent change for ancillary variables.

Full disclosure: the list comprehensions and most of the what's new entry were written by Copilot.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
