### PR TITLE
docs: add `:user:` extlinks convenience

### DIFF
--- a/docs/src/common_links.inc
+++ b/docs/src/common_links.inc
@@ -47,6 +47,7 @@
 .. _iris-esmf-regrid: https://github.com/SciTools-incubator/iris-esmf-regrid
 .. _netCDF4: https://github.com/Unidata/netcdf4-python
 .. _SciTools Contributor's License Agreement (CLA): https://cla-assistant.io/SciTools/
+.. _extlinks: https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 
 
 .. comment

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -288,6 +288,7 @@ extlinks = {
         "https://github.com/SciTools/iris/discussions/%s",
         "Discussion #%s",
     ),
+    "user": ("https://github.com/%s", "@%s"),
 }
 
 # -- Doctest ("make doctest")--------------------------------------------------

--- a/docs/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/src/developers_guide/documenting/whats_new_contributions.rst
@@ -82,6 +82,18 @@ The required content, in order, is as follows:
 
     .. _@tkknight: https://github.com/tkknight
 
+  .. hint::
+
+    Alternatively adopt the ``:user:`` `extlinks`_ convenience instead.
+
+    For example to reference the ``github`` user ``tkknight`` simply use
+    :literal:`:user:\`tkknight\``.
+
+    This will be rendered as :user:`tkknight`.
+
+    In addition, there is now no need to add a full reference to the user within
+    the documentation.
+
 * A succinct summary of the new/changed behaviour.
 
 * Context to the change. Possible examples include: what this fixes, why
@@ -143,3 +155,4 @@ users.  To achieve this several categories may be used.
 **💼 Internal**
   Changes to any internal or development related topics, such as testing,
   environment dependencies etc.
+

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -88,6 +88,9 @@ This document explains the changes made to Iris for this release
 
 #. `@tkknight`_ added a gallery carousel to the documentation homepage. (:pull:`6884`)
 
+#. :user:`bjlittle` added the ``:user:`` `extlinks`_ ``github`` user convenience.
+   (:pull:`6931`)
+
 
 💼 Internal
 ===========


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds a minor quality-of-life convenience for contributors i.e., supports the `:user:` [extlinks](https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html) so that we can use the pattern ``` :user:`bjlittle` ``` within the documentation to render automatically as [@bjlittle](https://github.com/bjlittle).

Advantage - using `:user:` means that a full URL reference to the user is no longer required, which sometime can be forgotten.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
