### PR TITLE
`str` representation of numpy scalars in cube summary

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -140,6 +140,10 @@ This document explains the changes made to Iris for this release
 
 #. `@hsteptoe`_ and `@ESadek-MO`_ (reviewer) added static type hinting to :mod:`iris.pandas`. (:pull:`6948`)
 
+#. `@ukmo-ccbunney`_ changed formatting of numpy scalars attributes when generating a
+    Cube/Coord summary to use ``str`` representation instead of ``repr``.
+    (:pull:`6966`, :issue:`6692`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/lib/iris/_representation/cube_summary.py
+++ b/lib/iris/_representation/cube_summary.py
@@ -81,7 +81,8 @@ def array_repr(arr):
 
 def value_repr(value, quote_strings=False, clip_strings=False):
     """Produce a single-line printable version of an attribute or scalar value."""
-    if hasattr(value, "dtype"):
+    if hasattr(value, "dtype") and hasattr(value, "shape") and len(value.shape) > 0:
+        # Only format as array if value is not a scalar.
         value = array_repr(value)
     elif isinstance(value, str):
         value = string_repr(

--- a/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
+++ b/lib/iris/tests/unit/representation/cube_summary/test_CubeSummary.py
@@ -220,15 +220,24 @@ class Test_CubeSummary:
 
     def test_attributes(self):
         cube = self.cube
-        cube.attributes = {"a": 1, "b": "two", "c": " this \n   that\tand."}
+        cube.attributes = {
+            "a": 1,
+            "b": "two",
+            "c": " this \n   that\tand.",
+            "d": np.array([1, 2]),
+            "e": np.float32(123.456),
+        }
         rep = CubeSummary(cube)
 
         attribute_section = rep.scalar_sections["Attributes:"]
         attribute_contents = attribute_section.contents
+        print(attribute_contents)
         expected_contents = [
             "a: 1",
             "b: 'two'",
             "c: ' this \\n   that\\tand.'",
+            "d: array([1, 2])",
+            "e: 123.456",
         ]
         # Note: a string with \n or \t in it gets "repr-d".
         # Other strings don't (though in coord 'extra' lines, they do.)


### PR DESCRIPTION
## 🚀 Pull Request

Fixes: #6692 

Updates `cube_summary.py` to use `str` representation for numpy scalar attribute values in Cube and Coord summaries.

For a cube attribute like this:
```python
cube.attributes['numpy_scalar'] = np.float32(123.456)
```

The cube summary will look like this:
```
<snip>
Attributes:
        scalar                      123.456
```
rather than this:
```
<snip>
Attributes:
        scalar                      np.float32(123.456)
```

