### PR TITLE
enable fail_on_warning for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,7 +23,7 @@ conda:
 
 sphinx:
   configuration: docs/src/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 python:
   install:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Enables `fail_on_warning` when building on **readthedocs**.


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
