### PR TITLE
RFC: Remove custom `__deepcopy__` method from DimCoord

### DIFF
--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -2794,19 +2794,6 @@ class DimCoord(Coord):
         #: Whether the coordinate wraps by ``coord.units.modulus``.
         self.circular = circular
 
-    def __deepcopy__(self, memo):  # numpydoc ignore=SS02
-        """coord.__deepcopy__() -> Deep copy of coordinate.
-
-        Used if copy.deepcopy is called on a coordinate.
-
-        """
-        new_coord = copy.deepcopy(super(), memo)
-        # Ensure points and bounds arrays are read-only.
-        new_coord._values_dm.data.flags.writeable = False
-        if new_coord._bounds_dm is not None:
-            new_coord._bounds_dm.data.flags.writeable = False
-        return new_coord
-
     @property
     def circular(self):
         return self._metadata_manager.circular


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

**Currently a request for comment, as there is probably a better way to fix this**, and I've not done all the checklist stuff yet.

The custom copy implementation for DimCoords causes a RecursionError under python 3.14 as the super() proxy object is now copied, instead of its copy implementation being used on the original object.

This change does lose the read-only latching on copy that DimCoords currently have, which is what makes me think there is a better way. On the other hand, is the DimCoord not being created with read-only points coordinates?

Fixes #6762

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
