### PR TITLE
gha: fix lychee

### DIFF
--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -5,13 +5,21 @@ on:
   schedule:
     - cron: "00 06 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Link Checker
         id: lychee
@@ -19,17 +27,25 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           fail: false
-          args: "--verbose --max-concurrency 1 './docs/**/*.rst' './docs/**/*.inc' './lib/**/*.py'"
+          args: |
+            --verbose
+            --max-concurrency 1
+            './docs/**/*.rst'
+            './docs/**/*.inc'
+            './lib/**/*.py'
 
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ fromJSON(steps.lychee.outputs.exit_code) != 0 }}
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
-          labels: "Bot, Type: Documentation, Type: Bug"
+          labels: |
+            Bot
+            Type: Documentation
+            Type: Bug
 
       - name: Fail Workflow On Link Errors
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ fromJSON(steps.lychee.outputs.exit_code) != 0 }}
         run:
-          exit {{ steps.lychee.outputs.exit_code }}
+          exit ${{ fromJSON(steps.lychee.outputs.exit_code) }}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Playing forward some quality-of-life improvements and fixes to `ci-linkcheck.yml`, namely:

1. Improve readabilty for `args` and `labels` by using multi-line input
2. Group and rationalise multiple job runs with `concurrency` controls
3. Adopt [artipacked](https://docs.zizmor.sh/audits/#artipacked) pattern remediation as [zizmor](https://github.com/zizmorcore/zizmor) recommended best practice regarding `actions/checkout` persisted credentials
4. Fix incorrect `if:` syntax - GHAs use expressions inside `${{ ... }}` for evaluation, otherwise the condition is treated as text, which can result in incorrect behaviour
   - Adopted `fromJSON` for readability. The flip would be to adopt `... != '0'` instead. 
6. Use `fromJSON` to coerce `exit_code` for integer comparison 

As an aside, I'd recommend that `iris` should adopt [zizmor](https://github.com/zizmorcore/zizmor) compliance for static analysis of its GHAs :100: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
