### PR TITLE
Rationalise CML

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -95,6 +95,9 @@ This document explains the changes made to Iris for this release
 #. `@melissaKG`_ upgraded Iris' tests to no longer use the deprecated
    ``git whatchanged`` command. (:pull:`6672`)
 
+#. `@ukmo-ccbunney` merged functionality of `assert_CML_approx_data` into
+   `assert_CML` via the use of a new `approx_data` keyword. (:pull:`6713`)
+
 
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -95,8 +95,8 @@ This document explains the changes made to Iris for this release
 #. `@melissaKG`_ upgraded Iris' tests to no longer use the deprecated
    ``git whatchanged`` command. (:pull:`6672`)
 
-#. `@ukmo-ccbunney` merged functionality of `assert_CML_approx_data` into
-   `assert_CML` via the use of a new `approx_data` keyword. (:pull:`6713`)
+#. `@ukmo-ccbunney` merged functionality of ``assert_CML_approx_data`` into
+   ``assert_CML`` via the use of a new ``approx_data`` keyword. (:pull:`6713`)
 
 
 .. comment

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -406,7 +406,7 @@ def assert_CML(
     approx_data : bool, optional, default=False
         When True, the cube's data will be compared with the reference
         data and asserted to be within a specified tolerance. Implies
-        `checksum=False`.
+        ``checksum=False``.
 
     """
     _check_for_request_fixture(request, "assert_CML")

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -431,7 +431,6 @@ def assert_CML(
         )
     else:
         cml = cubes.xml(checksum=checksum, order=False, byteorder=False)
-    #   reference_path = get_result_path(reference_filename)
     _check_same(cml, reference_path)
 
 

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -423,7 +423,7 @@ def assert_CML(
         for i, cube in enumerate(cubes):
             # Build the json stats filename based on CML file path:
             fname = reference_path.removesuffix(".cml")
-            fname += ".data.%d.json" % i
+            fname += f".data.{i}.json"
             assert_data_almost_equal(cube.data, fname, **kwargs)
     if isinstance(cubes, (list, tuple)):
         cml = iris.cube.CubeList(cubes).xml(

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -291,28 +291,6 @@ def result_path(request: pytest.FixtureRequest, basename=None, ext=""):
     return str(output_path)
 
 
-def assert_CML_approx_data(
-    request: pytest.FixtureRequest, cubes, reference_filename=None, **kwargs
-):
-    # passes args and kwargs on to approx equal
-    # See result_path() Examples for how to access the ``request`` fixture.
-
-    _check_for_request_fixture(request, "assert_CML_approx_data")
-
-    if isinstance(cubes, iris.cube.Cube):
-        cubes = [cubes]
-    if reference_filename is None:
-        reference_filename = result_path(request, None, "cml")
-        reference_filename = [get_result_path(reference_filename)]
-    for i, cube in enumerate(cubes):
-        fname = list(reference_filename)
-        # don't want the ".cml" for the json stats file
-        fname[-1] = fname[-1].removesuffix(".cml")
-        fname[-1] += ".data.%d.json" % i
-        assert_data_almost_equal(cube.data, fname, **kwargs)
-    assert_CML(request, cubes, reference_filename, checksum=False)
-
-
 def assert_CDL(
     request: pytest.FixtureRequest, netcdf_filename, reference_filename=None, flags="-h"
 ):
@@ -385,13 +363,29 @@ def assert_CDL(
 
 
 def assert_CML(
-    request: pytest.FixtureRequest, cubes, reference_filename=None, checksum=True
+    request: pytest.FixtureRequest,
+    cubes,
+    reference_filename=None,
+    checksum=True,
+    approx_data=False,
+    **kwargs,
 ):
     """Test that the CML for the given cubes matches the contents of
     the reference file.
 
     If the environment variable IRIS_TEST_CREATE_MISSING is
     non-empty, the reference file is created if it doesn't exist.
+
+    The data payload of individual cubes is not compared unless ``checksum``
+    or ``approx_data`` are True.
+
+    Notes
+    -----
+    The ``approx_data`` keyword provides functionality equivalent to the
+    old ``assert_CML_approx_data`` function.
+
+    ``**kwargs`` are passed through to :func:`assert_data_almost_equal` if
+    ``approx_data`` is True.
 
     Parameters
     ----------
@@ -409,6 +403,10 @@ def assert_CML(
     checksum : bool, optional
         When True, causes the CML to include a checksum for each
         Cube's data. Defaults to True.
+    approx_data : bool, optional, default=False
+        When True, the cube's data will be compared with the reference
+        data and asserted to be within a specified tolerance. Implies
+        `checksum=False`.
 
     """
     _check_for_request_fixture(request, "assert_CML")
@@ -417,15 +415,24 @@ def assert_CML(
         cubes = [cubes]
     if reference_filename is None:
         reference_filename = result_path(request, None, "cml")
-
+    # Note: reference_path could be a tuple of path parts
+    reference_path = get_result_path(reference_filename)
+    if approx_data:
+        # compare data payload stats against known good stats
+        checksum = False  # ensure we are not comparing data checksums
+        for i, cube in enumerate(cubes):
+            # Build the json stats filename based on CML file path:
+            fname = reference_path.removesuffix(".cml")
+            fname += ".data.%d.json" % i
+            assert_data_almost_equal(cube.data, fname, **kwargs)
     if isinstance(cubes, (list, tuple)):
-        xml = iris.cube.CubeList(cubes).xml(
+        cml = iris.cube.CubeList(cubes).xml(
             checksum=checksum, order=False, byteorder=False
         )
     else:
-        xml = cubes.xml(checksum=checksum, order=False, byteorder=False)
-    reference_path = get_result_path(reference_filename)
-    _check_same(xml, reference_path)
+        cml = cubes.xml(checksum=checksum, order=False, byteorder=False)
+    #   reference_path = get_result_path(reference_filename)
+    _check_same(cml, reference_path)
 
 
 def assert_text_file(source_filename, reference_filename, desc="text file"):

--- a/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
+++ b/lib/iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py
@@ -242,7 +242,9 @@ class TestAreaWeightedRegrid:
         src = self.simple_cube
         res = regrid_area_weighted(src, src)
         assert res == src
-        _shared_utils.assert_CML_approx_data(request, res, RESULT_DIR + ("simple.cml",))
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("simple.cml",), approx_data=True
+        )
 
     def test_equal_area_numbers(self):
         # Remove coords system and units so it is no longer spherical.
@@ -321,8 +323,8 @@ class TestAreaWeightedRegrid:
         # Reduce from (3, 4) to (2, 2).
         dest = _subsampled_grid(src, 2, 2)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("latlonreduced.cml",)
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("latlonreduced.cml",), approx_data=True
         )
 
     def test_regrid_reorder_axis(self):
@@ -360,8 +362,8 @@ class TestAreaWeightedRegrid:
         src = self.simple_cube
         dest = _resampled_grid(src, 0.5, 1.0)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("lonhalved.cml",)
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("lonhalved.cml",), approx_data=True
         )
 
     def test_regrid_to_non_int_frac(self, request):
@@ -370,21 +372,25 @@ class TestAreaWeightedRegrid:
         src = self.simple_cube
         dest = _resampled_grid(src, 0.75, 0.67)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(request, res, RESULT_DIR + ("lower.cml",))
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("lower.cml",), approx_data=True
+        )
 
     def test_regrid_to_higher_res(self, request):
         src = self.simple_cube
         frac = 3.5
         dest = _resampled_grid(src, frac, frac)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(request, res, RESULT_DIR + ("higher.cml",))
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("higher.cml",), approx_data=True
+        )
 
     def test_hybrid_height(self, request):
         src = self.realistic_cube
         dest = _resampled_grid(src, 0.7, 0.8)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("hybridheight.cml",)
+        _shared_utils.assert_CML(
+            request, res, RESULT_DIR + ("hybridheight.cml",), approx_data=True
         )
 
     def test_missing_data(self):
@@ -483,8 +489,11 @@ class TestAreaWeightedRegrid:
         dest.add_dim_coord(lon, 1)
         dest.add_aux_coord(src.coord("grid_latitude").copy(), None)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("const_lat_cross_section.cml",)
+        _shared_utils.assert_CML(
+            request,
+            res,
+            RESULT_DIR + ("const_lat_cross_section.cml",),
+            approx_data=True,
         )
         # Constant latitude, data order [x, z]
         # Using original and transposing the result should give the
@@ -493,8 +502,11 @@ class TestAreaWeightedRegrid:
         dest.transpose()
         res = regrid_area_weighted(src, dest)
         res.transpose()
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("const_lat_cross_section.cml",)
+        _shared_utils.assert_CML(
+            request,
+            res,
+            RESULT_DIR + ("const_lat_cross_section.cml",),
+            approx_data=True,
         )
 
         # Constant longitude
@@ -507,8 +519,11 @@ class TestAreaWeightedRegrid:
         dest.add_dim_coord(lat, 1)
         dest.add_aux_coord(src.coord("grid_longitude").copy(), None)
         res = regrid_area_weighted(src, dest)
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("const_lon_cross_section.cml",)
+        _shared_utils.assert_CML(
+            request,
+            res,
+            RESULT_DIR + ("const_lon_cross_section.cml",),
+            approx_data=True,
         )
         # Constant longitude, data order [y, z]
         # Using original and transposing the result should give the
@@ -517,8 +532,11 @@ class TestAreaWeightedRegrid:
         dest.transpose()
         res = regrid_area_weighted(src, dest)
         res.transpose()
-        _shared_utils.assert_CML_approx_data(
-            request, res, RESULT_DIR + ("const_lon_cross_section.cml",)
+        _shared_utils.assert_CML(
+            request,
+            res,
+            RESULT_DIR + ("const_lon_cross_section.cml",),
+            approx_data=True,
         )
 
     def test_scalar_source_cube(self):

--- a/lib/iris/tests/test_analysis.py
+++ b/lib/iris/tests/test_analysis.py
@@ -213,8 +213,8 @@ class TestAnalysisWeights:
         if a.dtype > np.float32:
             cast_data = a.data.astype(np.float32)
             a.data = cast_data
-        _shared_utils.assert_CML_approx_data(
-            self.request, a, ("analysis", "weighted_mean_lat.cml")
+        _shared_utils.assert_CML(
+            self.request, a, ("analysis", "weighted_mean_lat.cml"), approx_data=True
         )
 
         b = cube.collapsed(lon_coord, iris.analysis.MEAN, weights=weights)
@@ -222,8 +222,8 @@ class TestAnalysisWeights:
             cast_data = b.data.astype(np.float32)
             b.data = cast_data
         b.data = np.asarray(b.data)
-        _shared_utils.assert_CML_approx_data(
-            self.request, b, ("analysis", "weighted_mean_lon.cml")
+        _shared_utils.assert_CML(
+            self.request, b, ("analysis", "weighted_mean_lon.cml"), approx_data=True
         )
         assert b.coord("dummy").shape == (1,)
 
@@ -234,8 +234,8 @@ class TestAnalysisWeights:
         if c.dtype > np.float32:
             cast_data = c.data.astype(np.float32)
             c.data = cast_data
-        _shared_utils.assert_CML_approx_data(
-            self.request, c, ("analysis", "weighted_mean_latlon.cml")
+        _shared_utils.assert_CML(
+            self.request, c, ("analysis", "weighted_mean_latlon.cml"), approx_data=True
         )
         assert c.coord("dummy").shape == (1,)
 
@@ -331,25 +331,32 @@ class TestAnalysisBasic:
         _shared_utils.assert_CML(self.request, self.cube, ("analysis", original_name))
 
         a = self.cube.collapsed("grid_latitude", aggregate)
-        _shared_utils.assert_CML_approx_data(
-            self.request, a, ("analysis", "%s_latitude.cml" % name), *args, **kwargs
+        _shared_utils.assert_CML(
+            self.request,
+            a,
+            ("analysis", "%s_latitude.cml" % name),
+            *args,
+            approx_data=True,
+            **kwargs,
         )
 
         b = a.collapsed("grid_longitude", aggregate)
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             self.request,
             b,
             ("analysis", "%s_latitude_longitude.cml" % name),
             *args,
+            approx_data=True,
             **kwargs,
         )
 
         c = self.cube.collapsed(["grid_latitude", "grid_longitude"], aggregate)
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             self.request,
             c,
             ("analysis", "%s_latitude_longitude_1call.cml" % name),
             *args,
+            approx_data=True,
             **kwargs,
         )
 

--- a/lib/iris/tests/test_analysis_calculus.py
+++ b/lib/iris/tests/test_analysis_calculus.py
@@ -287,14 +287,20 @@ class TestCalculusSimple3:
     def test_diff_wrt_lon(self):
         t = iris.analysis.calculus.differentiate(self.cube, "longitude")
 
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade2_wrt_lon.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade2_wrt_lon.cml"),
+            approx_data=True,
         )
 
     def test_diff_wrt_lat(self):
         t = iris.analysis.calculus.differentiate(self.cube, "latitude")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade2_wrt_lat.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade2_wrt_lat.cml"),
+            approx_data=True,
         )
 
 
@@ -352,50 +358,74 @@ class TestCalculusSimple2:
 
     def test_diff_wrt_x(self):
         t = iris.analysis.calculus.differentiate(self.cube, "x")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade_wrt_x.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade_wrt_x.cml"),
+            approx_data=True,
         )
 
     def test_diff_wrt_y(self):
         t = iris.analysis.calculus.differentiate(self.cube, "y")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade_wrt_y.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade_wrt_y.cml"),
+            approx_data=True,
         )
 
     def test_diff_wrt_lon(self):
         t = iris.analysis.calculus.differentiate(self.cube, "longitude")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade_wrt_lon.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade_wrt_lon.cml"),
+            approx_data=True,
         )
 
     def test_diff_wrt_lat(self):
         t = iris.analysis.calculus.differentiate(self.cube, "latitude")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade_wrt_lat.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade_wrt_lat.cml"),
+            approx_data=True,
         )
 
     def test_delta_wrt_x(self):
         t = iris.analysis.calculus.cube_delta(self.cube, "x")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "delta_handmade_wrt_x.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "delta_handmade_wrt_x.cml"),
+            approx_data=True,
         )
 
     def test_delta_wrt_y(self):
         t = iris.analysis.calculus.cube_delta(self.cube, "y")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "delta_handmade_wrt_y.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "delta_handmade_wrt_y.cml"),
+            approx_data=True,
         )
 
     def test_delta_wrt_lon(self):
         t = iris.analysis.calculus.cube_delta(self.cube, "longitude")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "delta_handmade_wrt_lon.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "delta_handmade_wrt_lon.cml"),
+            approx_data=True,
         )
 
     def test_delta_wrt_lat(self):
         t = iris.analysis.calculus.cube_delta(self.cube, "latitude")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "delta_handmade_wrt_lat.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "delta_handmade_wrt_lat.cml"),
+            approx_data=True,
         )
 
 
@@ -428,14 +458,20 @@ class TestCalculusSimple1:
 
     def test_diff_wrt_x(self):
         t = iris.analysis.calculus.differentiate(self.cube, "x")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "handmade_simple_wrt_x.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "handmade_simple_wrt_x.cml"),
+            approx_data=True,
         )
 
     def test_delta_wrt_x(self):
         t = iris.analysis.calculus.cube_delta(self.cube, "x")
-        _shared_utils.assert_CML_approx_data(
-            self.request, t, ("analysis", "calculus", "delta_handmade_simple_wrt_x.cml")
+        _shared_utils.assert_CML(
+            self.request,
+            t,
+            ("analysis", "calculus", "delta_handmade_simple_wrt_x.cml"),
+            approx_data=True,
         )
 
 

--- a/lib/iris/tests/test_basic_maths.py
+++ b/lib/iris/tests/test_basic_maths.py
@@ -251,11 +251,11 @@ class TestBasicMaths:
             new_unit=a.units**2,
             in_place=False,
         )
-        _shared_utils.assert_CML_approx_data(
-            request, a, ("analysis", "apply_ufunc_original.cml")
+        _shared_utils.assert_CML(
+            request, a, ("analysis", "apply_ufunc_original.cml"), approx_data=True
         )
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ufunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ufunc.cml"), approx_data=True
         )
 
         b = iris.analysis.maths.apply_ufunc(
@@ -265,11 +265,11 @@ class TestBasicMaths:
             new_unit=a.units**2,
             in_place=True,
         )
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ufunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ufunc.cml"), approx_data=True
         )
-        _shared_utils.assert_CML_approx_data(
-            request, a, ("analysis", "apply_ufunc.cml")
+        _shared_utils.assert_CML(
+            request, a, ("analysis", "apply_ufunc.cml"), approx_data=True
         )
 
         def vec_mag(u, v):
@@ -279,8 +279,8 @@ class TestBasicMaths:
 
         vec_mag_ufunc = np.frompyfunc(vec_mag, 2, 1)
         b = iris.analysis.maths.apply_ufunc(vec_mag_ufunc, a, c)
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ufunc_frompyfunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ufunc_frompyfunc.cml"), approx_data=True
         )
 
     def test_apply_ufunc_fail(self):
@@ -301,20 +301,20 @@ class TestBasicMaths:
         my_ifunc = iris.analysis.maths.IFunc(np.square, lambda a: a.units**2)
         b = my_ifunc(a, new_name="squared temperature", in_place=False)
 
-        _shared_utils.assert_CML_approx_data(
-            request, a, ("analysis", "apply_ifunc_original.cml")
+        _shared_utils.assert_CML(
+            request, a, ("analysis", "apply_ifunc_original.cml"), approx_data=True
         )
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ifunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ifunc.cml"), approx_data=True
         )
 
         b = my_ifunc(a, new_name="squared temperature", in_place=True)
 
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ifunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ifunc.cml"), approx_data=True
         )
-        _shared_utils.assert_CML_approx_data(
-            request, a, ("analysis", "apply_ifunc.cml")
+        _shared_utils.assert_CML(
+            request, a, ("analysis", "apply_ifunc.cml"), approx_data=True
         )
 
         def vec_mag(u, v):
@@ -326,8 +326,8 @@ class TestBasicMaths:
         my_ifunc = iris.analysis.maths.IFunc(vec_mag_ufunc, lambda a, b: (a + b).units)
 
         b = my_ifunc(a, c)
-        _shared_utils.assert_CML_approx_data(
-            request, b, ("analysis", "apply_ifunc_frompyfunc.cml")
+        _shared_utils.assert_CML(
+            request, b, ("analysis", "apply_ifunc_frompyfunc.cml"), approx_data=True
         )
 
     def test_ifunc_init_fail(self):
@@ -562,8 +562,8 @@ class TestExponentiate:
     def test_exponentiate(self, request):
         a = self.cube
         e = pow(a, 4)
-        _shared_utils.assert_CML_approx_data(
-            request, e, ("analysis", "exponentiate.cml")
+        _shared_utils.assert_CML(
+            request, e, ("analysis", "exponentiate.cml"), approx_data=True
         )
 
     def test_square_root(self, request):
@@ -590,7 +590,7 @@ class TestExponential:
 
     def test_exp(self, request):
         e = iris.analysis.maths.exp(self.cube)
-        _shared_utils.assert_CML_approx_data(request, e, ("analysis", "exp.cml"))
+        _shared_utils.assert_CML(request, e, ("analysis", "exp.cml"), approx_data=True)
 
 
 class TestApplyUfunc:
@@ -688,16 +688,16 @@ class TestLog:
 
     def test_log(self, request):
         e = iris.analysis.maths.log(self.cube)
-        _shared_utils.assert_CML_approx_data(request, e, ("analysis", "log.cml"))
+        _shared_utils.assert_CML(request, e, ("analysis", "log.cml"), approx_data=True)
 
     def test_log2(self, request):
         e = iris.analysis.maths.log2(self.cube)
-        _shared_utils.assert_CML_approx_data(request, e, ("analysis", "log2.cml"))
+        _shared_utils.assert_CML(request, e, ("analysis", "log2.cml"), approx_data=True)
 
     def test_log10(self, request):
         e = iris.analysis.maths.log10(self.cube)
-        _shared_utils.assert_CML_approx_data(
-            request, e, ("analysis", "log10.cml"), rtol=1e-6
+        _shared_utils.assert_CML(
+            request, e, ("analysis", "log10.cml"), approx_data=True, rtol=1e-6
         )
 
 

--- a/lib/iris/tests/test_cdm.py
+++ b/lib/iris/tests/test_cdm.py
@@ -1221,7 +1221,7 @@ class TestCubeCollapsed:
         if dual_stage.dtype > cube.dtype:
             data = dual_stage.data.astype(cube.dtype)
             dual_stage.data = data
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             request,
             dual_stage,
             (
@@ -1230,13 +1230,14 @@ class TestCubeCollapsed:
             ),
             *args,
             **kwargs,
+            approx_data=True,
         )
 
         single_stage = cube.collapsed([a_name, b_name], iris.analysis.MEAN)
         if single_stage.dtype > cube.dtype:
             data = single_stage.data.astype(cube.dtype)
             single_stage.data = data
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             request,
             single_stage,
             (
@@ -1245,6 +1246,7 @@ class TestCubeCollapsed:
             ),
             *args,
             **kwargs,
+            approx_data=True,
         )
 
         # Compare the cube bits that should match
@@ -1309,20 +1311,22 @@ class TestCubeCollapsed:
             ["model_level_number", "time", "grid_longitude"],
             iris.analysis.MEAN,
         )
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             request,
             triple_collapse,
             ("cube_collapsed", ("triple_collapse_ml_pt_lon.cml")),
+            approx_data=True,
             rtol=5e-04,
         )
 
         triple_collapse = cube.collapsed(
             ["grid_latitude", "model_level_number", "time"], iris.analysis.MEAN
         )
-        _shared_utils.assert_CML_approx_data(
+        _shared_utils.assert_CML(
             request,
             triple_collapse,
             ("cube_collapsed", ("triple_collapse_lat_ml_pt.cml")),
+            approx_data=True,
             rtol=0.05,
         )
         # KNOWN PROBLEM: the previous 'rtol' is very large.

--- a/lib/iris/tests/test_name.py
+++ b/lib/iris/tests/test_name.py
@@ -12,36 +12,36 @@ from iris.tests import _shared_utils
 class TestLoad:
     def test_NAMEIII_field(self, request):
         cubes = iris.load(_shared_utils.get_data_path(("NAME", "NAMEIII_field.txt")))
-        _shared_utils.assert_CML_approx_data(
-            request, cubes, ("name", "NAMEIII_field.cml")
+        _shared_utils.assert_CML(
+            request, cubes, ("name", "NAMEIII_field.cml"), approx_data=True
         )
 
     def test_NAMEII_field(self, request):
         cubes = iris.load(_shared_utils.get_data_path(("NAME", "NAMEII_field.txt")))
-        _shared_utils.assert_CML_approx_data(
-            request, cubes, ("name", "NAMEII_field.cml")
+        _shared_utils.assert_CML(
+            request, cubes, ("name", "NAMEII_field.cml"), approx_data=True
         )
 
     def test_NAMEIII_timeseries(self, request):
         cubes = iris.load(
             _shared_utils.get_data_path(("NAME", "NAMEIII_timeseries.txt"))
         )
-        _shared_utils.assert_CML_approx_data(
-            request, cubes, ("name", "NAMEIII_timeseries.cml")
+        _shared_utils.assert_CML(
+            request, cubes, ("name", "NAMEIII_timeseries.cml"), approx_data=True
         )
 
     def test_NAMEII_timeseries(self, request):
         cubes = iris.load(
             _shared_utils.get_data_path(("NAME", "NAMEII_timeseries.txt"))
         )
-        _shared_utils.assert_CML_approx_data(
-            request, cubes, ("name", "NAMEII_timeseries.cml")
+        _shared_utils.assert_CML(
+            request, cubes, ("name", "NAMEII_timeseries.cml"), approx_data=True
         )
 
     def test_NAMEIII_version2(self, request):
         cubes = iris.load(_shared_utils.get_data_path(("NAME", "NAMEIII_version2.txt")))
-        _shared_utils.assert_CML_approx_data(
-            request, cubes, ("name", "NAMEIII_version2.cml")
+        _shared_utils.assert_CML(
+            request, cubes, ("name", "NAMEIII_version2.cml"), approx_data=True
         )
 
     def test_NAMEIII_trajectory(self, request):

--- a/lib/iris/tests/unit/analysis/cartography/test_project.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_project.py
@@ -133,7 +133,7 @@ class TestAll:
     @_shared_utils.skip_data
     def test_cube(self, request, low_res_4d):
         new_cube, _ = project(low_res_4d, ROBINSON)
-        _shared_utils.assert_CML_approx_data(request, new_cube)
+        _shared_utils.assert_CML(request, new_cube, approx_data=True)
 
     @_shared_utils.skip_data
     def test_no_coord_system(self, low_res_4d):

--- a/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
@@ -466,7 +466,7 @@ class Test___call___2D_non_contiguous(ThreeDimCube):
             "LinearInterpolator",
             "basic_orthogonal_cube.cml",
         )
-        _shared_utils.assert_CML_approx_data(request, result_cube, result_path)
+        _shared_utils.assert_CML(request, result_cube, result_path, approx_data=True)
         assert result_cube.coord("longitude").dtype == np.int32
         assert result_cube.coord("height").dtype == np.int64
 
@@ -479,7 +479,7 @@ class Test___call___2D_non_contiguous(ThreeDimCube):
             "LinearInterpolator",
             "orthogonal_cube_1d_squashed.cml",
         )
-        _shared_utils.assert_CML_approx_data(request, result_cube, result_path)
+        _shared_utils.assert_CML(request, result_cube, result_path, approx_data=True)
         assert result_cube.coord("longitude").dtype == np.int32
         assert result_cube.coord("height").dtype == np.int64
 

--- a/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
+++ b/lib/iris/tests/unit/analysis/regrid/test_RectilinearRegridder.py
@@ -1084,7 +1084,7 @@ class Test___call____rotated_to_lat_lon:
             result = regridder(src)
             result.transpose([3, 1, 2, 0])
             cml = RESULT_DIR + ("{}_subset.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def _grid_subset(self):
         # The destination grid points are entirely contained within the
@@ -1102,60 +1102,76 @@ class Test___call____rotated_to_lat_lon:
             cml = RESULT_DIR + ("{}_subset.cml".format(method),)
             regridder = Regridder(src, grid[::-1], method, self.mode)
             result = regridder(src)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1], cml)
+            _shared_utils.assert_CML(request, result[:, :, ::-1], cml, approx_data=True)
 
             sample = src[:, :, ::-1]
             regridder = Regridder(sample, grid[::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1], cml)
+            _shared_utils.assert_CML(request, result[:, :, ::-1], cml, approx_data=True)
 
             sample = src[:, :, :, ::-1]
             regridder = Regridder(sample, grid[::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1], cml)
+            _shared_utils.assert_CML(request, result[:, :, ::-1], cml, approx_data=True)
 
             sample = src[:, :, ::-1, ::-1]
             regridder = Regridder(sample, grid[::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1], cml)
+            _shared_utils.assert_CML(request, result[:, :, ::-1], cml, approx_data=True)
 
             regridder = Regridder(src, grid[:, ::-1], method, self.mode)
             result = regridder(src)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, :, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, :, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, ::-1]
             regridder = Regridder(sample, grid[:, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, :, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, :, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, :, ::-1]
             regridder = Regridder(sample, grid[:, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, :, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, :, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, ::-1, ::-1]
             regridder = Regridder(sample, grid[:, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, :, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, :, ::-1], cml, approx_data=True
+            )
 
             regridder = Regridder(src, grid[::-1, ::-1], method, self.mode)
             result = regridder(src)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, ::-1, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, ::-1]
             regridder = Regridder(sample, grid[::-1, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, ::-1, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, :, ::-1]
             regridder = Regridder(sample, grid[::-1, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, ::-1, ::-1], cml, approx_data=True
+            )
 
             sample = src[:, :, ::-1, ::-1]
             regridder = Regridder(sample, grid[::-1, ::-1], method, self.mode)
             result = regridder(sample)
-            _shared_utils.assert_CML_approx_data(request, result[:, :, ::-1, ::-1], cml)
+            _shared_utils.assert_CML(
+                request, result[:, :, ::-1, ::-1], cml, approx_data=True
+            )
 
     def test_grid_subset(self, request):
         # The destination grid points are entirely contained within the
@@ -1165,7 +1181,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(self.src, grid, method, self.mode)
             result = regridder(self.src)
             cml = RESULT_DIR + ("{}_subset.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def _big_grid(self):
         grid = self._grid_subset()
@@ -1182,7 +1198,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(self.src, big_grid, method, self.mode)
             result = regridder(self.src)
             cml = RESULT_DIR + ("{}_subset.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_subset_big_transposed(self, request):
         # The order of the grid's dimensions (including the X and Y
@@ -1193,7 +1209,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(self.src, big_grid, method, self.mode)
             result = regridder(self.src)
             cml = RESULT_DIR + ("{}_subset.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_subset_anon(self, request):
         # Must cope OK with anonymous source dimensions.
@@ -1204,7 +1220,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(src, grid, method, self.mode)
             result = regridder(src)
             cml = RESULT_DIR + ("{}_subset_anon.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_subset_missing_data_1(self, request):
         # The destination grid points are entirely contained within the
@@ -1217,7 +1233,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(src, grid, method, self.mode)
             result = regridder(src)
             cml = RESULT_DIR + ("{}_subset_masked_1.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_subset_missing_data_2(self, request):
         # The destination grid points are entirely contained within the
@@ -1230,7 +1246,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(src, grid, method, self.mode)
             result = regridder(src)
             cml = RESULT_DIR + ("{}_subset_masked_2.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_partial_overlap(self, request):
         # The destination grid points are partially contained within the
@@ -1242,7 +1258,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(self.src, grid, method, self.mode)
             result = regridder(self.src)
             cml = RESULT_DIR + ("{}_partial_overlap.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_grid_no_overlap(self, request):
         # The destination grid points are NOT contained within the
@@ -1253,8 +1269,8 @@ class Test___call____rotated_to_lat_lon:
         for method in self.methods:
             regridder = Regridder(self.src, grid, method, self.mode)
             result = regridder(self.src)
-            _shared_utils.assert_CML_approx_data(
-                request, result, RESULT_DIR + ("no_overlap.cml",)
+            _shared_utils.assert_CML(
+                request, result, RESULT_DIR + ("no_overlap.cml",), approx_data=True
             )
 
     def test_grid_subset_missing_data_aux(self, request):
@@ -1267,7 +1283,7 @@ class Test___call____rotated_to_lat_lon:
             regridder = Regridder(src, grid, method, self.mode)
             result = regridder(src)
             cml = RESULT_DIR + ("{}_masked_altitude.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
 
 @_shared_utils.skip_data
@@ -1338,7 +1354,7 @@ class Test___call____circular:
             result = regridder(self.src)
             assert not result.coord("longitude").circular
             cml = RESULT_DIR + ("{}_non_circular.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def _check_circular_results(self, src_cube, request, missingmask=""):
         results = []
@@ -1348,7 +1364,7 @@ class Test___call____circular:
             results.append(result)
             assert not result.coord("longitude").circular
             cml = RESULT_DIR + ("{}_circular_src{}.cml".format(method, missingmask),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
         return results
 
     def test_circular_src(self, request):
@@ -1465,7 +1481,7 @@ class Test___call____circular:
             result = regridder(self.src)
             assert result.coord("longitude").circular
             cml = RESULT_DIR + ("{}_circular_grid.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)
 
     def test_circular_src_and_grid(self, request):
         # Circular src -> circular grid
@@ -1478,4 +1494,4 @@ class Test___call____circular:
             result = regridder(src)
             assert result.coord("longitude").circular
             cml = RESULT_DIR + ("{}_both_circular.cml".format(method),)
-            _shared_utils.assert_CML_approx_data(request, result, cml)
+            _shared_utils.assert_CML(request, result, cml, approx_data=True)

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1275,12 +1275,12 @@ class Test_intersection__Metadata:
     def test_metadata(self, request):
         cube = create_cube(0, 360)
         result = cube.intersection(longitude=(170, 190))
-        _shared_utils.assert_CML_approx_data(request, result)
+        _shared_utils.assert_CML(request, result, approx_data=True)
 
     def test_metadata_wrapped(self, request):
         cube = create_cube(-180, 180)
         result = cube.intersection(longitude=(170, 190))
-        _shared_utils.assert_CML_approx_data(request, result)
+        _shared_utils.assert_CML(request, result, approx_data=True)
 
 
 # Explicitly check the handling of `circular` on the result.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Removes the `assert_CML_approx_data` function.
The functionality is now provided in `assert_CML` with a new `approx_data` keyword.

Addresses the first bullet point of #6244 


