### PR TITLE
Temporarily disable making str-dtyped coords 'no-unit'.

### DIFF
--- a/lib/iris/fileformats/_nc_load_rules/helpers.py
+++ b/lib/iris/fileformats/_nc_load_rules/helpers.py
@@ -1209,8 +1209,8 @@ def get_attr_units(cf_var, attributes, capture_invalid=False):
         attributes["invalid_units"] = attr_units
         attr_units = UNKNOWN_UNIT_STRING
 
-    if np.issubdtype(cf_var.dtype, np.str_):
-        attr_units = NO_UNIT_STRING
+    # if np.issubdtype(cf_var.dtype, np.str_):
+    #     attr_units = NO_UNIT_STRING
 
     if any(
         hasattr(cf_var.cf_data, name)


### PR DESCRIPTION
Just to see what tests a tiny change might break

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
