### PR TITLE
Fixed card when in dark mode.

### DIFF
--- a/docs/src/_static/theme_override.css
+++ b/docs/src/_static/theme_override.css
@@ -44,7 +44,7 @@ ul.squarelist {
 
 .custom-body {
     text-align: left;
-    margin-left: max(45px, 15%);
+    padding-left:  max(45px, 20%) !important;
 }
 
 .center {


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Change css so the card background is rendered correctly when in dark mode.

Card rendered without the fixed:
<img width="357" height="103" alt="image" src="https://github.com/user-attachments/assets/7260a826-eafc-4eb0-b1c5-46dd50631973" />

Card rendered with the fix:
<img width="351" height="104" alt="image" src="https://github.com/user-attachments/assets/8969d8a7-5fa7-4def-b73e-80b075d2e291" />



---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
