### PR TITLE
Fix carousel

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -507,7 +507,7 @@ def generate_carousel(
     cards_by_link = {}
 
     card = r""".. card::
-    :img-background: {image}
+    :img-bottom: {image}
     :link: {link}
     :link-type: ref
     :width: {width}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -513,7 +513,9 @@ def generate_carousel(
     :width: {width}
     :margin: {margin}
     :class-card: align-self-center
+    :class-body: d-none
 """
+    # :class-body: d-none = remove the text space, since we have no text.
 
     # TODO @bjlittle: use Path.walk when python >=3.12
     for root, _, files in os.walk(str(base)):

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -507,7 +507,7 @@ def generate_carousel(
     cards_by_link = {}
 
     card = r""".. card::
-    :img-bottom: {image}
+    :img-background: {image}
     :link: {link}
     :link-type: ref
     :width: {width}

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -60,13 +60,15 @@ This document explains the changes made to Iris for this release
 🔗 Dependencies
 ===============
 
-#. N/A
+#. `@trexfeathers`_ and `@tkknight`_ removed the maximum pin for the
+   PyData Sphinx Theme (used in the docs). (:issue:`6885`, :pull:`7053`)
 
 
 📚 Documentation
 ================
 
-#. N/A
+#. `@trexfeathers`_ and `@tkknight`_ made the docs compatible with the latest
+   versions of PyData Sphinx Theme (>=0.16). (:issue:`6885`, :pull:`7053`)
 
 
 💼 Internal

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -56,8 +56,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  # Pinned reason: https://github.com/SciTools/iris/issues/6885
-  - pydata-sphinx-theme !=0.16.0,!=0.16.1,<0.16.2
+  - pydata-sphinx-theme
   - sphinx-needs
   - sphinx-reredirects
 

--- a/requirements/py313.yml
+++ b/requirements/py313.yml
@@ -56,8 +56,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  # Pinned reason: https://github.com/SciTools/iris/issues/6885
-  - pydata-sphinx-theme !=0.16.0,!=0.16.1,<0.16.2
+  - pydata-sphinx-theme
   - sphinx-needs
   - sphinx-reredirects
 

--- a/requirements/py314.yml
+++ b/requirements/py314.yml
@@ -56,8 +56,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery >=0.11.0
   - sphinx-design
-  # Pinned reason: https://github.com/SciTools/iris/issues/6885
-  - pydata-sphinx-theme !=0.16.0,!=0.16.1,<0.16.2
+  - pydata-sphinx-theme
   - sphinx-needs
   - sphinx-reredirects
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Closes #6885 by a workaround of using `img-bottom` instead of `img-background` for all the `card`s in our `card-carousel`.

### Iris' custom CSS

I turned all this off and the problem still occurred.

### [sphinx-design](https://github.com/executablebooks/sphinx-design)

- The blanking problem relates to `sphinx-design` objects - `card`, and `card-carousel`.
- No evidence on the repository that they are aware of the problem.
- `sphinx-design` remains healthy, but activity and comments suggest there is not the resource for community engagement or PR reviews.
- They have demonstrations of using `sphinx-design` with `pydata-sphinx-theme` 👍
- They are currently pinned below v0.16 (where the problem first appeared) 👎. No evidence that this is in response to a problem, just a lack of resource to upgrade yet.

Conclusion: reporting the issue to `sphinx-design` is unlikely to yield results.

### [pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme)

- The blanking problem appeared when `pydata-sphinx-theme` released v0.16, so that project is directly related to the problem.
- No evidence on the repository that they are aware of the problem.
- Much better activity on this repo (compared to `sphinx-design`).
- They directly rely on `sphinx-design` for their own docs, including `card`, but not `card-carousel`.

Conclusion: this is a good place to report the issue.

### MRE

For reporting to `pydata-sphinx-theme`, I figured an example based on their own docs would be best! [Gallery of sites using this theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/examples/gallery.html) uses `img-bottom`, which still works fine with the latest releases of `pydata-sphinx-theme`. We have observed `img-background` not working, so I tried changing the gallery page to use that. I even used the same `width` and `margin` settings that we use. It still worked fine 👎. This might be because the problem is unique to `card-carousel`.

The next best would presumably be standing up a whole tiny docs site as an example, but I have run out of time, and I don't know if that would manage to replicate.

### Our workaround

Rather than spending longer trying to produce an MRE, we can make a one-line CSS modification to the card specification to remove the text box entirely, and that works fine:

<img width="816" height="227" alt="image" src="https://github.com/user-attachments/assets/a4e0ac78-8c57-40fa-89f0-2215feb4551f" />

https://scitools-iris--7053.org.readthedocs.build/en/7053/

### Dependencies

Since Iris' use of RTD does not honour our lock files, I have chosen not to update them, since they will develop a Git conflict when automatically updated over the weekend. Once this PR is merged, the next automatic lock file update will pick up the change anyway.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)