### PR TITLE
Adapt benchmarks `asv_delegated.py` for wntrblm/nox#1072

### DIFF
--- a/benchmarks/asv_delegated.py
+++ b/benchmarks/asv_delegated.py
@@ -136,14 +136,15 @@ class Delegated(_DelegatedABC):
                 )
 
                 env_parent_contents = list(env_parent_dir.iterdir())
-                if len(env_parent_contents) != 1:
+                env_parent_dirs = [p for p in env_parent_contents if p.is_dir()]
+                if len(env_parent_dirs) != 1:
                     message = (
-                        f"{env_parent_dir} contains {len(env_parent_contents)} "
-                        "items, expected 1. Cannot determine the environment "
+                        f"{env_parent_dir} contains {len(env_parent_dirs)} "
+                        "directories, expected 1. Cannot determine the environment "
                         "directory."
                     )
                     raise FileNotFoundError(message)
-                (delegated_env_path,) = env_parent_contents
+                (delegated_env_path,) = env_parent_dirs
 
             case _:
                 message = "No environment setup is known for this commit of Iris."

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -72,7 +72,9 @@ This document explains the changes made to Iris for this release
 💼 Internal
 ===========
 
-#. N/A
+#. `@trexfeathers`_ fixed the benchmarking ``asv_delegated.py`` to work with
+   Nox release ``2026.04.10`` (which adds more files to the environment parent
+   directory, breaking previous assumptions). (:pull:`7046`)
 
 
 .. comment


### PR DESCRIPTION
The current script is breaking because it was written on the assumption that Nox would only place the environment directory in the specified parent. It now also places a `.gitignore` and a `CACHEDIR.TAG` file too, presumably to help with Nox's internals.