### PR TITLE
Prototype idea for using `DatasetWrapper` in the NetCDF Proxies

### DIFF
--- a/lib/iris/exceptions.py
+++ b/lib/iris/exceptions.py
@@ -179,3 +179,9 @@ class CFParseError(IrisError):
     """Raised when a string associated with a CF defined syntax could not be parsed."""
 
     pass
+
+
+class NcParallelError(IrisError):
+    """Raised when a netCDF operation fails due to parallel I/O issues."""
+
+    pass


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Since #5095 - 2022 - it now seems much more difficult to replicate the `not a valid ID` error. This is even true if I check out Iris 3.5 and try it there, even when running large numbers of operations on a cluster. Expect this is due to hardware improvements.

So I think that the awkwardness of not using `DatasetWrapper` within `NetCDFDataProxy` and `NetCDFWriteProxy` might not be worth it any more. I wanted to capture my thoughts quickly while they were fresh in my head.

The use of a custom exception class with a meaningful error message should make it much easier for users to handle `not a valid ID` on the rare occasions it does occur, as well as encouraging users to contact us if they see it more often than expected.

### To do

- [ ] What's New entry
- [ ] Tests

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
