### PR TITLE
#6490: Fixed Search Highlighting in Dark Mode

### DIFF
--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -1,8 +1,3 @@
-/* import the standard theme css */
-@import url("styles/theme.css");
-
-/* now we can add custom css.... */
-
 /* Used for very strong warning */
 #slim-red-box-banner {
   background: #ff0000;


### PR DESCRIPTION
## 🚀 Pull Request

closes #6490 

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR fixes search highlighting in dark mode, which was previously difficult to read.

I have removed what seems to be a redundant import of the sphinx theme css in the css overrides file.

I've checked that the overrides are still rendering locally by commenting out the overrides on the home page cards and verifying they changed.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

